### PR TITLE
Fix 0x244 in stress tests.

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -478,15 +478,12 @@ export class DocumentDeltaConnection
             // had a chance to register its handlers.
             this.addTrackedListener("disconnect", (reason) => {
                 const err = this.createErrorObject("disconnect", reason);
-                this.emit("disconnect", err);
                 failAndCloseSocket(err);
             });
 
             this.addTrackedListener("error", ((error) => {
-                // First, raise an error event, to give clients a chance to observe error contents
                 // This includes "Invalid namespace" error, which we consider critical (reconnecting will not help)
                 const err = this.createErrorObject("error", error, error !== "Invalid namespace");
-                this.emit("error", err);
                 // Disconnect socket - required if happened before initial handshake
                 failAndCloseSocket(err);
             }));

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -356,7 +356,6 @@ export class DocumentDeltaConnection
             eventName: "AfterDisconnectEvent",
             driverVersion,
             details: JSON.stringify({
-                disposed: this._disposed,
                 socketConnected: this.socket.connected,
                 disconnectListenerCount: this.listenerCount("disconnect"),
             }),

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -600,12 +600,13 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
      * @param error - Error causing the socket to close.
      */
     protected closeSocket(error: IAnyDriverError) {
+        const socket = this.socketReference;
         // It is possible that we have already set this.socketReference to undefined in disconnectCore,
         // due to client closing the connection and then later have some error/disconnect event on socket
         // which will go through this closeSocket flow. So in that case we don't have to do anything.
-        if (this.socketReference !== undefined) {
+        if (socket !== undefined) {
             super.closeSocket(error);
-            this.socketReference.closeSocket(error);
+            socket.closeSocket(error);
         }
         assert(this.socketReference === undefined, 0x417 /* disconnect flow did not work correctly */);
     }

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -601,13 +601,8 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
      */
     protected closeSocket(error: IAnyDriverError) {
         const socket = this.socketReference;
-        // It is possible that we have already set this.socketReference to undefined in disconnectCore,
-        // due to client closing the connection and then later have some error/disconnect event on socket
-        // which will go through this closeSocket flow. So in that case we don't have to do anything.
-        if (socket !== undefined) {
-            super.closeSocket(error);
-            socket.closeSocket(error);
-        }
+        assert(socket !== undefined, 0x416 /* reentrancy not supported in close socket */);
+        socket.closeSocket(error);
         assert(this.socketReference === undefined, 0x417 /* disconnect flow did not work correctly */);
     }
 

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -454,8 +454,8 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 
     protected disconnectHandler = (error: IFluidErrorBase & OdspError, clientId?: string) => {
         if (clientId === undefined || clientId === this.clientId) {
-            this.disconnect(error);
             this.logger.sendTelemetryEvent({ eventName: "ServerDisconnect", clientId: this.hasDetails ? this.clientId : undefined }, error);
+            this.disconnect(error);
         }
     };
 
@@ -600,9 +600,13 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
      * @param error - Error causing the socket to close.
      */
     protected closeSocket(error: IAnyDriverError) {
-        const socket = this.socketReference;
-        assert(socket !== undefined, 0x416 /* reentrancy not supported in close socket */);
-        socket.closeSocket(error);
+        // It is possible that we have already set this.socketReference to undefined in disconnectCore,
+        // due to client closing the connection and then later have some error/disconnect event on socket
+        // which will go through this closeSocket flow. So in that case we don't have to do anything.
+        if (this.socketReference !== undefined) {
+            super.closeSocket(error);
+            this.socketReference.closeSocket(error);
+        }
         assert(this.socketReference === undefined, 0x417 /* disconnect flow did not work correctly */);
     }
 

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -304,7 +304,6 @@ export class OdspDocumentService implements IDocumentService {
                         && error.errorType === DriverErrorType.authorizationError) {
                         this.cache.sessionJoinCache.remove(this.joinSessionKey);
                     }
-                    assert(connection.disposed, "Connection should be disposed by now");
                     this.currentConnection = undefined;
                 });
                 this.currentConnection = connection;

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -297,7 +297,7 @@ export class OdspDocumentService implements IDocumentService {
                 });
                 // On disconnect with 401/403 error code, we can just clear the joinSession cache as we will again
                 // get the auth error on reconnecting and face latency.
-                connection.on("disconnect", (error: any) => {
+                connection.once("disconnect", (error: any) => {
                     // Clear the join session refresh timer so that it can be restarted on reconnection.
                     this.clearJoinSessionTimer();
                     if (typeof error === "object" && error !== null

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -304,6 +304,8 @@ export class OdspDocumentService implements IDocumentService {
                         && error.errorType === DriverErrorType.authorizationError) {
                         this.cache.sessionJoinCache.remove(this.joinSessionKey);
                     }
+                    // If we hit this assert, it means that "disconnect" event is emitted before the connection went through
+                    // dispose flow which is not correct and could lead to a bunch of erros.
                     assert(connection.disposed, "Connection should be disposed by now");
                     this.currentConnection = undefined;
                 });

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -304,6 +304,7 @@ export class OdspDocumentService implements IDocumentService {
                         && error.errorType === DriverErrorType.authorizationError) {
                         this.cache.sessionJoinCache.remove(this.joinSessionKey);
                     }
+                    assert(connection.disposed, "Connection should be disposed by now");
                     this.currentConnection = undefined;
                 });
                 this.currentConnection = connection;

--- a/packages/drivers/odsp-driver/src/test/joinSessionPeriodicCall.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/joinSessionPeriodicCall.spec.ts
@@ -118,6 +118,7 @@ describe("joinSessions Tests", () => {
             submit: (message) => {},
             submitSignal: (message) => {},
             on: (op: any, func?: any) => {},
+            once: (op: any, func?: any) => {},
         };
         const createDeltaConnectionStub = stub(
             odspDocumentDeltaConnection.OdspDocumentDeltaConnection, "create").callsFake(


### PR DESCRIPTION
## Description

Fix some asserts in odsp document delta connection disconnect flow. We are emitting the "disconnect"/"error" events before going through the dispose flow when we should first clear the connection or dispose it before let the external listeners to observe it and take actions.