### PR TITLE
Disable import/no-nodejs-modules for test files

### DIFF
--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -346,6 +346,7 @@ module.exports = {
             rules: {
                 "@typescript-eslint/no-invalid-this": "off",
                 "@typescript-eslint/unbound-method": "off", // This rule has false positives in many of our test projects.
+                "import/no-nodejs-modules": "off", // Node libraries are OK for test files.
             },
         },
         {

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -550,7 +550,7 @@
             1
         ],
         "import/no-nodejs-modules": [
-            "warn"
+            "off"
         ],
         "import/no-unassigned-import": [
             "error"


### PR DESCRIPTION
This rule is not needed for test files where we allow node libraries to be used.