### PR TITLE
Tree: Undo and repair data design docs

### DIFF
--- a/packages/dds/tree/docs/repair-data/README.md
+++ b/packages/dds/tree/docs/repair-data/README.md
@@ -1,0 +1,176 @@
+# Repair Data
+
+## What is Repair Data
+
+In order to undo a edit `e` that was applied to state `s1` and yielded state `s2`,
+we need to contract an inverse edit `e⁻¹` that yields state `s1` when applied to state `s2`. Computing `e⁻¹` requires the following information:
+
+-   The original change to be undone
+-   Any document state that we wish to restore as part of the undo,
+    but cannot derive from the the original change.
+
+This last bullet point may not be immediately obvious,
+but it is a critical issue.
+We may need to recover information about the state of the document before the change that we wish to undo
+because changes can be destructive:
+
+-   Setting the value on a node loses information about the prior value of that node.
+-   Deleting a subtree loses information about the contents of that subtree.
+
+Such data cannot be derived solely from the original changeset to be undone.
+We refer to the information that is needed in addition the original changeset as "repair data".
+
+## Three Contexts
+
+Repair data is used in three different contexts.
+
+### Rolling Back Local Transactions
+
+When a client needs to edit the document, it runs a command as part of a transaction.
+Commands are allowed to return a special value to communicate to the transaction code that the transaction should be aborted.
+When that happens, any edits that the command had already applied to the document state need to be rolled back.
+
+Rolling back changes could be achieved by editing a separate copy of the document during the transaction
+(possibly though a persistent data structure, or a copy on write system).
+The current implementation (which will likely change soon) edits the one true document state as the transaction progresses, and rolls back the changes afterward.
+It actually rolls back the changes even if the transaction succeeds,
+but that's not particularly relevant to our discussion.
+
+### Local Branch Updates
+
+When a client successfully completes a local transaction,
+it updates the local document state to reflect the impact of the edit,
+and it send the edit to the service for sequencing.
+Under ideal circumstances, the next edit that the client receives from the service is that same edit that it had applied locally and sent for sequencing.
+If that's the case then the client does not need to update the document state.
+Due to concurrency, it's possible for an edit from a peer to be sequenced before the edit that was applied locally and sent out.
+When that happens, the local client needs to update the document state to reflect not only the impact of the edit from the peer,
+but also the impact that the peer edit has on the local edit.
+
+For example, if a the local edit was deletion of two nodes A and B, with a constraint that both nodes must exist,
+and the peer change had deleted node A, then the net impact of the peer change is that node B ought to be revived.
+
+### User Undo
+
+See first section.
+Also, see the [undo design document](../undo/README.md).
+
+## Repair Data Stores
+
+Repair data is computed by each client as they apply changes to documents.
+For example, before deleting a subtree from the document,
+the client first takes note of the data in that subtree so that it can revive it later if need be.
+
+Each of the three context in which repair data may be needed maintains its own repair data store:
+
+### Rolling Back Local Transactions
+
+Each transaction uses a repair data store to keep track of the data destroyed during the transaction.
+This data is then pulled from the store when rolling back the transaction.
+
+The repair data for transaction steps is discarded when the transaction is completed/aborted.
+
+### Local Branch Updates
+
+The local state manager uses a repair data store to keep track of the data destroyed by edits that have been applied locally but have yet to be sequenced.
+This data is then pulled from the store when concurrent edits cause the local edits to be undone.
+
+The repair data for the local changes is discarded when the local changes are sequenced or rolled back as part of rebasing.
+
+### User Undo
+
+The trunk state manager uses a repair data store to keep track of the data destroyed by sequenced edits.
+This data is then pulled from the store when an undo edit is applied.
+
+The repair data for an individual edit in the trunk is discarded when the corresponding edit falls outside of the [undo window](../undo/README.md).
+
+## Characterizing Repair Data by Input Path
+
+In order to store repair data in a repair data store and be able to fetch it later,
+we need to establish a convention for unambiguously characterized what data is being stored or fetched.
+
+The convention we have opted for is to characterize a deleted node
+(or a deleted value on a node)
+by the path of the node in the input context of
+(i.e., the state prior to)
+the change that deleted the node (or its value).
+
+This has two consequences.
+
+### Computing Repair Data Per Individual Edit
+
+When first computing repair data for storage,
+one must compute it for the individual edit that next applies to the tip state,
+as opposed to computing it for a composed set of edits all at once.
+This is because the input context of a composed set of edits is
+different from the input context of the individual edits in the set
+(except for the first edit in the set).
+
+Depending on how much information was preserved in the composition of the edits,
+it may be possible to work out the correct path of the deleted data for each edit in a composed changeset.
+This would however be rather complicated,
+and would place restrictions on how lossy the composition could be,
+which in turn reduces the value of composing the edits in the first place.
+For example, document nodes that were inserted by an edit and deleted by the next may need to be preserved as part of the composition of these two edits.
+
+### Fetching Repair Data Before Rebasing
+
+TODOOOOOO
+
+## Characterizing Repair Data by Tip-State Path
+
+TODOOOOOO
+You have to keep it updated as new edits come in.
+
+Representing the location of the repair data within the tip context requires a way to represent the position where the data would be if it were revived. In optional and value fields this would mean all the repair data ends up in the same "slot". In sequence fields the repair data would be represented as places with lineage in order to differentiate them. Looking up repair data for a sequence field would require having an efficient way to sift thought all those places. More generally speaking, this approach seems to require field-kind-specific code in order to characterize the repair data. It is plausible that whatever field-kind-specific code is needed to accomplish this is also the same code that is needed for anchor management, but that's not clear at this time. It may become clearer as we expand our anchor capabilities and make them field-kind specific.
+
+## Extra Details
+
+### Avoiding Step-by-Step Delta Application
+
+Decouple the computation of repair data from the computation of the delta (and its application).
+
+### Late Repair Data Concretization
+
+TODOOOOOO
+
+### Deleting Revived Data
+
+It's possible for an edit to revive some subtree and delete a part of that subtree.
+When that occurs, we need the repair data stored for that changeset to include the deleted portion of the revived tree.
+
+In such as scenario, we must be careful about how we characterize the repair data.
+A naive approach may lead to the same path used to characterize different repair data.
+
+For example, if a document contains a sequenced of Point subtrees,
+and an edit revives the a Point a the start of the sequence,
+then deletes the X node under the revived Point,
+while also deleting the X node under the first Point in the sequence,
+then both deleted nodes will have path "points[0].x".
+
+A possible solution may be to characterize repair data by its path after all nodes have been revived,
+but before any nodes are inserted, deleted, or moved.
+
+### Computing Repair Data From Changes vs. Deltas
+
+The advantage of computing repair data based on deltas as opposed to changes,
+is that deltas are coupled to the details of `FieldKind` individual field kind implementations.
+
+In order to use deltas when computing repair data,
+we must ensure they preserve all the necessary information.
+This can be achieved by following two rules:
+
+1. Do not compute repair data based on deltas that represent composed changesets
+   (see [Computing Repair Data Per Individual Edit](#computing-repair-data-per-individual-edit)).
+2. Do not apply deletions to revived subtrees as part of the change-to-delta conversion.
+
+Interestingly, #2 is not possible if we follow the
+[Late Repair Data Concretization](#late-repair-data-concretization)
+approach.
+
+### Repair Data Flow
+
+TODOOOOOO
+From local to trunk: yes, upon sequencing of the local edits.
+
+From transaction to local: actually no, because of granularity.

--- a/packages/dds/tree/docs/repair-data/README.md
+++ b/packages/dds/tree/docs/repair-data/README.md
@@ -1,21 +1,25 @@
 # Repair Data
 
+This document offers a high-level view of our design choices regarding repair data.
+It should be updated once more progress is made on the implementation.
+
 ## What is Repair Data
 
-In order to undo a edit `e` that was applied to state `s1` and yielded state `s2`,
-we need to contract an inverse edit `e⁻¹` that yields state `s1` when applied to state `s2`. Computing `e⁻¹` requires the following information:
+In order to undo an edit `e` that was applied to state `s1` and yielded state `s2`,
+we need to construct an inverse edit `e⁻¹` that yields state `s1` when applied to state `s2`.
+Computing `e⁻¹` requires the following information:
 
 -   The original change to be undone
--   Any document state that we wish to restore as part of the undo,
+-   Any document state that we wish to restore as part of the undo
     but cannot derive from the the original change.
 
 This last bullet point may not be immediately obvious,
 but it is a critical issue.
 We may need to recover information about the state of the document before the change that we wish to undo
-because changes can be destructive:
+because document changes can be destructive:
 
--   Setting the value on a node loses information about the prior value of that node.
--   Deleting a subtree loses information about the contents of that subtree.
+-   Setting the value on a node erases information about the prior value of that node.
+-   Deleting a subtree erases information about the contents of that subtree.
 
 Such data cannot be derived solely from the original changeset to be undone.
 We refer to the information that is needed in addition the original changeset as "repair data".
@@ -40,40 +44,49 @@ but that's not particularly relevant to our discussion.
 
 When a client successfully completes a local transaction,
 it updates the local document state to reflect the impact of the edit,
-and it send the edit to the service for sequencing.
+and it sends the edit to the service for sequencing.
 Under ideal circumstances, the next edit that the client receives from the service is that same edit that it had applied locally and sent for sequencing.
-If that's the case then the client does not need to update the document state.
-Due to concurrency, it's possible for an edit from a peer to be sequenced before the edit that was applied locally and sent out.
-When that happens, the local client needs to update the document state to reflect not only the impact of the edit from the peer,
+If that's the case, the client does not need to update the document state.
+It's possible for an edit from a peer to be sequenced before the edit that was applied locally and sent out.
+When that happens,
+the local client needs to update the document state to reflect not only the impact of the edit from the peer,
 but also the impact that the peer edit has on the local edit.
 
-For example, if a the local edit was deletion of two nodes A and B, with a constraint that both nodes must exist,
-and the peer change had deleted node A, then the net impact of the peer change is that node B ought to be revived.
+For example,
+if a the local edit was deletion of two nodes A and B,
+with a constraint that both nodes must exist,
+and the peer change had deleted node A,
+then the net impact of the peer change is that node B ought to be revived.
 
 ### User Undo
 
-See first section.
-Also, see the [undo design document](../undo/README.md).
+This is the more obvious use case:
+undoing destructive operation requires the corresponding repair data.
+See the [undo design document](../undo/README.md) for more details.
 
 ## Repair Data Stores
 
 Repair data is computed by each client as they apply changes to documents.
 For example, before deleting a subtree from the document,
 the client first takes note of the data in that subtree so that it can revive it later if need be.
+Until it is needed,
+or until it can be discarded,
+repair data is stored in a `RepairDataStore`.
 
-Each of the three context in which repair data may be needed maintains its own repair data store:
+Each of the three contexts in which repair data may be needed maintains its own repair data store:
 
 ### Rolling Back Local Transactions
 
 Each transaction uses a repair data store to keep track of the data destroyed during the transaction.
 This data is then pulled from the store when rolling back the transaction.
+Note: this may change soon.
 
 The repair data for transaction steps is discarded when the transaction is completed/aborted.
 
 ### Local Branch Updates
 
 The local state manager uses a repair data store to keep track of the data destroyed by edits that have been applied locally but have yet to be sequenced.
-This data is then pulled from the store when concurrent edits cause the local edits to be undone.
+This data is then pulled from the store when concurrent edits cause the local edits to be rolled back as part of rebasing.
 
 The repair data for the local changes is discarded when the local changes are sequenced or rolled back as part of rebasing.
 
@@ -87,10 +100,10 @@ The repair data for an individual edit in the trunk is discarded when the corres
 ## Characterizing Repair Data by Input Path
 
 In order to store repair data in a repair data store and be able to fetch it later,
-we need to establish a convention for unambiguously characterized what data is being stored or fetched.
+we need to establish a convention for unambiguously characterizing what data is being stored or fetched.
 
-The convention we have opted for is to characterize a deleted node
-(or a deleted value on a node)
+The convention we have opted for is to characterize each deleted node
+(or deleted value on a node)
 by the path of the node in the input context of
 (i.e., the state prior to)
 the change that deleted the node (or its value).
@@ -115,46 +128,114 @@ For example, document nodes that were inserted by an edit and deleted by the nex
 
 ### Fetching Repair Data Before Rebasing
 
-TODOOOOOO
+Inverse edits sometimes need to be rebased.
+When that happens, the marks in the rebased changeset can shift to a different location.
+If we were to query a repair data store based on the path of a changeset mark that has been shifted due to rebasing,
+we would end up querying the store with the wrong path,
+which could lead to no repair data being found,
+or the wrong repair data being found.
+
+We avoid this issue by querying the repair data store for repair data based on the original inverse change
+(i.e., before any rebasing).
+
+Another alternative would be to record the original path within the changeset mark for which we need to request repair data,
+and use that path instead of the mark's path.
+This would however make such changeset marks more computationally expensive.
+It is tempting to think that such an approach would help avoid querying the repair data store for changeset marks that will end up being cancelled out.
+This line of thinking however does not take into account the fact that we do not want to cancel out such marks.
+For example, if a local change that deletes a node gets rebased,
+the revival of the deleted node and its deletion by the rebased local edit may ultimately cancel out in the delta being sent out to update the application state,
+but the repair data store needs to be updated to reflect that it is the rebased edit
+that performed the edit
+(which may now be occurring at different index).
 
 ## Characterizing Repair Data by Tip-State Path
 
-TODOOOOOO
-You have to keep it updated as new edits come in.
+This section documents an alternative way to characterize repair data.
+As such, **this section does not reflect how the system works**.
 
-Representing the location of the repair data within the tip context requires a way to represent the position where the data would be if it were revived. In optional and value fields this would mean all the repair data ends up in the same "slot". In sequence fields the repair data would be represented as places with lineage in order to differentiate them. Looking up repair data for a sequence field would require having an efficient way to sift thought all those places. More generally speaking, this approach seems to require field-kind-specific code in order to characterize the repair data. It is plausible that whatever field-kind-specific code is needed to accomplish this is also the same code that is needed for anchor management, but that's not clear at this time. It may become clearer as we expand our anchor capabilities and make them field-kind specific.
+Instead of characterizing repair data by its path in the document in the input context of the edit that deleted it,
+one can characterize by it by its path in the document's current (i.e., "tip") state.
 
-## Extra Details
+This makes some intuitive sense when considering that:
+
+-   The tip state is the _lingua franca_ of the rebase process: concurrent changesets are constantly reframed in terms of the tip state in order to be applied.
+-   The tip state forms the input context that inverse changes
+    (for which repair data needs to be fetched)
+    are applied to.
+    See [Fetching Repair Data Before Rebasing](#fetching-repair-data-before-rebasing).
+
+This approach however comes with some drawbacks:
+
+-   The repair store data would need to be updated (effectively, rebased) in the face of changes to keep the repair data in sync with the tip state.
+-   Representing the location of the repair data within the tip context requires a way to represent the position where the data would be if it were revived.
+    In optional and value fields this would mean all the repair data ends up in the same "slot".
+    In sequence fields the repair data would be represented as places with lineage in order to differentiate them.
+    Looking up repair data for a sequence field would require having an efficient way to sift thought all those places.
+    More generally speaking, this approach seems to require field-kind-specific code in order to characterize the repair data.
+    It is plausible that whatever field-kind-specific code is needed to accomplish this is also the same code that is needed for anchor management, but that has yet to be confirmed.
+    This may become clearer as we expand our anchor capabilities and make them field-kind specific.
+
+## Additional Considerations
 
 ### Avoiding Step-by-Step Delta Application
 
-Decouple the computation of repair data from the computation of the delta (and its application).
+When a peer edit is received by a client
+the local state need to be updated to reflect that edit.
+When the client has local edits
+(i.e., edits that have been applied locally, but have yet to be sequenced)
+updating the local state involves a combination of undoing the local edits,
+applying the newly received peer edit,
+and applying the rebased version of the local edits.
+It is common for the rollback of the local edits to cancel out with the application of the rebased version of the local edits.
+This leads to a delta that is minimal
+(e.g., it doesn't involve inserting then deleting the same node).
+Applications tend to prefer such minimal updates as it reduces the amount of update work that they need to perform.
 
-### Late Repair Data Concretization
+Ensuring that we send minimal deltas to applications may seem at odds we the requirements outlined in
+[Computing Repair Data Per Individual Edit](#computing-repair-data-per-individual-edit).
+It need not be.
+We can decouple the computation of the repair data from the computation of the delta,
+the former being carried out per changeset and the later one per update.
 
-TODOOOOOO
+### Abstract Repair Data
+
+Repair data can exist in repair data stores, changesets, and deltas.
+Ultimately, repair data is consumed by the application when applying deltas.
+
+While we could encode repair data in the same concrete representation we use for inserted subtrees,
+doing so may force the application to translate the repair data from its own encoding into this concrete representation,
+only to translate it back into its own encoding when consuming the delta.
+It therefore seems preferable to allow the repair data encoding to be application specific by default,
+and only convert it to a concrete application-agnostic encoding when it needs to be sent over the wire
+(e.g., in summaries).
+This also allows for the repair data to be encoded as an opaque token that only the application code can match to document data.
+This opaque token encoding simplifies clarifies the contract around repair data:
+the token can be cheaply copied and it does not allow for the repair data to be read or mutated.
 
 ### Deleting Revived Data
 
-It's possible for an edit to revive some subtree and delete a part of that subtree.
-When that occurs, we need the repair data stored for that changeset to include the deleted portion of the revived tree.
+It's possible for an edit to revive some subtree and delete a part of that same subtree.
+When that occurs, it necessary for the repair data associated with that changeset to include the deleted portion of the revived tree.
 
 In such as scenario, we must be careful about how we characterize the repair data.
 A naive approach may lead to the same path used to characterize different repair data.
 
 For example, if a document contains a sequenced of Point subtrees,
-and an edit revives the a Point a the start of the sequence,
+and an edit revives the Point at the start of the sequence,
 then deletes the X node under the revived Point,
 while also deleting the X node under the first Point in the sequence,
-then both deleted nodes will have path "points[0].x".
+then the repair data for the deleted nodes may end up characterized as the same path ("points[0].x").
 
 A possible solution may be to characterize repair data by its path after all nodes have been revived,
 but before any nodes are inserted, deleted, or moved.
+It may also be possible to simply track paths to deleted revived content separately
+(e.g., using a boolean to indicate this special case).
 
 ### Computing Repair Data From Changes vs. Deltas
 
 The advantage of computing repair data based on deltas as opposed to changes,
-is that deltas are coupled to the details of `FieldKind` individual field kind implementations.
+is that deltas are not coupled to the details of `FieldKind` individual field kind implementations.
 
 In order to use deltas when computing repair data,
 we must ensure they preserve all the necessary information.
@@ -164,13 +245,24 @@ This can be achieved by following two rules:
    (see [Computing Repair Data Per Individual Edit](#computing-repair-data-per-individual-edit)).
 2. Do not apply deletions to revived subtrees as part of the change-to-delta conversion.
 
-Interestingly, #2 is not possible if we follow the
-[Late Repair Data Concretization](#late-repair-data-concretization)
-approach.
+Interestingly, #2 is not possible if we follow the [Abstract Repair Data](#abstract-repair-data) approach.
 
 ### Repair Data Flow
 
-TODOOOOOO
-From local to trunk: yes, upon sequencing of the local edits.
+While the [three contexts](#three-contexts) in which repair data exists operate independently,
+it is interesting to consider how repair data effectively flows between them:
 
-From transaction to local: actually no, because of granularity.
+-   Repair data from a successful transaction is dropped along with the transaction's repair data store
+    Equivalent repair data is added to the local branch's repair store.
+-   Repair data from a local edit that gets rebased is dropped from the local branch's repair store.
+    Repair data from the rebased version of that local edit is added to the local branch's repair store.
+-   Repair data from a local edits that is sequenced is dropped from the local branch's repair store.
+    Equivalent repair data is added to the trunk's repair store.
+-   Repair data from a sequenced edit is dropped from the trunk's repair store when that edit falls outside of the undo window.
+
+It is tempting to build efficient pathways for the repair data flow from one repair data store to the next without being fully re-computed:
+
+-   A more direct transition of the repair data from the transaction to the local branch is currently impractical because the repair data of the transaction is based on a sequence of atomic changes instead of the unified changeset that makes it to the local branch.
+    Future iterations of the transaction code may remove this barrier but may also remove the need for repair data in the transaction code altogether.
+-   The repair data that flows out and back into the local branch repair data store as local edits get rebased may be hard to optimize because the repair data of the rebased edit may be subtly different from that of the non-rebased one.
+-   A more direct transition fom the local branch store to the trunk store seems possible.

--- a/packages/dds/tree/docs/undo/README.md
+++ b/packages/dds/tree/docs/undo/README.md
@@ -6,11 +6,11 @@ It should be updated once more progress is made on the implementation.
 ## Undo Model and Semantics
 
 There are several different choices for what the semantics of undo could be.
-At the same time, there are several different undo-related workflows that consuming application may want to support.
+At the same time, there are several different undo-related workflows that consuming applications may want to support.
 Understanding those workflows and uncovering what undo semantics would best serve them is still a work in progress,
 but two key points have emerged in that space:
 
-1. Undo as a feature very important in that it is likely to be the only/primary way that end users access document history.
+1. Undo as a feature is very important in that it is likely to be the only/primary way that end users access document history.
 2. While we can offer advanced/powerful undo semantics,
    most applications are likely to adopt a workflow that
    is simple for users to grasp,

--- a/packages/dds/tree/docs/undo/README.md
+++ b/packages/dds/tree/docs/undo/README.md
@@ -1,6 +1,7 @@
 # Undo
 
 This document offers a high-level description of the undo system.
+It should be updated once more progress is made on the implementation.
 
 ## Abstract vs. Concrete Undo Messages
 
@@ -20,7 +21,7 @@ This choice is subject to many tradeoffs:
 -   Access to historical data (original change, [repair data](../repair-data/README.md), [interim changes](#interim-change))
     -   Pre-broadcast computation puts the burden of providing historical data on the issuing client.
     -   Post-broadcast computation puts the burden of providing historical data on all peers
-        (which means that data must be included in summaries).
+        (which means that this data must be included in summaries).
 -   Access to sequencing information for the undone edit
     -   Pre-broadcast computation may occur before the undone edit is sequenced.
     -   Post-broadcast computation will occur after the undone edit is sequenced.
@@ -46,16 +47,16 @@ For this data to be retained, it must first be obtained.
 This happens in two ways:
 
 -   When a peer joins a session, the relevant historical information is included in the summary.\*
--   As the peer receives a new edit from the sequencing service,
+-   When a peer receives a new edit from the sequencing service,
     it computes the corresponding repair data and stores it alongside the edit.
 
-\* Technically, the historical data needed for undo could loaded separately in an effort to reduce startup time.
+\* Technically, the historical data needed for undo could be loaded separately in an effort to reduce startup time.
 
 As older edits fall outside of the undo window, the edit information, including its repair data,
-are deleted from the peer.
+can be deleted from the peer's memory.
 
 When issuing an undo,
-a client will therefore proceed differently depending on whether the change to be undone lies outside of the undo window.
+a client will therefore proceed differently depending on whether the change to be undone lies within the undo window or not.
 
 ## Undo Edits Within The Undo Window
 
@@ -64,11 +65,9 @@ and that client has yet to receive the change to be undone back from the sequenc
 This can happen when a client wants to issue an undo very soon after issuing the change to be undone.
 It can also happen whenever a client has been offline for some period of time.
 
-```typescript
-{
-    originalChange: RevisionTag;
-}
-```
+Issuing an undo for a change that falls within the undo window can be done by sending an edit that indicates the `RevisionTag` of the edit to be undone.
+Such an undo edit is not a changeset.
+The receiving peers will construct a changeset based on it, and apply that changeset to their tip trunk state.
 
 Note that the issuer of an undo may attempt to undo a change that is within the undo window,
 send the adequate undo message,
@@ -83,17 +82,34 @@ or try again in the new context (i.e., undoing an edit outside the undo window).
 In a low-frequency (i.e. non-live) collaboration environment,
 the edit to be undone will commonly lie outside of the undo window.
 
-Two options:
+There are several approaches we could consider:
 
-1. Do the same as within the undo window but send along the relevant historical data.
-2. Compute the net change to the tip state and send that, as though it was a normal edit. (normal rebasing only on peer side)
-3. Compute the net change to the tip state and send that, but mark it as "to be postbased" so the peer can finish the postbasing if needed.
+1. Do the same when the edit to undo is within the undo window but send along the relevant historical data.
+2. Compute the net change to the tip state
+   (possibly by re-running commands)
+   and send that as a normal changeset.
+   Such a changeset would be rebased over any concurrent edits.
+3. Same as #2 but with instruction for the changeset to be handled differently
+   (e.g., by [postbasing](#postbase) it over concurrent edits instead of rebasing it).
 
 ## Partial Undo
 
-Include in the undo message a characterization of the region of the document to be affected by the undo.
-This is likely best characterized as a combination of input context regions and output context regions.
+Longer term, we may support a more localized undo that only reverts changes within a specific region of the document.
+This could be achieved by including in the undo message a characterization of the region of the document to be affected by the undo.
+This may need to be characterized as a combination of input context regions and output context regions.
 
 ## Glossary
 
 ### Interim Change
+
+A change that is sequenced after the change to be undone, but before the undo change.
+Interim changes may depend on the change being undone.
+
+### Postbase
+
+A variant of rebase.
+Postbasing change `a` over change `b`,
+where `a` applies to state `s` and produces state `sa`
+and `b` applies to state `s` and produces state `sb`,
+produces a change `a'` that applies to state `sb` and produces the state `sab`,
+which is the same state one would get by applying `rebase(b, a)` to `sa`.

--- a/packages/dds/tree/docs/undo/README.md
+++ b/packages/dds/tree/docs/undo/README.md
@@ -1,0 +1,36 @@
+# Undo
+
+This document offers a high-level description of the undo system.
+
+## Abstract Undo Messages
+
+Conceptually, an undo edit starts as a very abstract and succinct intention:
+"undo changes from prior change _\<revision-tag\>_".
+It ultimately needs to be converted into a more concrete and verbose description of what changes the undo entails
+(e.g., "delete the node at this path").
+This concrete form is the one that the application code (commonly the Forest code) is able to process.
+
+One key design question is:
+what form should the undo edit be in when it is sent by the issuing client to the sequencing service?
+We can think of this as asking which part of the concretization process we want to happen on the client that is issuing the undo,
+and which part we want to happen on every peer receiving the undo.
+
+This choice is subject to many asymmetries:
+
+-   Access to historical data
+    -   Computation that is done before sending puts the burden of providing repair data solely on the issuing client.
+    -   Computation that is done after receiving puts the burden of providing repair data on all peers.
+-   Access to sequencing information for the undone edit
+    -   ... before sending may occur before the undone edit is sequenced.
+    -   ... after receiving will occur after the undone edit is sequenced.
+-   Access to sequencing information for the undo edit
+    -   ... before sending may occur before the undo edit is sequenced.
+    -   ... after receiving will occur after the undo edit is sequenced.
+-   Computational load
+    -   ... before sending only consumes computational resources on the issuing client.
+    -   ... after receiving consumes computational resources on all peers.
+
+Additionally, the more abstract the undo message, the smaller it will tend to be,
+which reduces the network and service loads.
+
+We opt to make the undo message sent over the wire as abstract as possible.

--- a/packages/dds/tree/docs/undo/README.md
+++ b/packages/dds/tree/docs/undo/README.md
@@ -7,9 +7,9 @@ It should be updated once more progress is made on the implementation.
 
 Conceptually, an undo edit starts as a very abstract and succinct intention:
 "Undo changes from prior change _\<revision-tag\>_".
-It ultimately needs to be converted into a more concrete and verbose description of what changes the undo entails
+It ultimately needs to be converted into a concrete description of how the undo changes the current state of the document
 (e.g., "delete the node at this path").
-This concrete form is the one that the application code (commonly the Forest code) is able to process.
+The application (typically through Forest) is able to process this concrete form, represented as a delta.
 
 One key design question is:
 what form should the undo edit be in when it is sent by the issuing client to the sequencing service?
@@ -42,8 +42,11 @@ We accomplish that by introducing the concept of an "undo window".
 
 The undo window defines how far back, in terms of the edit history,
 peers are expected to retain information about past edits and their associated repair data.
+Applications can decide to support an undo window of arbitrary size.
+The longer the undo window, the more edits are undone using the post-broadcast approach.
+The shorter the undo window, the more edits are undone using the pre-broadcast approach.
 
-For this data to be retained, it must first be obtained.
+For the relevant data to be retained, it must first be obtained.
 This happens in two ways:
 
 -   When a peer joins a session, the relevant historical information is included in the summary.\*
@@ -95,6 +98,9 @@ There are several approaches we could consider:
 ## Partial Undo
 
 Longer term, we may support a more localized undo that only reverts changes within a specific region of the document.
+For example, a user may wish to undo all the changes they made to a specific region of the document even though the edit that included those changes also included changes to other regions of the document.
+Partial undo would allow such a user to only undo the changes within the region of interest.
+
 This could be achieved by including in the undo message a characterization of the region of the document to be affected by the undo.
 This may need to be characterized as a combination of input context regions and output context regions.
 

--- a/packages/dds/tree/docs/undo/README.md
+++ b/packages/dds/tree/docs/undo/README.md
@@ -17,7 +17,7 @@ and which part should happen on peers upon receiving the undo (i.e, post broadca
 
 This choice is subject to many tradeoffs:
 
--   Access to historical data (original change, [repair data](#repair-data), [interim changes](#interim-change))
+-   Access to historical data (original change, [repair data](../repair-data/README.md), [interim changes](#interim-change))
     -   Pre-broadcast computation puts the burden of providing historical data on the issuing client.
     -   Post-broadcast computation puts the burden of providing historical data on all peers
         (which means that data must be included in summaries).
@@ -86,7 +86,8 @@ the edit to be undone will commonly lie outside of the undo window.
 Two options:
 
 1. Do the same as within the undo window but send along the relevant historical data.
-2. Compute the net change to the tip state and send that, as though it was a normal edit.
+2. Compute the net change to the tip state and send that, as though it was a normal edit. (normal rebasing only on peer side)
+3. Compute the net change to the tip state and send that, but mark it as "to be postbased" so the peer can finish the postbasing if needed.
 
 ## Partial Undo
 
@@ -94,7 +95,5 @@ Include in the undo message a characterization of the region of the document to 
 This is likely best characterized as a combination of input context regions and output context regions.
 
 ## Glossary
-
-### Repair Data
 
 ### Interim Change

--- a/packages/dds/tree/docs/wip/inverse-changes/README.md
+++ b/packages/dds/tree/docs/wip/inverse-changes/README.md
@@ -93,18 +93,18 @@ At a high level, we need to have a system for accomplishing the following:
 1. Producing an inverse change for a given change that needs to be undone.
 2. Reconciling this inverse change with any edits that have occurred since the undone change.
 3. Updating the reconciled inverse in the face of concurrent changes.
-4. Applying the updating and reconciled inverse to the current document state.
+4. Applying the updated and reconciled inverse to the current document state.
 
 In designing such a system, we need to consider the relevant computational costs and drawbacks:
 
 -   Whether the semantics of undo are guaranteed
 -   Whether the issuer of the undo can be starved out by edits from peers
--   The size of "normal" (i.e., non-inverse) changes sent over the wire.
--   The size of inverse changes sent over the wire.
--   The size of the local data a client needs in order to issue an inverse change.
--   The size of the local data a peer needs in order to apply an inverse change.
--   The ability for a client to issue an inverse change without needing to make network requests.
--   The ability for peers to apply an inverse change without needing to make network requests.
+-   The size of "normal" (i.e., non-undo) changes sent over the wire.
+-   The size of undo changes sent over the wire.
+-   The size of the local data a client needs in order to issue an undo change.
+-   The size of the local data a peer needs in order to apply an undo change.
+-   The ability for a client to issue an undo change without needing to make network requests.
+-   The ability for peers to apply an undo change without needing to make network requests.
 
 We need to consider the above for different application profiles.
 Indeed some applications may not want to support undo at all,


### PR DESCRIPTION
Rough design documents for undo support and repair data management.

The aim of this PR is to establish enough of a plan so that:
* Interested parties can reason about it
* Implementation can begin/continue