### PR TITLE
build: Update dev dependencies on `@fluidframework/eslint-config-fluid` in `build-tools` packages

### DIFF
--- a/build-tools/packages/build-cli/.eslintrc.cjs
+++ b/build-tools/packages/build-cli/.eslintrc.cjs
@@ -16,6 +16,9 @@ module.exports = {
         "@typescript-eslint/no-unused-vars": "warn",
         "unused-imports/no-unused-imports": "warn",
 
+        // This package is exclusively used in a Node.js context
+        "import/no-nodejs-modules": "off",
+
         // oclif uses default exports for commands
         "import/no-default-export": "off",
 

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -101,7 +101,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.1.0",
+    "@fluidframework/eslint-config-fluid": "^1.2.1",
     "@microsoft/api-extractor": "^7.22.2",
     "@trivago/prettier-plugin-sort-imports": "^3.3.0",
     "@types/chai": "^4",

--- a/build-tools/packages/build-tools/.eslintrc.js
+++ b/build-tools/packages/build-tools/.eslintrc.js
@@ -14,5 +14,8 @@ module.exports = {
         "@typescript-eslint/switch-exhaustiveness-check": "error",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-var-requires": "off",
+
+        // This package is exclusively used in a Node.js context
+        "import/no-nodejs-modules": "off",
     },
 };

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -80,7 +80,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.1.0",
+    "@fluidframework/eslint-config-fluid": "^1.2.1",
     "@trivago/prettier-plugin-sort-imports": "^3.3.0",
     "@types/async": "^3.2.6",
     "@types/fs-extra": "^8.1.0",

--- a/build-tools/packages/bundle-size-tools/.eslintrc.js
+++ b/build-tools/packages/bundle-size-tools/.eslintrc.js
@@ -14,5 +14,8 @@ module.exports = {
         "@typescript-eslint/switch-exhaustiveness-check": "error",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-var-requires": "off",
+
+        // This package is exclusively used in a Node.js context
+        "import/no-nodejs-modules": "off",
     },
 };

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.1.0",
+    "@fluidframework/eslint-config-fluid": "^1.2.1",
     "@microsoft/api-extractor": "^7.22.2",
     "@trivago/prettier-plugin-sort-imports": "^3.3.0",
     "@types/jszip": "^3.4.1",

--- a/build-tools/packages/version-tools/.eslintrc.js
+++ b/build-tools/packages/version-tools/.eslintrc.js
@@ -11,5 +11,8 @@ module.exports = {
     rules: {
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
+
+        // This package is exclusively used in a Node.js context
+        "import/no-nodejs-modules": "off",
     },
 };

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -82,7 +82,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.1.0",
+    "@fluidframework/eslint-config-fluid": "^1.2.1",
     "@microsoft/api-extractor": "^7.22.2",
     "@trivago/prettier-plugin-sort-imports": "^3.3.0",
     "@types/chai": "^4",

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.6.0
       '@fluidframework/bundle-size-tools': ^0.6.0
-      '@fluidframework/eslint-config-fluid': ^1.1.0
+      '@fluidframework/eslint-config-fluid': ^1.2.1
       '@microsoft/api-extractor': ^7.22.2
       '@oclif/core': ^1.9.5
       '@oclif/plugin-autocomplete': ^1.3.5
@@ -144,7 +144,7 @@ importers:
       type-fest: 2.19.0
     devDependencies:
       '@fluidframework/build-common': 1.1.0
-      '@fluidframework/eslint-config-fluid': 1.1.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@fluidframework/eslint-config-fluid': 1.2.1_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.27.1
       '@trivago/prettier-plugin-sort-imports': 3.3.0_prettier@2.6.2
       '@types/chai': 4.3.3
@@ -184,7 +184,7 @@ importers:
       '@fluid-tools/version-tools': ^0.6.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/bundle-size-tools': ^0.6.0
-      '@fluidframework/eslint-config-fluid': ^1.1.0
+      '@fluidframework/eslint-config-fluid': ^1.2.1
       '@rushstack/node-core-library': ^3.51.1
       '@trivago/prettier-plugin-sort-imports': ^3.3.0
       '@types/async': ^3.2.6
@@ -261,7 +261,7 @@ importers:
       yaml: 2.1.2
     devDependencies:
       '@fluidframework/build-common': 1.1.0
-      '@fluidframework/eslint-config-fluid': 1.1.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@fluidframework/eslint-config-fluid': 1.2.1_kufnqfq7tb5rpdawkdb6g5smma
       '@trivago/prettier-plugin-sort-imports': 3.3.0_prettier@2.6.2
       '@types/async': 3.2.15
       '@types/fs-extra': 8.1.2
@@ -291,7 +291,7 @@ importers:
   packages/bundle-size-tools:
     specifiers:
       '@fluidframework/build-common': ^1.1.0
-      '@fluidframework/eslint-config-fluid': ^1.1.0
+      '@fluidframework/eslint-config-fluid': ^1.2.1
       '@microsoft/api-extractor': ^7.22.2
       '@trivago/prettier-plugin-sort-imports': ^3.3.0
       '@types/jszip': ^3.4.1
@@ -321,7 +321,7 @@ importers:
       webpack: 5.74.0
     devDependencies:
       '@fluidframework/build-common': 1.1.0
-      '@fluidframework/eslint-config-fluid': 1.1.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@fluidframework/eslint-config-fluid': 1.2.1_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.27.1
       '@trivago/prettier-plugin-sort-imports': 3.3.0_prettier@2.6.2
       '@types/jszip': 3.4.1
@@ -340,7 +340,7 @@ importers:
   packages/version-tools:
     specifiers:
       '@fluidframework/build-common': ^1.1.0
-      '@fluidframework/eslint-config-fluid': ^1.1.0
+      '@fluidframework/eslint-config-fluid': ^1.2.1
       '@microsoft/api-extractor': ^7.22.2
       '@oclif/core': ^1.9.5
       '@oclif/plugin-autocomplete': ^1.3.5
@@ -386,7 +386,7 @@ importers:
       table: 6.8.0
     devDependencies:
       '@fluidframework/build-common': 1.1.0
-      '@fluidframework/eslint-config-fluid': 1.1.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@fluidframework/eslint-config-fluid': 1.2.1_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.27.1
       '@trivago/prettier-plugin-sort-imports': 3.3.0_prettier@2.6.2
       '@types/chai': 4.3.3
@@ -942,8 +942,8 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/eslint-config-fluid/1.1.0_kufnqfq7tb5rpdawkdb6g5smma:
-    resolution: {integrity: sha512-cyX4e6Jv05uA61Efa1+38bswBXdV6auyfNDARHMivyAlA7RNn1yRxe7LWu1CwbWn37rZojP8/+JR+KwHNwKVVg==}
+  /@fluidframework/eslint-config-fluid/1.2.1_kufnqfq7tb5rpdawkdb6g5smma:
+    resolution: {integrity: sha512-jOt6rWtg4Zigz33hv42hg/y8CUWXp6J+0Jn4ub0Bo/0H58agHD2XWfD0RAOD5bOtNxBLPAhsSUHD4XN7SCct+w==}
     dependencies:
       '@rushstack/eslint-patch': 1.1.4
       '@rushstack/eslint-plugin': 0.8.6_kufnqfq7tb5rpdawkdb6g5smma


### PR DESCRIPTION
Also update eslint configs to disable the [import/no-nodejs-modules](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-nodejs-modules.md) rule, as these packages are exclusively run in a Node.js context.