### PR TITLE
GC: Add container runtime create time and version to sweep ready and inactive object logs

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -498,8 +498,8 @@ export class GarbageCollector implements IGarbageCollector {
         this.getLastSummaryTimestampMs = createParams.getLastSummaryTimestampMs;
         this.activeConnection = createParams.activeConnection;
 
-        const metadata = createParams.metadata;
         const baseSnapshot = createParams.baseSnapshot;
+        const metadata = createParams.metadata;
         const readAndParseBlob = createParams.readAndParseBlob;
 
         this.mc = loggerToMonitoringContext(ChildLogger.create(
@@ -537,7 +537,7 @@ export class GarbageCollector implements IGarbageCollector {
          * For existing containers, we get this information from the metadata blob of its summary.
          */
         if (createParams.existing) {
-            prevSummaryGCVersion = getGCVersion(this.metadata);
+            prevSummaryGCVersion = getGCVersion(metadata);
             // Existing documents which did not have metadata blob or had GC disabled have version as 0. For all
             // other existing documents, GC is enabled.
             this.gcEnabled = prevSummaryGCVersion > 0;

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -535,7 +535,7 @@ export class GarbageCollector implements IGarbageCollector {
          */
         if (createParams.existing) {
             prevSummaryGCVersion = getGCVersion(this.metadata);
-            // Existing documents which did not have this.metadata blob or had GC disabled have version as 0. For all
+            // Existing documents which did not have metadata blob or had GC disabled have version as 0. For all
             // other existing documents, GC is enabled.
             this.gcEnabled = prevSummaryGCVersion > 0;
             this.sweepEnabled = this.metadata?.sweepEnabled ?? false;

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -451,7 +451,6 @@ export class GarbageCollector implements IGarbageCollector {
     private completedRuns = 0;
 
     private readonly runtime: IGarbageCollectionRuntime;
-    private readonly metadata: IContainerRuntimeMetadata | undefined;
     private readonly createContainerMetadata: ICreateContainerMetadata;
     private readonly gcOptions: IGCRuntimeOptions;
     private readonly isSummarizerClient: boolean;
@@ -494,12 +493,12 @@ export class GarbageCollector implements IGarbageCollector {
         this.runtime = createParams.runtime;
         this.isSummarizerClient = createParams.isSummarizerClient;
         this.gcOptions = createParams.gcOptions;
-        this.metadata = createParams.metadata;
         this.createContainerMetadata = createParams.createContainerMetadata;
         this.getNodePackagePath = createParams.getNodePackagePath;
         this.getLastSummaryTimestampMs = createParams.getLastSummaryTimestampMs;
         this.activeConnection = createParams.activeConnection;
 
+        const metadata = createParams.metadata;
         const baseSnapshot = createParams.baseSnapshot;
         const readAndParseBlob = createParams.readAndParseBlob;
 
@@ -542,10 +541,10 @@ export class GarbageCollector implements IGarbageCollector {
             // Existing documents which did not have metadata blob or had GC disabled have version as 0. For all
             // other existing documents, GC is enabled.
             this.gcEnabled = prevSummaryGCVersion > 0;
-            this.sweepEnabled = this.metadata?.sweepEnabled ?? false;
-            this.sessionExpiryTimeoutMs = this.metadata?.sessionExpiryTimeoutMs;
+            this.sweepEnabled = metadata?.sweepEnabled ?? false;
+            this.sessionExpiryTimeoutMs = metadata?.sessionExpiryTimeoutMs;
             this.sweepTimeoutMs =
-                this.metadata?.sweepTimeoutMs
+                metadata?.sweepTimeoutMs
                 ?? computeSweepTimeout(this.sessionExpiryTimeoutMs); // Backfill old documents that didn't persist this
         } else {
             // Sweep should not be enabled without enabling GC mark phase. We could silently disable sweep in this
@@ -665,7 +664,7 @@ export class GarbageCollector implements IGarbageCollector {
                 // consolidate into IGarbageCollectionState format.
                 // Add a node for the root node that is not present in older snapshot format.
                 const gcState: IGarbageCollectionState = { gcNodes: { "/": { outboundRoutes: [] } } };
-                const dataStoreSnapshotTree = getSummaryForDatastores(baseSnapshot, this.metadata);
+                const dataStoreSnapshotTree = getSummaryForDatastores(baseSnapshot, metadata);
                 assert(dataStoreSnapshotTree !== undefined,
                     0x2a8 /* "Expected data store snapshot tree in base snapshot" */);
                 for (const [dsId, dsSnapshotTree] of Object.entries(dataStoreSnapshotTree.trees)) {

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -54,6 +54,7 @@ import {
     ReadFluidDataStoreAttributes,
     dataStoreAttributesBlobName,
     IGCMetadata,
+    ICreateContainerMetadata,
 } from "./summaryFormat";
 
 /** This is the current version of garbage collection. */
@@ -184,6 +185,7 @@ export interface IGarbageCollectorCreateParams {
     readonly baseLogger: ITelemetryLogger;
     readonly existing: boolean;
     readonly metadata: IContainerRuntimeMetadata | undefined;
+    readonly createContainerMetadata: ICreateContainerMetadata;
     readonly baseSnapshot: ISnapshotTree | undefined;
     readonly isSummarizerClient: boolean;
     readonly getNodePackagePath: (nodePath: string) => Promise<readonly string[] | undefined>;
@@ -450,6 +452,7 @@ export class GarbageCollector implements IGarbageCollector {
 
     private readonly runtime: IGarbageCollectionRuntime;
     private readonly metadata: IContainerRuntimeMetadata | undefined;
+    private readonly createContainerMetadata: ICreateContainerMetadata;
     private readonly gcOptions: IGCRuntimeOptions;
     private readonly isSummarizerClient: boolean;
 
@@ -492,6 +495,7 @@ export class GarbageCollector implements IGarbageCollector {
         this.isSummarizerClient = createParams.isSummarizerClient;
         this.gcOptions = createParams.gcOptions;
         this.metadata = createParams.metadata;
+        this.createContainerMetadata = createParams.createContainerMetadata;
         this.getNodePackagePath = createParams.getNodePackagePath;
         this.getLastSummaryTimestampMs = createParams.getLastSummaryTimestampMs;
         this.activeConnection = createParams.activeConnection;
@@ -1497,8 +1501,7 @@ export class GarbageCollector implements IGarbageCollector {
                 : this.sweepTimeoutMs,
             completedGCRuns: this.completedRuns,
             lastSummaryTime: this.getLastSummaryTimestampMs(),
-            containerCreateTime: this.metadata?.createContainerTimestamp,
-            containerRuntimeVersion: this.metadata?.createContainerRuntimeVersion,
+            ...this.createContainerMetadata,
             externalRequest: requestHeaders?.[RuntimeHeaders.externalRequest],
             viaHandle: requestHeaders?.[RuntimeHeaders.viaHandle],
             fromId: fromNodeId,

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -46,6 +46,7 @@ import {
 } from "../garbageCollection";
 import { dataStoreAttributesBlobName, GCVersion, IContainerRuntimeMetadata, IGCMetadata } from "../summaryFormat";
 import { IGCRuntimeOptions } from "../containerRuntime";
+import { pkgVersion } from "../packageVersion";
 
 /** @see - sweepReadyUsageDetectionSetting */
 const SweepReadyUsageDetectionKey = "Fluid.GarbageCollection.Dogfood.SweepReadyUsageDetection";
@@ -119,6 +120,10 @@ describe("Garbage Collection Tests", () => {
             baseLogger: mockLogger,
             existing: createParams.metadata !== undefined /* existing */,
             metadata: createParams.metadata,
+            createContainerMetadata: {
+                createContainerRuntimeVersion: pkgVersion,
+                createContainerTimestamp: Date.now(),
+            },
             isSummarizerClient,
             readAndParseBlob: async <T>(id: string) => gcBlobsMap.get(id) as T,
             getNodePackagePath: async (nodeId: string) => testPkgPath,

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -617,10 +617,10 @@ describe("Garbage Collection Tests", () => {
                     assert(!mockLogger.events.some((event) => event.eventName === deleteEventName), "Should not have any delete events logged");
                 }
                 expectedEvents.push(
-                    { eventName: changedEventName, timeout, id: nodes[2], pkg: eventPkg },
-                    { eventName: loadedEventName, timeout, id: nodes[2], pkg: eventPkg },
-                    { eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
-                    { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                    { eventName: changedEventName, timeout, id: nodes[2], pkg: eventPkg, createContainerRuntimeVersion: pkgVersion },
+                    { eventName: loadedEventName, timeout, id: nodes[2], pkg: eventPkg, createContainerRuntimeVersion: pkgVersion },
+                    { eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg, createContainerRuntimeVersion: pkgVersion },
+                    { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg, createContainerRuntimeVersion: pkgVersion },
                 );
                 mockLogger.assertMatch(expectedEvents, "all events not generated as expected");
 


### PR DESCRIPTION
[AB#2581](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2581)

Add container runtime create time and version to sweep ready and inactive object logs