### PR TITLE
Revert --use-openssl-ca flag

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -287,9 +287,7 @@ jobs:
         inputs:
           command: 'custom'
           workingDir: ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}
-          # --use-openssl-ca flag required so node uses the build agent's cert store, where we installed
-          # the self-signed cert for the r11s deployment
-          customCommand: 'run ${{ parameters.testCommand }} -- ${{ variant.flags }} --use-openssl-ca'
+          customCommand: 'run ${{ parameters.testCommand }} -- ${{ variant.flags }}'
 
       # Upload results
       - task: PublishTestResults@2


### PR DESCRIPTION
## Description

The way some npm scripts are structured (not calling node directly, e.g. `start-server-and-test start:tinylicious:test 7070 test:realsvc:tinylicious:run`) means that adding this flag here causes some pipelines to fail. I'll need to evaluate passing the flag at a lower level (in specific npm scripts) but reverting this to unblock the pipelines that are failing.
