### PR TITLE
GC: Tombstone for attachment blob

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -591,17 +591,13 @@ export class BlobManager {
             );
             const blobId = pathParts[2];
 
-            // GC tombstones these blobs
             if (tombstone) {
+                // If tombstone is set, add this blob to the tombstone list.
                 this.tombstonedBlobs.add(blobId);
-                continue;
-            }
-
-            // The unused blobId could be a localId. If so, remove it from the redirect table and continue. The
-            // corresponding storageId may still be used either directly or via other localIds.
-            if (this.redirectTable?.has(blobId)) {
+            } else {
+                // The unused blobId could be a localId. If so, remove it from the redirect table and continue. The
+                // corresponding storageId may still be used either directly or via other localIds.
                 this.redirectTable.delete(blobId);
-                continue;
             }
         }
     }

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -555,13 +555,32 @@ export class BlobManager {
     }
 
     /**
-     * This is called to update objects whose routes are unused. The unused objects are either deleted or marked as
+     * This is called to update blobs whose routes are used. The used blobs are removed from the tombstone list.
+     * @param usedRoutes - The routes of the blob nodes that are used.
+     */
+    public updateUsedRoutes(usedRoutes: string[]) {
+        // The routes or blob node paths are in the same format as returned in getGCData -
+        // `/<BlobManager.basePath>/<blobId>`.
+        for (const route of usedRoutes) {
+            const pathParts = route.split("/");
+            assert(
+                pathParts.length === 3 && pathParts[1] === BlobManager.basePath,
+                "Invalid blob node id in used routes.",
+            );
+            const blobId = pathParts[2];
+            // Un-tombstone the blob if it was marked tombstone.
+            this.tombstonedBlobs.delete(blobId);
+        }
+    }
+
+    /**
+     * This is called to update blobs whose routes are unused. The unused blobs are either deleted or marked as
      * tombstones.
      * @param unusedRoutes - The routes of the blob nodes that are unused.
      * @param tombstone - if true, the objects corresponding to unused routes are marked tombstones. Otherwise, they
      * are deleted.
      */
