### PR TITLE
--use-openssl-ca only for r11s tests

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -32,7 +32,7 @@
     "test:realsvc:local:report": "cross-env FLUID_TEST_REPORT=1 npm run test:realsvc:local --",
     "test:realsvc:odsp": "npm run test:realsvc:run -- --driver=odsp --timeout=20s",
     "test:realsvc:odsp:report": "cross-env FLUID_TEST_REPORT=1 npm run test:realsvc:odsp --",
-    "test:realsvc:r11s": "npm run test:realsvc:run -- --driver=r11s --timeout=5s",
+    "test:realsvc:r11s": "npm run test:realsvc:run -- --driver=r11s --timeout=5s --use-openssl-ca",
     "test:realsvc:routerlicious": "npm run test:realsvc:r11s",
     "test:realsvc:routerlicious:report": "cross-env FLUID_TEST_REPORT=1 npm run test:realsvc:r11s --",
     "test:realsvc:run": "mocha dist/test --config src/test/.mocharc.js",


### PR DESCRIPTION
## Description

Re-adding `--use-openssl-ca` flag to fix the r11s end-to-end tests, now only being applied specifically when running tests against r11s.

Confirmed locally that this lets the tests start succeeding if the self-signed cert is installed in the local cert store (and they time out with the cert installed but no flag being passed).