### PR TITLE
[TaskManager] Cleanup TODOs

### DIFF
--- a/api-report/task-manager.api.md
+++ b/api-report/task-manager.api.md
@@ -43,8 +43,6 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
     complete(taskId: string): void;
     static create(runtime: IFluidDataStoreRuntime, id?: string): TaskManager;
     static getFactory(): IChannelFactory;
-    // (undocumented)
-    _getTaskQueues(): Map<string, string[]>;
     // @internal (undocumented)
     protected initializeLocalCore(): void;
     // @internal (undocumented)

--- a/packages/dds/task-manager/src/test/taskManager.spec.ts
+++ b/packages/dds/task-manager/src/test/taskManager.spec.ts
@@ -652,7 +652,7 @@ describe("TaskManager", () => {
                     await volunteerTaskP;
                     assert.ok(taskManager1.queued(taskId), "Should be queued");
                     assert.ok(taskManager1.assigned(taskId), "Should be assigned");
-                    assert.strictEqual(taskManager1._getTaskQueues().get(taskId)?.[0], placeholderClientId,
+                    assert.strictEqual((taskManager1 as any).taskQueues.get(taskId)?.[0], placeholderClientId,
                         "taskQueue should have placeholder clientId");
 
                     let taskManager1EventFired = false;
@@ -666,7 +666,7 @@ describe("TaskManager", () => {
                     assert.ok(!taskManager1.queued(taskId), "Should not be queued");
                     assert.ok(!taskManager1.assigned(taskId), "Should not be assigned");
                     assert.ok(taskManager1EventFired, "Should have raised lost event on taskManager1");
-                    assert.ok(taskManager1._getTaskQueues().size === 0, "taskQueue should be empty");
+                    assert.ok((taskManager1 as any).taskQueues.size === 0, "taskQueue should be empty");
                 });
             });
 
@@ -703,8 +703,8 @@ describe("TaskManager", () => {
                     assert.ok(taskManager1.assigned(taskId), "Task manager 1 should be assigned");
                     assert.ok(taskManager1.subscribed(taskId), "Task manager 1 should be subscribed");
 
-                    assert.ok(taskManager1._getTaskQueues().get(taskId)?.length !== 0, "taskQueue should not be empty");
-                    assert.notStrictEqual(taskManager1._getTaskQueues().get(taskId)?.[0], placeholderClientId,
+                    assert.ok((taskManager1 as any).taskQueues.get(taskId)?.length !== 0, "taskQueue should not be empty");
+                    assert.notStrictEqual((taskManager1 as any).taskQueues.get(taskId)?.[0], placeholderClientId,
                         "taskQueue should not have placeholder clientId");
                 });
 
@@ -839,13 +839,13 @@ describe("TaskManager", () => {
                     const clientId1 = containerRuntime1.clientId;
                     const clientId2 = containerRuntime2.clientId;
 
-                    assert.deepEqual(taskManager1._getTaskQueues().get(taskId), [clientId1, clientId2],
+                    assert.deepEqual((taskManager1 as any).taskQueues.get(taskId), [clientId1, clientId2],
                         "Task queue should have both clients");
 
                     containerRuntime2.connected = false;
                     containerRuntimeFactory.processAllMessages();
 
-                    assert.deepEqual(taskManager1._getTaskQueues().get(taskId), [clientId1],
+                    assert.deepEqual((taskManager1 as any).taskQueues.get(taskId), [clientId1],
                         "Task queue should only have client 1");
                 });
 

--- a/packages/dds/task-manager/src/test/types/validateTaskManagerPrevious.generated.ts
+++ b/packages/dds/task-manager/src/test/types/validateTaskManagerPrevious.generated.ts
@@ -85,4 +85,5 @@ declare function get_current_ClassDeclaration_TaskManager():
 declare function use_old_ClassDeclaration_TaskManager(
     use: TypeOnly<old.TaskManager>);
 use_old_ClassDeclaration_TaskManager(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_TaskManager());


### PR DESCRIPTION
## Description

This PR cleans up miscellaneous TODO items for TaskManager, such as the removal of debugging events/functions.

Note: This PR cherry-picks from https://github.com/microsoft/FluidFramework/pull/13014, but with the notable re-inclusion of `this.scrubClientsNotInQuorum()` and filtering `this.taskQueues` during summarization. The removal of these proved to be overly optimistic since we saw regressions in stress tests after the previously mentioned PR was merged. We may create a follow-up task in the future to further investigate the root cause.

## Breaking Changes

This PR removes `TaskManager._getTaskQueues()`. Although this is technically a breaking change, this function was always intended to be used for debugging purposes. Additionally, TaskManager is currently an experimental package.

## Reviewer Guidance

[AB#2422](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2422)
[AB#2752](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2752)