### PR TITLE
FRS specific stress config

### DIFF
--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -33,7 +33,7 @@
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
     "start": "node ./dist/nodeStressTest.js",
-    "start:frs": "node ./dist/nodeStressTest.js --driver routerlicious --driverEndpoint frs",
+    "start:frs": "node ./dist/nodeStressTest.js --driver routerlicious --driverEndpoint frs --profile ci_frs",
     "start:mini": "node ./dist/nodeStressTest.js  --profile mini",
     "start:odsp": "node ./dist/nodeStressTest.js --driver odsp",
     "start:odspdf": "node ./dist/nodeStressTest.js --driver odsp --driverEndpoint odsp-df",

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -24,6 +24,15 @@
                 }
             }
         },
+        "ci_frs": {
+            "opRatePerMin": 10,
+            "progressIntervalMs": 15000,
+            "numClients": 100,
+            "totalSendCount": 10000,
+            "readWriteCycleMs": 30000,
+            "faultInjectionMinMs": 0,
+            "faultInjectionMaxMs": 150000
+        },
         "full": {
             "opRatePerMin": 1920,
             "progressIntervalMs": 1500000,


### PR DESCRIPTION
Port #11206 to LTS to stop 0x12a assertion errors, since FRS does not support blobs

Fix [AB#2518](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2518)