### PR TITLE
Fix: Error: Internal error: calling method before _details is initialized

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -344,7 +344,7 @@ export class DocumentDeltaConnection
         // to prevent normal messages from being emitted.
         this._disposed = true;
 
-        // Let user of connection object know about disconnect. This has to happen in betwee setting _disposed and
+        // Let user of connection object know about disconnect. This has to happen in between setting _disposed and
         // removing all listeners!
         this.emit("disconnect", err);
 

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -455,7 +455,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
     protected disconnectHandler = (error: IFluidErrorBase & OdspError, clientId?: string) => {
         if (clientId === undefined || clientId === this.clientId) {
             this.disconnect(error);
-            this.logger.sendTelemetryEvent({ eventName: "ServerDisconnect", clientId: this.clientId }, error);
+            this.logger.sendTelemetryEvent({ eventName: "ServerDisconnect", clientId: this.hasDetails ? this.clientId : undefined }, error);
         }
     };
 


### PR DESCRIPTION
## Description

 While trying to send a telemetry event with the information regarding the disposal of the connection, we make use of the this.clientId (returns this.details.clientId) without knowing whether it has the details or not.

[Bug2522](https://dev.azure.com/fluidframework/internal/_queries/edit/2522/)

Stack for the error:
Error: Internal error: calling method before _details is initialized!
    at OdspDocumentDeltaConnection.get details [as details] (/mnt/vss/_work/1/test/node_modules/@***framework/driver-base/dist/documentDeltaConnection.js:96:19)
    at OdspDocumentDeltaConnection.get clientId [as clientId] (/mnt/vss/_work/1/test/node_modules/@***framework/driver-base/dist/documentDeltaConnection.js:106:21)
    at SocketReference.OdspDocumentDeltaConnection.disconnectHandler (/mnt/vss/_work/1/test/node_modules/@***framework/odsp-driver/dist/odspDocumentDeltaConnection.js:161:96)
    at SocketReference.emit (events.js:400:28)
    at SocketReference.closeSocket (/mnt/vss/_work/1/test/node_modules/@***framework/odsp-driver/dist/odspDocumentDeltaConnection.js:117:14)
    at OdspDocumentDeltaConnection.closeSocket (/mnt/vss/_work/1/test/node_modules/@***framework/odsp-driver/dist/odspDocumentDeltaConnection.js:479:16)
    at failAndCloseSocket (/mnt/vss/_work/1/test/node_modules/@***framework/driver-base/dist/documentDeltaConnection.js:290:22)
    at Socket.<anonymous> (/mnt/vss/_work/1/test/node_modules/@***framework/driver-base/dist/documentDeltaConnection.js:372:17)
    at Socket.Emitter.emit (/mnt/vss/_work/1/test/node_modules/@socket.io/component-emitter/index.js:143:20)
    at Socket.onclose (/mnt/vss/_work/1/test/node_modules/socket.io-client/build/cjs/socket.js:316:14)
/mnt/vss/_work/1/test/node_modules/@***framework/odsp-driver/node_modules/@***framework/common-utils/dist/assert.js:19
        throw new Error(typeof message === "number" ? `0x${message.toString(16).padStart(3, "0")}` : message);
