### PR TITLE
fix(build-tools): Add missing dependency

### DIFF
--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@fluid-tools/version-tools": "^0.6.0",
     "@fluidframework/bundle-size-tools": "^0.6.0",
+    "@rushstack/node-core-library": "^3.51.1",
     "async": "^3.2.0",
     "chalk": "^2.4.2",
     "commander": "^6.2.1",


### PR DESCRIPTION
This dependency was missed when some code was moved in PR #12849. It wasn't found due to lerna's hoisting behavior.