### PR TITLE
Remove Set Package Version step

### DIFF
--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -28,17 +28,6 @@ parameters:
   type: boolean
   default: false
 
-- name: buildNumberInPatch
-  type: string
-  default:
-
-- name: tagName
-  type: string
-
-- name: buildToolsVersionToInstall
-  type: string
-  default: repo
-
 - name: timeoutInMinutes
   type: number
   default: 60
@@ -70,7 +59,7 @@ jobs:
           echo "
           Pipeline Variables:
             releaseBuild=$(releaseBuildVar)
-            
+
           Tasks Parameters:
             BuildDir=${{ parameters.buildDirectory }}
             Build=${{ parameters.taskBuild }}
@@ -78,39 +67,6 @@ jobs:
             Test=${{ convertToJson(parameters.taskTest) }}
             TestCoverage=$(testCoverage)
           "
-
-          # Error checking
-          if [[ "$(release)" == "release" ]]; then
-            if [[ "${{ variables.canRelease }}" == "False" ]]; then
-              echo "##vso[task.logissue type=error]Invalid branch ${{ variables['Build.SourceBranch'] }} for release"
-              exit -1;
-            fi
-
-            if [ -f "lerna.json" ]; then
-              grep -e fluid.*[0-9]-[0-9] `find packages -name 'package.json'`
-            else
-              grep -e fluid.*[0-9]-[0-9] `find . -name 'package.json'`
-            fi
-
-            if [[ $? == 0 ]]; then
-              echo "##vso[task.logissue type=error]Release shouldn't contain prerelease dependencies"
-              exit -1;
-            fi
-          fi
-
-          if [[ "$(release)" == "prerelease" ]]; then
-            if [[ "${{ parameters.buildNumberInPatch }}" == "true" ]]; then
-              echo "##vso[task.logissue type=error] Prerelease not allow for builds that put build number as the patch version"
-              exit -1;
-            fi
-          fi
-
-          if [[ "$(release)" != "none" ]] && [[ "$(release)" != "" ]]; then
-            if [[ "${{ variables.publish }}" != "True" ]]; then
-              echo "##vso[task.logissue type=error]'$(release)'' is set but package is not published. Either the branch doesn't default to publish or it is skipped."
-              exit -1;
-            fi
-          fi
 
     # Install
     - task: UseNode@1
@@ -124,14 +80,6 @@ jobs:
         workingDir: ${{ parameters.buildDirectory }}
         customCommand: 'ci --unsafe-perm'
         customRegistry: 'useNpmrc'
-
-    # Set version
-    - template: include-set-package-version.yml
-      parameters:
-        buildDirectory: ${{ parameters.buildDirectory }}
-        buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
-        buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
-        tagName: ${{ parameters.tagName }}
 
     # Build
     - ${{ if ne(parameters.taskBuild, 'false') }}:

--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -135,15 +135,6 @@ parameters:
   type: boolean
   default: true
 
-- name: buildToolsVersionToInstall
-  displayName: Fluid build tools version (default = installs version in repo)
-  type: string
-  default: repo
-
-- name: tagName
-  type: string
-  default: TestStability
-
 schedules:
   - cron: "00 03 * * SUN"
     displayName: Scheduled Tests weekly at Saturday night
@@ -169,9 +160,7 @@ stages:
       jobs:
       - template: templates/include-test-stability.yml
         parameters:
-          buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
           buildDirectory: .
-          tagName: ${{ parameters.tagName }}
           poolBuild: ${{ parameters.poolBuild }}
           checkoutSubmodules: ${{ parameters.checkoutSubmodules }}
           timeoutInMinutes: 360


### PR DESCRIPTION
## Description

Remove the `Set Package Version` step from Test Stability pipeline, it is unnecessary for the testing stability purpose. Due to the recent changes in `include-set-package-version.yml`, the `$(release)` can not be none by default anymore. Please check [AB2700](https://dev.azure.com/fluidframework/internal/_workitems/edit/2700/) for more details

## Breaking Changes

N/A

## Testing

The updated yaml works well in test branch: https://dev.azure.com/fluidframework/internal/_build/results?buildId=112310&view=results
