### PR TITLE
GC: Add option to fail a load request instead of closing the container for GC violations

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -34,6 +34,7 @@ import {
 } from "@fluidframework/runtime-utils";
 import {
     ChildLogger,
+    generateStack,
     loggerToMonitoringContext,
     MonitoringContext,
     PerformanceEvent,
@@ -1446,6 +1447,7 @@ export class GarbageCollector implements IGarbageCollector {
                     ...propsToLog,
                     eventName: `${state}Object_${usageType}`,
                     pkg: packagePath ? { value: packagePath.join("/"), tag: TelemetryDataTag.CodeArtifact } : undefined,
+                    stack: generateStack(),
                 });
             }
 
@@ -1453,7 +1455,7 @@ export class GarbageCollector implements IGarbageCollector {
             // Once Sweep is fully implemented, this will be removed since the objects will be gone
             // and errors will arise elsewhere in the runtime
             if (state === UnreferencedState.SweepReady) {
-                this.sweepReadyUsageHandler.usageDetectedInInteractiveClient({ ...propsToLog, usageType });
+                this.sweepReadyUsageHandler.usageDetectedInInteractiveClient(usageType, propsToLog);
             }
         }
     }

--- a/packages/runtime/container-runtime/src/gcSweepReadyUsageDetection.ts
+++ b/packages/runtime/container-runtime/src/gcSweepReadyUsageDetection.ts
@@ -34,7 +34,7 @@ interface SweepReadyUsageDetectionConfig {
  * Feature gate key to enable closing the container if SweepReady objects are used.
  * Value should contain keywords "interactiveClient" and/or "summarizer" to enable detection in each container type
  */
- const sweepReadyUsageDetectionSetting = {
+const sweepReadyUsageDetectionSetting = {
     read(config: IConfigProvider): SweepReadyUsageDetectionConfig {
         const sweepReadyUsageDetectionKey = "Fluid.GarbageCollection.Dogfood.SweepReadyUsageDetection";
         const value = config.getString(sweepReadyUsageDetectionKey);
@@ -61,7 +61,7 @@ interface SweepReadyUsageDetectionConfig {
  */
 export class SweepReadyUsageError extends LoggingError implements IFluidErrorBase {
     /** This errorType will be in temporary use (until Sweep is fully implemented) so don't add to any errorType type */
-    public errorType: string = "unreferencedObjectUsedAfterGarbageCollected";
+    public errorType: string = "garbageObjectUsedError";
 }
 
 /**
@@ -139,7 +139,7 @@ export class SweepReadyUsageDetectionHandler {
         }
 
         const error = new SweepReadyUsageError(
-            "SweepReady object used in Non-Summarizer Client",
+            "Object used after garbage collected",
             { errorDetails: JSON.stringify({ ...errorProps, config, usageType, lastCloseTime, skipClosureForXDays }) },
         );
         if (shouldClose) {

--- a/packages/runtime/container-runtime/src/gcSweepReadyUsageDetection.ts
+++ b/packages/runtime/container-runtime/src/gcSweepReadyUsageDetection.ts
@@ -26,18 +26,8 @@ export const skipClosureForXDaysKey = "Fluid.GarbageCollection.Dogfood.SweepRead
  */
 export const closuresMapLocalStorageKey = "Fluid.GarbageCollection.Dogfood.SweepReadyUsageDetection.Closures";
 
-// interface SweepReadyUsageAction {
-//     action: "crashOnLoad" | "close";
-//     skipForXDays?: number;
-// }
-// interface SweepReadyUsageDetectionConfig {
-//     interactiveClient?: SweepReadyUsageAction;
-//     summarizer?: SweepReadyUsageAction;
-// }
-
 interface SweepReadyUsageDetectionConfig {
     interactiveClient?: "close" | "crashOnLoadOnly";
-    summarizer?: "close";
 }
 
 /**
@@ -57,7 +47,6 @@ interface SweepReadyUsageDetectionConfig {
                 : value.includes("interactiveClientCrashOnLoad")
                     ? "crashOnLoadOnly"
                     : undefined,
-            summarizer: value.includes("summarizer") ? "close" : undefined,
         };
     },
 };

--- a/packages/runtime/container-runtime/src/gcSweepReadyUsageDetection.ts
+++ b/packages/runtime/container-runtime/src/gcSweepReadyUsageDetection.ts
@@ -18,7 +18,7 @@ import { oneDayMs } from "./garbageCollection";
  * Feature Gate Key -
  * How many days between closing the container from this error (avoids locking user out of their file altogether)
  */
-export const skipClosureForXDaysKey = "Fluid.GarbageCollection.Dogfood.SweepReadyUsageDetection.SkipForXDays";
+export const skipClosureForXDaysKey = "Fluid.GarbageCollection.Dogfood.SweepReadyUsageDetection.SkipClosureForXDays";
 
 /**
  * LocalStorage key (NOT via feature gate / monitoring context)

--- a/packages/runtime/container-runtime/src/gcSweepReadyUsageDetection.ts
+++ b/packages/runtime/container-runtime/src/gcSweepReadyUsageDetection.ts
@@ -4,6 +4,7 @@
  */
 
 import { ITelemetryProperties } from "@fluidframework/common-definitions";
+import { assert } from "@fluidframework/common-utils";
 import { ICriticalContainerError } from "@fluidframework/container-definitions";
 import {
     IConfigProvider,
@@ -17,7 +18,7 @@ import { oneDayMs } from "./garbageCollection";
  * Feature Gate Key -
  * How many days between closing the container from this error (avoids locking user out of their file altogether)
  */
-export const skipClosureForXDaysKey = "Fluid.GarbageCollection.Dogfood.SweepReadyUsageDetection.SkipClosureForXDays";
+export const skipClosureForXDaysKey = "Fluid.GarbageCollection.Dogfood.SweepReadyUsageDetection.SkipForXDays";
 
 /**
  * LocalStorage key (NOT via feature gate / monitoring context)
@@ -25,20 +26,38 @@ export const skipClosureForXDaysKey = "Fluid.GarbageCollection.Dogfood.SweepRead
  */
 export const closuresMapLocalStorageKey = "Fluid.GarbageCollection.Dogfood.SweepReadyUsageDetection.Closures";
 
+// interface SweepReadyUsageAction {
+//     action: "crashOnLoad" | "close";
+//     skipForXDays?: number;
+// }
+// interface SweepReadyUsageDetectionConfig {
+//     interactiveClient?: SweepReadyUsageAction;
+//     summarizer?: SweepReadyUsageAction;
+// }
+
+interface SweepReadyUsageDetectionConfig {
+    interactiveClient?: "close" | "crashOnLoadOnly";
+    summarizer?: "close";
+}
+
 /**
  * Feature gate key to enable closing the container if SweepReady objects are used.
  * Value should contain keywords "interactiveClient" and/or "summarizer" to enable detection in each container type
  */
-const sweepReadyUsageDetectionSetting = {
-    read(config: IConfigProvider) {
+ const sweepReadyUsageDetectionSetting = {
+    read(config: IConfigProvider): SweepReadyUsageDetectionConfig {
         const sweepReadyUsageDetectionKey = "Fluid.GarbageCollection.Dogfood.SweepReadyUsageDetection";
         const value = config.getString(sweepReadyUsageDetectionKey);
         if (value === undefined) {
-            return { interactiveClient: false, summarizer: false };
+            return { };
         }
         return {
-            interactiveClient: value.includes("interactiveClient"),
-            summarizer: value.includes("summarizer"),
+            interactiveClient: value.includes("interactiveClientClose")
+                ? "close"
+                : value.includes("interactiveClientCrashOnLoad")
+                    ? "crashOnLoadOnly"
+                    : undefined,
+            summarizer: value.includes("summarizer") ? "close" : undefined,
         };
     },
 };
@@ -90,8 +109,18 @@ export class SweepReadyUsageDetectionHandler {
       * Once Sweep is fully implemented, this will be removed since the objects will be gone
       * and errors will arise elsewhere in the runtime
      */
-    public usageDetectedInInteractiveClient(errorProps: ITelemetryProperties) {
-        if (!sweepReadyUsageDetectionSetting.read(this.mc.config).interactiveClient) {
+    public usageDetectedInInteractiveClient(
+        usageType: "Changed" | "Loaded" | "Revived",
+        errorProps: ITelemetryProperties,
+    ) {
+        const config = sweepReadyUsageDetectionSetting.read(this.mc.config).interactiveClient;
+        if (config === undefined) {
+            return;
+        }
+
+        if (config === "crashOnLoadOnly" && usageType !== "Loaded") {
+            // If we're only wanting to detect on Load, then silently leave.
+            // The Changed/Revived events will be logged by the Summarizer anyway.
             return;
         }
 
@@ -122,7 +151,7 @@ export class SweepReadyUsageDetectionHandler {
 
         const error = new SweepReadyUsageError(
             "SweepReady object used in Non-Summarizer Client",
-            { errorDetails: JSON.stringify({ ...errorProps, lastCloseTime, skipClosureForXDays }) },
+            { errorDetails: JSON.stringify({ ...errorProps, config, usageType, lastCloseTime, skipClosureForXDays }) },
         );
         if (shouldClose) {
             // Update closures map in localStorage before closing
@@ -131,7 +160,15 @@ export class SweepReadyUsageDetectionHandler {
             pastClosuresMap[this.uniqueContainerKey] = { lastCloseTime: Date.now() };
             this.localStorage.setItem(closuresMapLocalStorageKey, JSON.stringify(pastClosuresMap));
 
-            this.closeFn(error);
+            if (config === "close") {
+                this.closeFn(error);
+            } else {
+                assert(config === "crashOnLoadOnly" && usageType === "Loaded", "unexpected config");
+                this.mc.logger.sendErrorEvent({ eventName: "SweepReadyObject_FailToLoad" }, error);
+
+                // This will result in a non-200 response on the request for the object but the session will continue
+                throw error;
+            }
         } else {
             this.mc.logger.sendErrorEvent({ eventName: "SweepReadyObject_UsageAllowed" }, error);
         }

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -999,7 +999,7 @@ describe("Garbage Collection Tests", () => {
                 assert(!mockLogger.events.some((event) => event.eventName !== loadedEventName && event.unrefTime === unrefTime), "shouldn't see any unreference events besides Loaded");
                 mockLogger.assertMatch([{ eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg, unrefTime }], "all events not generated as expected");
 
-                const expectedErrorType = sweepReadyUsageErrorExpected ? "unreferencedObjectUsedAfterGarbageCollected" : "N/A";
+                const expectedErrorType = sweepReadyUsageErrorExpected ? "garbageObjectUsedError" : "N/A";
                 assert.equal(lastCloseErrorType, expectedErrorType, "Incorrect lastCloseReason after using unreferenced nodes");
             }
 

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -1021,7 +1021,7 @@ describe("Garbage Collection Tests", () => {
 
             it("SweepReady object used - generates events and closes container (SweepReadyUsageDetection enabled)", async () => {
                 const sweepTimeoutMs = defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
-                injectedSettings[SweepReadyUsageDetectionKey] = "interactiveClient";
+                injectedSettings[SweepReadyUsageDetectionKey] = "interactiveClientClose";
 
                 await interactiveClientTestCode(
                     sweepTimeoutMs,

--- a/packages/runtime/container-runtime/src/test/gcSweepReadyUsageDetection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gcSweepReadyUsageDetection.spec.ts
@@ -76,13 +76,13 @@ describe("Garbage Collection Tests", () => {
             });
             it("setting does not contain 'interactiveClient' - do not close the container", () => {
                 mockLocalStorage[sweepReadyUsageDetectionKey] = "summarizer or whatever";
-                createHandler().usageDetectedInInteractiveClient({});
+                createHandler().usageDetectedInInteractiveClient("Changed", {});
                 assert.equal(closeErrors.length, 0, "Shouldn't close if setting doesn't include 'interactiveClient'");
             });
             it("NoopStorage - close the container back-to-back", () => {
                 const handler = createHandler("key1", true /* forceNoopStorage */);
-                handler.usageDetectedInInteractiveClient({});
-                handler.usageDetectedInInteractiveClient({});
+                handler.usageDetectedInInteractiveClient("Changed", {});
+                handler.usageDetectedInInteractiveClient("Changed", {});
                 assert.equal(closeErrors.length, 2, `Should have closed back-to-back with noopStorage defined. errors:\n${closeErrors}`);
                 assert(closeErrors.every((e) => e.errorType === sweepReadyUsageErrorType), `Expected all SweepReadyUsageErrors. errors:\n${closeErrors}`);
                 mockLogger.assertMatch([{ eventName: "SweepReadyUsageDetectionHandlerNoopStorage" }]);
@@ -90,8 +90,8 @@ describe("Garbage Collection Tests", () => {
             it("SkipClosure Period undefined - close the container back-to-back", () => {
                 mockLocalStorage[skipClosureForXDaysKey] = undefined;
                 const handler = createHandler();
-                handler.usageDetectedInInteractiveClient({});
-                handler.usageDetectedInInteractiveClient({});
+                handler.usageDetectedInInteractiveClient("Changed", {});
+                handler.usageDetectedInInteractiveClient("Changed", {});
                 assert.equal(closeErrors.length, 2, `Should have closed back-to-back with no Skip Closure Period defined. errors:\n${closeErrors}`);
                 assert(closeErrors.every((e) => e.errorType === sweepReadyUsageErrorType), `Expected all SweepReadyUsageErrors. errors:\n${closeErrors}`);
             });
@@ -99,17 +99,17 @@ describe("Garbage Collection Tests", () => {
                 const handler = createHandler();
 
                 clock.tick(10);
-                handler.usageDetectedInInteractiveClient({});
+                handler.usageDetectedInInteractiveClient("Changed", {});
                 assert.deepEqual(JSON.parse(mockLocalStorage[closuresMapLocalStorageKey] as string), { key1: { lastCloseTime: 10 } });
                 assert.equal(closeErrors.length, 1, `Expected to close the first time`);
                 assert.equal(closeErrors[0]?.errorType ?? "", sweepReadyUsageErrorType, "Expected sweepReadyUsageErrorType the first time");
 
                 clock.tick(10);
-                handler.usageDetectedInInteractiveClient({});
+                handler.usageDetectedInInteractiveClient("Changed", {});
                 assert.equal(closeErrors.length, 1, `Should NOT have closed back-to-back due to Skip Closure Period. errors:\n${closeErrors}`);
 
                 clock.tick(oneDayMs);
-                handler.usageDetectedInInteractiveClient({});
+                handler.usageDetectedInInteractiveClient("Changed", {});
                 assert.equal(closeErrors.length, 2, `Expected to close again after waiting 1 day`);
                 assert.equal(closeErrors[1]?.errorType ?? "", sweepReadyUsageErrorType, "Expected sweepReadyUsageErrorType the second time");
             });
@@ -119,23 +119,23 @@ describe("Garbage Collection Tests", () => {
                 const handler2 = createHandler("key2");
 
                 clock.tick(10);
-                handler1a.usageDetectedInInteractiveClient({});
+                handler1a.usageDetectedInInteractiveClient("Changed", {});
                 assert.deepEqual(JSON.parse(mockLocalStorage[closuresMapLocalStorageKey] as string), { key1: { lastCloseTime: 10 } });
                 assert.equal(closeErrors.length, 1, `Expected to close the first time`);
                 assert.equal(closeErrors[0]?.errorType ?? "", sweepReadyUsageErrorType, "Expected sweepReadyUsageErrorType the first time");
 
                 // The other handler on key1 should be blocked
                 clock.tick(10);
-                handler1b.usageDetectedInInteractiveClient({});
+                handler1b.usageDetectedInInteractiveClient("Changed", {});
                 assert.equal(closeErrors.length, 1, `Should NOT have closed back-to-back due to Skip Closure Period. errors:\n${closeErrors}`);
 
                 // But the handler on key2 should NOT be blocked
-                handler2.usageDetectedInInteractiveClient({});
+                handler2.usageDetectedInInteractiveClient("Changed", {});
                 assert.equal(closeErrors.length, 2, `Should have closed other container for the first time. errors:\n${closeErrors}`);
 
                 clock.tick(oneDayMs + 10);
-                handler1b.usageDetectedInInteractiveClient({});
-                handler2.usageDetectedInInteractiveClient({});
+                handler1b.usageDetectedInInteractiveClient("Changed", {});
+                handler2.usageDetectedInInteractiveClient("Changed", {});
                 assert.equal(closeErrors.length, 4, `Expected both to close again after waiting 1 day`);
                 assert(closeErrors.every((e) => e.errorType === sweepReadyUsageErrorType), `Expected all SweepReadyUsageErrors. errors:\n${closeErrors}`);
             });
@@ -144,17 +144,17 @@ describe("Garbage Collection Tests", () => {
                 mockLocalStorage[closuresMapLocalStorageKey] = "} Invalid JSON";
 
                 clock.tick(10);
-                handler.usageDetectedInInteractiveClient({});
+                handler.usageDetectedInInteractiveClient("Changed", {});
                 assert.deepEqual(JSON.parse(mockLocalStorage[closuresMapLocalStorageKey] as string), { key1: { lastCloseTime: 10 } });
                 assert.equal(closeErrors.length, 1, `Expected to close the first time`);
                 assert.equal(closeErrors[0]?.errorType ?? "", sweepReadyUsageErrorType, "Expected sweepReadyUsageErrorType the first time");
 
                 clock.tick(10);
-                handler.usageDetectedInInteractiveClient({});
+                handler.usageDetectedInInteractiveClient("Changed", {});
                 assert.equal(closeErrors.length, 1, `Should NOT have closed back-to-back due to Skip Closure Period. errors:\n${closeErrors}`);
 
                 clock.tick(oneDayMs);
-                handler.usageDetectedInInteractiveClient({});
+                handler.usageDetectedInInteractiveClient("Changed", {});
                 assert.equal(closeErrors.length, 2, `Expected to close again after waiting 1 day`);
                 assert.equal(closeErrors[1]?.errorType ?? "", sweepReadyUsageErrorType, "Expected sweepReadyUsageErrorType the second time");
             });
@@ -163,17 +163,17 @@ describe("Garbage Collection Tests", () => {
                 mockLocalStorage[closuresMapLocalStorageKey] = JSON.stringify("Not an object");
 
                 clock.tick(10);
-                handler.usageDetectedInInteractiveClient({});
+                handler.usageDetectedInInteractiveClient("Changed", {});
                 assert.deepEqual(JSON.parse(mockLocalStorage[closuresMapLocalStorageKey] as string), { key1: { lastCloseTime: 10 } });
                 assert.equal(closeErrors.length, 1, `Expected to close the first time`);
                 assert.equal(closeErrors[0]?.errorType ?? "", sweepReadyUsageErrorType, "Expected sweepReadyUsageErrorType the first time");
 
                 clock.tick(10);
-                handler.usageDetectedInInteractiveClient({});
+                handler.usageDetectedInInteractiveClient("Changed", {});
                 assert.equal(closeErrors.length, 1, `Should NOT have closed back-to-back due to Skip Closure Period. errors:\n${closeErrors}`);
 
                 clock.tick(oneDayMs);
-                handler.usageDetectedInInteractiveClient({});
+                handler.usageDetectedInInteractiveClient("Changed", {});
                 assert.equal(closeErrors.length, 2, `Expected to close again after waiting 1 day`);
                 assert.equal(closeErrors[1]?.errorType ?? "", sweepReadyUsageErrorType, "Expected sweepReadyUsageErrorType the second time");
             });
@@ -182,17 +182,17 @@ describe("Garbage Collection Tests", () => {
                 mockLocalStorage[closuresMapLocalStorageKey] = JSON.stringify({ key1: { wrongSchema: "no lastCloseTime member" } });
 
                 clock.tick(10);
-                handler.usageDetectedInInteractiveClient({});
+                handler.usageDetectedInInteractiveClient("Changed", {});
                 assert.deepEqual(JSON.parse(mockLocalStorage[closuresMapLocalStorageKey] as string), { key1: { lastCloseTime: 10 } });
                 assert.equal(closeErrors.length, 1, `Expected to close the first time`);
                 assert.equal(closeErrors[0]?.errorType ?? "", sweepReadyUsageErrorType, "Expected sweepReadyUsageErrorType the first time");
 
                 clock.tick(10);
-                handler.usageDetectedInInteractiveClient({});
+                handler.usageDetectedInInteractiveClient("Changed", {});
                 assert.equal(closeErrors.length, 1, `Should NOT have closed back-to-back due to Skip Closure Period. errors:\n${closeErrors}`);
 
                 clock.tick(oneDayMs);
-                handler.usageDetectedInInteractiveClient({});
+                handler.usageDetectedInInteractiveClient("Changed", {});
                 assert.equal(closeErrors.length, 2, `Expected to close again after waiting 1 day`);
                 assert.equal(closeErrors[1]?.errorType ?? "", sweepReadyUsageErrorType, "Expected sweepReadyUsageErrorType the second time");
             });

--- a/packages/runtime/container-runtime/src/test/gcSweepReadyUsageDetection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gcSweepReadyUsageDetection.spec.ts
@@ -21,7 +21,7 @@ describe("Garbage Collection Tests", () => {
 
     describe("SweepReady Usage Detection", () => {
         const sweepReadyUsageDetectionKey = "Fluid.GarbageCollection.Dogfood.SweepReadyUsageDetection";
-        const sweepReadyUsageErrorType = "unreferencedObjectUsedAfterGarbageCollected";
+        const sweepReadyUsageErrorType = "garbageObjectUsedError";
 
         let mockLogger: MockLogger = new MockLogger();
         let closeErrors: (ICriticalContainerError)[] = [];
@@ -208,7 +208,7 @@ describe("Garbage Collection Tests", () => {
                 it("setting contains 'interactiveClientCrashOnLoad' - throws with Loaded usage just once (due to skip)", () => {
                     assert.throws(
                         () => createHandler().usageDetectedInInteractiveClient("Loaded", {}),
-                        (e) => e.errorType === "unreferencedObjectUsedAfterGarbageCollected",
+                        (e) => e.errorType === "garbageObjectUsedError",
                         "Expected the proper error to be thrown");
                     mockLogger.assertMatch([{ eventName: "SweepReadyObject_FailToLoad" }], "expected error log");
                     assert.equal(closeErrors.length, 0, "Shouldn't close the whole container when failing load");

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -15,7 +15,7 @@ import {
     IFluidDataStoreRegistry,
     IProvideFluidDataStoreRegistry,
 } from "@fluidframework/runtime-definitions";
-import { generateErrorWithStack } from "@fluidframework/telemetry-utils";
+import { extractLogSafeErrorProperties, generateErrorWithStack } from "@fluidframework/telemetry-utils";
 
 interface IResponseException extends Error {
     errorFromRequestFluidObject: true;
@@ -39,11 +39,12 @@ export function exceptionToResponse(err: any): IResponse {
     // Capture error objects, not stack itself, as stack retrieval is very expensive operation, so we delay it
     const errWithStack = generateErrorWithStack();
 
+    const { message, stack } = extractLogSafeErrorProperties(err, false);
     return {
         mimeType: "text/plain",
         status,
-        value: `${err}`,
-        get stack() { return ((err?.stack) as (string | undefined)) ?? errWithStack.stack; },
+        value: message,
+        get stack() { return stack ?? errWithStack.stack; },
     };
 }
 

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -39,11 +39,12 @@ export function exceptionToResponse(err: any): IResponse {
     // Capture error objects, not stack itself, as stack retrieval is very expensive operation, so we delay it
     const errWithStack = generateErrorWithStack();
 
-    const { message, stack } = extractLogSafeErrorProperties(err, false);
+    const { message, errorType, stack } = extractLogSafeErrorProperties(err, false);
+    const errorTypePrefix = errorType === undefined ? "" : `[${errorType}] `;
     return {
         mimeType: "text/plain",
         status,
-        value: message,
+        value: `${errorTypePrefix}${message}`,
         get stack() { return stack ?? errWithStack.stack; },
     };
 }


### PR DESCRIPTION
## Description

The SweepReadyUsageDetection code as-is only can close the container.  When we shared this with some Msft internal partners, they expressed a preference for having the datastore request fail but let the session persist.

This change gives a way to throw the error instead which will get caught by the datastore's request routing code and turned into a 500 response.  So the session will be fine but the component will not load.

