### PR TITLE
Make the debugger panel resizable

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -54418,6 +54418,11 @@
                 }
             }
         },
+        "re-resizable": {
+            "version": "6.9.9",
+            "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.9.tgz",
+            "integrity": "sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA=="
+        },
         "react": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",

--- a/packages/tools/client-debug-view/package.json
+++ b/packages/tools/client-debug-view/package.json
@@ -62,6 +62,7 @@
 		"@fluidframework/protocol-definitions": "^1.1.0",
 		"@fluidframework/sequence": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
 		"@fluidframework/shared-object-base": ">=2.0.0-internal.1.2.0 <2.0.0-internal.3.0.0",
+		"re-resizable": "6.9.9",
 		"react": "^17.0.1",
 		"react-dom": "^17.0.1",
 		"react-json-view": "^1.21.3"

--- a/packages/tools/client-debug-view/src/Debugger.tsx
+++ b/packages/tools/client-debug-view/src/Debugger.tsx
@@ -4,6 +4,7 @@
  */
 import { IconButton, Stack, StackItem, TooltipHost } from "@fluentui/react";
 import { useId } from "@fluentui/react-hooks";
+import { Resizable } from "re-resizable";
 import React from "react";
 
 import { IFluidClientDebugger, getFluidClientDebuggers } from "@fluid-tools/client-debugger";
@@ -85,7 +86,7 @@ export function FluidClientDebugger(props: FluidClientDebuggerProps): React.Reac
 	}
 
 	return (
-		<div
+		<Resizable
 			style={{
 				position: "fixed",
 				width: "400px",
@@ -98,7 +99,7 @@ export function FluidClientDebugger(props: FluidClientDebuggerProps): React.Reac
 			className={"debugger-panel"}
 		>
 			{view}
-		</div>
+		</Resizable>
 	);
 }
 

--- a/packages/tools/client-debug-view/src/test/app/index.tsx
+++ b/packages/tools/client-debug-view/src/test/app/index.tsx
@@ -5,6 +5,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 
+import { renderClientDebuggerView } from "../../RenderClientDebugger";
 import { App } from "./App";
 
 console.log("Rendering app!");
@@ -15,3 +16,5 @@ ReactDOM.render(
 	</React.StrictMode>,
 	document.querySelector("#content"),
 );
+
+renderClientDebuggerView(document.body).catch((error) => console.error(error));


### PR DESCRIPTION
## Description
Including npm re-resizable package to make debugger panel resizable by dragging.

## Example
<img width="841" alt="1" src="https://user-images.githubusercontent.com/114451900/205764316-8b6aa421-c0b6-48d7-9bc2-f2d65164eb3e.png">
<img width="852" alt="2" src="https://user-images.githubusercontent.com/114451900/205764327-4fc688c2-fce0-4f02-a980-a36ecf582013.png">
