### PR TITLE
Fix escaping of path variable in DDS stress pipeline

### DIFF
--- a/tools/pipelines/templates/include-conditionally-run-stress-tests.yml
+++ b/tools/pipelines/templates/include-conditionally-run-stress-tests.yml
@@ -38,7 +38,7 @@ stages:
               foreach ($path in $env:AFFECTED_PATHS.Split(";")) {
                 $pathsChanged = git diff --name-only HEAD~1 $path
                 if ($pathsChanged -ne $null) {
-                  Write-Host "Found the following files changed in $path:"
+                  Write-Host "Found the following files changed in ${path}:"
                   Write-Host $pathsChanged
                   $filesWereChanged = 1
                 } else {


### PR DESCRIPTION
## Description

Previous syntax didn't properly escape the colon from the variable name. Wasn't caught by my test runs as I added debug information after testing the core functionality.