### PR TITLE
Tree: Remove Tomb marks

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -1078,7 +1078,6 @@ declare namespace SequenceField {
         SizedMark,
         SizedObjectMark,
         Tiebreak,
-        Tomb,
         Tombstones,
         TreeForestPath,
         TreeRootPath,
@@ -1174,7 +1173,7 @@ export function singleJsonCursor<T>(root: Jsonable<T>): ITreeCursorSynchronous;
 type SizedMark<TNodeChange = NodeChangeType> = Skip_2 | SizedObjectMark<TNodeChange>;
 
 // @public (undocumented)
-type SizedObjectMark<TNodeChange = NodeChangeType> = Tomb | Modify_2<TNodeChange> | Detach | ModifyDetach<TNodeChange>;
+type SizedObjectMark<TNodeChange = NodeChangeType> = Modify_2<TNodeChange> | Detach | ModifyDetach<TNodeChange>;
 
 // @public
 type Skip = number;
@@ -1212,16 +1211,6 @@ export type ToDelta = (child: NodeChangeset) => Delta.Modify;
 
 // @public (undocumented)
 type ToDelta_2<TNodeChange> = (child: TNodeChange) => Delta.Modify;
-
-// @public (undocumented)
-interface Tomb {
-    // (undocumented)
-    change: RevisionTag;
-    // (undocumented)
-    count: number;
-    // (undocumented)
-    type: "Tomb";
-}
 
 // @public
 interface Tombstones {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
@@ -21,7 +21,6 @@ import {
     isDetachMark,
     isReattach,
     isSkipMark,
-    isTomb,
     splitMarkOnInput,
     splitMarkOnOutput,
 } from "./utils";
@@ -94,9 +93,6 @@ function composeMarkLists<TNodeChange>(
             // TODO: properly compose detach marks with their matching new marks if any.
             factory.pushContent(baseMark);
             newIter.push(newMark);
-        } else if (isTomb(baseMark) || isTomb(newMark)) {
-            // We don't currently support Tomb marks (and don't offer ways to generate them).
-            fail("TODO: support Tomb marks");
         } else {
             // If we've reached this branch then `baseMark` and `newMark` start at the same location
             // in the document field at the revision after the base changes and before the new changes.

--- a/packages/dds/tree/src/feature-libraries/sequence-field/format.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/format.ts
@@ -20,16 +20,9 @@ export type ObjectMark<TNodeChange = NodeChangeType> =
 export type SizedMark<TNodeChange = NodeChangeType> = Skip | SizedObjectMark<TNodeChange>;
 
 export type SizedObjectMark<TNodeChange = NodeChangeType> =
-    | Tomb
     | Modify<TNodeChange>
     | Detach
     | ModifyDetach<TNodeChange>;
-
-export interface Tomb {
-    type: "Tomb";
-    change: RevisionTag;
-    count: number;
-}
 
 export interface Modify<TNodeChange = NodeChangeType> {
     type: "Modify";

--- a/packages/dds/tree/src/feature-libraries/sequence-field/index.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/index.ts
@@ -35,7 +35,6 @@ export {
     SizedMark,
     SizedObjectMark,
     Tiebreak,
-    Tomb,
     Tombstones,
     TreeForestPath,
     TreeRootPath,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldChangeEncoder.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldChangeEncoder.ts
@@ -47,7 +47,6 @@ export function encodeForJson<TNodeChange>(
                 case "MoveOut":
                 case "Return":
                 case "Revive":
-                case "Tomb":
                     jsonMarks.push(mark as unknown as JsonCompatible);
                     break;
                 default:
@@ -89,7 +88,6 @@ export function decodeJson<TNodeChange>(
                 case "MoveOut":
                 case "Return":
                 case "Revive":
-                case "Tomb":
                     marks.push(mark);
                     break;
                 default:

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -134,11 +134,6 @@ export function sequenceFieldToDelta<TNodeChange>(
                 case "Return":
                 case "MReturn":
                     fail(ERR_NOT_IMPLEMENTED);
-                case "Tomb": {
-                    // These tombs are only used to precisely describe the location of other attaches.
-                    // They have no impact on the current state.
-                    break;
-                }
                 default:
                     unreachableCase(type);
             }

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -21,7 +21,6 @@ import {
     SizedMark,
     SizedObjectMark,
     Skip,
-    Tomb,
 } from "./format";
 
 export function isModify<TNodeChange>(mark: Mark<TNodeChange>): mark is Modify<TNodeChange> {
@@ -49,10 +48,6 @@ export function isReattach<TNodeChange>(
             mark.type === "Return" ||
             mark.type === "MReturn")
     );
-}
-
-export function isTomb(mark: Mark<unknown>): mark is Tomb {
-    return isObjMark(mark) && mark.type === "Tomb";
 }
 
 export function getAttachLength(attach: Attach): number {
@@ -114,7 +109,6 @@ export function getOutputLength(mark: Mark<unknown>): number {
     }
     const type = mark.type;
     switch (type) {
-        case "Tomb":
         case "Revive":
         case "Return":
         case "MoveIn":
@@ -150,7 +144,6 @@ export function getInputLength(mark: Mark<unknown>): number {
     }
     const type = mark.type;
     switch (type) {
-        case "Tomb":
         case "Delete":
         case "MoveOut":
             return mark.count;
@@ -197,7 +190,6 @@ export function splitMarkOnInput<TMark extends SizedMark<unknown>>(
             fail(`Unable to split ${type} mark of length 1`);
         case "Delete":
         case "MoveOut":
-        case "Tomb":
             return [
                 { ...markObj, count: length },
                 { ...markObj, count: remainder },
@@ -248,7 +240,6 @@ export function splitMarkOnOutput<TMark extends Mark<unknown>>(
                 { ...markObj, content: markObj.content.slice(length) },
             ] as [TMark, TMark];
         case "MoveIn":
-        case "Tomb":
             return [
                 { ...markObj, count: length },
                 { ...markObj, count: remainder },
@@ -326,14 +317,6 @@ export function tryExtendMark(lhs: ObjectMark, rhs: Readonly<ObjectMark>): boole
                 lhsReattach.detachIndex + lhsReattach.count === rhs.detachIndex
             ) {
                 lhsReattach.count += rhs.count;
-                return true;
-            }
-            break;
-        }
-        case "Tomb": {
-            const lhsTomb = lhs as Tomb;
-            if (rhs.change === lhsTomb.change) {
-                lhsTomb.count += rhs.count;
                 return true;
             }
             break;

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
@@ -165,13 +165,4 @@ describe("SequenceField - MarkListFactory", () => {
         };
         assert.deepStrictEqual(factory.list, [expected]);
     });
-
-    it("Can merge consecutive tombs", () => {
-        const factory = new SF.MarkListFactory();
-        const tomb1: SF.Tomb = { type: "Tomb", change: detachedBy, count: 1 };
-        const tomb2: SF.Tomb = { type: "Tomb", change: detachedBy, count: 1 };
-        factory.pushContent(tomb1);
-        factory.pushContent(tomb2);
-        assert.deepStrictEqual(factory.list, [{ type: "Tomb", change: detachedBy, count: 2 }]);
-    });
 });

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
@@ -67,18 +67,6 @@ describe("SequenceField - toDelta", () => {
         assert.deepEqual(actual, expected);
     });
 
-    it("tomb", () => {
-        const actual = toDelta([
-            {
-                type: "Tomb",
-                change: tag,
-                count: 3,
-            },
-        ]);
-        const expected: Delta.MarkList = [];
-        assert.deepEqual(actual, expected);
-    });
-
     it("empty child change", () => {
         const actual = toDelta([{ type: "Modify", changes: TestChange.emptyChange }]);
         const expected: Delta.MarkList = [];
@@ -202,12 +190,6 @@ describe("SequenceField - toDelta", () => {
             {
                 type: "Modify",
                 changes: TestChange.mint([0], 1),
-            },
-            2,
-            {
-                type: "Tomb",
-                change: tag,
-                count: 3,
             },
         ];
         const del: Delta.Delete = {


### PR DESCRIPTION
Remove "Tomb" marks from the sequence field format. Those are not being used.