### PR TITLE
Gitrest: initial write speedup

### DIFF
--- a/server/charts/historian/templates/gitrest-configmap.yaml
+++ b/server/charts/historian/templates/gitrest-configmap.yaml
@@ -32,6 +32,7 @@ data:
                 "name": "{{ .Values.gitrest.git.lib.name }}"
             },
             "persistLatestFullSummary": {{ .Values.gitrest.git.persistLatestFullSummary }},
+            "enableLowIoWrite": {{ .Values.gitrest.git.enableLowIoWrite }},
             "repoPerDocEnabled": {{ .Values.gitrest.git.repoPerDocEnabled }},
             "enableRepositoryManagerMetrics": {{ .Values.gitrest.git.enableRepositoryManagerMetrics }}
         }

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -43,6 +43,7 @@ gitrest:
     lib:
       name: nodegit
     persistLatestFullSummary: false
+    enableLowIoWrite: false
     repoPerDocEnabled: false
     enableRepositoryManagerMetrics: false
 

--- a/server/gitrest/lerna-package-lock.json
+++ b/server/gitrest/lerna-package-lock.json
@@ -8887,7 +8887,7 @@
 		"clean-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
-			"integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
+			"integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
@@ -10011,7 +10011,7 @@
 				"yallist": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
 					"dev": true
 				}
 			}
@@ -11088,7 +11088,7 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
 		"fastq": {
@@ -11410,6 +11410,11 @@
 				"minipass": "^2.6.0"
 			}
 		},
