### PR TITLE
Adding GitRest metrics (part 1)

### DIFF
--- a/server/gitrest/lerna-package-lock.json
+++ b/server/gitrest/lerna-package-lock.json
@@ -8942,7 +8942,7 @@
 		"add-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-			"integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
 			"dev": true
 		},
 		"agent-base": {
@@ -9085,7 +9085,7 @@
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
 			"dev": true
 		},
 		"array-includes": {
@@ -9273,7 +9273,7 @@
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
 			"dev": true
 		},
 		"asn1": {
@@ -9553,7 +9553,7 @@
 		"builtins": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-			"integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
+			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
 			"dev": true
 		},
 		"byte-size": {
@@ -9964,7 +9964,7 @@
 		"clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
 			"dev": true
 		},
 		"clone-deep": {
@@ -10300,7 +10300,7 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"content-disposition": {
 			"version": "0.5.4",
@@ -10368,7 +10368,7 @@
 				"load-json-file": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -10392,7 +10392,7 @@
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
@@ -10411,13 +10411,13 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
@@ -10454,7 +10454,7 @@
 				"read-pkg-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-					"integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
+					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
@@ -10678,7 +10678,7 @@
 		"debuglog": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-			"integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
+			"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
 			"dev": true
 		},
 		"decamelize": {
@@ -10690,7 +10690,7 @@
 		"decamelize-keys": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 			"dev": true,
 			"requires": {
 				"decamelize": "^1.1.0",
@@ -10700,7 +10700,7 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
 					"dev": true
 				}
 			}
@@ -10716,7 +10716,7 @@
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
 			"dev": true
 		},
 		"deep-extend": {
@@ -10784,7 +10784,7 @@
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 		},
 		"denque": {
 			"version": "1.5.1",
@@ -10794,7 +10794,7 @@
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
 		},
 		"deprecation": {
 			"version": "2.3.1",
@@ -10810,7 +10810,7 @@
 		"detect-indent": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-			"integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==",
+			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
 			"dev": true
 		},
 		"detect-libc": {
@@ -12951,7 +12951,7 @@
 		"git-remote-origin-url": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-			"integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
+			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
 			"dev": true,
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
@@ -12961,7 +12961,7 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				}
 			}
@@ -13006,7 +13006,7 @@
 		"gitconfiglocal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-			"integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
+			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
 			"dev": true,
 			"requires": {
 				"ini": "^1.3.2"
@@ -13208,7 +13208,7 @@
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 		},
 		"hasha": {
 			"version": "5.2.2",
@@ -13295,7 +13295,7 @@
 		"humanize-ms": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+			"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
 			"dev": true,
 			"requires": {
 				"ms": "^2.0.0"
@@ -13753,7 +13753,7 @@
 		"is-lambda": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+			"integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
 			"dev": true
 		},
 		"is-negative-zero": {
@@ -13845,7 +13845,7 @@
 		"is-text-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-			"integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
+			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
 			"dev": true,
 			"requires": {
 				"text-extensions": "^1.0.0"
@@ -13899,7 +13899,7 @@
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
 		},
 		"isomorphic-git": {
@@ -14234,7 +14234,7 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json5": {
 			"version": "2.1.3",
@@ -14261,7 +14261,7 @@
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
 			"dev": true
 		},
 		"jsonwebtoken": {
@@ -14812,7 +14812,7 @@
 		"lodash.ismatch": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-			"integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
+			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
 			"dev": true
 		},
 		"lodash.isnumber": {
@@ -15196,13 +15196,13 @@
 				"arrify": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-					"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 					"dev": true
 				},
 				"is-plain-obj": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-					"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+					"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
 					"dev": true
 				}
 			}
