### PR TITLE
Tree: Update reattach mark format

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -90,9 +90,6 @@ export interface ChangeRebaser<TChangeset> {
 // @public (undocumented)
 type Changeset<TNodeChange = NodeChangeType> = MarkList_2<TNodeChange>;
 
-// @public (undocumented)
-type ChangesetTag = number | string;
-
 // @public
 export type ChildCollection = FieldKey | RootField;
 
@@ -192,7 +189,7 @@ interface Detach extends HasOpId {
     // (undocumented)
     count: NodeCount;
     // (undocumented)
-    tomb?: ChangesetTag;
+    tomb?: RevisionTag;
     // (undocumented)
     type: "Delete" | "MoveOut";
 }
@@ -200,9 +197,6 @@ interface Detach extends HasOpId {
 // @public
 export interface DetachedField extends Opaque<Brand<string, "tree.DetachedField">> {
 }
-
-// @public
-const DUMMY_INVERT_TAG: ChangesetTag;
 
 // @public
 export interface EditableField extends ArrayLike<UnwrappedEditableTree> {
@@ -434,6 +428,12 @@ interface HasOpId {
 interface HasPlaceFields {
     heed?: Effects | [Effects, Effects];
     lineage?: LineageEvent[];
+}
+
+// @public (undocumented)
+interface HasReattachFields extends HasOpId, HasPlaceFields {
+    detachedBy: RevisionTag | undefined;
+    detachIndex: number;
 }
 
 // @public (undocumented)
@@ -716,7 +716,7 @@ interface Modify_2<TNodeChange = NodeChangeType> {
     // (undocumented)
     changes: TNodeChange;
     // (undocumented)
-    tomb?: ChangesetTag;
+    tomb?: RevisionTag;
     // (undocumented)
     type: "Modify";
 }
@@ -745,7 +745,7 @@ interface ModifyDetach<TNodeChange = NodeChangeType> extends HasOpId {
     // (undocumented)
     changes: TNodeChange;
     // (undocumented)
-    tomb?: ChangesetTag;
+    tomb?: RevisionTag;
     // (undocumented)
     type: "MDelete" | "MMoveOut";
 }
@@ -769,11 +769,9 @@ interface ModifyMoveIn<TNodeChange = NodeChangeType> extends HasOpId, HasPlaceFi
 }
 
 // @public (undocumented)
-interface ModifyReattach<TNodeChange = NodeChangeType> extends HasOpId, HasPlaceFields {
+interface ModifyReattach<TNodeChange = NodeChangeType> extends HasReattachFields {
     // (undocumented)
     changes: TNodeChange;
-    // (undocumented)
-    tomb: ChangesetTag;
     // (undocumented)
     type: "MRevive" | "MReturn";
 }
@@ -958,7 +956,7 @@ export type PrimitiveValue = string | boolean | number;
 // @public (undocumented)
 interface PriorOp {
     // (undocumented)
-    change: ChangesetTag;
+    change: RevisionTag;
     // (undocumented)
     id: OpId;
 }
@@ -996,11 +994,9 @@ enum RangeType {
 }
 
 // @public (undocumented)
-interface Reattach extends HasOpId, HasPlaceFields {
+interface Reattach extends HasReattachFields {
     // (undocumented)
     count: NodeCount;
-    // (undocumented)
-    tomb: ChangesetTag;
     // (undocumented)
     type: "Revive" | "Return";
 }
@@ -1052,7 +1048,6 @@ declare namespace SequenceField {
     export {
         Attach,
         Changeset,
-        ChangesetTag,
         ClientId,
         Detach,
         Effects,
@@ -1088,6 +1083,7 @@ declare namespace SequenceField {
         TreeRootPath,
         Skip_2 as Skip,
         LineageEvent,
+        HasReattachFields,
         SequenceFieldChangeHandler,
         sequenceFieldChangeHandler,
         SequenceChangeRebaser,
@@ -1104,7 +1100,6 @@ declare namespace SequenceField {
         MarkListFactory,
         NodeChangeRebaser_2 as NodeChangeRebaser,
         rebase,
-        DUMMY_INVERT_TAG,
         invert,
         NodeChangeInverter_2 as NodeChangeInverter,
         compose,
@@ -1220,7 +1215,7 @@ type ToDelta_2<TNodeChange> = (child: TNodeChange) => Delta.Modify;
 // @public (undocumented)
 interface Tomb {
     // (undocumented)
-    change: ChangesetTag;
+    change: RevisionTag;
     // (undocumented)
     count: number;
     // (undocumented)
@@ -1230,7 +1225,7 @@ interface Tomb {
 // @public
 interface Tombstones {
     // (undocumented)
-    change: ChangesetTag;
+    change: RevisionTag;
     // (undocumented)
     count: NodeCount;
 }

--- a/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
@@ -209,7 +209,8 @@ function composeMarks<TNodeChange>(
                     const modRevive: ModifyReattach<TNodeChange> = {
                         type: "MRevive",
                         id: baseMark.id,
-                        tomb: baseMark.tomb,
+                        detachedBy: baseMark.detachedBy,
+                        detachIndex: baseMark.detachIndex,
                         changes: newMark.changes,
                     };
                     return modRevive;

--- a/packages/dds/tree/src/feature-libraries/sequence-field/format.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/format.ts
@@ -131,6 +131,9 @@ export interface ModifyDetach<TNodeChange = NodeChangeType> extends HasOpId {
 export interface HasReattachFields extends HasOpId, HasPlaceFields {
     /**
      * The tag of the change that detached the data being reattached.
+     *
+     * Undefined when the reattach is the product of a tag-less change being inverted.
+     * It is invalid to try convert such a reattach mark to a delta.
      */
     detachedBy: RevisionTag | undefined;
     /**

--- a/packages/dds/tree/src/feature-libraries/sequence-field/format.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/format.ts
@@ -27,13 +27,13 @@ export type SizedObjectMark<TNodeChange = NodeChangeType> =
 
 export interface Tomb {
     type: "Tomb";
-    change: ChangesetTag;
+    change: RevisionTag;
     count: number;
 }
 
 export interface Modify<TNodeChange = NodeChangeType> {
     type: "Modify";
-    tomb?: ChangesetTag;
+    tomb?: RevisionTag;
     changes: TNodeChange;
 }
 
@@ -117,25 +117,35 @@ export type Attach<TNodeChange = NodeChangeType> =
 export type NodeMark = Detach;
 
 export interface Detach extends HasOpId {
-    tomb?: ChangesetTag;
+    tomb?: RevisionTag;
     type: "Delete" | "MoveOut";
     count: NodeCount;
 }
 
 export interface ModifyDetach<TNodeChange = NodeChangeType> extends HasOpId {
     type: "MDelete" | "MMoveOut";
-    tomb?: ChangesetTag;
+    tomb?: RevisionTag;
     changes: TNodeChange;
 }
 
-export interface Reattach extends HasOpId, HasPlaceFields {
+export interface HasReattachFields extends HasOpId, HasPlaceFields {
+    /**
+     * The tag of the change that detached the data being reattached.
+     */
+    detachedBy: RevisionTag | undefined;
+    /**
+     * The original field index of the detached node(s).
+     * "Original" here means before the change that detached them was applied.
+     */
+    detachIndex: number;
+}
+
+export interface Reattach extends HasReattachFields {
     type: "Revive" | "Return";
-    tomb: ChangesetTag;
     count: NodeCount;
 }
-export interface ModifyReattach<TNodeChange = NodeChangeType> extends HasOpId, HasPlaceFields {
+export interface ModifyReattach<TNodeChange = NodeChangeType> extends HasReattachFields {
     type: "MRevive" | "MReturn";
-    tomb: ChangesetTag;
     changes: TNodeChange;
 }
 
@@ -150,11 +160,11 @@ export interface ModifyReattach<TNodeChange = NodeChangeType> extends HasOpId, H
  */
 export interface Tombstones {
     count: NodeCount;
-    change: ChangesetTag;
+    change: RevisionTag;
 }
 
 export interface PriorOp {
-    change: ChangesetTag;
+    change: RevisionTag;
     id: OpId;
 }
 
@@ -200,7 +210,6 @@ export type ProtoNode = JsonableTree;
 export type NodeCount = number;
 export type GapCount = number;
 export type Skip = number;
-export type ChangesetTag = number | string;
 export type ClientId = number;
 export enum Tiebreak {
     Left,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/index.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/index.ts
@@ -6,7 +6,6 @@
 export {
     Attach,
     Changeset,
-    ChangesetTag,
     ClientId,
     Detach,
     Effects,
@@ -42,6 +41,7 @@ export {
     TreeRootPath,
     Skip,
     LineageEvent,
+    HasReattachFields,
 } from "./format";
 export {
     SequenceFieldChangeHandler,
@@ -59,5 +59,5 @@ export { sequenceFieldToDelta, ToDelta } from "./sequenceFieldToDelta";
 export { SequenceFieldEditor, sequenceFieldEditor } from "./sequenceFieldEditor";
 export { MarkListFactory } from "./markListFactory";
 export { NodeChangeRebaser, rebase } from "./rebase";
-export { DUMMY_INVERT_TAG, invert, NodeChangeInverter } from "./invert";
+export { invert, NodeChangeInverter } from "./invert";
 export { compose, NodeChangeComposer } from "./compose";

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -248,12 +248,16 @@ export function splitMarkOnOutput<TMark extends Mark<unknown>>(
                 { ...markObj, content: markObj.content.slice(length) },
             ] as [TMark, TMark];
         case "MoveIn":
-        case "Return":
-        case "Revive":
         case "Tomb":
             return [
                 { ...markObj, count: length },
                 { ...markObj, count: remainder },
+            ] as [TMark, TMark];
+        case "Return":
+        case "Revive":
+            return [
+                { ...markObj, count: length },
+                { ...markObj, count: remainder, detachIndex: markObj.detachIndex + length },
             ] as [TMark, TMark];
         default:
             unreachableCase(type);
@@ -316,7 +320,11 @@ export function tryExtendMark(lhs: ObjectMark, rhs: Readonly<ObjectMark>): boole
         case "Revive":
         case "Return": {
             const lhsReattach = lhs as Reattach;
-            if (rhs.id === lhsReattach.id && rhs.tomb === lhsReattach.tomb) {
+            if (
+                rhs.id === lhsReattach.id &&
+                rhs.detachedBy === lhsReattach.detachedBy &&
+                lhsReattach.detachIndex + lhsReattach.count === rhs.detachIndex
+            ) {
                 lhsReattach.count += rhs.count;
                 return true;
             }

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { SequenceField as SF } from "../../../feature-libraries";
-import { makeAnonChange } from "../../../rebase";
+import { makeAnonChange, RevisionTag, tagChange } from "../../../rebase";
 import { TreeSchemaIdentifier } from "../../../schema-stored";
 import { brand } from "../../../util";
 import { TestChange } from "../../testChange";
@@ -19,9 +19,11 @@ function invert(change: TestChangeset): TestChangeset {
     return SF.invert(makeAnonChange(change), TestChange.invert);
 }
 
+const tag: RevisionTag = brand(42);
+
 function shallowInvert(change: SF.Changeset<unknown>): SF.Changeset<unknown> {
     deepFreeze(change);
-    return SF.invert(makeAnonChange(change), () =>
+    return SF.invert(tagChange(change, tag), () =>
         assert.fail("Unexpected call to child inverter"),
     );
 }
@@ -98,7 +100,8 @@ describe("SequenceField - Invert", () => {
                 type: "Revive",
                 id: 1,
                 count: 2,
-                tomb: SF.DUMMY_INVERT_TAG,
+                detachedBy: tag,
+                detachIndex: 0,
             },
         ];
         const actual = shallowInvert(input);
@@ -111,7 +114,8 @@ describe("SequenceField - Invert", () => {
                 type: "Revive",
                 id: 1,
                 count: 2,
-                tomb: SF.DUMMY_INVERT_TAG,
+                detachedBy: tag,
+                detachIndex: 0,
             },
         ];
         const expected: SF.Changeset = [

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
@@ -4,12 +4,14 @@
  */
 
 import { strict as assert } from "assert";
+import { RevisionTag } from "../../../core";
 import { SequenceField as SF } from "../../../feature-libraries";
 import { TreeSchemaIdentifier } from "../../../schema-stored";
 import { brand } from "../../../util";
 
 const dummyMark: SF.Detach = { type: "Delete", id: 0, count: 1 };
 const type: TreeSchemaIdentifier = brand("Node");
+const detachedBy: RevisionTag = brand(42);
 
 describe("SequenceField - MarkListFactory", () => {
     it("Inserts an offset when there is content after the offset", () => {
@@ -89,28 +91,87 @@ describe("SequenceField - MarkListFactory", () => {
 
     it("Can merge consecutive revives", () => {
         const factory = new SF.MarkListFactory();
-        const revive1: SF.Reattach = { type: "Revive", id: 0, tomb: 42, count: 1 };
-        const revive2: SF.Reattach = { type: "Revive", id: 0, tomb: 42, count: 1 };
+        const revive1: SF.Reattach = {
+            type: "Revive",
+            id: 0,
+            detachedBy,
+            detachIndex: 0,
+            count: 1,
+        };
+        const revive2: SF.Reattach = {
+            type: "Revive",
+            id: 0,
+            detachedBy,
+            detachIndex: 1,
+            count: 1,
+        };
         factory.pushContent(revive1);
         factory.pushContent(revive2);
-        assert.deepStrictEqual(factory.list, [{ type: "Revive", id: 0, tomb: 42, count: 2 }]);
+        const expected: SF.Reattach = {
+            type: "Revive",
+            id: 0,
+            detachedBy,
+            detachIndex: 0,
+            count: 2,
+        };
+        assert.deepStrictEqual(factory.list, [expected]);
+    });
+
+    it("Does not merge revives with gaps", () => {
+        const factory = new SF.MarkListFactory();
+        const revive1: SF.Reattach = {
+            type: "Revive",
+            id: 0,
+            detachedBy,
+            detachIndex: 0,
+            count: 1,
+        };
+        const revive2: SF.Reattach = {
+            type: "Revive",
+            id: 0,
+            detachedBy,
+            detachIndex: 2,
+            count: 1,
+        };
+        factory.pushContent(revive1);
+        factory.pushContent(revive2);
+        assert.deepStrictEqual(factory.list, [revive1, revive2]);
     });
 
     it("Can merge consecutive returns", () => {
         const factory = new SF.MarkListFactory();
-        const return1: SF.Reattach = { type: "Return", id: 0, tomb: 42, count: 1 };
-        const return2: SF.Reattach = { type: "Return", id: 0, tomb: 42, count: 1 };
+        const return1: SF.Reattach = {
+            type: "Return",
+            id: 0,
+            detachedBy,
+            detachIndex: 0,
+            count: 1,
+        };
+        const return2: SF.Reattach = {
+            type: "Return",
+            id: 0,
+            detachedBy,
+            detachIndex: 1,
+            count: 1,
+        };
         factory.pushContent(return1);
         factory.pushContent(return2);
-        assert.deepStrictEqual(factory.list, [{ type: "Return", id: 0, tomb: 42, count: 2 }]);
+        const expected: SF.Reattach = {
+            type: "Return",
+            id: 0,
+            detachedBy,
+            detachIndex: 0,
+            count: 2,
+        };
+        assert.deepStrictEqual(factory.list, [expected]);
     });
 
     it("Can merge consecutive tombs", () => {
         const factory = new SF.MarkListFactory();
-        const tomb1: SF.Tomb = { type: "Tomb", change: 42, count: 1 };
-        const tomb2: SF.Tomb = { type: "Tomb", change: 42, count: 1 };
+        const tomb1: SF.Tomb = { type: "Tomb", change: detachedBy, count: 1 };
+        const tomb2: SF.Tomb = { type: "Tomb", change: detachedBy, count: 1 };
         factory.pushContent(tomb1);
         factory.pushContent(tomb2);
-        assert.deepStrictEqual(factory.list, [{ type: "Tomb", change: 42, count: 2 }]);
+        assert.deepStrictEqual(factory.list, [{ type: "Tomb", change: detachedBy, count: 2 }]);
     });
 });

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { SequenceField as SF } from "../../../feature-libraries";
-import { makeAnonChange, tagChange, tagInverse } from "../../../rebase";
+import { makeAnonChange, RevisionTag, tagChange, tagInverse } from "../../../rebase";
 import { TreeSchemaIdentifier } from "../../../schema-stored";
 import { brand } from "../../../util";
 import { TestChange } from "../../testChange";
@@ -13,7 +13,7 @@ import { deepFreeze } from "../../utils";
 import { checkDeltaEquality, createInsertChangeset, rebaseTagged } from "./utils";
 
 const type: TreeSchemaIdentifier = brand("Node");
-const tomb = "Dummy Changeset Tag";
+const detachedBy: RevisionTag = brand(41);
 
 const testMarks: [string, SF.Mark<TestChange>][] = [
     ["SetValue", { type: "Modify", changes: TestChange.mint([], 1) }],
@@ -33,7 +33,7 @@ const testMarks: [string, SF.Mark<TestChange>][] = [
         },
     ],
     ["Delete", { type: "Delete", id: 0, count: 2 }],
-    ["Revive", { type: "Revive", id: 0, count: 2, tomb }],
+    ["Revive", { type: "Revive", id: 0, count: 2, detachedBy, detachIndex: 0 }],
 ];
 deepFreeze(testMarks);
 

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { fail, strict as assert } from "assert";
+import { RevisionTag } from "../../../core";
 import { Delta, FieldKey, ITreeCursorSynchronous } from "../../../tree";
 import {
     FieldChange,
@@ -23,7 +24,7 @@ const nodeX = { type, value: "X" };
 const content = [nodeX];
 const contentCursor: ITreeCursorSynchronous[] = [singleTextCursor(nodeX)];
 const opId = 42;
-const tag = "TestTag";
+const tag: RevisionTag = brand(42);
 const moveId = brandOpaque<Delta.MoveId>(opId);
 const fooField = brand<FieldKey>("foo");
 
@@ -58,7 +59,7 @@ describe("SequenceField - toDelta", () => {
         const actual = toDelta([
             {
                 type: "Modify",
-                tomb: "DummyTag",
+                tomb: tag,
                 changes: TestChange.mint([0], 1),
             },
         ]);
@@ -70,7 +71,7 @@ describe("SequenceField - toDelta", () => {
         const actual = toDelta([
             {
                 type: "Tomb",
-                change: "DummyTag",
+                change: tag,
                 count: 3,
             },
         ]);
@@ -96,7 +97,9 @@ describe("SequenceField - toDelta", () => {
     });
 
     it("revive", () => {
-        const changeset: TestChangeset = [{ type: "Revive", id: opId, tomb: tag, count: 2 }];
+        const changeset: TestChangeset = [
+            { type: "Revive", id: opId, detachedBy: tag, detachIndex: 0, count: 2 },
+        ];
         const actual = toDelta(changeset);
         assert.equal(actual.length, 1);
         const mark = actual[0];
@@ -116,7 +119,7 @@ describe("SequenceField - toDelta", () => {
             fieldChanges: new Map([[fooField, nestedChange]]),
         };
         const changeset: SF.Changeset = [
-            { type: "MRevive", id: opId, tomb: tag, changes: nodeChange },
+            { type: "MRevive", id: opId, detachedBy: tag, detachIndex: 0, changes: nodeChange },
         ];
         const fieldChanges = new Map([
             [fooField, [{ type: Delta.MarkType.Insert, id: opId, content: [] }]],
@@ -203,7 +206,7 @@ describe("SequenceField - toDelta", () => {
             2,
             {
                 type: "Tomb",
-                change: "DummyTag",
+                change: tag,
                 count: 3,
             },
         ];

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -5,14 +5,13 @@
 
 import { SequenceField as SF } from "../../../feature-libraries";
 import { brand } from "../../../util";
-import { TreeSchemaIdentifier } from "../../../schema-stored";
+import { Delta, RevisionTag, TaggedChange, TreeSchemaIdentifier } from "../../../core";
 import { TestChange } from "../../testChange";
-import { Delta, TaggedChange } from "../../../core";
 import { assertMarkListEqual, deepFreeze } from "../../utils";
 import { tagChange } from "../../../rebase";
 
 const type: TreeSchemaIdentifier = brand("Node");
-const tomb = "Dummy Changeset Tag";
+const detachedBy: RevisionTag = brand(42);
 
 export type TestChangeset = SF.Changeset<TestChange>;
 
@@ -47,7 +46,7 @@ export const cases: {
         },
     ],
     delete: [1, { type: "Delete", id: 1, count: 3 }],
-    revive: [2, { type: "Revive", id: 1, count: 2, tomb }],
+    revive: [2, { type: "Revive", id: 1, count: 2, detachedBy, detachIndex: 0 }],
 };
 
 export function createInsertChangeset(index: number, size: number): TestChangeset {


### PR DESCRIPTION
Updates the representation of sequence fields marks to pave the way for:
- Transaction rollback
- Cancellation of inverse marks in compose