### PR TITLE
GC: Add SweepReady objects into the GC tree in summary

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -230,6 +230,9 @@ export class FluidDataStoreRegistry implements IFluidDataStoreRegistry {
 export const gcBlobPrefix = "__gc";
 
 // @public (undocumented)
+export const gcTombstoneBlobKey = "__tombstones";
+
+// @public (undocumented)
 export const gcTreeKey = "gc";
 
 // @public

--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -74,7 +74,7 @@ export function createSummarizer(provider: ITestObjectProvider, container: ICont
 export function createSummarizerFromFactory(provider: ITestObjectProvider, container: IContainer, dataStoreFactory: IFluidDataStoreFactory, summaryVersion?: string, containerRuntimeFactoryType?: typeof ContainerRuntimeFactoryWithDefaultDataStore, registryEntries?: NamedFluidDataStoreRegistryEntries): Promise<ISummarizer>;
 
 // @public (undocumented)
-export function createSummarizerWithContainer(provider: ITestObjectProvider, absoluteUrl: string | undefined, testContainerConfig: ITestContainerConfig, summaryVersion?: string): Promise<{
+export function createSummarizerWithContainer(provider: ITestObjectProvider, absoluteUrl: string | undefined, summaryVersion?: string, gcOptions?: IGCRuntimeOptions, configProvider?: IConfigProviderBase): Promise<{
     container: IContainer;
     summarizer: ISummarizer;
 }>;

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -645,6 +645,9 @@ export class GarbageCollector implements IGarbageCollector {
                         gcSnapshotTree,
                         readAndParseBlob,
                     );
+                    if (baseGCData.tombstones !== undefined) {
+                        this.tombstones = baseGCData.tombstones;
+                    }
                     if (this.trackGCState) {
                         this.latestSummaryData = {
                             serializedGCState: JSON.stringify(generateSortedGCState(baseGCData.gcState)),

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -222,7 +222,7 @@ interface IUnreferencedEventProps {
 /**
  * The GC data that is tracked for a summary that is submitted.
  */
- interface IGCSummaryTrackingData {
+interface IGCSummaryTrackingData {
     serializedGCState: string | undefined;
     serializedTombstones: string | undefined;
 }
@@ -645,7 +645,7 @@ export class GarbageCollector implements IGarbageCollector {
                         gcSnapshotTree,
                         readAndParseBlob,
                     );
-                    if (baseGCData.tombstones !== undefined) {
+                    if (baseGCData.tombstones !== undefined && this.tombstoneMode) {
                         this.tombstones = baseGCData.tombstones;
                     }
                     if (this.trackGCState) {

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -25,6 +25,7 @@ import {
     ISummarizeResult,
     ITelemetryContext,
     IGarbageCollectionNodeData,
+    ISummaryTreeWithStats,
 } from "@fluidframework/runtime-definitions";
 import {
     mergeStats,
@@ -61,6 +62,8 @@ const GCVersion = 1;
 export const gcTreeKey = "gc";
 // They prefix for GC blobs in the GC tree in summary.
 export const gcBlobPrefix = "__gc";
+// The key for tombstone blob in the GC tree in summary.
+export const gcTombstoneBlobKey = "__tombstones";
 
 // Feature gate key to turn GC on / off.
 export const runGCKey = "Fluid.GarbageCollection.RunGC";
@@ -214,6 +217,14 @@ interface IUnreferencedEventProps {
     lastSummaryTime?: number;
     externalRequest?: boolean;
     viaHandle?: boolean;
+}
+
+/**
+ * The GC data that is tracked for a summary that is submitted.
+ */
+ interface IGCSummaryTrackingData {
+    serializedGCState: string | undefined;
+    serializedTombstones: string | undefined;
 }
 
 /**
@@ -396,17 +407,19 @@ export class GarbageCollector implements IGarbageCollector {
 
     // Keeps track of the GC state from the last run.
     private previousGCDataFromLastRun: IGarbageCollectionData | undefined;
-    /**
-     * Keeps track of the serialized GC blob from the latest summary successfully submitted to the server.
-     */
-    private latestSerializedSummaryState: string | undefined;
-    /**
-     * Keeps track of the serialized GC blob from the last GC run of the client.
-     */
-    private pendingSerializedSummaryState: string | undefined;
     // Keeps a list of references (edges in the GC graph) between GC runs. Each entry has a node id and a list of
     // outbound routes from that node.
     private readonly newReferencesSinceLastRun: Map<string, string[]> = new Map();
+    private tombstones: string[] = [];
+
+    /**
+     * Keeps track of the GC data from the latest summary successfully submitted to and acked from the server.
+     */
+    private latestSummaryData: IGCSummaryTrackingData | undefined;
+    /**
+     * Keeps track of the GC data from the last summary submitted to the server but not yet acked.
+     */
+    private pendingSummaryData: IGCSummaryTrackingData | undefined;
 
     // Promise when resolved initializes the base state of the nodes from the base summary state.
     private readonly initializeBaseStateP: Promise<void>;
@@ -628,14 +641,17 @@ export class GarbageCollector implements IGarbageCollector {
                 // For newer documents, GC data should be present in the GC tree in the root of the snapshot.
                 const gcSnapshotTree = baseSnapshot.trees[gcTreeKey];
                 if (gcSnapshotTree !== undefined) {
-                    const baseGCState = await getGCStateFromSnapshot(
+                    const baseGCData = await getGCDataFromSnapshot(
                         gcSnapshotTree,
                         readAndParseBlob,
                     );
                     if (this.trackGCState) {
-                        this.latestSerializedSummaryState = JSON.stringify(generateSortedGCState(baseGCState));
+                        this.latestSummaryData = {
+                            serializedGCState: JSON.stringify(generateSortedGCState(baseGCData.gcState)),
+                            serializedTombstones: JSON.stringify(baseGCData.tombstones),
+                        };
                     }
-                    return baseGCState;
+                    return baseGCData.gcState;
                 }
 
                 // back-compat - Older documents will have the GC blobs in each data store's summary tree. Get them and
@@ -942,35 +958,74 @@ export class GarbageCollector implements IGarbageCollector {
             };
         }
 
-        const newSerializedSummaryState = JSON.stringify(generateSortedGCState(gcState));
+        const serializedGCState = JSON.stringify(generateSortedGCState(gcState));
+        const serializedTombstones = this.tombstones.length > 0 ? JSON.stringify(this.tombstones.sort()) : undefined;
 
         /**
-         * As an optimization if the GC tree hasn't changed and we're tracking the gc state, return a tree handle
-         * instead of returning the whole GC tree. If there are changes, then we want to return the whole tree.
+         * Incremental summary of GC data - If any of the GC state or tombstone state hasn't changed since the last
+         * summary, send summary handles for them. Otherwise, send the data in summary blobs.
          */
         if (this.trackGCState) {
-            this.pendingSerializedSummaryState = newSerializedSummaryState;
-            if (
-                this.latestSerializedSummaryState !== undefined &&
-                this.latestSerializedSummaryState === newSerializedSummaryState &&
-                !fullTree &&
-                trackState
-            ) {
-                const stats = mergeStats();
-                stats.handleNodeCount++;
-                return {
-                    summary: {
-                        type: SummaryType.Handle,
-                        handle: `/${gcTreeKey}`,
-                        handleType: SummaryType.Tree,
-                    },
-                    stats,
-                };
+            this.pendingSummaryData = { serializedGCState, serializedTombstones };
+            if (trackState && !fullTree && this.latestSummaryData !== undefined) {
+                // If neither GC state or tombstone state changed, send a summary handle for the entire GC data.
+                if (this.latestSummaryData.serializedGCState === serializedGCState
+                    && this.latestSummaryData.serializedTombstones === serializedTombstones) {
+                    const stats = mergeStats();
+                    stats.handleNodeCount++;
+                    return {
+                        summary: {
+                            type: SummaryType.Handle,
+                            handle: `/${gcTreeKey}`,
+                            handleType: SummaryType.Tree,
+                        },
+                        stats,
+                    };
+                }
+
+                // If either or both of GC state or tombstone state changed, build a GC summary tree.
+                return this.buildGCSummaryTree(serializedGCState, serializedTombstones, true /* trackState */);
             }
         }
+        // If not tracking GC state, build a GC summary tree without any summary handles.
+        return this.buildGCSummaryTree(serializedGCState, serializedTombstones, false /* trackState */);
+    }
 
+    /**
+     * Builds the GC summary tree which contains GC state and tombstone state.
+     * If trackState is false, both GC state and tombstone state are written as summary blobs.
+     * If trackState is true, summary blob is written for GC state or tombstone state if they changed.
+     * @param serializedGCState - The GC state serialized as string.
+     * @param serializedTombstones - THe tombstone state serialized as string.
+     * @param trackState - Whether we are tracking GC state across summaries.
+     * @returns the GC summary tree.
+     */
+    private buildGCSummaryTree(
+        serializedGCState: string,
+        serializedTombstones: string | undefined,
+        trackState: boolean,
+    ): ISummaryTreeWithStats {
+        const gcStateBlobKey = `${gcBlobPrefix}_root`;
         const builder = new SummaryTreeBuilder();
-        builder.addBlob(`${gcBlobPrefix}_root`, newSerializedSummaryState);
+
+        // If the GC state hasn't changed, write a summary handle, else write a summary blob for it.
+        if (this.latestSummaryData?.serializedGCState === serializedGCState && trackState) {
+            builder.addHandle(gcStateBlobKey, SummaryType.Blob, `/${gcTreeKey}/${gcStateBlobKey}`);
+        } else {
+            builder.addBlob(gcStateBlobKey, serializedGCState);
+        }
+
+        // If there is no tombstone data, return only the GC state.
+        if (serializedTombstones === undefined) {
+            return builder.getSummaryTree();
+        }
+
+        // If the tombstone state hasn't changed, write a summary handle, else write a summary blob for it.
+        if (this.latestSummaryData?.serializedTombstones === serializedTombstones && trackState) {
+            builder.addHandle(gcTombstoneBlobKey, SummaryType.Blob, `/${gcTreeKey}/${gcTombstoneBlobKey}`);
+        } else {
+            builder.addBlob(gcTombstoneBlobKey, serializedTombstones);
+        }
         return builder.getSummaryTree();
     }
 
@@ -1013,8 +1068,8 @@ export class GarbageCollector implements IGarbageCollector {
             this.latestSummaryGCVersion = this.currentGCVersion;
             this.initialStateNeedsReset = false;
             if (this.trackGCState) {
-                this.latestSerializedSummaryState = this.pendingSerializedSummaryState;
-                this.pendingSerializedSummaryState = undefined;
+                this.latestSummaryData = this.pendingSummaryData;
+                this.pendingSummaryData = undefined;
             }
             return;
         }
@@ -1029,15 +1084,18 @@ export class GarbageCollector implements IGarbageCollector {
 
         const gcSnapshotTree = snapshot.trees[gcTreeKey];
         if (gcSnapshotTree !== undefined && this.trackGCState) {
-            const latestGCState = await getGCStateFromSnapshot(
+            const latestGCData = await getGCDataFromSnapshot(
                 gcSnapshotTree,
                 readAndParseBlob,
             );
-            this.latestSerializedSummaryState = JSON.stringify(generateSortedGCState(latestGCState));
+            this.latestSummaryData = {
+                serializedGCState: JSON.stringify(generateSortedGCState(latestGCData.gcState)),
+                serializedTombstones: JSON.stringify(latestGCData.tombstones),
+            };
         } else {
-            this.latestSerializedSummaryState = undefined;
+            this.latestSummaryData = undefined;
         }
-        this.pendingSerializedSummaryState = undefined;
+        this.pendingSummaryData = undefined;
     }
 
     /**
@@ -1115,6 +1173,7 @@ export class GarbageCollector implements IGarbageCollector {
         currentReferenceTimestampMs: number,
     ) {
         this.previousGCDataFromLastRun = cloneGCData(gcData);
+        this.tombstones = [];
         this.newReferencesSinceLastRun.clear();
 
         // Iterate through the referenced nodes and stop tracking if they were unreferenced before.
@@ -1147,6 +1206,12 @@ export class GarbageCollector implements IGarbageCollector {
                 );
             } else {
                 nodeStateTracker.updateTracking(currentReferenceTimestampMs);
+                if (this.tombstoneMode && nodeStateTracker.state === UnreferencedState.SweepReady) {
+                    const nodeType = this.runtime.getNodeType(nodeId);
+                    if (nodeType === GCNodeType.DataStore || nodeType === GCNodeType.Blob) {
+                        this.tombstones.push(nodeId);
+                    }
+                }
             }
         }
     }
@@ -1487,15 +1552,21 @@ export class GarbageCollector implements IGarbageCollector {
 }
 
 /**
- * Gets the garbage collection state from the given snapshot tree. The GC state may be written into multiple blobs.
- * Merge the GC state from all such blobs and return the merged GC state.
+ * Gets the garbage collection data from the given snapshot tree. It contains GC state and tombstone state.
+ * The GC state may be written into multiple blobs. Merge the GC state from all such blobs into one.
  */
-async function getGCStateFromSnapshot(
+async function getGCDataFromSnapshot(
     gcSnapshotTree: ISnapshotTree,
     readAndParseBlob: ReadAndParseBlob,
-): Promise<IGarbageCollectionState> {
+) {
     let rootGCState: IGarbageCollectionState = { gcNodes: {} };
+    let tombstones: string[] | undefined;
     for (const key of Object.keys(gcSnapshotTree.blobs)) {
+        if (key === gcTombstoneBlobKey) {
+            tombstones = await readAndParseBlob<string[]>(gcSnapshotTree.blobs[key]);
+            continue;
+        }
+
         // Skip blobs that do not start with the GC prefix.
         if (!key.startsWith(gcBlobPrefix)) {
             continue;
@@ -1510,7 +1581,7 @@ async function getGCStateFromSnapshot(
         // Merge the GC state of this blob into the root GC state.
         rootGCState = concatGarbageCollectionStates(rootGCState, gcState);
     }
-    return rootGCState;
+    return { gcState: rootGCState, tombstones };
 }
 
 function generateSortedGCState(gcState: IGarbageCollectionState): IGarbageCollectionState {

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -28,6 +28,7 @@ export {
 export { FluidDataStoreRegistry } from "./dataStoreRegistry";
 export {
     gcBlobPrefix,
+    gcTombstoneBlobKey,
     gcTreeKey,
     IGarbageCollectionRuntime,
     IGCStats,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTestSummaryUtils.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTestSummaryUtils.ts
@@ -6,6 +6,7 @@
 import { assert } from "@fluidframework/common-utils";
 import {
     gcBlobPrefix,
+    gcTombstoneBlobKey,
     gcTreeKey,
 } from "@fluidframework/container-runtime";
 import { concatGarbageCollectionStates } from "@fluidframework/garbage-collector";
@@ -14,12 +15,18 @@ import {
     IGarbageCollectionState,
 } from "@fluidframework/runtime-definitions";
 
-export function getGCStateFromSummary(summary: ISummaryTree): IGarbageCollectionState | undefined {
-    const rootGCTree = summary.tree[gcTreeKey];
+/**
+ * Returns the garbage collection state from the GC tree in the summary.
+ * Note that it assumes that all the GC data in the GC tree are summary trees or blobs and not summary handles.
+ * @param summaryTree - The summary tree that contains the GC summary.
+ * @returns The GC state if the GC summary tree exists, undefined otherwise.
+ */
+export function getGCStateFromSummary(summaryTree: ISummaryTree): IGarbageCollectionState | undefined {
+    const rootGCTree = summaryTree.tree[gcTreeKey];
     if (rootGCTree === undefined) {
         return undefined;
     }
-    assert(rootGCTree.type === SummaryType.Tree, `GC state should be a tree`);
+    assert(rootGCTree.type === SummaryType.Tree, `GC data should be a tree`);
 
     let rootGCState: IGarbageCollectionState = { gcNodes: {} };
     for (const key of Object.keys(rootGCTree.tree)) {
@@ -29,10 +36,33 @@ export function getGCStateFromSummary(summary: ISummaryTree): IGarbageCollection
         }
 
         const gcBlob = rootGCTree.tree[key];
-        assert(gcBlob?.type === SummaryType.Blob, `GC blob not available`);
+        assert(gcBlob !== undefined, "GC state not available");
+        assert(gcBlob.type === SummaryType.Blob, "GC state is not a blob");
         const gcState = JSON.parse(gcBlob.content as string) as IGarbageCollectionState;
         // Merge the GC state of this blob into the root GC state.
         rootGCState = concatGarbageCollectionStates(rootGCState, gcState);
     }
     return rootGCState;
+}
+
+/**
+ * Returns the tombstone data from the GC tree in the summary.
+ * Note that it assumes that the tombstone data in the GC tree is a summary blob and not summary handle.
+ * @param summaryTree - The summary tree that contains the GC summary.
+ * @returns The tombstone data if it exists, undefined otherwise.
+ */
+export function getGCTombstoneStateFromSummary(summaryTree: ISummaryTree): string[] | undefined {
+    const rootGCTree = summaryTree.tree[gcTreeKey];
+    if (rootGCTree === undefined) {
+        return undefined;
+    }
+
+    assert(rootGCTree.type === SummaryType.Tree, "GC data should be a tree");
+    const tombstoneBlob = rootGCTree.tree[gcTombstoneBlobKey];
+    if (tombstoneBlob === undefined) {
+        return undefined;
+    }
+
+    assert(tombstoneBlob.type === SummaryType.Blob, "Tombstone state is not a blob");
+    return JSON.parse(tombstoneBlob.content as string) as string[];
 }

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstone.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstone.spec.ts
@@ -5,6 +5,7 @@
 
 import { strict as assert } from "assert";
 import {
+    IGCRuntimeOptions,
     ISummarizer, RuntimeHeaders,
 } from "@fluidframework/container-runtime";
 import {
@@ -16,66 +17,43 @@ import {
     waitForContainerConnection,
     mockConfigProvider,
     ITestContainerConfig,
+    createSummarizer,
 } from "@fluidframework/test-utils";
 import { describeNoCompat, ITestDataObject, itExpects, TestDataObjectType } from "@fluidframework/test-version-utils";
 import { delay } from "@fluidframework/common-utils";
 import { IContainer, IErrorBase } from "@fluidframework/container-definitions";
 import { IRequest } from "@fluidframework/core-interfaces";
+import { ISummaryTree } from "@fluidframework/protocol-definitions";
+import { validateAssertionError } from "@fluidframework/test-runtime-utils";
+import { getGCStateFromSummary, getGCTombstoneStateFromSummary } from "./gcTestSummaryUtils";
 
 /**
- * When a datastore is tombstoned it should be unable to send and receive ops
- * TODO: add testing for sending and receiving signals
+ * These tests validate that SweepReady objects are correctly marked as tombstones. Tombstones should be added to the
+ * summary and changing them (sending / receiving ops, loading, etc.) is not allowed.
  */
-describeNoCompat("GC DataStore Tombstoned When It Is Sweep Ready", (getTestObjectProvider) => {
-    const remainingTimeUntilSweepMs = 100;
+describeNoCompat("GC tombstone tests", (getTestObjectProvider) => {
+    const waitLessThanSweepTimeoutMs = 100;
     const sweepTimeoutMs = 200;
-    assert(remainingTimeUntilSweepMs < sweepTimeoutMs, "remainingTimeUntilSweepMs should be < sweepTimeoutMs");
+    assert(waitLessThanSweepTimeoutMs < sweepTimeoutMs, "waitLessThanSweepTimeoutMs should be < sweepTimeoutMs");
     const settings = {
         "Fluid.GarbageCollection.Test.Tombstone": "true",
         "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": sweepTimeoutMs,
     };
 
+    const gcOptions: IGCRuntimeOptions = { inactiveTimeoutMs: 0 };
     const testContainerConfig: ITestContainerConfig = {
         runtimeOptions: {
             summaryOptions: {
                 summaryConfigOverrides: {
-                    state: "disableHeuristics",
-                    maxAckWaitTime: 10000,
-                    maxOpsSinceLastSummary: 7000,
-                    initialSummarizerDelayMs: 0,
-                    summarizerClientElection: false,
+                    state: "disabled",
                 },
             },
-            gcOptions: {
-                gcAllowed: true,
-                inactiveTimeoutMs: 0,
-            },
+            gcOptions,
         },
-        loaderProps: {
-            configProvider: mockConfigProvider(settings),
-        },
+        loaderProps: { configProvider: mockConfigProvider(settings) },
     };
 
     let provider: ITestObjectProvider;
-    let documentAbsoluteUrl: string | undefined;
-
-    const makeContainer = async () => {
-        const container = await provider.makeTestContainer(testContainerConfig);
-        documentAbsoluteUrl = await container.getAbsoluteUrl("");
-        return container;
-    };
-
-    const loadSummarizerAndContainer = async (summaryVersion?: string) => {
-        return createSummarizerWithContainer(
-            provider,
-            documentAbsoluteUrl,
-            testContainerConfig,
-            summaryVersion);
-    };
-    const summarize = async (summarizer: ISummarizer) => {
-        await provider.ensureSynchronized();
-        return summarizeNow(summarizer);
-    };
 
     beforeEach(async function() {
         provider = getTestObjectProvider({ syncSummarizer: true });
@@ -84,472 +62,611 @@ describeNoCompat("GC DataStore Tombstoned When It Is Sweep Ready", (getTestObjec
         }
     });
 
-    // This function creates an unreferenced datastore and returns the datastore's id and the summary version that
-    // datastore was unreferenced in.
-    const summarizationWithUnreferencedDataStoreAfterTime =
-    async (approximateUnreferenceTimestampMs: number) => {
-        const container = await makeContainer();
-        const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
-        await waitForContainerConnection(container);
+    describe("Using tombstone data stores is not allowed", () => {
+        let documentAbsoluteUrl: string | undefined;
 
-        const handleKey = "handle";
-        const dataStore = await defaultDataObject._context.containerRuntime.createDataStore(TestDataObjectType);
-        const testDataObject = await requestFluidObject<ITestDataObject>(dataStore, "");
-        const unreferencedId = testDataObject._context.id;
-
-        // Reference a datastore - important for making it live
-        defaultDataObject._root.set(handleKey, testDataObject.handle);
-        // Unreference a datastore
-        defaultDataObject._root.delete(handleKey);
-
-        // Summarize
-        const {
-            container: summarizingContainer1,
-            summarizer: summarizer1,
-        } = await loadSummarizerAndContainer();
-        const summaryVersion = (await summarize(summarizer1)).summaryVersion;
-
-        // TODO: trailing op test - note because of the way gc is currently structured, the error isn't logged,
-        // but it is detected - it's stored in the pending queue and the container closes before the error is sent.
-        testDataObject._root.set("send while unreferenced", "op");
-        await provider.ensureSynchronized();
-
-        // Close the containers as these containers would be closed by session expiry before sweep ready ever occurs
-        container.close();
-        summarizingContainer1.close();
-
-        // Wait some time, the datastore can be in many different unreference states
-        await delay(approximateUnreferenceTimestampMs);
-
-        // Load a new container and summarizer based on the latest summary, summarize
-        const {
-            container: summarizingContainer2,
-            summarizer: summarizer2,
-        } = await loadSummarizerAndContainer(summaryVersion);
-
-        return {
-            unreferencedId,
-            summarizingContainer: summarizingContainer2,
-            summarizer: summarizer2,
-            summaryVersion,
+        const makeContainer = async () => {
+            const container = await provider.makeTestContainer(testContainerConfig);
+            documentAbsoluteUrl = await container.getAbsoluteUrl("");
+            return container;
         };
-    };
 
-    const sendOpToUpdateSummaryTimestampToNow = async (container: IContainer) => {
-        const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
-        defaultDataObject._root.set("send a", "op");
-    };
+        const loadSummarizerAndContainer = async (summaryVersion?: string) => {
+            return createSummarizerWithContainer(
+                provider,
+                documentAbsoluteUrl,
+                testContainerConfig,
+                summaryVersion);
+        };
+        const summarize = async (summarizer: ISummarizer) => {
+            await provider.ensureSynchronized();
+            return summarizeNow(summarizer);
+        };
 
-    // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Send ops fails for tombstoned datastores in summarizing container loaded after sweep timeout",
-    [
-        { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded" },
-    ],
-    async () => {
-        const {
-            unreferencedId,
-            summarizingContainer,
-            summarizer,
-        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
 
-        // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-        // production application - causes a sweep ready loaded error
-        const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
 
-        // The datastore should be tombstoned now
-        await summarize(summarizer);
+        // This function creates an unreferenced datastore and returns the datastore's id and the summary version that
+        // datastore was unreferenced in.
+        const summarizationWithUnreferencedDataStoreAfterTime =
+        async (approximateUnreferenceTimestampMs: number) => {
+            const container = await makeContainer();
+            const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
+            await waitForContainerConnection(container);
 
-        // Modifying a testDataObject substantiated from the request pattern should fail!
-        assert.throws(() => dataObject._root.set("send", "op"),
-            (error) => {
-                const correctErrorType = error.errorType === "dataCorruptionError";
-                const correctErrorMessage = error.errorMessage?.startsWith(`Context is tombstoned`) === true;
-                return correctErrorType && correctErrorMessage;
-            },
-            `Should not be able to send ops for a tombstoned datastore.`,
-        );
-    });
+            const handleKey = "handle";
+            const dataStore = await defaultDataObject._context.containerRuntime.createDataStore(TestDataObjectType);
+            const testDataObject = await requestFluidObject<ITestDataObject>(dataStore, "");
+            const unreferencedId = testDataObject._context.id;
 
-    // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Send ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
-    [
-        { eventName: "fluid:telemetry:Summarizer:Running:InactiveObject_Loaded" },
-    ],
-    async () => {
-        const {
-            unreferencedId,
-            summarizingContainer,
-            summarizer,
-        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
+            // Reference a datastore - important for making it live
+            defaultDataObject._root.set(handleKey, testDataObject.handle);
+            // Unreference a datastore
+            defaultDataObject._root.delete(handleKey);
 
-        // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-        // production application - causes an inactive loaded and changed error
-        const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
+            // Summarize
+            const {
+                container: summarizingContainer1,
+                summarizer: summarizer1,
+            } = await loadSummarizerAndContainer();
+            const summaryVersion = (await summarize(summarizer1)).summaryVersion;
 
-        // Wait enough time so that the datastore is sweep ready
-        await delay(remainingTimeUntilSweepMs);
+            // TODO: trailing op test - note because of the way gc is currently structured, the error isn't logged,
+            // but it is detected - it's stored in the pending queue and the container closes before the error is sent.
+            testDataObject._root.set("send while unreferenced", "op");
+            await provider.ensureSynchronized();
 
-        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+            // Close the containers as these containers would be closed by session expiry before sweep ready ever occurs
+            container.close();
+            summarizingContainer1.close();
 
-        // The datastore should be tombstoned now
-        await summarize(summarizer);
+            // Wait some time, the datastore can be in many different unreference states
+            await delay(approximateUnreferenceTimestampMs);
 
-        // Sending an op from a datastore substantiated from the request pattern should fail!
-        assert.throws(() => dataObject._root.set("send", "op"),
-            (error) => {
-                const correctErrorType = error.errorType === "dataCorruptionError";
-                const correctErrorMessage = error.errorMessage?.startsWith(`Context is tombstoned`) === true;
-                return correctErrorType && correctErrorMessage;
-            },
-            `Should not be able to send ops for a tombstoned datastore.`,
-        );
-    });
+            // Load a new container and summarizer based on the latest summary, summarize
+            const {
+                container: summarizingContainer2,
+                summarizer: summarizer2,
+            } = await loadSummarizerAndContainer(summaryVersion);
 
-    // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Receive ops fails for tombstoned datastores in summarizing container loaded after sweep timeout",
-    [
-        { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
-        {
-            eventName: "fluid:telemetry:Container:ContainerClose",
-            error: "Context is tombstoned! Call site [process]",
-            errorType: "dataCorruptionError",
-        },
-    ],
-    async () => {
-        const {
-            unreferencedId,
-            summarizingContainer,
-            summarizer,
-            summaryVersion,
-        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-        // Setup close validation
-        let closeError: IErrorBase | undefined;
-        summarizingContainer.on("closed", (error) => {
-            closeError = error;
+            return {
+                unreferencedId,
+                summarizingContainer: summarizingContainer2,
+                summarizer: summarizer2,
+                summaryVersion,
+            };
+        };
+
+        const sendOpToUpdateSummaryTimestampToNow = async (container: IContainer) => {
+            const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
+            defaultDataObject._root.set("send a", "op");
+        };
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Send ops fails for tombstoned datastores in summarizing container loaded after sweep timeout",
+        [
+            { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded" },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+
+            // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
+            // production application - causes a sweep ready loaded error
+            const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
+
+            // The datastore should be tombstoned now
+            await summarize(summarizer);
+
+            // Modifying a testDataObject substantiated from the request pattern should fail!
+            assert.throws(() => dataObject._root.set("send", "op"),
+                (error) => {
+                    const correctErrorType = error.errorType === "dataCorruptionError";
+                    const correctErrorMessage = error.errorMessage?.startsWith(`Context is tombstoned`) === true;
+                    return correctErrorType && correctErrorMessage;
+                },
+                `Should not be able to send ops for a tombstoned datastore.`,
+            );
         });
 
-        // The datastore should be tombstoned now
-        await summarize(summarizer);
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Send ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
+        [
+            { eventName: "fluid:telemetry:Summarizer:Running:InactiveObject_Loaded" },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
 
-        // We load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
-        const container = await provider.loadTestContainer(testContainerConfig, { summaryVersion });
-        // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-        // production application
-        // This does not cause a sweep ready changed error as the container has loaded from a summary before sweep
-        // ready was set
-        const dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
+            // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
+            // production application - causes an inactive loaded and changed error
+            const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
 
-        // Receive an op - the summarizing container does not log a sweep ready changed error as it closes before
-        // the op is processed. The summarizing container does log a sweep ready loaded error and then it should
-        // process the op which causes the container to close.
-        dataObject._root.set("send an op to be received", "op");
-        await provider.ensureSynchronized();
-        assert(summarizingContainer.closed === true, `Summarizing container should close.`);
-        assert(closeError !== undefined, `Expecting an error!`);
-        assert(closeError.errorType === "dataCorruptionError");
-        assert(closeError.message === "Context is tombstoned! Call site [process]");
-    });
+            // Wait enough time so that the datastore is sweep ready
+            await delay(waitLessThanSweepTimeoutMs);
 
-    // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Receive ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
-    [
-        { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:InactiveObject_Loaded" },
-        {
-            eventName: "fluid:telemetry:Container:ContainerClose",
-            error: "Context is tombstoned! Call site [process]",
-            errorType: "dataCorruptionError",
-        },
-    ],
-    async () => {
-        const {
-            unreferencedId,
-            summarizingContainer,
-            summarizer,
-            summaryVersion,
-        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 
-        // Setup close validation
-        let closeError: IErrorBase | undefined;
-        summarizingContainer.on("closed", (error) => {
-            closeError = error;
+            // The datastore should be tombstoned now
+            await summarize(summarizer);
+
+            // Sending an op from a datastore substantiated from the request pattern should fail!
+            assert.throws(() => dataObject._root.set("send", "op"),
+                (error) => {
+                    const correctErrorType = error.errorType === "dataCorruptionError";
+                    const correctErrorMessage = error.errorMessage?.startsWith(`Context is tombstoned`) === true;
+                    return correctErrorType && correctErrorMessage;
+                },
+                `Should not be able to send ops for a tombstoned datastore.`,
+            );
         });
 
-        // We load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
-        const container = await provider.loadTestContainer(testContainerConfig, { summaryVersion });
-        // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-        // production application. Causes an inactiveObject loaded error
-        const dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
-
-        // Wait enough time so that the datastore is sweep ready
-        await delay(remainingTimeUntilSweepMs);
-
-        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-        // The datastore should be tombstoned now
-        await summarize(summarizer);
-
-        // Send an op to be received - no sweep changed or loaded - the summarizing container does not log sweep ready
-        // errors as it closes before the op is processed and the datastore is realized
-        dataObject._root.set("send an op to be received", "op");
-        await provider.ensureSynchronized();
-        assert(summarizingContainer.closed === true, `Summarizing container should close.`);
-        assert(closeError !== undefined, `Expecting an error!`);
-        assert(closeError.errorType === "dataCorruptionError");
-        assert(closeError.message === "Context is tombstoned! Call site [process]");
-    });
-
-    // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Send signals fails for tombstoned datastores in summarizing container loaded after sweep timeout",
-    [
-        { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded" },
-    ],
-    async () => {
-        const {
-            unreferencedId,
-            summarizingContainer,
-            summarizer,
-        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-
-        // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-        // production application - causes a sweep ready loaded error
-        const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
-
-        // The datastore should be tombstoned now
-        await summarize(summarizer);
-
-        // Sending a signal froma a testDataObject substantiated from the request pattern should fail!
-        assert.throws(() => dataObject._runtime.submitSignal("send", "signal"),
-            (error) => {
-                const correctErrorType = error.errorType === "dataCorruptionError";
-                const correctErrorMessage = error.errorMessage?.startsWith(`Context is tombstoned`) === true;
-                return correctErrorType && correctErrorMessage;
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Receive ops fails for tombstoned datastores in summarizing container loaded after sweep timeout",
+        [
+            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
+            {
+                eventName: "fluid:telemetry:Container:ContainerClose",
+                error: "Context is tombstoned! Call site [process]",
+                errorType: "dataCorruptionError",
             },
-            `Should not be able to send signals for a tombstoned datastore.`,
-        );
-    });
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+                summaryVersion,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+            // Setup close validation
+            let closeError: IErrorBase | undefined;
+            summarizingContainer.on("closed", (error) => {
+                closeError = error;
+            });
 
-    // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Receive signals fails for tombstoned datastores in summarizing container loaded after sweep timeout",
-    [
-        { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
-        {
-            eventName: "fluid:telemetry:Container:ContainerClose",
-            error: "Context is tombstoned! Call site [processSignal]",
-            errorType: "dataCorruptionError",
-        },
-    ],
-    async () => {
-        const {
-            unreferencedId,
-            summarizingContainer,
-            summarizer,
-            summaryVersion,
-        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-        // Setup close validation
-        let closeError: IErrorBase | undefined;
-        summarizingContainer.on("closed", (error) => {
-            closeError = error;
+            // The datastore should be tombstoned now
+            await summarize(summarizer);
+
+            // Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
+            const container = await provider.loadTestContainer(testContainerConfig, { summaryVersion });
+            // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
+            // production application
+            // This does not cause a sweep ready changed error as the container has loaded from a summary before sweep
+            // ready was set
+            const dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
+
+            // Receive an op - the summarizing container does not log a sweep ready changed error as it closes before
+            // the op is processed. The summarizing container does log a sweep ready loaded error and then it should
+            // process the op which causes the container to close.
+            dataObject._root.set("send an op to be received", "op");
+            await provider.ensureSynchronized();
+            assert(summarizingContainer.closed === true, `Summarizing container should close.`);
+            assert(closeError !== undefined, `Expecting an error!`);
+            assert(closeError.errorType === "dataCorruptionError");
+            assert(closeError.message === "Context is tombstoned! Call site [process]");
         });
 
-        // The datastore should be tombstoned now
-        await summarize(summarizer);
-
-        // We load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
-        const container = await provider.loadTestContainer(testContainerConfig, { summaryVersion });
-        // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-        // production application
-        // This does not cause a sweep ready changed error as the container has loaded from a summary before sweep
-        // ready was set
-        const dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
-
-        // Receive a signal by sending it from another container
-        dataObject._runtime.submitSignal("send a signal to be received", "signal");
-        await provider.ensureSynchronized();
-        assert(summarizingContainer.closed === true, `Summarizing container should close.`);
-        assert(closeError !== undefined, `Expecting an error!`);
-        assert(closeError.errorType === "dataCorruptionError");
-        assert(closeError.message === "Context is tombstoned! Call site [processSignal]");
-    });
-
-    // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Requesting tombstoned datastores fails in summarizing container loaded after sweep timeout",
-    [
-        {
-            error: "TombstonedDataStoreRequested",
-            eventName: "fluid:telemetry:ContainerRuntime:TombstonedDataStoreRequested",
-            viaHandle: false,
-        },
-    ],
-    async () => {
-        const {
-            unreferencedId,
-            summarizingContainer,
-            summarizer,
-        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-
-        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-        // The datastore should be tombstoned now
-        await summarize(summarizer);
-
-        // Requesting a tombstoned datastore should fail!
-        await assert.rejects(async () => requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId),
-            (error) => {
-                const correctErrorType = error.code === 404;
-                const correctErrorMessage = error.message.startsWith(`Datastore removed by gc`) === true;
-                return correctErrorType && correctErrorMessage;
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Receive ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
+        [
+            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:InactiveObject_Loaded" },
+            {
+                eventName: "fluid:telemetry:Container:ContainerClose",
+                error: "Context is tombstoned! Call site [process]",
+                errorType: "dataCorruptionError",
             },
-            `Should not be able to retrieve a tombstoned datastore.`,
-        );
-    });
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+                summaryVersion,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
 
-    // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Requesting tombstoned datastores fails in summarizing container loaded before sweep timeout",
-    [
-        {
-            error: "TombstonedDataStoreRequested",
-            eventName: "fluid:telemetry:ContainerRuntime:TombstonedDataStoreRequested",
-            viaHandle: false,
-        },
-    ],
-    async () => {
-        const {
-            unreferencedId,
-            summarizingContainer,
-            summarizer,
-        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
-        // Wait enough time so that the datastore is sweep ready
-        await delay(remainingTimeUntilSweepMs);
+            // Setup close validation
+            let closeError: IErrorBase | undefined;
+            summarizingContainer.on("closed", (error) => {
+                closeError = error;
+            });
 
-        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+            // Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
+            const container = await provider.loadTestContainer(testContainerConfig, { summaryVersion });
+            // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
+            // production application. Causes an inactiveObject loaded error
+            const dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
 
-        // The datastore should be tombstoned now
-        await summarize(summarizer);
+            // Wait enough time so that the datastore is sweep ready
+            await delay(waitLessThanSweepTimeoutMs);
 
-        // Requesting a tombstoned datastore should fail!
-        await assert.rejects(async () => requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId),
-            (error) => {
-                const correctErrorType = error.code === 404;
-                const correctErrorMessage = error.message.startsWith(`Datastore removed by gc`) === true;
-                return correctErrorType && correctErrorMessage;
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+            // The datastore should be tombstoned now
+            await summarize(summarizer);
+
+            // Send an op to be received - no sweep changed or loaded - the summarizing container does not log sweep
+            // ready errors as it closes before the op is processed and the datastore is realized
+            dataObject._root.set("send an op to be received", "op");
+            await provider.ensureSynchronized();
+            assert(summarizingContainer.closed === true, `Summarizing container should close.`);
+            assert(closeError !== undefined, `Expecting an error!`);
+            assert(closeError.errorType === "dataCorruptionError");
+            assert(closeError.message === "Context is tombstoned! Call site [process]");
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Send signals fails for tombstoned datastores in summarizing container loaded after sweep timeout",
+        [
+            { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded" },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+
+            // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
+            // production application - causes a sweep ready loaded error
+            const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
+
+            // The datastore should be tombstoned now
+            await summarize(summarizer);
+
+            // Sending a signal from a testDataObject substantiated from the request pattern should fail!
+            assert.throws(() => dataObject._runtime.submitSignal("send", "signal"),
+                (error) => {
+                    const correctErrorType = error.errorType === "dataCorruptionError";
+                    const correctErrorMessage = error.errorMessage?.startsWith(`Context is tombstoned`) === true;
+                    return correctErrorType && correctErrorMessage;
+                },
+                `Should not be able to send signals for a tombstoned datastore.`,
+            );
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Receive signals fails for tombstoned datastores in summarizing container loaded after sweep timeout",
+        [
+            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
+            {
+                eventName: "fluid:telemetry:Container:ContainerClose",
+                error: "Context is tombstoned! Call site [processSignal]",
+                errorType: "dataCorruptionError",
             },
-            `Should not be able to retrieve a tombstoned datastore.`,
-        );
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+                summaryVersion,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+            // Setup close validation
+            let closeError: IErrorBase | undefined;
+            summarizingContainer.on("closed", (error) => {
+                closeError = error;
+            });
+
+            // The datastore should be tombstoned now
+            await summarize(summarizer);
+
+            // Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
+            const container = await provider.loadTestContainer(testContainerConfig, { summaryVersion });
+            // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
+            // production application
+            // This does not cause a sweep ready changed error as the container has loaded from a summary before sweep
+            // ready was set
+            const dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
+
+            // Receive a signal by sending it from another container
+            dataObject._runtime.submitSignal("send a signal to be received", "signal");
+            await provider.ensureSynchronized();
+            assert(summarizingContainer.closed === true, `Summarizing container should close.`);
+            assert(closeError !== undefined, `Expecting an error!`);
+            assert(closeError.errorType === "dataCorruptionError");
+            assert(closeError.message === "Context is tombstoned! Call site [processSignal]");
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Requesting tombstoned datastores fails in summarizing container loaded after sweep timeout",
+        [
+            {
+                error: "TombstonedDataStoreRequested",
+                eventName: "fluid:telemetry:ContainerRuntime:TombstonedDataStoreRequested",
+                viaHandle: false,
+            },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+            // The datastore should be tombstoned now
+            await summarize(summarizer);
+
+            // Requesting a tombstoned datastore should fail!
+            await assert.rejects(async () => requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId),
+                (error) => {
+                    const correctErrorType = error.code === 404;
+                    const correctErrorMessage = error.message.startsWith(`Datastore removed by gc`) === true;
+                    return correctErrorType && correctErrorMessage;
+                },
+                `Should not be able to retrieve a tombstoned datastore.`,
+            );
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Requesting tombstoned datastores fails in summarizing container loaded before sweep timeout",
+        [
+            {
+                error: "TombstonedDataStoreRequested",
+                eventName: "fluid:telemetry:ContainerRuntime:TombstonedDataStoreRequested",
+                viaHandle: false,
+            },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
+            // Wait enough time so that the datastore is sweep ready
+            await delay(waitLessThanSweepTimeoutMs);
+
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+            // The datastore should be tombstoned now
+            await summarize(summarizer);
+
+            // Requesting a tombstoned datastore should fail!
+            await assert.rejects(async () => requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId),
+                (error) => {
+                    const correctErrorType = error.code === 404;
+                    const correctErrorMessage = error.message.startsWith(`Datastore removed by gc`) === true;
+                    return correctErrorType && correctErrorMessage;
+                },
+                `Should not be able to retrieve a tombstoned datastore.`,
+            );
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Handle request for tombstoned datastores fails in summarizing container loaded after sweep timeout",
+        [
+            { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded" },
+            {
+                error: "TombstonedDataStoreRequested",
+                eventName: "fluid:telemetry:ContainerRuntime:TombstonedDataStoreRequested",
+                viaHandle: true,
+            },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+
+            const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+            // The datastore should be tombstoned now
+            await summarize(summarizer);
+
+            // Note: if a user makes a request that looks like this, we will also think that the request is via handle
+            const request: IRequest = { url: unreferencedId, headers: { [RuntimeHeaders.viaHandle]: true } };
+            const response = await dataObject._context.IFluidHandleContext.resolveHandle(request);
+
+            assert(response !== undefined, `Expecting a response!`);
+            assert(response.status === 404);
+            assert(response.value.startsWith(`Datastore removed by gc`));
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Handle request for tombstoned datastores fails in summarizing container loaded before sweep timeout",
+        [
+            { eventName: "fluid:telemetry:Summarizer:Running:InactiveObject_Loaded" },
+            {
+                error: "TombstonedDataStoreRequested",
+                eventName: "fluid:telemetry:ContainerRuntime:TombstonedDataStoreRequested",
+                viaHandle: true,
+            },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
+            const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
+
+            // Wait enough time so that the datastore is sweep ready
+            await delay(waitLessThanSweepTimeoutMs);
+
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+            // The datastore should be tombstoned now
+            await summarize(summarizer);
+
+            // Note: if a user makes a request that looks like this, we will also think that the request is via handle
+            const request: IRequest = { url: unreferencedId, headers: { [RuntimeHeaders.viaHandle]: true } };
+            const response = await dataObject._context.IFluidHandleContext.resolveHandle(request);
+
+            assert(response !== undefined, `Expecting a response!`);
+            assert(response.status === 404);
+            assert(response.value.startsWith(`Datastore removed by gc`));
+        });
     });
 
-    // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Handle request for tombstoned datastores fails in summarizing container loaded after sweep timeout",
-    [
-        { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded" },
-        {
-            error: "TombstonedDataStoreRequested",
-            eventName: "fluid:telemetry:ContainerRuntime:TombstonedDataStoreRequested",
-            viaHandle: true,
-        },
-    ],
-    async () => {
-        const {
-            unreferencedId,
-            summarizingContainer,
-            summarizer,
-        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+    describe.only("Tombstone information in summary", () => {
+        function validateTombstoneState(summaryTree: ISummaryTree, expectedTombstones: string [] | undefined) {
+            const actualTombstones = getGCTombstoneStateFromSummary(summaryTree);
+            if (expectedTombstones === undefined) {
+                assert(actualTombstones === undefined, "GC tree should not have tombstones in summary");
+                return;
+            }
+            assert(actualTombstones !== undefined, "GC tree should have tombstones in summary");
+            assert.deepStrictEqual(actualTombstones, expectedTombstones.sort(), "Tombstone state is incorrect");
+        }
 
-        const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
-        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+        it("adds tombstone data stores information to tombstone blob in summary", async () => {
+            const mainContainer = await provider.makeTestContainer(testContainerConfig);
+            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
+            await waitForContainerConnection(mainContainer);
 
-        // The datastore should be tombstoned now
-        await summarize(summarizer);
+            const summarizer = await createSummarizer(
+                provider,
+                mainContainer,
+                undefined /* summaryVersion */,
+                gcOptions,
+                mockConfigProvider(settings),
+            );
 
-        // Note: if a user makes a request that looks like this, we will also think that the request is via handle
-        const request: IRequest = { url: unreferencedId, headers: { [RuntimeHeaders.viaHandle]: true } };
-        const response = await dataObject._context.IFluidHandleContext.resolveHandle(request);
+            // Create couple of data stores.
+            const newDataStore = await requestFluidObject<ITestDataObject>(
+                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
+            const newDataStore2 = await requestFluidObject<ITestDataObject>(
+                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
+            const newDataStoreUrl = `/${newDataStore._context.id}`;
+            const newDataStore2Url = `/${newDataStore2._context.id}`;
 
-        assert(response !== undefined, `Expecting a response!`);
-        assert(response.status === 404);
-        assert(response.value.startsWith(`Datastore removed by gc`));
-    });
+            // Add the data stores' handle so that they are live and referenced.
+            mainDataStore._root.set("newDataStore", newDataStore.handle);
+            mainDataStore._root.set("newDataStore2", newDataStore2.handle);
 
-    // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Handle request for tombstoned datastores fails in summarizing container loaded before sweep timeout",
-    [
-        { eventName: "fluid:telemetry:Summarizer:Running:InactiveObject_Loaded" },
-        {
-            error: "TombstonedDataStoreRequested",
-            eventName: "fluid:telemetry:ContainerRuntime:TombstonedDataStoreRequested",
-            viaHandle: true,
-        },
-    ],
-    async () => {
-        const {
-            unreferencedId,
-            summarizingContainer,
-            summarizer,
-        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
-        const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
+            // Remove the data stores' handle to make them unreferenced.
+            mainDataStore._root.delete("newDataStore");
+            mainDataStore._root.delete("newDataStore2");
 
-        // Wait enough time so that the datastore is sweep ready
-        await delay(remainingTimeUntilSweepMs);
+            // Summarize such that the above data stores are marked unreferenced.
+            await provider.ensureSynchronized();
+            const summary = await summarizeNow(summarizer);
+            validateTombstoneState(summary.summaryTree, undefined /* tombstoneUrls */);
 
-        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+            // Wait for sweep timeout so that the data stores become tombstoned.
+            await delay(sweepTimeoutMs + 10);
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
 
-        // The datastore should be tombstoned now
-        await summarize(summarizer);
+            // Summarize. The tombstoned data stores should now be part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+            validateTombstoneState(summary2.summaryTree, [newDataStoreUrl, newDataStore2Url]);
+        });
 
-        // Note: if a user makes a request that looks like this, we will also think that the request is via handle
-        const request: IRequest = { url: unreferencedId, headers: { [RuntimeHeaders.viaHandle]: true } };
-        const response = await dataObject._context.IFluidHandleContext.resolveHandle(request);
+        itExpects("removes un-tombstoned data store from tombstone blob in summary",
+            [{ eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived" }],
+            async () => {
+            const mainContainer = await provider.makeTestContainer(testContainerConfig);
+            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
+            await waitForContainerConnection(mainContainer);
 
-        assert(response !== undefined, `Expecting a response!`);
-        assert(response.status === 404);
-        assert(response.value.startsWith(`Datastore removed by gc`));
-    });
+            const summarizer = await createSummarizer(
+                provider,
+                mainContainer,
+                undefined /* summaryVersion */,
+                gcOptions,
+                mockConfigProvider(settings),
+            );
 
-    // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-    itExpects("Can untombstone datastores by storing a handle",
-    [
-        { eventName: "fluid:telemetry:Summarizer:Running:InactiveObject_Loaded" },
-        {
-            error: "TombstonedDataStoreRequested",
-            eventName: "fluid:telemetry:ContainerRuntime:TombstonedDataStoreRequested",
-            viaHandle: true,
-        },
-    ],
-    async () => {
-        const {
-            unreferencedId,
-            summarizingContainer,
-            summarizer,
-        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
-        const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
+            // Create couple of data stores.
+            const newDataStore = await requestFluidObject<ITestDataObject>(
+                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
+            const newDataStore2 = await requestFluidObject<ITestDataObject>(
+                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
+            const newDataStoreUrl = `/${newDataStore._context.id}`;
+            const newDataStore2Url = `/${newDataStore2._context.id}`;
 
-        // Wait enough time so that the datastore is sweep ready
-        await delay(remainingTimeUntilSweepMs);
+            // Add the data stores' handle so that they are live and referenced.
+            mainDataStore._root.set("newDataStore", newDataStore.handle);
+            mainDataStore._root.set("newDataStore2", newDataStore2.handle);
 
-        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+            // Remove the data stores' handle to make them unreferenced.
+            mainDataStore._root.delete("newDataStore");
+            mainDataStore._root.delete("newDataStore2");
 
-        // The datastore should be tombstoned now
-        await summarize(summarizer);
+            // Summarize such that the above data stores are marked unreferenced.
+            await provider.ensureSynchronized();
+            const summary = await summarizeNow(summarizer);
+            validateTombstoneState(summary.summaryTree, undefined /* tombstoneUrls */);
 
-        // Note: if a user makes a request that looks like this, we will also think that the request is via handle
-        const request: IRequest = { url: unreferencedId, headers: { [RuntimeHeaders.viaHandle]: true } };
-        const response = await dataObject._context.IFluidHandleContext.resolveHandle(request);
+            // Wait for sweep timeout so that the data stores become tombstoned.
+            await delay(sweepTimeoutMs + 10);
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
 
-        assert(response !== undefined, `Expecting a response!`);
-        assert(response.status === 404);
-        assert(response.value.startsWith(`Datastore removed by gc`));
+            // Summarize. The tombstoned data stores should now be part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+            validateTombstoneState(summary2.summaryTree, [newDataStoreUrl, newDataStore2Url]);
 
-        const mainDataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, "default");
-        mainDataObject._root.set("store", dataObject.handle);
+            // Mark one of the data stores as referenced so that its not tombstone anymore.
+            mainDataStore._root.set("newDataStore", newDataStore.handle);
+            await provider.ensureSynchronized();
 
-        // The datastore should be untombstoned now
-        const { summaryVersion } = await summarize(summarizer);
-        const untombstonedDataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
-        untombstonedDataObject._root.set("can send", "op");
-        untombstonedDataObject._runtime.submitSignal("can submit", "signal");
-        const container = await provider.loadTestContainer(testContainerConfig, { summaryVersion });
-        const sendDataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
-        sendDataObject._root.set("can receive", "an op");
-        sendDataObject._runtime.submitSignal("can receive", "a signal");
-        await provider.ensureSynchronized();
+            // Summarize. The tombstoned data stores should now be part of the summary.
+            const summary3 = await summarizeNow(summarizer);
+            validateTombstoneState(summary3.summaryTree, [newDataStore2Url]);
+        });
+
+        it("does not re-summarize GC state on only tombstone state changed", async () => {
+            const mainContainer = await provider.makeTestContainer(testContainerConfig);
+            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
+            await waitForContainerConnection(mainContainer);
+
+            const summarizer = await createSummarizer(
+                provider,
+                mainContainer,
+                undefined /* summaryVersion */,
+                gcOptions,
+                mockConfigProvider(settings),
+            );
+
+            // Create a data store.
+            const newDataStore = await requestFluidObject<ITestDataObject>(
+                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
+
+            // Add the data store's handle so that it is live and referenced.
+            mainDataStore._root.set("newDataStore", newDataStore.handle);
+
+            // Remove the data store's handle to make it unreferenced.
+            mainDataStore._root.delete("newDataStore");
+
+            // Summarize such that the above data stores are marked unreferenced.
+            await provider.ensureSynchronized();
+            const summary = await summarizeNow(summarizer);
+            const gcState = getGCStateFromSummary(summary.summaryTree);
+            assert(gcState !== undefined, "GC state should be available and should not be a handle");
+
+            // Wait for sweep timeout so that the data stores become tombstoned.
+            await delay(sweepTimeoutMs + 10);
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize. The tombstoned data stores should now be part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+            assert.throws(
+                () => getGCStateFromSummary(summary2.summaryTree),
+                (e) => validateAssertionError(e, "GC state is not a blob"),
+            );
+            const tombstoneState = getGCTombstoneStateFromSummary(summary2.summaryTree);
+            assert(tombstoneState !== undefined, "Tombstone state should be available and should be a blob");
+
+            // Summarize. The tombstoned state should be a handle.
+            const summary3 = await summarizeNow(summarizer);
+            assert.throws(
+                () => getGCTombstoneStateFromSummary(summary3.summaryTree),
+                (e) => validateAssertionError(e, "GC data should be a tree"),
+            );
+        });
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstone.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstone.spec.ts
@@ -75,8 +75,10 @@ describeNoCompat("GC tombstone tests", (getTestObjectProvider) => {
             return createSummarizerWithContainer(
                 provider,
                 documentAbsoluteUrl,
-                testContainerConfig,
-                summaryVersion);
+                summaryVersion,
+                gcOptions,
+                mockConfigProvider(settings),
+            );
         };
         const summarize = async (summarizer: ISummarizer) => {
             await provider.ensureSynchronized();

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstone.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstone.spec.ts
@@ -32,9 +32,9 @@ import { getGCStateFromSummary, getGCTombstoneStateFromSummary } from "./gcTestS
  * summary and changing them (sending / receiving ops, loading, etc.) is not allowed.
  */
 describeNoCompat("GC tombstone tests", (getTestObjectProvider) => {
-    const waitLessThanSweepTimeoutMs = 100;
+    const remainingTimeUntilSweepMs = 100;
     const sweepTimeoutMs = 200;
-    assert(waitLessThanSweepTimeoutMs < sweepTimeoutMs, "waitLessThanSweepTimeoutMs should be < sweepTimeoutMs");
+    assert(remainingTimeUntilSweepMs < sweepTimeoutMs, "remainingTimeUntilSweepMs should be < sweepTimeoutMs");
     const settings = {
         "Fluid.GarbageCollection.Test.Tombstone": "true",
         "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": sweepTimeoutMs,
@@ -181,14 +181,14 @@ describeNoCompat("GC tombstone tests", (getTestObjectProvider) => {
                 unreferencedId,
                 summarizingContainer,
                 summarizer,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
 
             // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
             // production application - causes an inactive loaded and changed error
             const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
 
             // Wait enough time so that the datastore is sweep ready
-            await delay(waitLessThanSweepTimeoutMs);
+            await delay(remainingTimeUntilSweepMs);
 
             await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 
@@ -267,7 +267,7 @@ describeNoCompat("GC tombstone tests", (getTestObjectProvider) => {
                 summarizingContainer,
                 summarizer,
                 summaryVersion,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
 
             // Setup close validation
             let closeError: IErrorBase | undefined;
@@ -282,7 +282,7 @@ describeNoCompat("GC tombstone tests", (getTestObjectProvider) => {
             const dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
 
             // Wait enough time so that the datastore is sweep ready
-            await delay(waitLessThanSweepTimeoutMs);
+            await delay(remainingTimeUntilSweepMs);
 
             await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 
@@ -418,9 +418,9 @@ describeNoCompat("GC tombstone tests", (getTestObjectProvider) => {
                 unreferencedId,
                 summarizingContainer,
                 summarizer,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
             // Wait enough time so that the datastore is sweep ready
-            await delay(waitLessThanSweepTimeoutMs);
+            await delay(remainingTimeUntilSweepMs);
 
             await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 
@@ -485,11 +485,11 @@ describeNoCompat("GC tombstone tests", (getTestObjectProvider) => {
                 unreferencedId,
                 summarizingContainer,
                 summarizer,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - waitLessThanSweepTimeoutMs);
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
             const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
 
             // Wait enough time so that the datastore is sweep ready
-            await delay(waitLessThanSweepTimeoutMs);
+            await delay(remainingTimeUntilSweepMs);
 
             await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 
@@ -503,6 +503,56 @@ describeNoCompat("GC tombstone tests", (getTestObjectProvider) => {
             assert(response !== undefined, `Expecting a response!`);
             assert(response.status === 404);
             assert(response.value.startsWith(`Datastore removed by gc`));
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Can untombstone datastores by storing a handle",
+        [
+            { eventName: "fluid:telemetry:Summarizer:Running:InactiveObject_Loaded" },
+            {
+                error: "TombstonedDataStoreRequested",
+                eventName: "fluid:telemetry:ContainerRuntime:TombstonedDataStoreRequested",
+                viaHandle: true,
+            },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
+            const dataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
+
+            // Wait enough time so that the datastore is sweep ready
+            await delay(remainingTimeUntilSweepMs);
+
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+            // The datastore should be tombstoned now
+            await summarize(summarizer);
+
+            // Note: if a user makes a request that looks like this, we will also think that the request is via handle
+            const request: IRequest = { url: unreferencedId, headers: { [RuntimeHeaders.viaHandle]: true } };
+            const response = await dataObject._context.IFluidHandleContext.resolveHandle(request);
+
+            assert(response !== undefined, `Expecting a response!`);
+            assert(response.status === 404);
+            assert(response.value.startsWith(`Datastore removed by gc`));
+
+            const mainDataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, "default");
+            mainDataObject._root.set("store", dataObject.handle);
+
+            // The datastore should be untombstoned now
+            const { summaryVersion } = await summarize(summarizer);
+            const untombstonedDataObject =
+                await requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId);
+            untombstonedDataObject._root.set("can send", "op");
+            untombstonedDataObject._runtime.submitSignal("can submit", "signal");
+            const container = await provider.loadTestContainer(testContainerConfig, { summaryVersion });
+            const sendDataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
+            sendDataObject._root.set("can receive", "an op");
+            sendDataObject._runtime.submitSignal("can receive", "a signal");
+            await provider.ensureSynchronized();
         });
     });
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstone.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstone.spec.ts
@@ -556,7 +556,7 @@ describeNoCompat("GC tombstone tests", (getTestObjectProvider) => {
         });
     });
 
-    describe.only("Tombstone information in summary", () => {
+    describe("Tombstone information in summary", () => {
         function validateTombstoneState(summaryTree: ISummaryTree, expectedTombstones: string [] | undefined) {
             const actualTombstones = getGCTombstoneStateFromSummary(summaryTree);
             if (expectedTombstones === undefined) {

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -105,6 +105,23 @@ export async function createSummarizer(
     gcOptions?: IGCRuntimeOptions,
     configProvider: IConfigProviderBase = mockConfigProvider(),
 ): Promise<ISummarizer> {
+    const absoluteUrl = await container.getAbsoluteUrl("");
+    return (await createSummarizerWithContainer(
+        provider,
+        absoluteUrl,
+        summaryVersion,
+        gcOptions,
+        configProvider,
+    )).summarizer;
+}
+
+export async function createSummarizerWithContainer(
+    provider: ITestObjectProvider,
+    absoluteUrl: string | undefined,
+    summaryVersion?: string,
+    gcOptions?: IGCRuntimeOptions,
+    configProvider: IConfigProviderBase = mockConfigProvider(),
+): Promise<{ container: IContainer; summarizer: ISummarizer; }> {
     const testContainerConfig: ITestContainerConfig = {
         runtimeOptions: {
             summaryOptions: defaultSummaryOptions,
@@ -112,18 +129,6 @@ export async function createSummarizer(
         },
         loaderProps: { configProvider },
     };
-
-    const loader = provider.makeTestLoader(testContainerConfig);
-    const absoluteUrl = await container.getAbsoluteUrl("");
-    return (await createSummarizerCore(absoluteUrl, loader, summaryVersion)).summarizer;
-}
-
-export async function createSummarizerWithContainer(
-    provider: ITestObjectProvider,
-    absoluteUrl: string | undefined,
-    testContainerConfig: ITestContainerConfig,
-    summaryVersion?: string,
-): Promise<{ container: IContainer; summarizer: ISummarizer; }> {
     const loader = provider.makeTestLoader(testContainerConfig);
     return createSummarizerCore(absoluteUrl, loader, summaryVersion);
 }


### PR DESCRIPTION
## Description
When GC runs, all sweep ready objects are marked tombstones by adding them to a tombstone array. In the next summary, the tombstone array is written into the summary.
When GC is loaded, the tombstone info is read from the summary and added to the tombstone array.

## Todo
- [x] Write tests for attachment blobs as tombstones.

[AB#2130](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2130)