### PR TITLE
Bump package version for compat testing

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1987,11 +1987,11 @@
 			}
 		},
 		"@fluid-experimental/property-changeset": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-changeset/-/property-changeset-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-+fBnu1i9dOWcjcnp1onTLR+KY6ebupywXPtgZ4HH1Gh3vJzwLZ9gTQqtuKpQRczIm+9ywC6FgwIzBVcn9pyJSQ==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-changeset/-/property-changeset-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-vcylyvKuEsx/Hp6YPS+HsOmF+TYEAApWfeMoj8j4jfHyY1OLTeZ/R36ZnuBaBMk4X9zvpCBee9Cdcc3Mfmzh5w==",
 			"requires": {
-				"@fluid-experimental/property-common": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-common": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"ajv": "7.1.1",
 				"ajv-keywords": "4.0.0",
 				"async": "^3.2.0",
@@ -2017,9 +2017,9 @@
 			}
 		},
 		"@fluid-experimental/property-common": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-common/-/property-common-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-NkXnoQZiG/T36AoHNQtEwbAmtRkeB5atdZrKxevz09moLdBQYGynIDzABnGsatZOMDth4izgUSRUKyogXvVXsw==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-common/-/property-common-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-+gUpPkFIUKChM2gmD3Jshubll4M5WzbTDkJIjjIMUj/SFJFJGJTRRGD3P2n/NIFOV8y3OWtCPKiRj0lvcq6I5A==",
 			"requires": {
 				"ajv": "7.1.1",
 				"async": "^3.2.0",
@@ -2049,20 +2049,20 @@
 			}
 		},
 		"@fluid-experimental/property-dds": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-dds/-/property-dds-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-XruLFCLNFUwRBH4megal/oNQp57wic3aK/PqEl5JpaG7JX5UnS0br6/ZASyZS7Tv3UPEOlr+z9Vaxoot4vCEFw==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-dds/-/property-dds-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-uwwAqIuB669T711A8tDGqtafHOhvKfpeh8xRn/nt7qQ7rLjLg7nzYrN2jhUNG44wpkH6xLsNUv8XHO8dLwNbRg==",
 			"requires": {
-				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluid-experimental/property-properties": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-properties": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"fastest-json-copy": "^1.0.1",
 				"lodash": "^4.17.21",
@@ -2116,12 +2116,12 @@
 			}
 		},
 		"@fluid-experimental/property-properties": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-properties/-/property-properties-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-UGjOO4U7rbf4DITOd9f3onQT2WEq1wKD4Amai5PXY/LU1Q4JjHVOZKuZ/R/hJhz4tKvSvPu/r3MHqKCX/nnjCg==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-properties/-/property-properties-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-oEZu3VCwulHfSaYMlZJwU7XlGiS+WcvvSyk2gykeLvKAfy8p8THcDZ9p2vFTV65pLQMHUEsl31lYVD8eOUiR5g==",
 			"requires": {
-				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluid-experimental/property-common": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-common": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"ajv": "7.1.1",
 				"async": "^3.2.0",
 				"fastest-json-copy": "^1.0.1",
@@ -2795,25 +2795,25 @@
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-X7fRE99jqd3I4qjJWqm5MHqnHfVot18RKYhidMwlXEr0cm7fWdbtZrEm2OwQ5u+AE2QGKc76Xv1G3+CpcQA5iw==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-HctjLrNjCMb7YkVN9C0DxrhTbFBXKuq6Af309yecyUMl/jI1w9BmabZih3wBLQz64PbZhR0pHhSiYPddE1lZ/w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/map": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/synthesize": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/map": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/synthesize": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -3201,17 +3201,17 @@
 			}
 		},
 		"@fluidframework/cell": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-0196LjkjApX0tDTu4ZRsiZM8LK1lXPMUYjH328nn3WDpWtUo9SQ5RiJfB7xfN+t8LYR9q91cXqVSpEmZUyAwaw==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-leMU7hUYpK5SA8q7pmF15YpuMX9dGIJaM1RCKm+PVYh1fqh4asXw8LVKlkSDWa4RsITtADRX8XXza2vPdTNeEg==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/cell-previous": {
