### PR TITLE
[GC-stress] Updated GC log to include attachment blob stats as well

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -899,7 +899,7 @@ export class GarbageCollector implements IGarbageCollector {
             const gcResult = runGarbageCollection(gcData.gcNodes, ["/"]);
 
             const gcStats = await this.runPostGCSteps(gcData, gcResult, logger, currentReferenceTimestampMs);
-            console.log(`................. GC: ${gcStats.unrefDataStoreCount} / ${gcStats.dataStoreCount}`);
+            console.log(`................. GC: ${JSON.stringify(gcStats)}`);
             event.end({ ...gcStats, timestamp: currentReferenceTimestampMs });
             this.completedRuns++;
             return gcStats;


### PR DESCRIPTION
## Reviewer Guidance
This is in a test branch (test/gc-stress) and not in the main branch. This is an experimental stress test that we eventually plan to get into main. For now, it lives and runs in the test branch so we can make quick progress :-).

## Description
Updated the GC log to include attachment blob stats.