### PR TITLE
Adds file version to snapshot key entry (#13127)

### DIFF
--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -338,7 +338,7 @@ export function toInstrumentedOdspTokenFetcher(
 export function createCacheSnapshotKey(odspResolvedUrl: IOdspResolvedUrl): ICacheEntry {
     const cacheEntry: ICacheEntry = {
         type: snapshotKey,
-        key: "",
+        key: odspResolvedUrl.fileVersion ?? "",
         file: {
             resolvedUrl: odspResolvedUrl,
             docId: odspResolvedUrl.hashedDocumentId,

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -125,7 +125,7 @@ describe("Tests for snapshot fetch", () => {
                 fileName: "",
                 summarizer: false,
                 id: "id"
-            }  ;
+            } ;
 
             epochTracker = new EpochTracker(
                 localCache,


### PR DESCRIPTION
[AB#2699](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2699)

If someone loaded the latest version of a file right before loading an older version of the file, the older version would fetch the latest version stored in cache.

The cache key of the latest version of a file and an older version of a file should be different.

Patch back to internal 2.1.x

Original PR: https://github.com/microsoft/FluidFramework/pull/13127