@@ -3255,13 +3255,13 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-VReCtqdefWivDGOIZKF3UWEjjcp1gD/J+lm153hfxwaRhOTAcys+XLn+mrT6GFBqxL8cuRb+pUJPZN2eIRug8A==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-y822qjw2E19yyixOIpu1KNVzQ6AxS66epQHJCyWpbWR4howmxKZcIGQH1SjmQdemkDhFKpC/V79UmMSx0kGq2Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0"
 			}
 		},
@@ -3277,20 +3277,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-e6JT8ekQ85KxB7X/1XQ7SXO4aY7r5yiNSWfnRQEh3C94xtrQnknlxq/CHMLdUkooDbfZfO0sAPTT1em+Jv8SBg==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-O+g17yxiddhciRlp/Se4RqPl1y0zFWPQcci+l9AjDlTyNaSKXI+89Ev7BCVxb432Fm2JZ5qbHhZbt24V81fU2g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -3321,41 +3321,41 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-HUhgysA/05Z0JiTCG+0zKJvfvV8K8jJYVDKeKCfAv04eFWrdzjGE5YjBYqESoZvbdEKe8bym9HHMFY3xqRAUuQ==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-wGA/ychiWlPfj+fFUsaIYoTplOMJ1CbA9zjb6zfpBeFqGiqqmTVk8wn6X5G4VNcVoGq6nJZme+TMq7VL7a/K9g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lz4js": "^0.2.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-l2hXNwOQyDP4mNFdm1ijHTf2aMwxXUF7WVkseeAfhq27KZHKgHiKySd5BWkgnIwslIJFzdS42SCS5WZFs0jkLA==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-0u1h0chnWgPwBLkUyRe5bCHcyGhpwPWOSFccfEt5xa8YiwNDmj5kSx5dUlVSk1UXJJFWTup6JaqIC8wwFQPNZw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@types/node": "^14.18.0"
 			}
 		},
@@ -3399,15 +3399,15 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-ILZmVJLK/cjogcU8r7NouOvoJnACLt3CNSZMax6NS8uuoWtYpNVJMRFrJxscP/z/rJBLDc8Tq3Tj49PKUdyG4g==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-pQ8OmKecWp833+XM8Vm5IvzM/nAAjqbBTA4WA4A39o2VWPiQ/mLnNXtTcLUVVmFYJUD04IxDK7NIMzzYVhB+NQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/container-utils-previous": {
@@ -3423,9 +3423,9 @@
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-M/YphV9t/tloO6DgvLIfwV27e60Y6+UEIVn+TmUpQGQkAShpHpbNYd50U+7kw5SvGTVc0ixaO5/2ecNCPP9Msw=="
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-ru0WcnuMHeMysngJA0YD3CMwp9cfJCd+JWW2KM77Trtwgz7PJaj9SyGj3190Ceq0HRB6QdPrzM5C5HVzAXZQBg=="
 		},
 		"@fluidframework/core-interfaces-previous": {
 			"version": "npm:@fluidframework/core-interfaces@2.0.0-internal.2.0.0",
@@ -3433,17 +3433,17 @@
 			"integrity": "sha512-S9sAqYtdOQgUqH5dj7Cy/zgMy97+YtEZ5nbtbZ3naEacngXdCPA46X2tlvNMzMloSQTlsJDx8r5N+bSCtpmrFA=="
 		},
 		"@fluidframework/counter": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-83wXKUR0vxDokdiDtDhpTr/Fsz81xR8pz3ivoJVkDaCVWjcD6UsjKOM6YzFe/gZcFRSVvQj/8qg1Vh9ph2Bngg==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-hVTaetymSXpKarVk0/L/RkCtNrrXAmXVFrWZ7n0ozZSBureBOibLOdJuXqkrg3AycnVq9eYZTs53By+xO+08Ow==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/counter-previous": {
