### PR TITLE
r11s-driver: properly reset discovery refresh flags

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -266,7 +266,6 @@ export class DocumentService implements api.IDocumentService {
         this.ordererUrl = fluidResolvedUrl.endpoints.ordererUrl;
         this.deltaStorageUrl = fluidResolvedUrl.endpoints.deltaStorageUrl;
         this.deltaStreamUrl = fluidResolvedUrl.endpoints.deltaStreamUrl || this.ordererUrl;
-        this.lastDiscoveredAt = Date.now();
     }
 
     /**
@@ -282,6 +281,15 @@ export class DocumentService implements api.IDocumentService {
         // Disconnect event is not so reliable in local testing. To ensure re-discovery when necessary,
         // re-discover if enough time has passed since last discovery.
         const pastLastDiscoveryTimeThreshold = (now - this.lastDiscoveredAt) > RediscoverAfterTimeSinceDiscoveryMs;
+        if (pastLastDiscoveryTimeThreshold) {
+            // Reset discover promise and refresh discovery.
+            this.lastDiscoveredAt = Date.now();
+            this.discoverP = undefined;
+            this.refreshDiscovery().catch(() => {
+                // Undo discovery time set on failure, so that next check refreshes.
+                this.lastDiscoveredAt = 0;
+            });
+        }
         return pastLastDiscoveryTimeThreshold;
     }
 }


### PR DESCRIPTION
## Description

@zhenmichael was asking about the discoverP variable, and I noticed it wasn't being reset anywhere. Must have gotten lost in a local iteration. Everything was working for 1 resfresh, but would not refresh a second time. This ensures that we refresh as many times as needed.