+		"fs-monkey": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
+			"integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q=="
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -11443,7 +11448,7 @@
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
 			"dev": true
 		},
 		"functions-have-names": {
@@ -12819,7 +12824,7 @@
 		"jju": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-			"integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
 			"dev": true
 		},
 		"js-sdsl": {
@@ -12891,7 +12896,7 @@
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
 		"json-stringify-nice": {
@@ -13705,6 +13710,14 @@
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
+		"memfs": {
+			"version": "3.4.12",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.12.tgz",
+			"integrity": "sha512-BcjuQn6vfqP+k100e0E9m61Hyqa//Brp+I3f0OBmN0ATHlFA8vx3Lt8z57R3u2bPqe3WGDBC+nF72fTH7isyEw==",
+			"requires": {
+				"fs-monkey": "^1.0.3"
+			}
+		},
 		"meow": {
 			"version": "8.1.2",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
@@ -14359,7 +14372,7 @@
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
 		"nconf": {
@@ -15413,7 +15426,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
 		},
 		"object-inspect": {
 			"version": "1.12.2",
@@ -16343,7 +16356,7 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
 			"dev": true
 		},
 		"psl": {
@@ -17111,7 +17124,7 @@
 		"sigmund": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+			"integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
 			"dev": true
 		},
 		"signal-exit": {
@@ -17287,7 +17300,7 @@
 		"spawn-command": {
 			"version": "0.0.2-1",
 			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+			"integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
 			"dev": true
 		},
 		"spawn-wrap": {
@@ -17698,7 +17711,7 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
 		"through": {

--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -4094,7 +4094,7 @@
 		"clean-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
-			"integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
+			"integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
@@ -5012,7 +5012,7 @@
 				"yallist": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
 					"dev": true
 				}
 			}
@@ -5945,7 +5945,7 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
 		"fast-safe-stringify": {
@@ -6276,7 +6276,7 @@
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
 			"dev": true
 		},
 		"functions-have-names": {
@@ -7486,7 +7486,7 @@
 		"jju": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-			"integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
 			"dev": true
 		},
 		"js-sdsl": {
@@ -7544,7 +7544,7 @@
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
 		"json-stringify-nice": {
@@ -8574,7 +8574,7 @@
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
 		"negotiator": {
@@ -9456,7 +9456,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"dev": true
 		},
 		"object-inspect": {
@@ -10102,7 +10102,7 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
 			"dev": true
 		},
 		"punycode": {
@@ -10664,7 +10664,7 @@
 		"sigmund": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+			"integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
 			"dev": true
 		},
 		"signal-exit": {
@@ -10772,7 +10772,7 @@
 		"spawn-command": {
 			"version": "0.0.2-1",
 			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+			"integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
 			"dev": true
 		},
 		"spawn-wrap": {
@@ -11138,7 +11138,7 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
 		"through": {

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -48,6 +48,7 @@
     "express": "^4.16.4",
     "isomorphic-git": "^1.14.0",
     "json-stringify-safe": "^5.0.1",
+    "memfs": "^3.4.12",
     "nconf": "^0.11.4",
     "nodegit": "^0.27.0",
     "prettier": "~2.6.2",

--- a/server/gitrest/packages/gitrest-base/src/externalStorageManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/externalStorageManager.ts
@@ -88,3 +88,16 @@ export class ExternalStorageManager implements IExternalStorageManager {
             });
     }
 }
+
+/**
+ * Throws away calls to external storage.
+ * For use in places where ExternalStorageManagement is explicitly not supported or does not make sense,
+ * but the manager is needed for compatibility with interface definitions.
+ */
+export class NullExternalStorageManager implements IExternalStorageManager {
+    public async read(tenantId: string, documentId: string): Promise<boolean> {
+        return false;
+    }
+
+    public async write(tenantId: string, ref: string, sha: string, update: boolean): Promise<void> { }
+}

--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -128,11 +128,12 @@ async function createSummary(
         repoManager,
         lumberjackProperties,
         externalWriterConfig?.enabled ?? false,
+        { enableLowIoWrite },
     );
 
     Lumberjack.info("Creating summary", lumberjackProperties);
 
-    const { isNew, writeSummaryResponse } = await wholeSummaryManager.writeSummary(payload, { enableLowIoWrite });
+    const { isNew, writeSummaryResponse } = await wholeSummaryManager.writeSummary(payload);
 
     // Waiting to pre-compute and persist latest summary would slow down document creation,
     // so skip this step if it is a new document.

--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -116,7 +116,7 @@ async function createSummary(
     repoManagerParams: IRepoManagerParams,
     externalWriterConfig?: IExternalWriterConfig,
     persistLatestFullSummary = false,
-    enableLowIoWrite: "initial" | false = false
+    enableLowIoWrite: "initial" | boolean = false
 ): Promise<IWriteSummaryResponse | IWholeFlatSummary> {
     const lumberjackProperties = {
         ...getLumberjackBasePropertiesFromRepoManagerParams(repoManagerParams),
@@ -232,7 +232,7 @@ export function create(
 ): Router {
     const router: Router = Router();
     const persistLatestFullSummary: boolean = store.get("git:persistLatestFullSummary") ?? false;
-    const enableLowIoWrite: "initial" | false = store.get("git:enableLowIoWrite") ?? false;
+    const enableLowIoWrite: "initial" | boolean = store.get("git:enableLowIoWrite") ?? false;
     const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
 
     /**

--- a/server/gitrest/packages/gitrest-base/src/test/utils.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/utils.ts
@@ -31,6 +31,14 @@ export const defaultProvider = new nconf.Provider({}).use("memory").defaults({
         enabled: false,
         endpoint: "http://localhost:3005",
     },
+    git: {
+        lib: {
+            name: "nodegit"
+        },
+        persistLatestFullSummary: false,
+        enableLowIoWrite: false,
+        repoPerDocEnabled: false
+    }
 });
 
 const rimraf = util.promisify(rimrafCallback);

--- a/server/gitrest/packages/gitrest-base/src/utils/filesystems.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/filesystems.ts
@@ -3,11 +3,18 @@
  * Licensed under the MIT License.
  */
 
-import fs from "fs";
+import fs from "node:fs";
+import { Volume } from "memfs";
 import { IFileSystemManager, IFileSystemManagerFactory, IFileSystemManagerParams } from "./definitions";
 
 export class NodeFsManagerFactory implements IFileSystemManagerFactory {
     public create(params?: IFileSystemManagerParams): IFileSystemManager {
         return fs;
+    }
+}
+
+export class MemFsManagerFactory implements IFileSystemManagerFactory {
+    public create(params?: IFileSystemManagerParams): IFileSystemManager {
+        return (new Volume() as unknown) as IFileSystemManager;
     }
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
@@ -56,14 +56,20 @@ interface IWriteSummaryInfo {
 
 interface ISummaryWriteOptions {
     /**
-     * WARNING: this option is highly optimized for read/write performance and has serious impact on storage space
+     * WARNING: this option is highly optimized for read/write performance when using a storage solution
+     * with high overhead on individual read/writes, and it has a serious impact on storage space
      * efficiency when maintaining all versions (summaries) of a document because Git cannot share blobs between
-     * summaries in this way. For optimal results, it is recommended to only use this flag when writing an initial
-     * document summary, which is in the critical path for performance.
+     * summarie versions this way. For optimal results, it is recommended to only use this flag when writing an initial
+     * document summary, which is in the critical path for performance. Then future summaries will efficiently
+     * share unchanged blobs across versions as the summary size grows.
      * 
-     * Uploading/downloading summaries from external filesystems using "Shredded Summary"
+     * Purpose: Uploading/downloading summaries from external filesystems using "Shredded Summary"
      * format can be very slow due to I/O overhead. Enabling low I/O summary writing moves the majority
      * of storage read/writes into memory and stores the resulting summary tree as a single blob in storage.
+     * 
+     * Caveats: Low-io mode will likely use more memory than high-io when using a local FS, 
+     * and as summary sizes grow, read/write speed worsens faster than in high-io mode. Low-io mode is not
+     * recommended when using a storage solution with low-overhead on individual read/writes.
      * 
      * true: All summary writes will use low I/O mode
      * false (default): No summary writes will use low I/O mode

--- a/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
@@ -703,6 +703,13 @@ export class GitWholeSummaryManager {
         const gitTree: IFullGitTree = await buildFullGitTreeFromGitTree(
             parentTree,
             this.repoManager,
+            /** TODO: current problem: when uploading channel in high-io mode
+             * referencing summary version from low-io mode, the sha for the path does not exist
+             * in storage, because it is hidden within a low-io tree blob.
+             * 
+             * potential solution: When in high-io mode, and detecting a low-io summary, write low-io tree to storage
+             * similar to writing into memory?
+             */
             true, /* parseInnerFullGitTrees */
             // We only need shas
             false, /* retrieveBlobs */

--- a/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
@@ -114,9 +114,6 @@ async function buildFullGitTreeFromGitTree(
     retrieveBlobs = true,
     depth = 0,
 ): Promise<IFullGitTree> {
-    if (depth > 100) {
-        throw new Error("Encountered recursion depth > 100 in buildFullGitTreeFromGitTree. Exiting to avoid infinite loop.");
-    }
     let parsedFullTreeBlobs = false;
     const blobPs: Promise<IBlob>[] = [];
     const treeEntries: ITreeEntry[] = [];
@@ -548,9 +545,6 @@ export class GitWholeSummaryManager {
             repoManager: IRepositoryManager,
             depth: number = 0,
         ): Promise<ITree> => {
-            if (depth > 100) {
-                throw new Error("Encountered recursion depth > 100 in getTreeWithStorageFallback. Exiting to avoid infinite loop.");
-            }
             try {
                 const tree = await repoManager.getTree(treeHandle, true /* recursive */);
                 return tree;

--- a/server/gitrest/packages/gitrest-base/src/utils/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/index.ts
@@ -18,8 +18,8 @@ export {
 	IStorageRoutingId,
 } from "./definitions";
 export {
-    BaseGitRestTelemetryProperties,
-    GitRestLumberEventName,
+	BaseGitRestTelemetryProperties,
+	GitRestLumberEventName,
 } from "./gitrestTelemetryDefinitions";
 export {
 	GitWholeSummaryManager,
@@ -46,5 +46,5 @@ export {
 	validateBlobEncoding,
 } from "./helpers";
 export { IsomorphicGitManagerFactory, IsomorphicGitRepositoryManager } from "./isomorphicgitManager";
-export { NodeFsManagerFactory } from "./nodeFsManagerFactory";
+export { NodeFsManagerFactory, MemFsManagerFactory } from "./filesystems";
 export { NodegitRepositoryManager, NodegitRepositoryManagerFactory } from "./nodegitManager";

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -20,6 +20,7 @@
             "name": "nodegit"
         },
         "persistLatestFullSummary": false,
+        "enableLowIoWrite": "initial",
         "repoPerDocEnabled": false
     }
 }

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -21,6 +21,7 @@
         },
         "persistLatestFullSummary": false,
         "enableLowIoWrite": false,
-        "repoPerDocEnabled": false
+        "repoPerDocEnabled": false,
+        "enableRepositoryManagerMetrics": false
     }
 }

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -20,7 +20,7 @@
             "name": "nodegit"
         },
         "persistLatestFullSummary": false,
-        "enableLowIoWrite": "initial",
+        "enableLowIoWrite": false,
         "repoPerDocEnabled": false
     }
 }


### PR DESCRIPTION
## Description

When using a remote filesystem, the overhead of filesystem operations makes shredded summaries extremely slow to read/write. We already work around this for Read by computing and storing a latest "Full Summary" single file that is used on read for most "Latest" summary reads.

The only Summary Write operation in the critical path is when creating the initial summary for a new document. This PR attempts to reduce the overhead of a shredded summary read/write by "compressing" the git tree for the initial summary into a single file (using Isomorphic git with `memfs`).

## Breaking Changes

N/A, only impacts new documents

## Reviewer Guidance

I validated the following scenarios to ensure functionality with each `enableLowIoWrite` setting ("initial", true, false) as well as forward/backwards compatibility using local R11s and my fluid app.
- Write service summary from initial summary
- Write client summary from initial summary from first client
- Write client summary from initial summary from 2nd client (no service summary in the middle)
- Write service summary after client summary(ies)
- Write client summary after service summary(ies)
- Load from service summary
- Load from initial summary
- Load from client summary