### PR TITLE
fix(fluid-build): Parse build-cli tasks properly in fluid-build

### DIFF
--- a/build-tools/packages/build-tools/src/common/utils.ts
+++ b/build-tools/packages/build-tools/src/common/utils.ts
@@ -20,8 +20,6 @@ export function getExecutableFromCommand(command: string) {
     } else {
         toReturn = commands[0];
     }
-
-    console.log(`"${command}" => "${toReturn}"`);
     return toReturn;
 }
 

--- a/build-tools/packages/build-tools/src/common/utils.ts
+++ b/build-tools/packages/build-tools/src/common/utils.ts
@@ -10,7 +10,19 @@ import * as path from "path";
 import * as util from "util";
 
 export function getExecutableFromCommand(command: string) {
-    return command.split(" ")[0];
+    let toReturn: string;
+    const commands = command.split(" ");
+    if (commands[0] === "flub") {
+        // Find the first flag argument, and filter them out. Assumes flags come at the end of the command, and that all
+        // subsequent arguments are flags.
+        const flagsStartIndex = commands.findIndex((c) => c.startsWith("-"));
+        toReturn = commands.slice(0, flagsStartIndex).join(" ");
+    } else {
+        toReturn = commands[0];
+    }
+
+    console.log(`"${command}" => "${toReturn}"`);
+    return toReturn;
 }
 
 export function toPosixPath(s: string) {


### PR DESCRIPTION
The new build-cli requires a bit more parsing to decompose the task into fluid-build's build graph. This change updates the parsing method to handle flub correctly.

The former implementation assumed that the command executable was the first argument of the command, but that doesn't hold for commands with subcommands.

The changed implementation assumes flags come at the end of the command, and that all subsequent arguments are flags. All non-flag arguments are then assumed to be the executable name. This is true for most of the commands today (and all of the ones that fluid-build needs to understand), but it is somewhat fragile.