### PR TITLE
fix(eslint-config-fluid): Fix type validation file glob in recommended config

### DIFF
--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -108,7 +108,7 @@ module.exports = {
         },
         {
             // Rules only for type validation files
-            files: ["**/types/*validate*Previous.ts"],
+            files: ["**/types/*validate*Previous*.ts"],
             rules: {
                 "@typescript-eslint/no-explicit-any": "off",
                 "@typescript-eslint/no-unsafe-argument": "off",


### PR DESCRIPTION
PR #12542 missed a place where we override the eslint config for type validation files. This corrects it.