@@ -3479,39 +3479,39 @@
 			}
 		},
 		"@fluidframework/datastore": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-e2z1eNCASsn1o9zluZEnSveoxAdysTYVjpWN8iIXcfY2OaBGC1EDGV2LbwiR5ldL/S9O4k1WQ3Rg4EtHUVgbfQ==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-YWTiGrJ53sEbNwj2BR/4rVQj6BJD0DZtEE1YyrQG7KXPRVOHr54LPG94BZFcl/U+Hv3PPWgOJYzixtRFIoRuAA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-EzfSGRgtc/DY0fIyVgoIYlUeocxb1+SeEnG99X2jQQTO1wuNMVHCXzersUE9JZ9zh4cmBkLMuHwvWxywSz+rew==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-/pNL61l0olrtRaLzJS+YsjVRJzaYr6zhaqx1S2DKQJjbukGaHYtBwzgNNccj98XueR0A7B4pywCtkz0yalKBfQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@types/node": "^14.18.0"
 			}
 		},
@@ -3578,16 +3578,16 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-aC6WKja4zNnjUR1pMAairM67x2wBYhsjWNK/ZzX8NowfIZ1AQjjAMkyTT4gv5+8W0S+j4NPSArBggMlsNSu/bQ==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-WFjG5CiLCR2WGhZZC1tKXBG1ulPOOnYkijh9C4rfwVK4IvWWiIiuEynGSTgBqpZh+Khlt++HrKx9HCcgpFJ3Vw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/driver-base-previous": {
@@ -3604,12 +3604,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-y+9/+NPA8aGO2tDg9u0jLqyLmVQ9BcP7D+D2fjNqBhW3diUQTrJftwouywtGsmlA4Q/rYOQLksYdBPuZp0/WQQ==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-Ah8hB6cAx6e46oA5HvZnc8f25CV9xOBxp3pY5adRxKHK+CwGyUVZb/Qe4PFXk1yd3sR4Bm51lJgR6xUyPTKksw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0"
 			}
 		},
@@ -3624,18 +3624,18 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-h6S9E8Up1z/BmXSB68qmTR0RyciHucKQXD9abSW5PeXrQE+JuPI9QQwT2A1ng5+X9AKWh0OgT5nMnF8Tj7P1lQ==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-y4ATUMFLZgXJfgyy9hjk9+EK8jPOC7aT3c0S77sxUb+HsIhnfq0uZel7GdOvITljqqItXWEa1Hl5tURr9TSTvQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"url": "^0.11.0",
 				"uuid": "^8.3.1"
@@ -3724,22 +3724,22 @@
 			}
 		},
 		"@fluidframework/fluid-static": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-tvsKRivMlxUnyTU1F/JWXZEOA3XbliCZjMC3XdQRlLgADg8ahVWQxJwsKc1qOHCS0IP46Ca4VLP7liOB4XErgA==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-qOZjeOCajk6I3l+Ke5qYnTbeO2XTeWQSb9P6wUNgj3J75ddnbvI2GCuW2s8iatqQYwuP/C2lWlfSvFti28W8oA==",
 			"requires": {
-				"@fluidframework/aqueduct": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0"
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
@@ -3762,13 +3762,13 @@
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-kq8hJK5TQ/p5zA4j4pHAS6ChkoN4ftunHaQSWRTsJxx/a4/1aO1et5GFZ6XFK94/+YqsYyFMDL3VZfpFeB9h4g==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-gxLeyYqB/UE4yBjHzzDj7wS9j/rojvbbTSnLfmogu1Q7RJKsWhI56ZjHD9kyjmumcbXxm58dA4/i9072PpxRkQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
@@ -3802,17 +3802,17 @@
 			}
 		},
 		"@fluidframework/ink": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-L8txo6Tgm8+TyKAfjUPc9I9TpUjyTSYFlVvHc0Lpwcli5JbyGBWGWE+wDsUYfhTAjcsudgqd0TwbXG8ySV69Gw==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-uCicH33IvH1Cnk+InhxQNu8OOFMa4UE1vxUW7PjRF3khLhfETjjyae3ElouzuH/Uf5w27aIZdUFO26DbdjJQzA==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -3832,24 +3832,24 @@
 			}
 		},
 		"@fluidframework/local-driver": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-o058xVCFyn2uozDNTILmizDYmnz6/luSV3Xkp+4d73YQTVn4YUDh1rROmBtGyp7jcpuBsX7N320l567z1Xrd9w==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-BMGQO0OQbsw18JWDHaogCTzWAkGnK383wlOXCs5mgKKRqruYy2yj+XTMOHkAnrJFnmgIazBeZ56OgHWg/HIoPA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-local-server": "^0.1038.2000",
 				"@fluidframework/server-services-client": "^0.1038.2000",
 				"@fluidframework/server-services-core": "^0.1038.2000",
 				"@fluidframework/server-test-utils": "^0.1038.2000",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"jsrsasign": "^10.5.25",
 				"url": "^0.11.0",
 				"uuid": "^8.3.1"
