### PR TITLE
[TaskManager] Handle read/read-only mode

### DIFF
--- a/api-report/task-manager.api.md
+++ b/api-report/task-manager.api.md
@@ -19,6 +19,7 @@ import { SharedObject } from '@fluidframework/shared-object-base';
 export interface ITaskManager extends ISharedObject<ITaskManagerEvents> {
     abandon(taskId: string): void;
     assigned(taskId: string): boolean;
+    canVolunteer(): boolean;
     complete(taskId: string): void;
     queued(taskId: string): boolean;
     subscribed(taskId: string): boolean;
@@ -38,6 +39,7 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
     // (undocumented)
     applyStashedOp(): void;
     assigned(taskId: string): boolean;
+    canVolunteer(): boolean;
     complete(taskId: string): void;
     static create(runtime: IFluidDataStoreRuntime, id?: string): TaskManager;
     static getFactory(): IChannelFactory;

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -103,9 +103,8 @@
     "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
     "baselineVersion": "2.0.0-internal.2.1.0",
     "broken": {
-      "ClassDeclaration_TaskManager": {
-        "backCompat": false
-      }
+      "ClassDeclaration_TaskManager": {"backCompat": false, "forwardCompat": false},
+      "InterfaceDeclaration_ITaskManager": {"forwardCompat": false}
     }
   }
 }

--- a/packages/dds/task-manager/src/interfaces.ts
+++ b/packages/dds/task-manager/src/interfaces.ts
@@ -66,4 +66,9 @@ export interface ITaskManager extends ISharedObject<ITaskManagerEvents> {
      * @param taskId - Identifier for the task
      */
     complete(taskId: string): void;
+
+    /**
+     * Check whether this client can currently volunteer for a task.
+     */
+    canVolunteer(): boolean;
 }

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -629,6 +629,17 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
     }
 
     /**
+     * {@inheritDoc ITaskManager.canVolunteer}
+     */
+    public canVolunteer(): boolean {
+        // A client can volunteer for a task if its both connected to the delta stream and in write mode.
+        // this.connected reflects that condition, but is unintuitive and may be changed in the future. This API allows
+        // us to make changes to this.connected without affecting our guidance on how to check if a client is eligigble
+        // to volunteer for a task.
+        return this.connected;
+    }
+
+    /**
      * Create a summary for the task manager
      *
      * @returns the summary of the current state of the task manager

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -632,9 +632,9 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
      * {@inheritDoc ITaskManager.canVolunteer}
      */
     public canVolunteer(): boolean {
-        // A client can volunteer for a task if its both connected to the delta stream and in write mode.
+        // A client can volunteer for a task if it's both connected to the delta stream and in write mode.
         // this.connected reflects that condition, but is unintuitive and may be changed in the future. This API allows
-        // us to make changes to this.connected without affecting our guidance on how to check if a client is eligigble
+        // us to make changes to this.connected without affecting our guidance on how to check if a client is eligible
         // to volunteer for a task.
         return this.connected;
     }

--- a/packages/dds/task-manager/src/test/taskManager.spec.ts
+++ b/packages/dds/task-manager/src/test/taskManager.spec.ts
@@ -11,6 +11,7 @@ import {
     MockContainerRuntimeForReconnection,
     MockStorage,
 } from "@fluidframework/test-runtime-utils";
+import { ReadOnlyInfo } from "@fluidframework/container-definitions";
 import { TaskManager } from "../taskManager";
 import { TaskManagerFactory } from "../taskManagerFactory";
 import { ITaskManager } from "../interfaces";
@@ -445,6 +446,89 @@ describe("TaskManager", () => {
         });
     });
 
