### PR TITLE
Update tree prettier

### DIFF
--- a/experimental/dds/tree-graphql/package.json
+++ b/experimental/dds/tree-graphql/package.json
@@ -59,7 +59,7 @@
     "eslint": "~8.6.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
-    "prettier": "~2.3.1",
+    "prettier": "~2.6.2",
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5"
   },

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -84,7 +84,7 @@
     "eslint": "~8.6.0",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
-    "prettier": "~2.3.1",
+    "prettier": "~2.6.2",
     "random-js": "^1.0.8",
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5"

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -50938,9 +50938,9 @@
 			"integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA=="
 		},
 		"prettier": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ=="
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+			"integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew=="
 		},
 		"pretty-bytes": {
 			"version": "5.6.0",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -105,7 +105,7 @@
     "good-fences": "^1.1.1",
     "mocha": "^10.0.0",
     "nyc": "^15.0.0",
-    "prettier": "~2.3.1",
+    "prettier": "~2.6.2",
     "rimraf": "^2.6.2",
     "source-map-support": "^0.5.16",
     "typescript": "~4.5.5"


### PR DESCRIPTION
### Description

Update `prettier` in tree from `2.3.1` to `2.6.2` in `experimental` and `packages` to avoid package version error 