### PR TITLE
Implement @fluid-internal/attributor

### DIFF
--- a/api-report/attributor.api.md
+++ b/api-report/attributor.api.md
@@ -4,8 +4,119 @@
 
 ```ts
 
+import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
+import { IUser } from '@fluidframework/protocol-definitions';
+import { Jsonable } from '@fluidframework/datastore-definitions';
+
+// @public
+export interface AttributionInfo {
+    timestamp: number;
+    user: IUser;
+}
+
+// @public
+export class Attributor implements IAttributor {
+    constructor(initialEntries?: Iterable<[number, AttributionInfo]>);
+    // (undocumented)
+    entries(): IterableIterator<[number, AttributionInfo]>;
+    getAttributionInfo(key: number): AttributionInfo;
+    // (undocumented)
+    protected readonly keyToInfo: Map<number, AttributionInfo>;
+    // (undocumented)
+    tryGetAttributionInfo(key: number): AttributionInfo | undefined;
+}
+
 // @public (undocumented)
-export const TODO: undefined;
+export class AttributorSerializer implements IAttributorSerializer {
+    constructor(makeAttributor: (entries: Iterable<[number, AttributionInfo]>) => IAttributor, timestampEncoder: TimestampEncoder);
+    // Warning: (ae-incompatible-release-tags) The symbol "decode" is marked as @public, but its signature references "SerializedAttributor" which is marked as @internal
+    //
+    // (undocumented)
+    decode(encoded: SerializedAttributor): IAttributor;
+    // Warning: (ae-incompatible-release-tags) The symbol "encode" is marked as @public, but its signature references "SerializedAttributor" which is marked as @internal
+    //
+    // (undocumented)
+    encode(attributor: IAttributor): SerializedAttributor;
+}
+
+// @public (undocumented)
+export const chain: <T1, T2, T3>(a: Encoder<T1, T2>, b: Encoder<T2, T3>) => Encoder<T1, T3>;
+
+// @public (undocumented)
+export const deltaEncoder: TimestampEncoder;
+
+// @public (undocumented)
+export interface Encoder<TDecoded, TEncoded> {
+    // (undocumented)
+    decode(encoded: TEncoded): TDecoded;
+    // (undocumented)
+    encode(decoded: TDecoded): TEncoded;
+}
+
+// @public
+export interface IAttributor {
+    // (undocumented)
+    entries(): IterableIterator<[number, AttributionInfo]>;
+    getAttributionInfo(key: number): AttributionInfo;
+    // (undocumented)
+    tryGetAttributionInfo(key: number): AttributionInfo | undefined;
+}
+
+// Warning: (ae-incompatible-release-tags) The symbol "IAttributorSerializer" is marked as @public, but its signature references "SerializedAttributor" which is marked as @internal
+//
+// @public (undocumented)
+export type IAttributorSerializer = Encoder<IAttributor, SerializedAttributor>;
+
+// @public
+export type InternedStringId = number & {
+    readonly InternedStringId: "e221abc9-9d17-4493-8db0-70c871a1c27c";
+};
+
+// @public (undocumented)
+export function makeGzipEncoder<T>(): Encoder<Jsonable<T>, string>;
+
+// @public
+export class MutableStringInterner implements StringInterner {
+    constructor(inputStrings?: readonly string[]);
+    // (undocumented)
+    getInternedId(input: string): InternedStringId | undefined;
+    // (undocumented)
+    getOrCreateInternedId(input: string): InternedStringId;
+    // (undocumented)
+    getSerializable(): readonly string[];
+    // (undocumented)
+    getString(internId: number): string;
+}
+
+// @public
+export class OpStreamAttributor extends Attributor implements IAttributor {
+    constructor(runtime: IFluidDataStoreRuntime, initialEntries?: Iterable<[number, AttributionInfo]>);
+}
+
+// @internal (undocumented)
+export interface SerializedAttributor {
+    // (undocumented)
+    attributionRefs: InternedStringId[];
+    // (undocumented)
+    interner: readonly string[];
+    // (undocumented)
+    keys: number[];
+    // (undocumented)
+    timestamps: number[];
+}
+
+// @public
+export interface StringInterner {
+    // (undocumented)
+    getInternedId(input: string): InternedStringId | undefined;
+    // (undocumented)
+    getSerializable(): readonly string[];
+    // (undocumented)
+    getString(internedId: number): string;
+}
+
+// @public (undocumented)
+export type TimestampEncoder = Encoder<number[], number[]>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/framework/attributor/.eslintrc.js
+++ b/packages/framework/attributor/.eslintrc.js
@@ -10,4 +10,15 @@ module.exports = {
     "parserOptions": {
         "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
     },
+    overrides: [{
+        // Rules only for test files
+        files: ["*.spec.ts", "src/test/**"],
+        rules: {
+            "import/no-nodejs-modules": [
+                "error",
+                { allow: ["assert"] },
+            ],
+        },
+    }],
+
 }

--- a/packages/framework/attributor/src/attributor.ts
+++ b/packages/framework/attributor/src/attributor.ts
@@ -7,31 +7,64 @@ import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { ISequencedDocumentMessage, IUser } from "@fluidframework/protocol-definitions";
 import { UsageError } from "@fluidframework/container-utils";
 
+/**
+ * Attribution information associated with a change.
+ */
 export interface AttributionInfo {
+	/**
+	 * The user that performed the change.
+	 */
 	user: IUser;
+	/**
+	 * When the change happened.
+	 */
 	timestamp: number;
 }
 
+/**
+ * Provides lookup between attribution keys and their associated attribution information.
+ */
 export interface IAttributor {
+	/**
+	 * Retrieves attribution information associated with a particular key.
+	 * @param key - Attribution key to look up.
+	 * @throws If no attribution information is recorded for that key.
+	 */
 	getAttributionInfo(key: number): AttributionInfo;
 
+	/**
+	 * @param key - Attribution key to look up.
+	 * @returns the attribution information associated with the provided key, or undefined if no information exists.
+	 */
 	tryGetAttributionInfo(key: number): AttributionInfo | undefined;
 
+	/**
+	 * @returns an iterable of (attribution key, attribution info) pairs for each stored key.
+	 */
 	entries(): IterableIterator<[number, AttributionInfo]>;
 
 	// TODO:
 	// - GC
 }
 
+/**
+ * {@inheritdoc IAttributor}
+ */
 export class Attributor implements IAttributor {
 	protected readonly keyToInfo: Map<number, AttributionInfo>;
 
+	/**
+	 * @param initialEntries - Any entries which should be populated on instantiation.
+	 */
 	constructor(
 		initialEntries?: Iterable<[number, AttributionInfo]>,
 	) {
 		this.keyToInfo = new Map(initialEntries ?? []);
 	}
 
+	/**
+	 * {@inheritdoc IAttributor.getAttributionInfo}
+	 */
 	public getAttributionInfo(key: number): AttributionInfo {
 		const result = this.tryGetAttributionInfo(key);
 		if (!result) {
@@ -40,15 +73,25 @@ export class Attributor implements IAttributor {
 		return result;
 	}
 
+	/**
+	 * {@inheritdoc IAttributor.tryGetAttributionInfo}
+	 */
 	public tryGetAttributionInfo(key: number): AttributionInfo | undefined {
 		return this.keyToInfo.get(key);
 	}
 
+	/**
+	 * {@inheritdoc IAttributor.entries}
+	 */
 	public entries(): IterableIterator<[number, AttributionInfo]> {
 		return this.keyToInfo.entries();
 	}
 }
 
+/**
+ * Attributor which listens to an op stream and records entries for each op.
+ * Sequence numbers are used as attribution keys.
+ */
 export class OpStreamAttributor extends Attributor implements IAttributor {
 	constructor(
 		runtime: IFluidDataStoreRuntime,

--- a/packages/framework/attributor/src/attributor.ts
+++ b/packages/framework/attributor/src/attributor.ts
@@ -1,0 +1,66 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { assert } from "@fluidframework/common-utils";
+import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
+import { ISequencedDocumentMessage, IUser } from "@fluidframework/protocol-definitions";
+import { UsageError } from "@fluidframework/container-utils";
+
+export interface AttributionInfo {
+	user: IUser;
+	timestamp: number;
+}
+
+export interface IAttributor {
+	getAttributionInfo(key: number): AttributionInfo;
+
+	tryGetAttributionInfo(key: number): AttributionInfo | undefined;
+
+	entries(): IterableIterator<[number, AttributionInfo]>;
+
+	// TODO:
+	// - GC
+}
+
+export class Attributor implements IAttributor {
+	protected readonly keyToInfo: Map<number, AttributionInfo>;
+
+	constructor(
+		initialEntries?: Iterable<[number, AttributionInfo]>,
+	) {
+		this.keyToInfo = new Map(initialEntries ?? []);
+	}
+
+	public getAttributionInfo(key: number): AttributionInfo {
+		const result = this.tryGetAttributionInfo(key);
+		if (!result) {
+			throw new UsageError(`Requested attribution information for unstored key: ${key}.`);
+		}
+		return result;
+	}
+
+	public tryGetAttributionInfo(key: number): AttributionInfo | undefined {
+		return this.keyToInfo.get(key);
+	}
+
+	public entries(): IterableIterator<[number, AttributionInfo]> {
+		return this.keyToInfo.entries();
+	}
+}
+
+export class OpStreamAttributor extends Attributor implements IAttributor {
+	constructor(
+		runtime: IFluidDataStoreRuntime,
+		initialEntries?: Iterable<[number, AttributionInfo]>,
+	) {
+		super(initialEntries);
+		const { deltaManager } = runtime;
+		deltaManager.on("op", (message: ISequencedDocumentMessage) => {
+			const client = runtime.getAudience().getMember(message.clientId);
+			// TODO: This case may be legitimate, and if so we need to figure out how to handle it.
+			assert(client !== undefined, "Received message from user not in the audience");
+			this.keyToInfo.set(message.sequenceNumber, { user: client.user, timestamp: message.timestamp });
+		});
+	}
+}

--- a/packages/framework/attributor/src/encoders.ts
+++ b/packages/framework/attributor/src/encoders.ts
@@ -98,6 +98,9 @@ export class AttributorSerializer implements IAttributorSerializer {
 	}
 }
 
+/**
+ * @returns an encoder which composes `a` and `b`.
+ */
 export const chain = <T1, T2, T3>(a: Encoder<T1, T2>, b: Encoder<T2, T3>): Encoder<T1, T3> => ({
 	encode: (content) => b.encode(a.encode(content)),
 	decode: (content) => a.decode(b.decode(content))

--- a/packages/framework/attributor/src/encoders.ts
+++ b/packages/framework/attributor/src/encoders.ts
@@ -1,0 +1,104 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { assert } from "@fluidframework/common-utils";
+import { Jsonable } from "@fluidframework/datastore-definitions";
+import { IUser } from "@fluidframework/protocol-definitions";
+import { IAttributor, AttributionInfo } from "./attributor";
+import { InternedStringId, MutableStringInterner } from "./stringInterner";
+
+export interface Encoder<TDecoded, TEncoded> {
+	encode(decoded: TDecoded): TEncoded;
+
+	decode(encoded: TEncoded): TDecoded;
+}
+
+// Note: the encoded format doesn't matter as long as it's serializable;
+// these types could be weakened.
+export type TimestampEncoder = Encoder<number[], number[]>;
+
+export const deltaEncoder: TimestampEncoder = {
+	encode: (timestamps: number[]) => {
+		const deltaTimestamps: number[] = new Array(timestamps.length);
+		let prev = 0;
+		for (let i = 0; i < timestamps.length; i++) {
+			deltaTimestamps[i] = timestamps[i] - prev;
+			prev = timestamps[i];
+		}
+		return deltaTimestamps;
+	},
+	decode: (encoded: Jsonable) => {
+		assert(Array.isArray(encoded), "Encoded timestamps should be an array of nummbers");
+		const timestamps: number[] = new Array(encoded.length);
+		let cumulativeSum = 0;
+		for (let i = 0; i < encoded.length; i++) {
+			cumulativeSum += encoded[i];
+			timestamps[i] = cumulativeSum;
+		}
+		return timestamps;
+	},
+};
+
+export type IAttributorSerializer = Encoder<IAttributor, SerializedAttributor>;
+
+/**
+ * @internal
+ */
+export interface SerializedAttributor {
+	interner: readonly string[]; /* result of calling getSerializable() on a StringInterner */
+	keys: number[];
+	timestamps: number[];
+	attributionRefs: InternedStringId[];
+}
+
+export class AttributorSerializer implements IAttributorSerializer {
+	constructor(
+		private readonly makeAttributor: (entries: Iterable<[number, AttributionInfo]>) => IAttributor,
+		private readonly timestampEncoder: TimestampEncoder,
+	) { }
+
+	public encode(attributor: IAttributor): SerializedAttributor {
+		const interner = new MutableStringInterner();
+		const keys: number[] = [];
+		const timestamps: number[] = [];
+		const attributionRefs: InternedStringId[] = [];
+		for (const [key, { user, timestamp }] of attributor.entries()) {
+			keys.push(key);
+			timestamps.push(timestamp);
+			const ref = interner.getOrCreateInternedId(JSON.stringify(user));
+			attributionRefs.push(ref);
+		}
+
+		const serialized: SerializedAttributor = {
+			interner: interner.getSerializable(),
+			keys,
+			timestamps: this.timestampEncoder.encode(timestamps),
+			attributionRefs,
+		};
+
+		return serialized;
+	}
+
+	public decode(encoded: SerializedAttributor): IAttributor {
+		const interner = new MutableStringInterner(encoded.interner);
+		const { keys, timestamps: encodedTimestamps, attributionRefs } = encoded;
+		const timestamps = this.timestampEncoder.decode(encodedTimestamps);
+		assert(keys.length === timestamps.length && timestamps.length === attributionRefs.length,
+			"serialized attribution columns should have the same length");
+		const entries = new Array(keys.length);
+		for (let i = 0; i < keys.length; i++) {
+			const key = keys[i];
+			const timestamp = timestamps[i];
+			const ref = attributionRefs[i];
+			const user: IUser = JSON.parse(interner.getString(ref));
+			entries[i] = [key, { user, timestamp }];
+		}
+		return this.makeAttributor(entries);
+	}
+}
+
+export const chain = <T1, T2, T3>(a: Encoder<T1, T2>, b: Encoder<T2, T3>): Encoder<T1, T3> => ({
+	encode: (content) => b.encode(a.encode(content)),
+	decode: (content) => a.decode(b.decode(content))
+});

--- a/packages/framework/attributor/src/gzipEncoder.ts
+++ b/packages/framework/attributor/src/gzipEncoder.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { gzip, ungzip } from "pako";
+import { bufferToString, stringToBuffer } from "@fluidframework/common-utils";
+import { Jsonable } from "@fluidframework/datastore-definitions";
+import { Encoder } from "./encoders";
+
+export function makeGzipEncoder<T>(): Encoder<Jsonable<T>, string> {
+	return {
+		encode: (decoded: Jsonable<T>) => {
+			const unzipped = new TextEncoder().encode(JSON.stringify(decoded));
+			const zipped = gzip(unzipped);
+			return bufferToString(zipped, "base64");
+		},
+		decode: (serializedSummary: string): Jsonable<T> => {
+			const zipped = new Uint8Array(stringToBuffer(serializedSummary, "base64"));
+			const unzipped = ungzip(zipped);
+			const decoded: Jsonable<T> = JSON.parse(new TextDecoder().decode(unzipped));
+			return decoded;
+		},
+	};
+}

--- a/packages/framework/attributor/src/index.ts
+++ b/packages/framework/attributor/src/index.ts
@@ -2,5 +2,26 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-
-export const TODO: undefined = undefined;
+export {
+	Attributor,
+	AttributionInfo,
+	OpStreamAttributor,
+	IAttributor,
+} from "./attributor";
+export {
+	AttributorSerializer,
+	chain,
+	deltaEncoder,
+	Encoder,
+	IAttributorSerializer,
+	SerializedAttributor,
+	TimestampEncoder,
+} from "./encoders";
+export {
+	makeGzipEncoder,
+} from "./gzipEncoder";
+export {
+	InternedStringId,
+	MutableStringInterner,
+	StringInterner,
+} from "./stringInterner";

--- a/packages/framework/attributor/src/stringInterner.ts
+++ b/packages/framework/attributor/src/stringInterner.ts
@@ -1,0 +1,84 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { UsageError } from "@fluidframework/container-utils";
+
+/**
+ * The ID of the string that has been interned, which can be used by a {@link StringInterner} to retrieve the
+ * original string.
+ * @public
+ */
+export type InternedStringId = number & { readonly InternedStringId: "e221abc9-9d17-4493-8db0-70c871a1c27c"; };
+
+/**
+ * Interns strings as integers.
+ */
+export interface StringInterner {
+	getInternedId(input: string): InternedStringId | undefined;
+	getString(internedId: number): string;
+	getSerializable(): readonly string[];
+}
+
+/**
+ * Interns strings as integers.
+ * Given a string, this class will produce a unique integer associated with that string that can then be used to
+ * retrieve the string.
+ */
+export class MutableStringInterner implements StringInterner {
+	private readonly stringToInternedIdMap = new Map<string, InternedStringId>();
+	private readonly internedStrings: string[] = [];
+
+	/**
+	 * @param inputStrings - A list of strings to intern in the order given. Can be used to rehydrate from a previous
+	 * `StringInterner`'s {@link StringInterner.getSerializable} return value.
+	 */
+	constructor(inputStrings: readonly string[] = []) {
+		for (const value of inputStrings) {
+			this.getOrCreateInternedId(value);
+		}
+	}
+
+	/**
+	 * @param input - The string to get the associated intern ID for
+	 * @returns an intern ID that is uniquely associated with the input string
+	 */
+	public getOrCreateInternedId(input: string): InternedStringId {
+		return this.getInternedId(input) ?? this.createNewId(input);
+	}
+
+	public getInternedId(input: string): InternedStringId | undefined {
+		return this.stringToInternedIdMap.get(input);
+	}
+
+	/**
+	 *
+	 * @param internId - The intern ID to get the associated string for. Can only retrieve strings that have been
+	 * used as inputs to calls of `getInternId`.
+	 * @returns a string that is uniquely associated with the given intern ID
+	 */
+	public getString(internId: number): string {
+		const result = this.internedStrings[internId];
+		if (!result) {
+			throw new UsageError(`No string associated with ${internId}.`);
+		}
+		return result;
+	}
+
+	/**
+	 * @returns The list of strings interned where the indices map to the associated {@link InternedStringId} of
+	 * each string.
+	 */
+	public getSerializable(): readonly string[] {
+		return this.internedStrings;
+	}
+
+	/** Create a new interned id. Assumes without validation that the input doesn't already have an interned id. */
+	private createNewId(input: string): InternedStringId {
+		const internedId = this.stringToInternedIdMap.size as InternedStringId;
+		this.stringToInternedIdMap.set(input, internedId);
+		this.internedStrings.push(input);
+		return internedId;
+	}
+}

--- a/packages/framework/attributor/src/test/attributor.spec.ts
+++ b/packages/framework/attributor/src/test/attributor.spec.ts
@@ -3,9 +3,41 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "assert";
+import { IUser } from "@fluidframework/protocol-definitions";
+import { AttributionInfo, Attributor } from "../attributor";
 
 describe("Attributor", () => {
-	it("dummy test", () => {
-        assert.equal(true, true);
-    });
+	it("can retrieve user information from its initial entries", () => {
+		const key = 42;
+		const timestamp = 50;
+		const user: IUser = { id: "user foo" };
+		const attributor = new Attributor([[key, { user, timestamp }]]);
+		assert.deepEqual(
+			attributor.getAttributionInfo(key),
+			{ user, timestamp },
+		);
+	});
+
+	it(".entries() retrieves all user information", () => {
+		const entries: Iterable<[number, AttributionInfo]> = [
+			[50, { user: { id: "a" }, timestamp: 30 }],
+			[51, { user: { id: "b" }, timestamp: 60 }]
+		];
+		const attributor = new Attributor(entries);
+		assert.deepEqual(Array.from(attributor.entries()), entries);
+	});
+
+	it("getAttributionInfo throws on attempt to retrieve user information for an invalid key", () => {
+		const attributor = new Attributor();
+		assert.throws(
+			() => attributor.getAttributionInfo(42),
+			/Requested attribution information for unstored key/,
+			"invalid key should throw",
+		);
+	});
+
+	it("tryGetAttributionInfo returns undefined to retrieve user information for an invalid key", () => {
+		const attributor = new Attributor();
+		assert.equal(attributor.tryGetAttributionInfo(42), undefined);
+	});
 });

--- a/packages/framework/attributor/src/test/attributorSerializer.spec.ts
+++ b/packages/framework/attributor/src/test/attributorSerializer.spec.ts
@@ -1,0 +1,135 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { strict as assert } from "assert";
+import { AttributionInfo, Attributor, IAttributor } from "../attributor";
+import { AttributorSerializer, chain, Encoder, SerializedAttributor } from "../encoders";
+
+function makeNoopEncoder<T>(): Encoder<T, T> {
+    return {
+        encode: (x) => x,
+        decode: (x) => x
+    };
+}
+
+describe("AttributorSerializer", () => {
+    it("uses its timestamp encoder", () => {
+        it("on encode", () => {
+            const attributor = new Attributor([
+                [1, { user: { id: "a" }, timestamp: 500 }],
+                [2, { user: { id: "a" }, timestamp: 6001 }],
+            ]);
+            const calls: any[] = [];
+            const serializer = new AttributorSerializer((entries) => new Attributor(entries), {
+                encode: (x) => {
+                    calls.push(x);
+                    return x;
+                },
+                decode: (x) => x
+            });
+            assert.equal(calls.length, 0);
+            serializer.encode(attributor);
+            assert.equal(calls.length, 1);
+            assert.deepEqual(calls[0], [500, 6001]);
+        });
+
+        it("on decode", () => {
+            const calls: any[] = [];
+            const serializer = new AttributorSerializer((entries) => new Attributor(entries), {
+                encode: (x) => x,
+                decode: (x) => {
+                    calls.push(x);
+                    return x;
+                }
+            });
+            const encoded: SerializedAttributor = {
+                interner: ["a"],
+                keys: [1, 2],
+                timestamps: [501, 604],
+                attributionRefs: [0, 0] as any[]
+            };
+
+            assert.equal(calls.length, 0);
+            serializer.decode(encoded);
+            assert.equal(calls.length, 1);
+            assert.deepEqual(calls[0], [501, 604]);
+        });
+    });
+
+    describe("correctly round-trips", () => {
+        const testCases: { name: string; entries: Iterable<[number, AttributionInfo]>; }[] = [
+            {
+                name: "empty attribution information",
+                entries: [],
+            },
+            {
+                name: "one attribution",
+                entries: [[5, { user: { id: "only user" }, timestamp: 6000 }]],
+            },
+            {
+                name: "multiple keys associated with the same user",
+                entries: [
+                    [1, { user: { id: "user foo" }, timestamp: 500 }],
+                    [2, { user: { id: "user foo" }, timestamp: 7000 }],
+                ]
+            },
+            {
+                name: "multiple keys associated with different users",
+                entries: [
+                    [1, { user: { id: "user foo" }, timestamp: 500 }],
+                    [2, { user: { id: "user bar" }, timestamp: 7000 }],
+                ],
+            },
+        ];
+
+        for (const { name, entries } of testCases) {
+            it(name, () => {
+                const calls: any[] = [];
+                let retVal: IAttributor | undefined;
+                const serializer = new AttributorSerializer(
+                    (providedEntries) => {
+                        calls.push(providedEntries);
+                        retVal = new Attributor(providedEntries);
+                        return retVal;
+                    },
+                    makeNoopEncoder(),
+                );
+                const attributor = new Attributor(entries);
+                const roundTrippedAttributor = serializer.decode(serializer.encode(attributor));
+                assert.equal(calls.length, 1);
+                assert.deepEqual(calls[0], entries);
+                assert.equal(retVal, roundTrippedAttributor);
+            });
+        }
+    });
+});
+
+describe("chain", () => {
+    it("correctly chains encoders", () => {
+        const encodeCalls: string[] = [];
+        const decodeCalls: string[] = [];
+        const makeLoggingChain = <T>(tag: string) => ({
+            encode: (s: T) => {
+                encodeCalls.push(tag);
+                return s;
+            },
+            decode: (s: T) => {
+                decodeCalls.push(tag);
+                return s;
+            }
+        });
+        const encoder = chain(
+            makeLoggingChain('A'),
+            makeLoggingChain('B')
+        );
+        assert.deepEqual(encodeCalls, []);
+        assert.deepEqual(decodeCalls, []);
+        assert.equal(encoder.encode('foo'), 'foo');
+        assert.deepEqual(encodeCalls, ['A', 'B']);
+        assert.deepEqual(decodeCalls, []);
+        assert.equal(encoder.decode('bar'), 'bar');
+        assert.deepEqual(encodeCalls, ['A', 'B']);
+        assert.deepEqual(decodeCalls, ['B', 'A']);
+    });
+});

--- a/packages/framework/attributor/src/test/deltaEncoder.spec.ts
+++ b/packages/framework/attributor/src/test/deltaEncoder.spec.ts
@@ -1,0 +1,38 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { strict as assert } from "assert";
+import { deltaEncoder } from "../encoders";
+
+describe("deltaEncoder", () => {
+	const cases: { name: string; data: number[]; expected: number[]; }[] = [
+		{ name: "empty lists", data: [], expected: [] },
+		{ name: "lists of size 1", data: [5], expected: [5] },
+		{ name: "increasing numbers", data: [7, 19], expected: [7, 12] },
+		{ name: "decreasing number", data: [19, 17], expected: [19, -2] },
+		{
+			name: "longer lists",
+			data: Array.from({ length: 10 }, (_, i) => 5 * i),
+			expected: [0, ...Array.from({ length: 9 }, () => 5)],
+		},
+	];
+
+	describe("correctly encodes", () => {
+		for (const { name, data, expected } of cases) {
+			it(name, () => {
+				const actual = deltaEncoder.encode(data);
+				assert.deepEqual(actual, expected);
+			});
+		}
+	});
+
+	describe("correctly round-trips", () => {
+		for (const { name, data } of cases) {
+			it(name, () => {
+				const actual = deltaEncoder.decode(deltaEncoder.encode(data));
+				assert.deepEqual(actual, data);
+			});
+		}
+	});
+});

--- a/packages/framework/attributor/src/test/gzipEncoder.spec.ts
+++ b/packages/framework/attributor/src/test/gzipEncoder.spec.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { strict as assert } from "assert";
+import { makeGzipEncoder } from "../gzipEncoder";
+
+describe("gzipEncoder", () => {
+	const cases: { name: string; data: any; }[] = [
+		{ name: "empty string", data: "" },
+        { name: "numbers", data: 0 },
+        { name: "objects", data: {} },
+        { name: "empty lists", data: [] },
+        { name: "null properties", data: { foo: null } },
+        { name: "more complex objects", data: { foo: { bar: [1, 2] }, baz: 3, bat: 'hello' } },
+	];
+
+	describe("correctly round-trips", () => {
+		for (const { name, data } of cases) {
+			it(name, () => {
+                const encoder = makeGzipEncoder<any>();
+				const actual = encoder.decode(encoder.encode(data));
+				assert.deepEqual(actual, data);
+			});
+		}
+	});
+});

--- a/packages/framework/attributor/src/test/opStreamAttributor.spec.ts
+++ b/packages/framework/attributor/src/test/opStreamAttributor.spec.ts
@@ -1,0 +1,53 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { strict as assert } from "assert";
+import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
+import { IAudience } from "@fluidframework/container-definitions";
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
+import { OpStreamAttributor } from "../attributor";
+import { makeMockAudience } from "./utils";
+
+const clientIds = ["A", "B", "C"];
+const defaultAudience = makeMockAudience(clientIds);
+
+class OpFactory {
+	private seq = 0;
+
+	public makeOp({ timestamp, clientId }: { timestamp: number; clientId: string; }): ISequencedDocumentMessage {
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+		return {
+			timestamp,
+			clientId,
+			sequenceNumber: this.seq++,
+		} as ISequencedDocumentMessage;
+	}
+}
+
+function makeMockRuntime(clientId: string, audience: IAudience = defaultAudience): IFluidDataStoreRuntime {
+	const runtime = new MockFluidDataStoreRuntime({ clientId });
+	runtime.getAudience = () => audience;
+	return runtime;
+}
+
+describe("OpStreamAttributor", () => {
+	let opFactory: OpFactory;
+	beforeEach(() => {
+		opFactory = new OpFactory();
+	});
+
+	it("can retrieve user information from ops submitted during the current session", () => {
+        const runtime = makeMockRuntime(clientIds[0]);
+        const attributor = new OpStreamAttributor(runtime);
+        const clientId = clientIds[1];
+        const timestamp = 50;
+        const op = opFactory.makeOp({ timestamp, clientId });
+        (runtime.deltaManager as any).emit("op", op);
+        assert.deepEqual(
+            attributor.getAttributionInfo(op.sequenceNumber),
+            { user: runtime.getAudience().getMember(clientId)?.user, timestamp },
+        );
+	});
+});

--- a/packages/framework/attributor/src/test/stringInterner.spec.ts
+++ b/packages/framework/attributor/src/test/stringInterner.spec.ts
@@ -1,0 +1,92 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { MutableStringInterner } from "../stringInterner";
+
+describe("MutableStringInterner", () => {
+	const inputStrings = ["test", "test2", "test3", "test4"];
+
+	it("can associate a string with an intern ID", () => {
+		const interner = new MutableStringInterner();
+
+		assert.equal(interner.getOrCreateInternedId(inputStrings[0]), 0);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[1]), 1);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[0]), 0);
+	});
+
+	it("can handle empty strings", () => {
+		const interner = new MutableStringInterner();
+
+		assert.equal(interner.getOrCreateInternedId(""), 0);
+	});
+
+	it("getInternedId returns undefined for un-created ids", () => {
+		const interner = new MutableStringInterner();
+
+		assert.equal(interner.getInternedId(inputStrings[0]), undefined);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[0]), 0);
+		assert.equal(interner.getInternedId(inputStrings[0]), 0);
+		assert.equal(interner.getInternedId(inputStrings[1]), undefined);
+	});
+
+	it("can retrieve the intern ID associated with a string", () => {
+		const interner = new MutableStringInterner();
+
+		assert.equal(interner.getOrCreateInternedId(inputStrings[0]), 0);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[1]), 1);
+		assert.equal(interner.getInternedId(inputStrings[0]), 0);
+		assert.equal(interner.getInternedId(inputStrings[1]), 1);
+
+		assert.equal(interner.getString(0), inputStrings[0]);
+		assert.equal(interner.getString(1), inputStrings[1]);
+	});
+
+	it("throws an error when trying to retrieve a string that hasn't been encountered", () => {
+		const interner = new MutableStringInterner();
+
+		assert.throws(() => interner.getString(0), /No string associated with 0\./, "error should be thrown");
+	});
+
+	it("can return a serializable representation of its state", () => {
+		const interner = new MutableStringInterner();
+
+		for (const value of inputStrings) {
+			interner.getOrCreateInternedId(value);
+		}
+
+		assert.deepEqual(interner.getSerializable(), inputStrings);
+	});
+
+	it("can be initialized with a list of input strings", () => {
+		const interner = new MutableStringInterner(inputStrings);
+
+		assert.equal(interner.getOrCreateInternedId(inputStrings[3]), 3);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[2]), 2);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[1]), 1);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[0]), 0);
+	});
+
+	it("can be initialized with a list of input strings that include duplicate IDs", () => {
+		const interner = new MutableStringInterner([...inputStrings, ...inputStrings]);
+
+		assert.equal(interner.getOrCreateInternedId(inputStrings[3]), 3);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[2]), 2);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[1]), 1);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[0]), 0);
+	});
+
+	it("doesn't change a string's intern ID when retrieving it multiple times", () => {
+		const interner = new MutableStringInterner();
+
+		assert.equal(interner.getOrCreateInternedId(inputStrings[0]), 0);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[1]), 1);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[1]), 1);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[0]), 0);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[0]), 0);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[1]), 1);
+		assert.equal(interner.getOrCreateInternedId(inputStrings[1]), 1);
+	});
+});

--- a/packages/framework/attributor/src/test/utils.ts
+++ b/packages/framework/attributor/src/test/utils.ts
@@ -1,0 +1,34 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { IClient } from "@fluidframework/protocol-definitions";
+import { IAudience } from "@fluidframework/container-definitions";
+
+export function makeMockAudience(clientIds: string[]): IAudience {
+	const clients = new Map<string, IClient>();
+	clientIds.forEach((clientId, index) => {
+		const stringId = String.fromCharCode(index + 65);
+		const name = stringId.repeat(10);
+		const userId = `${name}@microsoft.com`;
+		const email = userId;
+		const user = {
+			id: userId,
+			name,
+			email,
+		};
+		clients.set(clientId, {
+			mode: "write",
+			details: { capabilities: { interactive: true } },
+			permission: [],
+			user,
+			scopes: [],
+		});
+	});
+	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+	return {
+		getMember: (clientId: string): IClient | undefined => {
+			return clients.get(clientId);
+		},
+	} as IAudience;
+}


### PR DESCRIPTION
## Description

This implements a first cut of Attributor functionality and the core APIs. A couple design choice comments:

- I chose to decouple serialization of the attributor from the core interface as it tends to make things more testable. Also makes it a fair bit easier to play around with different serialization strategies before we settle on one that we commit to back-compat for.
- I split the portion of attributor which associates information from the portion that listens to the op stream and automatically adds two attribution keys. This looks a little silly right now (it's a trivial wrapper around `Map`), but my choice there has a couple more subtle reasons:
  - Once we add GC APIs, they should be implementable on the base attributor. This will make it no longer completely trivial
  - Having an Attributor implementation which works without an op stream is convenient for testing (requires less mocking)
  - We may eventually want attributors that don't automatically listen to the op stream. The main use case I'm keeping in mind here is framework support for attribution of external content (e.g. external copy-paste): the attribution for a piece of content may conceptually contain users that have never opened the document.

The main notable missing feature is GC. This PR doesn't make an attempt to commit to the final serialization format.
