### PR TITLE
GC: Configs for disabling tombstone feature and for enabling throwing error on tombstone usage

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -87,7 +87,7 @@ import {
     getAttributesFormatVersion,
     getFluidDataStoreAttributes,
 } from "./summaryFormat";
-import { enableThrowOnTombstoneUsageKey } from "./garbageCollection";
+import { throwOnTombstoneUsageKey } from "./garbageCollection";
 
 function createAttributes(
     pkg: readonly string[],
@@ -208,7 +208,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     private _tombstoned = false;
     public get tombstoned() { return this._tombstoned; }
     /** If true, throw an error when a tombstone data store is used. */
-    private readonly shouldThrowOnTombstoneUsage: boolean;
+    private readonly throwOnTombstoneUsage: boolean;
 
     public get attachState(): AttachState {
         return this._attachState;
@@ -310,7 +310,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
         this.thresholdOpsCounter = new ThresholdCounter(FluidDataStoreContext.pendingOpsCountThreshold, this.mc.logger);
 
         // Read the feature flag that tells whether to throw when a tombstone data store is used.
-        this.shouldThrowOnTombstoneUsage = this.mc.config.getBoolean(enableThrowOnTombstoneUsageKey) === true;
+        this.throwOnTombstoneUsage = this.mc.config.getBoolean(throwOnTombstoneUsageKey) === true;
     }
 
     public dispose(): void {
@@ -778,14 +778,14 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
             });
 
             // Always log an error when tombstoned data store is used. However, throw an error only if
-            // shouldThrowOnTombstoneUsage is set.
+            // throwOnTombstoneUsage is set.
             this.mc.logger.sendErrorEvent({
                 eventName: "GC_Tombstone_DataStore_Changed",
                 callSite,
                 pkg: packagePathToTelemetryProperty(this.pkg),
             }, error);
 
-            if (this.shouldThrowOnTombstoneUsage) {
+            if (this.throwOnTombstoneUsage) {
                 throw error;
             }
         }

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -65,7 +65,9 @@ import {
 } from "@fluidframework/runtime-utils";
 import {
     ChildLogger,
+    loggerToMonitoringContext,
     LoggingError,
+    MonitoringContext,
     TelemetryDataTag,
     ThresholdCounter,
 } from "@fluidframework/telemetry-utils";
@@ -85,6 +87,7 @@ import {
     getAttributesFormatVersion,
     getFluidDataStoreAttributes,
 } from "./summaryFormat";
+import { enableThrowOnTombstoneUsageKey } from "./garbageCollection";
 
 function createAttributes(
     pkg: readonly string[],
@@ -204,6 +207,8 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
      */
     private _tombstoned = false;
     public get tombstoned() { return this._tombstoned; }
+    /** If true, throw an error when a tombstone data store is used. */
+    private readonly shouldThrowOnTombstoneUsage: boolean;
 
     public get attachState(): AttachState {
         return this._attachState;
@@ -247,7 +252,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     protected _attachState: AttachState;
     private _isInMemoryRoot: boolean = false;
     protected readonly summarizerNode: ISummarizerNodeWithGC;
-    private readonly subLogger: ITelemetryLogger;
+    private readonly mc: MonitoringContext;
     private readonly thresholdOpsCounter: ThresholdCounter;
     private static readonly pendingOpsCountThreshold = 1000;
 
@@ -301,8 +306,11 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
             async () => this.getBaseGCDetails(),
         );
 
-        this.subLogger = ChildLogger.create(this.logger, "FluidDataStoreContext");
-        this.thresholdOpsCounter = new ThresholdCounter(FluidDataStoreContext.pendingOpsCountThreshold, this.subLogger);
+        this.mc = loggerToMonitoringContext(ChildLogger.create(this.logger, "FluidDataStoreContext"));
+        this.thresholdOpsCounter = new ThresholdCounter(FluidDataStoreContext.pendingOpsCountThreshold, this.mc.logger);
+
+        // Read the feature flag that tells whether to throw when a tombstone data store is used.
+        this.shouldThrowOnTombstoneUsage = this.mc.config.getBoolean(enableThrowOnTombstoneUsageKey) === true;
     }
 
     public dispose(): void {
@@ -769,13 +777,17 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
                 ...safeTelemetryProps,
             });
 
