### PR TITLE
assert client has the same payload during double insert to audience

### DIFF
--- a/packages/loader/container-loader/src/audience.ts
+++ b/packages/loader/container-loader/src/audience.ts
@@ -23,7 +23,11 @@ export class Audience extends EventEmitter implements IAudienceOwner {
     public addMember(clientId: string, details: IClient) {
         // Given that signal delivery is unreliable process, we might observe same client being added twice
         // In such case we should see exactly same payload (IClient), and should not raise event twice!
-        if (!this.members.has(clientId)) {
+        if (this.members.has(clientId)) {
+            const client = this.members.get(clientId);
+            assert(client === details, "new client has different payload from existing one");
+        }
+        else {
             this.members.set(clientId, details);
             this.emit("addMember", clientId, details);
         }

--- a/packages/loader/container-loader/src/audience.ts
+++ b/packages/loader/container-loader/src/audience.ts
@@ -26,7 +26,7 @@ export class Audience extends EventEmitter implements IAudienceOwner {
         // In such case we should see exactly same payload (IClient), and should not raise event twice!
         if (this.members.has(clientId)) {
             const client = this.members.get(clientId);
-            assert(client === details, "new client has different payload from existing one");
+            assert(JSON.stringify(client) === JSON.stringify(details), "new client has different payload from existing one");
         }
         else {
             this.members.set(clientId, details);

--- a/packages/loader/container-loader/src/audience.ts
+++ b/packages/loader/container-loader/src/audience.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 import { EventEmitter } from "events";
+import { assert } from "@fluidframework/common-utils";
 import { IAudienceOwner } from "@fluidframework/container-definitions";
 import { IClient } from "@fluidframework/protocol-definitions";
 


### PR DESCRIPTION
## Description

during audience.addMember, if client already exists, assert the new one and existing one are the same
