### PR TITLE
shared tree jsonbench

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1987,18 +1987,25 @@
 			}
 		},
 		"@fluid-experimental/property-changeset": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-changeset/-/property-changeset-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-vcylyvKuEsx/Hp6YPS+HsOmF+TYEAApWfeMoj8j4jfHyY1OLTeZ/R36ZnuBaBMk4X9zvpCBee9Cdcc3Mfmzh5w==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-changeset/-/property-changeset-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-nScLGykY9wAViszy42G7i9dx+Woq4Vq9zfvFON3t6QfnQNZFPvHnshTfMrfCB73FQo5dM3jd2z9yb7snzdxFMA==",
 			"requires": {
-				"@fluid-experimental/property-common": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-common": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"ajv": "7.1.1",
 				"ajv-keywords": "4.0.0",
-				"async": "^3.2.0",
+				"async": "^3.2.2",
 				"fastest-json-copy": "^1.0.1",
 				"lodash": "^4.17.21",
 				"semver": "^7.3.4",
 				"traverse": "0.6.6"
+			},
+			"dependencies": {
+				"async": {
+					"version": "3.2.4",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+					"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+				}
 			}
 		},
 		"@fluid-experimental/property-changeset-previous": {
@@ -2017,12 +2024,12 @@
 			}
 		},
 		"@fluid-experimental/property-common": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-common/-/property-common-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-+gUpPkFIUKChM2gmD3Jshubll4M5WzbTDkJIjjIMUj/SFJFJGJTRRGD3P2n/NIFOV8y3OWtCPKiRj0lvcq6I5A==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-common/-/property-common-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-Dh/8AETqJI25f285DBl7OgoEKUzWOpXNxk6coJnVtM7Z8UVMr67V/FGETFZpMkKkFh3m/k9giVMJ3Sgd6fGMPQ==",
 			"requires": {
 				"ajv": "7.1.1",
-				"async": "^3.2.0",
+				"async": "^3.2.2",
 				"base64-js": "1.3.0",
 				"events": "^3.1.0",
 				"fastest-json-copy": "^1.0.1",
@@ -2030,6 +2037,13 @@
 				"murmurhash3js": "3.0.1",
 				"semver": "^7.3.4",
 				"traverse": "0.6.6"
+			},
+			"dependencies": {
+				"async": {
+					"version": "3.2.4",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+					"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+				}
 			}
 		},
 		"@fluid-experimental/property-common-previous": {
@@ -2049,20 +2063,20 @@
 			}
 		},
 		"@fluid-experimental/property-dds": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-dds/-/property-dds-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-uwwAqIuB669T711A8tDGqtafHOhvKfpeh8xRn/nt7qQ7rLjLg7nzYrN2jhUNG44wpkH6xLsNUv8XHO8dLwNbRg==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-dds/-/property-dds-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-YkEmLQbNu+ysVWgW2JcGnY2voxM5lKMW7XV8MHdlgzudrcGcfl2wNRB4I0u3seb/9tF6qVA2btAwdda47wnMjg==",
 			"requires": {
-				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluid-experimental/property-properties": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-properties": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"fastest-json-copy": "^1.0.1",
 				"lodash": "^4.17.21",
@@ -2116,19 +2130,26 @@
 			}
 		},
 		"@fluid-experimental/property-properties": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-properties/-/property-properties-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-oEZu3VCwulHfSaYMlZJwU7XlGiS+WcvvSyk2gykeLvKAfy8p8THcDZ9p2vFTV65pLQMHUEsl31lYVD8eOUiR5g==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-properties/-/property-properties-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-0HqGYyx36jUKZkQUJ+TVQ+4jDuUNh+Qi6mdMXDmPc7goyhTV8YfbCX9/pOi4xaJtQG7AzL+xpFLSeinsbeg1sw==",
 			"requires": {
-				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluid-experimental/property-common": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-common": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"ajv": "7.1.1",
-				"async": "^3.2.0",
+				"async": "^3.2.2",
 				"fastest-json-copy": "^1.0.1",
 				"lodash": "^4.17.21",
 				"semver": "^7.3.4",
 				"traverse": "0.6.6",
 				"underscore": "^1.12.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "3.2.4",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+					"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+				}
 			}
 		},
 		"@fluid-experimental/property-properties-previous": {
@@ -2795,25 +2816,25 @@
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-HctjLrNjCMb7YkVN9C0DxrhTbFBXKuq6Af309yecyUMl/jI1w9BmabZih3wBLQz64PbZhR0pHhSiYPddE1lZ/w==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-9zJC60vFWQPmreMHANYu+IZRmeRDnIh1To+h4vPykZat24pvr1AFNCW5FI76r2KXbEg4pa+1LiDYD9iT2ODTAw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/map": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/synthesize": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/map": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/synthesize": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -3201,17 +3222,17 @@
 			}
 		},
 		"@fluidframework/cell": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-leMU7hUYpK5SA8q7pmF15YpuMX9dGIJaM1RCKm+PVYh1fqh4asXw8LVKlkSDWa4RsITtADRX8XXza2vPdTNeEg==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-+pOaJbnkS7pLiPOCKjACtWfVKRjDCHFiomMFBucy84Y9Hdp88FkIyLFFNB4UnpPTjQOGyK/ShV9Xm+OjyAztSQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/cell-previous": {