@@ -3891,20 +3891,20 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-LY3YIrqMLecqd7Fh+tkoiIXOHvh5T0FeWHyJNr80g8JiMvH4KdcPLUGUL7nFzrErUec6byyaoiySwc5KN313kA==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-W8+VXlTDwMznxcoz6Ju5wymFosaq3yAqSk7wQqMMxhvOb7mijfLHDmavgV9IcfzXhPlQYNehTj8ys/00/LBRKw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
@@ -3927,21 +3927,21 @@
 			}
 		},
 		"@fluidframework/matrix": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-NDq9PBlPVwMwfkpNZ45GVQBIm/S4QFdSpoPShGuXH5SPcL7evHfDjcYhE3FIKS3qoCap6fTTytaNOKo+jLH/wA==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-+pFC6AQ7TQ6IakNPZUSJYmNp1xvpCQ/H49o7OzWBPZvKE6ziGnwkfzBrYbukcSPuduChP1wBiAZTeT2119dfKQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			}
@@ -3967,21 +3967,21 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-H6tV7tu4xPoTdVkzTrm90VItL15JWGDOnQQvNdJpI909qUoogpub7fwpPpB98ZuawWI0eixS2++kYd9h5tI0cw==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-gkMrAeoF3wikJDLg2WakHT7tjXgMiCIljn1ZzSGtUVAFcHoZJIIiIgdJRr+fBsOJDaacpn0fO7qy0xxSp2eOhg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
@@ -4013,16 +4013,16 @@
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-KQOS4txiB2UxiCm2eABy5XF4FU/GI79nqZkT5ZOPZnXglOvNxw42fQ9jrzXRY4LfCnJXSEtpG/IIPHY5T6IMyQ==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-EI17vW9cPA/um0KuY/8ec9VjUqxutDX5WMv/Czjbe8oC3ISzAznmMF5ZgaEvtGeyiOiAukX+EI3lkxRd60NWQQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"node-fetch": "^2.6.1"
 			}
 		},
@@ -4041,22 +4041,22 @@
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-OgN+i6QusKnOhsPJ88p14UC6SC5AaJBIC2mG1qWZNYJ1IIgqLUHVg5F8ClqKmf1j0IvA2Nfoyxpk1qAL/psFCw==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-XBYGjIEnS33z1s+ETdpw2w61D0OFDtdjiL2S4EOT1c5SRI/OQzPEd9p8BHnklfg+wI9/meM2eZ12t6CRN5iK9g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -4064,11 +4064,11 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-4jaydzoNCgcYXuZxxl9hVaD3oAwbbgpdMo5I7upsQjoNh6Wc6QQp5aCUg/IMWfO42SWUaR1T8Cx8KLgxTsyCag==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-AdHooUBy01IKQTM2HL0+o4ml6dwHeQSpW9Uu3RoDHc73sF+fWS+krBGUlPAOsSDrhCPrv0R4r3yANj/AW9ArUQ==",
 			"requires": {
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0"
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
@@ -4103,14 +4103,14 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-iKF7GzyX9KzYmebBygNa/HXny/4ulU2GOwPspA8xXj+kt495YNy+1rCj2rfuD9p0tduoUAkpJWGRfOsR6pJxBA==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-mzBOY17KjNA9Aa4Preh+h5x9GCZmeYLpt8mhFzuYgWlqaJ/7iYvF9T5BmfEifg8mclfORXuGWrkaWizIT+Ve2A==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
@@ -4125,17 +4125,17 @@
 			}
 		},
 		"@fluidframework/ordered-collection": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-KnHAFO7mnmzEkBttXpA3hENXns7lSHNg3iaH4ze1NOofLRxYZ5+k0QcBn3rW2HeySDrDNgXHiFFuZ+Q8SfQ5+g==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-x4kJlqyrZN5wGvYy6ZXfhG5sTcrPlrvd7GWuK05RXjK0osQJaac1OLeh4n0RhPbi+v1C+CV+MWaGvsWwJOGCMQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -4174,17 +4174,17 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-npuAT+WUO5TmZIVJpDKOErrnWIqT79sb5ffWytHO5AFI4Zvtb7a4qxu20fu5L/rSyfW4CEQebltArhqwgM6zBw==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-Vb8IzoTsC2fZOI95TgWC+GOroi6/FowYBKFSz9gIzOO85OFCR52XBYU9b9PktzAa6HVIEKkkyPMW594EBuk1cA==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/register-collection-previous": {
