### PR TITLE
GC: Initialize tombstone state during garbage collector load

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -139,8 +139,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // (undocumented)
     getRootDataStore(id: string, wait?: boolean): Promise<IFluidRouter>;
     // (undocumented)
-    getSnapshotBlobs(): Promise<void>;
-    // (undocumented)
     get IContainerRuntime(): this;
     // (undocumented)
     get IFluidDataStoreRegistry(): IFluidDataStoreRegistry;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -769,7 +769,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             pendingRuntimeState.savedOps = [];
         }
 
-        await runtime.getSnapshotBlobs();
+        // Initialize the base state of the runtime before it's returned.
+        await runtime.initializeBaseState();
 
         return runtime;
     }
@@ -1312,6 +1313,14 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
         ReportOpPerfTelemetry(this.context.clientId, this.deltaManager, this.logger);
         BindBatchTracker(this, this.logger);
+    }
+
+    /**
+     * Initializes the state from the base snapshot this container runtime loaded from.
+     */
+    private async initializeBaseState(): Promise<void> {
+        await this.initializeBaseSnapshotBlobs();
+        await this.garbageCollector.initializeBaseState();
     }
 
     public dispose(error?: Error): void {
@@ -2980,7 +2989,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
     }
 
-    public async getSnapshotBlobs(): Promise<void> {
+    private async initializeBaseSnapshotBlobs(): Promise<void> {
         if (!(this.mc.config.getBoolean("enableOfflineLoad") ?? this.runtimeOptions.enableOfflineLoad) ||
             this.attachState !== AttachState.Attached || this.context.pendingLocalState) {
             return;

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -992,7 +992,7 @@ describe("Garbage Collection Tests", () => {
                 );
 
                 // Trigger loading GC state from base snapshot - but don't call GC since that's not what happens in real flow
-                await (garbageCollector as any).initializeStateFromBaseSnapshotP;
+                await (garbageCollector as any).initializeGCStateFromBaseSnapshotP;
 
                 // Update nodes and validate that all events for node 3 are logged.
                 updateAllNodes(garbageCollector);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstone.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstone.spec.ts
@@ -842,12 +842,8 @@ describeNoCompat("GC tombstone tests", (getTestObjectProvider) => {
             const summary2 = await summarizeNow(summarizer);
             validateTombstoneState(summary2.summaryTree, [newDataStoreUrl], [mainDataStoreUrl]);
 
-            // Load a container from the above summary. The tombstoned data store should be marked in this container.
+            // Load a container from the above summary. The tombstoned data store should be correctly marked.
             const container2 = await loadContainer(summary2.summaryVersion);
-            const mainDataStore2 = await requestFluidObject<ITestDataObject>(container2, "default");
-            // Send an op so that the container transitions to write mode.
-            mainDataStore2._root.set("writeMode", "true");
-            await waitForContainerConnection(container2);
 
             // Requesting the tombstoned data store should result in an error.
             await assert.rejects(async () => requestFluidObject<ITestDataObject>(container2, newDataStore._context.id),


### PR DESCRIPTION
During garbage collector load, initialize the tombstone state from the base snapshot.
Currently, this happens either when the container connects in write mode or when GC runs the first time. The problem with this is during the time window between container load and when it transitions to write mode, tombstoned objects can be loaded or receive ops. We will miss catching these scenarios. Also, read mode clients can load tombstone objects without any errors.
With this change, tombstone errors will occur in all cases.

[AB#2575](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2575) and [AB#2462](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2462)