### PR TITLE
Remove MergeTree.getStats

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -46,7 +46,6 @@ import {
 	MaxNodesInBlock,
 	MergeBlock,
 	MergeNode,
-	MergeTreeStats,
 	MinListener,
 	SegmentActions,
 	SegmentGroup,
@@ -773,52 +772,6 @@ export class MergeTree {
 
     public getCollabWindow() {
         return this.collabWindow;
-    }
-
-    public getStats() {
-        const nodeGetStats = (block: IMergeBlock): MergeTreeStats => {
-            const stats: MergeTreeStats = {
-                maxHeight: 0,
-                nodeCount: 0,
-                leafCount: 0,
-                removedLeafCount: 0,
-                liveCount: 0,
-                histo: [],
-            };
-            for (let k = 0; k < MaxNodesInBlock; k++) {
-                stats.histo[k] = 0;
-            }
-            for (let i = 0; i < block.childCount; i++) {
-                const child = block.children[i];
-                let height = 1;
-                if (!child.isLeaf()) {
-                    const childStats = nodeGetStats(child);
-                    height = 1 + childStats.maxHeight;
-                    stats.nodeCount += childStats.nodeCount;
-                    stats.leafCount += childStats.leafCount;
-                    stats.removedLeafCount += childStats.removedLeafCount;
-                    stats.liveCount += childStats.liveCount;
-                    for (let j = 0; j < MaxNodesInBlock; j++) {
-                        stats.histo[j] += childStats.histo[j];
-                    }
-                } else {
-                    stats.leafCount++;
-                    const segment = child;
-                    if (segment.removedSeq !== undefined) {
-                        stats.removedLeafCount++;
-                    }
-                }
-                if (height > stats.maxHeight) {
-                    stats.maxHeight = height;
-                }
-            }
-            stats.histo[block.childCount]++;
-            stats.nodeCount++;
-            stats.liveCount += block.childCount;
-            return stats;
-        };
-        const rootStats = nodeGetStats(this.root);
-        return rootStats;
     }
 
     public getLength(refSeq: number, clientId: number) {

--- a/packages/dds/merge-tree/src/test/beastTest.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.ts
@@ -46,7 +46,7 @@ import {
 import { reservedRangeLabelsKey, reservedTileLabelsKey } from "../referencePositions";
 import { MergeTree } from "../mergeTree";
 import { MergeTreeTextHelper } from "../MergeTreeTextHelper";
-import { specToSegment, TestClient } from "./testClient";
+import { getStats, specToSegment, TestClient } from "./testClient";
 import { TestServer } from "./testServer";
 import { insertText, loadTextFromFile, nodeOrdinalsHaveIntegrity } from "./testUtils";
 import { ProxString, TST } from "./tst";
@@ -631,7 +631,7 @@ export function TestPack(verbose = true) {
         }
         const aveTime = (client.accumTime / client.accumOps).toFixed(1);
         const aveLocalTime = (client.localTime / client.localOps).toFixed(1);
-        const stats = client.mergeTree.getStats();
+        const stats = getStats(client.mergeTree);
         const windowTime = stats.windowTime!;
         const packTime = stats.packTime;
         const aveWindowTime = ((windowTime || 0) / (client.accumOps)).toFixed(1);
@@ -897,7 +897,7 @@ export function TestPack(verbose = true) {
             */
             // log(server.getText());
             // log(server.mergeTree.toString());
-            // log(server.mergeTree.getStats());
+            // log(getStats(server.mergeTree));
             if (0 === (roundCount % 100)) {
                 const clockStart = clock();
                 if (checkTextMatch()) {
@@ -909,7 +909,7 @@ export function TestPack(verbose = true) {
                 if (verbose) {
                     log(`wall clock is ${((Date.now() - startTime) / 1000.0).toFixed(1)}`);
                 }
-                const stats = server.mergeTree.getStats();
+                const stats = getStats(server.mergeTree);
                 const liveAve = (stats.liveCount / stats.nodeCount).toFixed(1);
                 const posLeaves = stats.leafCount - stats.removedLeafCount;
                 let aveExtractSnapTime = "off";

--- a/packages/dds/merge-tree/src/test/index.ts
+++ b/packages/dds/merge-tree/src/test/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export { createRevertDriver, specToSegment, TestClient, TestClientRevertibleDriver } from "./testClient";
+export { createRevertDriver, getStats, specToSegment, TestClient, TestClientRevertibleDriver } from "./testClient";
 export { checkTextMatchRelative, TestServer } from "./testServer";
 export {
 	countOperations,

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -14,7 +14,7 @@ import {
     List,
 } from "../collections";
 import { UnassignedSequenceNumber } from "../constants";
-import { ISegment, Marker } from "../mergeTreeNodes";
+import { IMergeBlock, ISegment, Marker, MaxNodesInBlock, MergeTreeStats } from "../mergeTreeNodes";
 import { createInsertSegmentOp, createRemoveRangeOp } from "../opBuilder";
 import { IJSONSegment, IMarkerDef, IMergeTreeOp, MergeTreeDeltaType, ReferenceType } from "../ops";
 import { PropertySet } from "../properties";
@@ -430,3 +430,49 @@ export const createRevertDriver =
 
     };
 };
+
+export function getStats(tree: MergeTree) {
+    const nodeGetStats = (block: IMergeBlock): MergeTreeStats => {
+        const stats: MergeTreeStats = {
+            maxHeight: 0,
+            nodeCount: 0,
+            leafCount: 0,
+            removedLeafCount: 0,
+            liveCount: 0,
+            histo: [],
+        };
+        for (let k = 0; k < MaxNodesInBlock; k++) {
+            stats.histo[k] = 0;
+        }
+        for (let i = 0; i < block.childCount; i++) {
+            const child = block.children[i];
+            let height = 1;
+            if (!child.isLeaf()) {
+                const childStats = nodeGetStats(child);
+                height = 1 + childStats.maxHeight;
+                stats.nodeCount += childStats.nodeCount;
+                stats.leafCount += childStats.leafCount;
+                stats.removedLeafCount += childStats.removedLeafCount;
+                stats.liveCount += childStats.liveCount;
+                for (let j = 0; j < MaxNodesInBlock; j++) {
+                    stats.histo[j] += childStats.histo[j];
+                }
+            } else {
+                stats.leafCount++;
+                const segment = child;
+                if (segment.removedSeq !== undefined) {
+                    stats.removedLeafCount++;
+                }
+            }
+            if (height > stats.maxHeight) {
+                stats.maxHeight = height;
+            }
+        }
+        stats.histo[block.childCount]++;
+        stats.nodeCount++;
+        stats.liveCount += block.childCount;
+        return stats;
+    };
+    const rootStats = nodeGetStats(tree.root);
+    return rootStats;
+}

--- a/packages/dds/merge-tree/src/test/text.ts
+++ b/packages/dds/merge-tree/src/test/text.ts
@@ -76,8 +76,5 @@ export function loadSegments(content: string, segLimit: number, markers: boolean
 export function loadText(content: string, mergeTree: MergeTree, segLimit: number, markers = false) {
     const segments = loadSegments(content, segLimit, markers);
     mergeTree.reloadFromSegments(segments);
-    // console.log(`Number of Segments: ${segments.length}`);
-    // console.log(`Height: ${mergeTree.getStats().maxHeight}`);
-    // console.log(segTree.toString());
     return mergeTree;
 }

--- a/packages/dds/sequence/src/test/testFarm.ts
+++ b/packages/dds/sequence/src/test/testFarm.ts
@@ -162,7 +162,7 @@ export function TestPack(verbose = true) {
         }
         const aveTime = (client.accumTime / client.accumOps).toFixed(1);
         const aveLocalTime = (client.localTime / client.localOps).toFixed(1);
-        const stats = client.mergeTree.getStats();
+        const stats = MergeTree.getStats(client.mergeTree);
         const packTime = stats.packTime;
         const ordTime = stats.ordTime;
         const aveOrdTime = ((ordTime ?? 0) / (client.accumOps)).toFixed(1);
@@ -626,7 +626,7 @@ export function TestPack(verbose = true) {
             */
             // console.log(server.getText());
             // console.log(server.mergeTree.toString());
-            // console.log(server.mergeTree.getStats());
+            // console.log(MergeTree.getStats(server.mergeTree));
             if (0 === (roundCount % 100)) {
                 const clockStart = clock();
                 if (checkTextMatch()) {
@@ -638,7 +638,7 @@ export function TestPack(verbose = true) {
                 if (verbose) {
                     console.log(`wall clock is ${((Date.now() - startTime) / 1000.0).toFixed(1)}`);
                 }
-                const stats = testServer.mergeTree.getStats();
+                const stats = MergeTree.getStats(testServer.mergeTree);
                 const liveAve = (stats.liveCount / stats.nodeCount).toFixed(1);
                 const posLeaves = stats.leafCount - stats.removedLeafCount;
                 let aveExtractSnapTime = "off";


### PR DESCRIPTION

## Description

`getStats` was only used by test code, but bloats bundle size. This will move it out of the merge-tree bundle.