### PR TITLE
Hook up debug button in external-data example app to trigger custom debug signal

### DIFF
--- a/examples/hosts/app-integration/external-data/src/model/appModel.ts
+++ b/examples/hosts/app-integration/external-data/src/model/appModel.ts
@@ -22,6 +22,9 @@ export class AppModel extends TypedEventEmitter<IAppModelEvents> implements IApp
         this.runtime = runtime;
     }
 
+    /**
+     * {@inheritDoc IAppModel.debugSendCustomSignal}
+     */
     public readonly debugSendCustomSignal = (): void => {
         this.runtime.submitSignal('debugSignal', {message: "externalDataChanged"});
     }

--- a/examples/hosts/app-integration/external-data/src/model/appModel.ts
+++ b/examples/hosts/app-integration/external-data/src/model/appModel.ts
@@ -22,7 +22,7 @@ export class AppModel extends TypedEventEmitter<IAppModelEvents> implements IApp
         this.runtime = runtime;
     }
 
-    public readonly debugSendCustomSignal = (): void => {
+    private readonly debugSendCustomSignal = (): void => {
         this.runtime.submitSignal('debugSignal', {message: "externalDataChanged"});
     }
 }

--- a/examples/hosts/app-integration/external-data/src/model/appModel.ts
+++ b/examples/hosts/app-integration/external-data/src/model/appModel.ts
@@ -25,6 +25,6 @@ export class AppModel extends TypedEventEmitter<IAppModelEvents> implements IApp
      * {@inheritDoc IAppModel.debugSendCustomSignal}
      */
     public readonly debugSendCustomSignal = (): void => {
-        this.runtime.submitSignal('debugSignal', {message: "externalDataChanged"});
+        this.runtime.submitSignal("debugSignal", {message: "externalDataChanged"});
     }
 }

--- a/examples/hosts/app-integration/external-data/src/model/appModel.ts
+++ b/examples/hosts/app-integration/external-data/src/model/appModel.ts
@@ -19,7 +19,6 @@ export class AppModel extends TypedEventEmitter<IAppModelEvents> implements IApp
         container: IContainer,
         private readonly runtime: IContainerRuntime ) {
         super();
-        this.runtime = runtime;
     }
 
     /**

--- a/examples/hosts/app-integration/external-data/src/model/appModel.ts
+++ b/examples/hosts/app-integration/external-data/src/model/appModel.ts
@@ -5,6 +5,7 @@
 
 import { TypedEventEmitter } from "@fluidframework/common-utils";
 import { IContainer } from "@fluidframework/container-definitions";
+import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 
 import type { IAppModel, IAppModelEvents, ITaskList } from "../modelInterfaces";
 
@@ -13,7 +14,15 @@ import type { IAppModel, IAppModelEvents, ITaskList } from "../modelInterfaces";
  * responsibilities and functionality.
  */
 export class AppModel extends TypedEventEmitter<IAppModelEvents> implements IAppModel {
-    public constructor(public readonly taskList: ITaskList, container: IContainer) {
+    public constructor(
+        public readonly taskList: ITaskList,
+        container: IContainer,
+        private readonly runtime: IContainerRuntime ) {
         super();
+        this.runtime = runtime;
+    }
+
+    public readonly debugSendCustomSignal = (): void => {
+        this.runtime.submitSignal('debugSignal', {message: "externalDataChanged"});
     }
 }

--- a/examples/hosts/app-integration/external-data/src/model/appModel.ts
+++ b/examples/hosts/app-integration/external-data/src/model/appModel.ts
@@ -22,7 +22,7 @@ export class AppModel extends TypedEventEmitter<IAppModelEvents> implements IApp
         this.runtime = runtime;
     }
 
-    private readonly debugSendCustomSignal = (): void => {
+    public readonly debugSendCustomSignal = (): void => {
         this.runtime.submitSignal('debugSignal', {message: "externalDataChanged"});
     }
 }

--- a/examples/hosts/app-integration/external-data/src/model/containerCode.ts
+++ b/examples/hosts/app-integration/external-data/src/model/containerCode.ts
@@ -67,6 +67,6 @@ export class TaskListContainerRuntimeFactory extends ModelContainerRuntimeFactor
                 taskList.importExternalData();
             }
         });
-        return new AppModel(taskList, container);
+        return new AppModel(taskList, container, runtime);
     }
 }

