### PR TITLE
Fix compression path for attachBlob ops

### DIFF
--- a/packages/runtime/container-runtime/src/opDecompressor.ts
+++ b/packages/runtime/container-runtime/src/opDecompressor.ts
@@ -47,7 +47,7 @@ export class OpDecompressor {
             return { ...message, contents: this.rootMessageContents[this.processedCount++] };
         }
 
-        if (this.rootMessageContents !== undefined && message.metadata === undefined && this.activeBatch) {
+        if (this.rootMessageContents !== undefined && message.metadata?.batch === undefined && this.activeBatch) {
             // Continuation of compressed batch
             return { ...message, contents: this.rootMessageContents[this.processedCount++] };
         }


### PR DESCRIPTION
## Description
The recently-merged batch compression PR caused an ICM incident because of an incorrect assumption in the batch continuation path. The continuation path checked for `metadata === undefined` rather than `metdata.batch === undefined` and ops with metadata weren't correctly detected as a batch continuation. 

I've also added an end to end test that would've caught this. 