### PR TITLE
Only save sequence number to index mapping when edit eviction is enabled on legacy SharedTree

### DIFF
--- a/experimental/dds/tree/src/EditLog.ts
+++ b/experimental/dds/tree/src/EditLog.ts
@@ -270,6 +270,9 @@ export class EditLog<TChange = unknown> extends TypedEventEmitter<IEditLogEvents
 		}
 
 		if (targetLength !== Infinity) {
+            if (targetLength < 0 || evictionFrequency < 0) {
+                fail('targetLength and evictionFrequency should not be negative');
+            }
 			this.sequenceNumberToIndex = new BTree([[0, 0]]);
 			for (const handler of editEvictionHandlers) {
 				this.registerEditEvictionHandler(handler);

--- a/experimental/dds/tree/src/EditLog.ts
+++ b/experimental/dds/tree/src/EditLog.ts
@@ -534,8 +534,10 @@ export class EditLog<TChange = unknown> extends TypedEventEmitter<IEditLogEvents
 	}
 
 	private evictEdits(): void {
+        assert(this.sequenceNumberToIndex !== undefined, 'Edits should never be evicted if the target length is set to infinity');
+
 		const minSequenceIndex =
-			this.sequenceNumberToIndex?.getPairOrNextHigher(this._minSequenceNumber)?.[1] ??
+			this.sequenceNumberToIndex.getPairOrNextHigher(this._minSequenceNumber)?.[1] ??
 			fail('No index associated with that sequence number.');
 		// Exclude any edits in the collab window from being evicted
 		const numberOfEvictableEdits = minSequenceIndex - this.earliestAvailableEditIndex;
@@ -556,7 +558,7 @@ export class EditLog<TChange = unknown> extends TypedEventEmitter<IEditLogEvents
 			removedEdits.forEach((edit) => this.allEditIds.delete(edit.id));
 
 			// The minSequenceNumber is strictly increasing so we can clear sequence numbers before it
-			this.sequenceNumberToIndex?.deleteRange(0, this._minSequenceNumber, false);
+			this.sequenceNumberToIndex.deleteRange(0, this._minSequenceNumber, false);
 		}
 	}
 

--- a/experimental/dds/tree/src/EditLog.ts
+++ b/experimental/dds/tree/src/EditLog.ts
@@ -270,9 +270,9 @@ export class EditLog<TChange = unknown> extends TypedEventEmitter<IEditLogEvents
 		}
 
 		if (targetLength !== Infinity) {
-            if (targetLength < 0 || evictionFrequency < 0) {
-                fail('targetLength and evictionFrequency should not be negative');
-            }
+			if (targetLength < 0 || evictionFrequency < 0) {
+				fail('targetLength and evictionFrequency should not be negative');
+			}
 			this.sequenceNumberToIndex = new BTree([[0, 0]]);
 			for (const handler of editEvictionHandlers) {
 				this.registerEditEvictionHandler(handler);
@@ -511,7 +511,7 @@ export class EditLog<TChange = unknown> extends TypedEventEmitter<IEditLogEvents
 		this.emitAdd(edit, false, encounteredEditId !== undefined);
 
 		// Check if any edits need to be evicted due to this addition
-		if (this.numberOfSequencedEdits >= this.evictionFrequency) {
+		if (this.sequenceNumberToIndex !== undefined && this.numberOfSequencedEdits >= this.evictionFrequency) {
 			this.evictEdits();
 		}
 	}
@@ -534,7 +534,10 @@ export class EditLog<TChange = unknown> extends TypedEventEmitter<IEditLogEvents
 	}
 
 	private evictEdits(): void {
-        assert(this.sequenceNumberToIndex !== undefined, 'Edits should never be evicted if the target length is set to infinity');
+		assert(
+			this.sequenceNumberToIndex !== undefined,
+			'Edits should never be evicted if the target length is set to infinity'
+		);
 
 		const minSequenceIndex =
 			this.sequenceNumberToIndex.getPairOrNextHigher(this._minSequenceNumber)?.[1] ??

--- a/experimental/dds/tree/src/test/EditLog.perf.tests.ts
+++ b/experimental/dds/tree/src/test/EditLog.perf.tests.ts
@@ -32,5 +32,18 @@ describe('EditLog Perf', () => {
 				});
 			},
 		});
+
+		const targetEditLogSize = Math.floor(numberOfInserts / 4);
+		benchmark({
+			type: BenchmarkType.Measurement,
+			title: `process ${numberOfInserts} sequenced inserts with a target edit log size of ${targetEditLogSize}`,
+			benchmarkFn: () => {
+				const log = new EditLog(undefined, undefined, undefined, targetEditLogSize);
+
+				edits.forEach((edit) => {
+					log.addSequencedEdit(edit, { sequenceNumber: 1, referenceSequenceNumber: 0 });
+				});
+			},
+		});
 	});
 });


### PR DESCRIPTION
This mapping is unnecessary when eviction is not possible and caused a performance regression in those cases.