### PR TITLE
Listen for the ExternalDataChanged signal and act on it from the TaskList in ExternalData example app

### DIFF
--- a/examples/hosts/app-integration/external-data/src/model/containerCode.ts
+++ b/examples/hosts/app-integration/external-data/src/model/containerCode.ts
@@ -13,6 +13,9 @@ import { AppModel } from "./appModel";
 import { TaskListInstantiationFactory } from "./taskList";
 
 const taskListId = "task-list";
+const SignalType = {
+    ExternalDataChanged: "externalDataChange"
+};
 
 /**
  * {@inheritDoc ModelContainerRuntimeFactory}
@@ -51,6 +54,12 @@ export class TaskListContainerRuntimeFactory extends ModelContainerRuntimeFactor
             await runtime.getRootDataStore(taskListId),
             "",
         );
+        // Register listener only once the model is fully loaded and ready
+        runtime.on("signal", (message) => {
+            if (message.type === SignalType.ExternalDataChanged) {
+                taskList.importExternalData();
+            }
+        });
         return new AppModel(taskList, container);
     }
 }

--- a/examples/hosts/app-integration/external-data/src/model/containerCode.ts
+++ b/examples/hosts/app-integration/external-data/src/model/containerCode.ts
@@ -63,6 +63,7 @@ export class TaskListContainerRuntimeFactory extends ModelContainerRuntimeFactor
         // Register listener only once the model is fully loaded and ready
         runtime.on("signal", (message) => {
             if (message.type === SignalType.ExternalDataChanged) {
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises
                 taskList.importExternalData();
             }
         });

--- a/examples/hosts/app-integration/external-data/src/model/containerCode.ts
+++ b/examples/hosts/app-integration/external-data/src/model/containerCode.ts
@@ -13,6 +13,12 @@ import { AppModel } from "./appModel";
 import { TaskListInstantiationFactory } from "./taskList";
 
 const taskListId = "task-list";
+
+/*
+* This is a server origin signal that lets the client know that the external source of truth
+* for the data has changed. On receiving this, the client should take some action, such as
+* fetching the new data. This is an enum as there may be more signals that need to be created.
+*/
 const SignalType = {
     ExternalDataChanged: "externalDataChange"
 };

--- a/examples/hosts/app-integration/external-data/src/model/taskList.ts
+++ b/examples/hosts/app-integration/external-data/src/model/taskList.ts
@@ -162,6 +162,7 @@ export class TaskList extends DataObject implements ITaskList {
     // TODO: Guard against reentrancy
     // TODO: Use leader election to reduce noise from competing clients
     public async importExternalData(): Promise<void> {
+        console.log('Kicking off fetching external data from TaskList');
         const externalData = await externalDataSource.fetchData();
         const parsedTaskData = parseStringData(externalData);
         // TODO: Delete any items that are in the root but missing from the external data

--- a/examples/hosts/app-integration/external-data/src/modelInterfaces.ts
+++ b/examples/hosts/app-integration/external-data/src/modelInterfaces.ts
@@ -85,6 +85,12 @@ export interface ITaskList extends IEventProvider<ITaskListEvents> {
      */
     readonly saveChanges: () => Promise<void>;
 
+    /**
+     * Kick off fetching external data directly from the TaskList.
+     * Triggered on receipt of ExternalDataChanged signal from container.
+     */
+    readonly importExternalData: () => Promise<void>;
+
     // TODO: Should there be an imperative API to trigger importing changes from the external source?
     // Even if we don't want this to be how the signal gets routed, we might want a "fetch latest changes" button
     // in the UI.


### PR DESCRIPTION
This PR consumes the `ExternalDataChanged` signal and kicks off fetching the data. The hacked signal code can be found on this Draft PR: https://github.com/microsoft/FluidFramework/pull/13063. This PR mainlines the handling of this (currently non-existent) signal into the example app only. 