### PR TITLE
Summarization error: '"undefined" is not valid JSON' - 10k hits in the last 28 days

### DIFF
--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -250,7 +250,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
         // If GC is disabled, skip setting referenced used routes since we are not tracking GC state.
         if (!this.gcDisabled) {
             const summaryNode = this.pendingSummaries.get(proposalHandle) as SummaryNodeWithGC;
-            if (summaryNode !== undefined) {
+            if (summaryNode?.serializedUsedRoutes !== undefined) {
                 this.referenceUsedRoutes = JSON.parse(summaryNode.serializedUsedRoutes);
             }
         }


### PR DESCRIPTION
While looking at the reliability dashboard, this bug has been happening quite frequently and is affecting the reliability from 2.0.0-internal.1.4.8
![image](https://user-images.githubusercontent.com/26266632/206110674-0547aecc-5177-4324-8d64-2f61d3baa58f.png)


More information can be found in the [Task 2803](https://dev.azure.com/fluidframework/internal/_workitems/edit/2803) and [Task 2804](https://dev.azure.com/fluidframework/internal/_workitems/edit/2804)
Stack: 
at JSON.parse (<anonymous>)
    at A.refreshLatestSummaryFromPending (https://cdn.fluidpreview.office.net/fluid/prod/container/hashed/officeContainer.62b510cf76386cb50793-3.js:2:26614)
    at A.refreshLatestSummaryFromPending (https://cdn.fluidpreview.office.net/fluid/prod/container/hashed/officeContainer.62b510cf76386cb50793-3.js:2:21308)
    at A.refreshLatestSummaryFromPending (https://cdn.fluidpreview.office.net/fluid/prod/container/hashed/officeContainer.62b510cf76386cb50793-3.js:2:26658)
    at A.refreshLatestSummaryFromPending (https://cdn.fluidpreview.office.net/fluid/prod/container/hashed/officeContainer.62b510cf76386cb50793-3.js:2:21308)
    at A.refreshLatestSummaryFromPending (https://cdn.fluidpreview.office.net/fluid/prod/container/hashed/officeContainer.62b510cf76386cb50793-3.js:2:26658)
    at A.refreshLatestSummary (https://cdn.fluidpreview.office.net/fluid/prod/container/hashed/officeContainer.62b510cf76386cb50793-3.js:2:20449)
    at $t.refreshLatestSummaryAck (https://cdn.fluidpreview.office.net/fluid/prod/container/hashed/officeContainer.62b510cf76386cb50793-3.js:2:177284)
    at https://cdn.fluidpreview.office.net/fluid/prod/container/hashed/officeContainer.62b510cf76386cb50793-3.js:2:56491
    at de.lockedRefreshSummaryAckAction (https://cdn.fluidpreview.office.net/fluid/prod/container/hashed/officeContainer.62b510cf76386cb50793-3.js:2:48479)