-            this.subLogger.sendErrorEvent({
+            // Always log an error when tombstoned data store is used. However, throw an error only if
+            // shouldThrowOnTombstoneUsage is set.
+            this.mc.logger.sendErrorEvent({
                 eventName: "GC_Tombstone_DataStore_Changed",
                 callSite,
                 pkg: packagePathToTelemetryProperty(this.pkg),
             }, error);
 
-            throw error;
+            if (this.shouldThrowOnTombstoneUsage) {
+                throw error;
+            }
         }
     }
 

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryLogger, ITelemetryBaseLogger, IDisposable } from "@fluidframework/common-definitions";
+import { ITelemetryBaseLogger, IDisposable } from "@fluidframework/common-definitions";
 import { DataCorruptionError, extractSafePropertiesFromMessage } from "@fluidframework/container-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { FluidObjectHandle } from "@fluidframework/datastore";
@@ -37,7 +37,7 @@ import {
     packagePathToTelemetryProperty,
     SummaryTreeBuilder,
 } from "@fluidframework/runtime-utils";
-import { ChildLogger, LoggingError, TelemetryDataTag } from "@fluidframework/telemetry-utils";
+import { ChildLogger, loggerToMonitoringContext, LoggingError, MonitoringContext, TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { BlobCacheStorageService, buildSnapshotTree } from "@fluidframework/driver-utils";
 import { assert, Lazy, LazyPromise } from "@fluidframework/common-utils";
@@ -54,7 +54,7 @@ import {
 } from "./dataStoreContext";
 import { IContainerRuntimeMetadata, nonDataStorePaths, rootHasIsolatedChannels } from "./summaryFormat";
 import { IDataStoreAliasMessage, isDataStoreAliasMessage } from "./dataStore";
-import { GCNodeType } from "./garbageCollection";
+import { enableThrowOnTombstoneUsageKey, GCNodeType } from "./garbageCollection";
 
 type PendingAliasResolve = (success: boolean) => void;
 
@@ -68,7 +68,7 @@ export class DataStores implements IDisposable {
     // 0.24 back-compat attachingBeforeSummary
     public readonly attachOpFiredForDataStore = new Set<string>();
 
-    private readonly logger: ITelemetryLogger;
+    private readonly mc: MonitoringContext;
 
     private readonly disposeOnce = new Lazy<void>(() => this.contexts.dispose());
 
@@ -82,6 +82,8 @@ export class DataStores implements IDisposable {
     // Stores the ids of new data stores between two GC runs. This is used to notify the garbage collector of new
     // root data stores that are added.
     private dataStoresSinceLastGC: string[] = [];
+    /** If true, throw an error when a tombstone data store is retrieved. */
+    private readonly shouldThrowOnTombstoneUsage: boolean;
     // The handle to the container runtime. This is used mainly for GC purposes to represent outbound reference from
     // the container runtime to other nodes.
     private readonly containerRuntimeHandle: IFluidHandle;
@@ -101,7 +103,7 @@ export class DataStores implements IDisposable {
         private readonly aliasMap: Map<string, string>,
         private readonly contexts: DataStoreContexts = new DataStoreContexts(baseLogger),
     ) {
-        this.logger = ChildLogger.create(baseLogger);
+        this.mc = loggerToMonitoringContext(ChildLogger.create(baseLogger));
         this.containerRuntimeHandle = new FluidObjectHandle(this.runtime, "/", this.runtime.IFluidHandleContext);
 
         const baseGCDetailsP = new LazyPromise(async () => {
@@ -112,6 +114,8 @@ export class DataStores implements IDisposable {
             const baseGCDetails = await baseGCDetailsP;
             return baseGCDetails.get(dataStoreId);
         };
+        // Read the feature flag that tells whether to throw when a tombstone data store is used.
+        this.shouldThrowOnTombstoneUsage = this.mc.config.getBoolean(enableThrowOnTombstoneUsageKey) === true;
 
         // Extract stores stored inside the snapshot
         const fluidDataStores = new Map<string, ISnapshotTree>();
@@ -281,7 +285,7 @@ export class DataStores implements IDisposable {
 
         const context = this.contexts.get(aliasMessage.internalId);
         if (context === undefined) {
-            this.logger.sendErrorEvent({
+            this.mc.logger.sendErrorEvent({
                 eventName: "AliasFluidDataStoreNotFound",
                 fluidDataStoreId: aliasMessage.internalId,
             });
@@ -432,14 +436,18 @@ export class DataStores implements IDisposable {
         if (context.tombstoned) {
             const error = responseToException(createResponseError(404, "Datastore removed by gc", request), request);
             // Note: if a user writes a request to look like it's viaHandle, we will also send this telemetry event
-            this.logger.sendErrorEvent({
+            this.mc.logger.sendErrorEvent({
                 eventName: "GC_Tombstone_DataStore_Requested",
                 url: request.url,
                 pkg: packagePathToTelemetryProperty(context.isLoaded ? context.packagePath : undefined),
                 viaHandle,
             }, error);
-            // The requested data store is removed by gc. Throw a 404 gc response exception.
-            throw error;
+
+            // Always log an error when tombstoned data store is used. However, throw an error only if
+            // shouldThrowOnTombstoneUsage is set.
+            if (this.shouldThrowOnTombstoneUsage) {
+                throw error;
+            }
         }
 
         return context;
@@ -450,7 +458,7 @@ export class DataStores implements IDisposable {
         if (!context) {
             // Attach message may not have been processed yet
             assert(!local, 0x163 /* "Missing datastore for local signal" */);
-            this.logger.sendTelemetryEvent({
+            this.mc.logger.sendTelemetryEvent({
                 eventName: "SignalFluidDataStoreNotFound",
                 fluidDataStoreId: {
                     value: address,
@@ -468,7 +476,7 @@ export class DataStores implements IDisposable {
             try {
                 context.setConnectionState(connected, clientId);
             } catch (error) {
-                this.logger.sendErrorEvent({
+                this.mc.logger.sendErrorEvent({
                     eventName: "SetConnectionStateError",
                     clientId,
                     fluidDataStore,

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -54,7 +54,7 @@ import {
 } from "./dataStoreContext";
 import { IContainerRuntimeMetadata, nonDataStorePaths, rootHasIsolatedChannels } from "./summaryFormat";
 import { IDataStoreAliasMessage, isDataStoreAliasMessage } from "./dataStore";
-import { enableThrowOnTombstoneUsageKey, GCNodeType } from "./garbageCollection";
+import { throwOnTombstoneUsageKey, GCNodeType } from "./garbageCollection";
 
 type PendingAliasResolve = (success: boolean) => void;
 
@@ -83,7 +83,7 @@ export class DataStores implements IDisposable {
     // root data stores that are added.
     private dataStoresSinceLastGC: string[] = [];
     /** If true, throw an error when a tombstone data store is retrieved. */
-    private readonly shouldThrowOnTombstoneUsage: boolean;
+    private readonly throwOnTombstoneUsage: boolean;
     // The handle to the container runtime. This is used mainly for GC purposes to represent outbound reference from
     // the container runtime to other nodes.
     private readonly containerRuntimeHandle: IFluidHandle;
@@ -115,7 +115,7 @@ export class DataStores implements IDisposable {
             return baseGCDetails.get(dataStoreId);
         };
         // Read the feature flag that tells whether to throw when a tombstone data store is used.
-        this.shouldThrowOnTombstoneUsage = this.mc.config.getBoolean(enableThrowOnTombstoneUsageKey) === true;
+        this.throwOnTombstoneUsage = this.mc.config.getBoolean(throwOnTombstoneUsageKey) === true;
 
         // Extract stores stored inside the snapshot
         const fluidDataStores = new Map<string, ISnapshotTree>();
@@ -444,8 +444,8 @@ export class DataStores implements IDisposable {
             }, error);
 
             // Always log an error when tombstoned data store is used. However, throw an error only if
-            // shouldThrowOnTombstoneUsage is set.
-            if (this.shouldThrowOnTombstoneUsage) {
+            // throwOnTombstoneUsage is set.
+            if (this.throwOnTombstoneUsage) {
                 throw error;
             }
         }

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -78,8 +78,10 @@ export const runSessionExpiryKey = "Fluid.GarbageCollection.RunSessionExpiry";
 export const trackGCStateKey = "Fluid.GarbageCollection.TrackGCState";
 // Feature gate key to turn GC sweep log off.
 export const disableSweepLogKey = "Fluid.GarbageCollection.DisableSweepLog";
-// Feature gate key to tombstone datastores.
-export const testTombstoneKey = "Fluid.GarbageCollection.Test.Tombstone";
+// Feature gate key to disable the tombstone feature, i.e., tombstone information is not read / written into summary.
+export const disableTombstoneKey = "Fluid.GarbageCollection.DisableTombstone";
+// Feature gate to enable throwing an error when tombstone object is used.
+export const enableThrowOnTombstoneUsageKey = "Fluid.GarbageCollection.ThrowOnTombstoneUsage";
 
 // One day in milliseconds.
 export const oneDayMs = 1 * 24 * 60 * 60 * 1000;
@@ -636,7 +638,8 @@ export class GarbageCollector implements IGarbageCollector {
 
         // Whether we are running in test mode. In this mode, unreferenced nodes are immediately deleted.
         this.testMode = this.mc.config.getBoolean(gcTestModeKey) ?? this.gcOptions.runGCInTestMode === true;
-        this.tombstoneMode = this.mc.config.getBoolean(testTombstoneKey) ?? false;
+        // Whether we are running in tombstone mode. This is true by default unless disabled via feature flags.
+        this.tombstoneMode = this.mc.config.getBoolean(disableTombstoneKey) !== true;
 
         // The GC state needs to be reset if the base snapshot contains GC tree and GC is disabled or it doesn't
         // contain GC tree and GC is enabled.
@@ -982,7 +985,9 @@ export class GarbageCollector implements IGarbageCollector {
         }
 
         const serializedGCState = JSON.stringify(generateSortedGCState(gcState));
-        const serializedTombstones = this.tombstones.length > 0 ? JSON.stringify(this.tombstones.sort()) : undefined;
+        const serializedTombstones = this.tombstoneMode
+            ? (this.tombstones.length > 0 ? JSON.stringify(this.tombstones.sort()) : undefined)
+            : undefined;
 
         /**
          * Incremental summary of GC data - If any of the GC state or tombstone state hasn't changed since the last

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -81,7 +81,7 @@ export const disableSweepLogKey = "Fluid.GarbageCollection.DisableSweepLog";
 // Feature gate key to disable the tombstone feature, i.e., tombstone information is not read / written into summary.
 export const disableTombstoneKey = "Fluid.GarbageCollection.DisableTombstone";
 // Feature gate to enable throwing an error when tombstone object is used.
-export const enableThrowOnTombstoneUsageKey = "Fluid.GarbageCollection.ThrowOnTombstoneUsage";
+export const throwOnTombstoneUsageKey = "Fluid.GarbageCollection.ThrowOnTombstoneUsage";
 
 // One day in milliseconds.
 export const oneDayMs = 1 * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
Updated the tombstone feature configs. There are two separate configs now:
1. Fluid.GarbageCollection.DisableTombstone - This can be used to disable the tombstone feature altogether. This will be used in case we find any issues with the tombstone feature and need to disable it.
2. Fluid.GarbageCollection.ThrowOnTombstoneUsage - This will be used to enable throwing an error when a tombstoned object is used.

[AB#2131](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2131)