### PR TITLE
Improve error information in snapshot tests

### DIFF
--- a/packages/test/snapshots/src/replayMultipleFiles.ts
+++ b/packages/test/snapshots/src/replayMultipleFiles.ts
@@ -377,7 +377,7 @@ async function processNode(
                 + `Check README.md for more details.`;
                 reject(new Error(`${JSON.stringify(workerData)}\n${message}\n\n${extra}`));
             } else {
-                reject(new Error(`${JSON.stringify(workerData)}\nmessage`));
+                reject(new Error(`${JSON.stringify(workerData)}\n${message}`));
             }
         });
 

--- a/packages/test/snapshots/src/replayWorker.ts
+++ b/packages/test/snapshots/src/replayWorker.ts
@@ -11,7 +11,8 @@ processOneNode(data)
     .then(() => threads.parentPort.postMessage("true"))
     .catch((error) => {
         if (typeof error === "object" && error !== null && (error as Error).message !== undefined) {
-            threads.parentPort.postMessage((error as Error).message);
+            const typedError = error as Error;
+            threads.parentPort.postMessage(`${typedError.message}\n${typedError.stack}`);
         } else {
             threads.parentPort.postMessage(`Error AAA processing ${data.folder}`);
         }

--- a/packages/test/snapshots/src/replayWorker.ts
+++ b/packages/test/snapshots/src/replayWorker.ts
@@ -11,8 +11,7 @@ processOneNode(data)
     .then(() => threads.parentPort.postMessage("true"))
     .catch((error) => {
         if (typeof error === "object" && error !== null && (error as Error).message !== undefined) {
-            const typedError = error as Error;
-            threads.parentPort.postMessage(`${typedError.stack}`);
+            threads.parentPort.postMessage((error as Error).stack);
         } else {
             threads.parentPort.postMessage(`Error AAA processing ${data.folder}`);
         }

--- a/packages/test/snapshots/src/replayWorker.ts
+++ b/packages/test/snapshots/src/replayWorker.ts
@@ -12,7 +12,7 @@ processOneNode(data)
     .catch((error) => {
         if (typeof error === "object" && error !== null && (error as Error).message !== undefined) {
             const typedError = error as Error;
-            threads.parentPort.postMessage(`${typedError.message}\n${typedError.stack}`);
+            threads.parentPort.postMessage(`${typedError.stack}`);
         } else {
             threads.parentPort.postMessage(`Error AAA processing ${data.folder}`);
         }

--- a/packages/test/snapshots/src/replayWorker.ts
+++ b/packages/test/snapshots/src/replayWorker.ts
@@ -10,8 +10,9 @@ const data = threads.workerData as IWorkerArgs;
 processOneNode(data)
     .then(() => threads.parentPort.postMessage("true"))
     .catch((error) => {
-        if (typeof error === "object" && error !== null && (error as Error).message !== undefined) {
-            threads.parentPort.postMessage((error as Error).stack);
+        const typedError = (error as Error);
+        if (typeof error === "object" && error !== null && typedError.message !== undefined) {
+            threads.parentPort.postMessage(typedError.stack ?? typedError.message);
         } else {
             threads.parentPort.postMessage(`Error AAA processing ${data.folder}`);
         }


### PR DESCRIPTION
## Description

- Fix error message (interpolate `${message}` instead of a hardcoded string value of `message`).
- Include stack trace (which already has the error message) in error propagated to parent process for ease of troubleshooting.

## Reviewer Guidance

Example of the error I saw in console before this change:

```console
$ npx mocha --experimental-worker dist/test --exit -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict 

  Snapshots
Unhandled Error processing 
 {"folder":"content/snapshotTestContent/DeletedTables_0.43","mode":1,"snapFreq":50}
 TypeError: Cannot read property 'summarize' of undefined
    1) Stress Test


  0 passing (323ms)
  1 failing

  1) Snapshots
       Stress Test:
     Uncaught Error: {"folder":"content/snapshotTestContent/DeletedTables_0.43","mode":1,"snapFreq":50}
Cannot read property 'summarize' of undefined
      at Worker.<anonymous> (dist/replayMultipleFiles.js:343:24)
      at MessagePort.<anonymous> (internal/worker.js:236:53)
      at MessagePort.[nodejs.internal.kHybridDispatch] (internal/event_target.js:399:24)
      at MessagePort.exports.emitMessage (internal/per_context/messageport.js:18:26)
```

And after (now I know the real place where the error was thrown, the `uploadSummary` function):

```console
$ npx mocha --experimental-worker dist/test --exit -r node_modules/@fluidframework/mocha-test-setup --unhandled-rejections=strict 

  Snapshots
Unhandled Error processing 
 {"folder":"content/snapshotTestContent/Headings","mode":1,"snapFreq":50}
 TypeError: Cannot read property 'summarize' of undefined
    1) Stress Test


  0 passing (321ms)
  1 failing

  1) Snapshots
       Stress Test:
     Uncaught {"folder":"content/snapshotTestContent/Headings","mode":1,"snapFreq":50}
TypeError: Cannot read property 'summarize' of undefined
    at uploadSummary (/workspaces/FluidFramework/packages/tools/replay-tool/dist/helpers.js:136:41)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async Document.summarize (/workspaces/FluidFramework/packages/tools/replay-tool/dist/replayMessages.js:179:9)
    at async ReplayTool.generateMainSummary (/workspaces/FluidFramework/packages/tools/replay-tool/dist/replayMessages.js:470:9)
    at async ReplayTool.generateSummary (/workspaces/FluidFramework/packages/tools/replay-tool/dist/replayMessages.js:536:25)
    at async ReplayTool.mainCycle (/workspaces/FluidFramework/packages/tools/replay-tool/dist/replayMessages.js:443:13)
    at async ReplayTool.Go (/workspaces/FluidFramework/packages/tools/replay-tool/dist/replayMessages.js:218:9)
    at async processOneNode (/workspaces/FluidFramework/packages/test/snapshots/dist/replayMultipleFiles.js:144:24)
  Error: {"folder":"content/snapshotTestContent/Headings","mode":1,"snapFreq":50}
  TypeError: Cannot read property 'summarize' of undefined
      at uploadSummary (/workspaces/FluidFramework/packages/tools/replay-tool/dist/helpers.js:136:41)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
      at async Document.summarize (/workspaces/FluidFramework/packages/tools/replay-tool/dist/replayMessages.js:179:9)
      at async ReplayTool.generateMainSummary (/workspaces/FluidFramework/packages/tools/replay-tool/dist/replayMessages.js:470:9)
      at async ReplayTool.generateSummary (/workspaces/FluidFramework/packages/tools/replay-tool/dist/replayMessages.js:536:25)
      at async ReplayTool.mainCycle (/workspaces/FluidFramework/packages/tools/replay-tool/dist/replayMessages.js:443:13)
      at async ReplayTool.Go (/workspaces/FluidFramework/packages/tools/replay-tool/dist/replayMessages.js:218:9)
      at async processOneNode (dist/replayMultipleFiles.js:144:24)
      at Worker.<anonymous> (dist/replayMultipleFiles.js:343:24)
      at MessagePort.<anonymous> (internal/worker.js:236:53)
      at MessagePort.[nodejs.internal.kHybridDispatch] (internal/event_target.js:399:24)
      at MessagePort.exports.emitMessage (internal/per_context/messageport.js:18:26)
```

Not sure exactly why the error gets printed twice, I suspect `mocha` doing something weird as it prints errors. Because if I revert the `message->${message}` fix, I see the "message" string only printed once:

```console
  0 passing (466ms)
  1 failing

  1) Snapshots
       loads snapshots in old format:
     Uncaught Error: {"folder":"content/snapshotTestContent/Authoring-MVP3","mode":2,"snapFreq":1000,"initializeFromSnapshotsDir":"content/snapshotTestContent/Authoring-MVP3/src_snapshots/0.36.0"}
message
      at Worker.<anonymous> (dist/replayMultipleFiles.js:343:24)
      at MessagePort.<anonymous> (internal/worker.js:236:53)
      at MessagePort.[nodejs.internal.kHybridDispatch] (internal/event_target.js:399:24)
      at MessagePort.exports.emitMessage (internal/per_context/messageport.js:18:26)
```

By manually changing the test code to not do parallelism with child workers one can figure out the actual stack trace of the error, but it seems better to expose it regardless of whether the tests are being run with concurrency or not.

