### PR TITLE
Update azure client package to follow new unpack pattern for test pipeline runs

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -31,7 +31,7 @@
     "format": "npm run prettier:fix",
     "lint": "npm run prettier && npm run eslint",
     "lint:fix": "npm run prettier:fix && npm run eslint:fix",
-    "postpack": "cd dist && tar -cvf ../azure-client.test-files.tar ./test",
+    "postpack": "tar -cf ./azure-client.test-files.tar ./dist/test",
     "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
     "start:tinylicious:test": "npx @fluidframework/azure-local-service > tinylicious.log 2>&1",


### PR DESCRIPTION
In https://github.com/microsoft/FluidFramework/pull/12951 and https://github.com/microsoft/FluidFramework/pull/12778 we made the changes to pack and read the test files from the path `dist/test`. The azure client does not follow this pattern yet, so this PR updates the package to pack with the same pattern.