### PR TITLE
Add threshold for non-runtime ops triggering summary heuristics

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -590,8 +590,8 @@ export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfigurati
     maxTime: number;
     minIdleTime: number;
     minOpsForLastSummaryAttempt: number;
+    nonRuntimeHeuristicThreshold?: number;
     nonRuntimeOpWeight: number;
-    nonRuntimeSummarizeThreshold?: number;
     runtimeOpWeight: number;
     // (undocumented)
     state: "enabled";

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -591,6 +591,7 @@ export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfigurati
     minIdleTime: number;
     minOpsForLastSummaryAttempt: number;
     nonRuntimeOpWeight: number;
+    nonRuntimeSummarizeThreshold?: number;
     runtimeOpWeight: number;
     // (undocumented)
     state: "enabled";

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -277,6 +277,17 @@ export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfigurati
      * For example: (multiplier) * (number of non-runtime ops) = weighted number of non-runtime ops
      */
     nonRuntimeOpWeight: number;
+
+    /**
+     * Number of ops since last summary needed before a non-runtime op can trigger a summary.
+     *
+     * Note: Any runtime ops sent before the threshold is reached will trigger heuristics normally.
+     * This threshold ONLY applies to non-runtime ops triggering summaries.
+     *
+     * For example: Say the threshold is 20. Sending 19 non-runtime ops will not trigger any summaries. Sending the
+     * 20th non-runtime op will trigger the heuristic checks for summarizing.
+     */
+    nonRuntimeSummarizeThreshold?: number;
 }
 
 export interface ISummaryConfigurationDisableSummarizer {
@@ -316,6 +327,8 @@ export const DefaultSummaryConfiguration: ISummaryConfiguration = {
     nonRuntimeOpWeight: 0.1,
 
     runtimeOpWeight: 1.0,
+
+    nonRuntimeSummarizeThreshold: 20,
 };
 
 export interface IGCRuntimeOptions {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -279,15 +279,15 @@ export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfigurati
     nonRuntimeOpWeight: number;
 
     /**
-     * Number of ops since last summary needed before a non-runtime op can trigger a summary.
+     * Number of ops since last summary needed before a non-runtime op can trigger running summary heuristics.
      *
      * Note: Any runtime ops sent before the threshold is reached will trigger heuristics normally.
      * This threshold ONLY applies to non-runtime ops triggering summaries.
      *
-     * For example: Say the threshold is 20. Sending 19 non-runtime ops will not trigger any summaries. Sending the
-     * 20th non-runtime op will trigger the heuristic checks for summarizing.
+     * For example: Say the threshold is 20. Sending 19 non-runtime ops will not trigger any heuristic checks.
+     * Sending the 20th non-runtime op will trigger the heuristic checks for summarizing.
      */
-    nonRuntimeSummarizeThreshold?: number;
+    nonRuntimeHeuristicThreshold?: number;
 }
 
 export interface ISummaryConfigurationDisableSummarizer {
@@ -328,7 +328,7 @@ export const DefaultSummaryConfiguration: ISummaryConfiguration = {
 
     runtimeOpWeight: 1.0,
 
-    nonRuntimeSummarizeThreshold: 20,
+    nonRuntimeHeuristicThreshold: 20,
 };
 
 export interface IGCRuntimeOptions {

--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -265,9 +265,9 @@ export class RunningSummarizer implements IDisposable {
 
     /**
      * Can the given op trigger a summary?
-     * # Currently only prevents summaries for Summarize and SummaryAck ops
+     * # Currently always prevents summaries for Summarize and SummaryAck/Nack ops
      * @param op - op to check
-     * @returns true if this type of op can trigger a summary
+     * @returns true if this op can trigger a summary
      */
     private opCanTriggerSummary(op: ISequencedDocumentMessage): boolean {
         switch (op.type) {
@@ -288,8 +288,8 @@ export class RunningSummarizer implements IDisposable {
         // eslint-disable-next-line max-len
         const opsSinceLastAck = heuristicData.lastOpSequenceNumber - heuristicData.lastSuccessfulSummary.refSequenceNumber;
         return config.state === "enabled"
-            && (config.nonRuntimeSummarizeThreshold === undefined
-                || config.nonRuntimeSummarizeThreshold <= opsSinceLastAck);
+            && (config.nonRuntimeHeuristicThreshold === undefined
+                || config.nonRuntimeHeuristicThreshold <= opsSinceLastAck);
     }
 
     public async waitStop(allowLastSummary: boolean): Promise<void> {

--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -99,10 +99,8 @@ export class RunningSummarizer implements IDisposable {
         heuristicData.lastOpSequenceNumber = runtime.deltaManager.lastSequenceNumber;
 
         // Start heuristics
-        if (heuristicData.numRuntimeOps > 0 || this.nonRuntimeOpCanTriggerSummary(configuration, heuristicData)) {
-            summarizer.heuristicRunner?.start();
-            summarizer.heuristicRunner?.run();
-        }
+        summarizer.heuristicRunner?.start();
+        summarizer.heuristicRunner?.run();
 
         return summarizer;
     }
@@ -276,20 +274,16 @@ export class RunningSummarizer implements IDisposable {
             case MessageType.SummaryNack:
                 return false;
             default:
-                return isRuntimeMessage(op)
-                    || RunningSummarizer.nonRuntimeOpCanTriggerSummary(this.configuration, this.heuristicData);
+                return isRuntimeMessage(op) || this.nonRuntimeOpCanTriggerSummary();
         }
     }
 
-    private static nonRuntimeOpCanTriggerSummary(
-        config: ISummaryConfiguration,
-        heuristicData: ISummarizeHeuristicData,
-    ): boolean {
+    private nonRuntimeOpCanTriggerSummary(): boolean {
         // eslint-disable-next-line max-len
-        const opsSinceLastAck = heuristicData.lastOpSequenceNumber - heuristicData.lastSuccessfulSummary.refSequenceNumber;
-        return config.state === "enabled"
-            && (config.nonRuntimeHeuristicThreshold === undefined
-                || config.nonRuntimeHeuristicThreshold <= opsSinceLastAck);
+        const opsSinceLastAck = this.heuristicData.lastOpSequenceNumber - this.heuristicData.lastSuccessfulSummary.refSequenceNumber;
+        return this.configuration.state === "enabled"
+            && (this.configuration.nonRuntimeHeuristicThreshold === undefined
+                || this.configuration.nonRuntimeHeuristicThreshold <= opsSinceLastAck);
     }
 
     public async waitStop(allowLastSummary: boolean): Promise<void> {

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -65,7 +65,7 @@ describe("Runtime", () => {
                 maxIdleTime: 5000, // This must remain the same as minIdleTime for tests to pass nicely
                 nonRuntimeOpWeight: 0.1,
                 runtimeOpWeight: 1.0,
-                nonRuntimeSummarizeThreshold: 20,
+                nonRuntimeHeuristicThreshold: 20,
                 ...summaryCommon,
             };
             const summaryConfigDisableHeuristics: ISummaryConfiguration = {
@@ -473,15 +473,15 @@ describe("Runtime", () => {
                 it("Should not summarize on non-runtime op before threshold is reached", async () => {
                     assert.strictEqual(heuristicData.numRuntimeOps, 0);
                     assert.strictEqual(heuristicData.numNonRuntimeOps, 0);
-                    assert(summaryConfig.nonRuntimeSummarizeThreshold !== undefined,
-                        "Expect nonRuntimeSummarizeThreshold to be provided");
+                    assert(summaryConfig.nonRuntimeHeuristicThreshold !== undefined,
+                        "Expect nonRuntimeHeuristicThreshold to be provided");
 
-                    await emitNoOp(summaryConfig.nonRuntimeSummarizeThreshold - 1);
+                    await emitNoOp(summaryConfig.nonRuntimeHeuristicThreshold - 1);
                     await tickAndFlushPromises(summaryConfig.minIdleTime);
 
                     assertRunCounts(0, 0, 0, "should not perform summary");
                     assert.strictEqual(heuristicData.numRuntimeOps, 0);
-                    assert.strictEqual(heuristicData.numNonRuntimeOps, summaryConfig.nonRuntimeSummarizeThreshold - 1);
+                    assert.strictEqual(heuristicData.numNonRuntimeOps, summaryConfig.nonRuntimeHeuristicThreshold - 1);
 
                     await emitNoOp(1);
                     await tickAndFlushPromises(summaryConfig.minIdleTime);

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -65,6 +65,7 @@ describe("Runtime", () => {
                 maxIdleTime: 5000, // This must remain the same as minIdleTime for tests to pass nicely
                 nonRuntimeOpWeight: 0.1,
                 runtimeOpWeight: 1.0,
+                nonRuntimeSummarizeThreshold: 20,
                 ...summaryCommon,
             };
             const summaryConfigDisableHeuristics: ISummaryConfiguration = {
@@ -88,6 +89,20 @@ describe("Runtime", () => {
                     sequenceNumber: lastRefSeq,
                     timestamp,
                     type,
+                };
+                mockDeltaManager.emit("op", op);
+                await flushPromises();
+            }
+
+            async function emitNoOp(
+                increment: number = 1,
+            ) {
+                heuristicData.numNonRuntimeOps += increment - 1; // -1 because we emit an op below
+                lastRefSeq += increment;
+                const op: Partial<ISequencedDocumentMessage> = {
+                    sequenceNumber: lastRefSeq,
+                    timestamp: Date.now(),
+                    type: MessageType.NoOp,
                 };
                 mockDeltaManager.emit("op", op);
                 await flushPromises();
@@ -453,6 +468,25 @@ describe("Runtime", () => {
 
                     assert.strictEqual(heuristicData.numRuntimeOps, 0);
                     assert.strictEqual(heuristicData.numNonRuntimeOps, 1);
+                });
+
+                it("Should not summarize on non-runtime op before threshold is reached", async () => {
+                    assert.strictEqual(heuristicData.numRuntimeOps, 0);
+                    assert.strictEqual(heuristicData.numNonRuntimeOps, 0);
+                    assert(summaryConfig.nonRuntimeSummarizeThreshold !== undefined,
+                        "Expect nonRuntimeSummarizeThreshold to be provided");
+
+                    await emitNoOp(summaryConfig.nonRuntimeSummarizeThreshold - 1);
+                    await tickAndFlushPromises(summaryConfig.minIdleTime);
+
+                    assertRunCounts(0, 0, 0, "should not perform summary");
+                    assert.strictEqual(heuristicData.numRuntimeOps, 0);
+                    assert.strictEqual(heuristicData.numNonRuntimeOps, summaryConfig.nonRuntimeSummarizeThreshold - 1);
+
+                    await emitNoOp(1);
+                    await tickAndFlushPromises(summaryConfig.minIdleTime);
+
+                    assertRunCounts(1, 0, 0, "should perform summary");
                 });
             });
 


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

We are summarizing too frequently when the summary only contains a few non-system ops. There needs to be a threshold to control how many ops since last summary are required before a non-system op can trigger a summary.

https://portal.microsofticm.com/imp/v3/incidents/details/349754396/home

A threshold of 20 was chosen based on looking at telemetry. For every summary with 100 ops or less, the average number of non-runtime ops is below 20.
```
union database("Office Fluid").Office_Fluid_FluidRuntime_*
| where Event_Time > ago(30d) and Event_Time <= now() and Data_eventName == "fluid:telemetry:Summarizer:Running:Summarize_end"
| where Data_reason == "idle"
| where Data_opsSinceLastSummary < 100
| where Data_runtimeVersion == "2.0.0-internal.1.4.6"
| summarize avg(Data_nonRuntimeOpsSinceLastSummary) by Data_opsSinceLastSummary
| render linechart
```
<img width="1198" alt="image" src="https://user-images.githubusercontent.com/102998837/202818838-ab8dfd52-eca4-4a14-8bf6-2e4cb5ff6404.png">