### PR TITLE
(bundle-size) Add note about existing issue with ADO tasks and our tooling code

### DIFF
--- a/build-tools/packages/bundle-size-tools/src/ADO/AdoArtifactFileProvider.ts
+++ b/build-tools/packages/bundle-size-tools/src/ADO/AdoArtifactFileProvider.ts
@@ -28,6 +28,12 @@ export function getBundlePathsFromZipObject(jsZip: JSZip): BundleFileData[] {
  * Downloads an Azure Devops artifacts and parses it with the jszip library.
  * @param adoConnection - A connection to the ADO api.
  * @param buildNumber - The ADO build number that contains the artifact we wish to fetch
+ *
+ * @remarks
+ * This function doesn't work with artifacts created by the new PublishPipelineArtifact task, but works for the
+ * old PublishBuildArtifacts task.
+ * See https://github.com/microsoft/azure-devops-node-api/issues/432 for details and a potential workaround that we
+ * could implement at some point.
  */
 export async function getZipObjectFromArtifact(
     adoConnection: WebApi,

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -397,6 +397,9 @@ stages:
               workingDir: ${{ parameters.buildDirectory }}
               customCommand: 'run bundle-analysis:collect'
 
+          # NOTE: this task is deliberately not updated to the newer PublishPipelineArtifact because some of our tooling
+          # does not support the newer task.
+          # See the getZipObjectFromArtifact function in @fluidframework/bundle-size-tools for details about the issue.
           - task: PublishBuildArtifacts@1
             displayName: Publish Artifacts - bundle-analysis
             condition:


### PR DESCRIPTION
## Description

I got curious about why reverting the ADO task in #13248 fixed our bundle analysis check and followed the rabbit hole to an [unresolved known issue](https://github.com/microsoft/azure-devops-node-api/issues/432) in the azure-devops-node-api package. Our code that interacts with ADO to retrieve pipeline artifacts in order to complete the bundle size check leverages azure-devops-node-api so it's not compatible with the newer `PublishPipelineArtifact` task, but works with the older `PublishBuildArtifacts` task.

Here I just added a note in relevant places about why we deliberately are not updating that particular ADO step to use the new task.