### PR TITLE
[bump] eslint-config-fluid: 1.2.1 => 2.0.0 (major)

### DIFF
--- a/common/build/eslint-config-fluid/package-lock.json
+++ b/common/build/eslint-config-fluid/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@fluidframework/eslint-config-fluid",
-    "version": "1.2.1",
+    "version": "2.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluidframework/eslint-config-fluid",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Shareable ESLint config for the Fluid Framework",
   "homepage": "https://fluidframework.com",
   "repository": {


### PR DESCRIPTION
Bumped eslint-config-fluid from 1.2.1 to 2.0.0.

Changes generated via:
```shell
flub bump @fluidframework/eslint-config-fluid --bumpType major --scheme semver
```

Performing major bump in preparation of upcoming breaking changes.