### PR TITLE
Update summarizeOnDemand parameter in TestTreeProvider to allow disabling of summaries

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -21,7 +21,7 @@ import {
     Value,
 } from "../../tree";
 import { moveToDetachedField } from "../../forest";
-import { SharedTreeTestFactory, TestTreeProvider } from "../utils";
+import { SharedTreeTestFactory, SummarizeType, TestTreeProvider } from "../utils";
 import { ISharedTree } from "../../shared-tree";
 import { TransactionResult } from "../../checkout";
 import { fieldSchema, GlobalFieldKey, namedTreeSchema, SchemaData } from "../../schema-stored";
@@ -78,7 +78,7 @@ describe("SharedTree", () => {
     });
 
     it("can summarize and load", async () => {
-        const provider = await TestTreeProvider.create(1, true);
+        const provider = await TestTreeProvider.create(1, SummarizeType.onDemand);
         const [summarizingTree] = provider.trees;
         const value = 42;
         initializeTestTreeWithValue(summarizingTree, value);
@@ -90,7 +90,7 @@ describe("SharedTree", () => {
     });
 
     it("can process ops after loading from summary", async () => {
-        const provider = await TestTreeProvider.create(1, true);
+        const provider = await TestTreeProvider.create(1, SummarizeType.onDemand);
         const tree1 = provider.trees[0];
         const tree2 = await provider.createTree();
         const tree3 = await provider.createTree();
@@ -181,7 +181,7 @@ describe("SharedTree", () => {
         };
         const provider = await TestTreeProvider.create(
             1,
-            true,
+            SummarizeType.onDemand,
             new SharedTreeTestFactory(onCreate),
         );
         const [tree1] = provider.trees;

--- a/packages/dds/tree/src/test/shared-tree/summaryBenchmarkSizes.ts
+++ b/packages/dds/tree/src/test/shared-tree/summaryBenchmarkSizes.ts
@@ -12,7 +12,7 @@ import { FieldKinds, singleTextCursor } from "../../feature-libraries";
 import { ISharedTree } from "../../shared-tree";
 import { rootFieldKey, rootFieldKeySymbol, TreeValue } from "../../tree";
 import { brand } from "../../util";
-import { TestTreeProvider } from "../utils";
+import { SummarizeType, TestTreeProvider } from "../utils";
 import { fieldSchema, GlobalFieldKey, namedTreeSchema, SchemaData } from "../../schema-stored";
 // eslint-disable-next-line import/no-internal-modules
 import { PlacePath } from "../../feature-libraries/sequence-change-family";
@@ -27,7 +27,7 @@ enum TreeShape {
 // TODO: report these sizes as benchmark output which can be tracked over time.
 describe("Summary size benchmark", () => {
     it("for an empty tree.", async () => {
-        const provider = await TestTreeProvider.create(1, true);
+        const provider = await TestTreeProvider.create(1, SummarizeType.onDemand);
         const tree = provider.trees[0];
         const { summary } = tree.getAttachSummary();
         const summaryString = JSON.stringify(summary);
@@ -120,7 +120,7 @@ export async function getInsertsSummaryTree(
     numberOfNodes: number,
     shape: TreeShape,
 ): Promise<ISummaryTree> {
-    const provider = await TestTreeProvider.create(1, true);
+    const provider = await TestTreeProvider.create(1, SummarizeType.onDemand);
     const tree = provider.trees[0];
     initializeTestTreeWithValue(tree, 1);
 

--- a/packages/dds/tree/src/test/util/testTreeProvider.spec.ts
+++ b/packages/dds/tree/src/test/util/testTreeProvider.spec.ts
@@ -5,7 +5,7 @@
 
 import assert from "assert";
 import { SharedTreeCore } from "../../shared-tree-core";
-import { spyOnMethod, TestTreeProvider } from "../utils";
+import { spyOnMethod, SummarizeType, TestTreeProvider } from "../utils";
 
 describe("TestTreeProvider", () => {
     it("can manually trigger summaries with summarizeOnDemand", async () => {
@@ -14,7 +14,7 @@ describe("TestTreeProvider", () => {
             summaryCount += 1;
         });
 
-        const provider = await TestTreeProvider.create(1, true);
+        const provider = await TestTreeProvider.create(1, SummarizeType.onDemand);
         const summaries = summaryCount;
         await provider.summarize();
 
@@ -36,7 +36,7 @@ describe("TestTreeProvider", () => {
     it("cannot manually trigger summaries with 0 trees", async () => {
         let summarizerError;
         try {
-            const provider = await TestTreeProvider.create(0, true);
+            const provider = await TestTreeProvider.create(0, SummarizeType.onDemand);
             await provider.summarize();
         } catch (error) {
             summarizerError = error;
@@ -50,7 +50,7 @@ describe("TestTreeProvider", () => {
             summaryCount += 1;
         });
 
-        const provider = await TestTreeProvider.create(2, true);
+        const provider = await TestTreeProvider.create(2, SummarizeType.onDemand);
 
         const summaries = summaryCount;
         await provider.summarize();

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -107,6 +107,12 @@ export class MockDependent extends SimpleObservingDependent {
  */
 export type ITestTreeProvider = TestTreeProvider & ITestObjectProvider;
 
+export enum SummarizeType {
+    onDemand = 0,
+    automatic = 1,
+    disabled = 2,
+}
+
 /**
  * A test helper class that manages the creation, connection and retrieval of SharedTrees. Instances of this
  * class are created via {@link create} and satisfy the {@link ITestObjectProvider} interface.
@@ -130,7 +136,7 @@ export class TestTreeProvider {
     /**
      * Create a new {@link TestTreeProvider} with a number of trees pre-initialized.
      * @param trees - the number of trees to initialize this provider with. This is the same as calling
-     * @param summarizeOnDemand - if `true`, summaries will only be made when `TestTreeProvider.summarize` is called.
+     * @param summarizeType - if `onDemand`, summaries will only be made when `TestTreeProvider.summarize` is called.
      * @param factory - The factory to use for creating and loading trees. See {@link SharedTreeTestFactory}.
      * {@link create} followed by {@link createTree} _trees_ times.
      *
@@ -144,28 +150,34 @@ export class TestTreeProvider {
      */
     public static async create(
         trees = 0,
-        summarizeOnDemand = false,
+        summarizeType: SummarizeType = SummarizeType.disabled,
         factory: SharedTreeFactory = new SharedTreeFactory(),
     ): Promise<ITestTreeProvider> {
         // The on-demand summarizer shares a container with the first tree, so at least one tree and container must be created right away.
         assert(
-            !(trees === 0 && summarizeOnDemand),
+            !(trees === 0 && summarizeType === SummarizeType.onDemand),
             "trees must be >= 1 to allow summarization on demand",
         );
 
         const registry = [[TestTreeProvider.treeId, factory]] as ChannelFactoryRegistry;
         const driver = new LocalServerTestDriver();
-        const objProvider = new TestObjectProvider(
-            Loader,
-            driver,
-            () =>
-                new TestContainerRuntimeFactory(
-                    "@fluid-example/test-dataStore",
-                    new TestFluidObjectFactory(registry),
-                ),
-        );
+        const containerRuntimeFactory =
+            summarizeType === SummarizeType.disabled
+                ? () =>
+                      new TestContainerRuntimeFactory(
+                          "@fluid-example/test-dataStore",
+                          new TestFluidObjectFactory(registry),
+                          { summaryOptions: { disableSummaries: true } },
+                      )
+                : () =>
+                      new TestContainerRuntimeFactory(
+                          "@fluid-example/test-dataStore",
+                          new TestFluidObjectFactory(registry),
+                      );
 
-        if (summarizeOnDemand) {
+        const objProvider = new TestObjectProvider(Loader, driver, containerRuntimeFactory);
+
+        if (summarizeType === SummarizeType.onDemand) {
             const container = await objProvider.makeTestContainer();
             const dataObject = await requestFluidObject<ITestFluidObject>(container, "/");
             const firstTree = await dataObject.getSharedObject<ISharedTree>(

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -161,19 +161,12 @@ export class TestTreeProvider {
 
         const registry = [[TestTreeProvider.treeId, factory]] as ChannelFactoryRegistry;
         const driver = new LocalServerTestDriver();
-        const containerRuntimeFactory =
-            summarizeType === SummarizeType.disabled
-                ? () =>
-                      new TestContainerRuntimeFactory(
-                          "@fluid-example/test-dataStore",
-                          new TestFluidObjectFactory(registry),
-                          { summaryOptions: { disableSummaries: true } },
-                      )
-                : () =>
-                      new TestContainerRuntimeFactory(
-                          "@fluid-example/test-dataStore",
-                          new TestFluidObjectFactory(registry),
-                      );
+        const containerRuntimeFactory = () =>
+            new TestContainerRuntimeFactory(
+                "@fluid-example/test-dataStore",
+                new TestFluidObjectFactory(registry),
+                { summaryOptions: { disableSummaries: summarizeType === SummarizeType.disabled } },
+            )
 
         const objProvider = new TestObjectProvider(Loader, driver, containerRuntimeFactory);
 

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -166,7 +166,7 @@ export class TestTreeProvider {
                 "@fluid-example/test-dataStore",
                 new TestFluidObjectFactory(registry),
                 { summaryOptions: { disableSummaries: summarizeType === SummarizeType.disabled } },
-            )
+            );
 
         const objProvider = new TestObjectProvider(Loader, driver, containerRuntimeFactory);
 

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -136,7 +136,7 @@ export class TestTreeProvider {
     /**
      * Create a new {@link TestTreeProvider} with a number of trees pre-initialized.
      * @param trees - the number of trees to initialize this provider with. This is the same as calling
-     * @param summarizeType - if `onDemand`, summaries will only be made when `TestTreeProvider.summarize` is called.
+     * @param summarizeType - enum to manually, automatically, or disable summarization
      * @param factory - The factory to use for creating and loading trees. See {@link SharedTreeTestFactory}.
      * {@link create} followed by {@link createTree} _trees_ times.
      *


### PR DESCRIPTION
## Description

This PR updates the `summarizeOnDemand` parameter in the `TestTreeProvider` class, allowing us to disable summaries when needed.

## Breaking Changes

No
