### PR TITLE
Delete unnecessary eslint disable

### DIFF
--- a/packages/dds/tree/src/test/id-compressor/idCompressorTestUtilities.ts
+++ b/packages/dds/tree/src/test/id-compressor/idCompressorTestUtilities.ts
@@ -548,7 +548,6 @@ export class IdCompressorTestNetwork {
             assert(originatingClient !== undefined, "Expected originating client to be defined");
             idIndicesAggregator.set(
                 originatingClient,
-                // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
                 (idIndicesAggregator.get(originatingClient) ??
                     fail("Expected pre-existing index for originating client")) + 1,
             );


### PR DESCRIPTION
## Description

Quick cleanup PR removing the only warning in the tree directory for an unused eslint disable.

