### PR TITLE
Add facade level retry

### DIFF
--- a/server/BREAKING.md
+++ b/server/BREAKING.md
@@ -1,8 +1,8 @@
 > **Note:** These breaking changes are only relevant to the server packages and images released from `./routerlicious`.
 
 ## 0.1038 Breaking Changes
-- [aggregate function from `MongoCollection` become async](#aggregate-function-from-MongoCollection-become-async)
-#### `aggregate` function from `MongoCollection` become async
+- [aggregate function from `MongoCollection` became async](#aggregate-function-from-MongoCollection-became-async)
+#### `aggregate` function from `MongoCollection` became async
 Before: `const cursor = collection.aggregate([ ... ]);`
 
 Now: `const cursor = await collection.aggregate([ ... ]);`

--- a/server/BREAKING.md
+++ b/server/BREAKING.md
@@ -1,8 +1,8 @@
 > **Note:** These breaking changes are only relevant to the server packages and images released from `./routerlicious`.
 
 ## 0.1038 Breaking Changes
-- [aggregate function from mongodb.ts become async](#aggregate-function-in-mongodbts-become-async)
-#### `aggregate` function in mongodb.ts become async
+- [aggregate function from `MongoCollection` become async](#aggregate-function-from-MongoCollection-become-async)
+#### `aggregate` function from `MongoCollection` become async
 Before: `const cursor = collection.aggregate([ ... ]);`
 
 Now: `const cursor = await collection.aggregate([ ... ]);`

--- a/server/BREAKING.md
+++ b/server/BREAKING.md
@@ -1,5 +1,12 @@
 > **Note:** These breaking changes are only relevant to the server packages and images released from `./routerlicious`.
 
+## 0.1038 Breaking Changes
+- [aggregate function from mongodb.ts become async](#aggregate-function-in-mongodb-ts-become-async)
+#### `aggregate` function in mongodb.ts become async
+Before: `const cursor = collection.aggregate([ ... ]);`
+
+Now: `const cursor = await collection.aggregate([ ... ]);`
+
 ## 0.1037 Breaking Changes
 - [IDeltaService added to alfred runnerFactory and resource](#IDeltaService-added-to-alfred-runnerFactory-and-resource)
 #### `IDeltaService` added to alfred `runnerFactory` and `resource`

--- a/server/BREAKING.md
+++ b/server/BREAKING.md
@@ -1,7 +1,7 @@
 > **Note:** These breaking changes are only relevant to the server packages and images released from `./routerlicious`.
 
 ## 0.1038 Breaking Changes
-- [aggregate function from mongodb.ts become async](#aggregate-function-in-mongodb-ts-become-async)
+- [aggregate function from mongodb.ts become async](#aggregate-function-in-mongodbts-become-async)
 #### `aggregate` function in mongodb.ts become async
 Before: `const cursor = collection.aggregate([ ... ]);`
 

--- a/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
@@ -7,6 +7,7 @@ import {
     ICollection,
     IContext,
     IDocument,
+    isRetryAble,
     IScribe,
     ISequencedOperationMessage,
     runWithRetry,
@@ -18,6 +19,7 @@ import { ICheckpointManager } from "./interfaces";
  * MongoDB specific implementation of ICheckpointManager
  */
 export class CheckpointManager implements ICheckpointManager {
+    private readonly clientFacadeRetryEnabled: boolean;
     constructor(
         protected readonly context: IContext,
          private readonly tenantId: string,
@@ -25,6 +27,7 @@ export class CheckpointManager implements ICheckpointManager {
          private readonly documentCollection: ICollection<IDocument>,
          private readonly opCollection: ICollection<ISequencedOperationMessage>,
     ) {
+        this.clientFacadeRetryEnabled = isRetryAble(this.opCollection);
      }
 
     /**
@@ -54,7 +57,9 @@ export class CheckpointManager implements ICheckpointManager {
                 3 /* maxRetries */,
                 1000 /* retryAfterMs */,
                 getLumberBaseProperties(this.documentId, this.tenantId),
-                (error) => error.code === 11000 /* shouldIgnoreError */);
+                (error) => error.code === 11000 /* shouldIgnoreError */,
+                (error) => !this.clientFacadeRetryEnabled, /* shouldRetry */
+            );
         }
 
         // Write out the full state first that we require

--- a/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
@@ -7,7 +7,7 @@ import {
     ICollection,
     IContext,
     IDocument,
-    isRetryAble,
+    isRetryEnabled,
     IScribe,
     ISequencedOperationMessage,
     runWithRetry,
@@ -27,7 +27,7 @@ export class CheckpointManager implements ICheckpointManager {
          private readonly documentCollection: ICollection<IDocument>,
          private readonly opCollection: ICollection<ISequencedOperationMessage>,
     ) {
-        this.clientFacadeRetryEnabled = isRetryAble(this.opCollection);
+        this.clientFacadeRetryEnabled = isRetryEnabled(this.opCollection);
      }
 
     /**

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -12,6 +12,7 @@ import {
     ISequencedOperationMessage,
     SequencedOperationType,
     runWithRetry,
+    isRetryAble,
 } from "@fluidframework/server-services-core";
 import { getLumberBaseProperties } from "@fluidframework/server-services-telemetry";
 
@@ -19,12 +20,14 @@ export class ScriptoriumLambda implements IPartitionLambda {
     private pending = new Map<string, ISequencedOperationMessage[]>();
     private pendingOffset: IQueuedMessage | undefined;
     private current = new Map<string, ISequencedOperationMessage[]>();
+    private readonly clientFacadeRetryEnabled: boolean;
 
     constructor(
         private readonly opCollection: ICollection<any>,
         protected context: IContext,
         protected readonly tenantId: string,
         protected readonly documentId: string) {
+        this.clientFacadeRetryEnabled = isRetryAble(this.opCollection);
     }
 
     public handler(message: IQueuedMessage) {
@@ -109,6 +112,8 @@ export class ScriptoriumLambda implements IPartitionLambda {
             3 /* maxRetries */,
             1000 /* retryAfterMs */,
             getLumberBaseProperties(this.documentId, this.tenantId),
-            (error) => error.code === 11000 /* shouldIgnoreError */);
+            (error) => error.code === 11000,
+            (error) => !this.clientFacadeRetryEnabled, /* shouldRetry */
+        );
     }
 }

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -12,7 +12,7 @@ import {
     ISequencedOperationMessage,
     SequencedOperationType,
     runWithRetry,
-    isRetryAble,
+    isRetryEnabled,
 } from "@fluidframework/server-services-core";
 import { getLumberBaseProperties } from "@fluidframework/server-services-telemetry";
 
@@ -27,7 +27,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
         protected context: IContext,
         protected readonly tenantId: string,
         protected readonly documentId: string) {
-        this.clientFacadeRetryEnabled = isRetryAble(this.opCollection);
+        this.clientFacadeRetryEnabled = isRetryEnabled(this.opCollection);
     }
 
     public handler(message: IQueuedMessage) {

--- a/server/routerlicious/packages/services-core/src/database.ts
+++ b/server/routerlicious/packages/services-core/src/database.ts
@@ -144,8 +144,8 @@ export interface IRetryAble {
     retryEnabled: boolean;
 }
 
-export function isRetryAble<T>(collection: ICollection<T>): collection is ICollection<T> {
-    return "retryEnabled" in collection;
+export function isRetryEnabled<T>(collection: ICollection<T>): boolean {
+    return (collection as unknown as IRetryAble).retryEnabled === true;
 }
 
 export type IDbEvents = "close" | "reconnect" | "error" | "reconnectFailed";

--- a/server/routerlicious/packages/services-core/src/database.ts
+++ b/server/routerlicious/packages/services-core/src/database.ts
@@ -140,6 +140,14 @@ export interface ICollection<T> {
     createTTLIndex?(index: any, mongoExpireAfterSeconds?: number): Promise<void>;
 }
 
+export interface IRetryAble {
+    retryEnabled: boolean;
+}
+
+export function isRetryAble<T>(collection: ICollection<T>): collection is ICollection<T> {
+    return "retryEnabled" in collection;
+}
+
 export type IDbEvents = "close" | "reconnect" | "error" | "reconnectFailed";
 
 export interface IDb {

--- a/server/routerlicious/packages/services-core/src/database.ts
+++ b/server/routerlicious/packages/services-core/src/database.ts
@@ -140,12 +140,12 @@ export interface ICollection<T> {
     createTTLIndex?(index: any, mongoExpireAfterSeconds?: number): Promise<void>;
 }
 
-export interface IRetryAble {
+export interface IRetryable {
     retryEnabled: boolean;
 }
 
 export function isRetryEnabled<T>(collection: ICollection<T>): boolean {
-    return (collection as unknown as IRetryAble).retryEnabled === true;
+    return (collection as unknown as IRetryable).retryEnabled === true;
 }
 
 export type IDbEvents = "close" | "reconnect" | "error" | "reconnectFailed";

--- a/server/routerlicious/packages/services-core/src/index.ts
+++ b/server/routerlicious/packages/services-core/src/index.ts
@@ -22,7 +22,7 @@ export {
 	IServerConfiguration,
 	IServiceConfiguration,
 } from "./configuration";
-export { ICollection, IDatabaseManager, IDb, IDbEvents, IDbFactory, IRetryAble, isRetryAble } from "./database";
+export { ICollection, IDatabaseManager, IDb, IDbEvents, IDbFactory, IRetryAble, isRetryEnabled } from "./database";
 export { IDeltaService } from "./delta";
 export { IClientSequenceNumber, IDeliState, IDocument, IDocumentDetails, IDocumentStorage, IScribe } from "./document";
 export { EmptyTaskMessageSender } from "./emptyTaskMessageSender";

--- a/server/routerlicious/packages/services-core/src/index.ts
+++ b/server/routerlicious/packages/services-core/src/index.ts
@@ -22,7 +22,7 @@ export {
 	IServerConfiguration,
 	IServiceConfiguration,
 } from "./configuration";
-export { ICollection, IDatabaseManager, IDb, IDbEvents, IDbFactory } from "./database";
+export { ICollection, IDatabaseManager, IDb, IDbEvents, IDbFactory, IRetryAble, isRetryAble } from "./database";
 export { IDeltaService } from "./delta";
 export { IClientSequenceNumber, IDeliState, IDocument, IDocumentDetails, IDocumentStorage, IScribe } from "./document";
 export { EmptyTaskMessageSender } from "./emptyTaskMessageSender";

--- a/server/routerlicious/packages/services-core/src/index.ts
+++ b/server/routerlicious/packages/services-core/src/index.ts
@@ -22,7 +22,7 @@ export {
 	IServerConfiguration,
 	IServiceConfiguration,
 } from "./configuration";
-export { ICollection, IDatabaseManager, IDb, IDbEvents, IDbFactory, IRetryAble, isRetryEnabled } from "./database";
+export { ICollection, IDatabaseManager, IDb, IDbEvents, IDbFactory, IRetryable, isRetryEnabled } from "./database";
 export { IDeltaService } from "./delta";
 export { IClientSequenceNumber, IDeliState, IDocument, IDocumentDetails, IDocumentStorage, IScribe } from "./document";
 export { EmptyTaskMessageSender } from "./emptyTaskMessageSender";

--- a/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
@@ -24,8 +24,9 @@ export enum LumberEventName {
     ServiceSummary = "ServiceSummary",
     SummaryReader = "SummaryReader",
 
-    // Database
-    MongoQuery = "MongoQuery",
+    // Retries
+    RunWithRetry = "RunWithRetry",
+    RequestWithRetry = "RequestWithRetry",
 
     // Reliability
     SessionResult = "SessionResult",

--- a/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
@@ -24,6 +24,9 @@ export enum LumberEventName {
     ServiceSummary = "ServiceSummary",
     SummaryReader = "SummaryReader",
 
+    // Database
+    MongoQuery = "MongoQuery",
+
     // Reliability
     SessionResult = "SessionResult",
     StartSessionResult = "StartSessionResult",

--- a/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
+++ b/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
@@ -22,7 +22,7 @@ export async function deleteSummarizedOps(
         }
 
     const uniqueDocumentsCursor = await documentsCollection.aggregate([
-            { $group: { _id: { documentId: "$documentId", tenantId: "$tenantId" } } },
+        { $group: { _id: { documentId: "$documentId", tenantId: "$tenantId" } } },
     ]);
     const uniqueDocuments = await uniqueDocumentsCursor.toArray();
 

--- a/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
+++ b/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
@@ -21,9 +21,10 @@ export async function deleteSummarizedOps(
             return Promise.reject(error);
         }
 
-        const uniqueDocuments = await documentsCollection.aggregate([
+    const uniqueDocumentsCursor = await documentsCollection.aggregate([
             { $group: { _id: { documentId: "$documentId", tenantId: "$tenantId" } } },
-        ]).toArray();
+    ]);
+    const uniqueDocuments = await uniqueDocumentsCursor.toArray();
 
         const currentEpochTime = new Date().getTime();
         const epochTimeBeforeOfflineWindow = currentEpochTime - offlineWindowMs;

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/IMongoExceptionRetryRule.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/IMongoExceptionRetryRule.ts
@@ -11,10 +11,10 @@ export interface IMongoExceptionRetryRule {
 
 export abstract class BaseMongoExceptionRetryRule implements IMongoExceptionRetryRule {
 	public abstract match(error: any): boolean;
-	protected abstract defaultDecision: boolean;
+	protected abstract defaultRetryDecision: boolean;
 
 	public shouldRetry(): boolean {
-		return this.overrideRetryDecision ?? this.defaultDecision;
+		return this.overrideRetryDecision ?? this.defaultRetryDecision;
 	}
 
 	private readonly overrideRetryDecision?: boolean;

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/IMongoExceptionRetryRule.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/IMongoExceptionRetryRule.ts
@@ -4,6 +4,24 @@
  */
 
 export interface IMongoExceptionRetryRule {
+	ruleName: string;
 	match: (error: any) => boolean;
-	shouldRetry: boolean;
+	shouldRetry(): boolean;
+}
+
+export abstract class BaseMongoExceptionRetryRule implements IMongoExceptionRetryRule {
+	public abstract match(error: any): boolean;
+	protected abstract defaultDecision: boolean;
+
+	public shouldRetry(): boolean {
+		return this.overrideRetryDecision ?? this.defaultDecision;
+	}
+
+	private readonly overrideRetryDecision?: boolean;
+	constructor(
+		public readonly ruleName: string,
+		retryRuleOverride: Map<string, boolean>,
+	) {
+		this.overrideRetryDecision = retryRuleOverride.get(ruleName);
+	}
 }

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/IMongoExceptionRetryRule.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/IMongoExceptionRetryRule.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export interface IMongoExceptionRetryRule {
+	match: (error: any) => boolean;
+	shouldRetry: boolean;
+}

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/defaultExceptionRule.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/defaultExceptionRule.ts
@@ -3,14 +3,16 @@
  * Licensed under the MIT License.
  */
 
-import { Lumberjack } from "@fluidframework/server-services-telemetry";
-import { IMongoExceptionRetryRule } from "./IMongoExceptionRetryRule";
+import { BaseMongoExceptionRetryRule } from "./IMongoExceptionRetryRule";
 
-export class DefaultExceptionRule implements IMongoExceptionRetryRule {
-	match(error: any): boolean {
-		Lumberjack.error("DefaultRule.match() called for unknown error", undefined, error);
-		return true;
-	}
+export class DefaultExceptionRule extends BaseMongoExceptionRetryRule {
+    protected defaultDecision: boolean = false;
 
-	shouldRetry: boolean = false;
+    constructor(retryRuleOverride: Map<string, boolean>) {
+        super("DefaultExceptionRule", retryRuleOverride);
+    }
+
+    public match(error: any): boolean {
+        return true;
+    };
 }

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/defaultExceptionRule.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/defaultExceptionRule.ts
@@ -6,7 +6,7 @@
 import { BaseMongoExceptionRetryRule } from "./IMongoExceptionRetryRule";
 
 export class DefaultExceptionRule extends BaseMongoExceptionRetryRule {
-    protected defaultDecision: boolean = false;
+    protected defaultRetryDecision: boolean = false;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
         super("DefaultExceptionRule", retryRuleOverride);

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/defaultExceptionRule.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/defaultExceptionRule.ts
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { IMongoExceptionRetryRule } from "./IMongoExceptionRetryRule";
+
+export class DefaultExceptionRule implements IMongoExceptionRetryRule {
+	match(error: any): boolean {
+		Lumberjack.error("DefaultRule.match() called for unknown error", undefined, error);
+		return true;
+	}
+
+	shouldRetry: boolean = false;
+}

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { MongoErrorRetryAnalyzer } from "./mongoErrorRetryAnalyzer";

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
@@ -1,0 +1,172 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IMongoExceptionRetryRule } from "../IMongoExceptionRetryRule";
+class InternalErrorRule implements IMongoExceptionRetryRule {
+    private static readonly codeName = "InternalError";
+    match(error: any): boolean {
+        return error.code === 1
+            && error.codeName
+            && (error.codeName as string) === InternalErrorRule.codeName;
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// This handles the requested queued on client side buffer overflow. Should relies on reconnect instead of retry?
+class NoConnectionAvailableRule implements IMongoExceptionRetryRule {
+    private static readonly messagePrefix = "no connection available for operation and number of stored operation";
+    match(error: any): boolean {
+        // TODO: This timed out actually included two different messages:
+        // 1. Retries due to rate limiting: False.
+        // 2. Retries due to rate limiting: True.
+        // We might need to split this into two different rules after consult with DB team.
+        return error.message
+            && (error.message as string).startsWith(NoConnectionAvailableRule.messagePrefix);
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// This handles the no primary found in replicaset or invalid replica set name from client
+// Should not retry but relays on reconnect.
+class NoPrimaryInReplicasetRule implements IMongoExceptionRetryRule {
+    private static readonly message = "no primary found in replicaset or invalid replica set name";
+    match(error: any): boolean {
+        // TODO: This timed out actually included two different messages:
+        // 1. Retries due to rate limiting: False.
+        // 2. Retries due to rate limiting: True.
+        // We might need to split this into two different rules after consult with DB team.
+        return error.message
+            && (error.message as string) === NoPrimaryInReplicasetRule.message;
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// this handles the pool destroyed error from client side. Should relies on reconnect instead of retry?
+class PoolDestroyedRule implements IMongoExceptionRetryRule {
+    private static readonly message1 = "pool destroyed";
+    private static readonly message2 = "server instance pool was destroyed";
+    match(error: any): boolean {
+        return error.code === 16
+            && error.message
+            && ((error.message as string) === PoolDestroyedRule.message1
+                || (error.message as string) === PoolDestroyedRule.message2);
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// this handles the case where the request payload is too large from server.
+class RequestSizeLargeRule implements IMongoExceptionRetryRule {
+    private static readonly errorMsgPrefix =
+        "Error=16, Details='Response status code does not indicate success: RequestEntityTooLarge (413)";
+    match(error: any): boolean {
+        return error.code === 16
+            && error.errmsg
+            && (error.errmsg as string).startsWith(RequestSizeLargeRule.errorMsgPrefix);
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// This handles request timeout from server without additional rate limit info.
+class RequestTimedNoRateLimitInfo implements IMongoExceptionRetryRule {
+    private static readonly errmsg = "Request timed out.";
+    match(error: any): boolean {
+        return error.code === 50
+            && error.errmsg
+            && (error.errmsg as string) === RequestTimedNoRateLimitInfo.errmsg;
+    }
+
+    shouldRetry: boolean = true;
+}
+
+// This handles request timeout from server with http info.
+class RequestTimedOutWithHttpInfo implements IMongoExceptionRetryRule {
+    private static readonly errmsgPrefix =
+        "Error=50, Details='Response status code does not indicate success: RequestTimeout (408);";
+    match(error: any): boolean {
+        return error.code === 50
+            && error.errmsg
+            && (error.errmsg as string).startsWith(RequestTimedOutWithHttpInfo.errmsgPrefix);
+    }
+
+    shouldRetry: boolean = true;
+}
+
+// This handles request timeout from server with additional rate limit info.
+class RequestTimedOutWithRateLimit implements IMongoExceptionRetryRule {
+    private static readonly codeName = "ExceededTimeLimit";
+    match(error: any): boolean {
+        // TODO: This timed out actually included two different messages:
+        // 1. Retries due to rate limiting: False.
+        // 2. Retries due to rate limiting: True.
+        // We might need to split this into two different rules after consult with DB team.
+        return error.code === 50
+            && error.errmsg
+            && (error.errmsg as string) === RequestTimedOutWithRateLimit.codeName;
+    }
+    shouldRetry: boolean = true;
+}
+
+// This handles server side temporary 503 issue
+class ServiceUnavailableRule implements IMongoExceptionRetryRule {
+    private static readonly errorDetails = "Response status code does not indicate success: ServiceUnavailable (503)";
+    match(error: any): boolean {
+        return error.code === 50
+            && error.errorDetails
+            && (error.errorDetails as string).includes(ServiceUnavailableRule.errorDetails);
+    }
+
+    shouldRetry: boolean = true;
+}
+
+// this handles the pool destroyed error from client side. Should relies on reconnect instead of retry?
+class TopologyDestroyed implements IMongoExceptionRetryRule {
+    private static readonly message = "Topology was destroyed";
+    match(error: any): boolean {
+        return error.code === 16
+            && error.message
+            && (error.message as string) === TopologyDestroyed.message;
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// this handles the incorrect credentials set. Should not retry
+class UnUnauthorizedRule implements IMongoExceptionRetryRule {
+    private static readonly codeName = "Unauthorized";
+    match(error: any): boolean {
+        return error.code === 13
+            && error.codeName
+            && (error.codeName as string) === UnUnauthorizedRule.codeName;
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// Maintain the list from more strick faster comparison to less strict slower comparison
+export const mongoErrorRetryRuleset: IMongoExceptionRetryRule[] = [
+    // The rules are using exactly equal
+    new InternalErrorRule(),
+    new NoPrimaryInReplicasetRule(),
+    new RequestTimedNoRateLimitInfo(),
+    new RequestTimedOutWithRateLimit(),
+    new TopologyDestroyed(),
+    new UnUnauthorizedRule(),
+
+    // The rules are using multiple compare
+    new PoolDestroyedRule(),
+
+    // The rules are using string startWith
+    new NoConnectionAvailableRule(),
+    new RequestSizeLargeRule(),
+    new RequestTimedOutWithHttpInfo(),
+
+    // The rules are using string contains
+    new ServiceUnavailableRule(),
+];

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
@@ -3,22 +3,32 @@
  * Licensed under the MIT License.
  */
 
-import { IMongoExceptionRetryRule } from "../IMongoExceptionRetryRule";
-class InternalErrorRule implements IMongoExceptionRetryRule {
+import { BaseMongoExceptionRetryRule, IMongoExceptionRetryRule } from "../IMongoExceptionRetryRule";
+class InternalErrorRule extends BaseMongoExceptionRetryRule {
     private static readonly codeName = "InternalError";
-    match(error: any): boolean {
+    protected defaultDecision: boolean = false;
+
+    constructor(retryRuleOverride: Map<string, boolean>) {
+        super("InternalErrorRule", retryRuleOverride);
+    }
+
+    public match(error: any): boolean {
         return error.code === 1
             && error.codeName
             && (error.codeName as string) === InternalErrorRule.codeName;
     }
-
-    shouldRetry: boolean = false;
 }
 
 // This handles the requested queued on client side buffer overflow. Should relies on reconnect instead of retry?
-class NoConnectionAvailableRule implements IMongoExceptionRetryRule {
+class NoConnectionAvailableRule extends BaseMongoExceptionRetryRule {
     private static readonly messagePrefix = "no connection available for operation and number of stored operation";
-    match(error: any): boolean {
+    protected defaultDecision: boolean = false;
+
+    constructor(retryRuleOverride: Map<string, boolean>) {
+        super("NoConnectionAvailableRule", retryRuleOverride);
+    }
+
+    public match(error: any): boolean {
         // TODO: This timed out actually included two different messages:
         // 1. Retries due to rate limiting: False.
         // 2. Retries due to rate limiting: True.
@@ -26,15 +36,19 @@ class NoConnectionAvailableRule implements IMongoExceptionRetryRule {
         return error.message
             && (error.message as string).startsWith(NoConnectionAvailableRule.messagePrefix);
     }
-
-    shouldRetry: boolean = false;
 }
 
 // This handles the no primary found in replicaset or invalid replica set name from client
 // Should not retry but relays on reconnect.
-class NoPrimaryInReplicasetRule implements IMongoExceptionRetryRule {
+class NoPrimaryInReplicasetRule extends BaseMongoExceptionRetryRule {
     private static readonly message = "no primary found in replicaset or invalid replica set name";
-    match(error: any): boolean {
+    protected defaultDecision: boolean = false;
+
+    constructor(retryRuleOverride: Map<string, boolean>) {
+        super("NoPrimaryInReplicasetRule", retryRuleOverride);
+    }
+
+    public match(error: any): boolean {
         // TODO: This timed out actually included two different messages:
         // 1. Retries due to rate limiting: False.
         // 2. Retries due to rate limiting: True.
@@ -42,142 +56,183 @@ class NoPrimaryInReplicasetRule implements IMongoExceptionRetryRule {
         return error.message
             && (error.message as string) === NoPrimaryInReplicasetRule.message;
     }
-
-    shouldRetry: boolean = false;
 }
 
 // this handles the pool destroyed error from client side. Should relies on reconnect instead of retry?
-class PoolDestroyedRule implements IMongoExceptionRetryRule {
+class PoolDestroyedRule extends BaseMongoExceptionRetryRule {
     private static readonly message1 = "pool destroyed";
     private static readonly message2 = "server instance pool was destroyed";
-    match(error: any): boolean {
+    protected defaultDecision: boolean = false;
+
+    constructor(retryRuleOverride: Map<string, boolean>) {
+        super("PoolDestroyedRule", retryRuleOverride);
+    }
+
+    public match(error: any): boolean {
         return error.code === 16
             && error.message
             && ((error.message as string) === PoolDestroyedRule.message1
                 || (error.message as string) === PoolDestroyedRule.message2);
     }
-
-    shouldRetry: boolean = false;
 }
 
 // this handles the case where the request payload is too large from server.
-class RequestSizeLargeRule implements IMongoExceptionRetryRule {
+class RequestSizeLargeRule extends BaseMongoExceptionRetryRule {
     private static readonly errorMsgPrefix =
         "Error=16, Details='Response status code does not indicate success: RequestEntityTooLarge (413)";
-    match(error: any): boolean {
+    protected defaultDecision: boolean = false;
+
+    constructor(retryRuleOverride: Map<string, boolean>) {
+        super("RequestSizeLargeRule", retryRuleOverride);
+    }
+
+    public match(error: any): boolean {
         return error.code === 16
             && error.errmsg
             && (error.errmsg as string).startsWith(RequestSizeLargeRule.errorMsgPrefix);
     }
-
-    shouldRetry: boolean = false;
 }
 
 // This handles request timeout from server without additional rate limit info.
-class RequestTimedNoRateLimitInfo implements IMongoExceptionRetryRule {
+class RequestTimedNoRateLimitInfo extends BaseMongoExceptionRetryRule {
     private static readonly errmsg = "Request timed out.";
-    match(error: any): boolean {
+    protected defaultDecision: boolean = true;
+
+    constructor(retryRuleOverride: Map<string, boolean>) {
+        super("RequestTimedNoRateLimitInfo", retryRuleOverride);
+    }
+
+    public match(error: any): boolean {
         return error.code === 50
             && error.errmsg
             && (error.errmsg as string) === RequestTimedNoRateLimitInfo.errmsg;
     }
-
-    shouldRetry: boolean = true;
 }
 
 // This handles request timeout from server with http info.
-class RequestTimedOutWithHttpInfo implements IMongoExceptionRetryRule {
+class RequestTimedOutWithHttpInfo extends BaseMongoExceptionRetryRule {
     private static readonly errmsgPrefix =
         "Error=50, Details='Response status code does not indicate success: RequestTimeout (408);";
-    match(error: any): boolean {
+    protected defaultDecision: boolean = true;
+
+    constructor(retryRuleOverride: Map<string, boolean>) {
+        super("RequestTimedOutWithHttpInfo", retryRuleOverride);
+    }
+
+    public match(error: any): boolean {
         return error.code === 50
             && error.errmsg
             && (error.errmsg as string).startsWith(RequestTimedOutWithHttpInfo.errmsgPrefix);
     }
-
-    shouldRetry: boolean = true;
 }
 
 // This handles request timeout from server with additional rate limit info.
-class RequestTimedOutWithRateLimitTrue implements IMongoExceptionRetryRule {
+class RequestTimedOutWithRateLimitTrue extends BaseMongoExceptionRetryRule {
     private static readonly codeName = "ExceededTimeLimit";
     private static readonly errorMsg = "Request timed out. Retries due to rate limiting: True.";
-    match(error: any): boolean {
+    protected defaultDecision: boolean = false;
+
+    constructor(retryRuleOverride: Map<string, boolean>) {
+        super("RequestTimedOutWithRateLimitTrue", retryRuleOverride);
+    }
+
+    public match(error: any): boolean {
         return error.code === 50
             && error.errmsg
             && (error.codeName as string) === RequestTimedOutWithRateLimitTrue.codeName
             && (error.errmsg as string) === RequestTimedOutWithRateLimitTrue.errorMsg;
     }
-    shouldRetry: boolean = false;
 }
 
 // This handles request timeout from server with additional rate limit info.
-class RequestTimedOutWithRateLimitFalse implements IMongoExceptionRetryRule {
+class RequestTimedOutWithRateLimitFalse extends BaseMongoExceptionRetryRule {
     private static readonly codeName = "ExceededTimeLimit";
     private static readonly errorMsg = "Request timed out. Retries due to rate limiting: False.";
-    match(error: any): boolean {
+    protected defaultDecision: boolean = true;
+
+    constructor(retryRuleOverride: Map<string, boolean>) {
+        super("RequestTimedOutWithRateLimitFalse", retryRuleOverride);
+    }
+
+    public match(error: any): boolean {
         return error.code === 50
             && error.errmsg
             && (error.codeName as string) === RequestTimedOutWithRateLimitFalse.codeName
             && (error.errmsg as string) === RequestTimedOutWithRateLimitFalse.errorMsg;
     }
-    shouldRetry: boolean = true;
 }
 
 // This handles server side temporary 503 issue
-class ServiceUnavailableRule implements IMongoExceptionRetryRule {
+class ServiceUnavailableRule extends BaseMongoExceptionRetryRule {
     private static readonly errorDetails = "Response status code does not indicate success: ServiceUnavailable (503)";
-    match(error: any): boolean {
+    protected defaultDecision: boolean = true;
+
+    constructor(retryRuleOverride: Map<string, boolean>) {
+        super("ServiceUnavailableRule", retryRuleOverride);
+    }
+
+    public match(error: any): boolean {
         return error.code === 1
             && error.errorDetails
             && (error.errorDetails as string).includes(ServiceUnavailableRule.errorDetails);
     }
-
-    shouldRetry: boolean = true;
 }
 
 // this handles the pool destroyed error from client side. Should relies on reconnect instead of retry?
-class TopologyDestroyed implements IMongoExceptionRetryRule {
+class TopologyDestroyed extends BaseMongoExceptionRetryRule {
     private static readonly message = "Topology was destroyed";
-    match(error: any): boolean {
+    protected defaultDecision: boolean = false;
+
+    constructor(retryRuleOverride: Map<string, boolean>) {
+        super("TopologyDestroyed", retryRuleOverride);
+    }
+
+    public match(error: any): boolean {
         return error.message
             && (error.message as string) === TopologyDestroyed.message;
     }
-
-    shouldRetry: boolean = false;
 }
 
 // this handles the incorrect credentials set. Should not retry
-class UnUnauthorizedRule implements IMongoExceptionRetryRule {
+class UnUnauthorizedRule extends BaseMongoExceptionRetryRule {
     private static readonly codeName = "Unauthorized";
-    match(error: any): boolean {
+    protected defaultDecision: boolean = false;
+
+    constructor(retryRuleOverride: Map<string, boolean>) {
+        super("UnUnauthorizedRule", retryRuleOverride);
+    }
+
+    public match(error: any): boolean {
         return error.code === 13
             && error.codeName
             && (error.codeName as string) === UnUnauthorizedRule.codeName;
     }
-
-    shouldRetry: boolean = false;
 }
 
 // Maintain the list from more strick faster comparison to less strict slower comparison
-export const mongoErrorRetryRuleset: IMongoExceptionRetryRule[] = [
-    // The rules are using exactly equal
-    new InternalErrorRule(),
-    new NoPrimaryInReplicasetRule(),
-    new RequestTimedNoRateLimitInfo(),
-    new RequestTimedOutWithRateLimitTrue(),
-    new RequestTimedOutWithRateLimitFalse(),
-    new TopologyDestroyed(),
-    new UnUnauthorizedRule(),
+export function createMongoErrorRetryRuleset(
+    retryRuleOverride: Map<string, boolean>,
+): IMongoExceptionRetryRule[] {
+    const mongoErrorRetryRuleset: IMongoExceptionRetryRule[] = [
+        // The rules are using exactly equal
+        new InternalErrorRule(retryRuleOverride),
+        new NoPrimaryInReplicasetRule(retryRuleOverride),
+        new RequestTimedNoRateLimitInfo(retryRuleOverride),
+        new RequestTimedOutWithRateLimitTrue(retryRuleOverride),
+        new RequestTimedOutWithRateLimitFalse(retryRuleOverride),
+        new TopologyDestroyed(retryRuleOverride),
+        new UnUnauthorizedRule(retryRuleOverride),
 
-    // The rules are using multiple compare
-    new PoolDestroyedRule(),
+        // The rules are using multiple compare
+        new PoolDestroyedRule(retryRuleOverride),
 
-    // The rules are using string startWith
-    new NoConnectionAvailableRule(),
-    new RequestSizeLargeRule(),
-    new RequestTimedOutWithHttpInfo(),
+        // The rules are using string startWith
+        new NoConnectionAvailableRule(retryRuleOverride),
+        new RequestSizeLargeRule(retryRuleOverride),
+        new RequestTimedOutWithHttpInfo(retryRuleOverride),
 
-    // The rules are using string contains
-    new ServiceUnavailableRule(),
-];
+        // The rules are using string contains
+        new ServiceUnavailableRule(retryRuleOverride),
+    ];
+    return mongoErrorRetryRuleset;
+}

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
@@ -6,7 +6,7 @@
 import { BaseMongoExceptionRetryRule, IMongoExceptionRetryRule } from "../IMongoExceptionRetryRule";
 class InternalErrorRule extends BaseMongoExceptionRetryRule {
     private static readonly codeName = "InternalError";
-    protected defaultDecision: boolean = false;
+    protected defaultRetryDecision: boolean = false;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
         super("InternalErrorRule", retryRuleOverride);
@@ -22,7 +22,7 @@ class InternalErrorRule extends BaseMongoExceptionRetryRule {
 // This handles the requested queued on client side buffer overflow. Should relies on reconnect instead of retry?
 class NoConnectionAvailableRule extends BaseMongoExceptionRetryRule {
     private static readonly messagePrefix = "no connection available for operation and number of stored operation";
-    protected defaultDecision: boolean = false;
+    protected defaultRetryDecision: boolean = false;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
         super("NoConnectionAvailableRule", retryRuleOverride);
@@ -42,7 +42,7 @@ class NoConnectionAvailableRule extends BaseMongoExceptionRetryRule {
 // Should not retry but relays on reconnect.
 class NoPrimaryInReplicasetRule extends BaseMongoExceptionRetryRule {
     private static readonly message = "no primary found in replicaset or invalid replica set name";
-    protected defaultDecision: boolean = false;
+    protected defaultRetryDecision: boolean = false;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
         super("NoPrimaryInReplicasetRule", retryRuleOverride);
@@ -62,7 +62,7 @@ class NoPrimaryInReplicasetRule extends BaseMongoExceptionRetryRule {
 class PoolDestroyedRule extends BaseMongoExceptionRetryRule {
     private static readonly message1 = "pool destroyed";
     private static readonly message2 = "server instance pool was destroyed";
-    protected defaultDecision: boolean = false;
+    protected defaultRetryDecision: boolean = false;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
         super("PoolDestroyedRule", retryRuleOverride);
@@ -80,7 +80,7 @@ class PoolDestroyedRule extends BaseMongoExceptionRetryRule {
 class RequestSizeLargeRule extends BaseMongoExceptionRetryRule {
     private static readonly errorMsgPrefix =
         "Error=16, Details='Response status code does not indicate success: RequestEntityTooLarge (413)";
-    protected defaultDecision: boolean = false;
+    protected defaultRetryDecision: boolean = false;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
         super("RequestSizeLargeRule", retryRuleOverride);
@@ -96,7 +96,7 @@ class RequestSizeLargeRule extends BaseMongoExceptionRetryRule {
 // This handles request timeout from server without additional rate limit info.
 class RequestTimedNoRateLimitInfo extends BaseMongoExceptionRetryRule {
     private static readonly errmsg = "Request timed out.";
-    protected defaultDecision: boolean = true;
+    protected defaultRetryDecision: boolean = true;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
         super("RequestTimedNoRateLimitInfo", retryRuleOverride);
@@ -113,7 +113,7 @@ class RequestTimedNoRateLimitInfo extends BaseMongoExceptionRetryRule {
 class RequestTimedOutWithHttpInfo extends BaseMongoExceptionRetryRule {
     private static readonly errmsgPrefix =
         "Error=50, Details='Response status code does not indicate success: RequestTimeout (408);";
-    protected defaultDecision: boolean = true;
+    protected defaultRetryDecision: boolean = true;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
         super("RequestTimedOutWithHttpInfo", retryRuleOverride);
@@ -130,7 +130,7 @@ class RequestTimedOutWithHttpInfo extends BaseMongoExceptionRetryRule {
 class RequestTimedOutWithRateLimitTrue extends BaseMongoExceptionRetryRule {
     private static readonly codeName = "ExceededTimeLimit";
     private static readonly errorMsg = "Request timed out. Retries due to rate limiting: True.";
-    protected defaultDecision: boolean = false;
+    protected defaultRetryDecision: boolean = false;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
         super("RequestTimedOutWithRateLimitTrue", retryRuleOverride);
@@ -148,7 +148,7 @@ class RequestTimedOutWithRateLimitTrue extends BaseMongoExceptionRetryRule {
 class RequestTimedOutWithRateLimitFalse extends BaseMongoExceptionRetryRule {
     private static readonly codeName = "ExceededTimeLimit";
     private static readonly errorMsg = "Request timed out. Retries due to rate limiting: False.";
-    protected defaultDecision: boolean = true;
+    protected defaultRetryDecision: boolean = true;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
         super("RequestTimedOutWithRateLimitFalse", retryRuleOverride);
@@ -165,7 +165,7 @@ class RequestTimedOutWithRateLimitFalse extends BaseMongoExceptionRetryRule {
 // This handles server side temporary 503 issue
 class ServiceUnavailableRule extends BaseMongoExceptionRetryRule {
     private static readonly errorDetails = "Response status code does not indicate success: ServiceUnavailable (503)";
-    protected defaultDecision: boolean = true;
+    protected defaultRetryDecision: boolean = true;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
         super("ServiceUnavailableRule", retryRuleOverride);
@@ -181,7 +181,7 @@ class ServiceUnavailableRule extends BaseMongoExceptionRetryRule {
 // this handles the pool destroyed error from client side. Should relies on reconnect instead of retry?
 class TopologyDestroyed extends BaseMongoExceptionRetryRule {
     private static readonly message = "Topology was destroyed";
-    protected defaultDecision: boolean = false;
+    protected defaultRetryDecision: boolean = false;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
         super("TopologyDestroyed", retryRuleOverride);
@@ -196,7 +196,7 @@ class TopologyDestroyed extends BaseMongoExceptionRetryRule {
 // this handles the incorrect credentials set. Should not retry
 class UnauthorizedRule extends BaseMongoExceptionRetryRule {
     private static readonly codeName = "Unauthorized";
-    protected defaultDecision: boolean = false;
+    protected defaultRetryDecision: boolean = false;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
         super("UnauthorizedRule", retryRuleOverride);

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
@@ -194,18 +194,18 @@ class TopologyDestroyed extends BaseMongoExceptionRetryRule {
 }
 
 // this handles the incorrect credentials set. Should not retry
-class UnUnauthorizedRule extends BaseMongoExceptionRetryRule {
+class UnauthorizedRule extends BaseMongoExceptionRetryRule {
     private static readonly codeName = "Unauthorized";
     protected defaultDecision: boolean = false;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
-        super("UnUnauthorizedRule", retryRuleOverride);
+        super("UnauthorizedRule", retryRuleOverride);
     }
 
     public match(error: any): boolean {
         return error.code === 13
             && error.codeName
-            && (error.codeName as string) === UnUnauthorizedRule.codeName;
+            && (error.codeName as string) === UnauthorizedRule.codeName;
     }
 }
 
@@ -221,7 +221,7 @@ export function createMongoErrorRetryRuleset(
         new RequestTimedOutWithRateLimitTrue(retryRuleOverride),
         new RequestTimedOutWithRateLimitFalse(retryRuleOverride),
         new TopologyDestroyed(retryRuleOverride),
-        new UnUnauthorizedRule(retryRuleOverride),
+        new UnauthorizedRule(retryRuleOverride),
 
         // The rules are using multiple compare
         new PoolDestroyedRule(retryRuleOverride),

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoErrorRetryAnalyzer.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoErrorRetryAnalyzer.ts
@@ -28,7 +28,7 @@ export class MongoErrorRetryAnalyzer {
         this.defaultRule = new DefaultExceptionRule(retryRuleOverride);
     }
 
-    shouldRetry(error: Error): boolean {
+    public shouldRetry(error: Error): boolean {
         const rule = this.getRetryRule(error);
         if (!rule) {
             // This should not happen.
@@ -46,7 +46,7 @@ export class MongoErrorRetryAnalyzer {
         return decision;
     }
 
-    getRetryRule(error: Error): IMongoExceptionRetryRule {
+    private getRetryRule(error: Error): IMongoExceptionRetryRule {
         if (error.name === "MongoNetworkError") {
             return this.getRetryRuleFromSet(error, this.mongoNetworkErrorRetryRuleset);
         }
@@ -58,7 +58,7 @@ export class MongoErrorRetryAnalyzer {
         return this.defaultRule;
     }
 
-    getRetryRuleFromSet(error: any, ruleSet: IMongoExceptionRetryRule[]): IMongoExceptionRetryRule {
+    private getRetryRuleFromSet(error: any, ruleSet: IMongoExceptionRetryRule[]): IMongoExceptionRetryRule {
         return ruleSet.find((rule) => rule.match(error)) || this.defaultRule;
     }
 };

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoErrorRetryAnalyzer.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoErrorRetryAnalyzer.ts
@@ -35,7 +35,13 @@ export const MongoErrorRetryAnalyzer = {
 
     getRetryRuleFromSet(error: any, ruleSet: IMongoExceptionRetryRule[]): IMongoExceptionRetryRule {
         const resultRule = ruleSet.find((rule) => rule.match(error)) || new DefaultExceptionRule();
-        Lumberjack.info(`Error rule used ${resultRule.constructor.name}, shouldRetry: ${resultRule.shouldRetry}`);
-        return ruleSet.find((rule) => rule.match(error)) || new DefaultExceptionRule();
+        const ruleName = resultRule.constructor.name;
+        const shouldRetry = resultRule.shouldRetry;
+        const properties = {
+            ruleName,
+            shouldRetry,
+        };
+        Lumberjack.warning(`Error rule used ${ruleName}, shouldRetry: ${shouldRetry}`, properties, error);
+        return resultRule;
     },
 };

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoErrorRetryAnalyzer.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoErrorRetryAnalyzer.ts
@@ -1,0 +1,41 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { DefaultExceptionRule } from "./defaultExceptionRule";
+import { IMongoExceptionRetryRule } from "./IMongoExceptionRetryRule";
+import { mongoErrorRetryRuleset } from "./mongoError";
+import { mongoNetworkErrorRetryRuleset } from "./mongoNetworkError";
+
+export const MongoErrorRetryAnalyzer = {
+    shouldRetry(error: Error): boolean {
+        const rule = MongoErrorRetryAnalyzer.getRetryRule(error);
+        if (!rule) {
+            // This should not happen.
+            Lumberjack.error("MongoErrorRetryAnalyzer.shouldRetry() didn't get a rule", undefined, error);
+            return false;
+        }
+
+        return rule.shouldRetry;
+    },
+
+    getRetryRule(error: Error): IMongoExceptionRetryRule {
+        if (error.name === "MongoNetworkError") {
+            return MongoErrorRetryAnalyzer.getRetryRuleFromSet(error, mongoNetworkErrorRetryRuleset);
+        }
+
+        if (error.name === "MongoError") {
+            return MongoErrorRetryAnalyzer.getRetryRuleFromSet(error, mongoErrorRetryRuleset);
+        }
+
+        return new DefaultExceptionRule();
+    },
+
+    getRetryRuleFromSet(error: any, ruleSet: IMongoExceptionRetryRule[]): IMongoExceptionRetryRule {
+        const resultRule = ruleSet.find((rule) => rule.match(error)) || new DefaultExceptionRule();
+        Lumberjack.info(`Error rule used ${resultRule.constructor.name}, shouldRetry: ${resultRule.shouldRetry}`);
+        return ruleSet.find((rule) => rule.match(error)) || new DefaultExceptionRule();
+    },
+};

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoNetworkError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoNetworkError/index.ts
@@ -6,7 +6,7 @@
 import { BaseMongoExceptionRetryRule, IMongoExceptionRetryRule } from "../IMongoExceptionRetryRule";
 
 class MongoNetworkTransientTransactionError extends BaseMongoExceptionRetryRule {
-    protected defaultDecision: boolean = true;
+    protected defaultRetryDecision: boolean = true;
 
     constructor(retryRuleOverride: Map<string, boolean>) {
         super(MongoNetworkTransientTransactionError.constructor.name, retryRuleOverride);

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoNetworkError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoNetworkError/index.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IMongoExceptionRetryRule } from "../IMongoExceptionRetryRule";
+
+class MongoNetworkTransientTransactionError implements IMongoExceptionRetryRule {
+    match(error: any): boolean {
+        return error.errorLabels?.length && (error.errorLabels as string[]).includes("TransientTransactionError");
+    }
+
+    shouldRetry: boolean = false;
+}
+
+// Maintain the list from more strick faster comparison to less strict slower comparison
+export const mongoNetworkErrorRetryRuleset: IMongoExceptionRetryRule[] = [
+    new MongoNetworkTransientTransactionError(),
+];

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoNetworkError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoNetworkError/index.ts
@@ -3,17 +3,27 @@
  * Licensed under the MIT License.
  */
 
-import { IMongoExceptionRetryRule } from "../IMongoExceptionRetryRule";
+import { BaseMongoExceptionRetryRule, IMongoExceptionRetryRule } from "../IMongoExceptionRetryRule";
 
-class MongoNetworkTransientTransactionError implements IMongoExceptionRetryRule {
-    match(error: any): boolean {
-        return error.errorLabels?.length && (error.errorLabels as string[]).includes("TransientTransactionError");
+class MongoNetworkTransientTransactionError extends BaseMongoExceptionRetryRule {
+    protected defaultDecision: boolean = true;
+
+    constructor(retryRuleOverride: Map<string, boolean>) {
+        super(MongoNetworkTransientTransactionError.constructor.name, retryRuleOverride);
     }
 
-    shouldRetry: boolean = false;
+    public match(error: any): boolean {
+        return error.errorLabels?.length && (error.errorLabels as string[]).includes("TransientTransactionError");
+    }
 }
 
 // Maintain the list from more strick faster comparison to less strict slower comparison
-export const mongoNetworkErrorRetryRuleset: IMongoExceptionRetryRule[] = [
-    new MongoNetworkTransientTransactionError(),
-];
+export function createMongoNetworkErrorRetryRuleset(
+    retryRuleOverride: Map<string, boolean>,
+): IMongoExceptionRetryRule[] {
+    const mongoNetworkErrorRetryRuleset: IMongoExceptionRetryRule[] = [
+        new MongoNetworkTransientTransactionError(retryRuleOverride),
+    ];
+
+    return mongoNetworkErrorRetryRuleset;
+}


### PR DESCRIPTION
## Description

This added DB Facade level retry for all server side Database call based on server status code.

## Breaking Changes

> `aggregate` function was converted to async due to the `runWithRetry` only takes promises functions. So now you have to await on `aggregate`

## Testing

It is hard to simulate server side errors. What I ends up is regenerated serverside password and triggered `UnAuthroized` error and got:
![image](https://user-images.githubusercontent.com/3719246/200613696-d8acff4b-154b-4677-b0e4-bde6f3152e40.png)


![image](https://user-images.githubusercontent.com/3719246/200614851-da996607-fb8a-4792-b071-e8b063f9f828.png)
