### PR TITLE
fix(build-tools): Load workspaceGlobs from pnpm properly

### DIFF
--- a/build-tools/packages/build-tools/src/common/monoRepo.ts
+++ b/build-tools/packages/build-tools/src/common/monoRepo.ts
@@ -124,6 +124,8 @@ export class MonoRepo {
                 logger.verbose(`${kind}: Loading packages from ${lernaPath}`);
                 pkgs = lerna.packages;
             }
+            this.workspaceGlobs = pkgs;
+
             for (const dir of pkgs as string[]) {
                 // TODO: other glob pattern?
                 const loadDir = dir.endsWith("/**") ? dir.substr(0, dir.length - 3) : dir;
@@ -131,7 +133,6 @@ export class MonoRepo {
                     ...Packages.loadDir(path.join(this.repoPath, loadDir), kind, ignoredDirs, this),
                 );
             }
-            this.workspaceGlobs = lerna.packages;
             return;
         }
 


### PR DESCRIPTION
The workspaceGlobs property wasn't being set when the package manager is pnpm.