+    // Note: Since read/write modes are not yet implemented in mocks, tests are limited to simulate these secnarios.
+    describe("Read/Write Mode", () => {
+        let taskManager1: ITaskManager;
+        let containerRuntimeFactory: MockContainerRuntimeFactoryForReconnection;
+        let containerRuntime1: MockContainerRuntimeForReconnection;
+
+        const setReadOnlyInfo = (readOnlyInfo: ReadOnlyInfo) => {
+            (taskManager1 as any).runtime.deltaManager.readOnlyInfo = readOnlyInfo;
+            // Force connection to simulate read mode (TaskManager consideres the client disconnected in read mode)
+            containerRuntime1.connected = readOnlyInfo.readonly === false;
+        };
+
+        beforeEach(() => {
+            containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
+            const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
+            containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
+            const services1 = {
+                deltaConnection: containerRuntime1.createDeltaConnection(),
+                objectStorage: new MockStorage(),
+            };
+            taskManager1 = new TaskManager("task-manager-1", dataStoreRuntime1, TaskManagerFactory.Attributes);
+            taskManager1.connect(services1);
+        });
+
+        it("Immediately rejects attempts to volunteer in read mode", async () => {
+            const taskId = "taskId";
+            setReadOnlyInfo({ readonly: true, permissions: false, forced: false, storageOnly: false });
+
+            const volunteerTaskP = taskManager1.volunteerForTask(taskId);
+            assert.ok(!taskManager1.queued(taskId), "Should not be queued");
+            assert.ok(!taskManager1.assigned(taskId), "Should not be assigned");
+            await assert.rejects(volunteerTaskP);
+            containerRuntimeFactory.processAllMessages();
+            assert.ok(!taskManager1.queued(taskId), "Should not be queued");
+            assert.ok(!taskManager1.assigned(taskId), "Should not be assigned");
+        });
+
+        it("Immediately rejects attempts to volunteer with read-only permissions", async () => {
+            const taskId = "taskId";
+            setReadOnlyInfo({ readonly: true, permissions: true, forced: false, storageOnly: false });
+
+            const volunteerTaskP = taskManager1.volunteerForTask(taskId);
+            assert.ok(!taskManager1.queued(taskId), "Should not be queued");
+            assert.ok(!taskManager1.assigned(taskId), "Should not be assigned");
+            await assert.rejects(volunteerTaskP);
+            containerRuntimeFactory.processAllMessages();
+            assert.ok(!taskManager1.queued(taskId), "Should not be queued");
+            assert.ok(!taskManager1.assigned(taskId), "Should not be assigned");
+        });
+
+        it("Can subscribe while in read mode", async () => {
+            const taskId = "taskId";
+            setReadOnlyInfo({ readonly: true, permissions: false, forced: false, storageOnly: false });
+
+            taskManager1.subscribeToTask(taskId);
+            containerRuntimeFactory.processAllMessages();
+
+            assert.ok(!taskManager1.queued(taskId), "Should not be queued");
+            assert.ok(!taskManager1.assigned(taskId), "Should not be assigned");
+            assert.ok(taskManager1.subscribed(taskId), "Should be subscribed");
+
+            setReadOnlyInfo({ readonly: false });
+            containerRuntimeFactory.processAllMessages();
+
+            assert.ok(taskManager1.queued(taskId), "Should be queued");
+            assert.ok(taskManager1.assigned(taskId), "Should be assigned");
+            assert.ok(taskManager1.subscribed(taskId), "Should be subscribed");
+        });
+
+        it("Immediately rejects attempts to subscribe with read-only permissions", async () => {
+            const taskId = "taskId";
+            setReadOnlyInfo({ readonly: true, permissions: true, forced: false, storageOnly: false });
+
+            assert.throws(() => { taskManager1.subscribeToTask(taskId); },
+                "Should throw error if subscribing with read-only permissions");
+            containerRuntimeFactory.processAllMessages();
+
+            assert.ok(!taskManager1.queued(taskId), "Should not be queued");
+            assert.ok(!taskManager1.assigned(taskId), "Should not be assigned");
+            assert.ok(!taskManager1.subscribed(taskId), "Should not be subscribed");
+        });
+    });
+
     describe("Detached/Attach", () => {
         let taskManager1: TaskManager;
         let attachTaskManager1: () => Promise<void>;
@@ -681,7 +765,7 @@ describe("TaskManager", () => {
         beforeEach(async () => {
             containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 
-            // Create the first SharedMap.
+            // Create the first TaskManager.
             const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
             containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
             const services1 = {

--- a/packages/dds/task-manager/src/test/types/validateTaskManagerPrevious.generated.ts
+++ b/packages/dds/task-manager/src/test/types/validateTaskManagerPrevious.generated.ts
@@ -23,6 +23,7 @@ declare function get_old_InterfaceDeclaration_ITaskManager():
 declare function use_current_InterfaceDeclaration_ITaskManager(
     use: TypeOnly<current.ITaskManager>);
 use_current_InterfaceDeclaration_ITaskManager(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ITaskManager());
 
 /*
@@ -71,6 +72,7 @@ declare function get_old_ClassDeclaration_TaskManager():
 declare function use_current_ClassDeclaration_TaskManager(
     use: TypeOnly<current.TaskManager>);
 use_current_ClassDeclaration_TaskManager(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TaskManager());
 
 /*


### PR DESCRIPTION
## Description

This PR adds logic to clarify error messages while trying to volunteer in read/read-only mode, as well as tests to simulate these scenarios. Additionally, a `canVolunteer()` function is added to TaskManager to indicate if the client is able to volunteer for a task.

### Context:
`TaskManager.connected()` currently returns **false** while the client is in **read mode**. This leads to TaskManager handling read mode the same as the disconnected state. This behavior is correct, but the error messages would indicate that the volunteer failed due to being disconnected, instead of the client being in read/read-only mode.

## Reviewer Guidance

- Confirmation that `ReadOnlyInfo.permissions === true` means that the client does **not** have write permissions. The TSDocs were ambiguous, and I had trouble finding clarification.
- I chose not to include a helper "canVolunteer" function since that is essentially the existing `TaskManager.connected()` function. Does this seem sufficient?
- New error message wording
- Implementations of tests simulating read mode

## Misc
[AB#2653](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2653)
