### PR TITLE
Validate we never have empty clientId in quorum

### DIFF
--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -92,6 +92,7 @@ export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> imple
      * Adds a new client to the quorum
      */
     public addMember(clientId: string, details: ISequencedClient) {
+        assert(!!clientId, "clientId has to be non-empty string");
         assert(!this.members.has(clientId), 0x1ce /* clientId not found */);
         this.members.set(clientId, details);
         this.emit("addMember", clientId, details);
@@ -104,6 +105,7 @@ export class QuorumClients extends TypedEventEmitter<IQuorumClientsEvents> imple
      * Removes a client from the quorum
      */
     public removeMember(clientId: string) {
+        assert(!!clientId, "clientId has to be non-empty string");
         assert(this.members.has(clientId), 0x1cf /* clientId not found */);
         this.members.delete(clientId);
         this.emit("removeMember", clientId);


### PR DESCRIPTION
Based on feedback on Teams that we do have cases where clientId == undefined.
Run it by Gary and sounds like that should never happen and that's a bug somewhere if that happens.
I'm almost certain that actually never happens but want time (and these asserts) prove to us.