### PR TITLE
Tree: expose `getPrimaryField` and refactor EditableTree implementation & tests

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -416,6 +416,12 @@ export interface GenericTreeNode<TChild> extends GenericFieldsNode<TChild>, Node
 export const getField: unique symbol;
 
 // @public
+export function getPrimaryField(schema: TreeSchema): {
+    key: LocalFieldKey;
+    schema: FieldSchema;
+} | undefined;
+
+// @public
 export type GlobalFieldKey = Brand<string, "tree.GlobalFieldKey">;
 
 // @public

--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -236,6 +236,7 @@ export interface EditableTreeContext {
     free(): void;
     prepareForEdit(): void;
     readonly root: EditableField;
+    readonly schema: SchemaDataAndPolicy;
     readonly unwrappedRoot: UnwrappedEditableField;
 }
 

--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -416,7 +416,7 @@ export interface GenericTreeNode<TChild> extends GenericFieldsNode<TChild>, Node
 // @public
 export const getField: unique symbol;
 
-// @public
+// @public (undocumented)
 export function getPrimaryField(schema: TreeSchema): {
     key: LocalFieldKey;
     schema: FieldSchema;

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
@@ -361,7 +361,7 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
     }
 
     get type(): TreeSchema {
-        return lookupTreeSchema(this.context.forest.schema, this.typeName);
+        return lookupTreeSchema(this.context.schema, this.typeName);
     }
 
     get value(): Value {
@@ -385,7 +385,7 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
     }
 
     public getFieldSchema(field: FieldKey): FieldSchema {
-        return getFieldSchema(field, this.context.forest.schema, this.type);
+        return getFieldSchema(field, this.context.schema, this.type);
     }
 
     public getFieldKeys(): FieldKey[] {

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
@@ -23,6 +23,7 @@ import {
     Delta,
     Dependent,
     afterChangeToken,
+    SchemaDataAndPolicy,
 } from "../../core";
 import { DefaultChangeset, DefaultEditBuilder } from "../defaultChangeFamily";
 import { runSynchronousTransaction } from "../defaultTransaction";
@@ -53,6 +54,14 @@ export interface EditableTreeContext {
      * See ${@link UnwrappedEditableField} for what is unwrapped.
      */
     readonly unwrappedRoot: UnwrappedEditableField;
+
+    /**
+     * Schema used within this context.
+     * All data must conform to these schema.
+     *
+     * The root's schema is tracked under {@link rootFieldKey}.
+     */
+    readonly schema: SchemaDataAndPolicy;
 
     /**
      * Call before editing.
@@ -152,12 +161,16 @@ export class ProxyContext implements EditableTreeContext {
     private getRoot(unwrap: false): EditableField;
     private getRoot(unwrap: true): UnwrappedEditableField;
     private getRoot(unwrap: boolean): UnwrappedEditableField | EditableField {
-        const rootSchema = lookupGlobalFieldSchema(this.forest.schema, rootFieldKey);
+        const rootSchema = lookupGlobalFieldSchema(this.schema, rootFieldKey);
         const cursor = this.forest.allocateCursor();
         moveToDetachedField(this.forest, cursor);
         const proxifiedField = proxifyField(this, rootSchema, cursor, unwrap);
         cursor.free();
         return proxifiedField;
+    }
+
+    public get schema(): SchemaDataAndPolicy {
+        return this.forest.schema;
     }
 
     public attachAfterChangeHandler(

--- a/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
@@ -22,4 +22,4 @@ export {
 
 export { EditableTreeContext, getEditableTreeContext } from "./editableTreeContext";
 
-export { PrimitiveValue, isPrimitiveValue, isPrimitive } from "./utilities";
+export { PrimitiveValue, isPrimitiveValue, isPrimitive, getPrimaryField } from "./utilities";

--- a/packages/dds/tree/src/feature-libraries/editable-tree/utilities.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/utilities.ts
@@ -65,6 +65,11 @@ export function assertPrimitiveValueType(nodeValue: Value, schema: TreeSchema): 
     }
 }
 
+/**
+ * Returns the key and the schema of the primary field out of the given tree schema.
+ *
+ * See note on {@link EmptyKey} for what is a primary field.
+ */
 export function getPrimaryField(
     schema: TreeSchema,
 ): { key: LocalFieldKey; schema: FieldSchema } | undefined {

--- a/packages/dds/tree/src/feature-libraries/editable-tree/utilities.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/utilities.ts
@@ -66,7 +66,7 @@ export function assertPrimitiveValueType(nodeValue: Value, schema: TreeSchema): 
 }
 
 /**
- * Returns the key and the schema of the primary field out of the given tree schema.
+ * @returns the key and the schema of the primary field out of the given tree schema.
  *
  * See note on {@link EmptyKey} for what is a primary field.
  */

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -24,6 +24,7 @@ export {
     isEditableField,
     isPrimitive,
     isPrimitiveValue,
+    getPrimaryField,
     isUnwrappedNode,
     PrimitiveValue,
     proxyTargetSymbol,

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -146,6 +146,7 @@ export {
     EditableField,
     isPrimitiveValue,
     isPrimitive,
+    getPrimaryField,
     typeSymbol,
     typeNameSymbol,
     valueSymbol,

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
@@ -32,14 +32,7 @@ import {
     valueSymbol,
 } from "../../../feature-libraries";
 import { ITestTreeProvider, TestTreeProvider } from "../../utils";
-import {
-    ComplexPhoneType,
-    fullSchemaData,
-    personData,
-    PersonType,
-    schemaMap,
-    stringSchema,
-} from "./mockData";
+import { fullSchemaData, personData, Person, schemaMap, stringSchema } from "./mockData";
 
 const globalFieldKey: GlobalFieldKey = brand("foo");
 const globalFieldSymbol = symbolFromKey(globalFieldKey);
@@ -90,21 +83,22 @@ const testCases: (readonly [string, FieldKey])[] = [
 describe("editable-tree: editing", () => {
     it("assert set primitive value using assignment", async () => {
         const [, trees] = await createSharedTrees(fullSchemaData, [personData]);
-        const person = trees[0].root as PersonType;
+        const person = trees[0].root as Person;
         const nameNode = person[getField](brand("name")).getNode(0);
         const ageNode = person[getField](brand("age")).getNode(0);
-        const phonesField = person.address.phones;
-        assert(isEditableField(phonesField));
 
         assert.throws(
-            () => (person.friends[valueSymbol] = { kate: "kate" }),
+            () => {
+                assert(person.friends !== undefined);
+                person.friends[valueSymbol] = { kate: "kate" };
+            },
             (e) => validateAssertionError(e, "The value is not primitive"),
             "Expected exception was not thrown",
         );
         assert.throws(
             () => {
-                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-                phonesField[2] = {} as ComplexPhoneType;
+                assert(person.address !== undefined);
+                person.address[valueSymbol] = 123;
             },
             (e) => validateAssertionError(e, "Cannot set a value of a non-primitive field"),
             "Expected exception was not thrown",

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -336,7 +336,7 @@ describe("editable-tree: read-only", () => {
         assert.equal(EmptyKey in personProxy, false);
         assert.equal("child" in personProxy, false);
         assert(personProxy.address !== undefined);
-        assert.equal("zip" in personProxy.address, false);
+        assert.equal("city" in personProxy.address, false);
         // Value does not show up when empty:
         assert.equal(valueSymbol in personProxy, false);
 
@@ -606,15 +606,16 @@ describe("editable-tree: read-only", () => {
         const cloned = clone(proxy.friends);
         assert.deepEqual(cloned, { Mat: "Mat" });
         assert(proxy.address !== undefined);
-        assert.deepEqual(Object.keys(proxy.address), ["street", "phones", "sequencePhones"]);
+        assert.deepEqual(Object.keys(proxy.address), ["zip", "street", "phones", "sequencePhones"]);
         assert.equal(proxy.address.street, "treeStreet");
-        assert.equal(proxy.address.zip, undefined);
+        assert.equal(proxy.address.city, undefined);
     });
 
     it("read upwards", () => {
         const [, proxy] = buildTestPerson();
         assert(proxy.address !== undefined);
-        assert.deepEqual(Object.keys(proxy.address), ["street", "phones", "sequencePhones"]);
+        assert.deepEqual(Object.keys(proxy.address), ["zip", "street", "phones", "sequencePhones"]);
+        assert.equal(proxy.address.city, undefined);
         assert.equal(proxy.address.street, "treeStreet");
         assert.equal(proxy.name, "Adam");
     });

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTreeContext.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTreeContext.spec.ts
@@ -9,9 +9,12 @@ import { createField, isUnwrappedNode, singleTextCursor } from "../../../feature
 import { ISharedTree } from "../../../shared-tree";
 import { brand } from "../../../util";
 import { ITestTreeProvider, TestTreeProvider } from "../../utils";
-// eslint-disable-next-line import/no-internal-modules
+
+// Allow importing from this specific file which is being tested:
+/* eslint-disable-next-line import/no-internal-modules */
 import { ProxyContext } from "../../../feature-libraries/editable-tree/editableTreeContext";
-import { fullSchemaData, int32Schema, personData, PersonType } from "./mockData";
+
+import { fullSchemaData, int32Schema, personData, Person } from "./mockData";
 
 async function createSharedTrees(
     schemaData: SchemaData,
@@ -31,8 +34,8 @@ async function createSharedTrees(
 describe("editable-tree context", () => {
     it("can't synchronize trees after the context been freed", async () => {
         const [provider, [tree1, tree2]] = await createSharedTrees(fullSchemaData, [personData], 2);
-        const person1 = tree1.root as PersonType;
-        const person2 = tree2.root as PersonType;
+        const person1 = tree1.root as Person;
+        const person2 = tree2.root as Person;
         tree2.context.free();
 
         assert.equal(person1.age, 35);
@@ -46,12 +49,12 @@ describe("editable-tree context", () => {
     it("can clear and reuse context", async () => {
         const [provider, [tree1, tree2]] = await createSharedTrees(fullSchemaData, [personData], 2);
         const context2 = tree2.context;
-        const person1 = tree1.root as PersonType;
+        const person1 = tree1.root as Person;
 
-        let person2 = tree2.root as PersonType;
+        let person2 = tree2.root as Person;
         context2.attachAfterChangeHandler((context) => {
             context.clear();
-            person2 = context.unwrappedRoot as PersonType;
+            person2 = context.unwrappedRoot as Person;
         });
 
         // reify EditableTrees

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/mockData.ts
@@ -240,6 +240,7 @@ export const personData: JsonableTree = {
         address: [
             {
                 fields: {
+                    zip: [{ value: "99999", type: stringSchema.name }],
                     street: [{ value: "treeStreet", type: stringSchema.name }],
                     phones: [
                         {
@@ -275,8 +276,8 @@ export const personData: JsonableTree = {
                 },
                 globalFields: {
                     [globalFieldKeySequencePhones]: [
-                        { type: stringSchema.name, value: "113" },
-                        { type: stringSchema.name, value: "114" },
+                        { type: stringSchema.name, value: "115" },
+                        { type: stringSchema.name, value: "116" },
                     ],
                 },
                 type: addressSchema.name,

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/mockData.ts
@@ -37,10 +37,24 @@ export const int32Schema = namedTreeSchema({
     value: ValueSchema.Number,
 });
 
-export const float32Schema = namedTreeSchema({
-    name: brand("Float32"),
+export const float64Schema = namedTreeSchema({
+    name: brand("Float64"),
     extraLocalFields: emptyField,
     value: ValueSchema.Number,
+});
+
+export const boolSchema = namedTreeSchema({
+    name: brand("Bool"),
+    extraLocalFields: emptyField,
+    value: ValueSchema.Boolean,
+});
+
+export const simplePhonesSchema = namedTreeSchema({
+    name: brand("Test:SimplePhones-1.0.0"),
+    localFields: {
+        [EmptyKey]: fieldSchema(FieldKinds.sequence, [stringSchema.name]),
+    },
+    extraLocalFields: emptyField,
 });
 
 export const complexPhoneSchema = namedTreeSchema({
@@ -48,14 +62,7 @@ export const complexPhoneSchema = namedTreeSchema({
     localFields: {
         number: fieldSchema(FieldKinds.value, [stringSchema.name]),
         prefix: fieldSchema(FieldKinds.value, [stringSchema.name]),
-    },
-    extraLocalFields: emptyField,
-});
-
-export const simplePhonesSchema = namedTreeSchema({
-    name: brand("Test:SimplePhones-1.0.0"),
-    localFields: {
-        [EmptyKey]: fieldSchema(FieldKinds.sequence, [stringSchema.name]),
+        extraPhones: fieldSchema(FieldKinds.optional, [simplePhonesSchema.name]),
     },
     extraLocalFields: emptyField,
 });
@@ -85,8 +92,10 @@ export const globalFieldSchemaSequencePhones = fieldSchema(FieldKinds.sequence, 
 export const addressSchema = namedTreeSchema({
     name: brand("Test:Address-1.0.0"),
     localFields: {
-        street: fieldSchema(FieldKinds.value, [stringSchema.name]),
-        zip: fieldSchema(FieldKinds.optional, [stringSchema.name, int32Schema.name]),
+        zip: fieldSchema(FieldKinds.value, [stringSchema.name, int32Schema.name]),
+        street: fieldSchema(FieldKinds.optional, [stringSchema.name]),
+        city: fieldSchema(FieldKinds.optional, [stringSchema.name]),
+        country: fieldSchema(FieldKinds.optional, [stringSchema.name]),
         phones: fieldSchema(FieldKinds.optional, [phonesSchema.name]),
         sequencePhones: fieldSchema(FieldKinds.sequence, [stringSchema.name]),
     },
@@ -106,9 +115,10 @@ export const personSchema = namedTreeSchema({
     localFields: {
         name: fieldSchema(FieldKinds.value, [stringSchema.name]),
         age: fieldSchema(FieldKinds.optional, [int32Schema.name]),
-        salary: fieldSchema(FieldKinds.value, [float32Schema.name]),
+        adult: fieldSchema(FieldKinds.optional, [boolSchema.name]),
+        salary: fieldSchema(FieldKinds.optional, [float64Schema.name, int32Schema.name]),
         friends: fieldSchema(FieldKinds.optional, [mapStringSchema.name]),
-        address: fieldSchema(FieldKinds.value, [addressSchema.name]),
+        address: fieldSchema(FieldKinds.optional, [addressSchema.name]),
     },
     extraLocalFields: emptyField,
 });
@@ -136,8 +146,9 @@ export const schemaTypes: Set<NamedTreeSchema> = new Set([
     arraySchema,
     optionalChildSchema,
     stringSchema,
-    float32Schema,
+    float64Schema,
     int32Schema,
+    boolSchema,
     complexPhoneSchema,
     phonesSchema,
     simplePhonesSchema,
@@ -163,40 +174,61 @@ export const fullSchemaData: SchemaData = {
 
 // TODO: derive types like these from those schema, which subset EditableTree
 
-export type Int32 = Brand<number, "Int32">;
+export type Float64 = Brand<number, "editable-tree.Float64"> & EditableTree;
+export type Int32 = Brand<number, "editable-tree.Int32"> & EditableTree;
+export type Bool = Brand<boolean, "editable-tree.Bool"> & EditableTree;
 
-export type ComplexPhoneType = EditableTree & {
-    number: string;
-    prefix: string;
-};
+export type ComplexPhone = EditableTree &
+    Brand<
+        {
+            number: string;
+            prefix: string;
+            extraPhones?: SimplePhones;
+        },
+        "editable-tree.Test:Phone-1.0.0"
+    >;
 
-export type SimplePhonesType = EditableField & string[];
+export type SimplePhones = EditableField & Brand<string[], "editable-tree.Test:SimplePhones-1.0.0">;
 
-export type PhonesType = EditableField & (number | string | ComplexPhoneType | SimplePhonesType)[];
+export type Phones = EditableField &
+    Brand<(Int32 | string | ComplexPhone | SimplePhones)[], "editable-tree.Test:Phones-1.0.0">;
 
-export type AddressType = EditableTree & {
-    street: string;
-    zip?: string;
-    phones?: PhonesType;
-    sequencePhones?: SimplePhonesType;
-};
+export type Address = EditableTree &
+    Brand<
+        {
+            zip: string | Int32;
+            street?: string;
+            city?: string;
+            country?: string;
+            phones?: Phones;
+            sequencePhones?: SimplePhones;
+        },
+        "editable-tree.Test:Address-1.0.0"
+    >;
 
-export type FriendsType = EditableTree & Record<LocalFieldKey, string>;
+export type Friends = EditableTree &
+    Brand<Record<LocalFieldKey, string>, "editable-tree.Map<String>">;
 
-export type PersonType = EditableTree & {
-    name: string;
-    age?: Int32;
-    salary: number;
-    friends: FriendsType;
-    address: AddressType;
-};
+export type Person = EditableTree &
+    Brand<
+        {
+            name: string;
+            age?: Int32;
+            adult?: Bool;
+            salary?: Float64 | Int32;
+            friends?: Friends;
+            address?: Address;
+        },
+        "editable-tree.Test:Person-1.0.0"
+    >;
 
 export const personData: JsonableTree = {
     type: personSchema.name,
     fields: {
         name: [{ value: "Adam", type: stringSchema.name }],
         age: [{ value: 35, type: int32Schema.name }],
-        salary: [{ value: 10420.2, type: float32Schema.name }],
+        adult: [{ value: true, type: boolSchema.name }],
+        salary: [{ value: 10420.2, type: float64Schema.name }],
         friends: [
             {
                 fields: {


### PR DESCRIPTION
This PR exposes `getPrimaryField` and refactors the EditableTree and its tests.

The main cause of this is to prepare the code base for the upcoming implementation of "simple assignments" and hence to make the latter smaller i.e. better for a review.

Some points worth mentioning:

#### API changes
- `getPrimaryField` is exposed to let users handle corresponding cases (e.g. working with arrays)
- added schema to `EditableTreeContext` to shorten the `context.forest.schema` way of accessing it

#### Implementation refactoring
- `getFieldSchema` is wrapped within the EditableTree proxy - this has no use currently, but will be needed in "simple assignments"

#### Test refactoring

Changes in tests are mainly caused by improving the mock data. Those improvements are the result of the "Property Inspector" PoC demoed for various user groups, introducing among others the type `Bool` and schemas (and types) for "array of array" usecases.