### PR TITLE
Re-add postpack script

### DIFF
--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -33,6 +33,7 @@
     "format": "npm run prettier:fix",
     "lint": "npm run prettier && npm run eslint",
     "lint:fix": "npm run prettier:fix && npm run eslint:fix",
+    "postpack": "tar -cf ./tree.test-files.tar ./src/test ./dist/test",
     "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
     "test": "npm run test:mocha",


### PR DESCRIPTION
## Description

Something seems to have gone wrong with a merge in a recent PR (#12963  I think) that removed a new npm script added to packages/dds/tree when merging `main` to `next`. Restoring it so the Performance benchmarks pipeline doesn't fail when it runs for the `next` branch.