### PR TITLE
Fail fast when encountering errors in pipelines

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -202,6 +202,7 @@ jobs:
             else
               ls -1 ${{ variables.testPackagePathPattern }}
               echo "##vso[task.logissue type=error]Test package '${{ parameters.testPackage }}' not found, or there are more than one found"
+              exit -1
             fi
 
       # Auth to internal feed

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -230,6 +230,7 @@ stages:
                 else
                   ls -1 $TEST_PACKAGE_PATH_PATTERN
                   echo "##vso[task.logissue type=error]Test package '${{ execTestPackage }}' not found, or there are more then one found"
+                  exit -1
                 fi
 
                 npm install $TEST_PACKAGE_TGZ
@@ -332,6 +333,7 @@ stages:
                 else
                   ls -1 $TEST_PACKAGE_PATH_PATTERN
                   echo "##vso[task.logissue type=error]Test package '${{ testPackage }}' not found, or there are more then one found"
+                  exit -1
                 fi
 
                 npm install $TEST_PACKAGE_TGZ


### PR DESCRIPTION
## Description

Fail fast when encountering some unexpected conditions in pipelines. In the case of the performance tests pipeline, since it has more commands in the same step after the error was reported, if they succeed the step won't report failure and subsequent steps will try to execute (and fail). We saw this actually happen, e.g.:

<img width="903" alt="image" src="https://user-images.githubusercontent.com/716334/202041871-bb8c3697-cd36-4aa6-ad2d-aa36a0a7d399.png">


This change will make it clearer where the error actually is.
