### PR TITLE
Abort legacy SharedTree revert early if a change can't be applied

### DIFF
--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -16,7 +16,7 @@ import {
 	BuildNodeInternal,
 	Side,
 	StableRangeInternal,
-    EditStatus,
+	EditStatus,
 } from './persisted-types';
 import { TransactionInternal } from './TransactionInternal';
 import { RangeValidationResultKind, validateStableRange } from './EditUtilities';
@@ -170,9 +170,9 @@ export function revert(
 		}
 
 		// Abort the entire revert if this change can't be applied successfully.
-        if (editor.applyChange(change).status !== EditStatus.Applied) {
-            return undefined;
-        }
+		if (editor.applyChange(change).status !== EditStatus.Applied) {
+			return undefined;
+		}
 	}
 
 	editor.close();

--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -169,7 +169,7 @@ export function revert(
 				fail('Revert does not support the change type.');
 		}
 
-		// Update the revision and abort the revert if this edit can't be applied successfully
+		// Abort the entire revert if this change can't be applied successfully.
         if (editor.applyChange(change).status !== EditStatus.Applied) {
             return undefined;
         }

--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -16,6 +16,7 @@ import {
 	BuildNodeInternal,
 	Side,
 	StableRangeInternal,
+    EditStatus,
 } from './persisted-types';
 import { TransactionInternal } from './TransactionInternal';
 import { RangeValidationResultKind, validateStableRange } from './EditUtilities';
@@ -168,8 +169,10 @@ export function revert(
 				fail('Revert does not support the change type.');
 		}
 
-		// Update the revision
-		editor.applyChange(change);
+		// Update the revision and abort the revert if this edit can't be applied successfully
+        if (editor.applyChange(change).status !== EditStatus.Applied) {
+            return undefined;
+        }
 	}
 
 	editor.close();


### PR DESCRIPTION
Adds an additional check to abort `revert` early. No corresponding regression test is added because this issue was found through manipulation of the code that isn't present in main. This improvement will handle issues not already caught by the existing specific malformed/invalid checks.