### PR TITLE
Batch validation when using getPendingLocalState()

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3094,7 +3094,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const previousPendingState = this.context.pendingLocalState as IPendingRuntimeState | undefined;
         if (previousPendingState) {
             return {
-                pending: this.pendingStateManager.getLocalState(),
+                pending: pendingMessages,
                 pendingAttachmentBlobs: this.blobManager.getPendingBlobs(),
                 snapshotBlobs: previousPendingState.snapshotBlobs,
                 baseSnapshot: previousPendingState.baseSnapshot,
@@ -3104,7 +3104,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         assert(!!this.context.baseSnapshot, 0x2e6 /* "Must have a base snapshot" */);
         assert(!!this.baseSnapshotBlobs, 0x2e7 /* "Must serialize base snapshot blobs before getting runtime state" */);
         return {
-            pending: this.pendingStateManager.getLocalState(),
+            pending: pendingMessages,
             pendingAttachmentBlobs: this.blobManager.getPendingBlobs(),
             snapshotBlobs: this.baseSnapshotBlobs,
             baseSnapshot: this.context.baseSnapshot,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3043,46 +3043,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         this.baseSnapshotBlobs = await SerializedSnapshotStorage.serializeTree(this.context.baseSnapshot, this.storage);
     }
 
-    private validatePendingMessages(pendingMessages: IPendingLocalState | undefined): void {
-        if (pendingMessages === undefined) {
-            return;
-        }
-
-        // batchingState values:
-        // 1 = it is in the middle of a batch
-        // 0 = it is not in a batch
-        // any other value (-1, 2) would mean incomplete or corrupt batch in pendingMessages.
-        let batchingState = 0;
-        let incompleteBatch = false;
-        const pendingStates = pendingMessages.pendingStates;
-        for (const initialState of pendingStates) {
-            // Skip over "flush" messages
-            if (initialState.type === "message") {
-                if (initialState.opMetadata?.batch) {
-                    batchingState++;
-                } else if (initialState.opMetadata?.batch === false) {
-                    batchingState--;
-                }
-                if ( batchingState < 0 || batchingState > 1) {
-                    incompleteBatch = true;
-                    break;
-                }
-            }
-        }
-        if (incompleteBatch || batchingState !== 0) {
-            const error = new Error("Incomplete batch in pending states");
-            this.logger.sendErrorEvent({ eventName: "incompleteBatchWhileGetPendingLocalState" }, error);
-             throw error;
-        }
-    }
-
     public getPendingLocalState(): unknown {
         if (!(this.mc.config.getBoolean("enableOfflineLoad") ?? this.runtimeOptions.enableOfflineLoad)) {
             throw new UsageError("can't get state when offline load disabled");
         }
 
-        const pendingMessages = this.pendingStateManager.getLocalState();
-        this.validatePendingMessages(pendingMessages);
         if (this._orderSequentiallyCalls !== 0) {
             throw new UsageError("can't get state during orderSequentially");
         }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3094,7 +3094,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         const previousPendingState = this.context.pendingLocalState as IPendingRuntimeState | undefined;
         if (previousPendingState) {
             return {
-                pending: pendingMessages,
+                pending: this.pendingStateManager.getLocalState(),
                 pendingAttachmentBlobs: this.blobManager.getPendingBlobs(),
                 snapshotBlobs: previousPendingState.snapshotBlobs,
                 baseSnapshot: previousPendingState.baseSnapshot,
@@ -3104,7 +3104,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         assert(!!this.context.baseSnapshot, 0x2e6 /* "Must have a base snapshot" */);
         assert(!!this.baseSnapshotBlobs, 0x2e7 /* "Must serialize base snapshot blobs before getting runtime state" */);
         return {
-            pending: pendingMessages,
+            pending: this.pendingStateManager.getLocalState(),
             pendingAttachmentBlobs: this.blobManager.getPendingBlobs(),
             snapshotBlobs: this.baseSnapshotBlobs,
             baseSnapshot: this.context.baseSnapshot,

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -498,6 +498,23 @@ describeNoCompat("Flushing ops", (getTestObjectProvider) => {
         });
     });
 
+    describe("Batch validation when using getPendingLocalState()", () => {
+        beforeEach(async () => {
+            await setupContainers({ flushMode: FlushMode.TurnBased, enableOfflineLoad: true });
+        });
+        it("cannot capture the pending local state during ordersequentially", async () => {
+            dataObject1.context.containerRuntime.orderSequentially(() => {
+                dataObject1map1.set("key1", "value1");
+                dataObject1map2.set("key2", "value2");
+                assert.throws(() => {
+                    container1.closeAndGetPendingLocalState();
+                }, "Should throw for incomplete batch");
+                dataObject1map1.set("key3", "value3");
+                dataObject1map2.set("key4", "value4");
+            });
+        });
+    });
+
     describe("Document Dirty State when batches are flushed", () => {
         // Verifies that the document dirty state for the given document is as expected.
         function verifyDocumentDirtyState(dataStore: ITestFluidObject, expectedState: boolean) {

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -500,7 +500,7 @@ describeNoCompat("Flushing ops", (getTestObjectProvider) => {
 
     describe("Batch validation when using getPendingLocalState()", () => {
         beforeEach(async () => {
-            await setupContainers({ flushMode: FlushMode.TurnBased, enableOfflineLoad: true });
+            await setupContainers({ enableOfflineLoad: true });
         });
         it("cannot capture the pending local state during ordersequentially", async () => {
             dataObject1.context.containerRuntime.orderSequentially(() => {


### PR DESCRIPTION
## Description

https://dev.azure.com/fluidframework/internal/_workitems/edit/1911

While fixing [Task 297: Prevent stashed ops during orderSequentially - Boards (azure.com)](https://dev.azure.com/fluidframework/internal/_workitems/edit/297) we found that there are no batch validation during getPendingLocalState, besides, given prior code state, we couldn't add a pending UT for testing no use of getPendingLocalState while running in orderSequentially.
This PR contains a UT for batch validation when using getPendingLocalState while orderSequentially plus extra validation in getPendingLocalState making sure there are complete batches in the pending state.
