### PR TITLE
[GC-stress] Enable session expiry, sweep timeout and tombstone for data stores

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -8,13 +8,24 @@
             "inactiveTimeoutMs": [10000],
             "optionOverrides":{
                 "tinylicious":{
+                    "comment": "SessionExpiry: 30 seconds. Inactive Timeout: 33 seconds. Sweep Timeout: 35 seconds.",
                     "configurations":{
-                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [10000]
+                        "Fluid.GarbageCollection.RunSessionExpiry": [true],
+                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [33000],
+                        "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [35000],
+                        "Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [30000],
+                        "Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
                     }
                 },
                 "odsp":{
+                    "comment": "SessionExpiry: 30 seconds. Inactive Timeout: 33 seconds. Sweep Timeout: 35 seconds.",
                     "configurations":{
-                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [10000]
+                        "Fluid.GarbageCollection.RunSessionExpiry": [true],
+                        "Fluid.Driver.Odsp.TestOverride.DisableSnapshotCache": [true],
+                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [33000],
+                        "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [35000],
+                        "Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [30000],
+                        "Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
                     }
                 }
             }
@@ -27,13 +38,24 @@
             "inactiveTimeoutMs": [60000],
             "optionOverrides":{
                 "tinylicious":{
+                    "comment": "SessionExpiry: 15 mins. Inactive Timeout: 16 mins. Sweep Timeout: 17 mins.",
                     "configurations":{
-                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [60000]
+                        "Fluid.GarbageCollection.RunSessionExpiry": [true],
+                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [960000],
+                        "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1020000],
+                        "Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [900000],
+                        "Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
                     }
                 },
                 "odsp":{
+                    "comment": "SessionExpiry: 15 mins. Inactive Timeout: 16 mins. Sweep Timeout: 17 mins.",
                     "configurations":{
-                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [60000]
+                        "Fluid.GarbageCollection.RunSessionExpiry": [true],
+                        "Fluid.Driver.Odsp.TestOverride.DisableSnapshotCache": [true],
+                        "Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [960000],
+                        "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1020000],
+                        "Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [900000],
+                        "Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
                     }
                 }
             }


### PR DESCRIPTION
- Added configs to enable session expiry, sweep timeout and tombstone for data stores in the stress tests.
- Configured inactive timeout to be > that session expiry so that we don't see errors from it.
- Removed the code that checked for inactive timeout because its not needed for sweep / tombstone.
- This will test sweep timeout telemetry error and tombstone for data stores.