-     public updateUnusedRoutes(unusedRoutes: string[], tombstone: boolean): void {
+    public updateUnusedRoutes(unusedRoutes: string[], tombstone: boolean): void {
         // The routes or blob node paths are in the same format as returned in getGCData -
         // `/<BlobManager.basePath>/<blobId>`.
         for (const route of unusedRoutes) {

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -7,18 +7,24 @@ import { v4 as uuid } from "uuid";
 import { IFluidHandle, IFluidHandleContext } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { ICreateBlobResponse, ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
-import { generateHandleContextPath, SummaryTreeBuilder } from "@fluidframework/runtime-utils";
-import { ITelemetryLogger } from "@fluidframework/common-definitions";
+import {
+    createResponseError,
+    generateHandleContextPath,
+    responseToException,
+    SummaryTreeBuilder,
+} from "@fluidframework/runtime-utils";
 import { assert, bufferToString, Deferred, stringToBuffer, TypedEventEmitter } from "@fluidframework/common-utils";
 import { IContainerRuntime, IContainerRuntimeEvents } from "@fluidframework/container-runtime-definitions";
 import { AttachState } from "@fluidframework/container-definitions";
-import { ChildLogger, PerformanceEvent } from "@fluidframework/telemetry-utils";
+import { ChildLogger, loggerToMonitoringContext, MonitoringContext, PerformanceEvent } from "@fluidframework/telemetry-utils";
 import {
     IGarbageCollectionData,
     ISummaryTreeWithStats,
     ITelemetryContext,
 } from "@fluidframework/runtime-definitions";
 import { Throttler, formExponentialFn, IThrottler } from "./throttler";
+import { summarizerClientType } from "./summarizerClientElection";
+import { throwOnTombstoneUsageKey } from "./garbageCollectionConstants";
 
 /**
  * This class represents blob (long string)
@@ -83,7 +89,7 @@ export interface IBlobManagerLoadInfo {
 // Restrict the IContainerRuntime interface to the subset required by BlobManager.  This helps to make
 // the contract explicit and reduces the amount of mocking required for tests.
 export type IBlobManagerRuntime =
-    Pick<IContainerRuntime, "attachState" | "connected" | "logger"> & TypedEventEmitter<IContainerRuntimeEvents>;
+    Pick<IContainerRuntime, "attachState" | "connected" | "logger" | "clientDetails"> & TypedEventEmitter<IContainerRuntimeEvents>;
 
 // Note that while offline we "submit" an op before uploading the blob, but we always
 // expect blobs to be uploaded before we actually see the op round-trip
@@ -107,7 +113,7 @@ export interface IPendingBlobs { [id: string]: { blob: string; }; }
 export class BlobManager {
     public static readonly basePath = "_blobs";
     private static readonly redirectTableBlobName = ".redirectTable";
-    private readonly logger: ITelemetryLogger;
+    private readonly mc: MonitoringContext;
 
     /**
      * Map of local (offline/detached) IDs to storage IDs. Contains identity entries
@@ -137,6 +143,14 @@ export class BlobManager {
         formExponentialFn({ coefficient: 20, initialDelay: 0 }),
     ));
 
+    /** If true, throw an error when a tombstone attachment blob is retrieved. */
+    private readonly throwOnTombstoneUsage: boolean;
+    /**
+     * This stores ides of tombstoned blobs.
+     * Tombstone is a temporary feature that imitates a blob getting swept by garbage collection.
+     */
+    private readonly tombstonedBlobs: Set<string> = new Set();
+
     constructor(
         private readonly routeContext: IFluidHandleContext,
         snapshot: IBlobManagerLoadInfo,
@@ -158,7 +172,12 @@ export class BlobManager {
         private readonly runtime: IBlobManagerRuntime,
         stashedBlobs: IPendingBlobs = {},
     ) {
-        this.logger = ChildLogger.create(this.runtime.logger, "BlobManager");
+        this.mc = loggerToMonitoringContext(ChildLogger.create(this.runtime.logger, "BlobManager"));
+        // Read the feature flag that tells whether to throw when a tombstone blob is requested.
+        this.throwOnTombstoneUsage =
+            this.mc.config.getBoolean(throwOnTombstoneUsageKey) === true &&
+            this.runtime.clientDetails.type !== summarizerClientType;
+
         this.runtime.on("disconnected", () => this.onDisconnected());
         this.redirectTable = this.load(snapshot);
 
@@ -189,7 +208,7 @@ export class BlobManager {
     public async onConnected() {
         this.retryThrottler.cancel();
         const pendingUploads = this.pendingOfflineUploads.map(async (e) => e.uploadP);
-        await PerformanceEvent.timedExecAsync(this.logger, {
+        await PerformanceEvent.timedExecAsync(this.mc.logger, {
                 eventName: "BlobUploadOnConnected",
                 count: pendingUploads.length,
             }, async () => Promise.all(pendingUploads),
@@ -239,6 +258,18 @@ export class BlobManager {
     }
 
     public async getBlob(blobId: string): Promise<ArrayBufferLike> {
+        const request = { url: blobId };
+        if (this.tombstonedBlobs.has(blobId) ) {
+            const error = responseToException(createResponseError(404, "Blob removed by gc", request), request);
+            this.mc.logger.sendErrorEvent({
+                eventName: "GC_Tombstone_Blob_Requested",
+                url: request.url,
+            }, error);
+            if (this.throwOnTombstoneUsage) {
+                throw error;
+            }
+        }
+
         const pending = this.pendingBlobs.get(blobId);
         if (pending) {
             return pending.blob;
@@ -259,7 +290,7 @@ export class BlobManager {
         this.gcNodeUpdated(this.getBlobGCNodePath(blobId));
 
         return PerformanceEvent.timedExecAsync(
-            this.logger,
+            this.mc.logger,
             { eventName: "AttachmentReadBlob", id: storageId },
             async () => {
                 return this.getStorage().readBlob(storageId);
@@ -292,7 +323,7 @@ export class BlobManager {
         }
         if (this.runtime.attachState === AttachState.Attaching) {
             // blob upload is not supported in "Attaching" state
-            this.logger.sendTelemetryEvent({ eventName: "CreateBlobWhileAttaching" });
+            this.mc.logger.sendTelemetryEvent({ eventName: "CreateBlobWhileAttaching" });
             await new Promise<void>((resolve) => this.runtime.once("attached", resolve));
         }
         assert(this.runtime.attachState === AttachState.Attached,
@@ -314,7 +345,7 @@ export class BlobManager {
 
     private async uploadBlob(localId: string, blob: ArrayBufferLike): Promise<ICreateBlobResponse> {
         return PerformanceEvent.timedExecAsync(
-            this.logger,
+            this.mc.logger,
             { eventName: "createBlob" },
             async () => this.getStorage().createBlob(blob),
             { end: true, cancel: this.runtime.connected ? "error" : "generic" },
@@ -351,7 +382,7 @@ export class BlobManager {
             }
         } else {
             // connected to storage but not ordering service?
-            this.logger.sendTelemetryEvent({ eventName: "BlobUploadSuccessWhileDisconnected" });
+            this.mc.logger.sendTelemetryEvent({ eventName: "BlobUploadSuccessWhileDisconnected" });
             if (entry.status === PendingBlobStatus.OnlinePendingUpload) {
                 this.transitionToOffline(localId);
             }
@@ -477,7 +508,7 @@ export class BlobManager {
      * Load a set of previously attached blob IDs and redirect table from a previous snapshot.
      */
     private load(snapshot: IBlobManagerLoadInfo): Map<string, string | undefined> {
-        this.logger.sendTelemetryEvent({
+        this.mc.logger.sendTelemetryEvent({
             eventName: "AttachmentBlobsLoaded",
             count: snapshot.ids?.length ?? 0,
             redirectTable: snapshot.redirectTable?.length,
@@ -524,10 +555,13 @@ export class BlobManager {
     }
 
     /**
-     * When running GC in test mode, this is called to delete blobs that are unused.
-     * @param unusedRoutes - These are the blob node ids that are unused and should be deleted.
+     * This is called to update objects whose routes are unused. The unused objects are either deleted or marked as
+     * tombstones.
+     * @param unusedRoutes - The routes of the blob nodes that are unused.
+     * @param tombstone - if true, the objects corresponding to unused routes are marked tombstones. Otherwise, they
+     * are deleted.
      */
-    public deleteUnusedRoutes(unusedRoutes: string[]): void {
+     public updateUnusedRoutes(unusedRoutes: string[], tombstone: boolean): void {
         // The routes or blob node paths are in the same format as returned in getGCData -
         // `/<BlobManager.basePath>/<blobId>`.
         for (const route of unusedRoutes) {
@@ -537,6 +571,12 @@ export class BlobManager {
                 0x2d5 /* "Invalid blob node id in unused routes." */,
             );
             const blobId = pathParts[2];
+
+            // GC tombstones these blobs
+            if (tombstone) {
+                this.tombstonedBlobs.add(blobId);
+                continue;
+            }
 
             // The unused blobId could be a localId. If so, remove it from the redirect table and continue. The
             // corresponding storageId may still be used either directly or via other localIds.

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2277,14 +2277,18 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         // always referenced, so the used routes is only self-route (empty string).
         this.summarizerNode.updateUsedRoutes([""]);
 
+        const blobManagerUsedRoutes: string[] = [];
         const dataStoreUsedRoutes: string[] = [];
         for (const route of usedRoutes) {
-            if (route.split("/")[1] !== BlobManager.basePath) {
+            if (this.isBlobPath(route)) {
+                blobManagerUsedRoutes.push(route);
+            } else {
                 dataStoreUsedRoutes.push(route);
             }
         }
 
-        return this.dataStores.updateUsedRoutes(dataStoreUsedRoutes);
+        this.blobManager.updateUsedRoutes(blobManagerUsedRoutes);
+        this.dataStores.updateUsedRoutes(dataStoreUsedRoutes);
     }
 
     /**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2290,7 +2290,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     /**
      * This is called to update objects whose routes are unused. The unused objects are either deleted or marked as
      * tombstones.
-     * @param unusedRoutes - The routes that are unused in all data stores in this Container.
+     * @param unusedRoutes - The routes that are unused in all data stores and attachment blobs in this Container.
      * @param tombstone - if true, the objects corresponding to unused routes are marked tombstones. Otherwise, they
      * are deleted.
      */
@@ -2305,10 +2305,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             }
         }
 
-        // Todo: Add tombstone for attachment blobs. For now, we ignore attachment blobs that should be tombstoned.
-        if (!tombstone) {
-            this.blobManager.deleteUnusedRoutes(blobManagerUnusedRoutes);
-        }
+        this.blobManager.updateUnusedRoutes(blobManagerUnusedRoutes, tombstone);
         this.dataStores.updateUnusedRoutes(dataStoreUnusedRoutes, tombstone);
     }
 

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -11,7 +11,7 @@ import { AttachState } from "@fluidframework/container-definitions";
 import { IContainerRuntimeEvents } from "@fluidframework/container-runtime-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
-import { ISequencedDocumentMessage, SummaryType } from "@fluidframework/protocol-definitions";
+import { IClientDetails, ISequencedDocumentMessage, SummaryType } from "@fluidframework/protocol-definitions";
 import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 
 import { BlobManager, IBlobManagerLoadInfo, IBlobManagerRuntime } from "../blobManager";
@@ -43,6 +43,7 @@ class NonDedupeStorage extends BaseMockBlobStorage {
 }
 
 class MockRuntime extends TypedEventEmitter<IContainerRuntimeEvents> implements IBlobManagerRuntime {
+    public readonly clientDetails: IClientDetails = { capabilities: { interactive: true } };
     constructor(snapshot: IBlobManagerLoadInfo = {}, attached = false) {
         super();
         this.attachState = attached ? AttachState.Attached : AttachState.Detached;

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -5,18 +5,14 @@
 
 import { strict as assert } from "assert";
 import { bufferToString, stringToBuffer } from "@fluidframework/common-utils";
-import { IContainer } from "@fluidframework/container-definitions";
-import { Container, IDetachedBlobStorage } from "@fluidframework/container-loader";
 import {
     CompressionAlgorithms,
     ContainerMessageType,
-    ContainerRuntime,
     DefaultSummaryConfiguration,
 } from "@fluidframework/container-runtime";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ReferenceType } from "@fluidframework/merge-tree";
 import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
-import { ICreateBlobResponse } from "@fluidframework/protocol-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { SharedString } from "@fluidframework/sequence";
 import { ITestContainerConfig, ITestObjectProvider } from "@fluidframework/test-utils";
@@ -28,8 +24,7 @@ import {
     itExpects,
 } from "@fluidframework/test-version-utils";
 import { v4 as uuid } from "uuid";
-// eslint-disable-next-line import/no-internal-modules
-import { getGCStateFromSummary } from "./gc/gcTestSummaryUtils";
+import { getUrlFromItemId, MockDetachedBlobStorage } from "./mockDetachedBlobStorage";
 
 const testContainerConfig: ITestContainerConfig = {
     runtimeOptions: {
@@ -50,36 +45,6 @@ const testContainerConfig: ITestContainerConfig = {
     },
     registry: [["sharedString", SharedString.getFactory()]],
 };
-
-const ensureContainerConnectedWriteMode = async (container: Container) => {
-    const resolveIfActive = (res: () => void) => { if (container.deltaManager.active) { res(); } };
-    if (!container.deltaManager.active) {
-        await new Promise<void>((resolve) => container.on("connected", () => resolveIfActive(resolve)));
-        container.off("connected", resolveIfActive);
-    }
-};
-
-class MockDetachedBlobStorage implements IDetachedBlobStorage {
-    public readonly blobs = new Map<string, ArrayBufferLike>();
-
-    public get size() { return this.blobs.size; }
-
-    public getBlobIds(): string[] {
-        return Array.from(this.blobs.keys());
-    }
-
-    public async createBlob(content: ArrayBufferLike): Promise<ICreateBlobResponse> {
-        const id = this.size.toString();
-        this.blobs.set(id, content);
-        return { id };
-    }
-
-    public async readBlob(blobId: string): Promise<ArrayBufferLike> {
-        const blob = this.blobs.get(blobId);
-        assert(blob);
-        return blob;
-    }
-}
 
 const usageErrorMessage = "Empty file summary creation isn't supported in this driver.";
 
@@ -226,15 +191,6 @@ describeFullCompat("blobs", (getTestObjectProvider) => {
         await Promise.all([dataStore._runtime.uploadBlob(blob), dataStore._runtime.uploadBlob(blob)]);
     });
 });
-
-// TODO: #7684
-const getUrlFromItemId = (itemId: string, provider: ITestObjectProvider): string => {
-    assert(provider.driver.type === "odsp");
-    assert(itemId);
-    const url = (provider.driver as any).getUrlFromItemId(itemId);
-    assert(url && typeof url === "string");
-    return url;
-};
 
 // this functionality was added in 0.47 and can be added to the compat-enabled
 // tests above when the LTS version is bumped > 0.47
@@ -476,260 +432,5 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         const uploadP = Promise.all([dataStore1._runtime.uploadBlob(blob), dataStore2._runtime.uploadBlob(blob)]);
         provider.opProcessingController.resumeProcessing();
         await uploadP;
-    });
-});
-
-/**
- * Validates that unreferenced blobs are marked as unreferenced and deleted correctly.
- */
-describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
-    // If deleteUnreferencedContent is true, GC is run in test mode where content that is not referenced is
-    // deleted after each GC run.
-    const tests = (deleteUnreferencedContent: boolean = false) => {
-        const gcContainerConfig: ITestContainerConfig = {
-            runtimeOptions: {
-                gcOptions: {
-                    gcAllowed: true, runGCInTestMode: deleteUnreferencedContent,
-                },
-            },
-        };
-
-        let provider: ITestObjectProvider;
-        let container: IContainer;
-        let containerRuntime: ContainerRuntime;
-        let defaultDataStore: ITestDataObject;
-
-        /**
-         * Returns the referenced / unreferenced state of each node if the GC state in summary.
-         */
-        async function getUnreferencedNodeStates() {
-            await provider.ensureSynchronized();
-            const { summary } = await containerRuntime.summarize({
-                runGC: true,
-                fullTree: true,
-                trackState: false,
-            });
-
-            const gcState = getGCStateFromSummary(summary);
-            assert(gcState !== undefined, "GC tree is not available in the summary");
-
-            const nodeTimestamps: Map<string, "referenced" | "unreferenced"> = new Map();
-            for (const [nodePath, nodeData] of Object.entries(gcState.gcNodes)) {
-                // Unreferenced nodes have unreferenced timestamp associated with them.
-                nodeTimestamps.set(nodePath, nodeData.unreferencedTimestampMs ? "unreferenced" : "referenced");
-            }
-            return nodeTimestamps;
-        }
-
-        beforeEach(async function() {
-            provider = getTestObjectProvider();
-            if (provider.driver.type !== "odsp") {
-                this.skip();
-            }
-            const detachedBlobStorage = new MockDetachedBlobStorage();
-            const loader = provider.makeTestLoader({ ...gcContainerConfig, loaderProps: { detachedBlobStorage } });
-            container = await loader.createDetachedContainer(provider.defaultCodeDetails);
-            defaultDataStore = await requestFluidObject<ITestDataObject>(container, "/");
-            containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
-        });
-
-        it("collects blobs uploaded in attached container", async () => {
-            // Attach the container.
-            await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-
-            // Upload an attachment blob and mark it referenced by storing its handle in a DDS.
-            const blobContents = "Blob contents";
-            const blobHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
-            defaultDataStore._root.set("blob", blobHandle);
-
-            const s1 = await getUnreferencedNodeStates();
-            assert(s1.get(blobHandle.absolutePath) === "referenced", "blob should be referenced");
-
-            // Remove the blob's handle and verify its marked as unreferenced.
-            defaultDataStore._root.delete("blob");
-            const s2 = await getUnreferencedNodeStates();
-            assert(s2.get(blobHandle.absolutePath) === "unreferenced", "blob should be unreferenced");
-
-            // Add the blob's handle back. If deleteUnreferencedContent is true, the blob's node would have been
-            // deleted from the GC state. Else, it would be referenced.
-            defaultDataStore._root.set("blob", blobHandle);
-            const s3 = await getUnreferencedNodeStates();
-            if (deleteUnreferencedContent) {
-                assert(s3.get(blobHandle.absolutePath) === undefined, "blob should not have a GC entry");
-            } else {
-                assert(s3.get(blobHandle.absolutePath) === "referenced", "blob should be re-referenced");
-            }
-        });
-
-        it("collects blobs uploaded in detached container", async () => {
-            // Upload an attachment blob and mark it referenced by storing its handle in a DDS.
-            const blobContents = "Blob contents";
-            const blobHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
-            defaultDataStore._root.set("blob", blobHandle);
-
-            // Attach the container after the blob is uploaded.
-            await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-
-            // GC requires at least one op to have been processed. It needs a server timestamp and
-            // uses the timestamp of the op.
-            defaultDataStore._root.set("make container connect in", "write mode");
-
-            // Load a second container.
-            const url = getUrlFromItemId((container.resolvedUrl as IOdspResolvedUrl).itemId, provider);
-            const container2 = await provider.makeTestLoader(gcContainerConfig).resolve({ url });
-            const defaultDataStore2 = await requestFluidObject<ITestDataObject>(container2, "/");
-
-            // Validate the blob handle's path is the same as the one in the first container. This is to validate that
-            // we don't expose the storageId for the blob's uploaded in detached container.
-            const blobHandle2 = defaultDataStore2._root.get<IFluidHandle<ArrayBufferLike>>("blob");
-            assert.strictEqual(blobHandle.absolutePath, blobHandle2?.absolutePath,
-                    "The blob handle has a different path in remote container.");
-
-            const s1 = await getUnreferencedNodeStates();
-            assert(s1.get(blobHandle.absolutePath) === "referenced", "blob should be referenced");
-
-            // Remove the blob's handle and verify its marked as unreferenced.
-            defaultDataStore._root.delete("blob");
-            const s2 = await getUnreferencedNodeStates();
-            assert(s2.get(blobHandle.absolutePath) === "unreferenced", "blob should be unreferenced");
-
-            // Add the blob's handle in second container. If deleteUnreferencedContent is true, the blob's node would
-            // have been deleted from the GC state. Else, it would be referenced.
-            defaultDataStore2._root.set("blobContainer2", blobHandle2);
-            const s3 = await getUnreferencedNodeStates();
-            if (deleteUnreferencedContent) {
-                assert(s3.get(blobHandle.absolutePath) === undefined, "blob should not have a GC entry");
-            } else {
-                assert(s3.get(blobHandle.absolutePath) === "referenced", "blob should be re-referenced");
-            }
-        });
-
-        it("collects blobs uploaded in detached and de-duped in attached container", async () => {
-            // Upload an attachment blob. We should get a handle with a localId for the blob. Mark it referenced by
-            // storing its handle in a DDS.
-            const blobContents = "Blob contents";
-            const localHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
-            defaultDataStore._root.set("blob", localHandle);
-
-            // Attach the container after the blob is uploaded.
-            await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-
-            // GC requires at least one op to have been processed. It needs a server timestamp and
-            // uses the timestamp of the op.
-            defaultDataStore._root.set("make container connect in", "write mode");
-            // Make sure we are connected or we may get a local ID handle
-            await ensureContainerConnectedWriteMode(container as Container);
-
-            // Upload the same blob. This will get de-duped and we will get back a handle with the stoageId instead of
-            // the localId that we got when uploading in detached container.
-            const storageHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
-
-            // Validate that storing the localId handle makes both the localId and storageId nodes as referenced since
-            // localId is simply an alias to the storageId.
-            const s1 = await getUnreferencedNodeStates();
-            assert(s1.get(localHandle.absolutePath) === "referenced", "local id blob should be referenced");
-            assert(s1.get(storageHandle.absolutePath) === "referenced",
-                "storage id blob should also be referenced (1)");
-
-            // Replace the localId handle with the storageId handle. The storageId node should be referenced but the
-            // localId node should be unreferenced. Basically, the alias is deleted.
-            defaultDataStore._root.set("blob", storageHandle);
-            const s2 = await getUnreferencedNodeStates();
-            assert(s2.get(localHandle.absolutePath) === "unreferenced", "local id blob should still be unreferenced");
-            assert(s2.get(storageHandle.absolutePath) === "referenced",
-                "storage id blob should also be referenced (2)");
-
-            // Delete the storageId handle. The storageId node should be unreferenced. If deleteUnreferencedContent is
-            // true, the localId node should be deleted from the GC state. Else, it would be unreferenced.
-            defaultDataStore._root.delete("blob");
-            const s3 = await getUnreferencedNodeStates();
-            assert(s3.get(storageHandle.absolutePath) === "unreferenced", "storage id blob should be unreferenced");
-            if (deleteUnreferencedContent) {
-                assert(s3.get(localHandle.absolutePath) === undefined, "local id blob should not have a GC entry");
-            } else {
-                assert(s3.get(localHandle.absolutePath) === "unreferenced", "local id blob should be unreferenced");
-            }
-
-            // Add the localId handle back. If deleteUnreferencedContent is true, both the nodes would have been
-            // deleted from the GC state. Else, they would both be referenced.
-            defaultDataStore._root.set("blob", localHandle);
-            const s4 = await getUnreferencedNodeStates();
-            if (deleteUnreferencedContent) {
-                assert(s4.get(localHandle.absolutePath) === undefined, "local id blob should not have a GC entry");
-                assert(s4.get(storageHandle.absolutePath) === undefined, "storage id blob should not have a GC entry");
-            } else {
-                assert(s4.get(localHandle.absolutePath) === "referenced", "local id blob should be re-referenced");
-                assert(s4.get(storageHandle.absolutePath) === "referenced", "storage id blob should be re-referenced");
-            }
-        });
-
-        it("collects blobs uploaded and de-duped in detached container", async () => {
-            // Upload couple of attachment blobs with the same content. When these blobs are uploaded to the server,
-            // they will be de-duped and redirect to the same storageId.
-            const blobContents = "Blob contents";
-            const localHandle1 = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
-            const localHandle2 = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
-
-            // Attach the container after the blob is uploaded.
-            await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-
-            // GC requires at least one op to have been processed. It needs a server timestamp and
-            // uses the timestamp of the op.
-            defaultDataStore._root.set("make container connect in", "write mode");
-            // Make sure we are connected or we may get a local ID handle
-            await ensureContainerConnectedWriteMode(container as Container);
-
-            // Upload the same blob. This will get de-duped and we will get back a handle with the storageId instead of
-            // the localId that we got when uploading in detached container.
-            const storageHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
-
-            // Store the localId1 and localId2 handles. This would make the localId nodes and storageId node referenced.
-            defaultDataStore._root.set("local1", localHandle1);
-            defaultDataStore._root.set("local2", localHandle2);
-            const s1 = await getUnreferencedNodeStates();
-            assert(s1.get(localHandle1.absolutePath) === "referenced", "local id 1 blob should be referenced");
-            assert(s1.get(localHandle2.absolutePath) === "referenced", "local id 2 blob should be referenced");
-            assert(s1.get(storageHandle.absolutePath) === "referenced", "storage id blob should be referenced (1)");
-
-            // Delete the localId1 handle. This would make localId1 node unreferenced.
-            defaultDataStore._root.delete("local1");
-            const s2 = await getUnreferencedNodeStates();
-            assert(s2.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should be unreferenced");
-            assert(s2.get(localHandle2.absolutePath) === "referenced", "local id 2 blob should be referenced");
-            assert(s2.get(storageHandle.absolutePath) === "referenced", "storage id blob should be referenced (2)");
-
-            // Delete the localId2 handle. This would make the localId2 node referenced. If deleteUnreferencedContent
-            // is true, localId2 node would be deleted from GC state. Store the storageId handle to keep it referenced.
-            defaultDataStore._root.delete("local2");
-            defaultDataStore._root.set("storage", storageHandle);
-            const s3 = await getUnreferencedNodeStates();
-            assert(s3.get(localHandle2.absolutePath) === "unreferenced", "local id 2 blob should be unreferenced");
-            assert(s3.get(storageHandle.absolutePath) === "referenced", "storage id blob should be referenced (3)");
-            if (deleteUnreferencedContent) {
-                assert(s3.get(localHandle1.absolutePath) === undefined, "local id 1 blob should not have a GC entry");
-            } else {
-                assert(s3.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should be unreferenced");
-            }
-
-            // Delete the storageId handle. It should now be unreferenced.
-            defaultDataStore._root.delete("storage");
-            const s4 = await getUnreferencedNodeStates();
-            assert(s4.get(storageHandle.absolutePath) === "unreferenced", "storage id blob should be unreferenced");
-            if (deleteUnreferencedContent) {
-                assert(s4.get(localHandle1.absolutePath) === undefined, "local id blob 1 should not have a GC entry");
-                assert(s4.get(localHandle2.absolutePath) === undefined, "local id blob 2 should not have a GC entry");
-            } else {
-                assert(s4.get(localHandle1.absolutePath) === "unreferenced", "local id blob 1 should be unreferenced");
-                assert(s4.get(localHandle2.absolutePath) === "unreferenced", "local id blob 2 should be unreferenced");
-            }
-        });
-    };
-
-    describe("Verify data store state when unreferenced content is marked", () => {
-        tests();
-    });
-
-    describe("Verify data store state when unreferenced content is deleted", () => {
-        tests(true /* deleteUnreferencedContent */);
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
@@ -1,0 +1,280 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { stringToBuffer } from "@fluidframework/common-utils";
+import { IContainer } from "@fluidframework/container-definitions";
+import { Container } from "@fluidframework/container-loader";
+import { ContainerRuntime } from "@fluidframework/container-runtime";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { ITestContainerConfig, ITestObjectProvider } from "@fluidframework/test-utils";
+import { describeNoCompat, ITestDataObject } from "@fluidframework/test-version-utils";
+import { getUrlFromItemId, MockDetachedBlobStorage } from "../mockDetachedBlobStorage";
+import { getGCStateFromSummary } from "./gcTestSummaryUtils";
+
+const ensureContainerConnectedWriteMode = async (container: Container) => {
+    const resolveIfActive = (res: () => void) => { if (container.deltaManager.active) { res(); } };
+    if (!container.deltaManager.active) {
+        await new Promise<void>((resolve) => container.on("connected", () => resolveIfActive(resolve)));
+        container.off("connected", resolveIfActive);
+    }
+};
+
+/**
+ * Validates that unreferenced blobs are marked as unreferenced and deleted correctly.
+ */
+describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
+    // If deleteUnreferencedContent is true, GC is run in test mode where content that is not referenced is
+    // deleted after each GC run.
+    const tests = (deleteUnreferencedContent: boolean = false) => {
+        const gcContainerConfig: ITestContainerConfig = {
+            runtimeOptions: {
+                gcOptions: {
+                    gcAllowed: true, runGCInTestMode: deleteUnreferencedContent,
+                },
+            },
+        };
+
+        let provider: ITestObjectProvider;
+        let container: IContainer;
+        let containerRuntime: ContainerRuntime;
+        let defaultDataStore: ITestDataObject;
+
+        /**
+         * Returns the referenced / unreferenced state of each node if the GC state in summary.
+         */
+        async function getUnreferencedNodeStates() {
+            await provider.ensureSynchronized();
+            const { summary } = await containerRuntime.summarize({
+                runGC: true,
+                fullTree: true,
+                trackState: false,
+            });
+
+            const gcState = getGCStateFromSummary(summary);
+            assert(gcState !== undefined, "GC tree is not available in the summary");
+
+            const nodeTimestamps: Map<string, "referenced" | "unreferenced"> = new Map();
+            for (const [nodePath, nodeData] of Object.entries(gcState.gcNodes)) {
+                // Unreferenced nodes have unreferenced timestamp associated with them.
+                nodeTimestamps.set(nodePath, nodeData.unreferencedTimestampMs ? "unreferenced" : "referenced");
+            }
+            return nodeTimestamps;
+        }
+
+        beforeEach(async function() {
+            provider = getTestObjectProvider();
+            if (provider.driver.type !== "odsp") {
+                this.skip();
+            }
+            const detachedBlobStorage = new MockDetachedBlobStorage();
+            const loader = provider.makeTestLoader({ ...gcContainerConfig, loaderProps: { detachedBlobStorage } });
+            container = await loader.createDetachedContainer(provider.defaultCodeDetails);
+            defaultDataStore = await requestFluidObject<ITestDataObject>(container, "/");
+            containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
+        });
+
+        it("collects blobs uploaded in attached container", async () => {
+            // Attach the container.
+            await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+
+            // Upload an attachment blob and mark it referenced by storing its handle in a DDS.
+            const blobContents = "Blob contents";
+            const blobHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            defaultDataStore._root.set("blob", blobHandle);
+
+            const s1 = await getUnreferencedNodeStates();
+            assert(s1.get(blobHandle.absolutePath) === "referenced", "blob should be referenced");
+
+            // Remove the blob's handle and verify its marked as unreferenced.
+            defaultDataStore._root.delete("blob");
+            const s2 = await getUnreferencedNodeStates();
+            assert(s2.get(blobHandle.absolutePath) === "unreferenced", "blob should be unreferenced");
+
+            // Add the blob's handle back. If deleteUnreferencedContent is true, the blob's node would have been
+            // deleted from the GC state. Else, it would be referenced.
+            defaultDataStore._root.set("blob", blobHandle);
+            const s3 = await getUnreferencedNodeStates();
+            if (deleteUnreferencedContent) {
+                assert(s3.get(blobHandle.absolutePath) === undefined, "blob should not have a GC entry");
+            } else {
+                assert(s3.get(blobHandle.absolutePath) === "referenced", "blob should be re-referenced");
+            }
+        });
+
+        it("collects blobs uploaded in detached container", async () => {
+            // Upload an attachment blob and mark it referenced by storing its handle in a DDS.
+            const blobContents = "Blob contents";
+            const blobHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            defaultDataStore._root.set("blob", blobHandle);
+
+            // Attach the container after the blob is uploaded.
+            await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+
+            // GC requires at least one op to have been processed. It needs a server timestamp and
+            // uses the timestamp of the op.
+            defaultDataStore._root.set("make container connect in", "write mode");
+
+            // Load a second container.
+            const url = getUrlFromItemId((container.resolvedUrl as IOdspResolvedUrl).itemId, provider);
+            const container2 = await provider.makeTestLoader(gcContainerConfig).resolve({ url });
+            const defaultDataStore2 = await requestFluidObject<ITestDataObject>(container2, "/");
+
+            // Validate the blob handle's path is the same as the one in the first container. This is to validate that
+            // we don't expose the storageId for the blob's uploaded in detached container.
+            const blobHandle2 = defaultDataStore2._root.get<IFluidHandle<ArrayBufferLike>>("blob");
+            assert.strictEqual(blobHandle.absolutePath, blobHandle2?.absolutePath,
+                    "The blob handle has a different path in remote container.");
+
+            const s1 = await getUnreferencedNodeStates();
+            assert(s1.get(blobHandle.absolutePath) === "referenced", "blob should be referenced");
+
+            // Remove the blob's handle and verify its marked as unreferenced.
+            defaultDataStore._root.delete("blob");
+            const s2 = await getUnreferencedNodeStates();
+            assert(s2.get(blobHandle.absolutePath) === "unreferenced", "blob should be unreferenced");
+
+            // Add the blob's handle in second container. If deleteUnreferencedContent is true, the blob's node would
+            // have been deleted from the GC state. Else, it would be referenced.
+            defaultDataStore2._root.set("blobContainer2", blobHandle2);
+            const s3 = await getUnreferencedNodeStates();
+            if (deleteUnreferencedContent) {
+                assert(s3.get(blobHandle.absolutePath) === undefined, "blob should not have a GC entry");
+            } else {
+                assert(s3.get(blobHandle.absolutePath) === "referenced", "blob should be re-referenced");
+            }
+        });
+
+        it("collects blobs uploaded in detached and de-duped in attached container", async () => {
+            // Upload an attachment blob. We should get a handle with a localId for the blob. Mark it referenced by
+            // storing its handle in a DDS.
+            const blobContents = "Blob contents";
+            const localHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            defaultDataStore._root.set("blob", localHandle);
+
+            // Attach the container after the blob is uploaded.
+            await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+
+            // GC requires at least one op to have been processed. It needs a server timestamp and
+            // uses the timestamp of the op.
+            defaultDataStore._root.set("make container connect in", "write mode");
+            // Make sure we are connected or we may get a local ID handle
+            await ensureContainerConnectedWriteMode(container as Container);
+
+            // Upload the same blob. This will get de-duped and we will get back a handle with the stoageId instead of
+            // the localId that we got when uploading in detached container.
+            const storageHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+
+            // Validate that storing the localId handle makes both the localId and storageId nodes as referenced since
+            // localId is simply an alias to the storageId.
+            const s1 = await getUnreferencedNodeStates();
+            assert(s1.get(localHandle.absolutePath) === "referenced", "local id blob should be referenced");
+            assert(s1.get(storageHandle.absolutePath) === "referenced",
+                "storage id blob should also be referenced (1)");
+
+            // Replace the localId handle with the storageId handle. The storageId node should be referenced but the
+            // localId node should be unreferenced. Basically, the alias is deleted.
+            defaultDataStore._root.set("blob", storageHandle);
+            const s2 = await getUnreferencedNodeStates();
+            assert(s2.get(localHandle.absolutePath) === "unreferenced", "local id blob should still be unreferenced");
+            assert(s2.get(storageHandle.absolutePath) === "referenced",
+                "storage id blob should also be referenced (2)");
+
+            // Delete the storageId handle. The storageId node should be unreferenced. If deleteUnreferencedContent is
+            // true, the localId node should be deleted from the GC state. Else, it would be unreferenced.
+            defaultDataStore._root.delete("blob");
+            const s3 = await getUnreferencedNodeStates();
+            assert(s3.get(storageHandle.absolutePath) === "unreferenced", "storage id blob should be unreferenced");
+            if (deleteUnreferencedContent) {
+                assert(s3.get(localHandle.absolutePath) === undefined, "local id blob should not have a GC entry");
+            } else {
+                assert(s3.get(localHandle.absolutePath) === "unreferenced", "local id blob should be unreferenced");
+            }
+
+            // Add the localId handle back. If deleteUnreferencedContent is true, both the nodes would have been
+            // deleted from the GC state. Else, they would both be referenced.
+            defaultDataStore._root.set("blob", localHandle);
+            const s4 = await getUnreferencedNodeStates();
+            if (deleteUnreferencedContent) {
+                assert(s4.get(localHandle.absolutePath) === undefined, "local id blob should not have a GC entry");
+                assert(s4.get(storageHandle.absolutePath) === undefined, "storage id blob should not have a GC entry");
+            } else {
+                assert(s4.get(localHandle.absolutePath) === "referenced", "local id blob should be re-referenced");
+                assert(s4.get(storageHandle.absolutePath) === "referenced", "storage id blob should be re-referenced");
+            }
+        });
+
+        it("collects blobs uploaded and de-duped in detached container", async () => {
+            // Upload couple of attachment blobs with the same content. When these blobs are uploaded to the server,
+            // they will be de-duped and redirect to the same storageId.
+            const blobContents = "Blob contents";
+            const localHandle1 = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            const localHandle2 = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+
+            // Attach the container after the blob is uploaded.
+            await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+
+            // GC requires at least one op to have been processed. It needs a server timestamp and
+            // uses the timestamp of the op.
+            defaultDataStore._root.set("make container connect in", "write mode");
+            // Make sure we are connected or we may get a local ID handle
+            await ensureContainerConnectedWriteMode(container as Container);
+
+            // Upload the same blob. This will get de-duped and we will get back a handle with the storageId instead of
+            // the localId that we got when uploading in detached container.
+            const storageHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+
+            // Store the localId1 and localId2 handles. This would make the localId nodes and storageId node referenced.
+            defaultDataStore._root.set("local1", localHandle1);
+            defaultDataStore._root.set("local2", localHandle2);
+            const s1 = await getUnreferencedNodeStates();
+            assert(s1.get(localHandle1.absolutePath) === "referenced", "local id 1 blob should be referenced");
+            assert(s1.get(localHandle2.absolutePath) === "referenced", "local id 2 blob should be referenced");
+            assert(s1.get(storageHandle.absolutePath) === "referenced", "storage id blob should be referenced (1)");
+
+            // Delete the localId1 handle. This would make localId1 node unreferenced.
+            defaultDataStore._root.delete("local1");
+            const s2 = await getUnreferencedNodeStates();
+            assert(s2.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should be unreferenced");
+            assert(s2.get(localHandle2.absolutePath) === "referenced", "local id 2 blob should be referenced");
+            assert(s2.get(storageHandle.absolutePath) === "referenced", "storage id blob should be referenced (2)");
+
+            // Delete the localId2 handle. This would make the localId2 node referenced. If deleteUnreferencedContent
+            // is true, localId2 node would be deleted from GC state. Store the storageId handle to keep it referenced.
+            defaultDataStore._root.delete("local2");
+            defaultDataStore._root.set("storage", storageHandle);
+            const s3 = await getUnreferencedNodeStates();
+            assert(s3.get(localHandle2.absolutePath) === "unreferenced", "local id 2 blob should be unreferenced");
+            assert(s3.get(storageHandle.absolutePath) === "referenced", "storage id blob should be referenced (3)");
+            if (deleteUnreferencedContent) {
+                assert(s3.get(localHandle1.absolutePath) === undefined, "local id 1 blob should not have a GC entry");
+            } else {
+                assert(s3.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should be unreferenced");
+            }
+
+            // Delete the storageId handle. It should now be unreferenced.
+            defaultDataStore._root.delete("storage");
+            const s4 = await getUnreferencedNodeStates();
+            assert(s4.get(storageHandle.absolutePath) === "unreferenced", "storage id blob should be unreferenced");
+            if (deleteUnreferencedContent) {
+                assert(s4.get(localHandle1.absolutePath) === undefined, "local id blob 1 should not have a GC entry");
+                assert(s4.get(localHandle2.absolutePath) === undefined, "local id blob 2 should not have a GC entry");
+            } else {
+                assert(s4.get(localHandle1.absolutePath) === "unreferenced", "local id blob 1 should be unreferenced");
+                assert(s4.get(localHandle2.absolutePath) === "unreferenced", "local id blob 2 should be unreferenced");
+            }
+        });
+    };
+
+    describe("Verify data store state when unreferenced content is marked", () => {
+        tests();
+    });
+
+    describe("Verify data store state when unreferenced content is deleted", () => {
+        tests(true /* deleteUnreferencedContent */);
+    });
+});

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -1,0 +1,456 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { IGCRuntimeOptions, ISummarizer } from "@fluidframework/container-runtime";
+import {
+    requestFluidObject } from "@fluidframework/runtime-utils";
+import {
+    ITestObjectProvider,
+    createSummarizer,
+    summarizeNow,
+    waitForContainerConnection,
+    mockConfigProvider,
+    ITestContainerConfig,
+} from "@fluidframework/test-utils";
+import { describeNoCompat, ITestDataObject, itExpects } from "@fluidframework/test-version-utils";
+import { delay, stringToBuffer } from "@fluidframework/common-utils";
+import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
+import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
+import { getUrlFromItemId, MockDetachedBlobStorage } from "../mockDetachedBlobStorage";
+
+/**
+ * These tests validate that SweepReady attachment blobs are correctly marked as tombstones. Tombstones should be added
+ * to the summary and changing them (sending / receiving ops, loading, etc.) is not allowed.
+ */
+describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) => {
+    const sweepTimeoutMs = 200;
+    const settings = {};
+    const gcOptions: IGCRuntimeOptions = { inactiveTimeoutMs: 0 };
+    const testContainerConfig: ITestContainerConfig = {
+        runtimeOptions: {
+            summaryOptions: {
+                summaryConfigOverrides: {
+                    state: "disabled",
+                },
+            },
+            gcOptions,
+        },
+        loaderProps: { configProvider: mockConfigProvider(settings) },
+    };
+
+    let provider: ITestObjectProvider;
+    let mainContainer: IContainer;
+    let mainDataStore: ITestDataObject;
+
+    async function loadContainer(summaryVersion: string) {
+        return provider.loadTestContainer(
+            testContainerConfig,
+            { [LoaderHeader.version]: summaryVersion },
+        );
+    }
+
+    describe("Attachment blobs in attached container", () => {
+        let summarizer: ISummarizer;
+
+        beforeEach(async function() {
+            provider = getTestObjectProvider({ syncSummarizer: true });
+            if (provider.driver.type !== "local") {
+                this.skip();
+            }
+
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
+            settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
+        });
+
+        async function createMainContainerAndSummarizer() {
+            mainContainer = await provider.makeTestContainer(testContainerConfig);
+            mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
+
+            // Send an op to transition the container to write mode.
+            mainDataStore._root.set("transition to write", "true");
+            await waitForContainerConnection(mainContainer);
+
+            summarizer = await createSummarizer(
+                provider,
+                mainContainer,
+                undefined /* summaryVersion */,
+                gcOptions,
+                mockConfigProvider(settings),
+            );
+        }
+
+        itExpects("fails retrieval of tombstones attachment blobs",
+        [
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            },
+        ], async () => {
+            await createMainContainerAndSummarizer();
+
+            // Upload an attachment blob.
+            const blobContents = "Blob contents";
+            const blobHandle = await mainDataStore._runtime.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+
+            // Reference and then unreference the blob so that it's unreferenced in the next summary.
+            mainDataStore._root.set("blob1", blobHandle);
+            mainDataStore._root.delete("blob1");
+
+            // Summarize so that the above attachment blobs are marked unreferenced.
+            await provider.ensureSynchronized();
+            await summarizeNow(summarizer);
+
+            // Wait for sweep timeout so that the data stores are tombstoned.
+            await delay(sweepTimeoutMs + 10);
+
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize. The tombstoned data stores should now be part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+            const container2 = await loadContainer(summary2.summaryVersion);
+
+            // Retrieving the blob should fail. Note that the blob is requested via its url since this container does
+            // not have access to the blob's handle.
+            const response = await container2.request({ url: blobHandle.absolutePath });
+            assert.strictEqual(response?.status, 404, `Expecting a 404 response`);
+            assert(response.value.startsWith("Blob removed by gc:"), `Unexpected response value`);
+            assert(container2.closed !== true, "Container should not have closed");
+        });
+
+        itExpects("fails retrieval of de-duped attachment blobs that are tombstoned",
+        [
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            },
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            },
+        ], async () => {
+            await createMainContainerAndSummarizer();
+
+            // Upload an attachment blob.
+            const blobContents = "Blob contents";
+            const blobHandle1 = await mainDataStore._runtime.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+
+            // Upload another blob with the same content so that it is de-duped.
+            const blobHandle2 = await mainDataStore._runtime.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            assert.strictEqual(blobHandle1.absolutePath, blobHandle2.absolutePath, "Blobs are not de-duped");
+
+            // Reference and then unreference the blob via one of the handles so that it's unreferenced in next summary.
+            mainDataStore._root.set("blob1", blobHandle1);
+            mainDataStore._root.delete("blob1");
+
+            // Summarize so that the above attachment blobs are marked unreferenced.
+            await provider.ensureSynchronized();
+            await summarizeNow(summarizer);
+
+            // Wait for sweep timeout so that the data stores are tombstoned.
+            await delay(sweepTimeoutMs + 10);
+
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize. The tombstoned data stores should now be part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+            const container2 = await loadContainer(summary2.summaryVersion);
+
+            // Retrieving the blob via any of the handles should fail. Note that the blob is requested via its url since
+            // this container does not have access to the blob's handle.
+            const response1 = await container2.request({ url: blobHandle1.absolutePath });
+            assert.strictEqual(response1?.status, 404, `Expecting a 404 response for blob handle 1`);
+            assert(response1.value.startsWith("Blob removed by gc:"), `Unexpected response value for blob handle 1`);
+
+            const response2 = await container2.request({ url: blobHandle2.absolutePath });
+            assert.strictEqual(response2?.status, 404, `Expecting a 404 response for blob handle 2`);
+            assert(response2.value.startsWith("Blob removed by gc:"), `Unexpected response value for blob handle 2`);
+        });
+
+        itExpects("logs error on retrieval of tombstones attachment blobs when ThrowOnTombstoneUsage is not enabled",
+        [
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            },
+            {
+                error: "SweepReadyObject_Loaded",
+                eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
+            },
+        ],
+        async () => {
+            // Turn ThrowOnTombstoneUsage setting off.
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
+
+            await createMainContainerAndSummarizer();
+
+            // Upload an attachment blob.
+            const blobContents = "Blob contents";
+            const blobHandle = await mainDataStore._runtime.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+
+            // Reference and then unreference the blob so that it's unreferenced in the next summary.
+            mainDataStore._root.set("blob1", blobHandle);
+            mainDataStore._root.delete("blob1");
+
+            // Summarize so that the above attachment blobs are marked unreferenced.
+            await provider.ensureSynchronized();
+            await summarizeNow(summarizer);
+
+            // Wait for sweep timeout so that the data stores are tombstoned.
+            await delay(sweepTimeoutMs + 10);
+
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize. The tombstoned data stores should now be part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+            const container2 = await loadContainer(summary2.summaryVersion);
+
+            // Retrieving the blob should fail. Note that the blob is requested via its url since this container does
+            // not have access to the blob's handle.
+            const response = await container2.request({ url: blobHandle.absolutePath });
+            assert.strictEqual(response?.status, 200, `Expecting a 200 response`);
+            assert(container2.closed !== true, "Container should not have closed");
+        });
+    });
+
+    describe("Attachment blobs in detached container", () => {
+        beforeEach(async function() {
+            provider = getTestObjectProvider();
+            if (provider.driver.type !== "odsp") {
+                this.skip();
+            }
+
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
+            settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
+
+            const detachedBlobStorage = new MockDetachedBlobStorage();
+            const loader = provider.makeTestLoader({
+                ...testContainerConfig,
+                loaderProps: { ...testContainerConfig.loaderProps, detachedBlobStorage },
+            });
+            mainContainer = await loader.createDetachedContainer(provider.defaultCodeDetails);
+            mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "/");
+        });
+
+        itExpects("tombstones blobs uploaded in detached container",
+        [
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            },
+        ],
+        async () => {
+            // Upload an attachment blob and mark it referenced by storing its handle in a DDS.
+            const blobContents = "Blob contents";
+            const blobHandle = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            mainDataStore._root.set("blob", blobHandle);
+
+            // Attach the container after the blob is uploaded.
+            await mainContainer.attach(provider.driver.createCreateNewRequest(provider.documentId));
+
+            // Send an op to transition the container to write mode.
+            mainDataStore._root.set("transition to write", "true");
+            await waitForContainerConnection(mainContainer);
+
+            const summarizer = await createSummarizer(
+                provider,
+                mainContainer,
+                undefined /* summaryVersion */,
+                gcOptions,
+                mockConfigProvider(settings),
+            );
+
+            // Remove the blob's handle to unreference it.
+            mainDataStore._root.delete("blob");
+
+            // Summarize so that the above attachment blob is marked unreferenced.
+            await provider.ensureSynchronized();
+            await summarizeNow(summarizer);
+
+            // Wait for sweep timeout so that the blob is tombstoned.
+            await delay(sweepTimeoutMs + 10);
+
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize. The tombstoned blob should now be part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+
+            // Load a new container from the above summary which should have the blob tombstoned.
+            const url = getUrlFromItemId((mainContainer.resolvedUrl as IOdspResolvedUrl).itemId, provider);
+            const container2 = await provider.makeTestLoader(testContainerConfig).resolve({
+                url,
+                headers: { [LoaderHeader.version]: summary2.summaryVersion },
+            });
+
+            // Retrieving the blob should fail. Note that the blob is requested via its url since this container does
+            // not have access to the blob's handle.
+            const response = await container2.request({ url: blobHandle.absolutePath });
+            assert.strictEqual(response?.status, 404, `Expecting a 404 response`);
+            assert(response.value.startsWith("Blob removed by gc:"), `Unexpected response value`);
+            assert(container2.closed !== true, "Container should not have closed");
+        });
+
+        itExpects("tombstones blobs uploaded in detached and de-duped in attached container",
+        [
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            },
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            }
+        ],
+        async () => {
+            // Upload an attachment blob. We should get a handle with a localId for the blob. Mark it referenced by
+            // storing its handle in a DDS.
+            const blobContents = "Blob contents";
+            const localHandle = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            mainDataStore._root.set("localBlob", localHandle);
+
+            // Attach the container after the blob is uploaded.
+            await mainContainer.attach(provider.driver.createCreateNewRequest(provider.documentId));
+
+            // Send an op to transition the container to write mode.
+            mainDataStore._root.set("transition to write", "true");
+            await waitForContainerConnection(mainContainer);
+
+            const summarizer = await createSummarizer(
+                provider,
+                mainContainer,
+                undefined /* summaryVersion */,
+                gcOptions,
+                mockConfigProvider(settings),
+            );
+
+
+            // Upload the same blob. This will get de-duped and we will get back a handle with the storageId instead of
+            // the localId that we got when uploading in detached container.
+            const storageHandle = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            assert.notStrictEqual(
+                localHandle.absolutePath, storageHandle.absolutePath, "local and storage handles should be different");
+
+            // Remove the blob's handle to unreference it.
+            mainDataStore._root.delete("localBlob");
+
+            // Summarize so that the above attachment blob is marked unreferenced.
+            await provider.ensureSynchronized();
+            await summarizeNow(summarizer);
+
+            // Wait for sweep timeout so that the blob is tombstoned.
+            await delay(sweepTimeoutMs + 10);
+
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize. The tombstoned blob should now be part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+
+            // Load a new container from the above summary which should have the blob tombstoned.
+            const url = getUrlFromItemId((mainContainer.resolvedUrl as IOdspResolvedUrl).itemId, provider);
+            const container2 = await provider.makeTestLoader(testContainerConfig).resolve({
+                url,
+                headers: { [LoaderHeader.version]: summary2.summaryVersion },
+            });
+
+            // Retrieving the blob via any of the handles should fail. Note that the blob is requested via its url since
+            // this container does not have access to the blob's handle.
+            const localResponse = await container2.request({ url: localHandle.absolutePath });
+            assert.strictEqual(localResponse?.status, 404, `Expecting a 404 response for local handle`);
+            assert(localResponse.value.startsWith("Blob removed by gc:"), `Unexpected value for local handle 1`);
+
+            // Retrieving the blob via the storage handle should fail as well.
+            const storageResponse = await container2.request({ url: storageHandle.absolutePath });
+            assert.strictEqual(storageResponse?.status, 404, `Expecting a 404 response for storage handle`);
+            assert(storageResponse.value.startsWith("Blob removed by gc:"), `Unexpected value for local handle 2`);
+        });
+
+        itExpects("tombstones blobs uploaded and de-duped in detached container",
+        [
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            },
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            },
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            }
+        ],
+        async () => {
+            // Upload couple of attachment blobs with the same content. When these blobs are uploaded to the server,
+            // they will be de-duped and redirect to the same storageId.
+            const blobContents = "Blob contents";
+            const localHandle1 = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            const localHandle2 = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+
+            // Attach the container after the blob is uploaded.
+            await mainContainer.attach(provider.driver.createCreateNewRequest(provider.documentId));
+
+            // Send an op to transition the container to write mode.
+            mainDataStore._root.set("transition to write", "true");
+            await waitForContainerConnection(mainContainer);
+
+            const summarizer = await createSummarizer(
+                provider,
+                mainContainer,
+                undefined /* summaryVersion */,
+                gcOptions,
+                mockConfigProvider(settings),
+            );
+
+            // Add the blob's local handles to reference them.
+            mainDataStore._root.set("localBlob1", localHandle1);
+            mainDataStore._root.set("localBlob2", localHandle2);
+
+            // Upload the same blob. This will get de-duped and we will get back a handle with the storageId instead of
+            // the localId that we got when uploading in detached container.
+            const storageHandle = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            assert.notStrictEqual(
+                localHandle1.absolutePath, storageHandle.absolutePath, "local and storage handles should be different");
+
+            // Remove the blob's local handles to unreference them.
+            mainDataStore._root.delete("localBlob1");
+            mainDataStore._root.delete("localBlob2");
+
+            // Summarize so that the above attachment blobs are marked unreferenced.
+            await provider.ensureSynchronized();
+            await summarizeNow(summarizer);
+
+            // Wait for sweep timeout so that the blob is tombstoned.
+            await delay(sweepTimeoutMs + 10);
+
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize. The tombstoned blobs should now be part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+
+            // Load a new container from the above summary which should have the blobs tombstoned.
+            const url = getUrlFromItemId((mainContainer.resolvedUrl as IOdspResolvedUrl).itemId, provider);
+            const container2 = await provider.makeTestLoader(testContainerConfig).resolve({
+                url,
+                headers: { [LoaderHeader.version]: summary2.summaryVersion },
+            });
+
+            // Retrieving the blob via any of the handles should fail. Note that the blob is requested via its url since
+            // this container does not have access to the blob's handle.
+            const localResponse1 = await container2.request({ url: localHandle1.absolutePath });
+            assert.strictEqual(localResponse1?.status, 404, `Expecting a 404 response for local handle 1`);
+            assert(localResponse1.value.startsWith("Blob removed by gc:"), `Unexpected value for local handle 1`);
+
+            const localResponse2 = await container2.request({ url: localHandle2.absolutePath });
+            assert.strictEqual(localResponse2?.status, 404, `Expecting a 404 response for local handle 2`);
+            assert(localResponse2.value.startsWith("Blob removed by gc:"), `Unexpected value for local handle 2`);
+
+            const storageResponse = await container2.request({ url: storageHandle.absolutePath });
+            assert.strictEqual(storageResponse?.status, 404, `Expecting a 404 response for storage handle`);
+            assert(storageResponse.value.startsWith("Blob removed by gc:"), `Unexpected value for storage handle`);
+        });
+    });
+});

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -170,7 +170,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
             assert(response2.value.startsWith("Blob removed by gc:"), `Unexpected response value for blob handle 2`);
         });
 
-        itExpects.only("Can un-tombstone attachment blob by storing a handle",
+        itExpects("Can un-tombstone attachment blob by storing a handle",
         [
             {
                 eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -28,10 +28,10 @@ import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
 import { getGCStateFromSummary, getGCTombstoneStateFromSummary } from "./gcTestSummaryUtils";
 
 /**
- * These tests validate that SweepReady objects are correctly marked as tombstones. Tombstones should be added to the
- * summary and changing them (sending / receiving ops, loading, etc.) is not allowed.
+ * These tests validate that SweepReady data stores are correctly marked as tombstones. Tombstones should be added
+ * to the summary and changing them (sending / receiving ops, loading, etc.) is not allowed.
  */
-describeNoCompat("GC tombstone tests", (getTestObjectProvider) => {
+describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
     const remainingTimeUntilSweepMs = 100;
     const sweepTimeoutMs = 200;
     assert(remainingTimeUntilSweepMs < sweepTimeoutMs, "remainingTimeUntilSweepMs should be < sweepTimeoutMs");

--- a/packages/test/test-end-to-end-tests/src/test/mockDetachedBlobStorage.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mockDetachedBlobStorage.ts
@@ -1,0 +1,40 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { IDetachedBlobStorage } from "@fluidframework/container-loader";
+import { ICreateBlobResponse } from "@fluidframework/protocol-definitions";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
+
+export class MockDetachedBlobStorage implements IDetachedBlobStorage {
+    public readonly blobs = new Map<string, ArrayBufferLike>();
+
+    public get size() { return this.blobs.size; }
+
+    public getBlobIds(): string[] {
+        return Array.from(this.blobs.keys());
+    }
+
+    public async createBlob(content: ArrayBufferLike): Promise<ICreateBlobResponse> {
+        const id = this.size.toString();
+        this.blobs.set(id, content);
+        return { id };
+    }
+
+    public async readBlob(blobId: string): Promise<ArrayBufferLike> {
+        const blob = this.blobs.get(blobId);
+        assert(blob);
+        return blob;
+    }
+}
+
+// TODO: #7684
+export const getUrlFromItemId = (itemId: string, provider: ITestObjectProvider): string => {
+    assert(provider.driver.type === "odsp");
+    assert(itemId);
+    const url = (provider.driver as any).getUrlFromItemId(itemId);
+    assert(url && typeof url === "string");
+    return url;
+};


### PR DESCRIPTION
Added GC tombstone feature to attachment blobs. Attachment blobs that have been unreferenced for a sufficient amount of time (sweep timeout) become sweep ready, i.e., they can be deleted by GC. With tombstone, these blobs are not deleted but marked as tombstones. Tombstone blobs cannot be retrieved but they are still present and can be recovered.

Some key changes in this PR:
- BlobManager maintains a list of tombstone blobs. Whenever a blob becomes sweep ready, it is marked as tombstone.
- In BlobManager::getBlob(), if the blob retrieved is a tombstone, an error is thrown if throwOnTombstone setting is enabled.
- Moved GC attachment blob tests from `test/test-end-to-end-tests/blobs.spec.ts` to `test/test-end-to-end-tests/gc/gcAttachmentBlobs.spec.ts`.
- Added a bunch of attachement blob tombstone tests.

Note - This is created in favor of https://github.com/microsoft/FluidFramework/pull/12880.

[AB#2132](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2132)