@@ -3255,14 +3276,15 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-y822qjw2E19yyixOIpu1KNVzQ6AxS66epQHJCyWpbWR4howmxKZcIGQH1SjmQdemkDhFKpC/V79UmMSx0kGq2Q==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-VqwMsYW4k2SBzgnUD/DiWLsJK94+aNpnzpsifZB3gEnFQoZf/4ikjVJAvNWyehDBV0FuyKeuz/wJ4ChahI3R5Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/protocol-definitions": "^1.1.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"events": "^3.1.0"
 			}
 		},
 		"@fluidframework/container-definitions-previous": {
@@ -3277,22 +3299,23 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-O+g17yxiddhciRlp/Se4RqPl1y0zFWPQcci+l9AjDlTyNaSKXI+89Ev7BCVxb432Fm2JZ5qbHhZbt24V81fU2g==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-v36ciS1V+VlNXU78p30oW9Mu2TvniWbEgQPmdQDr2Ea14JWi7YwVQLNlolTt6aggIK6h9A4G5vZcSKWm1UZyGw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
 				"lodash": "^4.17.21",
 				"url": "^0.11.0",
 				"uuid": "^8.3.1"
@@ -3321,42 +3344,42 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-wGA/ychiWlPfj+fFUsaIYoTplOMJ1CbA9zjb6zfpBeFqGiqqmTVk8wn6X5G4VNcVoGq6nJZme+TMq7VL7a/K9g==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-xVsI7pT9QEBf6avfEuL/0iESiD1Zch5+dt7muun1d509R9w+MNrG01RqLxHnlY0bolsdkSSpLR2VKAqRwbbgsw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"double-ended-queue": "^2.1.0-0",
+				"events": "^3.1.0",
 				"lz4js": "^0.2.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-0u1h0chnWgPwBLkUyRe5bCHcyGhpwPWOSFccfEt5xa8YiwNDmj5kSx5dUlVSk1UXJJFWTup6JaqIC8wwFQPNZw==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-MaPs3Gc6wuSTjnOBvuK07Pbpf3XE3dckNSXMzpeHOwbhudp3+zPNTlgE9SE3b9CnGFOMNIqFj4ZBdxCtA9UyvQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@types/node": "^14.18.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/container-runtime-definitions-previous": {
@@ -3399,15 +3422,15 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-pQ8OmKecWp833+XM8Vm5IvzM/nAAjqbBTA4WA4A39o2VWPiQ/mLnNXtTcLUVVmFYJUD04IxDK7NIMzzYVhB+NQ==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-mn+E3GMSDD3JhYQVAn6gnmoNLDDhrq7XfqSIrEeydyzocc5wnBzSxwkF8zk6PwvvRHzojRstgWMuLtXwNU3eyQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/container-utils-previous": {
@@ -3423,9 +3446,9 @@
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-ru0WcnuMHeMysngJA0YD3CMwp9cfJCd+JWW2KM77Trtwgz7PJaj9SyGj3190Ceq0HRB6QdPrzM5C5HVzAXZQBg=="
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-q3Vzti54PaPP4BzYIQ/FjNM+8kqHG1ewa23qBUMIZ6qU5eL7Nz5wLrIEScSd208nvaPI/paSeIKpgncriAYFrg=="
 		},
 		"@fluidframework/core-interfaces-previous": {
 			"version": "npm:@fluidframework/core-interfaces@2.0.0-internal.2.0.0",
@@ -3433,17 +3456,17 @@
 			"integrity": "sha512-S9sAqYtdOQgUqH5dj7Cy/zgMy97+YtEZ5nbtbZ3naEacngXdCPA46X2tlvNMzMloSQTlsJDx8r5N+bSCtpmrFA=="
 		},
 		"@fluidframework/counter": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-hVTaetymSXpKarVk0/L/RkCtNrrXAmXVFrWZ7n0ozZSBureBOibLOdJuXqkrg3AycnVq9eYZTs53By+xO+08Ow==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-M8BDIoRYuLs8ZXIYVYhhuM26xic/l3wkYS9OQbgf+iuRLWfvbbhZRWR5q/2bW1n11tByvzcH6ZztzRsRuJOlAw==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/counter-previous": {
@@ -3479,40 +3502,39 @@
 			}
 		},
 		"@fluidframework/datastore": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-YWTiGrJ53sEbNwj2BR/4rVQj6BJD0DZtEE1YyrQG7KXPRVOHr54LPG94BZFcl/U+Hv3PPWgOJYzixtRFIoRuAA==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-+QQL72EYcBanTqE5VYvBN6SsrJWGU3xbXFp0t9JThpy7A9tDIJZMcleFCgurAPntp3Y7mP3pRPcrfCiCM5TpYA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-/pNL61l0olrtRaLzJS+YsjVRJzaYr6zhaqx1S2DKQJjbukGaHYtBwzgNNccj98XueR0A7B4pywCtkz0yalKBfQ==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-nS6kkoj0BgnyHDk/GJFmiqSPjctkeCTw1A4wzdV3W48fFFLXDdW8wMyMxgvUootqn72TSeTiOyErttCOc92dEQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@types/node": "^14.18.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/datastore-definitions-previous": {
@@ -3578,16 +3600,16 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-WFjG5CiLCR2WGhZZC1tKXBG1ulPOOnYkijh9C4rfwVK4IvWWiIiuEynGSTgBqpZh+Khlt++HrKx9HCcgpFJ3Vw==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-+OmqtmVBAdt8anHt5kXwDNc8qVj54f2VG9Yot/ABWGH2aZXnuFNN9CIptfCN1t6+lIBdGzoCED/pCLTlw4jDvA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/driver-base-previous": {
@@ -3604,12 +3626,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-Ah8hB6cAx6e46oA5HvZnc8f25CV9xOBxp3pY5adRxKHK+CwGyUVZb/Qe4PFXk1yd3sR4Bm51lJgR6xUyPTKksw==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-jv+ryQ4roA/iCty9eXB1yKyknaMyFP56hAMS1NMB2P7xRIcLBkaEfDqGu7+8dcDTy2sDEyHdPQ4gSV0MvQVX0A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0"
 			}
 		},
@@ -3624,18 +3646,18 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-y4ATUMFLZgXJfgyy9hjk9+EK8jPOC7aT3c0S77sxUb+HsIhnfq0uZel7GdOvITljqqItXWEa1Hl5tURr9TSTvQ==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-4/5FsPn7BbUal5wl8lwczDBskF5savEu5mh+r0T8QdQc3rkIlhur0x8v7vu/9zqDlJOeD3Vxy/cmGhSh1WPRoQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"url": "^0.11.0",
 				"uuid": "^8.3.1"
