### PR TITLE
General-use telemetry type defs

### DIFF
--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -141,7 +141,7 @@ export interface ITelemetryGenErrorEvent extends ITelemetryGenEventBase {
 }
 
 /**
- * General-use Service event. Represents a call from app to an external service or storage.
+ * General-use Service event. Represents a call from FF to an external service or storage.
  */
 export interface ITelemetryGenServiceEvent extends ITelemetryGenEventBase {
     type: "service";
@@ -180,7 +180,7 @@ export interface ITelemetryGenClassEvent extends ITelemetryGenEventBase {
 }
 
 export type ITelemetryGenEvent =
-    | ITelemetryGenClassEvent
+    | ITelemetryGenApiEvent
     | ITelemetryGenServiceEvent
     | ITelemetryGenErrorEvent
     | ITelemetryGenClassEvent;

--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -53,30 +53,30 @@ export type TelemetryErrorCategory = "verbose" | "information" | "warning" | "er
 export interface ITelemetryGenEventBase extends ITelemetryBaseEvent {
     /*
      * Flag indicating this is general use event.
-     * Note: It may seem redundant if we end up emitting general use events separately.
-     * It may be useful if all (dev and general-use) telemetry is routed to a singlee table.
+     * Note: It may seem redundant if we end up emitting general use-events separately.
+     * However, it still may be useful if all (dev and general-use) telemetry is routed to a single table.
      */
     genUse: true;
     /*
-     * Subtype. Further description in sublasses.
+     * Subtype (Further description in sublasses).
      */
     type: "api" | "service" | "event" | "error";
     /*
-     * Package name where this event was emitted from.
-     * It may be useful for consumers to filter out packages whose APIs they are consuming directly.
+     * Package this event was emitted from.
+     * It may be useful for consumers to filter out specific packages they are working with.
      */
     packageName: string;
     /*
      * Class name where this event was emitted from.
-     * It may be useful for consumers to filter out classes whose APIs they are consuming directly.
+     * It may be useful for consumers to filter out specific classes they are working with.
      */
     className: string;
     /*
-     * Fluid document ID (when applicable).
+     * Fluid document ID (when applicable). This could be ID, resolved URL etc.
      */
     docId?: string;
     /*
-     * Client ID that generated this telemetry event (when applicable).
+     * Id of a client who generated this telemetry event (when applicable).
      */
     clientId?: string;
 }
@@ -107,6 +107,9 @@ export interface ITelemetryGenApiEvent extends ITelemetryGenEventBase {
      * Optional response status.
      */
     status?: string;
+    /*
+     * Optional bag od details on the event.
+     */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     details?: any;
 }
@@ -129,19 +132,19 @@ export interface ITelemetryGenErrorEvent extends ITelemetryGenEventBase {
      */
     severityLevel: TelemetryErrorCategory;
     /*
-     * Optional strack trac
+     * Optional strack trace
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     stackTrace?: any;
     /*
-     * Stack track or more details on conditions leading to error
+     * More details on condition(s) leading to this error
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     details?: any;
 }
 
 /**
- * General-use dependency event. Represents a call from app to an external service or storage.
+ * General-use Service event. Represents a call from app to an external service or storage.
  */
 export interface ITelemetryGenServiceEvent extends ITelemetryGenEventBase {
     type: "service";
@@ -168,7 +171,7 @@ export interface ITelemetryGenServiceEvent extends ITelemetryGenEventBase {
 }
 
 /**
- * General-use API event - Represents an event firing on a specific class.
+ * General-use class event - Represents an event firing on a specific object.
  * (Need a better name. "Event" has few different meanings in logger.)
  */
 export interface ITelemetryGenClassEvent extends ITelemetryGenEventBase {

--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -48,7 +48,7 @@ export interface ITelemetryBaseEvent extends ITelemetryProperties {
 export type TelemetryErrorCategory = "verbose" | "information" | "warning" | "error" | "critical";
 
 /**
- * General-use event. These statically typed events that consumers can understand and act on.
+ * General-use event. These are statically typed events that clients can understand and act on.
  */
 export interface ITelemetryGenEventBase extends ITelemetryBaseEvent {
     /*

--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -108,10 +108,9 @@ export interface ITelemetryGenApiEvent extends ITelemetryGenEventBase {
      */
     status?: string;
     /*
-     * Optional bag od details on the event.
+     * JSON stringifed bag od details on the event.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    details?: any;
+    details?: string;
 }
 
 /**
@@ -132,15 +131,13 @@ export interface ITelemetryGenErrorEvent extends ITelemetryGenEventBase {
      */
     severityLevel: TelemetryErrorCategory;
     /*
-     * Optional strack trace
+     * JSON stringifed stack trace
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    stackTrace?: any;
+    stackTrace?: string;
     /*
-     * More details on condition(s) leading to this error
+     * JSON stringifed details on condition(s) leading to this error
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    details?: any;
+    details?: string;
 }
 
 /**
@@ -177,10 +174,9 @@ export interface ITelemetryGenServiceEvent extends ITelemetryGenEventBase {
 export interface ITelemetryGenClassEvent extends ITelemetryGenEventBase {
     type: "event";
     /*
-     * Optional bag od details on the event.
+     * JSON stringifed bag od details on the event.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    details?: any;
+    details?: string;
 }
 
 export type ITelemetryGenEvent =


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Introduction

This PR explores how we can offer new set of general-use telemetry that Fluid Framework consumers can use to reason about state of the system, while providing them information that is actionable in nature.

We are advising FF consumers to rely on FF APIs, first and foremost, to inspect the state of the system. However, more often than not, they end up using our current "dev" telemetry to troubleshoot issues that do not yield clear set of errors (ex. why am I not seeing member A? is my data saved/lost? Are my docs loading too slow etc?), or to understand what led to the errors they are seeing. 

While current dev telemetry is often helpful in surfacing explicit errors, it lacks ability to coherently communicate the state around concepts that consumer is working with (ex. Azure client, audience, containers, DDSes etc), or interactions with services. App developers often start with diving into our telemetry and spending quite a bit of time trying to understand it before concluding they need their own instrumentation. Further, for the customers who do add their own layer of instrumentation, we often find it challenging to parse and understand their logs. Terminology used is often vague, and the data is skewed by the customer-specific scenarios. 

With general-use telemetry in place we should be able to communicate following to developers: 

 1. Use general observability points to understand the system. Our APIs/events often contain enough relevant information to determine action items. 

2. For the situations where (1) is not sufficient, use general-use telemetry to determine actionable items. This set of telemetry should be well-defined so that developers can also use it in their automation flows, dashboards etc. 

3. If no actions can be derived from (2), collect “dev” logs (our current set of logs) and share them with FF team. App developers should not use (3) to derive actionable items, but (2) and (3) should be coherent enough that FF developer can interpret them in some unified way. 

 
## Description

With this PR we are only bringing type definitions needed for general-use telemetry, and offering new pipe (sendGenTelemetry) through ITelemetryBaseLogger. The pipe is intentionally different API call so the loggers in the chain have more explicit clarity when they can transform event properties and when they can't. Also having them separated offers consumers easier time distinguishing the two types (open to suggestions on merging them).

Here is a draft PR that explores adoption: https://github.com/microsoft/FluidFramework/pull/12945

We are limiting general-use telemetry to following categories: 

(1) Exceptions/Errors Telemetry – exception that causes operation to fail. 
(2) Requests/APIs Telemetry - telemetry logging requests received by our (mostly public) APIs. 
(3) API Events Telemetry - telemetry capturing events off our observability points. 
(4) Service Telemetry - telemetry capturing interactions with service endpoints.

## Principles/tenants

(1) Consumers should still be dealing with a single logger (ITelemetryBaseLogger) 
(2) Consumers should be able to clearly differentiate dev logs from general-use logs. 
(3) Dev logs and general-use logs should play nicely together, with no duplication of information (for example we should not have to generate two types of events for same telemetry we want to capture). We should be able to route them through same aria/kusto channels. 
(4) Opt-in into general-use telemetry should be simple. 
(5) Start with smaller scope (3P only). 

## Understanding cost 

The moment we add structured telemetry, we are introducing the cost of maintaining it. There are two aspects: (a) change the shape of telemetry, (b) changing the behavior (when telemetry is emitted). With that in mind we should focus on: 

 1. Limit the telemetry we are emitting. We will target only few specific categories.  
 2. Limit well-defined properties that we are supporting on events, while allowing custom properties to change. 
 3. (Initially) limit the use to instrumentation to 3P libraries (fluid-framework etc), and routerlicious driver packages. (Basically, don’t inject any general-use telemetry in core client packages for now). 

## Breaking Changes

None with this PR.

## Reviewer Guidance

Looking for some feedback on:
1. Naming. I don't like "general-use" logs, but I could not come up with a better one :) Curious in your take about inverting the names. current telemetry -> "dev telemetry", and general-use telemetry -> just "telemetry".
2. Limiting incurred cost.
3. Considerations I have missed.
4. And anything else, of course.
