### PR TITLE
Set minimum number of checks for bot to merge pr 

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -707,7 +707,7 @@
         "deleteBranches": true,
         "allowAutoMergeInstructionsWithoutLabel": true,
         "enforceDMPAsStatus": true,
-        "removeLabelOnPush": true,
+        "removeLabelOnPush": false,
         "usePrDescriptionAsCommitMessage": true,
         "requireAllStatuses": false,
         "conditionalMergeTypes": [
@@ -728,7 +728,24 @@
             }
           }
         ],
-        "mergeType": "squash"
+        "mergeType": "squash",
+        "requireSpecificCheckRuns": true,
+        "requireSpecificCheckRunsList": [
+          "Build - tinylicious",
+          "Build - build-tools",
+          "Build - build-common",
+          "build - common-definitions",
+          "Build - common-utils",
+          "Build - client packages",
+          "Build - eslint-config-fluid",
+          "Build - protocol-definitions",
+          "license/cla",
+          "server-gitrest",
+          "server-gitssh",
+          "server-routerlicious",
+          "repo-policy-check",
+          "Build - azure"
+        ]
       },
       "disabled": false
     },


### PR DESCRIPTION
As of now, the bot waits until real service e2e and stress test succeeds on the PR. These are non-required PR checks. Setting a minimum number of checks limits to 10 and the required check to be Build - client packages before the bot merges the PR in next. 

Feedback:
1. Should the minimum number of checks limit be increased
2. Any other required checks to add in