### PR TITLE
Fix/property dds/summarization bug

### DIFF
--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -69,6 +69,8 @@
     "@fluidframework/server-local-server": "^0.1038.2000",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+    "@fluidframework/test-drivers": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+    "@fluidframework/container-loader": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/lodash": "^4.14.118",
@@ -95,3 +97,4 @@
     "broken": {}
   }
 }
+

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -61,16 +61,16 @@
     "@fluid-experimental/property-common": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluid-experimental/property-dds-previous": "npm:@fluid-experimental/property-dds@2.0.0-internal.2.1.0",
     "@fluidframework/build-common": "^1.1.0",
+    "@fluidframework/container-loader": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/local-driver": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluidframework/sequence": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluidframework/server-local-server": "^0.1038.2000",
+    "@fluidframework/test-drivers": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/test-drivers": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/container-loader": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/lodash": "^4.14.118",
@@ -97,4 +97,3 @@
     "broken": {}
   }
 }
-

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -73,7 +73,7 @@ export interface ISnapshotSummary {
 	remoteTipView?: SerializedChangeSet;
 	remoteChanges?: IPropertyTreeMessage[];
 	unrebasedRemoteChanges?: Record<string, IRemotePropertyTreeMessage>;
-    remoteHeadGuid: string;
+	remoteHeadGuid: string;
 }
 
 export interface SharedPropertyTreeOptions {
@@ -194,14 +194,14 @@ export class SharedPropertyTree extends SharedObject {
 		// for the serialization of the data structure
 		if (this.listenerCount("localModification") > 0) {
 			const changes = this._root._serialize(true, false, BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
-            this._root.cleanDirty(BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
+			this._root.cleanDirty(BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
 			const _changeSet = new ChangeSet(changes);
 			if (!isEmpty(_changeSet.getSerializedChangeSet())) {
 				this.emit("localModification", _changeSet);
 			}
 		} else {
-            this._root.cleanDirty(BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
-        }
+			this._root.cleanDirty(BaseProperty.MODIFIED_STATE_FLAGS.DIRTY);
+		}
 	}
 
 	public get changeSet(): SerializedChangeSet {
@@ -211,8 +211,8 @@ export class SharedPropertyTree extends SharedObject {
 
 	public get activeCommit(): IPropertyTreeMessage {
 		return this.localChanges.length > 0
-            ? this.localChanges[this.localChanges.length - 1]
-            : this.remoteChanges[this.remoteChanges.length - 1];
+			? this.localChanges[this.localChanges.length - 1]
+			: this.remoteChanges[this.remoteChanges.length - 1];
 	}
 	public get root(): NodeProperty {
 		return this._root as NodeProperty;
@@ -245,7 +245,7 @@ export class SharedPropertyTree extends SharedObject {
 	/**
  	 * This method decodes message from the transfer form.
 	 * @param transferChange - The message to be decoded.
-     	 */
+	 	 */
 	private decodeMessage(transferChange: IPropertyTreeMessage): IPropertyTreeMessage {
 		return this.propertyTreeConfig.encDec.messageEncoder.decode(transferChange);
 	}
@@ -264,8 +264,8 @@ export class SharedPropertyTree extends SharedObject {
 			remoteHeadGuid: this.headCommitGuid,
 			referenceGuid:
 				this.localChanges.length > 0
-                ? this.localChanges[this.localChanges.length - 1].guid
-                : this.headCommitGuid,
+				? this.localChanges[this.localChanges.length - 1].guid
+				: this.headCommitGuid,
 			localBranchStart: this.localChanges.length > 0 ? this.localChanges[0].guid : undefined,
 			useMH: this.useMH,
 		};
@@ -338,17 +338,17 @@ export class SharedPropertyTree extends SharedObject {
 		}
 	}
 
-    private addRemoteChange(change: IPropertyTreeMessage) {
-        this.remoteChanges.push(change);
-        this.updateRemoteHeadGuid();
-    }
+	private addRemoteChange(change: IPropertyTreeMessage) {
+		this.remoteChanges.push(change);
+		this.updateRemoteHeadGuid();
+	}
 
 
-    private updateRemoteHeadGuid() {
-        this.headCommitGuid = this.remoteChanges.length > 0
+	private updateRemoteHeadGuid() {
+		this.headCommitGuid = this.remoteChanges.length > 0
 				? this.remoteChanges[this.remoteChanges.length - 1].guid
 				: this.headCommitGuid;
-    }
+	}
 
 	public static prune(
 		minimumSequenceNumber: number,
@@ -507,11 +507,11 @@ export class SharedPropertyTree extends SharedObject {
 			const summary: ISnapshotSummary = {
 				remoteTipView: this.remoteTipView,
 				remoteChanges: this.remoteChanges,
-                remoteHeadGuid: this.headCommitGuid,
+				remoteHeadGuid: this.headCommitGuid,
 				unrebasedRemoteChanges: this.unrebasedRemoteChanges,
 			};
 
-            const chunkSize = 5000 * 1024; // Default limit seems to be 5MB
+			const chunkSize = 5000 * 1024; // Default limit seems to be 5MB
 			let totalBlobsSize = 0;
 			const serializedSummary = this.encodeSummary(summary);
 			for (let pos = 0, i = 0; pos < serializedSummary.length; pos += chunkSize, i++) {
@@ -557,16 +557,31 @@ export class SharedPropertyTree extends SharedObject {
 				if (
 					snapshotSummary.remoteChanges === undefined ||
 					snapshotSummary.remoteTipView === undefined ||
-                    snapshotSummary.remoteHeadGuid === undefined ||
 					snapshotSummary.unrebasedRemoteChanges === undefined
 				) {
 					throw new Error("Invalid Snapshot.");
 				}
 
+				if (snapshotSummary.remoteHeadGuid === undefined) {
+					// The summary does not contain a remoteHeadGuid. This means the summary has
+					// been created by an old version of PropertyDDS, that did not yet have this patch.
+					snapshotSummary.remoteHeadGuid = (snapshotSummary.remoteChanges.length > 0) ?
+							// If there are remote changes in the
+							// summary we can deduce the head GUID from these changes.
+							snapshotSummary.remoteChanges[snapshotSummary.remoteChanges.length - 1].guid :
+
+							// If no remote head GUID is available, we will fall back to the old behaviour,
+							// where the head GUID was set to an empty string. However, this could lead to
+							// divergence between the clients, if there is still a client in the session
+							// that is using a version of this library without this patch and which
+							// has started the session at a different summary.
+							"";
+				}
+
 				this.remoteTipView = snapshotSummary.remoteTipView;
 				this.remoteChanges = snapshotSummary.remoteChanges;
 				this.unrebasedRemoteChanges = snapshotSummary.unrebasedRemoteChanges;
-                this.headCommitGuid = snapshotSummary.remoteHeadGuid;
+				this.headCommitGuid = snapshotSummary.remoteHeadGuid;
 				const isPartialCheckoutActive = !!(this.options.clientFiltering && this.options.paths);
 				if (isPartialCheckoutActive && this.options.paths) {
 					this.remoteTipView = ChangeSetUtils.getFilteredChangeSetByPaths(
@@ -628,7 +643,7 @@ export class SharedPropertyTree extends SharedObject {
 									this.options.paths,
 								);
 							}
-                            this.addRemoteChange(remoteChange);
+							this.addRemoteChange(remoteChange);
 						}
 					} else {
 						this.processCore(missingDeltas[i], false, {});
@@ -677,7 +692,7 @@ export class SharedPropertyTree extends SharedObject {
 			);
 		}
 
-        this.addRemoteChange(change);
+		this.addRemoteChange(change);
 		// Apply the remote change set to the remote tip view
 		const remoteChangeSetWrapper = new ChangeSet(this.remoteTipView);
 		remoteChangeSetWrapper.applyChangeSet(change.changeSet);

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -510,8 +510,8 @@ export class SharedPropertyTree extends SharedObject {
                 remoteHeadGuid: this.headCommitGuid,
 				unrebasedRemoteChanges: this.unrebasedRemoteChanges,
 			};
-            console.log("Summary sent", summary);
-			const chunkSize = 5000 * 1024; // Default limit seems to be 5MB
+
+            const chunkSize = 5000 * 1024; // Default limit seems to be 5MB
 			let totalBlobsSize = 0;
 			const serializedSummary = this.encodeSummary(summary);
 			for (let pos = 0, i = 0; pos < serializedSummary.length; pos += chunkSize, i++) {

--- a/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
@@ -12,15 +12,150 @@ import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { LocalDeltaConnectionServer, ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import { IUrlResolver } from "@fluidframework/driver-definitions";
 import {
-	createAndAttachContainer,
-	createLoader,
-	LoaderContainerTracker,
-	ITestFluidObject,
-	TestFluidObjectFactory,
+    createAndAttachContainer,
+    createLoader,
+    LoaderContainerTracker,
+    ITestFluidObject,
+    TestFluidObjectFactory,
+    TestObjectProvider,
+    TestContainerRuntimeFactory,
+    ChannelFactoryRegistry,
+    ITestObjectProvider,
+    createSummarizer,
+    summarizeNow
 } from "@fluidframework/test-utils";
-import { PropertyFactory, StringProperty, BaseProperty } from "@fluid-experimental/property-properties";
+import { PropertyFactory, StringProperty, BaseProperty, NodeProperty, ArrayProperty } from "@fluid-experimental/property-properties";
+import { Loader as ContainerLoader } from "@fluidframework/container-loader";
+import { LocalServerTestDriver } from "@fluidframework/test-drivers";
 import { DeflatedPropertyTree, LZ4PropertyTree } from "../propertyTreeExt";
 import { SharedPropertyTree } from "../propertyTree";
+import { PropertyTreeFactory } from "../propertyTreeFactory";
+
+interface Result {
+    container: IContainer;
+    client: SharedPropertyTree;
+}
+
+interface withSummarizer extends Result {
+    summarizer: Awaited<ReturnType<typeof createSummarizer>>;
+}
+
+describe("PropertyDDS summarizer", () => {
+    let objProvider: ITestObjectProvider;
+    const propertyDdsId = "PropertyTree";
+    const USERS = "users";
+    const getClient = async (withSummarizer = false, load = false) => {
+        const container = await (load ? objProvider.loadTestContainer() : objProvider.makeTestContainer());
+        const dataObject = await requestFluidObject<ITestFluidObject>(container, "/");
+
+        let summarizer;
+        if (withSummarizer) {
+            summarizer = await getSummarizer(container);
+        }
+        const client = await dataObject.getSharedObject<SharedPropertyTree>(propertyDdsId);
+        const res: withSummarizer = {
+            summarizer,
+            client,
+            container
+        };
+        return res;
+    };
+
+    const getSummarizer = async (container) => {
+        const summarizer = await createSummarizer(objProvider, container);
+        return summarizer;
+    };
+
+    const createUserNode = (name: string) => {
+        const node = PropertyFactory.create<NodeProperty>("NodeProperty");
+        node.insert("name", PropertyFactory.create("String", undefined, name));
+    };
+
+    beforeEach(async () => {
+        const driver = new LocalServerTestDriver();
+        const registry = [[propertyDdsId, new PropertyTreeFactory()]] as ChannelFactoryRegistry;
+
+        objProvider = new TestObjectProvider(
+            ContainerLoader as any,
+            driver,
+            () =>
+                new TestContainerRuntimeFactory(
+                    "@fluid-experimental/test-propertyTree",
+                    new TestFluidObjectFactory(registry)
+                )
+        );
+
+    });
+
+    it("Scenario 1", async function() {
+        /**
+         * This test produces a scenario where a summarizer creates a summary with an empty remoteChanges array.
+         * This can happen, if the summarizer client prunes all remote changes. However, all remote changes will only be
+         * pruned, when the last operation in the stream is not a changeset op (e.g. a join/remove operation).
+         * In addition to that, the minimum sequence number has to point to the last operation in the stream. For this,
+         * all clients must be synced and have updated their referenceSequenceNumber.
+         *
+         * We create this scenario to reproduce a bug, where a client that joined after such a summary had been created,
+         * submitted an operation with an incorrect referenceGuid. Clients that already had been joined to the session
+         * before the summarization, then performed an incorrect rebase which resulted in exceptions or an incorrect
+         * state in the property tree after the rebase.
+         */
+        this.timeout(30000);
+
+        // 1- U1 joins together with summarizer
+        const { client: u1, summarizer, container } = await getClient(true);
+        await objProvider.ensureSynchronized();
+
+        // Test debugging code
+        // container.deltaManager.inbound.on("op", (task: any) => {
+        //     console.info(task);
+        // });
+
+        // container.deltaManager.outbound.on("op", (task: any) => {
+        //     console.info(task);
+        // });
+
+        // 2- Insert array with u1 as user
+        u1.root.insert(USERS, PropertyFactory.create("NodeProperty", "array"));
+        u1.commit();
+        await objProvider.ensureSynchronized();
+
+        let users = u1.root.get<ArrayProperty>(USERS);
+        users?.push(createUserNode("u1"));
+
+        users?.push(createUserNode("u2"));
+        u1.commit();
+
+        await objProvider.ensureSynchronized();
+
+        // Wait enough time to send noop
+        // @TODO is there a way to make sure all clients sent the "noop" without waiting ?
+        // This is required to make sure all clients has the same referenceSequenceNumber
+        await new Promise((resolve) => setTimeout(() => {
+            resolve(undefined);
+        }, 20000));
+
+        const { client: u2 } = await getClient(false, true);
+        await objProvider.ensureSynchronized();
+
+        // Summarize
+        await summarizeNow(summarizer);
+
+        await objProvider.ensureSynchronized();
+
+        // U3 joins and remove a user
+        const { client: u3 } = await getClient(false, true);
+
+        users = u3.root.get<ArrayProperty>(USERS);
+
+        users?.remove(1);
+        u3.commit();
+        await objProvider.ensureSynchronized();
+
+        expect(u1.root.get<ArrayProperty>(USERS)?.getValues().length).to.equal(1);
+    });
+});
+
 
 describe("PropertyTree", () => {
     const documentId = "localServerTest";


### PR DESCRIPTION
This PR introduce a bug fix for PropertyDDS summarizer, where users could end-up with inconsistent state in a very spefic scenario described in more details in the [test](https://github.com/microsoft/FluidFramework/compare/main...nedalhy:FluidFramework:fix/property_dds/summarization_bug?expand=1#diff-4e672dc85e3021cf5cf96522a3bcf6653dfaaf10639ef2bf0c3de0a12fc8870eR91) .

This is a fixed version of the PR https://github.com/microsoft/FluidFramework/pull/13084. I added a fix to ensure backwards compatibility to summaries that have been generate before by clients without the fix.