### PR TITLE
Ensure error is not undefined when raising "disconnected" event

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -18,6 +18,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import type { Socket, io as SocketIOClientStatic } from "socket.io-client";
 import { v4 as uuid } from "uuid";
+import { createGenericNetworkError } from "@fluidframework/driver-utils";
 import { IOdspSocketError, IGetOpsResponse, IFlushOpsResponse } from "./contracts";
 import { EpochTracker } from "./epochTracker";
 import { errorObjectFromSocketError } from "./odspError";
@@ -161,7 +162,12 @@ class SocketReference extends TypedEventEmitter<ISocketEvents> {
         this._socket = undefined;
 
         // Let all connections know they need to go through disconnect flow
-        this.emit("disconnect", error, undefined /* clientId */);
+        this.emit("disconnect",
+            error ?? createGenericNetworkError(
+                "Socket closed without error",
+                { canRetry: true },
+                { driverVersion: pkgVersion }),
+            undefined /* clientId */);
 
         // We should not have any users now, assuming synchronous disconnect flow in response to
         // "disconnect" event


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/microsoft/FluidFramework/pull/12223 which we probably want to patch