### PR TITLE
Use dev feed

### DIFF
--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -86,10 +86,7 @@ stages:
           releaseBuildVar: $[variables.releaseBuild]
           toolAbsolutePath: $(Build.SourcesDirectory)/tools/telemetry-generator
           artifactPipeline: Build - client packages
-          ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}:
-            feed: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
-          ${{ else }}:
-            feed: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
+          feed: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
 
         steps:
         # Setup. Need to checkout the repo in order to run @fluid-tools/telemetry-generator which we don't publish right now.


### PR DESCRIPTION
## Description

Use dev feed to download dependencies when running the performance tests pipeline, since the new way it works needs to be able to install some dependencies that only live there.

Relevant [thread in Teams](https://teams.microsoft.com/l/message/19:50292e8934024fc19d6ca2080dd7681e@thread.skype/1668555542277?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=9ce27575-2f82-4689-abdb-bcff07e8063b&parentMessageId=1668555542277&teamName=Fluid%20Framework&channelName=Dev&createdTime=1668555542277) (Microsoft internal).