### PR TITLE
Tree: remove partially implement forest observation tracking APIs

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -472,7 +472,7 @@ export interface IForestSubscription extends Dependee {
     forgetAnchor(anchor: Anchor): void;
     readonly schema: StoredSchemaRepository;
     tryMoveCursorToField(destination: FieldAnchor, cursorToMove: ITreeSubscriptionCursor): TreeNavigationResult;
-    tryMoveCursorToNode(destination: Anchor, cursorToMove: ITreeSubscriptionCursor, observer?: ObservingDependent): TreeNavigationResult;
+    tryMoveCursorToNode(destination: Anchor, cursorToMove: ITreeSubscriptionCursor): TreeNavigationResult;
 }
 
 // @public
@@ -594,9 +594,8 @@ export interface ITreeSubscriptionCursor extends ITreeCursor {
     buildFieldAnchor(): FieldAnchor;
     clear(): void;
     // (undocumented)
-    fork(observer?: ObservingDependent): ITreeSubscriptionCursor;
+    fork(): ITreeSubscriptionCursor;
     free(): void;
-    observer?: ObservingDependent;
     readonly state: ITreeSubscriptionCursorState;
 }
 

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -285,9 +285,7 @@ function assertValidIndex(index: number, array: unknown[], allowOnePastEnd: bool
 type ObjectField = MapTree[];
 
 /**
- * TODO: track observations.
- * When doing observation tracking, it might make more sense to have this wrap a RootedTextCursor
- * (which can be undefined when cleared), instead of sub-classing it.
+ * Cursor implementation for ObjectForest.
  */
 class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
     state: ITreeSubscriptionCursorState;

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -5,8 +5,6 @@
 
 import { assert } from "@fluidframework/common-utils";
 import {
-    DisposingDependee,
-    ObservingDependent,
     recordDependency,
     SimpleDependee,
     SimpleObservingDependent,
@@ -55,8 +53,6 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
     private readonly dependent = new SimpleObservingDependent(() => this.invalidateDependents());
 
     public readonly roots: MapTree = makeRoot();
-
-    private readonly dependees: Map<ObjectField | MapTree, DisposingDependee> = new Map();
 
     // All cursors that are in the "Current" state. Must be empty when editing.
     public readonly currentCursors: Set<Cursor> = new Set();
@@ -157,21 +153,6 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
         cursor.free();
     }
 
-    public observeItem(
-        item: ObjectField | MapTree,
-        observer: ObservingDependent | undefined,
-    ): void {
-        let result = this.dependees.get(item);
-        if (result === undefined) {
-            result = new DisposingDependee("ObjectForest item");
-            this.dependees.set(item, result);
-            recordDependency(observer, result);
-            result.endInitialization(() => this.dependees.delete(item));
-        } else {
-            recordDependency(observer, result);
-        }
-    }
-
     private nextRange = 0;
     public newDetachedField(): DetachedField {
         const range: DetachedField = brand(String(this.nextRange));
@@ -230,13 +211,12 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
     tryMoveCursorToNode(
         destination: Anchor,
         cursorToMove: ITreeSubscriptionCursor,
-        observer?: ObservingDependent,
     ): TreeNavigationResult {
         const path = this.anchors.locate(destination);
         if (path === undefined) {
             return TreeNavigationResult.NotFound;
         }
-        this.moveCursorToPath(path, cursorToMove, observer);
+        this.moveCursorToPath(path, cursorToMove);
         return TreeNavigationResult.Ok;
     }
 
@@ -261,11 +241,7 @@ export class ObjectForest extends SimpleDependee implements IEditableForest {
      * This is NOT a relative move: current position is discarded.
      * Path must point to existing node.
      */
-    moveCursorToPath(
-        destination: UpPath | undefined,
-        cursorToMove: ITreeSubscriptionCursor,
-        observer?: ObservingDependent,
-    ): void {
+    moveCursorToPath(destination: UpPath | undefined, cursorToMove: ITreeSubscriptionCursor): void {
         assert(
             cursorToMove instanceof Cursor,
             0x337 /* ObjectForest must only be given its own Cursor type */,
@@ -419,8 +395,6 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
         return this.innerCursor.value;
     }
 
-    observer?: ObservingDependent | undefined;
-
     // TODO: tests for clear when not at root.
     public clear(): void {
         assert(
@@ -462,7 +436,7 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
         return [node, key];
     }
 
-    fork(observer?: ObservingDependent): ITreeSubscriptionCursor {
+    fork(): ITreeSubscriptionCursor {
         assert(this.innerCursor !== undefined, 0x460 /* Cursor must be current to be used */);
         return new Cursor(this.forest, this.innerCursor.fork());
     }

--- a/packages/dds/tree/src/forest/forest.ts
+++ b/packages/dds/tree/src/forest/forest.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { Dependee, ObservingDependent } from "../dependency-tracking";
+import { Dependee } from "../dependency-tracking";
 import { StoredSchemaRepository } from "../schema-stored";
 import {
     Anchor,
@@ -58,16 +58,12 @@ export interface IForestSubscription extends Dependee {
     forgetAnchor(anchor: Anchor): void;
 
     /**
-     * If observer is provided, it will be invalidated if the value returned from this changes
-     * (including from or to undefined).
-     *
      * It is an error not to free `cursorToMove` before the next edit.
      * Must provide a `cursorToMove` from this subscription (acquired via `allocateCursor`).
      */
     tryMoveCursorToNode(
         destination: Anchor,
         cursorToMove: ITreeSubscriptionCursor,
-        observer?: ObservingDependent,
     ): TreeNavigationResult;
 
     /**
@@ -125,25 +121,13 @@ export interface FieldAnchor {
  */
 export interface ITreeSubscriptionCursor extends ITreeCursor {
     /**
-     * Where observations get recorded for invalidation.
-     * When modified, future observations will count toward the new one.
-     *
-     * Observations made when in an OutOfDate state will never cause invalidation.
+     * @returns an independent copy of this cursor at the same location in the tree.
      */
-    observer?: ObservingDependent;
-
-    /**
-     * @param observer - sets the starting value for the observer.
-     * If undefined there is no observer for the returned ITreeSubscriptionCursor.
-     *
-     * Doing this has no impact on this.observer.
-     */
-    fork(observer?: ObservingDependent): ITreeSubscriptionCursor;
+    fork(): ITreeSubscriptionCursor;
 
     /**
      * Release any resources this cursor is holding onto.
      * After doing this, further use of this object other than reading `state` is forbidden (undefined behavior).
-     * Invalidation will still happen for the observer: it needs to unsubscribe separately if desired.
      */
     free(): void;
 
@@ -151,7 +135,6 @@ export interface ITreeSubscriptionCursor extends ITreeCursor {
      * Release any resources this cursor is holding onto.
      * After doing this, further use of this object other than reading `state` or passing to `tryGet`
      * or calling `free` is forbidden (undefined behavior).
-     * Invalidation will still happen for the observer: it needs to unsubscribe separately if desired.
      */
     clear(): void;
 


### PR DESCRIPTION
## Description

Forest focuses on efficiently storing the tree data.

Since forests are updated via deltas, any user of the forest that wants messages about changes could subscribe to deltas instead. This would also allow them to know about changes independent of if they happen to be cached in the forest.

Additionally, the existing observation API on forest wouldn't be an efficient way to notify editable tree about modifications since it would add cost per node, and its better to add cost per change instead as there can be a very large number of nodes.
