### PR TITLE
Remove tsfmt from @fluid-internal/attributor

### DIFF
--- a/packages/framework/attributor/package.json
+++ b/packages/framework/attributor/package.json
@@ -35,8 +35,6 @@
     "test:mocha": "mocha --ignore 'dist/test/memory/**/*' --recursive 'dist/test/**/*.spec.js' -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict",
     "test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
     "tsc": "tsc",
-    "tsfmt": "tsfmt --verify",
-    "tsfmt:fix": "tsfmt --replace",
     "typetests:gen": "fluid-type-validator -g -d ."
   },
   "nyc": {
@@ -85,8 +83,7 @@
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
     "rimraf": "^2.6.2",
-    "typescript": "~4.5.5",
-    "typescript-formatter": "7.1.0"
+    "typescript": "~4.5.5"
   },
   "typeValidation": {
     "version": "2.1.0",


### PR DESCRIPTION

## Description

Recent addition to this package merged at a similar time to #12802. This removes tsfmt references from the new package.
