### PR TITLE
feat(generate:typetests): Add --branch flag to typetest generator

### DIFF
--- a/build-tools/packages/build-cli/docs/generate.md
+++ b/build-tools/packages/build-cli/docs/generate.md
@@ -15,8 +15,8 @@ This command is used to compute the version number of Fluid packages. The releas
 
 ```
 USAGE
-  $ flub generate buildVersion --build <value> [-v] [--testBuild <value>] [--release release|prerelease|none] [--patch
-    <value>] [--base <value>] [--tag <value>] [-i <value>]
+  $ flub generate buildVersion --build <value> [--testBuild <value>] [--release release|prerelease|none] [--patch <value>]
+    [--base <value>] [--tag <value>] [-i <value>] [-v]
 
 FLAGS
   -i, --includeInternalVersions=<value>  Include Fluid internal versions.

--- a/build-tools/packages/build-cli/docs/generate.md
+++ b/build-tools/packages/build-cli/docs/generate.md
@@ -163,7 +163,7 @@ FLAGS
 
   --pin
       Searches the release git tags in the repo and selects the baseline version as the maximum
-      eleased version that matches the range.
+      released version that matches the range.
 
       This effectively pins the version to a specific version while allowing it to be updated manually as
       needed by running type test preparation again.

--- a/build-tools/packages/build-cli/docs/generate.md
+++ b/build-tools/packages/build-cli/docs/generate.md
@@ -15,8 +15,8 @@ This command is used to compute the version number of Fluid packages. The releas
 
 ```
 USAGE
-  $ flub generate buildVersion --build <value> [--testBuild <value>] [--release release|prerelease|none] [--patch <value>]
-    [--base <value>] [--tag <value>] [-i <value>] [-v]
+  $ flub generate buildVersion --build <value> [-v] [--testBuild <value>] [--release release|prerelease|none] [--patch
+    <value>] [--base <value>] [--tag <value>] [-i <value>]
 
 FLAGS
   -i, --includeInternalVersions=<value>  Include Fluid internal versions.
@@ -113,24 +113,33 @@ Generates type tests based on the individual package settings in package.json.
 
 ```
 USAGE
-  $ flub generate typetests [-d <value> | --packages | -g client|server|azure|build-tools] [--prepare | --generate]
-    [--pin] [--exact <value> |  | -s ^previousMajor|^previousMinor|~previousMajor|~previousMinor|previousMajor|previousM
-    inor|previousPatch|baseMinor|baseMajor|~baseMinor] [--reset | ] [--generateInName] [-v]
+  $ flub generate typetests [-v] [-d <value> | --packages | -g client|server|azure|build-tools] [--prepare | --generate]
+    [--reset | ] [-b <value> | -s ^previousMajor|^previousMinor|~previousMajor|~previousMinor|previousMajor|previousMino
+    r|previousPatch|baseMinor|baseMajor|~baseMinor] [--exact <value> |  | ] [--pin] [--generateInName]
 
 FLAGS
+  -b, --branch=<value>
+      Use the specified branch name to determine the version constraint to use for previous versions, rather than using
+      the current branch name.
+
+      The version constraint used will still be loaded from branch configuration; this flag only controls which branch's
+      settings are used.
+
   -d, --dir=<value>
-      Run on the package in this directory.
+      Run on the package in this directory. Cannot be used with --releaseGroup or --packages.
 
   -g, --releaseGroup=<option>
-      Run on all packages within this release group.
+      Run on all packages within this release group. Cannot be used with --dir or --packages.
       <options: client|server|azure|build-tools>
 
   -s, --versionConstraint=<option>
-      The type of version constraint to use for previous versions. Only applies to the prepare phase. This overrides the
-      branch-specific configuration in package.json, which is used by default.
+      The type of version constraint to use for previous versions. This overrides the branch-specific configuration in
+      package.json, which is used by default.
 
       For more information about the options, see https://github.com/microsoft/FluidFramework/blob/main/build-tools/packag
       es/build-cli/docs/typetestDetails.md#configuring-a-branch-for-a-specific-baseline
+
+      Cannot be used with --dir or --packages.
 
       <options: ^previousMajor|^previousMinor|~previousMajor|~previousMinor|previousMajor|previousMinor|previousPatch|base
       Minor|baseMajor|~baseMinor>

--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -95,7 +95,7 @@ export default class GenerateTypeTestsCommand extends BaseCommand<
         }),
         pin: Flags.boolean({
             description: `Searches the release git tags in the repo and selects the baseline version as the maximum
