### PR TITLE
[GC Stress] Added attachment blobs to the stress tests

### DIFF
--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -108,7 +108,8 @@
     "random-js": "^1.0.8",
     "start-server-and-test": "^1.11.7",
     "tinylicious": "^0.4.89251",
-    "xml": "^1.0.0"
+    "xml": "^1.0.0",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.6.0-109663",


### PR DESCRIPTION
## Reviewer Guidance
This is in a test branch (test/gc-stress) and not in the main branch. This is an experimental stress test that we eventually plan to get into main. For now, it lives and runs in the test branch so we can make quick progress :-).

## Description
Added attachment blobs to the GC stress test:
- After every few ops,one of the following blob activities is performed at random (along with existing data store activity):
  - An attachment blob is uploaded and referened. An attachment blob activity object is created and run which tries to `get` the blob at regular intervals.
  - A referenced attachment blob is unreferenced and the corresponding activity object is asked to stop running. The object will stop getting the blob.
  - An unreferenced attachment blob is referenced again and the corresponding activity object is run.

Also, made the following additional changes:
- Renamed some of the interfaces and members to distinguish data stores and attachment blobs.
- Run all the referenced child data stores when run is called. Without this, when a container reloads (due to session expiry), existing children were not run until they were unreferenced and then revived.

Follow up:
[AB#2750](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2750) - Add handling attachment blob referencing / unreferencing to collab data stores.

[AB#2136](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2136)