### PR TITLE
minor fixes for azure e2e tests to detect no server connection.

### DIFF
--- a/azure/packages/test/end-to-end-tests/src/test/containerCopy.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/containerCopy.spec.ts
@@ -63,9 +63,17 @@ describe("Container copy scenarios", () => {
      */
     it("can handle bad versions of current document", async () => {
         const resources = client.getContainerVersions("badid");
+        const errorFn = (error: Error): boolean => {
+            assert.notStrictEqual(
+                error.message.startsWith("connect ECONNREFUSED"),
+                true,
+                "Connection not established.",
+            );
+            return true;
+        };
         await assert.rejects(
             resources,
-            () => true,
+            errorFn,
             "We should not be able to get container versions.",
         );
     });
@@ -179,6 +187,15 @@ describe("Container copy scenarios", () => {
      */
     it("can handle non-existing container", async () => {
         const resources = client.copyContainer("badidoncopy", schema);
-        await assert.rejects(resources, () => true, "We should not be able to copy container.");
+        const errorFn = (error: Error): boolean => {
+            assert.notStrictEqual(
+                error.message.startsWith("connect ECONNREFUSED"),
+                true,
+                "Connection not established.",
+            );
+            return true;
+        };
+
+        await assert.rejects(resources, errorFn, "We should not be able to copy container.");
     });
 });

--- a/azure/packages/test/end-to-end-tests/src/test/containerCreate.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/containerCreate.spec.ts
@@ -3,11 +3,13 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "assert";
+
+import { AzureClient } from "@fluidframework/azure-client";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map";
 import { timeoutPromise } from "@fluidframework/test-utils";
-import { AzureClient } from "@fluidframework/azure-client";
+
 import { createAzureClient } from "./AzureClientFactory";
 
 describe("Container create scenarios", () => {
@@ -25,23 +27,6 @@ describe("Container create scenarios", () => {
     });
 
     /**
-     * Scenario: test when Azure Client is instantiated correctly, it can create
-     * a container successfully.
-     *
-     * Expected behavior: an error should not be thrown nor should a rejected promise
-     * be returned.
-     */
-    it("can create new Azure Fluid Relay container successfully", async () => {
-        const resourcesP = client.createContainer(schema);
-
-        await assert.doesNotReject(
-            resourcesP,
-            () => true,
-            "container cannot be created in Azure Fluid Relay",
-        );
-    });
-
-    /**
      * Scenario: test when an Azure Client container is created,
      * it is initially detached.
      *
@@ -55,6 +40,10 @@ describe("Container create scenarios", () => {
             AttachState.Detached,
             "Container should be detached",
         );
+
+        // Make sure we can attach.
+        const containerId = await container.attach();
+        assert.strictEqual(typeof containerId, "string", "Attach did not return a string ID");
     });
 
     /**
@@ -139,6 +128,11 @@ describe("Container create scenarios", () => {
 
         const errorFn = (error: Error): boolean => {
             assert.notStrictEqual(error.message, undefined, "Azure Client error is undefined");
+            assert.notStrictEqual(
+                error.message.startsWith("connect ECONNREFUSED"),
+                true,
+                "Connection not established.",
+            );
             return true;
         };
 

--- a/azure/packages/test/end-to-end-tests/src/test/ddsTests.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/ddsTests.spec.ts
@@ -233,6 +233,7 @@ describe("Fluid data updates", () => {
         };
 
         const { container } = await client.createContainer(dynamicSchema);
+        await container.attach();
 
         const newDo = await container.create(TestDataObject);
         assert.ok(newDo?.handle);


### PR DESCRIPTION
Azure e2e tests should be able to detect lack of server connectivity. Otherwise our tests are resulting in false positives.