### PR TITLE
build: Pin dependencies on `tinylicious` to prevent semver-incomplient server dep updates

### DIFF
--- a/azure/packages/azure-local-service/package.json
+++ b/azure/packages/azure-local-service/package.json
@@ -35,7 +35,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "tinylicious": "^0.4.89251"
+    "tinylicious": "0.4.89251"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",

--- a/azure/packages/external-controller/package.json
+++ b/azure/packages/external-controller/package.json
@@ -74,7 +74,7 @@
     "puppeteer": "^1.20.0",
     "rimraf": "^2.6.2",
     "start-server-and-test": "^1.11.7",
-    "tinylicious": "^0.4.89251",
+    "tinylicious": "0.4.89251",
     "ts-jest": "^26.4.4",
     "ts-loader": "^9.3.0",
     "typescript": "~4.5.5",

--- a/azure/packages/test/end-to-end-tests/package.json
+++ b/azure/packages/test/end-to-end-tests/package.json
@@ -73,7 +73,7 @@
     "mocha": "^10.0.0",
     "sinon": "^7.4.2",
     "start-server-and-test": "^1.11.7",
-    "tinylicious": "^0.4.89251",
+    "tinylicious": "0.4.89251",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/azure/packages/test/scenario-runner/package.json
+++ b/azure/packages/test/scenario-runner/package.json
@@ -86,7 +86,7 @@
     "mocha": "^10.0.0",
     "sinon": "^7.4.2",
     "start-server-and-test": "^1.11.7",
-    "tinylicious": "^0.4.89251",
+    "tinylicious": "0.4.89251",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/examples/hosts/app-integration/external-data/package.json
+++ b/examples/hosts/app-integration/external-data/package.json
@@ -101,7 +101,7 @@
     "puppeteer": "^1.20.0",
     "rimraf": "^2.6.2",
     "start-server-and-test": "^1.11.7",
-    "tinylicious": "^0.4.89251",
+    "tinylicious": "0.4.89251",
     "ts-jest": "^26.4.4",
     "ts-loader": "^9.3.0",
     "typescript": "~4.5.5",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -73,7 +73,7 @@
     "prettier": "~2.6.2",
     "rimraf": "^2.6.2",
     "start-server-and-test": "^1.11.7",
-    "tinylicious": "^0.4.89251",
+    "tinylicious": "0.4.89251",
     "typescript": "~4.5.5"
   },
   "peerDependencies": {

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -112,7 +112,7 @@
     "semver": "^7.3.4",
     "sinon": "^7.4.2",
     "start-server-and-test": "^1.11.7",
-    "tinylicious": "^0.4.89251",
+    "tinylicious": "0.4.89251",
     "url": "^0.11.0",
     "uuid": "^8.3.1"
   },

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -52,8 +52,7 @@
     "test:stress:tinylicious:run": "npm run test:stress:run",
     "tsc": "tsc",
     "typetests:gen": "flub generate typetests --generate --dir .",
-    "typetests:prepare": "flub generate typetests --prepare --dir . --pin"
-,
+    "typetests:prepare": "flub generate typetests --prepare --dir . --pin",
     "usePrereleaseDeps": "node ./scripts/usePrereleaseDeps.js"
   },
   "nyc": {
@@ -102,7 +101,7 @@
     "ps-node": "^0.1.6",
     "random-js": "^1.0.8",
     "start-server-and-test": "^1.11.7",
-    "tinylicious": "^0.4.89251"
+    "tinylicious": "0.4.89251"
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.6.0-109663",


### PR DESCRIPTION
See discussion in #13188 (subsequently reverted in #13213).

Pinning dependencies to prevent inadvertent future updates, and to signal that more care is required when making updates to that particular dependency.