### PR TITLE
tools: Fix `directory` path in package.json

### DIFF
--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/FluidFramework.git",
-    "directory": "packages/tools/api-markdown-documenter"
+    "directory": "tools/api-markdown-documenter"
   },
   "license": "MIT",
   "author": "Microsoft and contributors",


### PR DESCRIPTION
Existing `directory` entry incorrectly pointed to `packages/tools` instead of `tools`