### PR TITLE
Added missing export to property binder.

### DIFF
--- a/experimental/PropertyDDS/packages/property-binder/src/index.ts
+++ b/experimental/PropertyDDS/packages/property-binder/src/index.ts
@@ -16,6 +16,7 @@ import { SingletonDataBinding, StatelessDataBinding } from './data_binder/statel
 import { DataBinderHandle } from './internal/dataBinderHandle';
 import { PropertyElement } from './internal/propertyElement';
 import { UpgradeType } from './internal/semvermap';
+import { RemovalContext } from './data_binder/removalContext';
 
 import { IActivateDataBindingOptions } from './data_binder/IActivateDataBindingOptions';
 import {
@@ -42,6 +43,7 @@ export {
   representationDestroyer,
   representationGenerator,
   representationInitializer,
+  RemovalContext,
   forEachProperty,
   UpgradeType,
 };


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The sections included below are suggestions for what you may want to include.
Feel free to remove or alter parts of this template that do not offer value for your specific change.

## Description

This adds a missing export for the RemovalContext to propertyBinder.

## Breaking Changes

This should not break anything.
