### PR TITLE
Draft addbackscrub clients not in quorum

### DIFF
--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -767,8 +767,6 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
                 } else {
                     this.taskQueues.set(taskId, filteredClientQueue);
                 }
-                // TODO remove, just for debugging
-                this.emit("changed");
                 this.queueWatcher.emit("queueChange", taskId);
             }
         }


### PR DESCRIPTION
WE are seeing a regression in the tinylicious runs, in which we have several timeouts - this PR is just to test whether it might have caused by the removal of a method from taskManager.