### PR TITLE
chore(build-tools): bump build-tools: 0.6.0 => 1.0.0 (major)

### DIFF
--- a/build-tools/lerna.json
+++ b/build-tools/lerna.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.6.0",
+    "version": "1.0.0",
     "npmClient": "pnpm",
     "useWorkspaces": true
 }

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluid-tools/build-cli",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "Build tools for the Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": {
@@ -70,9 +70,9 @@
     "temp-directory": "nyc/.nyc_output"
   },
   "dependencies": {
-    "@fluid-tools/version-tools": "^0.6.0",
-    "@fluidframework/build-tools": "^0.6.0",
-    "@fluidframework/bundle-size-tools": "^0.6.0",
+    "@fluid-tools/version-tools": "^1.0.0",
+    "@fluidframework/build-tools": "^1.0.0",
+    "@fluidframework/bundle-size-tools": "^1.0.0",
     "@oclif/core": "^1.9.5",
     "@oclif/plugin-autocomplete": "^1.3.5",
     "@oclif/plugin-commands": "^2.2.0",

--- a/build-tools/packages/build-cli/src/packageVersion.ts
+++ b/build-tools/packages/build-cli/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-tools/build-cli";
-export const pkgVersion = "0.6.0";
+export const pkgVersion = "1.0.0";

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/build-tools",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "Fluid Build tools",
   "homepage": "https://fluidframework.com",
   "repository": {
@@ -52,8 +52,8 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@fluid-tools/version-tools": "^0.6.0",
-    "@fluidframework/bundle-size-tools": "^0.6.0",
+    "@fluid-tools/version-tools": "^1.0.0",
+    "@fluidframework/bundle-size-tools": "^1.0.0",
     "@rushstack/node-core-library": "^3.51.1",
     "async": "^3.2.0",
     "chalk": "^2.4.2",

--- a/build-tools/packages/build-tools/src/packageVersion.ts
+++ b/build-tools/packages/build-tools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/build-tools";
-export const pkgVersion = "0.6.0";
+export const pkgVersion = "1.0.0";

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/bundle-size-tools",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "Utility for analyzing bundle size regressions",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/build-tools/packages/bundle-size-tools/src/packageVersion.ts
+++ b/build-tools/packages/bundle-size-tools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/bundle-size-tools";
-export const pkgVersion = "0.6.0";
+export const pkgVersion = "1.0.0";

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluid-tools/version-tools",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "Versioning tools for Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": {

--- a/build-tools/packages/version-tools/src/packageVersion.ts
+++ b/build-tools/packages/version-tools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-tools/version-tools";
-export const pkgVersion = "0.6.0";
+export const pkgVersion = "1.0.0";

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -50,10 +50,10 @@ importers:
 
   packages/build-cli:
     specifiers:
-      '@fluid-tools/version-tools': ^0.6.0
+      '@fluid-tools/version-tools': ^1.0.0
       '@fluidframework/build-common': ^1.1.0
-      '@fluidframework/build-tools': ^0.6.0
-      '@fluidframework/bundle-size-tools': ^0.6.0
+      '@fluidframework/build-tools': ^1.0.0
+      '@fluidframework/bundle-size-tools': ^1.0.0
       '@fluidframework/eslint-config-fluid': ^1.1.0
       '@microsoft/api-extractor': ^7.22.2
       '@oclif/core': ^1.9.5
@@ -181,9 +181,9 @@ importers:
 
   packages/build-tools:
     specifiers:
-      '@fluid-tools/version-tools': ^0.6.0
+      '@fluid-tools/version-tools': ^1.0.0
       '@fluidframework/build-common': ^1.1.0
-      '@fluidframework/bundle-size-tools': ^0.6.0
+      '@fluidframework/bundle-size-tools': ^1.0.0
       '@fluidframework/eslint-config-fluid': ^1.1.0
       '@rushstack/node-core-library': ^3.51.1
       '@trivago/prettier-plugin-sort-imports': ^3.3.0


### PR DESCRIPTION
Bumped build-tools from 0.6.0 to 1.0.0 since 1.0 will be the next build-tools release.