### PR TITLE
Prerelease version support in versionUtils

### DIFF
--- a/packages/test/test-version-utils/src/test/versionUtils.spec.ts
+++ b/packages/test/test-version-utils/src/test/versionUtils.spec.ts
@@ -62,6 +62,12 @@ describe("versionUtils", () => {
         assert.strictEqual(getRequestedRange("0.59.1002", -1), "^0.58.0-0");
         assert.strictEqual(getRequestedRange("1.1.0", -1), "^0.59.0-0");
         assert.strictEqual(getRequestedRange("2.4.5", -1), "^1.0.0-0");
+
+        // asserts for prereleases/dev versions
+        assert.strictEqual(getRequestedRange("2.0.0-dev.2.2.0.110039", -1), ">=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0");
+        assert.strictEqual(getRequestedRange("2.0.0-dev.2.2.0.110039", -2), "^1.0.0-0");
+        assert.strictEqual(getRequestedRange("2.0.0-dev.2.1.0.110039", -1), ">=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0");
+        assert.strictEqual(getRequestedRange("2.0.0-dev.2.1.0.110039", -2), "^1.0.0-0");
     });
 
     describe("versionHasMovedSparsedMatrix", () => {

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -237,10 +237,18 @@ export function getRequestedRange(baseVersion: string, requested?: number | stri
     if (typeof requested === "string") { return requested; }
 
     const isInternal = baseVersion.includes("internal");
+    const isDev = baseVersion.includes("dev");
 
+    // if the baseVersion passed is an internal version
     if (isInternal) {
         const internalVersions = baseVersion.split("-internal.");
         return internalSchema(internalVersions[0], internalVersions[1], requested);
+    }
+
+    // if the baseVersion passed is a pre-released version
+    if(isDev) {
+        const devVersions = baseVersion.split("-dev.");
+        return internalSchema(devVersions[0], devVersions[1].split(".", 3).join("."), requested);
     }
 
     let version;


### PR DESCRIPTION
Initially, the versionUtils did not support pre-release versions passed. The corresponding N-1 and N-2 were incorrect since the base version was not recognized as being "internal". This PR adds support for dev releases. 

[AB#2603](https://dev.azure.com/fluidframework/internal/_workitems/edit/2603)

Feedback:

1. If any more test cases should be added