### PR TITLE
(benchmark) Fixes for memory test reporter and change some defaults

### DIFF
--- a/tools/benchmark/package-lock.json
+++ b/tools/benchmark/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluid-tools/benchmark",
-  "version": "0.43.0",
+  "version": "0.45.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluid-tools/benchmark",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "description": "Benchmarking tools",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/tools/benchmark/src/MemoryTestRunner.ts
+++ b/tools/benchmark/src/MemoryTestRunner.ts
@@ -92,13 +92,13 @@ export interface MemoryTestObjectProps extends MochaExclusiveOptions {
      * The max time in seconds to run the benchmark.
      * This is not a guaranteed immediate stop time.
      * Elapsed time gets checked between iterations of the test that is being benchmarked.
-     * Defaults to 10 seconds.
+     * Defaults to 30 seconds.
      */
     maxBenchmarkDurationSeconds?: number;
 
     /**
      * The min sample count to reach.
-     * Defaults to 5.
+     * Defaults to 50.
      *
      * @remarks This takes precedence over {@link MemoryTestObjectProps.maxBenchmarkDurationSeconds}.
      */
@@ -128,7 +128,7 @@ export interface MemoryTestObjectProps extends MochaExclusiveOptions {
 
     /**
      * Percentage of samples (0.1 - 1) to use for calculating the statistics.
-     * Defaults to 1.
+     * Defaults to 0.95.
      * Use a lower number to drop the highest/lowest measurements.
      */
     samplePercentageToUse?: number;

--- a/tools/benchmark/src/MemoryTestRunner.ts
+++ b/tools/benchmark/src/MemoryTestRunner.ts
@@ -173,7 +173,7 @@ export interface MemoryTestObjectProps extends MochaExclusiveOptions {
 
 export function benchmarkMemory(testObject: IMemoryTestObject): Test {
     const options: Required<MemoryTestObjectProps> = {
-        maxBenchmarkDurationSeconds: testObject.maxBenchmarkDurationSeconds ?? 10,
+        maxBenchmarkDurationSeconds: testObject.maxBenchmarkDurationSeconds ?? 30,
         minSampleCount: testObject.minSampleCount ?? 50,
         maxRelativeMarginOfError: testObject.maxRelativeMarginOfError ?? 2.5,
         only: testObject.only ?? false,

--- a/tools/benchmark/src/MemoryTestRunner.ts
+++ b/tools/benchmark/src/MemoryTestRunner.ts
@@ -39,7 +39,7 @@ export interface MemoryTestData {
 export interface MemoryBenchmarkStats {
     runs: number;
     samples: { before: MemoryTestData; after: MemoryTestData; };
-    stats: Benchmark.Stats | undefined;
+    stats: Benchmark.Stats;
     aborted: boolean;
     error?: Error;
 }
@@ -174,12 +174,12 @@ export interface MemoryTestObjectProps extends MochaExclusiveOptions {
 export function benchmarkMemory(testObject: IMemoryTestObject): Test {
     const options: Required<MemoryTestObjectProps> = {
         maxBenchmarkDurationSeconds: testObject.maxBenchmarkDurationSeconds ?? 10,
-        minSampleCount: testObject.minSampleCount ?? 5,
+        minSampleCount: testObject.minSampleCount ?? 50,
         maxRelativeMarginOfError: testObject.maxRelativeMarginOfError ?? 2.5,
         only: testObject.only ?? false,
         title: testObject.title,
         type: testObject.type ?? BenchmarkType.Measurement,
-        samplePercentageToUse: testObject.samplePercentageToUse ?? 1,
+        samplePercentageToUse: testObject.samplePercentageToUse ?? 0.95,
         category: testObject.category ?? "",
     };
 
@@ -283,13 +283,29 @@ export function benchmarkMemory(testObject: IMemoryTestObject): Test {
                     heapSpace: [],
                 },
             },
-            stats: undefined,
+            stats: {
+                moe: NaN,
+                rme: NaN,
+                sem: NaN,
+                deviation: NaN,
+                mean: NaN,
+                sample: [],
+                variance: NaN,
+            },
             aborted: false,
         };
 
         try {
             const startTime = performance.now();
-            let heapUsedStats: Benchmark.Stats | undefined;
+            let heapUsedStats: Benchmark.Stats = {
+                moe: NaN,
+                rme: NaN,
+                sem: NaN,
+                deviation: NaN,
+                mean: NaN,
+                sample: [],
+                variance: NaN,
+            };
             do {
                 await testObject.beforeIteration?.();
 
@@ -310,18 +326,18 @@ export function benchmarkMemory(testObject: IMemoryTestObject): Test {
 
                 benchmarkStats.runs++;
 
-                // Break if max elapsed time passed, only if we've reached the min sample count
-                if (benchmarkStats.runs >= options.minSampleCount &&
-                    (performance.now() - startTime) / 1000 > options.maxBenchmarkDurationSeconds) {
-                    break;
-                }
-
                 const heapUsedArray: number[] = [];
                 for (let i = 0; i < benchmarkStats.samples.before.memoryUsage.length; i++) {
                     heapUsedArray.push(benchmarkStats.samples.after.memoryUsage[i].heapUsed
                         - benchmarkStats.samples.before.memoryUsage[i].heapUsed);
                 }
                 heapUsedStats = getArrayStatistics(heapUsedArray, options.samplePercentageToUse);
+
+                // Break if max elapsed time passed, only if we've reached the min sample count
+                if (benchmarkStats.runs >= options.minSampleCount &&
+                    (performance.now() - startTime) / 1000 > options.maxBenchmarkDurationSeconds) {
+                    break;
+                }
             } while (benchmarkStats.runs < options.minSampleCount
                 || heapUsedStats.rme > options.maxRelativeMarginOfError);
 

--- a/tools/benchmark/src/MochaMemoryTestReporter.ts
+++ b/tools/benchmark/src/MochaMemoryTestReporter.ts
@@ -15,7 +15,6 @@ import {
     pad,
     prettyNumber,
     red,
-    getArrayStatistics,
     getName,
     getSuiteName,
 } from "./ReporterUtilities";
@@ -125,18 +124,14 @@ class MochaMemoryTestReporter {
                         }
                         table.cell("name", italicize(testName));
                         if (!testData.aborted) {
-                            const heapUsedArray: number[] = [];
-                            for (let i = 0; i < testData.samples.before.memoryUsage.length; i++) {
-                                heapUsedArray.push(testData.samples.after.memoryUsage[i].heapUsed
-                                                   - testData.samples.before.memoryUsage[i].heapUsed);
-                            }
-                            const heapUsedStats = getArrayStatistics(heapUsedArray);
-                            table.cell("Heap Used Avg", prettyNumber(heapUsedStats.mean, 2), Table.padLeft);
-                            table.cell("Heap Used StdDev", prettyNumber(heapUsedStats.deviation, 2), Table.padLeft);
-                            table.cell("Margin of Error", `±${prettyNumber(heapUsedStats.moe, 2)}`, Table.padLeft);
+                            table.cell("Heap Used Avg", prettyNumber(testData.stats.mean, 2), Table.padLeft);
+                            table.cell("Heap Used StdDev", prettyNumber(testData.stats.deviation, 2), Table.padLeft);
+                            table.cell("Margin of Error", `±${prettyNumber(testData.stats.moe, 2)}`, Table.padLeft);
                             table.cell("Relative Margin of Error",
-                                `±${prettyNumber(heapUsedStats.rme, 2)}%`, Table.padLeft);
-                            table.cell("Samples", testData.runs.toString(), Table.padLeft);
+                                `±${prettyNumber(testData.stats.rme, 2)}%`, Table.padLeft);
+
+                            table.cell("Iterations", testData.runs.toString(), Table.padLeft);
+                            table.cell("Samples used", testData.stats.sample.length.toString(), Table.padLeft);
                         }
                         table.newRow();
                     });


### PR DESCRIPTION
## Description

- Fix the reporter for memory tests so it prints the correct statistics (no need to (incorrectly) recompute them, they already come computed from the runner).
- Add a column to report the total iterations ran and the number of samples actually used for statistical computations separately.
- Move a condition that breaks out of a loop to prevent scenarios where the reporter says N iterations of the test were run, but N-1 were used for computations, where 100% of the samples were supposed to be used.
- Change some default when running memory tests: max benchmark duration from 10 to 30 seconds; percentage of samples to use from 100% to 95%; minimum sample count from 5 to 50. Overall the intention is to get better statistics for a broader set of tests.
 
## Reviewer Guidance

I made it so `MemoryBenchmarkStats.stats` cannot be undefined anymore, initializing with `NaN` where necessary, to simplify the reporter a bit (it can now trust that some properties will always be there, so I didn't need to add null-chaining and/or non-null-assertions).

The results below show how with the new default of 95% of samples used to compute statistics, fewer samples are necessary (these were run before the minimum of 50 samples was put in place), 
and the relative margin of error goes down (at least for some tests; others here are being limited by a 10s max runtime before I changed that, and those don't see a lot of improvement):

Using 100% of samples:

```console
$ echo "samplePercentageToUse = 1"; npm run test:memory
samplePercentageToUse = 1

> @fluidframework/map@2.0.0-internal.2.2.0 test:memory /workspaces/FluidFramework/packages/dds/map
> mocha --config ./src/test/memory/.mocharc.js


SharedDirectory memory usage
status  name                                                Heap Used Avg  Heap Used StdDev  Margin of Error  Relative Margin of Error  Iterations  Samples used
------  --------------------------------------------------  -------------  ----------------  ---------------  ------------------------  ----------  ------------
    ✔   Create empty directory                                   1,916.83          5,215.84          ±391.46                   ±20.42%         682           682
    ✔   Add 1000 integers to a local directory                  91,721.73         25,706.92        ±2,557.94                    ±2.79%         388           388
    ✔   Add 1000 integers to a local directory, clear it         6,451.44         13,824.09        ±1,388.13                   ±21.52%         381           381
    ✔   Add 10000 integers to a local directory              1,023,902.40          2,745.93        ±3,408.98                    ±0.33%           5             5
    ✔   Add 10000 integers to a local directory, clear it        4,291.30          8,109.42        ±1,121.11                   ±26.13%         201           201
    ✔   Add 100000 integers to a local directory             9,188,270.67        181,041.21      ±190,022.01                    ±2.07%           6             6
    ✔   Add 100000 integers to a local directory, clear it      -1,021.76         14,305.38        ±5,905.26                  ±577.95%          25            25


SharedMap memory usage
status  name                                          Heap Used Avg  Heap Used StdDev  Margin of Error  Relative Margin of Error  Iterations  Samples used
------  --------------------------------------------  -------------  ----------------  ---------------  ------------------------  ----------  ------------
    ✔   Create empty map                                   2,131.03          5,315.53          ±530.28                   ±24.88%         386           386
    ✔   Add 1000 integers to a local map                  89,366.03         20,862.23        ±2,296.61                    ±2.57%         317           317
    ✔   Add 1000 integers to a local map, clear it         7,034.15         27,144.17        ±3,066.55                   ±43.60%         301           301
    ✔   Add 10000 integers to a local map              1,020,600.00         17,985.42       ±22,328.27                    ±2.19%           5             5
    ✔   Add 10000 integers to a local map, clear it        3,723.78          7,144.65          ±992.68                   ±26.66%         199           199
    ✔   Add 100000 integers to a local map             9,249,683.20         35,495.94       ±44,066.97                    ±0.48%           5             5
    ✔   Add 100000 integers to a local map, clear it      -4,404.24          8,480.64        ±2,850.66                   ±64.73%          34            34
```

Using 95% of samples:

```console
$ echo "samplePercentageToUse = 0.95"; npm run test:memory
samplePercentageToUse = 0.95

> @fluidframework/map@2.0.0-internal.2.2.0 test:memory /workspaces/FluidFramework/packages/dds/map
> mocha --config ./src/test/memory/.mocharc.js


SharedDirectory memory usage
status  name                                                Heap Used Avg  Heap Used StdDev  Margin of Error  Relative Margin of Error  Iterations  Samples used
------  --------------------------------------------------  -------------  ----------------  ---------------  ------------------------  ----------  ------------
    ✔   Create empty directory                                   2,256.20            181.30           ±55.50                    ±2.46%          43            41
    ✔   Add 1000 integers to a local directory                  91,263.79         17,726.67        ±2,281.07                    ±2.50%         244           232
    ✔   Add 1000 integers to a local directory, clear it         5,996.22         11,916.76        ±1,118.59                   ±18.65%         459           436
    ✔   Add 10000 integers to a local directory              1,029,924.80         12,694.57       ±15,759.86                    ±1.53%           5             5
    ✔   Add 10000 integers to a local directory, clear it        4,007.73          6,629.48          ±905.32                   ±22.59%         217           206
    ✔   Add 100000 integers to a local directory             9,188,620.00        194,912.37      ±204,581.26                    ±2.23%           6             6
    ✔   Add 100000 integers to a local directory, clear it      -6,113.28         16,781.29        ±6,927.32                  ±113.32%          26            25


SharedMap memory usage
status  name                                          Heap Used Avg  Heap Used StdDev  Margin of Error  Relative Margin of Error  Iterations  Samples used
------  --------------------------------------------  -------------  ----------------  ---------------  ------------------------  ----------  ------------
    ✔   Create empty map                                   2,260.32            249.15           ±56.02                    ±2.48%          80            76
    ✔   Add 1000 integers to a local map                  89,145.24         17,495.63        ±2,222.78                    ±2.49%         251           238
    ✔   Add 1000 integers to a local map, clear it         6,271.39         23,395.63        ±2,444.10                   ±38.97%         371           352
    ✔   Add 10000 integers to a local map              1,023,432.00         20,987.35       ±22,028.46                    ±2.15%           6             6
    ✔   Add 10000 integers to a local map, clear it        3,298.76          3,856.55          ±522.86                   ±15.85%         220           209
    ✔   Add 100000 integers to a local map             9,241,595.20         51,255.47       ±63,631.87                    ±0.69%           5             5
    ✔   Add 100000 integers to a local map, clear it      -5,221.00          1,952.77          ±676.60                   ±12.96%          34            32

```

And here are some results with all the new defaults. All tests run a minimum of 50 samples, all of them only use 95% of the samples, and the ones that don't immediately have a relative margin of error under the default of 2.5% keep iterating until they do, or until they hit the default 30s for max runtime.

```console
$ npm run test:memory

> @fluidframework/map@2.0.0-internal.2.2.0 test:memory /workspaces/FluidFramework/packages/dds/map
> mocha --config ./src/test/memory/.mocharc.js


SharedDirectory memory usage
status  name                                                Heap Used Avg  Heap Used StdDev  Margin of Error  Relative Margin of Error  Iterations  Samples used
------  --------------------------------------------------  -------------  ----------------  ---------------  ------------------------  ----------  ------------
    ✔   Create empty directory                                   2,239.83            174.65           ±49.93                    ±2.23%          50            47
    ✔   Add 1000 integers to a local directory                  91,348.54         21,902.01        ±2,281.59                    ±2.50%         373           354
    ✔   Add 1000 integers to a local directory, clear it         5,863.36         12,536.99          ±728.41                   ±12.42%        1198          1138
    ✔   Add 10000 integers to a local directory              1,023,613.62          7,360.49        ±2,104.33                    ±0.21%          50            47
    ✔   Add 10000 integers to a local directory, clear it        3,889.68          6,460.52          ±548.48                   ±14.10%         561           533
    ✔   Add 100000 integers to a local directory             9,270,628.09         10,656.85        ±3,046.75                    ±0.03%          50            47
    ✔   Add 100000 integers to a local directory, clear it       1,595.20         10,794.57        ±2,528.79                  ±158.52%          74            70


SharedMap memory usage
status  name                                          Heap Used Avg  Heap Used StdDev  Margin of Error  Relative Margin of Error  Iterations  Samples used
------  --------------------------------------------  -------------  ----------------  ---------------  ------------------------  ----------  ------------
    ✔   Create empty map                                   2,223.76            200.02           ±48.26                    ±2.17%          70            66
    ✔   Add 1000 integers to a local map                  89,759.47         18,382.03        ±2,238.72                    ±2.49%         273           259
    ✔   Add 1000 integers to a local map, clear it         7,124.71         23,530.86        ±1,679.61                   ±23.57%         794           754
    ✔   Add 10000 integers to a local map              1,021,524.94          4,021.66        ±1,149.77                    ±0.11%          50            47
    ✔   Add 10000 integers to a local map, clear it        2,910.27          3,034.88          ±269.82                    ±9.27%         512           486
    ✔   Add 100000 integers to a local map             9,267,252.94          1,591.02          ±454.87                    ±0.00%          50            47
    ✔   Add 100000 integers to a local map, clear it      -2,257.51            559.30          ±115.55                    ±5.12%          95            90
```