### PR TITLE
Skip adding additionalContent to summarize messages in single commit flow

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -17,6 +17,7 @@ import {
     ScopeType,
     ISignalMessage,
     ISummaryAck,
+    ISummaryContent,
     IDocumentMessage,
 } from "@fluidframework/protocol-definitions";
 import { canSummarize, defaultHash, getNextHash, isNetworkError } from "@fluidframework/server-services-client";
@@ -1209,10 +1210,23 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
         } as any;
         if (message.operation.type === MessageType.Summarize || message.operation.type === MessageType.NoClient) {
             const augmentedOutputMessage = outputMessage as ISequencedDocumentAugmentedMessage;
-            if (message.operation.type === MessageType.Summarize ||
-                this.serviceConfiguration.scribe.generateServiceSummary) {
-                // only add additional content if scribe will use this op for generating a summary
-                // NoClient ops are ignored by scribe when generateServiceSummary is disabled
+
+            // only add additional content if scribe will use this op for generating a summary
+            // NoClient ops are ignored by scribe when generateServiceSummary is disabled
+            let addAdditionalContent = false;
+
+            if (this.serviceConfiguration.scribe.generateServiceSummary) {
+                addAdditionalContent = true;
+            } else if (message.operation.type === MessageType.Summarize) {
+                // no need to add additionalContent for summarize messages using the single commit flow
+                // because scribe will not be involved
+                if (!this.serviceConfiguration.deli.skipSummarizeAugmentationForSingleCommmit ||
+                    !(JSON.parse(message.operation.contents) as ISummaryContent).details?.includesProtocolTree) {
+                    addAdditionalContent = true;
+                }
+            }
+
+            if (addAdditionalContent) {
                 const checkpointData = JSON.stringify(this.generateDeliCheckpoint());
                 augmentedOutputMessage.additionalContent = checkpointData;
             }

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -45,6 +45,9 @@ export interface IDeliServerConfiguration {
 
     // Controls if ops should be nacked if a summary hasn't been made for a while
     summaryNackMessages: IDeliSummaryNackMessagesServerConfiguration;
+
+    // Enable to make deli not add additionalContent to summarize messages that are for the single commit flow
+    skipSummarizeAugmentationForSingleCommmit: boolean;
 }
 
 export interface IDeliCheckpointHeuristicsServerConfiguration {
@@ -199,6 +202,7 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
                 message: "Submit a summary before inserting additional operations",
             },
         },
+        skipSummarizeAugmentationForSingleCommmit: false,
     },
     broadcaster: {
         includeEventInMessageBatchName: false,


### PR DESCRIPTION
The additionalContent property will not be used in the single commit flow since scribe will not be involved. Add a config to disable it.