### PR TITLE
Use build agent's cert store when running e2e tests

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -270,6 +270,8 @@ jobs:
         inputs:
           command: 'custom'
           workingDir: ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}
+          # --use-openssl-ca flag required so node uses the build agent's cert store, where we installed
+          # the self-signed cert for the r11s deployment
           customCommand: 'run ${{ parameters.testCommand }} -- ${{ variant.flags }} --use-openssl-ca'
 
       # Upload results

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -270,7 +270,7 @@ jobs:
         inputs:
           command: 'custom'
           workingDir: ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}
-          customCommand: 'run ${{ parameters.testCommand }} -- ${{ variant.flags }}'
+          customCommand: 'run ${{ parameters.testCommand }} -- ${{ variant.flags }} --use-openssl-ca'
 
       # Upload results
       - task: PublishTestResults@2


### PR DESCRIPTION
## Description

Ensures that node uses the certificate store of the build agent when running e2e tests. Without this, it defaults to using its bundled certs, so it doesn't "see" the self-signed cert that we added to the system cert store in a previous step, and our r11s e2e tests all time out because of that (long story).

## Reviewer Guidance

It seems our e2e tests pipeline [doesn't like `test/` branches](https://dev.azure.com/fluidframework/internal/_build/results?buildId=106915&view=logs&j=5d40b943-5a8e-529c-ed4b-95198832abfc&t=fb8cf0ae-41a8-58f6-d156-329de70d0970) (line 39), so I can't fully validate that the tests now execute successfully without first investigating and addressing the apparent issue that `test-version-utils` seems to have with `test/` branches. But the invocation seems correct:

<img width="854" alt="image" src="https://user-images.githubusercontent.com/716334/200646748-b5aa1da2-2323-48f0-a06e-7c6fa8004efc.png">

The e2e tests for r11s are almost all timing out right now so this can't make things much worse. The new flag will get passed to e2e tests against all targets (local, tinylicious, r11s, frs, odsp), but I don't expect it to have any impact on the other targets.