-            eleased version that matches the range.
+            released version that matches the range.
 
             This effectively pins the version to a specific version while allowing it to be updated manually as
             needed by running type test preparation again.`,

--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -32,7 +32,8 @@ export default class GenerateTypeTestsCommand extends BaseCommand<
     static flags = {
         dir: Flags.directory({
             char: "d",
-            description: "Run on the package in this directory.",
+            description:
+                "Run on the package in this directory. Cannot be used with --releaseGroup or --packages.",
             exclusive: ["packages", "releaseGroup"],
         }),
         packages: Flags.boolean({
@@ -42,7 +43,8 @@ export default class GenerateTypeTestsCommand extends BaseCommand<
             exclusive: ["dir", "releaseGroup"],
         }),
         releaseGroup: releaseGroupFlag({
-            description: "Run on all packages within this release group.",
+            description:
+                "Run on all packages within this release group. Cannot be used with --dir or --packages.",
             exclusive: ["dir", "packages"],
         }),
         prepare: Flags.boolean({
@@ -54,11 +56,18 @@ export default class GenerateTypeTestsCommand extends BaseCommand<
             description: "Generates tests only. Doesn't prepare the package.json.",
             exclusive: ["prepare"],
         }),
+        reset: Flags.boolean({
+            description:
+                "Resets the broken type test settings in package.json. Only applies to the prepare phase.",
+            exclusive: ["generate"],
+        }),
         versionConstraint: Flags.string({
             char: "s",
-            description: `The type of version constraint to use for previous versions. Only applies to the prepare phase. This overrides the branch-specific configuration in package.json, which is used by default.
+            description: `The type of version constraint to use for previous versions. This overrides the branch-specific configuration in package.json, which is used by default.
 
-                For more information about the options, see https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-cli/docs/typetestDetails.md#configuring-a-branch-for-a-specific-baseline\n`,
+                For more information about the options, see https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-cli/docs/typetestDetails.md#configuring-a-branch-for-a-specific-baseline
+
+                Cannot be used with --dir or --packages.\n`,
             options: [
                 "^previousMajor",
                 "^previousMinor",
@@ -72,6 +81,18 @@ export default class GenerateTypeTestsCommand extends BaseCommand<
                 "~baseMinor",
             ],
         }),
+        branch: Flags.string({
+            char: "b",
+            description: `Use the specified branch name to determine the version constraint to use for previous versions, rather than using the current branch name.
+
+            The version constraint used will still be loaded from branch configuration; this flag only controls which branch's settings are used.`,
+            exclusive: ["versionConstraint"],
+        }),
+        exact: Flags.string({
+            description:
+                "An exact string to use as the previous version constraint. The string will be used as-is. Only applies to the prepare phase.",
+            exclusive: ["generate", "versionConstraint"],
+        }),
         pin: Flags.boolean({
             description: `Searches the release git tags in the repo and selects the baseline version as the maximum
             eleased version that matches the range.
@@ -79,16 +100,6 @@ export default class GenerateTypeTestsCommand extends BaseCommand<
             This effectively pins the version to a specific version while allowing it to be updated manually as
             needed by running type test preparation again.`,
             default: false,
-        }),
-        exact: Flags.string({
-            description:
-                "An exact string to use as the previous version constraint. The string will be used as-is. Only applies to the prepare phase.",
-            exclusive: ["generate", "versionConstraint"],
-        }),
-        reset: Flags.boolean({
-            description:
-                "Resets the broken type test settings in package.json. Only applies to the prepare phase.",
-            exclusive: ["generate"],
         }),
         generateInName: Flags.boolean({
             description: "Includes .generated in the generated type test filenames.",
@@ -213,9 +224,11 @@ export default class GenerateTypeTestsCommand extends BaseCommand<
                             packageDir,
                             /* writeUpdates */ runPrepare,
                             flags.versionConstraint as PreviousVersionStyle | undefined,
+                            flags.branch,
                             flags.exact,
                             flags.reset,
                             flags.pin,
+                            this.logger,
                         ).finally(() => output.push(`Loaded(${Date.now() - start}ms)`));
 
                         if (packageData.skipReason !== undefined) {

--- a/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
@@ -20,6 +20,7 @@ import {
 } from "@fluid-tools/version-tools";
 
 import { Context } from "../bumpVersion/context";
+import { Logger, defaultLogger } from "../common/logging";
 import { BrokenCompatTypes, PackageJson } from "../common/npmPackage";
 
 export type PackageDetails = {
@@ -297,6 +298,8 @@ function getPreviousVersionBaseline(version: ReleaseVersion, style: PreviousVers
  * @param style - The version style to use when determining the previous version. Can be the exact
  * previous major or minor versions, or caret/tilde-equivalent dependency ranges on those previous versions. If this
  * is undefined, then the style will be set according to the branchReleaseTypes defined in package.json.
+ * @param branchName - If provided, this branch name will be used to set the previous version style according to the
+ * branchReleaseTypes defined in package.json. If undefined, then the current branch name will be used.
  * @param exactPreviousVersionString - If provided, this string will be used as the previous version string.
  * @param resetBroken - If true, clears the "broken" section of the type validation, effectively clearing all known
  * breaking changes.
@@ -304,6 +307,7 @@ function getPreviousVersionBaseline(version: ReleaseVersion, style: PreviousVers
  * effectively pins the version to a specific version while allowing it to be updated manually as needed. This is
  * functionally similar to what a lockfile does, but this provides us with an extra level of control so we don't rely on
  * lockfiles (in which we have found bugs).
+ * @param log - A {@link Logger} that will be used for logging. Uses {@link defaultLogger} by default.
  * @returns package metadata or a reason the package was skipped.
  *
  * @internal
@@ -313,9 +317,11 @@ export async function getAndUpdatePackageDetails(
     packageDir: string,
     writeUpdates: boolean | undefined,
     style?: PreviousVersionStyle,
+    branchName?: string,
     exactPreviousVersionString?: string,
     resetBroken?: boolean,
     pinRange = false,
+    log: Logger = defaultLogger,
 ): Promise<(PackageDetails & { skipReason?: undefined }) | { skipReason: string }> {
     const packageDetails = await getPackageDetails(packageDir);
     const pkg = context.fullPackageMap.get(packageDetails.json.name);
@@ -348,6 +354,7 @@ export async function getAndUpdatePackageDetails(
 
     const version = packageDetails.json.version;
     const fluidConfig = pkg.monoRepo?.fluidBuildConfig ?? pkg.fluidBuildConfig;
+    const branch = branchName ?? context.originalBranchName;
     let releaseType: VersionBumpType | undefined;
     let previousVersionStyle: PreviousVersionStyle | undefined;
 
@@ -363,7 +370,7 @@ export async function getAndUpdatePackageDetails(
         }
 
         for (const [branchPattern, branchReleaseType] of Object.entries(releaseTypes)) {
-            if (minimatch(context.originalBranchName, branchPattern)) {
+            if (minimatch(branch, branchPattern)) {
                 // The config can be either a VersionBumpType (major/minor/patch) which will be used to calculate the
                 // previous version or a PreviousVersionStyle that will used as-is.
                 if (isVersionBumpType(branchReleaseType)) {
@@ -375,9 +382,15 @@ export async function getAndUpdatePackageDetails(
         }
     }
 
+    // if(previousVersionStyle !== undefined && style !== undefined && previousVersionStyle !== style) {
+    //     log.info(`Using previous version style '${style}' because you asked me to, but the branch config says: '${previousVersionStyle}'.`);
+    // }
+
     previousVersionStyle =
-        previousVersionStyle ??
+        // If the style was explicitly passed in, use it
         style ??
+        // if the branch config was a version style, use it
+        previousVersionStyle ??
         (releaseType === "major"
             ? "^previousMajor"
             : releaseType === "minor"
@@ -386,10 +399,12 @@ export async function getAndUpdatePackageDetails(
             ? "previousPatch"
             : undefined);
 
+    log.verbose(`${pkg.nameColored}: Using previousVersionStyle: ${previousVersionStyle}`);
+
     if (previousVersionStyle === undefined) {
         // Skip if there's no previous version style defined for the package.
         return {
-            skipReason: "Skipping package: no previousVersionStyle is defined for the branch",
+            skipReason: `Skipping package: no previousVersionStyle is defined for the branch`,
         };
     }
 

--- a/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
@@ -382,10 +382,6 @@ export async function getAndUpdatePackageDetails(
         }
     }
 
-    // if(previousVersionStyle !== undefined && style !== undefined && previousVersionStyle !== style) {
-    //     log.info(`Using previous version style '${style}' because you asked me to, but the branch config says: '${previousVersionStyle}'.`);
-    // }
-
     previousVersionStyle =
         // If the style was explicitly passed in, use it
         style ??


### PR DESCRIPTION
The `--branch` flag overrides the current branch with the branch provided. This is useful when you're working on a feature branch and need to run typetest commands as though they were run on main or next.