### PR TITLE
Fixed propertyDDS array setValues performance.

### DIFF
--- a/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
@@ -404,26 +404,26 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
             }
         } else {
           if (_.isArray(in_values)) {
-            if (in_values.length < this._dataArrayGetLength()) {
-              this.removeRange(in_values.length, this._dataArrayGetLength() - in_values.length);
-            }
-            this.setRange(0, in_values.slice(0, this._dataArrayGetLength()));
-            if (in_values.length > this._dataArrayGetLength()) {
-              this.insertRange(this._dataArrayGetLength(), in_values.slice(this._dataArrayGetLength()));
-            }
-          } else {
-            var that = this;
-            var maxIndex = this._dataArrayGetLength() - 1;
-            _.each(in_values, function(value, index) {
-              if (index > maxIndex) {
-                that.insert(index, value);
-              } else {
-                if (that._dataArrayGetValue(index) !== value) {
-                  that.set(index, value);
-                }
+              if (in_values.length < this._dataArrayGetLength()) {
+                  this.removeRange(in_values.length, this._dataArrayGetLength() - in_values.length);
               }
-            });
-          }
+              this.setRange(0, in_values.slice(0, this._dataArrayGetLength()));
+              if (in_values.length > this._dataArrayGetLength()) {
+                  this.insertRange(this._dataArrayGetLength(), in_values.slice(this._dataArrayGetLength()));
+              }
+          } else {
+              var that = this;
+              var maxIndex = this._dataArrayGetLength() - 1;
+              _.each(in_values, function(value, index) {
+                  if (index > maxIndex) {
+                      that.insert(index, value);
+                  } else {
+                      if (that._dataArrayGetValue(index) !== value) {
+                          that.set(index, value);
+                      }
+                  }
+              });
+            }
         }
     }
 

--- a/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
+++ b/experimental/PropertyDDS/packages/property-properties/src/properties/arrayProperty.js
@@ -403,21 +403,27 @@ export class ArrayProperty extends AbstractStaticCollectionProperty {
                 AbstractStaticCollectionProperty.prototype.setValues.call(this, in_values);
             }
         } else {
-            if (_.isArray(in_values) && in_values.length < this._dataArrayGetLength()) {
-                this.removeRange(in_values.length, this._dataArrayGetLength() - in_values.length);
+          if (_.isArray(in_values)) {
+            if (in_values.length < this._dataArrayGetLength()) {
+              this.removeRange(in_values.length, this._dataArrayGetLength() - in_values.length);
             }
-
+            this.setRange(0, in_values.slice(0, this._dataArrayGetLength()));
+            if (in_values.length > this._dataArrayGetLength()) {
+              this.insertRange(this._dataArrayGetLength(), in_values.slice(this._dataArrayGetLength()));
+            }
+          } else {
             var that = this;
             var maxIndex = this._dataArrayGetLength() - 1;
             _.each(in_values, function(value, index) {
-                if (index > maxIndex) {
-                    that.insert(index, value);
-                } else {
-                    if (that._dataArrayGetValue(index) !== value) {
-                        that.set(index, value);
-                    }
+              if (index > maxIndex) {
+                that.insert(index, value);
+              } else {
+                if (that._dataArrayGetValue(index) !== value) {
+                  that.set(index, value);
                 }
+              }
             });
+          }
         }
     }
 


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The sections included below are suggestions for what you may want to include.
Feel free to remove or alter parts of this template that do not offer value for your specific change.

## Description

This improves the performance of the setValues operation, because we no logner update every entry in the array separately, but directly update the whole range.

## Breaking Changes

This change should not break anything.