### PR TITLE
add prettier to packages/common

### DIFF
--- a/experimental/dds/tree-graphql/package.json
+++ b/experimental/dds/tree-graphql/package.json
@@ -59,7 +59,7 @@
     "eslint": "~8.6.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
-    "prettier": "~2.3.1",
+    "prettier": "~2.6.2",
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5"
   },

--- a/experimental/dds/tree-graphql/prettier.config.cjs
+++ b/experimental/dds/tree-graphql/prettier.config.cjs
@@ -4,8 +4,5 @@
  */
 
 module.exports = {
-    "extends": [
-        "@fluidframework/eslint-config-fluid",
-        "prettier"
-    ]
-}
+    ...require("@fluidframework/build-common/prettier.config.cjs"),
+};

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -84,7 +84,7 @@
     "eslint": "~8.6.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
-    "prettier": "~2.3.1",
+    "prettier": "~2.6.2",
     "random-js": "^1.0.8",
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5"

--- a/experimental/dds/tree/prettier.config.cjs
+++ b/experimental/dds/tree/prettier.config.cjs
@@ -4,8 +4,5 @@
  */
 
 module.exports = {
-    "extends": [
-        "@fluidframework/eslint-config-fluid",
-        "prettier"
-    ]
-}
+    ...require("@fluidframework/build-common/prettier.config.cjs"),
+};

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -50938,9 +50938,9 @@
 			"integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA=="
 		},
 		"prettier": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ=="
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+			"integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew=="
 		},
 		"pretty-bytes": {
 			"version": "5.6.0",

--- a/packages/common/container-definitions/.eslintrc.js
+++ b/packages/common/container-definitions/.eslintrc.js
@@ -5,7 +5,8 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
+        require.resolve("@fluidframework/eslint-config-fluid"),
+        "prettier"
     ],
     "parserOptions": {
         "project": ["./tsconfig.json", "./src/test/types/tsconfig.json"]

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -32,6 +32,8 @@
     "eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
+    "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
+    "prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
     "tsc": "tsc",
     "tsc:watch": "tsc --watch",
     "typetests:gen": "fluid-type-validator -g -d ."
@@ -54,6 +56,7 @@
     "concurrently": "^6.2.0",
     "copyfiles": "^2.4.1",
     "eslint": "~8.6.0",
+    "prettier": "~2.6.2",
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5"
   },

--- a/packages/common/container-definitions/prettier.config.cjs
+++ b/packages/common/container-definitions/prettier.config.cjs
@@ -4,8 +4,5 @@
  */
 
 module.exports = {
-    "extends": [
-        "@fluidframework/eslint-config-fluid",
-        "prettier"
-    ]
-}
+    ...require("@fluidframework/build-common/prettier.config.cjs"),
+};

--- a/packages/common/core-interfaces/.eslintrc.js
+++ b/packages/common/core-interfaces/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        "@fluidframework/eslint-config-fluid",
+       require.resolve("@fluidframework/eslint-config-fluid"),
         "prettier"
     ]
 }

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -28,8 +28,11 @@
     "clean": "rimraf dist lib *.tsbuildinfo *.build.log",
     "eslint": "eslint --format stylish src",
     "eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
+    "format": "npm run prettier:fix",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
+    "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
+    "prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
     "tsc": "tsc",
     "tsc:watch": "tsc --watch",
     "typetests:gen": "fluid-type-validator -g -d ."
@@ -46,6 +49,7 @@
     "concurrently": "^6.2.0",
     "copyfiles": "^2.4.1",
     "eslint": "~8.6.0",
+    "prettier": "~2.6.2",
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5"
   },

--- a/packages/common/core-interfaces/prettier.config.cjs
+++ b/packages/common/core-interfaces/prettier.config.cjs
@@ -4,8 +4,5 @@
  */
 
 module.exports = {
-    "extends": [
-        "@fluidframework/eslint-config-fluid",
-        "prettier"
-    ]
-}
+    ...require("@fluidframework/build-common/prettier.config.cjs"),
+};

--- a/packages/common/driver-definitions/.eslintrc.js
+++ b/packages/common/driver-definitions/.eslintrc.js
@@ -5,6 +5,7 @@
 
 module.exports = {
     "extends": [
-        "@fluidframework/eslint-config-fluid"
+        "@fluidframework/eslint-config-fluid",
+        "prettier"
     ]
 }

--- a/packages/common/driver-definitions/.eslintrc.js
+++ b/packages/common/driver-definitions/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        "@fluidframework/eslint-config-fluid",
+        require.resolve("@fluidframework/eslint-config-fluid"),
         "prettier"
     ]
 }

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -28,8 +28,11 @@
     "clean": "rimraf dist lib *.tsbuildinfo *.build.log",
     "eslint": "eslint --format stylish src",
     "eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
+    "format": "npm run prettier:fix",
     "lint": "npm run eslint",
     "lint:fix": "npm run eslint:fix",
+    "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
+    "prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
     "tsc": "tsc",
     "tsc:watch": "tsc --watch",
     "typetests:gen": "fluid-type-validator -g -d ."
@@ -50,6 +53,7 @@
     "concurrently": "^6.2.0",
     "copyfiles": "^2.4.1",
     "eslint": "~8.6.0",
+    "prettier": "~2.6.2",
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5"
   },

--- a/packages/common/driver-definitions/prettier.config.cjs
+++ b/packages/common/driver-definitions/prettier.config.cjs
@@ -4,8 +4,5 @@
  */
 
 module.exports = {
-    "extends": [
-        "@fluidframework/eslint-config-fluid",
-        "prettier"
-    ]
-}
+    ...require("@fluidframework/build-common/prettier.config.cjs"),
+};

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -105,7 +105,7 @@
     "good-fences": "^1.1.1",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
-    "prettier": "~2.3.1",
+    "prettier": "~2.6.2",
     "rimraf": "^2.6.2",
     "source-map-support": "^0.5.16",
     "typescript": "~4.5.5"


### PR DESCRIPTION
### Description

Add prettier infrastructure repo-wide (enforcement disabled)
https://dev.azure.com/fluidframework/internal/_workitems/edit/2118/


#### Objective 
- Enable `format` script which will do the following:
    - Root of Release Group: `"format": "lerna run format --no-sort --stream -- -- -- --color"`
    - Root of Package: `"format": "npm run prettier:fix"`
- Add `prettier.config.cjs` in the root 
- Extend `prettier` in `eslintrc.js` 

#### Related PRs

- Update Tree's `prettier` from `2.3.1` to `2.6.2.`

- `azure`
https://github.com/microsoft/FluidFramework/pull/12932

- `server`
https://github.com/microsoft/FluidFramework/pull/12940

- `tools`
https://github.com/microsoft/FluidFramework/pull/12970

- `packages/common`
https://github.com/microsoft/FluidFramework/pull/12987

- `packages/dds`
https://github.com/microsoft/FluidFramework/pull/12998

- `packages/drivers`
https://github.com/microsoft/FluidFramework/pull/13004

- `packages/framework`
https://github.com/microsoft/FluidFramework/pull/13007

- `packages/loader`
https://github.com/microsoft/FluidFramework/pull/13008

- `packages/runtime`
https://github.com/microsoft/FluidFramework/pull/13010

- `packages/test`
https://github.com/microsoft/FluidFramework/pull/13011

- `packages/tools`
https://github.com/microsoft/FluidFramework/pull/13012

- `packages/utils`
https://github.com/microsoft/FluidFramework/pull/13013



