### PR TITLE
Move 'Jsonable' to core-interfaces - Part 1

### DIFF
--- a/api-report/core-interfaces.api.md
+++ b/api-report/core-interfaces.api.md
@@ -186,6 +186,11 @@ export const isFluidCodeDetails: (details: unknown) => details is Readonly<IFlui
 // @public @deprecated
 export const isFluidPackage: (pkg: any) => pkg is Readonly<IFluidPackage>;
 
+// @public
+export type Jsonable<T = any, TReplaced = void> = T extends undefined | null | boolean | number | string | TReplaced ? T : Extract<T, Function> extends never ? {
+    [K in keyof T]: Extract<K, symbol> extends never ? Jsonable<T[K], TReplaced> : never;
+} : never;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/api-report/sequence-deprecated.api.md
+++ b/api-report/sequence-deprecated.api.md
@@ -13,7 +13,7 @@ import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IJSONSegment } from '@fluidframework/merge-tree';
 import { ISegment } from '@fluidframework/merge-tree';
 import { ISharedObject } from '@fluidframework/shared-object-base';
-import { Jsonable } from '@fluidframework/datastore-definitions';
+import { Jsonable } from '@fluidframework/core-interfaces';
 import { PropertySet } from '@fluidframework/merge-tree';
 import { Serializable } from '@fluidframework/datastore-definitions';
 import { SharedSegmentSequence } from '@fluidframework/sequence';

--- a/api-report/shared-summary-block.api.md
+++ b/api-report/shared-summary-block.api.md
@@ -13,7 +13,7 @@ import { IFluidSerializer } from '@fluidframework/shared-object-base';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISharedObject } from '@fluidframework/shared-object-base';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
-import { Jsonable } from '@fluidframework/datastore-definitions';
+import { Jsonable } from '@fluidframework/core-interfaces';
 import { SharedObject } from '@fluidframework/shared-object-base';
 
 // @public