@@ -3724,22 +3746,22 @@
 			}
 		},
 		"@fluidframework/fluid-static": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-qOZjeOCajk6I3l+Ke5qYnTbeO2XTeWQSb9P6wUNgj3J75ddnbvI2GCuW2s8iatqQYwuP/C2lWlfSvFti28W8oA==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-oWPuROROD90assA2ieABSQUsbPR6T7OtdAmcwb+FfMO49uG5t39VdHZyp9BtuR8K3atwpqEAlm6m0Y9PTVAuwQ==",
 			"requires": {
-				"@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
@@ -3762,13 +3784,14 @@
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-gxLeyYqB/UE4yBjHzzDj7wS9j/rojvbbTSnLfmogu1Q7RJKsWhI56ZjHD9kyjmumcbXxm58dA4/i9072PpxRkQ==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-zJVELgDSlmTK3fRh3F8gMX/JmojIczAFlW1D20JCVJAvt9UaLSHyikeF0uN+4lHMqPFouWkwn3LjCScc5By+Jg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/protocol-definitions": "^1.1.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
@@ -3802,17 +3825,17 @@
 			}
 		},
 		"@fluidframework/ink": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-uCicH33IvH1Cnk+InhxQNu8OOFMa4UE1vxUW7PjRF3khLhfETjjyae3ElouzuH/Uf5w27aIZdUFO26DbdjJQzA==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-a415hyaNAGuHTb9N0Gv9323sK05bde0d7tMm3e9HK/hIRzAEOd8zbIawj/pzTicF0nER95pmFQuPwQSBuv79EQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -3832,24 +3855,25 @@
 			}
 		},
 		"@fluidframework/local-driver": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-BMGQO0OQbsw18JWDHaogCTzWAkGnK383wlOXCs5mgKKRqruYy2yj+XTMOHkAnrJFnmgIazBeZ56OgHWg/HIoPA==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-X7jQXV77zcWVEL9zFR44oR0f0X1GwdOrXmy5vze4Gu3lQ8GRdUIFtWJeS3PdZFNUlXrmHqe9K51bVmDYm9NZRA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-local-server": "^0.1038.2000",
 				"@fluidframework/server-services-client": "^0.1038.2000",
 				"@fluidframework/server-services-core": "^0.1038.2000",
 				"@fluidframework/server-test-utils": "^0.1038.2000",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"events": "^3.1.0",
 				"jsrsasign": "^10.5.25",
 				"url": "^0.11.0",
 				"uuid": "^8.3.1"
@@ -3891,20 +3915,20 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-W8+VXlTDwMznxcoz6Ju5wymFosaq3yAqSk7wQqMMxhvOb7mijfLHDmavgV9IcfzXhPlQYNehTj8ys/00/LBRKw==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-7tWssmf4e3PY54yM+4jIvhxU+4DP/0+brR9ZwvDyIvu1q+eL0L3i93zR+kMk+gesDKAVw45Cpd4v+ksOos2nwg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
@@ -3927,22 +3951,23 @@
 			}
 		},
 		"@fluidframework/matrix": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-+pFC6AQ7TQ6IakNPZUSJYmNp1xvpCQ/H49o7OzWBPZvKE6ziGnwkfzBrYbukcSPuduChP1wBiAZTeT2119dfKQ==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-W57mgxTwi10NEtxOijXYhtR0cgw8RWqjSuQdxtoNaJLP7ynenbtnjPHynvlWzdxuYua/9DULME8pM8J4Dc0cGw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
+				"events": "^3.1.0",
 				"tslib": "^1.10.0"
 			}
 		},
@@ -3967,21 +3992,21 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-gkMrAeoF3wikJDLg2WakHT7tjXgMiCIljn1ZzSGtUVAFcHoZJIIiIgdJRr+fBsOJDaacpn0fO7qy0xxSp2eOhg==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-eY53aSR7YoKn44AUYpqzSNTX3G/C1LAeR+SNBuxcILqpAw2NtHYs7HcF93oN7bOpIA6HhDXJYvTP/alNNWyfwg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
@@ -4013,16 +4038,16 @@
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-EI17vW9cPA/um0KuY/8ec9VjUqxutDX5WMv/Czjbe8oC3ISzAznmMF5ZgaEvtGeyiOiAukX+EI3lkxRd60NWQQ==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-Y++o1mZPlqHk2dMkh9hAIX9uV7l19ZZJhuzJGsfbJakkizGU6w4ENtlXfJ1yFC2Y90mzdcSchvmuMG0IzCL9sA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"node-fetch": "^2.6.1"
 			}
 		},
@@ -4041,22 +4066,22 @@
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-XBYGjIEnS33z1s+ETdpw2w61D0OFDtdjiL2S4EOT1c5SRI/OQzPEd9p8BHnklfg+wI9/meM2eZ12t6CRN5iK9g==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-VJ8gtbk20XGH1bVXs5Z+EvIys0zEr+wkWUK7rujM0hiR/eJc0TM6e8g+mshFNpiKDYFuGzcYccUKtnPACpwvOQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -4064,11 +4089,11 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-AdHooUBy01IKQTM2HL0+o4ml6dwHeQSpW9Uu3RoDHc73sF+fWS+krBGUlPAOsSDrhCPrv0R4r3yANj/AW9ArUQ==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-HqAbuRtXrkU04rlFHkkvzHeuW279ZJPsV0f7A+bcNGcwgiPTGH9sqNCu324X/IvZTZPiKdyjI4jEgZPvQOp2Sw==",
 			"requires": {
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
@@ -4103,14 +4128,14 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-mzBOY17KjNA9Aa4Preh+h5x9GCZmeYLpt8mhFzuYgWlqaJ/7iYvF9T5BmfEifg8mclfORXuGWrkaWizIT+Ve2A==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-dRZliF/smZOP8wvjXCMuOEuFZ4wHh9/b384g+4bpIAja5AtHXPQ/srDP1pM06dj5VBRzE/EebAywZnShp7Ednw==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
@@ -4125,17 +4150,17 @@
 			}
 		},
 		"@fluidframework/ordered-collection": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-x4kJlqyrZN5wGvYy6ZXfhG5sTcrPlrvd7GWuK05RXjK0osQJaac1OLeh4n0RhPbi+v1C+CV+MWaGvsWwJOGCMQ==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-RQutZsy8UJpvLw9S0SIRBny7HeKldNFSVsQMa1pDaDggLmu0FdxuueAyneIepxwYeUYKcmnkcHrB9ZL6aIZfWw==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -4174,17 +4199,17 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-Vb8IzoTsC2fZOI95TgWC+GOroi6/FowYBKFSz9gIzOO85OFCR52XBYU9b9PktzAa6HVIEKkkyPMW594EBuk1cA==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-1lIua78N1NwYPHyxUrVwOBReQ8MxlFfFyglmgamqaxs6023cMd+kmYTlu6xcEuPFjs1b3fBNGQt9xlmkPkiJFA==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/register-collection-previous": {
