### PR TITLE
Handle the treesLatestDeferral in epoch tracker

### DIFF
--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -418,6 +418,17 @@ export class EpochTracker implements IPersistedFileCache {
 export class EpochTrackerWithRedemption extends EpochTracker {
     private readonly treesLatestDeferral = new Deferred<void>();
 
+    constructor(
+        protected readonly cache: IPersistedCache,
+        protected readonly fileEntry: IFileEntry,
+        protected readonly logger: ITelemetryLogger,
+        protected readonly clientIsSummarizer?: boolean,
+    ) {
+        super(cache, fileEntry, logger, clientIsSummarizer);
+        // Handles the rejected promise within treesLatestDeferral.
+        this.treesLatestDeferral.promise.catch(() => {});
+    }
+
     protected validateEpochFromResponse(
         epochFromResponse: string | undefined,
         fetchType: FetchType,

--- a/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
@@ -66,7 +66,7 @@ describe("Tests for Epoch Tracker With Redemption", () => {
             epochCallback = new DeferralWithCallback();
             (epochTracker as any).treesLatestDeferral = epochCallback;
         });
-        it.skip("joinSession call should succeed on retrying after snapshot cached read succeeds", async () => {
+        it("joinSession call should succeed on retrying after snapshot cached read succeeds", async () => {
             epochTracker.setEpoch("epoch1", true, "test");
             const cacheEntry1: IEntry = {
                 type: snapshotKey,

--- a/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
@@ -55,80 +55,94 @@ describe("Tests for Epoch Tracker With Redemption", () => {
                 resolvedUrl,
             },
             new TelemetryUTLogger());
-        epochCallback = new DeferralWithCallback();
-        (epochTracker as any).treesLatestDeferral = epochCallback;
     });
 
     afterEach(async () => {
         await epochTracker.removeEntries().catch(() => {});
     });
 
-    it.skip("joinSession call should succeed on retrying after snapshot cached read succeeds", async () => {
-        epochTracker.setEpoch("epoch1", true, "test");
-        const cacheEntry1: IEntry = {
-            type: snapshotKey,
-            key: "key1",
-        };
-        await epochTracker.put(cacheEntry1, { val: "val1" });
-
-        // We will trigger a successful call to return the value set in the cache after the failed joinSession call
-        epochCallback.setCallback(async () => epochTracker.get(cacheEntry1));
-
-        // Initial joinSession call will return 404 but after the timeout, the call will be retried and succeed
-        await mockFetchMultiple(
-            async () => epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "joinSession"),
-            [notFound, async () => okResponse({ "x-fluid-epoch": "epoch1" }, {})],
-        );
-    });
-
-    it("joinSession call should succeed on retrying after any network call to the file succeeds", async () => {
-        epochTracker.setEpoch("epoch1", true, "test");
-        const cacheEntry1: IEntry = {
-            type: snapshotKey,
-            key: "key1",
-        };
-        await epochTracker.put(cacheEntry1, { val: "val1" });
-
-        // We will trigger a successful call to return the value set in the cache after the failed joinSession call
-        epochCallback.setCallback(async () => {
-            return epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "treesLatest");
+    describe("Test Suite 1", () => {
+        beforeEach(() => {
+            epochCallback = new DeferralWithCallback();
+            (epochTracker as any).treesLatestDeferral = epochCallback;
         });
-
-        // Initial joinSession call will return 404 but after the timeout, the call will be retried and succeed
-        await mockFetchMultiple(
-            async () => epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "joinSession"),
-            [
-                notFound, // joinSession
-                async () => okResponse({ "x-fluid-epoch": "epoch1" }, {}), // "treesLatest"
-                async () => okResponse({ "x-fluid-epoch": "epoch1" }, {}), // "joinSession"
-            ],
-        );
+        it.skip("joinSession call should succeed on retrying after snapshot cached read succeeds", async () => {
+            epochTracker.setEpoch("epoch1", true, "test");
+            const cacheEntry1: IEntry = {
+                type: snapshotKey,
+                key: "key1",
+            };
+            await epochTracker.put(cacheEntry1, { val: "val1" });
+    
+            // We will trigger a successful call to return the value set in the cache after the failed joinSession call
+            epochCallback.setCallback(async () => epochTracker.get(cacheEntry1));
+    
+            // Initial joinSession call will return 404 but after the timeout, the call will be retried and succeed
+            await mockFetchMultiple(
+                async () => epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "joinSession"),
+                [notFound, async () => okResponse({ "x-fluid-epoch": "epoch1" }, {})],
+            );
+        });
+    
+        it("joinSession call should succeed on retrying after any network call to the file succeeds", async () => {
+            epochTracker.setEpoch("epoch1", true, "test");
+            const cacheEntry1: IEntry = {
+                type: snapshotKey,
+                key: "key1",
+            };
+            await epochTracker.put(cacheEntry1, { val: "val1" });
+    
+            // We will trigger a successful call to return the value set in the cache after the failed joinSession call
+            epochCallback.setCallback(async () => {
+                return epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "treesLatest");
+            });
+    
+            // Initial joinSession call will return 404 but after the timeout, the call will be retried and succeed
+            await mockFetchMultiple(
+                async () => epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "joinSession"),
+                [
+                    notFound, // joinSession
+                    async () => okResponse({ "x-fluid-epoch": "epoch1" }, {}), // "treesLatest"
+                    async () => okResponse({ "x-fluid-epoch": "epoch1" }, {}), // "joinSession"
+                ],
+            );
+        });
+    
+        it("Requests should fail if joinSession call fails and the getLatest call also fails", async () => {
+            let success: boolean = true;
+    
+            try {
+                epochCallback.setCallback(async () => {
+                    try {
+                        await mockFetchSingle(
+                            async () => epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "treesLatest"),
+                            notFound,
+                            "internal");
+                    } catch (error: any) {
+                        assert.strictEqual(error.errorType, DriverErrorType.fileNotFoundOrAccessDeniedError,
+                            "Error should be file not found or access denied error");
+                    }
+                });
+                await mockFetchSingle(
+                    async () => epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "joinSession"),
+                    async () => notFound({ "x-fluid-epoch": "epoch1" }),
+                    "external");
+            } catch (error: any) {
+                success = false;
+                assert.strictEqual(error.errorType, DriverErrorType.fileNotFoundOrAccessDeniedError,
+                    "Error should be file not found or access denied error");
+            }
+            assert.strictEqual(success, false, "Join session should fail if treesLatest call has failed");
+        });
     });
 
-    it("Requests should fail if joinSession call fails and the getLatest call also fails", async () => {
-        let success: boolean = true;
-
-        try {
-            epochCallback.setCallback(async () => {
-                try {
-                    await mockFetchSingle(
-                        async () => epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "treesLatest"),
-                        notFound,
-                        "internal");
-                } catch (error: any) {
-                    assert.strictEqual(error.errorType, DriverErrorType.fileNotFoundOrAccessDeniedError,
-                        "Error should be file not found or access denied error");
-                }
-            });
-            await mockFetchSingle(
-                async () => epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "joinSession"),
-                async () => notFound({ "x-fluid-epoch": "epoch1" }),
-                "external");
-        } catch (error: any) {
-            success = false;
-            assert.strictEqual(error.errorType, DriverErrorType.fileNotFoundOrAccessDeniedError,
-                "Error should be file not found or access denied error");
-        }
-        assert.strictEqual(success, false, "Join session should fail if treesLatest call has failed");
+    describe("Tests Suite 2", () => {
+        it("Failed treesLatest call should not trigger unhandled rejection event", async () => {
+            const treesLatestP = mockFetchSingle(
+                async () => epochTracker.fetchAndParseAsJSON("fetchUrl", {}, "treesLatest"),
+                notFound,
+            );
+            await assert.rejects(treesLatestP, "should fail without causing an unhandledRejection event.");
+        });
     });
 });


### PR DESCRIPTION
## Description

Inside EpochTrackerWithRedemption, treesLatestDeferral.reject() is called without handling the rejected promise. This results in an un-intentional unhandledRejection event being triggered. This PR resolves this issue by handing the rejected promise.

The actual response to join session/trees latest request or other calls are truly returned. This promise was more of waiting logic in case join session call is made before the trees latest call. This promise is imp only in this class and its rejection does not need to be propagated. So, we just need to add a empty catch statement so as to avoid unhandledPromiseRejection error