@@ -56,7 +56,6 @@ export class SharedSummaryBlockFactory implements IChannelFactory {
     // (undocumented)
     get type(): string;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -10,7 +10,7 @@ import { IChannelServices } from '@fluidframework/datastore-definitions';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { ISharedObject } from '@fluidframework/shared-object-base';
 import { IsoBuffer } from '@fluidframework/common-utils';
-import { Jsonable } from '@fluidframework/datastore-definitions';
+import { Jsonable } from '@fluidframework/core-interfaces';
 import { Serializable } from '@fluidframework/datastore-definitions';
 
 // @public

--- a/experimental/dds/ot/sharejs/json1/src/test/json1.spec.ts
+++ b/experimental/dds/ot/sharejs/json1/src/test/json1.spec.ts
@@ -9,7 +9,7 @@ import {
     MockFluidDataStoreRuntime,
     MockStorage,
 } from "@fluidframework/test-runtime-utils";
-import { Jsonable } from "@fluidframework/datastore-definitions";
+import { Jsonable } from "@fluidframework/core-interfaces";
 import { SharedJson1, Json1Factory } from "..";
 
 const createLocalOT = (id: string) => {

--- a/experimental/dds/sequence-deprecated/src/sparsematrix.ts
+++ b/experimental/dds/sequence-deprecated/src/sparsematrix.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { IFluidHandle, Jsonable } from "@fluidframework/core-interfaces";
 import {
     BaseSegment,
     createGroupOp,
@@ -18,8 +18,7 @@ import {
     IFluidDataStoreRuntime,
     IChannelServices,
     IChannelFactory,
-    Serializable,
-    Jsonable,
+    Serializable
 } from "@fluidframework/datastore-definitions";
 import { SharedSegmentSequence, SubSequence } from "@fluidframework/sequence";
 import { ISharedObject } from "@fluidframework/shared-object-base";

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -34,7 +34,7 @@
     "@fluidframework/aqueduct": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^1.0.0",
-    "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+    "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
     "@fluidframework/map": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
     "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
   },

--- a/experimental/framework/data-objects/src/signaler/signaler.ts
+++ b/experimental/framework/data-objects/src/signaler/signaler.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from "events";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IErrorEvent } from "@fluidframework/common-definitions";
 import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
-import { Jsonable } from "@fluidframework/datastore-definitions";
+import { Jsonable } from "@fluidframework/core-interfaces";
 import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 
 // TODO:

--- a/packages/common/core-interfaces/src/fluidPackage.ts
+++ b/packages/common/core-interfaces/src/fluidPackage.ts
@@ -146,7 +146,6 @@ export interface IFluidCodeDetailsComparer extends IProvideFluidCodeDetailsCompa
      */
     satisfies(candidate: IFluidCodeDetails, constraint: IFluidCodeDetails): Promise<boolean>;
 
-/* eslint-disable max-len */
     /**
      * Returns a number representing the ascending sort order of the `a` and `b` code details:
      *
@@ -162,5 +161,4 @@ export interface IFluidCodeDetailsComparer extends IProvideFluidCodeDetailsCompa
      * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description | Array.sort}
      */
     compare(a: IFluidCodeDetails, b: IFluidCodeDetails): Promise<number | undefined>;
-/* eslint-enable max-len */
 }

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -33,6 +33,10 @@ export {
 } from "./handles";
 
 export {
+    Jsonable
+} from "./jsonable";
+
+export {
     IFluidPackageEnvironment,
     IFluidPackage,
     isFluidPackage,

--- a/packages/common/core-interfaces/src/jsonable.ts
+++ b/packages/common/core-interfaces/src/jsonable.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Used to constrain a type `T` to types that are serializable as JSON.
+ * Produces a compile-time error if `T` contains non-Jsonable members.
+ *
+ * @remarks
+ * Note that this does NOT prevent using of values with non-json compatible data,
+ * it only prevents using values with types that include non-json compatible data.
+ * This means that one can, for example, pass an a value typed with json compatible
+ * interface into this function,
+ * that could actually be a class with lots on non-json compatible fields and methods.
+ *
+ * Important: `T extends Jsonable<T>` is incorrect (does not even compile).
+ * `T extends Jsonable` is also incorrect since `Jsonable` is just `any` and thus applies no constraint at all.
+ *
+ * The optional 'TReplaced' parameter may be used to permit additional leaf types to support
+ * situations where a `replacer` is used to handle special values (e.g., `Jsonable<{ x: IFluidHandle }, IFluidHandle>`).
+ *
+ * Note that `Jsonable<T>` does not protect against the following pitfalls when serializing with JSON.stringify():
+ *
+ * - `undefined` properties on objects are omitted (i.e., properties become undefined instead of equal to undefined).
+ *
+ * - When `undefined` appears as the root object or as an array element it is coerced to `null`.
+ *
+ * - Non-finite numbers (`NaN`, `+/-Infinity`) are also coerced to `null`.
+ *
+ * - prototypes and non-enumerable properties are lost.
+ *
+ * Also, `Jsonable<T>` does not prevent the construction of circular references.
+ *
+ * Using `Jsonable` (with no type parameters) or `Jsonable<any>` is just a type alias for `any`
+ * and should not be used if type safety is desired.
+ *
+ * @example
+ * Typical usage:
+ * ```ts
+ *      function foo<T>(value: Jsonable<T>) { ... }
+ * ```
+ */
+export type Jsonable<T = any, TReplaced = void> =
+    // eslint-disable-next-line @rushstack/no-new-null
+    T extends undefined | null | boolean | number | string | TReplaced
+        ? T
+        // eslint-disable-next-line @typescript-eslint/ban-types
+        : Extract<T, Function> extends never
+            ? {
+                [K in keyof T]: Extract<K, symbol> extends never
+                    ? Jsonable<T[K], TReplaced>
+                    : never
+            }
+            : never;

--- a/packages/common/core-interfaces/src/test/types/jsonable.ts
+++ b/packages/common/core-interfaces/src/test/types/jsonable.ts
@@ -1,0 +1,173 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Jsonable } from "../..";
+
+declare function foo<T>(jsonable: Jsonable<T>): void;
+
+// --- ideally wouldn't work but do as we don't know how to just exclude classes
+
+// test simple class.
+class Z {
+    public a = "a";
+}
+
+foo<Z>(new Z());
+
+// test class with getter
+class getter {
+    public get baz(): number {
+        return 0;
+    }
+}
+
+foo(new getter());
+
+// --- should work
+
+// test plain types
+foo(1);
+foo("");
+foo(undefined);
+foo(null);
+foo(true);
+foo([]);
+foo([0]);
+foo([""]);
+foo({});
+foo({ a: "a" });
+
+// test simple interface
+interface IA {
+    a: "a";
+}
+declare const a: IA;
+foo(a);
+
+// test simple indexed interface
+interface IA2 {
+    ["a"]: "a";
+}
+declare const a2: IA2;
+foo(a2);
+
+// text complex indexed interface
+declare const a3: { [key: string]: Jsonable<string>; };
+foo(a3);
+
+// test interface with multiple properties
+interface A5 {
+    a: "a";
+    b: "b";
+}
+declare const a5: A5;
+foo(a5);
+
+// test interface with optional property
+interface A6 {
+    a?: "a";
+}
+declare const a6: A6;
+foo(a6);
+
+// test simple type
+interface A7 {
+    a: "a";
+}
+
+declare const a7: A7;
+foo(a7);
+
+// test nested interface
+interface IBN {
+    b2: string;
+}
+
+interface INested {
+    a: string;
+    b: IBN;
+}
+
+const nested: INested = {
+    a: "a",
+    b: {
+        b2: "foo",
+    },
+};
+foo(nested);
+
+// --- should not work
+
+// test interface with method, and member
+interface IA11 {
+    ["a"]: "a";
+    foo: () => void;
+}
+declare const a11: IA11;
+// @ts-expect-error should not be jsonable
+foo(a11);
+
+// test interface with optional method
+interface A12 {
+    foo?: () => void;
+}
+declare const a12: A12;
+// @ts-expect-error should not be jsonable
+foo(a12);
+
+// test type with method
+interface A13 {
+    foo: () => void;
+}
+declare const a13: A13;
+// @ts-expect-error should not be jsonable
+foo(a13);
+
+// test type with primative and object with classes union
+interface IA14 {
+    a: number | Date;
+}
+declare const a14: IA14;
+// @ts-expect-error should not be jsonable
+foo(a14);
+
+// test class with function
+class bar {
+    public baz() {
+    }
+}
+// @ts-expect-error should not be jsonable
+foo(new bar());
+
+// test class with complex property
+interface MapProp{
+    m: Map<string, string>;
+}
+const mt: MapProp = {
+    m: new Map(),
+};
+// @ts-expect-error should not be jsonable
+foo(mt);
+
+// test nested interface with complex property
+interface NestedMapProp{
+    n: MapProp;
+}
+const nmt: NestedMapProp = {
+    n: mt,
+};
+// @ts-expect-error should not be jsonable
+foo(nmt);
+
+// test class with symbol indexer for property
+const sym = Symbol.for("test");
+interface ISymbol{
+    [sym]: string;
+}
+const isym: ISymbol = {
+    [sym]: "foo",
+};
+// @ts-expect-error should not be jsonable
+foo(isym);