@@ -4202,16 +4227,16 @@
 			}
 		},
 		"@fluidframework/replay-driver": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-dvgzNVyjf/+WcXFGTbgXsZmUFJkzHMw+74b5nEjcyAuSljkdrUS5a/YnXC4khCddOoQ8rOGIReiywIE4ERv8bA==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-J2vyi0Is+s3wykQash8+veRjaQ389Weffab4U23KgqsJQG2t2pMXcFKSG+IQsm+SP0XnIhW3SX0O4czOe8vfRw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
@@ -4228,15 +4253,15 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-iZgkhRiJf7C8qCC0opCSxdyxPyWYwWFaht9MsyefyLZEGqPXQkjonHe8AMciMnsR+G5Ygpjql1Uv+SR653AGRQ==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-A8MyrpcpprqXfjhmlYetRWFzGmqQUkJwYubHbPilKPRsETSBSIqXjyhTkvHg71S6KLCts9yJmvUeJoK15v9OIQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/request-handler-previous": {
@@ -4252,20 +4277,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-xrBRWo68ThGsaHynIDo49na36ko+DNm5LzqL9sf74WwtrM6ruuGsv/KUlh1qWCf3ee+ewQI1KZtqKUJvgoXJmg==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-1qiVpHOaj3avpe/8/Stp9Gma4cxnm/eGoXCuQzxyAldXEdzKCwVnUuHGVdXno3kyM56mX+g6kt1ioRPEBnOHTA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -4311,17 +4336,16 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-774zXBWdEanxPV0Bz/Fr6w0cutApSnWBIOz2v5v17pO6ACtlMLP/ZZBMQU2TRVxmJltMk1x/av+wOxNV6/8PYw==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-9Ho3150Dsxc4NBSJZU6IsLZxhxIo0VL9WMUm/1WkV+qh39HwGPUK9RATsIFGO+pdNve7aNPsk2G1Xphrmm+9/A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@types/node": "^14.18.0"
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/protocol-definitions": "^1.1.0"
 			}
 		},
 		"@fluidframework/runtime-definitions-previous": {
@@ -4339,21 +4363,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-udPWFNWcPeQLizKy9xAJoyZQjxIxz0HZVDub7Gu5xpRttcFfZ+0H1FDyNJCxsxOFcQ780dQCgv0QHZwXoDdUmg==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-6NzRIuDOhqMwQCp11uy3k22y60jcvez6SoMXD9spQ7+bdGpvAQjS/co0pH301aIA7tlpmhpYCMyobxFgCc/C3w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
@@ -4375,21 +4399,22 @@
 			}
 		},
 		"@fluidframework/sequence": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-xxypuuIkORnaIdZhXp0Jd0l2Wf+z8rbTw0LLBv2jnFyYEyrs/FIkGP7j+TEpcSFPBXpBjRtBzUqHl74Rstmc2w==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-ndoynB1AofaWGluFqsUxKbWgyyL9GdXrMIISBiyEfwhYd1zQ7rQGMnQz7g7vUwSaptypOFkIYiwDaliJvrFCAg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -5165,22 +5190,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-Tkgl0b5wDECCMr+xsi7rvqzU3yLDDtqj5+ancjqZSjqkwd77XcbblJysZlQLTux36q8lJqhK83/Q8S2PfszXzQ==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-B+7Y95KO6u5bMnbjHpvdENdrAAxyoqwgdG9XOsPrn/qqINkQaAC4ZVXNRmGYecHgkrl0SDrPgrIC4B0OGZUA0g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -5219,9 +5244,9 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-+v+qbTLl9w8zhi3BxrfJfRQBPLousRj4RxjwvDTPtpyHxvzDrvHQJt+z291XNFVS0xBXv7dkjBP4gK5JiOFMEQ=="
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-nJCoLpLNlW5DY7++QGeN8F9QYRvQgTV+7LFyRjvRVu6H6ZoFQY3e4q+MKTCh7s5aS1RLke8K5xA2aQzxD4htTg=="
 		},
 		"@fluidframework/synthesize-previous": {
 			"version": "npm:@fluidframework/synthesize@2.0.0-internal.2.0.0",
@@ -5229,9 +5254,9 @@
 			"integrity": "sha512-+wkBqKT4iEjMpGxJwH8fgW8We18xAQ9ZstQ49bPHt0HdQN6Gjn+csTSV/ODD4+vQKJZNwt0ArnpVlLmDls4glQ=="
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-VTUFKw6YsHELlRcAhb1m6EqO9hRj1VRFSU9LQwn5qj3C7zJcYdiDwopg4qknlxHrbWWPX1xNlICBMWQrxu4/vg==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-Yfkk7R+mOVGry86ekoGxz6pfx2bkdhoL62ITck/fAl0x+LvN2KPbAJcF6EpewBdKj2IuVVspN/UWkaav20HQ8Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
@@ -5263,13 +5288,13 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-Cd6s27iFtAR35mCvYUwHYTddzR1f5OehX0o/Wz+lQJFxClx5N39/vlz71n44r/4Afe5DUN/67Q9rzD2rPrShGw==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-AOGIlRFpNXhEcfW60eh9Z5tow9awlKw7W+rXfqsT8SCJn4aypEI80Ult/nXoCA5Bz42Yn/X1BSRMTH1WFdghiw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
@@ -5287,27 +5312,27 @@
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-USwVl6ybMwXTcVk5nYlDC2QesZSNa9BQQrW+qGj04aGqtDPZzTR5MHmi9uRuYKShE7lM0BPX/cT4VOp7wsH/dA==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-lyVbtkzHuXQl6dbe9954XQTgzsXi0wwGzxVTpWenNc9wqK8q6Bk6iYYr1RA5swprkd/WDUcrKDbOqxbePgc3sw==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/local-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/local-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-local-server": "^0.1038.2000",
-				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/tool-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/tool-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -5353,9 +5378,9 @@
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-t/4dtya41PvWk0lu0abYZTXYZHeP/YS5/AvQ3FMB/SVNFefrVsSUy18AsYEhLTtlcqhj3L33fVZP6c1gnksKnA==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-6iEcLTLcuJyaqX3vwPBUcvl0zcMIXQA0c15y4BGV25YHyGMMLqxF6pdCYF0nnE97qQ3vUDUU1ubD5+T/75k5Aw==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
 				"random-js": "^1.0.8"
@@ -5371,23 +5396,24 @@
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-OCV68XMlUBKAhlQJWiEf7roXgSRTKGW6zz1AfHK88ue1TK7iHc5h21N7S7pweadSBYJtg2gU1TJMlntD3Z7cdA==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-6UjTORkfd5RKpYYpj62M3EJ5Tn4Gq5E4QLG3YtC5+K3Lo84R8wTQ+GeaHRCvhFrGe4b0l7qPyRabfsIZ+VwL6g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
+				"events": "^3.1.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
 			}
