### PR TITLE
Tree: fix deepFreeze for maps and sets

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/deltaUtils.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/deltaUtils.spec.ts
@@ -24,7 +24,7 @@ const fooField = brand<FieldKey>("foo");
 const moveId = brandOpaque<Delta.MoveId>(42);
 
 function applyModifyToTree(node: MapTree, modify: Delta.Modify): Map<FieldKey, Delta.MarkList> {
-    deepFreeze(modify);
+    deepFreeze(modify, false);
     return applyModifyToTreeImpl(node, modify);
 }
 
@@ -97,7 +97,7 @@ describe("DeltaUtils", () => {
                     ],
                 ],
             ]);
-            deepFreeze(input);
+            deepFreeze(input, false);
             const actual = mapFieldMarks(input, mapTreeFromCursor);
             const nestedMapTreeInsert = new Map([
                 [

--- a/packages/dds/tree/src/test/feature-libraries/deltaUtils.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/deltaUtils.spec.ts
@@ -24,7 +24,7 @@ const fooField = brand<FieldKey>("foo");
 const moveId = brandOpaque<Delta.MoveId>(42);
 
 function applyModifyToTree(node: MapTree, modify: Delta.Modify): Map<FieldKey, Delta.MarkList> {
-    deepFreeze(modify, false);
+    deepFreeze(modify);
     return applyModifyToTreeImpl(node, modify);
 }
 
@@ -97,7 +97,7 @@ describe("DeltaUtils", () => {
                     ],
                 ],
             ]);
-            deepFreeze(input, false);
+            deepFreeze(input);
             const actual = mapFieldMarks(input, mapTreeFromCursor);
             const nestedMapTreeInsert = new Map([
                 [
@@ -165,6 +165,7 @@ describe("DeltaUtils", () => {
                     ],
                 ],
             ]);
+            deepFreeze(expected);
             assert.deepEqual(actual, expected);
         });
     });