@@ -4202,16 +4202,16 @@
 			}
 		},
 		"@fluidframework/replay-driver": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-o1I/Jf1gy0qXYQJGHWNM2LKJw3D2pLs3g5zm3TxexndmQIC7adGqf62boqVMrm1xPt6HrdqOZGymmg7oItV88A==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-dvgzNVyjf/+WcXFGTbgXsZmUFJkzHMw+74b5nEjcyAuSljkdrUS5a/YnXC4khCddOoQ8rOGIReiywIE4ERv8bA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
@@ -4228,15 +4228,15 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-YYPujFOo3vxIeq1KERClmIvvEH3HJPA95nxvZUBxl8n/+iX22/CXbaLWciy8mGWtR/71kk/JfEBv5G6MFHWCZw==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-iZgkhRiJf7C8qCC0opCSxdyxPyWYwWFaht9MsyefyLZEGqPXQkjonHe8AMciMnsR+G5Ygpjql1Uv+SR653AGRQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0"
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/request-handler-previous": {
@@ -4252,20 +4252,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-C1rBfacAj0H2wBp7Q0GZqs4hAhokTx7QhI8v9j6NNtIqWc9elN8IeDPALr2mN8tzmbBmavQ/XFd+9bryeQVOqg==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-xrBRWo68ThGsaHynIDo49na36ko+DNm5LzqL9sf74WwtrM6ruuGsv/KUlh1qWCf3ee+ewQI1KZtqKUJvgoXJmg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -4311,15 +4311,15 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-YrSba46hex1ExZvJSMHTAEJFgN/3x3t2gvfzrH234MRvY0DHkW+lOxc+AYhjXUmy2jwums3UPux7tK6t71q8kA==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-774zXBWdEanxPV0Bz/Fr6w0cutApSnWBIOz2v5v17pO6ACtlMLP/ZZBMQU2TRVxmJltMk1x/av+wOxNV6/8PYw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"@types/node": "^14.18.0"
 			}
