### PR TITLE
Adds file version to snapshot key entry (#13127)

### DIFF
--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -338,7 +338,7 @@ export function toInstrumentedOdspTokenFetcher(
 export function createCacheSnapshotKey(odspResolvedUrl: IOdspResolvedUrl): ICacheEntry {
     const cacheEntry: ICacheEntry = {
         type: snapshotKey,
-        key: "",
+        key: odspResolvedUrl.fileVersion ?? "",
         file: {
             resolvedUrl: odspResolvedUrl,
             docId: odspResolvedUrl.hashedDocumentId,

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -118,13 +118,13 @@ describe("Tests for snapshot fetch", () => {
                     snapshotStorageUrl: "fake",
                     attachmentPOSTStorageUrl: "",
                     attachmentGETStorageUrl: "",
-                    deltaStorageUrl: ""
+                    deltaStorageUrl: "",
                 },
                 tokens: {},
                 fileName: "",
                 summarizer: false,
-                id: "id"
-            } ;
+                id: "id",
+            };
 
             epochTracker = new EpochTracker(
                 localCache,

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { TelemetryNullLogger } from "@fluidframework/common-utils";
+import { TelemetryNullLogger, delay } from "@fluidframework/common-utils";
 import {
     IOdspResolvedUrl,
     ICacheEntry,
@@ -100,6 +100,100 @@ describe("Tests for snapshot fetch", () => {
 
     before(async () => {
         hashedDocumentId = await getHashedDocumentId(driveId, itemId);
+    });
+
+    describe("Tests for caching of different file versions", () => {
+        beforeEach(async () => {
+            localCache = createUtLocalCache();
+            const resolvedUrlWithFileVersion: IOdspResolvedUrl = {
+                siteUrl,
+                driveId,
+                itemId,
+                odspResolvedUrl: true,
+                fileVersion: "2",
+                type: "fluid",
+                url: "",
+                hashedDocumentId,
+                endpoints: {
+                    snapshotStorageUrl: "fake",
+                    attachmentPOSTStorageUrl: "",
+                    attachmentGETStorageUrl: "",
+                    deltaStorageUrl: ""
+                },
+                tokens: {},
+                fileName: "",
+                summarizer: false,
+                id: "id"
+            } ;
+
+            epochTracker = new EpochTracker(
+                localCache,
+                {
+                    docId: hashedDocumentId,
+                    resolvedUrl,
+                },
+                new TelemetryNullLogger(),
+            );
+
+            service = new OdspDocumentStorageService(
+                resolvedUrlWithFileVersion,
+                async (_options) => "token",
+                logger,
+                true,
+                { ...nonPersistentCache, persistedCache: epochTracker },
+                GetHostStoragePolicyInternal(),
+                epochTracker,
+                async () => { return {}; },
+                () => "tenantid/id",
+                undefined,
+            );
+        });
+
+        afterEach(async () => {
+            await epochTracker.removeEntries().catch(() => { });
+        });
+
+        it("should not fetch from cache with the same snapshot", async () => {
+            const latestContent: ISnapshotContents = {
+                snapshotTree: {
+                    id: "WrongId",
+                    blobs: {},
+                    trees: {},
+                },
+                blobs: new Map(),
+                ops: [],
+                sequenceNumber: 0,
+                latestSequenceNumber: 0,
+            };
+
+            const latestValue: IVersionedValueWithEpoch = {
+                value: { ...latestContent, cacheEntryTime: Date.now() },
+                fluidEpoch: "epoch1",
+                version: persistedCacheValueVersion,
+            };
+
+            const cacheEntry: ICacheEntry = {
+                key: "",
+                type: "snapshot",
+                file: { docId: hashedDocumentId, resolvedUrl },
+            };
+
+            await localCache.put(cacheEntry, latestValue);
+
+            const version = await mockFetchSingle(
+                async () => service.getVersions(null, 1),
+                async () => {
+                    await delay(50); // insure cache response is faster
+                    return createResponse(
+                        { "x-fluid-epoch": "epoch1", "content-type": "application/json" },
+                        odspSnapshot,
+                        200,
+                    );
+                },
+            );
+
+            assert.deepStrictEqual(version, expectedVersion, "incorrect version");
+        });
     });
 
     describe("Tests for regular snapshot fetch", () => {


### PR DESCRIPTION
[AB#2699](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2699)

If someone loaded the latest version of a file right before loading an older version of the file, the older version would fetch the latest version stored in cache.

The cache key of the latest version of a file and an older version of a file should be different.

Patch back to internal 1.4.x

Original PR: https://github.com/microsoft/FluidFramework/pull/13127