@@ -201,7 +202,7 @@ describe("DeltaUtils", () => {
                                 type,
                                 value: "Y",
                                 fields: new Map([
-                                    [fooField, [{ type, value: "Z", fields: emptyMap }]],
+                                    [fooField, [{ type, value: "Z", fields: new Map() }]],
                                 ]),
                             },
                         ],

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.spec.ts
@@ -17,17 +17,17 @@ const tag1: RevisionTag = brand(1);
 const tag2: RevisionTag = brand(2);
 
 function compose(changes: TestChangeset[]): TestChangeset {
-    changes.forEach(deepFreeze);
+    changes.forEach((c) => deepFreeze(c));
     return SF.compose(changes, TestChange.compose);
 }
 
 function composeNoVerify(changes: TestChangeset[]): TestChangeset {
-    changes.forEach(deepFreeze);
+    changes.forEach((c) => deepFreeze(c));
     return SF.compose(changes, (cs: TestChange[]) => TestChange.compose(cs, false));
 }
 
 function shallowCompose(changes: SF.Changeset[]): SF.Changeset {
-    changes.forEach(deepFreeze);
+    changes.forEach((c) => deepFreeze(c));
     return SF.sequenceFieldChangeRebaser.compose(changes, () =>
         assert.fail("Unexpected call to child rebaser"),
     );

--- a/packages/dds/tree/src/test/sequence-change-family/compose.spec.ts
+++ b/packages/dds/tree/src/test/sequence-change-family/compose.spec.ts
@@ -18,7 +18,7 @@ const type: TreeSchemaIdentifier = brand("Node");
 const tomb = "Dummy Changeset Tag";
 
 function compose(changes: SequenceChangeset[]): SequenceChangeset {
-    changes.forEach(deepFreeze);
+    changes.forEach((c) => deepFreeze(c));
     return sequenceChangeRebaser.compose(changes);
 }
 

--- a/packages/dds/tree/src/test/util/deepFreeze.spec.ts
+++ b/packages/dds/tree/src/test/util/deepFreeze.spec.ts
@@ -72,17 +72,24 @@ describe("deepFreeze", () => {
         });
     });
     it("freezes maps", () => {
-        const inner: any = { c: 2 };
-        const frozen = new Map<number, any>([
+        const innerKey: any = { k: 2 };
+        const innerValue: any = { v: 2 };
+        const frozen = new Map<any, any>([
             [0, 1],
-            [1, inner],
+            [innerKey, innerValue],
         ]);
         deepFreeze(frozen);
         assert.throws(() => {
-            inner.d = 42;
+            innerKey.x = 42;
         });
         assert.throws(() => {
-            inner.c = 42;
+            innerKey.v = 42;
+        });
+        assert.throws(() => {
+            innerValue.x = 42;
+        });
+        assert.throws(() => {
+            innerValue.v = 42;
         });
         assert.throws(() => {
             frozen.set(0, 42);

--- a/packages/dds/tree/src/test/util/deepFreeze.spec.ts
+++ b/packages/dds/tree/src/test/util/deepFreeze.spec.ts
@@ -130,6 +130,28 @@ describe("deepFreeze", () => {
             frozen.clear();
         });
     });
+    it("detects partially frozen maps and sets", () => {
+        const map: any = new Map<number, any>([[0, 1]]);
+        const set: any = new Set<number>([0, 1]);
+        Object.freeze(map);
+        Object.freeze(set);
+        assert.throws(() => {
+            deepFreeze(map);
+        });
+        assert.throws(() => {
+            deepFreeze(set);
+        });
+    });
+    it("frozen maps and sets are deep comparable", () => {
+        const map1: any = new Map<number, any>([[0, 1]]);
+        const map2: any = new Map<number, any>([[0, 1]]);
+        const set1: any = new Set<number>([0, 1]);
+        const set2: any = new Set<number>([0, 1]);
+        deepFreeze(map1);
+        deepFreeze(set1);
+        assert.deepEqual(map1, map2);
+        assert.deepEqual(set1, set2);
+    });
     it("optionally does not freeze map and set methods", () => {
         const map: any = new Map<number, any>([[0, 1]]);
         const set: any = new Set<number>([0, 1]);

--- a/packages/dds/tree/src/test/util/deepFreeze.spec.ts
+++ b/packages/dds/tree/src/test/util/deepFreeze.spec.ts
@@ -1,0 +1,174 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { deepFreeze } from "../utils";
+
+describe("deepFreeze", () => {
+    it("freezes plain objects", () => {
+        const inner: any = { c: 2 };
+        const frozen: any = { a: 1, b: inner };
+        deepFreeze(frozen);
+        assert.throws(() => {
+            frozen.a = 42;
+        });
+        assert.throws(() => {
+            frozen.b = 42;
+        });
+        assert.throws(() => {
+            inner.c = 42;
+        });
+        assert.throws(() => {
+            frozen.d = 42;
+        });
+        assert.throws(() => {
+            inner.d = 42;
+        });
+    });
+    it("freezes arrays", () => {
+        const inner: any = { c: 2 };
+        const frozen: any[] = [1, inner];
+        deepFreeze(frozen);
+        assert.throws(() => {
+            frozen[0] = 42;
+        });
+        assert.throws(() => {
+            frozen[1] = 42;
+        });
+        assert.throws(() => {
+            inner.c = 42;
+        });
+        assert.throws(() => {
+            frozen[42] = 42;
+        });
+        assert.throws(() => {
+            inner.d = 42;
+        });
+        assert.throws(() => {
+            frozen.fill(42);
+        });
+        assert.throws(() => {
+            frozen.copyWithin(0, 1);
+        });
+        assert.throws(() => {
+            frozen.pop();
+        });
+        assert.throws(() => {
+            frozen.push(42);
+        });
+        assert.throws(() => {
+            frozen.shift();
+        });
+        assert.throws(() => {
+            frozen.sort();
+        });
+        assert.throws(() => {
+            frozen.splice(0, 1);
+        });
+        assert.throws(() => {
+            frozen.unshift(42);
+        });
+    });
+    it("freezes maps", () => {
+        const inner: any = { c: 2 };
+        const frozen = new Map<number, any>([
+            [0, 1],
+            [1, inner],
+        ]);
+        deepFreeze(frozen);
+        assert.throws(() => {
+            inner.d = 42;
+        });
+        assert.throws(() => {
+            inner.c = 42;
+        });
+        assert.throws(() => {
+            frozen.set(0, 42);
+        });
+        assert.throws(() => {
+            frozen.set(1, 42);
+        });
+        assert.throws(() => {
+            frozen.set(42, 42);
+        });
+        assert.throws(() => {
+            frozen.delete(0);
+        });
+        assert.throws(() => {
+            frozen.clear();
+        });
+    });
+    it("freezes sets", () => {
+        const inner: any = { c: 2 };
+        const frozen = new Set<any>([1, inner]);
+        deepFreeze(frozen);
+        assert.throws(() => {
+            inner.d = 42;
+        });
+        assert.throws(() => {
+            inner.c = 42;
+        });
+        assert.throws(() => {
+            frozen.add(0);
+        });
+        assert.throws(() => {
+            frozen.add(1);
+        });
+        assert.throws(() => {
+            frozen.delete(0);
+        });
+        assert.throws(() => {
+            frozen.clear();
+        });
+    });
+    it("optionally does not freeze map and set methods", () => {
+        const map: any = new Map<number, any>([[0, 1]]);
+        const set: any = new Set<number>([0, 1]);
+        const frozen = new Map<number, any>([
+            [0, map],
+            [1, set],
+        ]);
+        deepFreeze(frozen, false);
+        assert.throws(() => {
+            map.c = 42;
+        });
+        assert.throws(() => {
+            set.c = 42;
+        });
+        assert.doesNotThrow(() => {
+            map.set(0, 42);
+            set.add(5);
+            set.delete(5);
+            set.clear(5);
+            frozen.set(0, 42);
+            frozen.set(1, 42);
+            frozen.set(42, 42);
+            frozen.delete(0);
+            frozen.clear();
+        });
+    });
+    it("freezes objects that are reachable through multiple fields", () => {
+        const inner: any = {
+            c: new Map<number, any>([[0, 1]]),
+        };
+        const frozen: any = { a: inner, b: inner };
+        deepFreeze(frozen);
+        assert.throws(() => {
+            frozen.a = 42;
+        });
+        assert.throws(() => {
+            frozen.b = 42;
+        });
+        assert.throws(() => {
+            inner.c = 42;
+        });
+        assert.throws(() => {
+            frozen.d = 42;
+        });
+        assert.throws(() => {
+            inner.d = 42;
+        });
+    });
+});

--- a/packages/dds/tree/src/test/util/deepFreeze.spec.ts
+++ b/packages/dds/tree/src/test/util/deepFreeze.spec.ts
@@ -152,32 +152,6 @@ describe("deepFreeze", () => {
         assert.deepEqual(map1, map2);
         assert.deepEqual(set1, set2);
     });
-    it("optionally does not freeze map and set methods", () => {
-        const map: any = new Map<number, any>([[0, 1]]);
-        const set: any = new Set<number>([0, 1]);
-        const frozen = new Map<number, any>([
-            [0, map],
-            [1, set],
-        ]);
-        deepFreeze(frozen, false);
-        assert.throws(() => {
-            map.c = 42;
-        });
-        assert.throws(() => {
-            set.c = 42;
-        });
-        assert.doesNotThrow(() => {
-            map.set(0, 42);
-            set.add(5);
-            set.delete(5);
-            set.clear(5);
-            frozen.set(0, 42);
-            frozen.set(1, 42);
-            frozen.set(42, 42);
-            frozen.delete(0);
-            frozen.clear();
-        });
-    });
     it("freezes objects that are reachable through multiple fields", () => {
         const inner: any = {
             c: new Map<number, any>([[0, 1]]),

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -62,31 +62,24 @@ function freezeObjectMethods<T>(object: T, methods: (keyof T)[]): void {
 /**
  * Recursively freezes the given object.
  *
- * Note: Calling `Object.freeze` on a Set or Map does not prevent it from being mutated.
- * If `freezeMethods` is true, we freeze the mutating methods from the Set or Map to ensure that its state cannot be changed.
- * Regardless of the value of `freezeMethods`, `deepFreeze` will freeze the keys and values of a Map or Set.
+ * WARNING: this function mutates Map and Set instances to override their mutating methods in order to ensure that the
+ * state of those instances cannot be changed. This is necessary because calling `Object.freeze` on a Set or Map does
+ * not prevent it from being mutated.
  *
  * @param object - The object to freeze.
- * @param freezeMethods - Whether to freeze mutation methods on Set and Map instances.
- * Passing `true` provides greater protection against mutation but does so at the cost of mutating the Set and
- * Map instances which may not be desirable.
  */
-export function deepFreeze<T>(object: T, freezeMethods: boolean = true): void {
+export function deepFreeze<T>(object: T): void {
     if (object instanceof Map) {
         for (const [key, value] of object.entries()) {
-            deepFreeze(key, freezeMethods);
-            deepFreeze(value, freezeMethods);
+            deepFreeze(key);
+            deepFreeze(value);
         }
-        if (freezeMethods) {
-            freezeObjectMethods(object, ["set", "delete", "clear"]);
-        }
+        freezeObjectMethods(object, ["set", "delete", "clear"]);
     } else if (object instanceof Set) {
         for (const key of object.keys()) {
-            deepFreeze(key, freezeMethods);
+            deepFreeze(key);
         }
-        if (freezeMethods) {
-            freezeObjectMethods(object, ["add", "delete", "clear"]);
-        }
+        freezeObjectMethods(object, ["add", "delete", "clear"]);
     } else {
         // Retrieve the property names defined on object
         const propNames: (keyof T)[] = Object.getOwnPropertyNames(object) as (keyof T)[];
@@ -94,7 +87,7 @@ export function deepFreeze<T>(object: T, freezeMethods: boolean = true): void {
         for (const name of propNames) {
             const value = object[name];
             if (typeof value === "object") {
-                deepFreeze(value, freezeMethods);
+                deepFreeze(value);
             }
         }
     }

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -43,17 +43,22 @@ const frozenMethod = () => {
 };
 
 export function deepFreeze<T>(object: T, freezeMethods: boolean = true): void {
-    if (object instanceof Map || object instanceof Set) {
-        for (const value of object.values()) {
+    if (object instanceof Map) {
+        for (const [key, value] of object.entries()) {
+            deepFreeze(key, freezeMethods);
             deepFreeze(value, freezeMethods);
         }
         if (freezeMethods && !Object.isFrozen(object)) {
-            if (object instanceof Map) {
-                object.set = frozenMethod;
-            }
-            if (object instanceof Set) {
-                object.add = frozenMethod;
-            }
+            object.set = frozenMethod;
+            object.delete = frozenMethod;
+            object.clear = frozenMethod;
+        }
+    } else if (object instanceof Set) {
+        for (const key of object.keys()) {
+            deepFreeze(key, freezeMethods);
+        }
+        if (freezeMethods && !Object.isFrozen(object)) {
+            object.add = frozenMethod;
             object.delete = frozenMethod;
             object.clear = frozenMethod;
         }

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -46,6 +46,7 @@ const frozenMethod = () => {
  * Recursively freezes the given object.
  * @param object - The object to freeze.
  * @param freezeMethods - Whether to freeze mutation methods on `Set` and `Map` instances.
+ * Passing `true` mutates the `Set` and `Map` instances encountered in the recursion.
  */
 export function deepFreeze<T>(object: T, freezeMethods: boolean = true): void {
     if (object instanceof Map) {

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -42,6 +42,11 @@ const frozenMethod = () => {
     assert.fail("Object is frozen");
 };
 
+/**
+ * Recursively freezes the given object.
+ * @param object - The object to freeze.
+ * @param freezeMethods - Whether to freeze mutation methods on `Set` and `Map` instances.
+ */
 export function deepFreeze<T>(object: T, freezeMethods: boolean = true): void {
     if (object instanceof Map) {
         for (const [key, value] of object.entries()) {


### PR DESCRIPTION
The test utility function `deepFreeze` was not freezing `Map` and `Set` objects as well as their contents.