### PR TITLE
Mark internal tree package as publishable

### DIFF
--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluid-internal/tree",
   "version": "2.0.0-internal.2.2.0",
-  "private": true,
   "description": "Tree",
   "homepage": "https://fluidframework.com",
   "repository": {


### PR DESCRIPTION
In https://github.com/microsoft/FluidFramework/pull/12778 I mean to remove the private marker from the @fluid-interna/tree package but the change got rolled back from a main merge. This PR allows the package to be published.