### PR TITLE
Tree: test cursor paths

### DIFF
--- a/packages/dds/tree/src/test/cursorTestSuite.ts
+++ b/packages/dds/tree/src/test/cursorTestSuite.ts
@@ -495,7 +495,7 @@ function checkTraversal(cursor: ITreeCursor, expectedPath: UpPath | undefined) {
         assert(expectedFieldLength > 0, "only non empty fields should show up in field iteration");
         assert(compareFieldUpPaths(cursor.getFieldPath(), { field: key, parent: path }));
 
-        // Check that iterating nodes withing field works as expected.
+        // Check that iterating nodes of this field works as expected.
         let actualChildNodesTraversed = 0;
         for (let inNode = cursor.firstNode(); inNode; inNode = cursor.nextNode()) {
             assert(cursor.chunkStart <= actualChildNodesTraversed);
@@ -523,7 +523,7 @@ function checkTraversal(cursor: ITreeCursor, expectedPath: UpPath | undefined) {
             "Did not traverse expected number of children",
         );
 
-        // Cheek node access by index
+        // Check node access by index
         for (let index = 0; index < expectedFieldLength; index++) {
             assert.equal(cursor.mode, CursorLocationType.Fields);
             cursor.enterNode(index);

--- a/packages/dds/tree/src/test/cursorTestSuite.ts
+++ b/packages/dds/tree/src/test/cursorTestSuite.ts
@@ -17,6 +17,9 @@ import {
     symbolFromKey,
     setGenericTreeField,
     isLocalKey,
+    UpPath,
+    compareUpPaths,
+    compareFieldUpPaths,
 } from "../tree";
 import { brand } from "../util";
 
@@ -267,6 +270,14 @@ function testTreeCursor<TData, TCursor extends ITreeCursor>(config: {
     const withLocalKeys =
         withKeys ?? (typeof builder === "object" ? builder.withLocalKeys : undefined);
 
+    const parent = !extraRoot
+        ? undefined
+        : {
+              parent: undefined,
+              parentField: rootFieldKeySymbol,
+              parentIndex: 0,
+          };
+
     return describe(`${cursorName} cursor implementation`, () => {
         describe("test trees", () => {
             for (const { name, data, reference } of testData) {
@@ -281,7 +292,7 @@ function testTreeCursor<TData, TCursor extends ITreeCursor>(config: {
                     });
 
                     it("traversal", () => {
-                        checkTraversal(cursorFactory(data));
+                        checkTraversal(cursorFactory(data), parent);
                     });
 
                     if (reference !== undefined) {
@@ -334,14 +345,6 @@ function testTreeCursor<TData, TCursor extends ITreeCursor>(config: {
                 });
             }
             describe("getPath() and getFieldPath()", () => {
-                const parent = !extraRoot
-                    ? undefined
-                    : {
-                          parent: undefined,
-                          parentField: rootFieldKeySymbol,
-                          parentIndex: 0,
-                      };
-
                 it("at root", () => {
                     const cursor = factory({
                         type: brand("Foo"),
@@ -469,15 +472,16 @@ function testTreeCursor<TData, TCursor extends ITreeCursor>(config: {
  * Test that cursor works as a cursor.
  * This does NOT test that the data the cursor exposes is correct,
  * it simply checks that the traversal APIs function, and that a few aspects of them conform with the spec.
- *
- * TODO: add testing for paths to this, or separate tests for it.
  */
-function checkTraversal(cursor: ITreeCursor) {
+function checkTraversal(cursor: ITreeCursor, expectedPath: UpPath | undefined) {
     assert.equal(cursor.mode, CursorLocationType.Nodes);
     assert.equal(cursor.pending, false);
     // Keep track of current node properties to check it during ascent
     const originalNodeValue = cursor.value;
     const originalNodeType = cursor.type;
+
+    const path = cursor.getPath();
+    assert(compareUpPaths(path, expectedPath));
 
     const fieldLengths: Map<FieldKey, number> = new Map();
 
@@ -489,14 +493,28 @@ function checkTraversal(cursor: ITreeCursor) {
         assert(!fieldLengths.has(key), "no duplicate keys");
         fieldLengths.set(cursor.getFieldKey(), expectedFieldLength);
         assert(expectedFieldLength > 0, "only non empty fields should show up in field iteration");
+        assert(compareFieldUpPaths(cursor.getFieldPath(), { field: key, parent: path }));
+
+        // Check that iterating nodes withing field works as expected.
         let actualChildNodesTraversed = 0;
         for (let inNode = cursor.firstNode(); inNode; inNode = cursor.nextNode()) {
             assert(cursor.chunkStart <= actualChildNodesTraversed);
             assert(cursor.chunkLength > actualChildNodesTraversed - cursor.chunkStart);
             assert(cursor.chunkLength + cursor.chunkStart <= expectedFieldLength);
+
+            // Make sure down+up navigation gets back to where it started.
+            // Testing this explicitly here before recursing makes debugging issues with this easier.
+            assert.equal(cursor.fieldIndex, actualChildNodesTraversed);
+            cursor.enterField(EmptyKey);
+            cursor.exitField();
+            assert.equal(cursor.fieldIndex, actualChildNodesTraversed);
+            if (cursor.firstField()) {
+                cursor.enterNode(0);
+                cursor.exitNode();
+                cursor.exitField();
+            }
             assert.equal(cursor.fieldIndex, actualChildNodesTraversed);
             actualChildNodesTraversed++;
-            checkTraversal(cursor);
         }
 
         assert.equal(
@@ -505,7 +523,7 @@ function checkTraversal(cursor: ITreeCursor) {
             "Did not traverse expected number of children",
         );
 
-        // Cheek field access by index
+        // Cheek node access by index
         for (let index = 0; index < expectedFieldLength; index++) {
             assert.equal(cursor.mode, CursorLocationType.Fields);
             cursor.enterNode(index);
@@ -546,6 +564,19 @@ function checkTraversal(cursor: ITreeCursor) {
         // skipPendingFields should have no effect since not pending
         assert(cursor.skipPendingFields());
         assert.equal(cursor.getFieldKey(), key);
+
+        // Recursively validate.
+        actualChildNodesTraversed = 0;
+        for (let inNode = cursor.firstNode(); inNode; inNode = cursor.nextNode()) {
+            assert.equal(cursor.fieldIndex, actualChildNodesTraversed);
+            checkTraversal(cursor, {
+                parent: path,
+                parentField: key,
+                parentIndex: actualChildNodesTraversed,
+            });
+            assert.equal(cursor.fieldIndex, actualChildNodesTraversed);
+            actualChildNodesTraversed++;
+        }
     }
 
     // Add some fields which should be empty to check:

--- a/packages/dds/tree/src/test/tree/pathTree.spec.ts
+++ b/packages/dds/tree/src/test/tree/pathTree.spec.ts
@@ -4,7 +4,14 @@
  */
 
 import { strict as assert } from "assert";
-import { FieldKey, getDepth, UpPath } from "../../tree";
+import {
+    FieldKey,
+    getDepth,
+    UpPath,
+    compareUpPaths,
+    clonePath,
+    compareFieldUpPaths,
+} from "../../tree";
 import { brand } from "../../util";
 
 const rootKey = brand<FieldKey>("root");
@@ -28,14 +35,105 @@ const grandChild: UpPath = {
     parentIndex: 0,
 };
 
-describe("getDepth", () => {
-    it("Returns 0 for the root", () => {
-        assert.strictEqual(getDepth(root), 0);
+describe("pathTree", () => {
+    describe("getDepth", () => {
+        it("Returns 0 for the root", () => {
+            assert.equal(getDepth(root), 0);
+        });
+        it("Returns 1 for a child of the root", () => {
+            assert.equal(getDepth(child), 1);
+        });
+        it("Returns 2 for a child of the child of the root", () => {
+            assert.equal(getDepth(grandChild), 2);
+        });
     });
-    it("Returns 1 for a child of the root", () => {
-        assert.strictEqual(getDepth(child), 1);
+
+    describe("compareUpPaths", () => {
+        it("handles undefined", () => {
+            assert(compareUpPaths(undefined, undefined));
+            assert(!compareUpPaths(root, undefined));
+            assert(!compareUpPaths(undefined, root));
+        });
+
+        it("handles same object", () => {
+            assert(compareUpPaths(root, root));
+            assert(compareUpPaths(grandChild, grandChild));
+        });
+
+        it("handles different objects cases", () => {
+            // Different contents and depths
+            assert(!compareUpPaths(child, grandChild));
+
+            const root2 = {
+                parent: undefined,
+                parentField: rootKey,
+                parentIndex: 0,
+            };
+            assert(compareUpPaths(root, root2));
+            // Common parent object, same data
+            assert(
+                compareUpPaths(child, {
+                    parent: root,
+                    parentField: fooKey,
+                    parentIndex: 0,
+                }),
+            );
+            // Equal parent object, same data
+            assert(
+                compareUpPaths(child, {
+                    parent: root2,
+                    parentField: fooKey,
+                    parentIndex: 0,
+                }),
+            );
+            // Same parent object, different data (index)
+            assert(
+                !compareUpPaths(child, {
+                    parent: root,
+                    parentField: fooKey,
+                    parentIndex: 1,
+                }),
+            );
+            // Same parent object, different data (key)
+            assert(
+                !compareUpPaths(child, {
+                    parent: root,
+                    parentField: brand<FieldKey>("bar"),
+                    parentIndex: 0,
+                }),
+            );
+            // Different parent object, same data
+            assert(
+                compareUpPaths(child, {
+                    parent: root2,
+                    parentField: fooKey,
+                    parentIndex: 0,
+                }),
+            );
+        });
     });
-    it("Returns 2 for a child of the child of the root", () => {
-        assert.strictEqual(getDepth(grandChild), 2);
+
+    it("compareFieldUpPaths", () => {
+        assert(
+            compareFieldUpPaths(
+                { field: fooKey, parent: undefined },
+                { field: fooKey, parent: undefined },
+            ),
+        );
+        assert(
+            !compareFieldUpPaths(
+                { field: fooKey, parent: undefined },
+                { field: rootKey, parent: undefined },
+            ),
+        );
+        assert(
+            compareFieldUpPaths(
+                { field: fooKey, parent: root },
+                { field: fooKey, parent: clonePath(root) },
+            ),
+        );
+        assert(
+            !compareFieldUpPaths({ field: fooKey, parent: root }, { field: fooKey, parent: child }),
+        );
     });
 });

--- a/packages/dds/tree/src/tree/index.ts
+++ b/packages/dds/tree/src/tree/index.ts
@@ -20,7 +20,14 @@ export {
     symbolIsFieldKey,
 } from "./globalFieldKeySymbol";
 export { getMapTreeField, MapTree } from "./mapTree";
-export { clonePath, getDepth, UpPath, FieldUpPath } from "./pathTree";
+export {
+    clonePath,
+    getDepth,
+    UpPath,
+    FieldUpPath,
+    compareUpPaths,
+    compareFieldUpPaths,
+} from "./pathTree";
 export {
     FieldMapObject,
     FieldScope,

--- a/packages/dds/tree/src/tree/pathTree.ts
+++ b/packages/dds/tree/src/tree/pathTree.ts
@@ -101,3 +101,34 @@ export function topDownPath(path: UpPath | undefined): UpPath[] {
     }
     return out;
 }
+
+/**
+ * @returns true iff `a` and `b` describe the same path.
+ *
+ * Note that for mutable paths (as used in `AnchorSet`), this equality may change over time: this only checks if the two paths are currently the same.
+ */
+export function compareUpPaths(a: UpPath | undefined, b: UpPath | undefined): boolean {
+    if (a === b) {
+        // This handles the both `undefined` case, as well as provides an early out if a shared node is encountered.
+        return true;
+    }
+    if (a === undefined || b === undefined) {
+        return false;
+    }
+    if (a.parentField !== b.parentField || a.parentIndex !== b.parentIndex) {
+        return false;
+    }
+    return compareUpPaths(a.parent, b.parent);
+}
+
+/**
+ * @returns true iff `a` and `b` describe the same field path.
+ *
+ * Note that for mutable paths (as used in `AnchorSet`), this equality may change over time: this only checks if the two paths are currently the same.
+ */
+export function compareFieldUpPaths(a: FieldUpPath, b: FieldUpPath): boolean {
+    if (a.field !== b.field) {
+        return false;
+    }
+    return compareUpPaths(a.parent, b.parent);
+}


### PR DESCRIPTION
## Description

Adds path comparisons utilities and uses them to check that paths reported from cursors are correct.
