### PR TITLE
docs: Update azure READMEs with template contents

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -6,6 +6,12 @@ The azure-client package provides a simple and powerful way to consume collabora
 
 See the [package README](./packages/azure-client/README.md) for more information.
 
+## @fluidframework/azure-local-services
+
+The azure-local-services package provides a minimal, self-contained, test implementation of the Azure Fluid Relay service that can be run locally and used for development/testing Fluid functionality in conjunction with the `AzureClient` in local mode.
+
+See the [package README](./packages/azure-client/README.md) for more information.
+
 ## @fluidframework/azure-service-utils
 
 A set of helper utilities for building backend APIs for use with Azure Fluid Relay service.
@@ -17,3 +23,13 @@ See the [package README](./packages/azure-service-utils/README.md) for more info
 An example application demonstrating how to use the azure-client package.
 
 See the [package README](./packages/external-controller/README.md) for more information.
+
+## Help
+
+Not finding what you're looking for in this README?
+Check out our [Github Wiki](https://github.com/microsoft/FluidFramework/wiki) or [fluidframework.com](https://fluidframework.com/docs/).
+
+Still not finding what you're looking for? Please [file an issue](https://github.com/microsoft/FluidFramework/wiki/Submitting-Bugs-and-Feature-Requests).
+Thank you!
+
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/azure/README.md
+++ b/azure/README.md
@@ -8,7 +8,7 @@ See the [package README](./packages/azure-client/README.md) for more information
 
 ## @fluidframework/azure-local-services
 
-The azure-local-services package provides a minimal, self-contained, test implementation of the Azure Fluid Relay service that can be run locally and used for development/testing Fluid functionality in conjunction with the `AzureClient` in local mode.
+The azure-local-service package provides a minimal, self-contained, test implementation of the Azure Fluid Relay service that can be run locally and used for development/testing Fluid functionality in conjunction with the `AzureClient` in local mode.
 
 See the [package README](./packages/azure-client/README.md) for more information.
 

--- a/azure/README.md
+++ b/azure/README.md
@@ -10,7 +10,7 @@ See the [package README](./packages/azure-client/README.md) for more information
 
 The azure-local-service package provides a minimal, self-contained, test implementation of the Azure Fluid Relay service that can be run locally and used for development/testing Fluid functionality in conjunction with the `AzureClient` in local mode.
 
-See the [package README](./packages/azure-client/README.md) for more information.
+See the [package README](./packages/azure-local-service/README.md) for more information.
 
 ## @fluidframework/azure-service-utils
 

--- a/azure/README.md
+++ b/azure/README.md
@@ -6,7 +6,7 @@ The azure-client package provides a simple and powerful way to consume collabora
 
 See the [package README](./packages/azure-client/README.md) for more information.
 
-## @fluidframework/azure-local-services
+## @fluidframework/azure-local-service
 
 The azure-local-service package provides a minimal, self-contained, test implementation of the Azure Fluid Relay service that can be run locally and used for development/testing Fluid functionality in conjunction with the `AzureClient` in local mode.
 

--- a/azure/packages/azure-client/README.md
+++ b/azure/packages/azure-client/README.md
@@ -2,6 +2,8 @@
 
 The azure-client package provides a simple and powerful way to consume collaborative Fluid data with the Azure Fluid Relay service.
 
+See [GitHub](https://github.com/microsoft/FluidFramework) for more details on the Fluid Framework and packages within.
+
 ## Using azure-client
 
 The azure-client package has a `AzureClient` class that allows you to interact with Fluid.
@@ -163,4 +165,32 @@ const text1 = await map1.get(); // Resolve the handle to get the object
 const text1 = await map1.get("text1-unique-id").get();
 ```
 
-See [GitHub](https://github.com/microsoft/FluidFramework) for more details on the Fluid Framework and packages within.
+<!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->
+
+## Contribution Guidelines
+
+Please refer to our [Github Wiki](https://github.com/microsoft/FluidFramework/wiki/Contributing) for an overview of our contribution guidelines.
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (README_HELP_SECTION:includeHeading=TRUE) -->
+
+## Help
+
+Not finding what you're looking for in this README?
+Check out our [GitHub Wiki](https://github.com/microsoft/FluidFramework/wiki) or [fluidframework.com](https://fluidframework.com/docs/).
+
+Still not finding what you're looking for? Please [file an issue](https://github.com/microsoft/FluidFramework/wiki/Submitting-Bugs-and-Feature-Requests).
+Thank you!
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (README_TRADEMARK_SECTION:includeHeading=TRUE) -->
+
+## Trademark
+
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services.
+Use of these trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
+
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/azure/packages/azure-local-service/README.md
+++ b/azure/packages/azure-local-service/README.md
@@ -7,6 +7,7 @@ Azure local service is a minimal, self-contained, test implementation of the Azu
 The Azure local service includes most of the basic features needed to **test** data stores and containers. While we use the [Webpack Fluid Loader](../../packages/tools/webpack-fluid-loader)'s in browser service for much of our data store and container development, the Azure local service offers some advantages because it's a standalone process. For instance, testing a Fluid container from 2+ simultaneously connected clients is much easier using the Azure local service.
 
 ## Getting Started
+
 You can install, build, and start this service by running the following
 
 ```sh
@@ -16,10 +17,43 @@ npm run start
 ```
 
 ## Configuration
+
 ### Port
-The Azure local service uses port 7070 by default.  You can change the port number by setting an environment
-variable named PORT to the desired number.  For example:
+
+The Azure local service uses port 7070 by default. You can change the port number by setting an environment
+variable named PORT to the desired number. For example:
+
 ```sh
 $env:PORT=6502
 npm run start
 ```
+
+<!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->
+
+## Contribution Guidelines
+
+Please refer to our [Github Wiki](https://github.com/microsoft/FluidFramework/wiki/Contributing) for an overview of our contribution guidelines.
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (README_HELP_SECTION:includeHeading=TRUE) -->
+
+## Help
+
+Not finding what you're looking for in this README?
+Check out our [GitHub Wiki](https://github.com/microsoft/FluidFramework/wiki) or [fluidframework.com](https://fluidframework.com/docs/).
+
+Still not finding what you're looking for? Please [file an issue](https://github.com/microsoft/FluidFramework/wiki/Submitting-Bugs-and-Feature-Requests).
+Thank you!
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (README_TRADEMARK_SECTION:includeHeading=TRUE) -->
+
+## Trademark
+
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services.
+Use of these trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
+
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/azure/packages/azure-service-utils/README.md
+++ b/azure/packages/azure-service-utils/README.md
@@ -5,3 +5,33 @@ A set of helper utilities for building backend APIs for use with Azure Fluid Rel
 ## generateToken
 
 This function will generate a JWT token that can be sent to an `ITokenProvider` instance that is being passed into the constructor of `AzureClient`. The `tenantId` and `key` map to the values provided to you as part of the onboarding process for the Azure Fluid Relay service. The `user` objects allows you to define the properties for the current user that this token will be used to authenticate for. The values passed in here represent the values that will be supplied as part of the `audience` in the `FluidContainer` that will be provided by the `AzureClient`.
+
+<!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->
+
+## Contribution Guidelines
+
+Please refer to our [Github Wiki](https://github.com/microsoft/FluidFramework/wiki/Contributing) for an overview of our contribution guidelines.
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (README_HELP_SECTION:includeHeading=TRUE) -->
+
+## Help
+
+Not finding what you're looking for in this README?
+Check out our [GitHub Wiki](https://github.com/microsoft/FluidFramework/wiki) or [fluidframework.com](https://fluidframework.com/docs/).
+
+Still not finding what you're looking for? Please [file an issue](https://github.com/microsoft/FluidFramework/wiki/Submitting-Bugs-and-Feature-Requests).
+Thank you!
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (README_TRADEMARK_SECTION:includeHeading=TRUE) -->
+
+## Trademark
+
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services.
+Use of these trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
+
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/azure/packages/external-controller/README.md
+++ b/azure/packages/external-controller/README.md
@@ -86,3 +86,33 @@ const connectionConfig: AzureConnectionConfig = useAzure
 In this way, we can toggle between remote and local mode using the same config format. We make use of
 `AzureFunctionTokenProvider` for running against live Azure Fluid Relay instance since it is more secured, without exposing the tenant
 secret key in the client-side code whereas while running the service locally for development purpose, we make use of `InsecureTokenProvider`.
+
+<!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->
+
+## Contribution Guidelines
+
+Please refer to our [Github Wiki](https://github.com/microsoft/FluidFramework/wiki/Contributing) for an overview of our contribution guidelines.
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (README_HELP_SECTION:includeHeading=TRUE) -->
+
+## Help
+
+Not finding what you're looking for in this README?
+Check out our [GitHub Wiki](https://github.com/microsoft/FluidFramework/wiki) or [fluidframework.com](https://fluidframework.com/docs/).
+
+Still not finding what you're looking for? Please [file an issue](https://github.com/microsoft/FluidFramework/wiki/Submitting-Bugs-and-Feature-Requests).
+Thank you!
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (README_TRADEMARK_SECTION:includeHeading=TRUE) -->
+
+## Trademark
+
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services.
+Use of these trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
+
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/azure/packages/test/end-to-end-tests/README.md
+++ b/azure/packages/test/end-to-end-tests/README.md
@@ -6,3 +6,26 @@ To run FRS e2e tests: `test:realsvc:azure`.
 
 To run Azure Local Service e2e tests: `test:realsvc`.
 
+<!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->
+## Contribution Guidelines
+
+Please refer to our [Github Wiki](https://github.com/microsoft/FluidFramework/wiki/Contributing) for an overview of our contribution guidelines.
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (README_HELP_SECTION:includeHeading=TRUE) -->
+## Help
+
+Not finding what you're looking for in this README?
+Check out our [GitHub Wiki](https://github.com/microsoft/FluidFramework/wiki) or [fluidframework.com](https://fluidframework.com/docs/).
+
+Still not finding what you're looking for? Please [file an issue](https://github.com/microsoft/FluidFramework/wiki/Submitting-Bugs-and-Feature-Requests).
+Thank you!
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (README_TRADEMARK_SECTION:includeHeading=TRUE) -->
+## Trademark
+
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services.
+Use of these trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/azure/packages/test/scenario-runner/README.md
+++ b/azure/packages/test/scenario-runner/README.md
@@ -3,3 +3,33 @@
 Scenario runnner for FRS and Azure Local Service. This package can be used to create and execute various scenarios involving azure-client, IFluidContainer and a range of distributed data structures (DDSes), while collecting telemetry and validating state in the process. Scenarios are sourced via yaml config files.
 
 To execute test: `npm run start`.
+
+<!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->
+
+## Contribution Guidelines
+
+Please refer to our [Github Wiki](https://github.com/microsoft/FluidFramework/wiki/Contributing) for an overview of our contribution guidelines.
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (README_HELP_SECTION:includeHeading=TRUE) -->
+
+## Help
+
+Not finding what you're looking for in this README?
+Check out our [GitHub Wiki](https://github.com/microsoft/FluidFramework/wiki) or [fluidframework.com](https://fluidframework.com/docs/).
+
+Still not finding what you're looking for? Please [file an issue](https://github.com/microsoft/FluidFramework/wiki/Submitting-Bugs-and-Feature-Requests).
+Thank you!
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (README_TRADEMARK_SECTION:includeHeading=TRUE) -->
+
+## Trademark
+
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services.
+Use of these trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
+
+<!-- AUTO-GENERATED-CONTENT:END -->


### PR DESCRIPTION
Adds `Contribution Guidelines`, `Help`, and `Trademark` sections to package READMEs, and adds missing package entry to mono-repo README.