### PR TITLE
[bump] eslint-config-fluid: 1.2.0 => 1.3.0 (minor)

### DIFF
--- a/common/build/eslint-config-fluid/package-lock.json
+++ b/common/build/eslint-config-fluid/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@fluidframework/eslint-config-fluid",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Shareable ESLint config for the Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": {


### PR DESCRIPTION
Bumped eslint-config-fluid from 1.2.0 to 1.3.0.


## Description

Bumped eslint-config-fluid from 1.2.0 to 1.3.0 as directed by flub.

## Reviewer Guidance

It seems like it would make more sense to wait until it's time to do the next release of this package to do a version bump like this.
At that point it will be known if that release will contain breaking changes or not.
The downslide to this seems to just be that the version numbers in the source code on main don't reflect the version the features will be released in, but in general that's never possible since the feature might be removed before the next release.

If we merge this now, we have to guess that 1.3.0 will be the next version we want to release, which might end up being wrong.

Our process suggests doing this now, and arbitrarily selecting "minor", so what is what I have done, but this PR can serve as a location to discuss if this is the right approach.