@@ -4339,21 +4339,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-888ud9wAjx98slF8qiDZwpnbbI6kTxNUw/J8OyiIwsKGu8T4mf82vnkI2RABohGKbLlIPhNxdcxf673oF9EcBw==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-udPWFNWcPeQLizKy9xAJoyZQjxIxz0HZVDub7Gu5xpRttcFfZ+0H1FDyNJCxsxOFcQ780dQCgv0QHZwXoDdUmg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
@@ -4375,21 +4375,21 @@
 			}
 		},
 		"@fluidframework/sequence": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-8UiHkiQuFNjyNIwqnnB7ic2w+C4xzG9wP7XLeZPrHE+8PFdc+7AzxzWh/dmSdWAm1DFrFSJtOfniOQ6gWFenWw==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-xxypuuIkORnaIdZhXp0Jd0l2Wf+z8rbTw0LLBv2jnFyYEyrs/FIkGP7j+TEpcSFPBXpBjRtBzUqHl74Rstmc2w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -5730,22 +5730,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-AMiaET5jA0GBEEvvO0eOJvQUl6eJmbHO7jmoFlL/MrRCmuqCW5NmBXmHK7JA/nGkbosck9rmYu1wKteIr1ktXQ==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-Tkgl0b5wDECCMr+xsi7rvqzU3yLDDtqj5+ancjqZSjqkwd77XcbblJysZlQLTux36q8lJqhK83/Q8S2PfszXzQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -5784,9 +5784,9 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-w7S8OWg932c8P1pEc8Y0i06G0aob0fzWYgLPUyZfnvrDlZFUBAWg9jmVpg30eZKu5qCWXJGwZl1hy5JucfrLUg=="
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-+v+qbTLl9w8zhi3BxrfJfRQBPLousRj4RxjwvDTPtpyHxvzDrvHQJt+z291XNFVS0xBXv7dkjBP4gK5JiOFMEQ=="
 		},
 		"@fluidframework/synthesize-previous": {
 			"version": "npm:@fluidframework/synthesize@2.0.0-internal.2.0.0",
@@ -5794,9 +5794,9 @@
 			"integrity": "sha512-+wkBqKT4iEjMpGxJwH8fgW8We18xAQ9ZstQ49bPHt0HdQN6Gjn+csTSV/ODD4+vQKJZNwt0ArnpVlLmDls4glQ=="
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-3w5dlgYSAOY1RG6eQ3S/Anpny30GehJbNwBJselIIkxF0JGhUdvA9ZQ7ELdOsMRdkT3oGfkEw9NsW65X4GCOmg==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-VTUFKw6YsHELlRcAhb1m6EqO9hRj1VRFSU9LQwn5qj3C7zJcYdiDwopg4qknlxHrbWWPX1xNlICBMWQrxu4/vg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
@@ -5828,13 +5828,13 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-+XDoy+4BPnt/Atvu/Q1d2p+6+WkeaQCRXdg8eV5D4pmwSZabd4aO/a6kexKWKmVtWXT082+jo1KkIVwGRCNoEA==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-Cd6s27iFtAR35mCvYUwHYTddzR1f5OehX0o/Wz+lQJFxClx5N39/vlz71n44r/4Afe5DUN/67Q9rzD2rPrShGw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
@@ -5852,27 +5852,27 @@
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-N4NXiEY5Dgx4w/Is+2AntYgqX444jT5zlXU09xUnrsXVlUW821DDJ9gewq3pjgx7CCDgX6PIPyEQQojfgr+Cng==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-USwVl6ybMwXTcVk5nYlDC2QesZSNa9BQQrW+qGj04aGqtDPZzTR5MHmi9uRuYKShE7lM0BPX/cT4VOp7wsH/dA==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/local-driver": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/local-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-local-server": "^0.1038.2000",
-				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/tool-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/tool-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -5918,9 +5918,9 @@
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-kMzqZxnipLxDsuNL2A5lKsfYopEhcNXFcj6MEMNct1iwXoUU/0bg4tJOe5j6cbmNRVGvxR7herdwbE1CqTMITA==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-t/4dtya41PvWk0lu0abYZTXYZHeP/YS5/AvQ3FMB/SVNFefrVsSUy18AsYEhLTtlcqhj3L33fVZP6c1gnksKnA==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
 				"random-js": "^1.0.8"
@@ -5936,22 +5936,22 @@
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-aejX2pDGQg42OlCo4PQDTEugbOsi8KQ4Qc1n0b1wqpNsQOAvH/M0sf1huKfq2nweVt4/kG04HhzbfHyfz4qyiQ==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-OCV68XMlUBKAhlQJWiEf7roXgSRTKGW6zz1AfHK88ue1TK7iHc5h21N7S7pweadSBYJtg2gU1TJMlntD3Z7cdA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -6656,32 +6656,32 @@
 			},
 			"dependencies": {
 				"@fluidframework/test-utils": {
-					"version": "2.0.0-internal.2.0.3",
-					"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.0.3.tgz",
-					"integrity": "sha512-fhiZNyOQ+ME7UnkX7+v0jd+GqdUkNF/QkdhQtF+WB8bho/ySSnnZT42OPhOZZ8JDsD92C1tqTb27gm8i9sxYWQ==",
+					"version": "2.0.0-internal.2.1.0",
+					"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.1.0.tgz",
+					"integrity": "sha512-Ex9sGDVnWL/Ii/LVcA7GnrREJSuyaZGfya6I1X9ldsujR0g2EUZFupAmj8InRuUeoa5XdOL53eS+RZ1FHihkew==",
 					"requires": {
-						"@fluidframework/aqueduct": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+						"@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 						"@fluidframework/common-definitions": "^0.20.1",
 						"@fluidframework/common-utils": "^1.0.0",
-						"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/container-loader": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/container-runtime": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/datastore": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/local-driver": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/map": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+						"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/local-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/map": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 						"@fluidframework/protocol-definitions": "^1.1.0",
-						"@fluidframework/request-handler": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-						"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+						"@fluidframework/request-handler": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+						"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 						"best-random": "^1.0.0",
 						"debug": "^4.1.1",
 						"uuid": "^8.3.1"
@@ -6710,15 +6710,15 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-ESdOZNWHndZz+kmMJIR8BQ43xkjgxODprj6PmEg6XG7rbCHDZ6+INhaLlZxMGhBOOBdL0jHeyFEEFsLHGn1O/g==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-F+eRGnkQNQHcwR4mov1lA+Cb+g5Fx4KMOBG5ykoEMfoPFwXGrPBEZc4upJNpULHNBxJtJgsBJbityEbBNWQ2nQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-services-client": "^0.1038.2000",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -6740,12 +6740,12 @@
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-u2YdjQqRDfY+nHv7fUFKMBK72oNUlILXDfLRWd7Tkea7KgJqPaGvwp2wzw5l9VWVnL94VujzQMWw8NYOhvNEng==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-Yj6LWTxeZ3/v0L6jr+CgV/qgfBEbsV/Zw5R6HKCh9RT6iwzHadXH/XBE++avWOQDGylKNdJ26q2grKjrKIbSVw==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"async-mutex": "^0.3.1",
@@ -6781,12 +6781,12 @@
 			}
 		},
 		"@fluidframework/view-adapters": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-dB9UZNIg4Gl4BY7zF6EIwID2eXgN7JUXRW0xr5riP6KIX9TLbOWelDEqRLJbGkjMZpZJxgR0Xv+m4KC8PBE8AA==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-dptqCYkf/YUtOSfC8WaAd6WRPXGMgdD8q09TYEVFX5AlZRoHaumfbC32vzmAVHwQGnAxq704NoHh6HquHtbaOw==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"react": "^17.0.1",
 				"react-dom": "^17.0.1"
 			}
