### PR TITLE
Tree: Separate Checkout interface from transaction code

### DIFF
--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -121,7 +121,7 @@ export {
 
 export { ICheckout, TransactionResult } from "../checkout";
 
-export { Checkout, runSynchronousTransaction } from "../transaction";
+export { Checkout } from "../transaction";
 
 export {
     Index,

--- a/packages/dds/tree/src/feature-libraries/defaultTransaction.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultTransaction.ts
@@ -13,6 +13,9 @@ import {
 } from "../core";
 import { brand } from "../util";
 
+// This is intended to be used by checkout, and not depend on it.
+// This allows transaction to be tested in isolation.
+
 /**
  * Keeps a forest in sync with a ProgressiveEditBuilder.
  */

--- a/packages/dds/tree/src/feature-libraries/defaultTransaction.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultTransaction.ts
@@ -1,0 +1,57 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    ChangeFamily,
+    Checkout,
+    IEditableForest,
+    IForestSubscription,
+    ProgressiveEditBuilder,
+    TransactionResult,
+} from "../core";
+import { brand } from "../util";
+
+/**
+ * Keeps a forest in sync with a ProgressiveEditBuilder.
+ */
+class Transaction<TEditor extends ProgressiveEditBuilder<TChange>, TChange> {
+    public readonly editor: TEditor;
+    constructor(
+        private readonly forest: IEditableForest,
+        changeFamily: ChangeFamily<TEditor, TChange>,
+    ) {
+        this.editor = changeFamily.buildEditor((delta) => {
+            this.forest.applyDelta(delta);
+        }, forest.anchors);
+    }
+}
+
+export function runSynchronousTransaction<TEditor extends ProgressiveEditBuilder<TChange>, TChange>(
+    checkout: Checkout<TEditor, TChange>,
+    command: (forest: IForestSubscription, editor: TEditor) => TransactionResult,
+): TransactionResult {
+    const t = new Transaction(checkout.forest, checkout.changeFamily);
+    const result = command(checkout.forest, t.editor);
+    const changes = t.editor.getChanges();
+    const edit = checkout.changeFamily.rebaser.compose(changes);
+
+    // TODO: in the non-abort case, optimize this to not rollback the edit,
+    // then reapply it (when the local edit is added) when possible.
+    {
+        // Roll back changes
+        const inverse = checkout.changeFamily.rebaser.invert({ revision: brand(-1), change: edit });
+
+        // TODO: maybe unify logic to edit forest and its anchors here with that in ProgressiveEditBuilder.
+        // TODO: update schema in addition to anchors and tree data (in both places).
+        checkout.changeFamily.rebaser.rebaseAnchors(checkout.forest.anchors, inverse);
+        checkout.forest.applyDelta(checkout.changeFamily.intoDelta(inverse));
+    }
+
+    if (result === TransactionResult.Apply) {
+        checkout.submitEdit(edit);
+    }
+
+    return result;
+}

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
@@ -15,7 +15,6 @@ import {
     ITreeCursor,
     IForestSubscription,
     TransactionResult,
-    runSynchronousTransaction,
     Checkout as TransactionCheckout,
     UpPath,
     FieldKey,
@@ -26,6 +25,7 @@ import {
     afterChangeToken,
 } from "../../core";
 import { DefaultChangeset, DefaultEditBuilder } from "../defaultChangeFamily";
+import { runSynchronousTransaction } from "../defaultTransaction";
 import { ProxyTarget, EditableField, proxifyField, UnwrappedEditableField } from "./editableTree";
 
 /**

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -86,3 +86,5 @@ export {
     parseSummary as loadSummary,
     stringifySummary as encodeSummary,
 } from "./editManagerIndex";
+
+export { runSynchronousTransaction } from "./defaultTransaction";

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -21,7 +21,6 @@ import {
     Index,
     SharedTreeCore,
     Checkout as TransactionCheckout,
-    runSynchronousTransaction,
     Anchor,
     AnchorLocator,
     AnchorSet,
@@ -44,6 +43,7 @@ import {
     SchemaEditor,
     DefaultChangeset,
     EditManagerIndex,
+    runSynchronousTransaction,
 } from "../feature-libraries";
 
 /**

--- a/packages/dds/tree/src/transaction/README.md
+++ b/packages/dds/tree/src/transaction/README.md
@@ -1,6 +1,5 @@
 # transaction
 
-This folder contains a proof-of-concept level prototype code for a transaction system for editing [checkouts](../checkout/README.md).
+This folder contains code and abstractions related to transactions for editing [checkouts](../checkout/README.md).
 
-This is intended to be used by checkout, and not depend on it.
-This allows transaction to be tested in isolation.
+More functionality may be added to this module in the future to account for the needs of async transactions.

--- a/packages/dds/tree/src/transaction/index.ts
+++ b/packages/dds/tree/src/transaction/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export { runSynchronousTransaction, Checkout } from "./transaction";
+export { Checkout } from "./transaction";

--- a/packages/dds/tree/src/transaction/transaction.ts
+++ b/packages/dds/tree/src/transaction/transaction.ts
@@ -3,10 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IEditableForest, IForestSubscription } from "../forest";
-import { ChangeFamily, ProgressiveEditBuilder } from "../change-family";
-import { TransactionResult } from "../checkout";
-import { brand } from "../util";
+import { IEditableForest } from "../forest";
+import { ChangeFamily } from "../change-family";
 
 /**
  * The interface a checkout has to implement for a transaction to be able to be applied to it.
@@ -15,48 +13,4 @@ export interface Checkout<TEditor, TChange> {
     readonly forest: IEditableForest;
     readonly changeFamily: ChangeFamily<TEditor, TChange>;
     submitEdit(edit: TChange): void;
-}
-
-/**
- * Keeps a forest in sync with a ProgressiveEditBuilder.
- */
-class Transaction<TEditor extends ProgressiveEditBuilder<TChange>, TChange> {
-    public readonly editor: TEditor;
-    constructor(
-        private readonly forest: IEditableForest,
-        changeFamily: ChangeFamily<TEditor, TChange>,
-    ) {
-        this.editor = changeFamily.buildEditor(
-            (delta) => this.forest.applyDelta(delta),
-            forest.anchors,
-        );
-    }
-}
-
-export function runSynchronousTransaction<TEditor extends ProgressiveEditBuilder<TChange>, TChange>(
-    checkout: Checkout<TEditor, TChange>,
-    command: (forest: IForestSubscription, editor: TEditor) => TransactionResult,
-): TransactionResult {
-    const t = new Transaction(checkout.forest, checkout.changeFamily);
-    const result = command(checkout.forest, t.editor);
-    const changes = t.editor.getChanges();
-    const edit = checkout.changeFamily.rebaser.compose(changes);
-
-    // TODO: in the non-abort case, optimize this to not rollback the edit,
-    // then reapply it (when the local edit is added) when possible.
-    {
-        // Roll back changes
-        const inverse = checkout.changeFamily.rebaser.invert({ revision: brand(-1), change: edit });
-
-        // TODO: maybe unify logic to edit forest and its anchors here with that in ProgressiveEditBuilder.
-        // TODO: update schema in addition to anchors and tree data (in both places).
-        checkout.changeFamily.rebaser.rebaseAnchors(checkout.forest.anchors, inverse);
-        checkout.forest.applyDelta(checkout.changeFamily.intoDelta(inverse));
-    }
-
-    if (result === TransactionResult.Apply) {
-        checkout.submitEdit(edit);
-    }
-
-    return result;
 }


### PR DESCRIPTION
This PR just moves the transaction code outside of the `./core` area so that it can depend on feature libraries (which it does not need to do yet).
This is in preparation of a future PR that makes the transaction code dependent on an implementation of the `RepairDataStore` abstraction (also introduced by that future PR).