@@ -5421,32 +5447,32 @@
 			"dev": true
 		},
 		"@fluidframework/test-utils": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-Ex9sGDVnWL/Ii/LVcA7GnrREJSuyaZGfya6I1X9ldsujR0g2EUZFupAmj8InRuUeoa5XdOL53eS+RZ1FHihkew==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-jLOknNQg1iGgwYN98qKdsDDAlF1fc9tJ9E7qRG6306i0HPQjqO8JjzmMUEVLgcp4O6oxI5gAyIgcEkpxq5nONQ==",
 			"requires": {
-				"@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/local-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/map": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/local-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/map": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"best-random": "^1.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
@@ -5539,15 +5565,15 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-F+eRGnkQNQHcwR4mov1lA+Cb+g5Fx4KMOBG5ykoEMfoPFwXGrPBEZc4upJNpULHNBxJtJgsBJbityEbBNWQ2nQ==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-OQtFzZIOxwQVlxalQl6GbVR7R9LbpT2EEdwsYOaIhpk1kmGFR6/JsQ2vgh2P7tO3P/5QzDZSf592F0o/wIcoZA==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-services-client": "^0.1038.2000",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -5569,12 +5595,12 @@
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-Yj6LWTxeZ3/v0L6jr+CgV/qgfBEbsV/Zw5R6HKCh9RT6iwzHadXH/XBE++avWOQDGylKNdJ26q2grKjrKIbSVw==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-2sguFkVhEOrX/a3+ePKePUoyt8WmEaVBZ1fBxzy63l7ZMPZrfSPCchMbgDKRJNxPCfRTEI/G2TEZg5QJsrKmeg==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"async-mutex": "^0.3.1",
@@ -5610,12 +5636,12 @@
 			}
 		},
 		"@fluidframework/view-adapters": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-dptqCYkf/YUtOSfC8WaAd6WRPXGMgdD8q09TYEVFX5AlZRoHaumfbC32vzmAVHwQGnAxq704NoHh6HquHtbaOw==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-z3l4wnut3X/87ljIFR8aI1VxVwmSh6HYxppwDECHV9sBTKmvqHUeHiZ9F6tkg5QBUoPko2TlQag6G2A5E0HwmQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"react": "^17.0.1",
 				"react-dom": "^17.0.1"
 			}
@@ -5632,11 +5658,11 @@
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-ko7Kb8QQOaymp+DoMT9wJKNjcF5oOvamheCPv6kwoQEwJo2Q78SgrvHeoQNRxOTAIDf9Sj2PHFIYw+W9z1IHDA==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-Owdq4DBru4vSH1BZkFoTmchXAI0evrqEtRmF+j5JtOsgi9xfmoEkU7RLLK/K6w4uJmc/jIBF1kRhQNqiqNZxWQ==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
@@ -5648,12 +5674,12 @@
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-eldNOEo7mJ36exkNznPiOqX0D13f7WyMeWZHmnRBNx3h85tK7g4SC7ewONjzNxTJUuLJmmV3I4VKJ8u7AL91Cg==",
+			"version": "2.0.0-internal.2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.3.0.tgz",
+			"integrity": "sha512-kOtwpD9zclH/3e4zEVa5OBOtV8NMsBqlN7Tt77whBLPkZPDLGdABMyXPTfS+VnLFLg+Y1Y3dSFwEd4EhxeypPQ==",
 			"requires": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},

--- a/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
@@ -166,7 +166,7 @@ class StackCursor<TNode> extends SynchronousCursor implements CursorWithNode<TNo
             return undefined; // At root
         }
 
-        assert(length > 0, 0x44a /* invalid offset to above root */);
+        // assert(length > 0, 0x44a /* invalid offset to above root */);
         assert(length % 2 === 0, 0x44b /* offset path must point to node not field */);
 
         // Perf Note:

--- a/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
@@ -166,7 +166,7 @@ class StackCursor<TNode> extends SynchronousCursor implements CursorWithNode<TNo
             return undefined; // At root
         }
 