--- a/packages/dds/shared-summary-block/src/interfaces.ts
+++ b/packages/dds/shared-summary-block/src/interfaces.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Jsonable } from "@fluidframework/datastore-definitions";
+import { Jsonable } from "@fluidframework/core-interfaces";
 import { ISharedObject } from "@fluidframework/shared-object-base";
 
 /**

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
  */
 
+import { Jsonable } from "@fluidframework/core-interfaces";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import {
     IChannelAttributes,
     IFluidDataStoreRuntime,
     IChannelStorageService,
-    Jsonable,
     IChannelFactory,
 } from "@fluidframework/datastore-definitions";
 import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";

--- a/packages/dds/tree/src/domains/json/jsonCursor.ts
+++ b/packages/dds/tree/src/domains/json/jsonCursor.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { Jsonable } from "@fluidframework/datastore-definitions";
+import { Jsonable } from "@fluidframework/core-interfaces";
 import {
     LocalFieldKey,
     ITreeCursor,

--- a/packages/dds/tree/src/test/domains/json/benchmarks.ts
+++ b/packages/dds/tree/src/test/domains/json/benchmarks.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Jsonable } from "@fluidframework/datastore-definitions";
+import { Jsonable } from "@fluidframework/core-interfaces";
 import { forEachNode, forEachField, ITreeCursor } from "../../../tree";
 
 export function sum(cursor: ITreeCursor): number {

--- a/packages/dds/tree/src/test/domains/json/jsDirectObject.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsDirectObject.bench.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { benchmark, BenchmarkType, isInPerformanceTestingMode } from "@fluid-tools/benchmark";
-import { Jsonable } from "@fluidframework/datastore-definitions";
+import { Jsonable } from "@fluidframework/core-interfaces";
 import { averageTwoValues, sumDirect } from "./benchmarks";
 import { generateTwitterJsonByByteSize, TwitterJson } from "./twitter";
 import { Canada, generateCanada } from "./canada";

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { benchmark, BenchmarkType, isInPerformanceTestingMode } from "@fluid-tools/benchmark";
-import { Jsonable } from "@fluidframework/datastore-definitions";
+import { Jsonable } from "@fluidframework/core-interfaces";
 import {
     ITreeCursor,
     singleJsonCursor,

--- a/packages/dds/tree/src/test/sequence-change-family/sequenceChangeRebaser.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/sequence-change-family/sequenceChangeRebaser.fuzz.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { Jsonable } from "@fluidframework/datastore-definitions";
+import { Jsonable } from "@fluidframework/core-interfaces";
 import { makeRandom } from "@fluid-internal/stochastic-test-utils";
 
 import {


### PR DESCRIPTION
Rationale: Jsonable type has generic utility outside of datastores.  'core-interfaces' exists at the right layer (zero-dependencies) and is already included by almost all current users.  (I think there was one exception.)