### PR TITLE
Bump client to latest prerelease of build-tools

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2027,14 +2027,14 @@
 			}
 		},
 		"@fluid-tools/build-cli": {
-			"version": "0.6.0-109663",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/build-cli/-/build-cli-0.6.0-109663.tgz",
-			"integrity": "sha512-b6NsPpF2vuhW1nzpPkRZYUvpHOx286z8jD2QS7z0G7dBheRjZCbgnyU2bP5gZnsiMK6FxEFR8pZEmsA1wXb47Q==",
+			"version": "0.6.0-110101",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/build-cli/-/build-cli-0.6.0-110101.tgz",
+			"integrity": "sha512-8TxTJxP72SXY0duppKZ6QgRwZOFIiTYLDEvkIpqbxJJJQSFGIQwSCSJYOVdEJGJ7bZ8Tnvuc+jUDT0Fkvmo6sQ==",
 			"dev": true,
 			"requires": {
-				"@fluid-tools/version-tools": "0.6.0-109663",
-				"@fluidframework/build-tools": "0.6.0-109663",
-				"@fluidframework/bundle-size-tools": "0.6.0-109663",
+				"@fluid-tools/version-tools": "0.6.0-110101",
+				"@fluidframework/build-tools": "0.6.0-110101",
+				"@fluidframework/bundle-size-tools": "0.6.0-110101",
 				"@oclif/core": "^1.9.5",
 				"@oclif/plugin-autocomplete": "^1.3.5",
 				"@oclif/plugin-commands": "^2.2.0",
@@ -2493,9 +2493,9 @@
 			}
 		},
 		"@fluid-tools/version-tools": {
-			"version": "0.6.0-109663",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/version-tools/-/version-tools-0.6.0-109663.tgz",
-			"integrity": "sha512-04hUL6TLyQI0d43ULENmF7smmUY+DCH0bKhnDHsDlQNZxFBT02TXf68M8kXJixrRPu/9TGa7SBNyay0UNthzOQ==",
+			"version": "0.6.0-110101",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/version-tools/-/version-tools-0.6.0-110101.tgz",
+			"integrity": "sha512-23PhJ7/F8aCya84WqcK3x1SL9xWeiSfYHe6y1kHZUgRYewADtzml3IaMfcbt7UbZETgn39es0W+IMsQGOdiOWg==",
 			"dev": true,
 			"requires": {
 				"@oclif/core": "^1.9.5",
@@ -2645,13 +2645,13 @@
 			"integrity": "sha512-ueCMYxa8/xgptrQc3JDAUio9HaXbwpiHe1A/CllbRXRlJfKJa31m6wcoBpmqkDzNPbCS+oehNDZOd6ZpnrUwnA=="
 		},
 		"@fluidframework/build-tools": {
-			"version": "0.6.0-109663",
-			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.6.0-109663.tgz",
-			"integrity": "sha512-s6NpL/pLNMvHew3T8IIUW80QIhfmNRmV1h4ROoBlQiwj12rPa/cxdkFZl/c6XX4fUQCJDbW4p3EOOR3iYrkakA==",
+			"version": "0.6.0-110101",
+			"resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.6.0-110101.tgz",
+			"integrity": "sha512-O9SME4rwoyIvhwuUOqzN17cZcq6hrCniDAJjuSZjOjnCud6wlvHbO+YiBqxnk66Gr6NlkAFyiD8jPcpx681VXA==",
 			"dev": true,
 			"requires": {
-				"@fluid-tools/version-tools": "0.6.0-109663",
-				"@fluidframework/bundle-size-tools": "0.6.0-109663",
+				"@fluid-tools/version-tools": "0.6.0-110101",
+				"@fluidframework/bundle-size-tools": "0.6.0-110101",
 				"@rushstack/node-core-library": "^3.51.1",
 				"async": "^3.2.0",
 				"chalk": "^2.4.2",
@@ -2771,9 +2771,9 @@
 			}
 		},
 		"@fluidframework/bundle-size-tools": {
-			"version": "0.6.0-109663",
-			"resolved": "https://registry.npmjs.org/@fluidframework/bundle-size-tools/-/bundle-size-tools-0.6.0-109663.tgz",
-			"integrity": "sha512-OPz35ffI7qaUoYMo6R8PVQWm8qF6G8q33FTPKhrpnplkFFlwsq+jkVHL8+F2DgLHrAd2FsT8pA524JQU5aMSBg==",
+			"version": "0.6.0-110101",
+			"resolved": "https://registry.npmjs.org/@fluidframework/bundle-size-tools/-/bundle-size-tools-0.6.0-110101.tgz",
+			"integrity": "sha512-qUwXa1aBrQEjJXikuVR+lTFFDvX8DP/9DljWcQnMOJk4Xn86mW8ZAzKOqAsjTm7sb90p745FMXDl7GQM3nCSMw==",
 			"requires": {
 				"azure-devops-node-api": "^11.2.0",
 				"jszip": "^3.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,14 +121,14 @@
       }
     },
     "@fluid-tools/build-cli": {
-      "version": "0.6.0-109663",
-      "resolved": "https://registry.npmjs.org/@fluid-tools/build-cli/-/build-cli-0.6.0-109663.tgz",
-      "integrity": "sha512-b6NsPpF2vuhW1nzpPkRZYUvpHOx286z8jD2QS7z0G7dBheRjZCbgnyU2bP5gZnsiMK6FxEFR8pZEmsA1wXb47Q==",
+      "version": "0.6.0-110101",
+      "resolved": "https://registry.npmjs.org/@fluid-tools/build-cli/-/build-cli-0.6.0-110101.tgz",
+      "integrity": "sha512-8TxTJxP72SXY0duppKZ6QgRwZOFIiTYLDEvkIpqbxJJJQSFGIQwSCSJYOVdEJGJ7bZ8Tnvuc+jUDT0Fkvmo6sQ==",
       "dev": true,
       "requires": {
-        "@fluid-tools/version-tools": "0.6.0-109663",
-        "@fluidframework/build-tools": "0.6.0-109663",
-        "@fluidframework/bundle-size-tools": "0.6.0-109663",
+        "@fluid-tools/version-tools": "0.6.0-110101",
+        "@fluidframework/build-tools": "0.6.0-110101",
+        "@fluidframework/bundle-size-tools": "0.6.0-110101",
         "@oclif/core": "^1.9.5",
         "@oclif/plugin-autocomplete": "^1.3.5",
         "@oclif/plugin-commands": "^2.2.0",
@@ -488,9 +488,9 @@
       }
     },
     "@fluid-tools/version-tools": {
-      "version": "0.6.0-109663",
-      "resolved": "https://registry.npmjs.org/@fluid-tools/version-tools/-/version-tools-0.6.0-109663.tgz",
-      "integrity": "sha512-04hUL6TLyQI0d43ULENmF7smmUY+DCH0bKhnDHsDlQNZxFBT02TXf68M8kXJixrRPu/9TGa7SBNyay0UNthzOQ==",
+      "version": "0.6.0-110101",
+      "resolved": "https://registry.npmjs.org/@fluid-tools/version-tools/-/version-tools-0.6.0-110101.tgz",
+      "integrity": "sha512-23PhJ7/F8aCya84WqcK3x1SL9xWeiSfYHe6y1kHZUgRYewADtzml3IaMfcbt7UbZETgn39es0W+IMsQGOdiOWg==",
       "dev": true,
       "requires": {
         "@oclif/core": "^1.9.5",
@@ -537,13 +537,13 @@
       }
     },
     "@fluidframework/build-tools": {
-      "version": "0.6.0-109663",
-      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.6.0-109663.tgz",
-      "integrity": "sha512-s6NpL/pLNMvHew3T8IIUW80QIhfmNRmV1h4ROoBlQiwj12rPa/cxdkFZl/c6XX4fUQCJDbW4p3EOOR3iYrkakA==",
+      "version": "0.6.0-110101",
+      "resolved": "https://registry.npmjs.org/@fluidframework/build-tools/-/build-tools-0.6.0-110101.tgz",
+      "integrity": "sha512-O9SME4rwoyIvhwuUOqzN17cZcq6hrCniDAJjuSZjOjnCud6wlvHbO+YiBqxnk66Gr6NlkAFyiD8jPcpx681VXA==",
       "dev": true,
       "requires": {
-        "@fluid-tools/version-tools": "0.6.0-109663",
-        "@fluidframework/bundle-size-tools": "0.6.0-109663",
+        "@fluid-tools/version-tools": "0.6.0-110101",
+        "@fluidframework/bundle-size-tools": "0.6.0-110101",
         "@rushstack/node-core-library": "^3.51.1",
         "async": "^3.2.0",
         "chalk": "^2.4.2",
@@ -657,9 +657,9 @@
       }
     },
     "@fluidframework/bundle-size-tools": {
-      "version": "0.6.0-109663",
-      "resolved": "https://registry.npmjs.org/@fluidframework/bundle-size-tools/-/bundle-size-tools-0.6.0-109663.tgz",
-      "integrity": "sha512-OPz35ffI7qaUoYMo6R8PVQWm8qF6G8q33FTPKhrpnplkFFlwsq+jkVHL8+F2DgLHrAd2FsT8pA524JQU5aMSBg==",
+      "version": "0.6.0-110101",
+      "resolved": "https://registry.npmjs.org/@fluidframework/bundle-size-tools/-/bundle-size-tools-0.6.0-110101.tgz",
+      "integrity": "sha512-qUwXa1aBrQEjJXikuVR+lTFFDvX8DP/9DljWcQnMOJk4Xn86mW8ZAzKOqAsjTm7sb90p745FMXDl7GQM3nCSMw==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^11.2.0",


### PR DESCRIPTION
Since the package.json has already been bumped to a compatible range, this change updates only the lockfiles to pick up prerelease `0.6.0-110101`.