-        // assert(length > 0, 0x44a /* invalid offset to above root */);
+        assert(length > 0, 0x44a /* invalid offset to above root */);
         assert(length % 2 === 0, 0x44b /* offset path must point to node not field */);
 
         // Perf Note:

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -1,0 +1,476 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { strict as assert } from "assert";
+import { IRandom, makeRandom } from "@fluid-internal/stochastic-test-utils";
+import { benchmark, BenchmarkType } from "@fluid-tools/benchmark";
+import {
+    buildForest,
+    defaultSchemaPolicy,
+    emptyField,
+    FieldKinds,
+    singleTextCursor,
+} from "../../feature-libraries";
+import { brand, unreachableCase } from "../../util";
+import { JsonableTree, rootFieldKey, rootFieldKeySymbol } from "../../tree";
+import { IEditableForest, initializeForest, moveToDetachedField } from "../../forest";
+import { ITestTreeProvider, TestTreeProvider } from "../utils";
+import { ISharedTree } from "../../shared-tree";
+import { TransactionResult } from "../../checkout";
+import {
+    fieldSchema,
+    InMemoryStoredSchemaRepository,
+    namedTreeSchema,
+    SchemaData,
+    ValueSchema,
+} from "../../schema-stored";
+// eslint-disable-next-line import/no-internal-modules
+import { PlacePath } from "../../feature-libraries/sequence-change-family";
+import {
+    float32Schema,
+    int32Schema,
+    mapStringSchema,
+    schemaMap,
+    stringSchema,
+    // eslint-disable-next-line import/no-internal-modules
+} from "../feature-libraries/editable-tree/mockData";
+
+enum TreeShape {
+    Wide = 0,
+    Deep = 1,
+}
+
+enum TestPrimitives {
+    Number = 0,
+    Float = 1,
+    String = 2,
+    Boolean = 3,
+    Map = 4,
+}
+
+// TODO: Once the "BatchTooLarge" error is no longer an issue, extend tests for larger trees.
+describe("SharedTree benchmarks", () => {
+    describe("Direct JS Object", () => {
+        for (let dataType = 0 as TestPrimitives; dataType <= 4; dataType++) {
+            for (let i = 10; i < 100; i += 10) {
+                let tree: ISharedTree;
+                benchmark({
+                    type: BenchmarkType.Measurement,
+                    title: `Deep Tree as JS Object (${TestPrimitives[dataType]}): reads with ${i} nodes`,
+                    before: async () => {
+                        tree = getTestTreeAsJSObject(i, TreeShape.Deep, dataType);
+                    },
+                    benchmarkFn: () => {
+                        readTreeAsJSObject(tree);
+                    },
+                });
+            }
+            for (let i = 100; i < 1500; i += 100) {
+                let tree: ISharedTree;
+                benchmark({
+                    type: BenchmarkType.Measurement,
+                    title: `Wide Tree as JS Object (${TestPrimitives[dataType]}): reads with ${i} nodes`,
+                    before: async () => {
+                        tree = getTestTreeAsJSObject(i, TreeShape.Wide, TestPrimitives.String);
+                    },
+                    benchmarkFn: () => {
+                        readTreeAsJSObject(tree);
+                    },
+                });
+            }
+            for (let i = 10; i < 100; i += 10) {
+                let tree: ISharedTree;
+                benchmark({
+                    type: BenchmarkType.Measurement,
+                    title: `Deep Tree as JS Object (${TestPrimitives[dataType]}): writes with ${i} nodes`,
+                    before: async () => {},
+                    benchmarkFn: () => {
+                        tree = getTestTreeAsJSObject(i, TreeShape.Deep, TestPrimitives.String);
+                    },
+                });
+            }
+            for (let i = 100; i < 1500; i += 100) {
+                let tree: ISharedTree;
+                benchmark({
+                    type: BenchmarkType.Measurement,
+                    title: `Wide Tree as JS Object (${TestPrimitives[dataType]}): writes with ${i} nodes`,
+                    before: async () => {},
+                    benchmarkFn: () => {
+                        tree = getTestTreeAsJSObject(i, TreeShape.Wide, TestPrimitives.String);
+                    },
+                });
+            }
+        }
+    });
+    describe("Cursors", () => {
+        for (let dataType = 0 as TestPrimitives; dataType <= 4; dataType++) {
+            for (let i = 10; i < 100; i += 10) {
+                let tree: ISharedTree;
+                const random = makeRandom(0);
+                benchmark({
+                    type: BenchmarkType.Measurement,
+                    title: `Deep Tree (${TestPrimitives[dataType]}) with cursor: reads with ${i} nodes`,
+                    before: async () => {
+                        tree = await generateTestTree(i, TreeShape.Deep, dataType, random);
+                    },
+                    benchmarkFn: () => {
+                        readTree(tree.forest, i, TreeShape.Deep);
+                    },
+                });
+            }
+            for (let i = 100; i < 1500; i += 100) {
+                let tree: ISharedTree;
+                const random = makeRandom(0);
+                benchmark({
+                    type: BenchmarkType.Measurement,
+                    title: `Wide Tree (${TestPrimitives[dataType]}) with cursor: reads with ${i} nodes`,
+                    before: async () => {
+                        tree = await generateTestTree(i, TreeShape.Wide, dataType, random);
+                    },
+                    benchmarkFn: () => {
+                        readTree(tree.forest, i, TreeShape.Wide);
+                    },
+                });
+            }
+            for (let i = 10; i < 100; i += 10) {
+                let tree: ISharedTree;
+                const random = makeRandom(0);
+                benchmark({
+                    type: BenchmarkType.Measurement,
+                    title: `Deep Tree (${TestPrimitives[dataType]}) with cursor: writes ${i} nodes`,
+                    before: () => {},
+                    benchmarkFn: async () => {
+                        tree = await generateTestTree(i, TreeShape.Deep, dataType, random);
+                    },
+                });
+            }
+            for (let i = 100; i < 1500; i += 100) {
+                let tree: ISharedTree;
+                const random = makeRandom(0);
+                benchmark({
+                    type: BenchmarkType.Measurement,
+                    title: `Wide Tree (${TestPrimitives[dataType]}) with cursor: writes ${i} nodes`,
+                    before: () => {},
+                    benchmarkFn: async () => {
+                        tree = await generateTestTree(i, TreeShape.Wide, dataType, random);
+                    },
+                });
+            }
+        }
+    });
+    describe("Editable Tree", () => {
+        for (let dataType = 0 as TestPrimitives; dataType <= 4; dataType++) {
+            for (let i = 10; i < 100; i += 10) {
+                let tree;
+                let forest: IEditableForest;
+                benchmark({
+                    type: BenchmarkType.Measurement,
+                    title: `Deep Tree (${TestPrimitives[dataType]}) with Editable Tree: reads with ${i} nodes`,
+                    before: async () => {
+                        tree = getTestTreeAsJSObject(i, TreeShape.Deep, dataType);
+                        forest = setupForest(fullSchemaData, tree);
+                    },
+                    benchmarkFn: () => {
+                        readTree(forest, i, TreeShape.Deep);
+                    },
+                });
+            }
+            for (let i = 100; i < 1500; i += 100) {
+                let tree;
+                let forest: IEditableForest;
+                benchmark({
+                    type: BenchmarkType.Measurement,
+                    title: `Wide Tree (${TestPrimitives[dataType]}) with Editable Tree: reads with ${i} nodes`,
+                    before: async () => {
+                        tree = getTestTreeAsJSObject(i, TreeShape.Wide, dataType);
+                        forest = setupForest(fullSchemaData, tree);
+                    },
+                    benchmarkFn: () => {
+                        readTree(forest, i, TreeShape.Wide);
+                    },
+                });
+            }
+            for (let i = 10; i < 100; i += 10) {
+                let tree;
+                let forest: IEditableForest;
+                benchmark({
+                    type: BenchmarkType.Measurement,
+                    title: `Deep Tree (${TestPrimitives[dataType]}) with Editable Tree: writes ${i} nodes`,
+                    before: () => {},
+                    benchmarkFn: async () => {
+                        tree = getTestTreeAsJSObject(i, TreeShape.Deep, dataType);
+                        forest = setupForest(fullSchemaData, tree);
+                    },
+                });
+            }
+            for (let i = 100; i < 1500; i += 100) {
+                let tree;
+                let forest: IEditableForest;
+                benchmark({
+                    type: BenchmarkType.Measurement,
+                    title: `Deep Tree (${TestPrimitives[dataType]}) with Editable Tree: writes ${i} nodes`,
+                    before: () => {},
+                    benchmarkFn: async () => {
+                        tree = getTestTreeAsJSObject(i, TreeShape.Deep, dataType);
+                        forest = setupForest(fullSchemaData, tree);
+                    },
+                });
+            }
+        }
+    });
+});
+
+const booleanSchema = namedTreeSchema({
+    name: brand("Boolean"),
+    extraLocalFields: emptyField,
+    value: ValueSchema.Boolean,
+});
+
+const personSchema = namedTreeSchema({
+    name: brand("Test:Person-1.0.0"),
+    localFields: {
+        name: fieldSchema(FieldKinds.value, [stringSchema.name]),
+        age: fieldSchema(FieldKinds.value, [int32Schema.name]),
+        salary: fieldSchema(FieldKinds.value, [float32Schema.name]),
+        friends: fieldSchema(FieldKinds.value, [mapStringSchema.name]),
+        isMarried: fieldSchema(FieldKinds.value, [booleanSchema.name]),
+    },
+    extraLocalFields: emptyField,
+});
+
+const rootPersonSchema = fieldSchema(FieldKinds.value, [personSchema.name]);
+
+const fullSchemaData: SchemaData = {
+    treeSchema: schemaMap,
+    globalFieldSchema: new Map([[rootFieldKey, rootPersonSchema]]),
+};
+
+async function generateTestTree(
+    numberOfNodes: number,
+    shape: TreeShape,
+    dataType: TestPrimitives,
+    random: IRandom,
+): Promise<ISharedTree> {
+    const provider = await TestTreeProvider.create(1);
+    const [tree] = provider.trees;
+    const personData: JsonableTree = generateTreeData(dataType, random);
+    // Insert root node
+    initializeTestTree(tree, personData, fullSchemaData);
+    switch (shape) {
+        case TreeShape.Deep:
+            await setNodesNarrow(tree, numberOfNodes - 1, dataType, provider, random);
+            break;
+        case TreeShape.Wide:
+            await setNodesWide(tree, numberOfNodes - 1, dataType, provider, random);
+            break;
+        default:
+            unreachableCase(shape);
+    }
+    return tree;
+}
+
+async function setNodesNarrow(
+    tree: ISharedTree,
+    numberOfNodes: number,
+    dataType: TestPrimitives,
+    provider: ITestTreeProvider,
+    random: IRandom,
+): Promise<void> {
+    let path: PlacePath = {
+        parent: undefined,
+        parentField: rootFieldKeySymbol,
+        parentIndex: 0,
+    };
+    for (let i = 0; i < numberOfNodes; i++) {
+        const personData = generateTreeData(dataType, random);
+        tree.runTransaction((forest, editor) => {
+            const writeCursor = singleTextCursor(personData);
+            const field = editor.sequenceField(path, rootFieldKeySymbol);
+            field.insert(0, writeCursor);
+            return TransactionResult.Apply;
+        });
+        path = {
+            parent: path,
+            parentField: rootFieldKeySymbol,
+            parentIndex: 0,
+        };
+    }
+    await provider.ensureSynchronized();
+}
+
+async function setNodesWide(
+    tree: ISharedTree,
+    numberOfNodes: number,
+    dataType: TestPrimitives,
+    provider: ITestTreeProvider,
+    random: IRandom,
+): Promise<void> {
+    for (let j = 0; j < numberOfNodes; j++) {
+        const personData = generateTreeData(dataType, random);
+        tree.runTransaction((forest, editor) => {
+            const writeCursor = singleTextCursor(personData);
+            const field = editor.sequenceField(undefined, rootFieldKeySymbol);
+            field.insert(j, writeCursor);
+            return TransactionResult.Apply;
+        });
+    }
+    await provider.ensureSynchronized();
+}
+
+function generateTreeData(dataType: TestPrimitives, random: IRandom): JsonableTree {
+    let field;
+    let booleanValue;
+    const insertValue = random.integer(Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
+    switch (dataType) {
+        case TestPrimitives.Number:
+            field = { age: [{ value: insertValue, type: int32Schema.name }] };
+            break;
+        case TestPrimitives.Float:
+            field = { age: [{ value: insertValue, type: float32Schema.name }] };
+            break;
+        case TestPrimitives.String:
+            field = {
+                name: [
+                    {
+                        value: random.real(0, Number.MAX_SAFE_INTEGER).toString(),
+                        type: stringSchema.name,
+                    },
+                ],
+            };
+            break;
+        case TestPrimitives.Boolean:
+            booleanValue = insertValue % 2 === 0 ? true : false;
+            field = { isMarried: [{ value: booleanValue, type: booleanSchema.name }] };
+            break;
+        case TestPrimitives.Map:
+            field = {
+                friends: [
+                    {
+                        fields: {
+                            Mat: [{ type: stringSchema.name, value: insertValue.toString() }],
+                        },
+                        type: mapStringSchema.name,
+                    },
+                ],
+            };
+            break;
+        default:
+            unreachableCase(dataType);
+    }
+    const personData: JsonableTree = {
+        type: personSchema.name,
+        fields: field,
+    };
+    return personData;
+}
+
+/**
+ * Updates the given `tree` to the given `schema` and inserts `state` as its root.
+ */
+function initializeTestTree(
+    tree: ISharedTree,
+    state: JsonableTree,
+    schema: SchemaData = fullSchemaData,
+): void {
+    tree.storedSchema.update(schema);
+    // Apply an edit to the tree which inserts a node with a value
+    tree.runTransaction((forest, editor) => {
+        const writeCursor = singleTextCursor(state);
+        const field = editor.sequenceField(undefined, rootFieldKeySymbol);
+        field.insert(0, writeCursor);
+        return TransactionResult.Apply;
+    });
+}
+
+function readTree(forest: any, numberOfNodes: number, shape: TreeShape) {
+    const readCursor = forest.allocateCursor();
+    moveToDetachedField(forest, readCursor);
+    assert(readCursor.firstNode());
+    switch (shape) {
+        case TreeShape.Deep:
+            for (let i = 0; i < numberOfNodes - 1; i++) {
+                readCursor.enterField(rootFieldKeySymbol);
+                assert(readCursor.firstNode());
+            }
+            break;
+        case TreeShape.Wide:
+            for (let j = 0; j < numberOfNodes - 1; j++) {
+                readCursor.nextNode();
+            }
+            break;
+        default:
+            unreachableCase(shape);
+    }
+    readCursor.free();
+}
+
+function getTestTreeAsJSObject(
+    numberOfNodes: number,
+    shape: TreeShape,
+    dataType: TestPrimitives,
+): any {
+    const seed = 0;
+    const random = makeRandom(seed);
+    let tree;
+    switch (shape) {
+        case TreeShape.Deep:
+            tree = [getJSTestTreeDeep(numberOfNodes, dataType, random)];
+            break;
+        case TreeShape.Wide:
+            tree = getJSTestTreeWide(numberOfNodes, dataType, random);
+            break;
+        default:
+            unreachableCase(shape);
+    }
+    const testTreeJS = JSON.parse(JSON.stringify(tree));
+    return testTreeJS;
+}
+
+function getJSTestTreeWide(numberOfNodes: number, dataType: TestPrimitives, random: IRandom): any {
+    const tree = [];
+    for (let i = 0; i < numberOfNodes; i++) {
+        const node = generateTreeData(dataType, random);
+        tree.push(node);
+    }
+    return tree;
+}
+
+interface DeepTree {
+    type: any;
+    fields: any;
+    globalFields: {
+        rootFieldKey: any;
+    };
+}
+
+function getJSTestTreeDeep(numberOfNodes: number, dataType: TestPrimitives, random: IRandom): any {
+    if (numberOfNodes === 1) {
+        return generateTreeData(dataType, random);
+    }
+    const node = generateTreeData(dataType, random);
+    const tree: DeepTree = {
+        type: node.type,
+        fields: node.fields,
+        globalFields: {
+            rootFieldKey: [getJSTestTreeDeep(numberOfNodes - 1, dataType, random)],
+        },
+    };
+    return tree;
+}
+
+function readTreeAsJSObject(tree: any) {
+    for (const key of Object.keys(tree)) {
+        if (typeof tree[key] === "object" && tree[key] !== null) readTreeAsJSObject(tree[key]);
+        else if (key === "value") {
+            assert(tree[key] !== undefined);
+        }
+    }
+}
+
+function setupForest(schema: SchemaData, data: JsonableTree[]): IEditableForest {
+    const schemaRepo = new InMemoryStoredSchemaRepository(defaultSchemaPolicy, schema);
+    const forest = buildForest(schemaRepo);
+    initializeForest(forest, data.map(singleTextCursor));
+    return forest;
+}


### PR DESCRIPTION
## Description

This PR adds benchmarks for reading and writing different sized trees, primitive types, and shapes (wide vs narrow) using direct JS objects, cursors, and editable tree with different primitives, using our internal benchmark() function.

The benchmark tests use the different fields in the `PersonType` type defined in `mockData.ts` to test the different primitive types (i.e. int, string, float, etc.).

## Reviewer Guidance

Questions
1. Currently the "reads" are just iterating through the tree making sure that the correct number of nodes exist. Should there be something else that needs to be added to be considered "reading" the node? For example, should the map 
2. Currently no "manipulation" tests are added, but how should these tests be structured? For example, for a tree with strictly integers as values, would iterating through the tree and adding a random integer to each be sufficient?