--- a/examples/hosts/app-integration/external-data/src/modelInterfaces.ts
+++ b/examples/hosts/app-integration/external-data/src/modelInterfaces.ts
@@ -19,7 +19,7 @@ export interface IAppModel extends IEventProvider<IAppModelEvents> {
     readonly taskList: ITaskList;
 
     /**
-    * Trigger custom signals for external data change and for sending the data
+    * Trigger custom signals for external data change and for fetching the data
     */
     readonly debugSendCustomSignal: () => void;
 }

--- a/examples/hosts/app-integration/external-data/src/modelInterfaces.ts
+++ b/examples/hosts/app-integration/external-data/src/modelInterfaces.ts
@@ -17,6 +17,11 @@ export interface IAppModel extends IEventProvider<IAppModelEvents> {
      * A task tracker list.
      */
     readonly taskList: ITaskList;
+
+    /**
+    * Trigger custom signals for external data change and for sending the data
+    */
+    readonly debugSendCustomSignal: () => void;
 }
 
 export interface ITaskEvents extends IEvent {

--- a/examples/hosts/app-integration/external-data/src/modelInterfaces.ts
+++ b/examples/hosts/app-integration/external-data/src/modelInterfaces.ts
@@ -19,7 +19,9 @@ export interface IAppModel extends IEventProvider<IAppModelEvents> {
     readonly taskList: ITaskList;
 
     /**
-    * Trigger custom signals for external data change and for fetching the data
+    * Send custom signals to the server which will cause the server to respond
+    * with the (currently experimental) RuntimeMessage Signal to communicate
+    * an external data change and and possibly the changed data as well
     */
     readonly debugSendCustomSignal: () => void;
 }

--- a/examples/hosts/app-integration/external-data/src/start.ts
+++ b/examples/hosts/app-integration/external-data/src/start.ts
@@ -33,7 +33,7 @@ const render = (model: IAppModel): void => {
     const debugDiv = document.querySelector("#debug") as HTMLDivElement;
     ReactDOM.unmountComponentAtNode(debugDiv);
     ReactDOM.render(
-        React.createElement(DebugView, { }),
+        React.createElement(DebugView, { model }),
         debugDiv,
     );
 };

--- a/examples/hosts/app-integration/external-data/src/view/debugView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/debugView.tsx
@@ -5,9 +5,10 @@
 
 import React, { useEffect, useState } from "react";
 import { externalDataSource, parseStringData } from "../externalData";
+import type { IAppModel } from "../modelInterfaces";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IDebugViewProps {
+    model: IAppModel;
 }
 
 export const DebugView: React.FC<IDebugViewProps> = (props: IDebugViewProps) => {
@@ -16,7 +17,7 @@ export const DebugView: React.FC<IDebugViewProps> = (props: IDebugViewProps) => 
             <h2 style={{ textDecoration: "underline" }}>Debug info</h2>
             <ExternalDataView />
             <SyncStatusView />
-            <ControlsView />
+            <ControlsView model={ props.model }/>
         </div>
     );
 };
@@ -91,8 +92,8 @@ const SyncStatusView: React.FC<ISyncStatusViewProps> = (props: ISyncStatusViewPr
     );
 };
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface IControlsViewProps {
+    model: IAppModel;
 }
 
 // TODO: Implement simulation of an external data change.  Maybe include UI for the debug user to edit the data
@@ -104,7 +105,7 @@ const ControlsView: React.FC<IControlsViewProps> = (props: IControlsViewProps) =
             <h3>Debug controls</h3>
             <div style={{ margin: "10px 0" }}>
                 <button onClick={ externalDataSource.debugResetData }>Reset external data</button><br />
-                <button>Simulate external data change (not implemented)</button><br />
+                <button onClick={ props.model.debugSendCustomSignal }>Trigger external data change signal</button><br />
             </div>
         </div>
     );


### PR DESCRIPTION
This PR hooks up the debug button in the external-data example app to send a custom signal simulating an external data change. 

The following image demonstrates the button on the bottom left - on clicking it, you can see that a `submitSignal` websocket message is sent by the example app: 
![image](https://user-images.githubusercontent.com/6777404/206287010-1ccb9f0d-0472-425b-a7ef-9e77802ad18b.png)


The server then responds with a RuntimeMessage communicating that the external data has changed:
![image](https://user-images.githubusercontent.com/6777404/206287307-5576d3ac-f5b3-4152-968e-d42a7d5446b3.png)


The server side code is in an experimental PR located here: https://github.com/microsoft/FluidFramework/pull/13063/files