@@ -6803,11 +6803,11 @@
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-b9qKrkIk18ku7zBotqy0bEvzlOQvEYJW3IZQZdhpkK6TpAwGvKPSQ30SVQK0eHeciTIjNR8TAyBpsXRBX8ZUzA==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-ko7Kb8QQOaymp+DoMT9wJKNjcF5oOvamheCPv6kwoQEwJo2Q78SgrvHeoQNRxOTAIDf9Sj2PHFIYw+W9z1IHDA==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
@@ -6819,12 +6819,12 @@
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "2.0.0-internal.2.0.3",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.0.3.tgz",
-			"integrity": "sha512-NZOtPL8Axiy0KRVUl1mXGyXjo6idwrm7sauh/DJqL3ggnv9ofmpuk+FoR1fwYjs9CUdSAp1EeOXaoysIIylIYw==",
+			"version": "2.0.0-internal.2.1.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.1.0.tgz",
+			"integrity": "sha512-eldNOEo7mJ36exkNznPiOqX0D13f7WyMeWZHmnRBNx3h85tK7g4SC7ewONjzNxTJUuLJmmV3I4VKJ8u7AL91Cg==",
 			"requires": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.0.3 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},


### PR DESCRIPTION
Run `npm i` to update package lock file for 2.1.0 publishing.