### PR TITLE
Refactored GC tests that were taking long time due to mulitple summarizations and container loads

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInLocalSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInLocalSummary.spec.ts
@@ -159,79 +159,63 @@ describeFullCompat("GC reference updates in local summary", (getTestObjectProvid
     });
 
     describe("SharedMatrix", () => {
-        it("should reflect handle updates with undo / redo immediately in the next summary", async () => {
+        it("should reflect undo / redo of data stores in the next summary", async () => {
             // Create a second data store (dataStore2).
 
             const dataStore2 = await factory.createInstance(containerRuntime);
             // Add the handle of dataStore2 to the matrix to mark it as referenced.
-            {
-                mainDataStore.matrix.setCell(0, 0, dataStore2.handle);
-                await validateDataStoreInSummary(dataStore2.id, true /* referenced */);
-                mainDataStore.undoRedoStackManager.closeCurrentOperation();
-            }
+            mainDataStore.matrix.setCell(0, 0, dataStore2.handle);
+            await validateDataStoreInSummary(dataStore2.id, true /* referenced */);
+            mainDataStore.undoRedoStackManager.closeCurrentOperation();
 
             // Remove its handle and verify its marked as unreferenced.
-            {
-                mainDataStore.matrix.removeCols(0, 1);
-                await validateDataStoreInSummary(dataStore2.id, false /* referenced */);
-            }
+            mainDataStore.matrix.removeCols(0, 1);
+            await validateDataStoreInSummary(dataStore2.id, false /* referenced */);
 
             // Undo column remove so that its marked as referenced again.
-            {
-                mainDataStore.undoRedoStackManager.undoOperation();
-                await validateDataStoreInSummary(dataStore2.id, true /* referenced */);
-            }
+            mainDataStore.undoRedoStackManager.undoOperation();
+            await validateDataStoreInSummary(dataStore2.id, true /* referenced */);
 
             // Redo column remove so that its marked as unreferenced again.
-            {
-                mainDataStore.undoRedoStackManager.redoOperation();
-                await validateDataStoreInSummary(dataStore2.id, false /* referenced */);
-            }
+            mainDataStore.undoRedoStackManager.redoOperation();
+            await validateDataStoreInSummary(dataStore2.id, false /* referenced */);
         });
     });
 
     describe("SharedString", () => {
-        it("should reflect handle updates immediately in the next summary", async () => {
+        it("should reflect unreferenced data stores in the next summary", async () => {
             // Create a second data store (dataStore2).
             const dataStore2 = await factory.createInstance(containerRuntime);
 
             // Add the handle of dataStore2 to the shared string to mark it as referenced.
-            {
-                mainDataStore.sharedString.insertText(0, "Hello");
-                mainDataStore.sharedString.insertMarker(
-                    0,
-                    ReferenceType.Simple,
-                    {
-                        [reservedMarkerIdKey]: "markerId",
-                        ["handle"]: dataStore2.handle,
-                    },
-                );
-                await validateDataStoreInSummary(dataStore2.id, true /* referenced */);
-            }
+            mainDataStore.sharedString.insertText(0, "Hello");
+            mainDataStore.sharedString.insertMarker(
+                0,
+                ReferenceType.Simple,
+                {
+                    [reservedMarkerIdKey]: "markerId",
+                    ["handle"]: dataStore2.handle,
+                },
+            );
+            await validateDataStoreInSummary(dataStore2.id, true /* referenced */);
 
             // Remove its handle and verify its marked as unreferenced.
-            {
-                const marker = mainDataStore.sharedString.getMarkerFromId("markerId") as Marker;
-                mainDataStore.sharedString.annotateMarker(
-                    marker,
-                    {
-                        ["handle"]: "",
-                    },
-                );
-                await validateDataStoreInSummary(dataStore2.id, false /* referenced */);
-            }
+            mainDataStore.sharedString.annotateMarker(
+                mainDataStore.sharedString.getMarkerFromId("markerId") as Marker,
+                {
+                    ["handle"]: "",
+                },
+            );
+            await validateDataStoreInSummary(dataStore2.id, false /* referenced */);
 
             // Add the handle back and verify its marked as referenced.
-            {
-                const marker = mainDataStore.sharedString.getMarkerFromId("markerId") as Marker;
-                mainDataStore.sharedString.annotateMarker(
-                    marker,
-                    {
-                        ["handle"]: dataStore2.handle,
-                    },
-                );
-                await validateDataStoreInSummary(dataStore2.id, true /* referenced */);
-            }
+            mainDataStore.sharedString.annotateMarker(
+                mainDataStore.sharedString.getMarkerFromId("markerId") as Marker,
+                {
+                    ["handle"]: dataStore2.handle,
+                },
+            );
+            await validateDataStoreInSummary(dataStore2.id, true /* referenced */);
         });
     });
 });


### PR DESCRIPTION
The GC end-to-end tests in gcReferenceUpdatesInSummarizer.spec.ts were taking >20 seconds at times for ODSP. The tests were waiting for multiple summaries to complete and loaded containers for these summaries.
Refactored the test so that there are max 2 summaries and max 2 container loads happening. This should reduce the running time of the test.

[AB#2209](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2209)