### PR TITLE
Tree: fix node.js module imports and comment spelling error

### DIFF
--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-nodejs-modules
-import { fail } from "assert";
 import { assert } from "@fluidframework/common-utils";
 import {
     Value,
@@ -26,7 +24,7 @@ import {
     FieldAnchor,
     ITreeCursor,
 } from "../../core";
-import { brand } from "../../util";
+import { brand, fail } from "../../util";
 import { FieldKind, Multiplicity } from "../modular-schema";
 import {
     AdaptingProxyHandler,

--- a/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
@@ -98,7 +98,7 @@ class StackCursor<TNode> extends SynchronousCursor implements CursorWithNode<TNo
      * does not include current level (which is stored in `siblings`).
      * Even levels in the stack (starting from 0) are sequences of nodes and odd levels
      * are for fields keys on a node.
-     * @param indexStack - Stack of indices into the corosponding levels in `siblingStack`.
+     * @param indexStack - Stack of indices into the corresponding levels in `siblingStack`.
      * @param siblings - Siblings at the current level (not included in `siblingStack`).
      * @param index - Index into `siblings`.
      */

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-nodejs-modules
 import { strict as assert } from "assert";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 import {

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-nodejs-modules
 import { strict as assert } from "assert";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 import {

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/utils.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-nodejs-modules
 import { strict as assert } from "assert";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 import { SchemaDataAndPolicy } from "../../../schema-stored";


### PR DESCRIPTION
## Description

Avoid importing node.js modules in non-test code, and remove no longer needed linter suppression related for importing them in test code.

Fix spelling error.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

