### PR TITLE
fix(run:bundleStats): Take path to dangerfile instead of directory

### DIFF
--- a/build-tools/packages/build-cli/docs/run.md
+++ b/build-tools/packages/build-cli/docs/run.md
@@ -11,11 +11,11 @@ Generate a report from input bundle stats collected through the collect bundleSt
 
 ```
 USAGE
-  $ flub run bundleStats [-v] [--dirname <value>]
+  $ flub run bundleStats [-v] [--dangerfile <value>]
 
 FLAGS
-  -v, --verbose      Verbose logging.
-  --dirname=<value>  [default: current directory] Directory containing bundle stats input
+  -v, --verbose         Verbose logging.
+  --dangerfile=<value>  Path to dangerfile
 
 DESCRIPTION
   Generate a report from input bundle stats collected through the collect bundleStats command.

--- a/build-tools/packages/build-cli/src/commands/run/bundleStats.ts
+++ b/build-tools/packages/build-cli/src/commands/run/bundleStats.ts
@@ -4,6 +4,7 @@
  */
 import { Flags } from "@oclif/core";
 import { execSync } from "child_process";
+import path from "path";
 
 import { BaseCommand } from "../../base";
 
@@ -11,8 +12,8 @@ export default class RunBundlestats extends BaseCommand<typeof RunBundlestats.fl
     static description = `Generate a report from input bundle stats collected through the collect bundleStats command.`;
 
     static flags = {
-        dirname: Flags.string({
-            description: "[default: current directory] Directory containing bundle stats input",
+        dangerfile: Flags.file({
+            description: "Path to dangerfile",
             required: false,
         }),
         ...BaseCommand.flags,
@@ -21,8 +22,8 @@ export default class RunBundlestats extends BaseCommand<typeof RunBundlestats.fl
     public async run(): Promise<void> {
         const flags = this.processedFlags;
         // eslint-disable-next-line unicorn/prefer-module
-        const dirname = flags.dirname ?? __dirname;
+        const dangerfile = flags.dangerfile ?? path.join(__dirname, "../../lib/dangerfile.js");
 
-        execSync(`npx danger ci -d ${dirname}/lib/dangerfile.js`, { stdio: "inherit" });
+        execSync(`npx danger ci -d ${dangerfile}`, { stdio: "inherit" });
     }
 }


### PR DESCRIPTION
The dangerfile path had some magic strings in the code, so this change makes the full path to the dangerfile the argument instead of a folder containing a dangerfile at a specific place inside it. The default dangerfile is still used in all known uses, so the real meaningful value is the default.

BREAKING CHANGE: The `--dirname` argument has been removed. There is now a `--dangerfile` argument that defaults to the built-in dangerfile but can be customized if needed.