### PR TITLE
changing .fluid extension to .loadTest

### DIFF
--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -309,7 +309,7 @@ export class OdspTestDriver implements ITestDriver {
             const driveItem = await getDriveItemByRootFileName(
                 this.config.siteUrl,
                 undefined,
-                `/${this.config.directory}/${testId}.fluid`,
+                `/${this.config.directory}/${testId}.loadTest`,
                 {
                     accessToken: await this.getStorageToken({ siteUrl, refresh: false }),
                     refreshTokenFn: async () => this.getStorageToken({ siteUrl, refresh: false }),
@@ -347,7 +347,7 @@ export class OdspTestDriver implements ITestDriver {
             this.config.siteUrl,
             this.config.driveId,
             this.config.directory,
-            `${testId}.fluid`,
+            `${testId}.loadTest`,
         );
     }
 

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -309,7 +309,7 @@ export class OdspTestDriver implements ITestDriver {
             const driveItem = await getDriveItemByRootFileName(
                 this.config.siteUrl,
                 undefined,
-                `/${this.config.directory}/${testId}.loadTest`,
+                `/${this.config.directory}/${testId}.tstFluid`,
                 {
                     accessToken: await this.getStorageToken({ siteUrl, refresh: false }),
                     refreshTokenFn: async () => this.getStorageToken({ siteUrl, refresh: false }),
@@ -347,7 +347,7 @@ export class OdspTestDriver implements ITestDriver {
             this.config.siteUrl,
             this.config.driveId,
             this.config.directory,
-            `${testId}.loadTest`,
+            `${testId}.tstFluid`,
         );
     }
 


### PR DESCRIPTION
## Description
This changes the .fluid extension to .loadTest in order to easily differentiate between stress test traffic and client data. 

## Breaking Changes
Potential issues that can come up are new scenarios needing to onboard the extension in order to test properly. 

## Reviewer Guidance
Are there any breaking scenarios with this change?