@@ -17096,7 +17096,7 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"osenv": {
 			"version": "0.1.5",
@@ -17123,7 +17123,7 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "1.3.0",
@@ -17715,7 +17715,7 @@
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-			"integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
 			"dev": true
 		},
 		"promise-retry": {
@@ -17731,7 +17731,7 @@
 		"promzard": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-			"integrity": "sha512-JZeYqd7UAcHCwI+sTOeUDYkvEU+1bQ7iE0UT1MgB/tERkAPkesW46MrpIySzODi+owTjZtiF8Ay5j9m60KmMBw==",
+			"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
 			"dev": true,
 			"requires": {
 				"read": "1"
@@ -17751,7 +17751,7 @@
 		"proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
 			"dev": true
 		},
 		"protocols": {
@@ -17797,7 +17797,7 @@
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
 			"dev": true
 		},
 		"qs": {
@@ -17867,7 +17867,7 @@
 		"read": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-			"integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
 			"dev": true,
 			"requires": {
 				"mute-stream": "~0.0.4"
@@ -18280,7 +18280,7 @@
 		"retry": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
 			"dev": true
 		},
 		"reusify": {
@@ -18649,7 +18649,7 @@
 		"sort-keys": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-			"integrity": "sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==",
+			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 			"dev": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
@@ -18658,7 +18658,7 @@
 				"is-plain-obj": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-					"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+					"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
 					"dev": true
 				}
 			}
@@ -19037,7 +19037,7 @@
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
 			"dev": true
 		},
 		"test-exclude": {
@@ -19071,7 +19071,7 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
 			"version": "4.0.2",
@@ -19241,7 +19241,7 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
 		"typedarray-to-buffer": {
@@ -19373,7 +19373,7 @@
 		"validate-npm-package-name": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-			"integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
+			"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
 			"dev": true,
 			"requires": {
 				"builtins": "^1.0.3"
@@ -19403,7 +19403,7 @@
 		"wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
@@ -19520,7 +19520,7 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
 			"dev": true
 		},
 		"workerpool": {

--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -4351,7 +4351,7 @@
 		"add-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-			"integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
 			"dev": true
 		},
 		"agent-base": {
@@ -4506,7 +4506,7 @@
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
 			"dev": true
 		},
 		"array-includes": {
@@ -4694,7 +4694,7 @@
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
 			"dev": true
 		},
 		"async": {
@@ -4869,7 +4869,7 @@
 		"builtins": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-			"integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
+			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
 			"dev": true
 		},
 		"byte-size": {
@@ -5178,7 +5178,7 @@
 		"clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
 			"dev": true
 		},
 		"clone-deep": {
@@ -5438,7 +5438,7 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 			"dev": true
 		},
 		"conventional-changelog-angular": {
@@ -5494,7 +5494,7 @@
 				"load-json-file": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -5518,7 +5518,7 @@
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
@@ -5537,13 +5537,13 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
@@ -5580,7 +5580,7 @@
 				"read-pkg-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-					"integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
+					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
@@ -5771,7 +5771,7 @@
 		"debuglog": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-			"integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
+			"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
 			"dev": true
 		},
 		"decamelize": {
@@ -5783,7 +5783,7 @@
 		"decamelize-keys": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 			"dev": true,
 			"requires": {
 				"decamelize": "^1.1.0",
@@ -5793,7 +5793,7 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
 					"dev": true
 				}
 			}
@@ -5801,7 +5801,7 @@
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
 			"dev": true
 		},
 		"deep-is": {
@@ -5860,13 +5860,13 @@
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 			"dev": true
 		},
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
 			"dev": true
 		},
 		"deprecation": {
@@ -5878,7 +5878,7 @@
 		"detect-indent": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-			"integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==",
+			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
 			"dev": true
 		},
 		"dezalgo": {
@@ -7842,7 +7842,7 @@
 		"git-remote-origin-url": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-			"integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
+			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
 			"dev": true,
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
@@ -7852,7 +7852,7 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				}
 			}
@@ -7897,7 +7897,7 @@
 		"gitconfiglocal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-			"integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
+			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
 			"dev": true,
 			"requires": {
 				"ini": "^1.3.2"
@@ -8037,7 +8037,7 @@
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 			"dev": true
 		},
 		"hasha": {
@@ -8104,7 +8104,7 @@
 		"humanize-ms": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+			"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
 			"dev": true,
 			"requires": {
 				"ms": "^2.0.0"
@@ -8507,7 +8507,7 @@
 		"is-lambda": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+			"integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
 			"dev": true
 		},
 		"is-negative-zero": {
@@ -8600,7 +8600,7 @@
 		"is-text-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-			"integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
+			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
 			"dev": true,
 			"requires": {
 				"text-extensions": "^1.0.0"
@@ -8657,7 +8657,7 @@
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
 		},
 		"istanbul-lib-coverage": {
@@ -8943,7 +8943,7 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
 		"json5": {
@@ -8974,7 +8974,7 @@
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
 			"dev": true
 		},
 		"jsx-ast-utils": {
@@ -9295,7 +9295,7 @@
 		"lodash.ismatch": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-			"integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
+			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
 			"dev": true
 		},
 		"lodash.merge": {
@@ -9638,13 +9638,13 @@
 				"arrify": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-					"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 					"dev": true
 				},
 				"is-plain-obj": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-					"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+					"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
 					"dev": true
 				}
 			}
@@ -11131,13 +11131,13 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
 		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 			"dev": true
 		},
 		"p-limit": {
@@ -11542,7 +11542,7 @@
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-			"integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
 			"dev": true
 		},
 		"promise-retry": {
@@ -11558,7 +11558,7 @@
 		"promzard": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-			"integrity": "sha512-JZeYqd7UAcHCwI+sTOeUDYkvEU+1bQ7iE0UT1MgB/tERkAPkesW46MrpIySzODi+owTjZtiF8Ay5j9m60KmMBw==",
+			"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
 			"dev": true,
 			"requires": {
 				"read": "1"
@@ -11578,7 +11578,7 @@
 		"proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
 			"dev": true
 		},
 		"protocols": {
@@ -11602,7 +11602,7 @@
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
 			"dev": true
 		},
 		"qs": {
@@ -11635,7 +11635,7 @@
 		"read": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-			"integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
 			"dev": true,
 			"requires": {
 				"mute-stream": "~0.0.4"
@@ -11985,7 +11985,7 @@
 		"retry": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
 			"dev": true
 		},
 		"reusify": {
@@ -12184,7 +12184,7 @@
 		"sort-keys": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-			"integrity": "sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==",
+			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 			"dev": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
@@ -12193,7 +12193,7 @@
 				"is-plain-obj": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-					"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+					"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
 					"dev": true
 				}
 			}
@@ -12526,7 +12526,7 @@
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
 			"dev": true
 		},
 		"test-exclude": {
@@ -12561,7 +12561,7 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
 		"through2": {
@@ -12687,7 +12687,7 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
 		"typedarray-to-buffer": {
@@ -12808,7 +12808,7 @@
 		"validate-npm-package-name": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-			"integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
+			"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
 			"dev": true,
 			"requires": {
 				"builtins": "^1.0.3"
@@ -12823,7 +12823,7 @@
 		"wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
@@ -12931,7 +12931,7 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
 			"dev": true
 		},
 		"workerpool": {

--- a/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
@@ -118,15 +118,3 @@ export enum GitObjectType {
     ofsdelta = 6,   /** < A delta, base is given by an offset. */
     refdelta = 7,   /** < A delta, base is given by object id. */
 }
-
-export enum BaseGitRestTelemetryProperties {
-    directoryPath = "directoryPath",
-    ref = "ref",
-    repoName = "repoName",
-    repoOwner = "repoOwner",
-    repoPerDocEnabled = "repoPerDocEnabled",
-    sha = "sha",
-    softDelete = "softDelete",
-    storageName = "storageName",
-    summaryType = "summaryType",
-}

--- a/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
@@ -22,7 +22,9 @@ import {
     NetworkError,
     WholeSummaryTreeEntry,
 } from "@fluidframework/server-services-client";
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import { IRepositoryManager } from "./definitions";
+import { GitRestLumberEventName } from "./gitrestTelemetryDefinitions";
 
 interface ISummaryVersion {
     id: string;
@@ -77,52 +79,63 @@ export class GitWholeSummaryManager {
     constructor(
         private readonly documentId: string,
         private readonly repoManager: IRepositoryManager,
+        private readonly lumberjackProperties: Record<string, any>,
         private readonly externalStorageEnabled = true,
     ) {}
 
     public async readSummary(sha: string): Promise<IWholeFlatSummary> {
-        let version: ISummaryVersion;
-        if (sha === latestSummarySha) {
-            version = await this.getLatestVersion();
-        } else {
-            const commit = await this.repoManager.getCommit(sha);
-            version = { id: commit.sha, treeId: commit.tree.sha };
-        }
-        const rawTree = await this.repoManager.getTree(version.treeId, true /* recursive */);
-        const wholeFlatSummaryTreeEntries: IWholeFlatSummaryTreeEntry[] = [];
-        const wholeFlatSummaryBlobPs: Promise<IWholeFlatSummaryBlob>[] = [];
-        rawTree.tree.forEach((treeEntry) => {
-            if (treeEntry.type === "blob") {
-                wholeFlatSummaryTreeEntries.push({
-                    type: "blob",
-                    id: treeEntry.sha,
-                    path: treeEntry.path,
-                });
-                wholeFlatSummaryBlobPs.push(
-                    this.getBlob(
-                        treeEntry.sha,
-                    ),
-                );
+        const readSummaryMetric = Lumberjack.newLumberMetric(
+            GitRestLumberEventName.WholeSummaryManagerReadSummary,
+            this.lumberjackProperties);
+
+        try {
+            let version: ISummaryVersion;
+            if (sha === latestSummarySha) {
+                version = await this.getLatestVersion();
             } else {
-                wholeFlatSummaryTreeEntries.push({
-                    type: "tree",
-                    path: treeEntry.path,
-                });
+                const commit = await this.repoManager.getCommit(sha);
+                version = { id: commit.sha, treeId: commit.tree.sha };
             }
-        });
-        const wholeFlatSummaryBlobs = await Promise.all(wholeFlatSummaryBlobPs);
-        return {
-            id: version.id,
-            trees: [
-                {
-                    id: rawTree.sha,
-                    entries: wholeFlatSummaryTreeEntries,
-                    // We don't store sequence numbers in git
-                    sequenceNumber: undefined,
-                },
-            ],
-            blobs: wholeFlatSummaryBlobs,
-        };
+            const rawTree = await this.repoManager.getTree(version.treeId, true /* recursive */);
+            const wholeFlatSummaryTreeEntries: IWholeFlatSummaryTreeEntry[] = [];
+            const wholeFlatSummaryBlobPs: Promise<IWholeFlatSummaryBlob>[] = [];
+            rawTree.tree.forEach((treeEntry) => {
+                if (treeEntry.type === "blob") {
+                    wholeFlatSummaryTreeEntries.push({
+                        type: "blob",
+                        id: treeEntry.sha,
+                        path: treeEntry.path,
+                    });
+                    wholeFlatSummaryBlobPs.push(
+                        this.getBlob(
+                            treeEntry.sha,
+                        ),
+                    );
+                } else {
+                    wholeFlatSummaryTreeEntries.push({
+                        type: "tree",
+                        path: treeEntry.path,
+                    });
+                }
+            });
+            const wholeFlatSummaryBlobs = await Promise.all(wholeFlatSummaryBlobPs);
+            readSummaryMetric.success("GitWholeSummaryManager succeeded in reading summary");
+            return {
+                id: version.id,
+                trees: [
+                    {
+                        id: rawTree.sha,
+                        entries: wholeFlatSummaryTreeEntries,
+                        // We don't store sequence numbers in git
+                        sequenceNumber: undefined,
+                    },
+                ],
+                blobs: wholeFlatSummaryBlobs,
+            };
+        } catch (error: any) {
+            readSummaryMetric.error("GitWholeSummaryManager failed to read summary", error);
+            throw error;
+        }
     }
 
     private async getBlob(sha: string): Promise<IWholeFlatSummaryBlob> {
@@ -150,20 +163,30 @@ export class GitWholeSummaryManager {
     }
 
     public async writeSummary(payload: IWholeSummaryPayload): Promise<IWriteSummaryInfo> {
-        if (isChannelSummary(payload)) {
-            const summaryTreeHandle = await this.writeChannelSummary(payload);
-            return {
-                isNew: false,
-                writeSummaryResponse: {
-                    id: summaryTreeHandle,
-                },
-            };
+        const writeSummaryMetric = Lumberjack.newLumberMetric(
+            GitRestLumberEventName.WholeSummaryManagerWriteSummary,
+            this.lumberjackProperties);
+        try {
+            if (isChannelSummary(payload)) {
+                const summaryTreeHandle = await this.writeChannelSummary(payload);
+                writeSummaryMetric.success("GitWholeSummaryManager succeeded in writing channel summary");
+                return {
+                    isNew: false,
+                    writeSummaryResponse: {
+                        id: summaryTreeHandle,
+                    },
+                };
+            }
+            if (isContainerSummary(payload)) {
+                const writeSummaryInfo = await this.writeContainerSummary(payload);
+                writeSummaryMetric.success("GitWholeSummaryManager succeeded in writing container summary");
+                return writeSummaryInfo;
+            }
+            throw new NetworkError(400, `Unknown Summary Type: ${payload.type}`);
+        } catch (error: any) {
+            writeSummaryMetric.error("GitWholeSummaryManager failed to write summary", error);
+            throw error;
         }
-        if (isContainerSummary(payload)) {
-            const writeSummaryInfo = await this.writeContainerSummary(payload);
-            return writeSummaryInfo;
-        }
-        throw new NetworkError(400, `Unknown Summary Type: ${payload.type}`);
     }
 
     private async writeChannelSummary(payload: IWholeSummaryPayload): Promise<string> {

--- a/server/gitrest/packages/gitrest-base/src/utils/gitrestTelemetryDefinitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/gitrestTelemetryDefinitions.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// List of event names that should identify Lumber events throughout GitRest.
+// Values in the enum must be strings.
+export enum GitRestLumberEventName {
+    // Summaries
+    PersistLatestFullSummaryInStorage = "GitRestPersistLatestFullSummaryInStorage",
+    RetrieveLatestFullSummaryFromStorage = "RetrieveLatestFullSummaryFromStorage",
+    WholeSummaryManagerReadSummary = "ReadSummary",
+    WholeSummaryManagerWriteSummary = "WriteSummary",
+}
+
+// List of properties used in telemetry throughout GitRest
+export enum BaseGitRestTelemetryProperties {
+    directoryPath = "directoryPath",
+    emptyFullSummary = "emptyFullSummary",
+    fullSummaryirectoryExists = "fullSummaryirectoryExists",
+    ref = "ref",
+    repoName = "repoName",
+    repoOwner = "repoOwner",
+    repoPerDocEnabled = "repoPerDocEnabled",
+    sha = "sha",
+    softDelete = "softDelete",
+    storageName = "storageName",
+    summaryType = "summaryType",
+
+}

--- a/server/gitrest/packages/gitrest-base/src/utils/gitrestTelemetryDefinitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/gitrestTelemetryDefinitions.ts
@@ -7,7 +7,7 @@
 // Values in the enum must be strings.
 export enum GitRestLumberEventName {
     // Summaries
-    PersistLatestFullSummaryInStorage = "GitRestPersistLatestFullSummaryInStorage",
+    PersistLatestFullSummaryInStorage = "PersistLatestFullSummaryInStorage",
     RetrieveLatestFullSummaryFromStorage = "RetrieveLatestFullSummaryFromStorage",
     WholeSummaryManagerReadSummary = "ReadSummary",
     WholeSummaryManagerWriteSummary = "WriteSummary",

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -14,7 +14,6 @@ import {
 } from "@fluidframework/server-services-client";
 import { BaseTelemetryProperties, HttpProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
 import {
-    BaseGitRestTelemetryProperties,
     Constants,
     IExternalWriterConfig,
     IFileSystemManager,
@@ -22,6 +21,10 @@ import {
     IRepositoryManagerFactory,
     IStorageRoutingId,
 } from "./definitions";
+import {
+    BaseGitRestTelemetryProperties,
+    GitRestLumberEventName,
+} from "./gitrestTelemetryDefinitions";
 
 /**
  * Validates that the input encoding is valid
@@ -84,35 +87,60 @@ export async function persistLatestFullSummaryInStorage(
     fileSystemManager: IFileSystemManager,
     storageDirectoryPath: string,
     latestFullSummary: IWholeFlatSummary,
+    lumberjackProperties: Record<string, any>,
 ): Promise<void> {
-    const directoryExists = await exists(fileSystemManager, storageDirectoryPath);
-    if (directoryExists === false) {
-        await fileSystemManager.promises.mkdir(storageDirectoryPath, { recursive: true });
-    } else if (!directoryExists.isDirectory()) {
-        throw new NetworkError(400, "Document storage directory path is not a directory");
+    const persistLatestFullSummaryInStorageMetric = Lumberjack.newLumberMetric(
+        GitRestLumberEventName.PersistLatestFullSummaryInStorage,
+        lumberjackProperties);
+    try {
+        const directoryExists = await exists(fileSystemManager, storageDirectoryPath);
+        persistLatestFullSummaryInStorageMetric.setProperty(
+            BaseGitRestTelemetryProperties.fullSummaryirectoryExists,
+            directoryExists !== false);
+        if (directoryExists === false) {
+            await fileSystemManager.promises.mkdir(storageDirectoryPath, { recursive: true });
+        } else if (!directoryExists.isDirectory()) {
+            throw new NetworkError(400, "Document storage directory path is not a directory");
+        }
+        await fileSystemManager.promises.writeFile(
+            getLatestFullSummaryFilePath(storageDirectoryPath),
+            JSON.stringify(latestFullSummary),
+        );
+        persistLatestFullSummaryInStorageMetric.success("Successfully persisted latest full summary in storage");
+    } catch (error: any) {
+        persistLatestFullSummaryInStorageMetric.error("Failed to persist latest full summary in storage", error);
+        throw error;
     }
-    await fileSystemManager.promises.writeFile(
-        getLatestFullSummaryFilePath(storageDirectoryPath),
-        JSON.stringify(latestFullSummary),
-    );
 }
 
 export async function retrieveLatestFullSummaryFromStorage(
     fileSystemManager: IFileSystemManager,
     storageDirectoryPath: string,
+    lumberjackProperties: Record<string, any>,
 ): Promise<IWholeFlatSummary | undefined> {
+    const retrieveLatestFullSummaryMetric = Lumberjack.newLumberMetric(
+        GitRestLumberEventName.RetrieveLatestFullSummaryFromStorage,
+        lumberjackProperties);
     try {
         const summaryFile = await fileSystemManager.promises.readFile(
             getLatestFullSummaryFilePath(storageDirectoryPath),
         );
         // TODO: This will be converted back to a JSON string for the HTTP response
         const summary: IWholeFlatSummary = JSON.parse(summaryFile.toString());
+        retrieveLatestFullSummaryMetric.setProperty(BaseGitRestTelemetryProperties.emptyFullSummary, false);
+        retrieveLatestFullSummaryMetric.success("Successfully read full summary from storage");
         return summary;
     } catch (error: any) {
         if (error?.code === "ENOENT") {
+            retrieveLatestFullSummaryMetric.setProperty(BaseGitRestTelemetryProperties.emptyFullSummary, true);
+            retrieveLatestFullSummaryMetric.success(
+                "Tried to retrieve latest from summary from storage but it does not exist");
             // File does not exist.
             return undefined;
         }
+        retrieveLatestFullSummaryMetric.error(
+            "Failed to read latest full summary from storage",
+            error);
         throw error;
     }
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/index.ts
@@ -4,7 +4,6 @@
  */
 
 export {
-	BaseGitRestTelemetryProperties,
 	Constants,
 	GitObjectType,
 	IExternalWriterConfig,
@@ -18,6 +17,10 @@ export {
 	IStorageDirectoryConfig,
 	IStorageRoutingId,
 } from "./definitions";
+export {
+    BaseGitRestTelemetryProperties,
+    GitRestLumberEventName,
+} from "./gitrestTelemetryDefinitions";
 export {
 	GitWholeSummaryManager,
 	isChannelSummary,

--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -16,8 +16,8 @@ import {
     IFileSystemManager,
     IFileSystemManagerFactory,
     IStorageDirectoryConfig,
-    BaseGitRestTelemetryProperties,
 } from "./definitions";
+import { BaseGitRestTelemetryProperties } from "./gitrestTelemetryDefinitions";
 import { RepositoryManagerFactoryBase } from "./repositoryManagerFactoryBase";
 
 export class IsomorphicGitRepositoryManager implements IRepositoryManager {

--- a/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
@@ -16,9 +16,9 @@ import {
     IRepositoryManager,
     IFileSystemManagerFactory,
     IStorageDirectoryConfig,
-    BaseGitRestTelemetryProperties,
     IFileSystemManager,
 } from "./definitions";
+import { BaseGitRestTelemetryProperties } from "./gitrestTelemetryDefinitions";
 import { RepositoryManagerFactoryBase } from "./repositoryManagerFactoryBase";
 
 export class NodegitRepositoryManager implements IRepositoryManager {

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
@@ -15,9 +15,9 @@ import {
     IFileSystemManagerFactory,
     IRepoManagerParams,
     IStorageDirectoryConfig,
-    BaseGitRestTelemetryProperties,
     Constants,
 } from "./definitions";
+import { BaseGitRestTelemetryProperties } from "./gitrestTelemetryDefinitions";
 
 type RepoOperationType = "create" | "open";
 


### PR DESCRIPTION
## Description

Adding summary-related metrics for GitRest, focusing on the following events:
- PersistLatestFullSummaryInStorage
- RetrieveLatestFullSummaryFromStorage
- WholeSummaryManagerReadSummary
- WholeSummaryManagerWriteSummary

The goal here is to collect performance data around the different GitRest flows, including when GitRest spends time on computation and also when communicating with storage.
This is the first iteration on this topic. I will follow up with more pull request soon (e.g. I plan to also add optional metrics at the `RepositoryManager` layer).
