### PR TITLE
GC: Added tests where unreferenced node adds reference to other unreferenced nodes

### DIFF
--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -1124,9 +1124,13 @@ describe("Garbage Collection Tests", () => {
         });
     });
 
-    /**
-     * These tests validate such scenarios where nodes transition from unreferenced -\> referenced -\> unreferenced
-     * state by verifying that their unreferenced timestamps are updated correctly.
+    /*
+     * These tests validate scenarios where nodes that are referenced between summaries have their unreferenced
+     * timestamp updated. These scenarios fall into the following categories:
+     * 1. Nodes transition from unreferenced -> referenced -> unreferenced between 2 summaries - In these scenarios
+     *    when GC runs, it should detect that the node was referenced and update its unreferenced timestamp.
+     * 2. Unreferenced nodes are referenced from other unreferenced nodes - In this case, even though the node remains
+     *    unreferenced, its unreferenced timestamp should be updated.
      *
      * In these tests, V = nodes and E = edges between nodes. Root nodes that are always referenced are marked as *.
      */
@@ -1174,319 +1178,423 @@ describe("Garbage Collection Tests", () => {
             garbageCollector = createGarbageCollector();
         });
 
-        /**
-         * Validates that we can detect references that were added and then removed.
-         * 1. Summary 1 at t1. V = [A*, B]. E = []. B has unreferenced time t1.
-         * 2. Reference from A to B added. E = [A -\> B].
-         * 3. Reference from A to B removed. E = [].
-         * 4. Summary 2 at t2. V = [A*, B]. E = []. B has unreferenced time t2.
-         * Validates that the unreferenced time for B is t2 which is \> t1.
-         */
-        it(`Scenario 1 - Reference added and then removed`, async () => {
-            // Initialize nodes A and B.
-            defaultGCData.gcNodes["/"] = [nodeA];
-            defaultGCData.gcNodes[nodeA] = [];
-            defaultGCData.gcNodes[nodeB] = [];
+        describe("Nodes transitioning from unreferenced -> referenced -> unreferenced", () => {
+            /**
+             * Validates that we can detect references that were added and then removed.
+             * 1. Summary 1 at t1. V = [A*, B]. E = []. B has unreferenced time t1.
+             * 2. Reference from A to B added. E = [A -\> B].
+             * 3. Reference from A to B removed. E = [].
+             * 4. Summary 2 at t2. V = [A*, B]. E = []. B has unreferenced time t2.
+             * Validates that the unreferenced time for B is t2 which is \> t1.
+             */
+            it(`Scenario 1 - Reference added and then removed`, async () => {
+                // Initialize nodes A and B.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeB] = [];
 
-            // 1. Run GC and generate summary 1. E = [].
-            const timestamps1 = await getUnreferencedTimestamps();
-            assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+                // 1. Run GC and generate summary 1. E = [].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
 
-            const nodeBTime1 = timestamps1.get(nodeB);
-            assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+                const nodeBTime1 = timestamps1.get(nodeB);
+                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
 
-            // 2. Add reference from A to B. E = [A -\> B].
-            garbageCollector.addedOutboundReference(nodeA, nodeB);
-            defaultGCData.gcNodes[nodeA] = [nodeB];
+                // 2. Add reference from A to B. E = [A -\> B].
+                garbageCollector.addedOutboundReference(nodeA, nodeB);
+                defaultGCData.gcNodes[nodeA] = [nodeB];
 
-            // 3. Remove reference from A to B. E = [].
-            defaultGCData.gcNodes[nodeA] = [];
+                // 3. Remove reference from A to B. E = [].
+                defaultGCData.gcNodes[nodeA] = [];
 
-            // 4. Run GC and generate summary 2. E = [].
-            const timestamps2 = await getUnreferencedTimestamps();
-            assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+                // 4. Run GC and generate summary 2. E = [].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
 
-            const nodeBTime2 = timestamps2.get(nodeB);
+                const nodeBTime2 = timestamps2.get(nodeB);
 
-            assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
+                assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
+            });
+
+            /**
+             * Validates that we can detect references that were added transitively and then removed.
+             * 1. Summary 1 at t1. V = [A*, B, C]. E = [B -\> C]. B and C have unreferenced time t2.
+             * 2. Reference from A to B added. E = [A -\> B, B -\> C].
+             * 3. Reference from B to C removed. E = [A -\> B].
+             * 4. Reference from A to B removed. E = [].
+             * 5. Summary 2 at t2. V = [A*, B, C]. E = []. B and C have unreferenced time t2.
+             * Validates that the unreferenced time for B and C is t2 which is \> t1.
+             */
+            it(`Scenario 2 - Reference transitively added and removed`, async () => {
+                // Initialize nodes A, B and C.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeB] = [nodeC];
+                defaultGCData.gcNodes[nodeC] = [];
+
+                // 1. Run GC and generate summary 1. E = [B -\> C].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime1 = timestamps1.get(nodeB);
+                const nodeCTime1 = timestamps1.get(nodeC);
+                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+
+                // 2. Add reference from A to B. E = [A -\> B, B -\> C].
+                garbageCollector.addedOutboundReference(nodeA, nodeB);
+                defaultGCData.gcNodes[nodeA] = [nodeB];
+
+                // 3. Remove reference from B to C. E = [A -\> B].
+                defaultGCData.gcNodes[nodeB] = [];
+
+                // 4. Remove reference from A to B. E = [].
+                defaultGCData.gcNodes[nodeA] = [];
+
+                // 5. Run GC and generate summary 2. E = [].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime2 = timestamps2.get(nodeB);
+                const nodeCTime2 = timestamps2.get(nodeC);
+                assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
+                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+            });
+
+            /**
+             * Validates that we can detect chain of references in which the first reference was added and then removed.
+             * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [B -\> C, C -\> D]. B, C and D have unreferenced time t2.
+             * 2. Reference from A to B added. E = [A -\> B, B -\> C, C -\> D].
+             * 3. Reference from A to B removed. E = [B -\> C, C -\> D].
+             * 4. Summary 2 at t2. V = [A*, B, C, D]. E = [B -\> C, C -\> D]. B, C and D have unreferenced time t2.
+             * Validates that the unreferenced time for B, C and D is t2 which is \> t1.
+             */
+            it(`Scenario 3 - Reference added through chain of references and removed`, async () => {
+                // Initialize nodes A, B, C and D.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeB] = [nodeC];
+                defaultGCData.gcNodes[nodeC] = [nodeD];
+                defaultGCData.gcNodes[nodeD] = [];
+
+                // 1. Run GC and generate summary 1. E = [B -\> C, C -\> D].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime1 = timestamps1.get(nodeB);
+                const nodeCTime1 = timestamps1.get(nodeC);
+                const nodeDTime1 = timestamps1.get(nodeD);
+                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+                assert(nodeDTime1 !== undefined, "D should have unreferenced timestamp");
+
+                // 2. Add reference from A to B. E = [A -\> B, B -\> C, C -\> D].
+                garbageCollector.addedOutboundReference(nodeA, nodeB);
+                defaultGCData.gcNodes[nodeA] = [nodeB];
+
+                // 3. Remove reference from A to B. E = [B -\> C, C -\> D].
+                defaultGCData.gcNodes[nodeA] = [];
+
+                // 4. Run GC and generate summary 2. E = [B -\> C, C -\> D].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime2 = timestamps2.get(nodeB);
+                const nodeCTime2 = timestamps2.get(nodeC);
+                const nodeDTime2 = timestamps2.get(nodeD);
+                assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
+                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+                assert(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
+            });
+
+            /**
+             * Validates that we can detect references that were added and removed via new nodes.
+             * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
+             * 2. Node B is created. E = [].
+             * 3. Reference from A to B added. E = [A -\> B].
+             * 4. Reference from B to C added. E = [A -\> B, B -\> C].
+             * 5. Reference from B to C removed. E = [A -\> B].
+             * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -\> B]. C has unreferenced time t2.
+             * Validates that the unreferenced time for C is t2 which is \> t1.
+             */
+            it(`Scenario 4 - Reference added via new nodes and removed`, async () => {
+                // Initialize nodes A, B and C.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeC] = [];
+
+                // 1. Run GC and generate summary 1. E = [].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeCTime1 = timestamps1.get(nodeC);
+                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+
+                // 2. Create node B, i.e., add B to GC data. E = [].
+                defaultGCData.gcNodes[nodeB] = [];
+
+                // 3. Add reference from A to B. E = [A -\> B].
+                garbageCollector.addedOutboundReference(nodeA, nodeB);
+                defaultGCData.gcNodes[nodeA] = [nodeB];
+
+                // 4. Add reference from B to C. E = [A -\> B, B -\> C].
+                garbageCollector.addedOutboundReference(nodeB, nodeC);
+                defaultGCData.gcNodes[nodeB] = [nodeC];
+
+                // 5. Remove reference from B to C. E = [A -\> B].
+                defaultGCData.gcNodes[nodeB] = [];
+
+                // 6. Run GC and generate summary 2. E = [A -\> B].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+                assert(timestamps2.get(nodeB) === undefined, "B should be referenced");
+
+                const nodeCTime2 = timestamps2.get(nodeC);
+                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+            });
+
+            /**
+             * Validates that we can detect multiple references that were added and then removed by the same node.
+             * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
+             * 2. Reference from A to B added. E = [A -\> B].
+             * 3. Reference from A to C added. E = [A -\> B, A -\> C].
+             * 4. Reference from A to B removed. E = [A -\> C].
+             * 5. Reference from A to C removed. E = [].
+             * 6. Summary 2 at t2. V = [A*, B]. E = []. B and C have unreferenced time t2.
+             * Validates that the unreferenced time for B and C is t2 which is \> t1.
+             */
+            it(`Scenario 5 - Multiple references added and then removed by same node`, async () => {
+                // Initialize nodes A, B and C.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeB] = [];
+                defaultGCData.gcNodes[nodeC] = [];
+
+                // 1. Run GC and generate summary 1. E = [].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime1 = timestamps1.get(nodeB);
+                const nodeCTime1 = timestamps1.get(nodeC);
+                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+
+                // 2. Add reference from A to B. E = [A -\> B].
+                garbageCollector.addedOutboundReference(nodeA, nodeB);
+                defaultGCData.gcNodes[nodeA] = [nodeB];
+
+                // 3. Add reference from A to C. E = [A -\> B, A -\> C].
+                garbageCollector.addedOutboundReference(nodeA, nodeC);
+                defaultGCData.gcNodes[nodeA] = [nodeB, nodeC];
+
+                // 4. Remove reference from A to B. E = [A -\> C].
+                defaultGCData.gcNodes[nodeA] = [nodeC];
+
+                // 5. Remove reference from A to C. E = [].
+                defaultGCData.gcNodes[nodeA] = [];
+
+                // 6. Run GC and generate summary 2. E = [].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime2 = timestamps2.get(nodeB);
+                const nodeCTime2 = timestamps2.get(nodeC);
+                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+                assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
+            });
+
+            /**
+             * Validates that we generate error on detecting reference during GC that was not notified explicitly.
+             * 1. Summary 1 at t1. V = [A*]. E = [].
+             * 2. Node B is created. E = [].
+             * 3. Reference from A to B added without notifying GC. E = [A -\> B].
+             * 4. Summary 2 at t2. V = [A*, B]. E = [A -\> B].
+             * Validates that we log an error since B is detected as a referenced node but its reference was notified
+             * to GC.
+             */
+            it(`Scenario 6 - Reference added without notifying GC`, async () => {
+                // Initialize nodes A & D.
+                defaultGCData.gcNodes["/"] = [nodeA, nodeD];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeD] = [];
+
+                // 1. Run GC and generate summary 1. E = [].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+                assert(timestamps1.get(nodeD) === undefined, "D should be referenced");
+
+                // 2. Create nodes B & C. E = [].
+                defaultGCData.gcNodes[nodeB] = [];
+                defaultGCData.gcNodes[nodeC] = [];
+
+                // 3. Add reference from A to B, A to C, A to E, D to C, and E to A without calling addedOutboundReference.
+                // E = [A -\> B, A -\> C, A -\> E, D -\> C, E -\> A].
+                defaultGCData.gcNodes[nodeA] = [nodeB, nodeC, nodeE];
+                defaultGCData.gcNodes[nodeD] = [nodeC];
+                defaultGCData.gcNodes[nodeE] = [nodeA];
+
+                // 4. Add reference from A to D with calling addedOutboundReference
+                defaultGCData.gcNodes[nodeA].push(nodeD);
+                garbageCollector.addedOutboundReference(nodeA, nodeD);
+
+                // 5. Run GC and generate summary 2. E = [A -\> B, A -\> C, A -\> E, D -\> C, E -\> A].
+                await getUnreferencedTimestamps();
+
+                // Validate that we got the "gcUnknownOutboundReferences" error.
+                const unknownReferencesEvent = "GarbageCollector:gcUnknownOutboundReferences";
+                const eventsFound = mockLogger.matchEvents([
+                    {
+                        eventName: unknownReferencesEvent,
+                        gcNodeId: "/A",
+                        gcRoutes: JSON.stringify(["/B", "/C"]),
+                    },
+                    {
+                        eventName: unknownReferencesEvent,
+                        gcNodeId: "/D",
+                        gcRoutes: JSON.stringify(["/C"]),
+                    },
+                ]);
+                assert(eventsFound, `Expected unknownReferenceEvent event!`);
+            });
         });
 
-        /**
-         * Validates that we can detect references that were added transitively and then removed.
-         * 1. Summary 1 at t1. V = [A*, B, C]. E = [B -\> C]. B and C have unreferenced time t2.
-         * 2. Reference from A to B added. E = [A -\> B, B -\> C].
-         * 3. Reference from B to C removed. E = [A -\> B].
-         * 4. Reference from A to B removed. E = [].
-         * 5. Summary 2 at t2. V = [A*, B, C]. E = []. B and C have unreferenced time t2.
-         * Validates that the unreferenced time for B and C is t2 which is \> t1.
-         */
-        it(`Scenario 2 - Reference transitively added and removed`, async () => {
-            // Initialize nodes A, B and C.
-            defaultGCData.gcNodes["/"] = [nodeA];
-            defaultGCData.gcNodes[nodeA] = [];
-            defaultGCData.gcNodes[nodeB] = [nodeC];
-            defaultGCData.gcNodes[nodeC] = [];
+        describe("References to unreferenced nodes", () => {
+            /**
+             * Function that asserts the given value is not true. Used in these tests to demonstrate that because of
+             * a bug we are not getting the expected results. Once the bug is fixed, these asserts should start working
+             * as expected.
+             */
+            function assertNotTrue(value: boolean, message: string) {
+                assert(!value, message);
+            }
 
-            // 1. Run GC and generate summary 1. E = [B -\> C].
-            const timestamps1 = await getUnreferencedTimestamps();
-            assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+            /**
+             * Validates that we can detect references that are added from an unreferenced node to another.
+             * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
+             * 2. Reference from B to C. E = [B -\> C].
+             * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -\> C]. B and C have unreferenced time t1.
+             * Validates that the unreferenced time for B and C is still t1.
+             */
+             it(`Scenario 1 - Reference added to unreferenced node`, async () => {
+                // Initialize nodes A, B and C.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeB] = [];
+                defaultGCData.gcNodes[nodeC] = [];
 
-            const nodeBTime1 = timestamps1.get(nodeB);
-            const nodeCTime1 = timestamps1.get(nodeC);
-            assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-            assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+                // 1. Run GC and generate summary 1. E = [B -\> C].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
 
-            // 2. Add reference from A to B. E = [A -\> B, B -\> C].
-            garbageCollector.addedOutboundReference(nodeA, nodeB);
-            defaultGCData.gcNodes[nodeA] = [nodeB];
+                const nodeBTime1 = timestamps1.get(nodeB);
+                const nodeCTime1 = timestamps1.get(nodeC);
+                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
 
-            // 3. Remove reference from B to C. E = [A -\> B].
-            defaultGCData.gcNodes[nodeB] = [];
+                // 2. Add reference from B to C. E = [B -\> C].
+                garbageCollector.addedOutboundReference(nodeB, nodeC);
+                defaultGCData.gcNodes[nodeB] = [nodeC];
 
-            // 4. Remove reference from A to B. E = [].
-            defaultGCData.gcNodes[nodeA] = [];
+                // 3. Run GC and generate summary 2. E = [B -\> C].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
 
-            // 5. Run GC and generate summary 2. E = [].
-            const timestamps2 = await getUnreferencedTimestamps();
-            assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+                const nodeBTime2 = timestamps2.get(nodeB);
+                const nodeCTime2 = timestamps2.get(nodeC);
+                assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
+                assertNotTrue(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+            });
 
-            const nodeBTime2 = timestamps2.get(nodeB);
-            const nodeCTime2 = timestamps2.get(nodeC);
-            assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
-            assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
-        });
+            /*
+             * Validates that we can detect references that are added from an unreferenced node to a list of
+             * unreferenced nodes, i.e., nodes with references to each other but are overall unreferenced.
+             * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [C -\> D]. B, C and D have unreferenced time t1.
+             * 2. Op adds reference from B to C. E = [B -\> C, C -\> D].
+             * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -\> C, C -\> D]. C and D have unreferenced time t2.
+             * Validates that the unreferenced time for C and D is t2 which is > t1.
+             */
+            it(`Scenario 2 - Reference added to a list of unreferenced nodes from an unreferenced node`, async () => {
+                // Initialize nodes A, B and C.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeB] = [];
+                defaultGCData.gcNodes[nodeC] = [nodeD];
+                defaultGCData.gcNodes[nodeD] = [];
 
-        /**
-         * Validates that we can detect chain of references in which the first reference was added and then removed.
-         * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [B -\> C, C -\> D]. B, C and D have unreferenced time t2.
-         * 2. Reference from A to B added. E = [A -\> B, B -\> C, C -\> D].
-         * 3. Reference from A to B removed. E = [B -\> C, C -\> D].
-         * 4. Summary 2 at t2. V = [A*, B, C, D]. E = [B -\> C, C -\> D]. B, C and D have unreferenced time t2.
-         * Validates that the unreferenced time for B, C and D is t2 which is \> t1.
-         */
-        it(`Scenario 3 - Reference added through chain of references and removed`, async () => {
-            // Initialize nodes A, B, C and D.
-            defaultGCData.gcNodes["/"] = [nodeA];
-            defaultGCData.gcNodes[nodeA] = [];
-            defaultGCData.gcNodes[nodeB] = [nodeC];
-            defaultGCData.gcNodes[nodeC] = [nodeD];
-            defaultGCData.gcNodes[nodeD] = [];
+                // 1. Run GC and generate summary 1. E = [B -\> C].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
 
-            // 1. Run GC and generate summary 1. E = [B -\> C, C -\> D].
-            const timestamps1 = await getUnreferencedTimestamps();
-            assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+                const nodeBTime1 = timestamps1.get(nodeB);
+                const nodeCTime1 = timestamps1.get(nodeC);
+                const nodeDTime1 = timestamps1.get(nodeC);
+                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+                assert(nodeDTime1 !== undefined, "C should have unreferenced timestamp");
 
-            const nodeBTime1 = timestamps1.get(nodeB);
-            const nodeCTime1 = timestamps1.get(nodeC);
-            const nodeDTime1 = timestamps1.get(nodeD);
-            assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-            assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-            assert(nodeDTime1 !== undefined, "D should have unreferenced timestamp");
+                // 2. Add reference from B to C. E = [B -\> C, C-\> D].
+                garbageCollector.addedOutboundReference(nodeB, nodeC);
+                defaultGCData.gcNodes[nodeB] = [nodeC];
 
-            // 2. Add reference from A to B. E = [A -\> B, B -\> C, C -\> D].
-            garbageCollector.addedOutboundReference(nodeA, nodeB);
-            defaultGCData.gcNodes[nodeA] = [nodeB];
+                // 3. Run GC and generate summary 2. E = [B -\> C. C -\> D].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
 
-            // 3. Remove reference from A to B. E = [B -\> C, C -\> D].
-            defaultGCData.gcNodes[nodeA] = [];
+                const nodeBTime2 = timestamps2.get(nodeB);
+                const nodeCTime2 = timestamps2.get(nodeC);
+                const nodeDTime2 = timestamps2.get(nodeD);
+                assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
+                assertNotTrue(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+                assertNotTrue(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
+            });
 
-            // 4. Run GC and generate summary 2. E = [B -\> C, C -\> D].
-            const timestamps2 = await getUnreferencedTimestamps();
-            assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+            /*
+             * Validates that we can detect references that are added from an unreferenced node to a list of
+             * unreferenced nodes, i.e., nodes with references to each other but are overall unreferenced. Then
+             * a reference between the list is removed
+             * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [C -> D]. B, C and D have unreferenced time t1.
+             * 2. Op adds reference from B to C. E = [B -> C, C -> D].
+             * 3. Op removes reference from C to D. E = [B -> C].
+             * 4. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. C and D have unreferenced time t2.
+             * Validates that the unreferenced time for C and D is t2 which is > t1.
+             */
+            it(`Scenario 2 - Reference added to a list of unreferenced nodes and a reference is removed`, async () => {
+                // Initialize nodes A, B and C.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeB] = [];
+                defaultGCData.gcNodes[nodeC] = [nodeD];
+                defaultGCData.gcNodes[nodeD] = [];
 
-            const nodeBTime2 = timestamps2.get(nodeB);
-            const nodeCTime2 = timestamps2.get(nodeC);
-            const nodeDTime2 = timestamps2.get(nodeD);
-            assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
-            assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
-            assert(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
-        });
+                // 1. Run GC and generate summary 1. E = [B -\> C].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
 
-        /**
-         * Validates that we can detect references that were added and removed via new nodes.
-         * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
-         * 2. Node B is created. E = [].
-         * 3. Reference from A to B added. E = [A -\> B].
-         * 4. Reference from B to C added. E = [A -\> B, B -\> C].
-         * 5. Reference from B to C removed. E = [A -\> B].
-         * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -\> B]. C has unreferenced time t2.
-         * Validates that the unreferenced time for C is t2 which is \> t1.
-         */
-        it(`Scenario 4 - Reference added via new nodes and removed`, async () => {
-            // Initialize nodes A, B and C.
-            defaultGCData.gcNodes["/"] = [nodeA];
-            defaultGCData.gcNodes[nodeA] = [];
-            defaultGCData.gcNodes[nodeC] = [];
+                const nodeBTime1 = timestamps1.get(nodeB);
+                const nodeCTime1 = timestamps1.get(nodeC);
+                const nodeDTime1 = timestamps1.get(nodeC);
+                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+                assert(nodeDTime1 !== undefined, "C should have unreferenced timestamp");
 
-            // 1. Run GC and generate summary 1. E = [].
-            const timestamps1 = await getUnreferencedTimestamps();
-            assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+                // 2. Add reference from B to C. E = [B -\> C, C-\> D].
+                garbageCollector.addedOutboundReference(nodeB, nodeC);
+                defaultGCData.gcNodes[nodeB] = [nodeC];
 
-            const nodeCTime1 = timestamps1.get(nodeC);
-            assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+                // 3. Remove reference from C to D. E = [B -\> C].
+                defaultGCData.gcNodes[nodeC] = [];
 
-            // 2. Create node B, i.e., add B to GC data. E = [].
-            defaultGCData.gcNodes[nodeB] = [];
+                // 3. Run GC and generate summary 2. E = [B -\> C].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
 
-            // 3. Add reference from A to B. E = [A -\> B].
-            garbageCollector.addedOutboundReference(nodeA, nodeB);
-            defaultGCData.gcNodes[nodeA] = [nodeB];
-
-            // 4. Add reference from B to C. E = [A -\> B, B -\> C].
-            garbageCollector.addedOutboundReference(nodeB, nodeC);
-            defaultGCData.gcNodes[nodeB] = [nodeC];
-
-            // 5. Remove reference from B to C. E = [A -\> B].
-            defaultGCData.gcNodes[nodeB] = [];
-
-            // 6. Run GC and generate summary 2. E = [A -\> B].
-            const timestamps2 = await getUnreferencedTimestamps();
-            assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-            assert(timestamps2.get(nodeB) === undefined, "B should be referenced");
-
-            const nodeCTime2 = timestamps2.get(nodeC);
-            assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
-        });
-
-        /**
-         * Validates that references added by unreferences nodes do not show up as references.
-         * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
-         * 2. Reference from B to C. E = [B -\> C].
-         * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -\> C]. B and C have unreferenced time t1.
-         * Validates that the unreferenced time for B and C is still t1.
-         */
-        it(`Scenario 5 - Reference added via unreferenced nodes`, async () => {
-            // Initialize nodes A, B and C.
-            defaultGCData.gcNodes["/"] = [nodeA];
-            defaultGCData.gcNodes[nodeA] = [];
-            defaultGCData.gcNodes[nodeB] = [];
-            defaultGCData.gcNodes[nodeC] = [];
-
-            // 1. Run GC and generate summary 1. E = [B -\> C].
-            const timestamps1 = await getUnreferencedTimestamps();
-            assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-            const nodeBTime1 = timestamps1.get(nodeB);
-            const nodeCTime1 = timestamps1.get(nodeC);
-            assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-            assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-
-            // 2. Add reference from B to C. E = [B -\> C].
-            garbageCollector.addedOutboundReference(nodeB, nodeC);
-            defaultGCData.gcNodes[nodeB] = [nodeC];
-
-            // 3. Run GC and generate summary 2. E = [B -\> C].
-            const timestamps2 = await getUnreferencedTimestamps();
-            assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-            const nodeBTime2 = timestamps2.get(nodeB);
-            const nodeCTime2 = timestamps2.get(nodeC);
-            assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
-            assert(nodeCTime2 === nodeCTime1, "C's timestamp should be unchanged");
-        });
-
-        /**
-         * Validates that we can detect multiple references that were added and then removed by the same node.
-         * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
-         * 2. Reference from A to B added. E = [A -\> B].
-         * 3. Reference from A to C added. E = [A -\> B, A -\> C].
-         * 4. Reference from A to B removed. E = [A -\> C].
-         * 5. Reference from A to C removed. E = [].
-         * 6. Summary 2 at t2. V = [A*, B]. E = []. B and C have unreferenced time t2.
-         * Validates that the unreferenced time for B and C is t2 which is \> t1.
-         */
-        it(`Scenario 6 - Multiple references added and then removed by same node`, async () => {
-            // Initialize nodes A, B and C.
-            defaultGCData.gcNodes["/"] = [nodeA];
-            defaultGCData.gcNodes[nodeA] = [];
-            defaultGCData.gcNodes[nodeB] = [];
-            defaultGCData.gcNodes[nodeC] = [];
-
-            // 1. Run GC and generate summary 1. E = [].
-            const timestamps1 = await getUnreferencedTimestamps();
-            assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-            const nodeBTime1 = timestamps1.get(nodeB);
-            const nodeCTime1 = timestamps1.get(nodeC);
-            assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-            assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-
-            // 2. Add reference from A to B. E = [A -\> B].
-            garbageCollector.addedOutboundReference(nodeA, nodeB);
-            defaultGCData.gcNodes[nodeA] = [nodeB];
-
-            // 3. Add reference from A to C. E = [A -\> B, A -\> C].
-            garbageCollector.addedOutboundReference(nodeA, nodeC);
-            defaultGCData.gcNodes[nodeA] = [nodeB, nodeC];
-
-            // 4. Remove reference from A to B. E = [A -\> C].
-            defaultGCData.gcNodes[nodeA] = [nodeC];
-
-            // 5. Remove reference from A to C. E = [].
-            defaultGCData.gcNodes[nodeA] = [];
-
-            // 6. Run GC and generate summary 2. E = [].
-            const timestamps2 = await getUnreferencedTimestamps();
-            assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-            const nodeBTime2 = timestamps2.get(nodeB);
-            const nodeCTime2 = timestamps2.get(nodeC);
-            assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
-            assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
-        });
-
-        /**
-         * Validates that we generate error on detecting reference during GC that was not notified explicitly.
-         * 1. Summary 1 at t1. V = [A*]. E = [].
-         * 2. Node B is created. E = [].
-         * 3. Reference from A to B added without notifying GC. E = [A -\> B].
-         * 4. Summary 2 at t2. V = [A*, B]. E = [A -\> B].
-         * Validates that we log an error since B is detected as a referenced node but its reference was notified
-         * to GC.
-         */
-        it(`Scenario 7 - Reference added without notifying GC`, async () => {
-            // Initialize nodes A & D.
-            defaultGCData.gcNodes["/"] = [nodeA, nodeD];
-            defaultGCData.gcNodes[nodeA] = [];
-            defaultGCData.gcNodes[nodeD] = [];
-
-            // 1. Run GC and generate summary 1. E = [].
-            const timestamps1 = await getUnreferencedTimestamps();
-            assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-            assert(timestamps1.get(nodeD) === undefined, "D should be referenced");
-
-            // 2. Create nodes B & C. E = [].
-            defaultGCData.gcNodes[nodeB] = [];
-            defaultGCData.gcNodes[nodeC] = [];
-
-            // 3. Add reference from A to B, A to C, A to E, D to C, and E to A without calling addedOutboundReference.
-            // E = [A -\> B, A -\> C, A -\> E, D -\> C, E -\> A].
-            defaultGCData.gcNodes[nodeA] = [nodeB, nodeC, nodeE];
-            defaultGCData.gcNodes[nodeD] = [nodeC];
-            defaultGCData.gcNodes[nodeE] = [nodeA];
-
-            // 4. Add reference from A to D with calling addedOutboundReference
-            defaultGCData.gcNodes[nodeA].push(nodeD);
-            garbageCollector.addedOutboundReference(nodeA, nodeD);
-
-            // 5. Run GC and generate summary 2. E = [A -\> B, A -\> C, A -\> E, D -\> C, E -\> A].
-            await getUnreferencedTimestamps();
-
-            // Validate that we got the "gcUnknownOutboundReferences" error.
-            const unknownReferencesEvent = "GarbageCollector:gcUnknownOutboundReferences";
-            const eventsFound = mockLogger.matchEvents([
-                {
-                    eventName: unknownReferencesEvent,
-                    gcNodeId: "/A",
-                    gcRoutes: JSON.stringify(["/B", "/C"]),
-                },
-                {
-                    eventName: unknownReferencesEvent,
-                    gcNodeId: "/D",
-                    gcRoutes: JSON.stringify(["/C"]),
-                },
-            ]);
-            assert(eventsFound, `Expected unknownReferenceEvent event!`);
+                const nodeBTime2 = timestamps2.get(nodeB);
+                const nodeCTime2 = timestamps2.get(nodeC);
+                const nodeDTime2 = timestamps2.get(nodeD);
+                assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
+                assertNotTrue(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+                assertNotTrue(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
+            });
         });
     });
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -621,7 +621,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
              * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. C has unreferenced time t2.
              * Validates that the unreferenced time for C is t2 which is > t1.
              */
-            it(`Scenario 1 - Reference added to an unreferenced node`, async () => {
+            it(`Scenario 5 - Reference added to unreferenced node`, async () => {
                 const summarizer = await createSummarizer(provider, mainContainer);
 
                 // Create data stores B and C and mark them referenced as follows by storing their handles as follows:
@@ -649,7 +649,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
                 // 2. Add reference from B to C. E = [B -> C].
                 dataStoreB._root.set("dataStoreC", dataStoreC.handle);
 
-                // 3. Get summary 2 and validate that both C's unreferenced timestamp has updated. E = [B -> C].
+                // 3. Get summary 2 and validate that C's unreferenced timestamp has updated. E = [B -> C].
                 await provider.ensureSynchronized();
                 const summaryResult2 = await summarizeNow(summarizer);
                 const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -201,445 +201,580 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
     });
 
     /*
-     * These tests validate such scenarios where nodes transition from unreferenced -> referenced -> unreferenced state
-     * by verifying that their unreferenced timestamps are updated correctly.
+     * These tests validate scenarios where nodes that are referenced between summaries have their unreferenced
+     * timestamp updated. These scenarios fall into the following categories:
+     * 1. Nodes transition from unreferenced -> referenced -> unreferenced between 2 summaries - In these scenarios
+     *    when GC runs, it should detect that the node was referenced and update its unreferenced timestamp.
+     * 2. Unreferenced nodes are referenced from other unreferenced nodes - In this case, even though the node remains
+     *    unreferenced, its unreferenced timestamp should be updated.
      *
      * In these tests, V = nodes and E = edges between nodes. Root nodes that are always referenced are marked as *.
      * The nodes are data stores / DDSes represented by alphabets A, B, C and so on.
      */
     describe("References between summaries", () => {
-        /*
-         * Validates that we can detect references that were added and then removed.
-         * 1. Summary 1 at t1. V = [A*, B]. E = []. B has unreferenced time t1.
-         * 2. Op adds reference from A to B. E = [A -> B].
-         * 3. Op removes reference from A to B. E = [].
-         * 4. Summary 2 at t2. V = [A*, B]. E = []. B has unreferenced time t2.
-         * Validates that the unreferenced time for B is t2 which is > t1.
-         */
-        it(`Scenario 1 - Reference added and then removed`, async () => {
-            const summarizer = await createSummarizer(provider, mainContainer);
+        describe("Nodes transitioning from unreferenced -> referenced -> unreferenced", () => {
+            /*
+            * Validates that we can detect references that were added and then removed.
+            * 1. Summary 1 at t1. V = [A*, B]. E = []. B has unreferenced time t1.
+            * 2. Op adds reference from A to B. E = [A -> B].
+            * 3. Op removes reference from A to B. E = [].
+            * 4. Summary 2 at t2. V = [A*, B]. E = []. B has unreferenced time t2.
+            * Validates that the unreferenced time for B is t2 which is > t1.
+            */
+            it(`Scenario 1 - Reference added and then removed`, async () => {
+                const summarizer = await createSummarizer(provider, mainContainer);
 
-            // Create data store B and mark it as referenced by storing its handle in A.
-            const dataStoreB = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+                // Create data store B and mark it as referenced by storing its handle in A.
+                const dataStoreB = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                dataStoreA._root.set("dataStoreB", dataStoreB.handle);
 
-            // Remove the reference to B which marks is as unreferenced.
-            dataStoreA._root.delete("dataStoreB");
+                // Remove the reference to B which marks is as unreferenced.
+                dataStoreA._root.delete("dataStoreB");
 
-            // 1. Get summary 1 and validate that B has unreferenced timestamp. E = [].
-            await provider.ensureSynchronized();
-            const summaryResult1 = await summarizeNow(summarizer);
-            const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
-            const dsBTime1 = timestamps1.get(dataStoreB._context.id);
-            assert(dsBTime1 !== undefined, `B should have unreferenced timestamp`);
+                // 1. Get summary 1 and validate that B has unreferenced timestamp. E = [].
+                await provider.ensureSynchronized();
+                const summaryResult1 = await summarizeNow(summarizer);
+                const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
+                const dsBTime1 = timestamps1.get(dataStoreB._context.id);
+                assert(dsBTime1 !== undefined, `B should have unreferenced timestamp`);
 
-            // 2. Add referenced from A to B. E = [A -> B].
-            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+                // 2. Add referenced from A to B. E = [A -> B].
+                dataStoreA._root.set("dataStoreB", dataStoreB.handle);
 
-            // 3. Remove reference from A to B. E = [].
-            dataStoreA._root.delete("dataStoreB");
+                // 3. Remove reference from A to B. E = [].
+                dataStoreA._root.delete("dataStoreB");
 
-            // 4. Get summary 2 and validate B's unreferenced timestamp updated. E = [].
-            await provider.ensureSynchronized();
-            const summaryResult2 = await summarizeNow(summarizer);
-            const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
-            const dsBTime2 = timestamps2.get(dataStoreB._context.id);
-            assert(dsBTime2 !== undefined && dsBTime2 > dsBTime1, `B's timestamp should have updated`);
+                // 4. Get summary 2 and validate B's unreferenced timestamp updated. E = [].
+                await provider.ensureSynchronized();
+                const summaryResult2 = await summarizeNow(summarizer);
+                const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+                const dsBTime2 = timestamps2.get(dataStoreB._context.id);
+                assert(dsBTime2 !== undefined && dsBTime2 > dsBTime1, `B's timestamp should have updated`);
+            });
+
+            /*
+            * Validates that we can detect references that were added transitively and then removed.
+            * 1. Summary 1 at t1. V = [A*, B, C]. E = [B -> C]. B and C have unreferenced time t1.
+            * 2. Op adds reference from A to B. E = [A -> B, B -> C].
+            * 3. Op removes reference from B to C. E = [A -> B].
+            * 4. Op removes reference from A to B. E = [].
+            * 5. Summary 2 at t2. V = [A*, B, C]. E = []. B and C have unreferenced time t2.
+            * Validates that the unreferenced time for B and C is t2 which is > t1.
+            */
+            it(`Scenario 2 - Reference transitively added and removed`, async () => {
+                const summarizer = await createSummarizer(provider, mainContainer);
+
+                // Create data stores B and C and mark them referenced as follows by storing their handles as follows:
+                // dataStoreA -> dataStoreB -> dataStoreC
+                const dataStoreB = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                const dataStoreC = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+                dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+
+                // Remove the reference to B which marks both B and C as unreferenced.
+                dataStoreA._root.delete("dataStoreB");
+
+                // 1. Get summary 1 and validate that both B and C have unreferenced timestamps. E = [B -> C].
+                await provider.ensureSynchronized();
+                const summaryResult1 = await summarizeNow(summarizer);
+                const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
+                const dsBTime1 = timestamps1.get(dataStoreB._context.id);
+                const dsCTime1 = timestamps1.get(dataStoreC._context.id);
+                assert(dsBTime1 !== undefined, `B should have unreferenced timestamp`);
+                assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+
+                // 2. Add reference from A to B. E = [A -> B, B -> C].
+                dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+
+                // 3. Remove reference from B to C. E = [A -> B].
+                dataStoreB._root.delete("dataStoreC");
+
+                // 4. Remove reference from A to B. E = [].
+                dataStoreA._root.delete("dataStoreB");
+
+                // 5. Get summary 2 and validate that both B and C's unreferenced timestamps updated. E = [].
+                await provider.ensureSynchronized();
+                const summaryResult2 = await summarizeNow(summarizer);
+                const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+                const dsBTime2 = timestamps2.get(dataStoreB._context.id);
+                const dsCTime2 = timestamps2.get(dataStoreC._context.id);
+                assert(dsBTime2 !== undefined && dsBTime2 > dsBTime1, `B's timestamp should have updated`);
+                assert(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+            });
+
+            /*
+            * Validates that we can detect chain of references in which the first reference was added and then removed.
+            * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [B -> C, C -> D]. B, C and D have unreferenced time t1.
+            * 2. Op adds reference from A to B. E = [A -> B, B -> C, C -> D].
+            * 3. Op removes reference from A to B. E = [B -> C, C -> D].
+            * 4. Summary 2 at t2. V = [A*, B, C, D]. E = [B -> C, C -> D]. B, C and D have unreferenced time t2.
+            * Validates that the unreferenced time for B, C and D is t2 which is > t1.
+            */
+            it(`Scenario 3 - Reference added through chain of references and removed`, async () => {
+                const summarizer = await createSummarizer(provider, mainContainer);
+
+                // Create data stores B, C and D and mark them referenced as follows by storing their handles as follows:
+                // dataStoreA -> dataStoreB -> dataStoreC -> dataStoreD
+                const dataStoreB = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                const dataStoreC = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                const dataStoreD = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+                dataStoreC._root.set("dataStoreD", dataStoreD.handle);
+                dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+
+                // Remove the reference to B which marks B, C and D as unreferenced.
+                dataStoreA._root.delete("dataStoreB");
+
+                // 1. Get summary 1 and validate that B, C and D have unreferenced timestamps. E = [B -> C, C -> D].
+                await provider.ensureSynchronized();
+                const summaryResult1 = await summarizeNow(summarizer);
+                const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
+                const dsBTime1 = timestamps1.get(dataStoreB._context.id);
+                const dsCTime1 = timestamps1.get(dataStoreC._context.id);
+                const dsDTime1 = timestamps1.get(dataStoreD._context.id);
+                assert(dsBTime1 !== undefined, `B should have unreferenced timestamp`);
+                assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+                assert(dsDTime1 !== undefined, `D should have unreferenced timestamp`);
+
+                // 2. Add reference from A to B. E = [A -> B, B -> C, C -> D].
+                dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+
+                // 3. Remove reference from A to B. E = [B -> C, C -> D].
+                dataStoreA._root.delete("dataStoreB");
+
+                // 4. Get summary 2 and validate that B, C and D's unreferenced timestamps updated. E = [B -> C, C -> D].
+                await provider.ensureSynchronized();
+                const summaryResult2 = await summarizeNow(summarizer);
+                const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+                const dsBTime2 = timestamps2.get(dataStoreB._context.id);
+                const dsCTime2 = timestamps2.get(dataStoreC._context.id);
+                const dsDTime2 = timestamps2.get(dataStoreD._context.id);
+                assert(dsBTime2 !== undefined && dsBTime2 > dsBTime1, `B's timestamp should have updated`);
+                assert(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+                assert(dsDTime2 !== undefined && dsDTime2 > dsDTime1, `D's timestamp should have updated`);
+            });
+
+            /*
+            * Validates that we can detect references that were added and removed via new data stores.
+            * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
+            * 2. Data store B is created. E = [].
+            * 3. Op adds reference from A to B. E = [A -> B].
+            * 4. Op adds reference from B to C. E = [A -> B, B -> C].
+            * 5. Op removes reference from B to C. E = [A -> B].
+            * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -> B]. C has unreferenced time t2.
+            * Validates that the unreferenced time for C is t2 which is > t1.
+            */
+            it(`Scenario 4 - Reference added and removed via new nodes`, async () => {
+                const summarizer = await createSummarizer(provider, mainContainer);
+
+                // Create data store C and mark it referenced by storing its handle in data store A.
+                const dataStoreC = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                dataStoreA._root.set("dataStoreC", dataStoreC.handle);
+
+                // Remove the reference to C to make it unreferenced.
+                dataStoreA._root.delete("dataStoreC");
+
+                // 1. Get summary 1 and validate that C is has unreferenced timestamp. E = [].
+                await provider.ensureSynchronized();
+                const summaryResult1 = await summarizeNow(summarizer);
+                const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
+                const dsCTime1 = timestamps1.get(dataStoreC._context.id);
+                assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+
+                // 2. Create data store B. E = [].
+                const dataStoreB = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+
+                // 3. Add reference from A to B. E = [A -> B].
+                dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+
+                // 4. Add reference from B to C. E = [A -> B, B -> C].
+                dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+
+                // 5. Remove reference from B to C. E = [A -> B].
+                dataStoreB._root.delete("dataStoreC");
+
+                // 6. Get summary 2 and validate that C's unreferenced timestamps updated. E = [A -> B].
+                await provider.ensureSynchronized();
+                const summaryResult2 = await summarizeNow(summarizer);
+                const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+                const dsCTime2 = timestamps2.get(dataStoreC._context.id);
+                assert(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+            });
+
+            /*
+            * Validates that we can detect references that were added and removed via new aliased data stores.
+            * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
+            * 2. Root data store B is created. E = [].
+            * 3. Op adds reference from A to B. E = [A -> B].
+            * 4. Op adds reference from B to C. E = [A -> B, B -> C].
+            * 5. Op removes reference from B to C. E = [A -> B].
+            * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -> B]. C has unreferenced time t2.
+            * Validates that the unreferenced time for C is t2 which is > t1.
+            *
+            * The difference from the previous tests is that the new data stores is a root data store. So, this validates
+            * that we can detect new root data stores and outbound references from them.
+            */
+            it(`Scenario 5 - Reference added via new root nodes and removed`, async () => {
+                const summarizer = await createSummarizer(provider, mainContainer);
+
+                // Create data store C and mark it referenced by storing its handle in data store A.
+                const dataStoreC = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                dataStoreA._root.set("dataStoreC", dataStoreC.handle);
+
+                // Remove the reference to C to make it unreferenced.
+                dataStoreA._root.delete("dataStoreC");
+
+                // 1. Get summary 1 and validate that C is has unreferenced timestamp. E = [].
+                await provider.ensureSynchronized();
+                const summaryResult1 = await summarizeNow(summarizer);
+                const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
+                const dsCTime1 = timestamps1.get(dataStoreC._context.id);
+                assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+
+                // 2. Create data store B. E = [].
+                const dataStore = await containerRuntime.createDataStore(TestDataObjectType);
+                await dataStore.trySetAlias("dataStoreA");
+                const dataStoreB = await requestFluidObject<ITestDataObject>(dataStore, "");
+
+                // 4. Add reference from B to C. E = [A -> B, B -> C].
+                dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+
+                // 5. Remove reference from B to C. E = [A -> B].
+                dataStoreB._root.delete("dataStoreC");
+
+                // 6. Get summary 2 and validate that C's unreferenced timestamps updated. E = [A -> B].
+                await provider.ensureSynchronized();
+                const summaryResult2 = await summarizeNow(summarizer);
+                const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+                const dsCTime2 = timestamps2.get(dataStoreC._context.id);
+                assert(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+            });
+
+            /*
+            * Validates that we can detect references that were added via new data stores before they are referenced
+            * themselves, and then the reference from the new data store is removed.
+            * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
+            * 2. Data store B is created. E = [].
+            * 3. Add reference from B to C. E = [].
+            * 4. Op adds reference from A to B. E = [A -> B, B -> C].
+            * 5. Op removes reference from B to C. E = [A -> B].
+            * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -> B]. C has unreferenced time t2.
+            * Validates that the unreferenced time for C is t2 which is > t1.
+            *
+            * The difference from previous test case is that the reference from B to C is added before B is referenced and
+            * observed by summarizer. So, the summarizer does not see this reference directly but only when B is realized.
+            */
+            it(`Scenario 6 - Reference added via new unreferenced nodes and removed`, async () => {
+                const summarizer = await createSummarizer(provider, mainContainer);
+
+                // Create data store C and mark it referenced by storing its handle in data store A.
+                const dataStoreC = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                dataStoreA._root.set("dataStoreC", dataStoreC.handle);
+
+                // Remove the reference to C to make it unreferenced.
+                dataStoreA._root.delete("dataStoreC");
+
+                // 1. Get summary 1 and validate that C is has unreferenced timestamp. E = [].
+                await provider.ensureSynchronized();
+                const summaryResult1 = await summarizeNow(summarizer);
+                const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
+                const dsCTime1 = timestamps1.get(dataStoreC._context.id);
+                assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+
+                // 2. Create data store B. E = [].
+                const dataStoreB = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+
+                // 3. Add reference from B to C. E = [].
+                dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+
+                // 4. Add reference from A to B. E = [A -> B, B -> C].
+                dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+
+                // 5. Remove reference from B to C. E = [A -> B].
+                dataStoreB._root.delete("dataStoreC");
+
+                // 6. Get summary 2 and validate that C's unreferenced timestamps updated. E = [A -> B].
+                await provider.ensureSynchronized();
+                const summaryResult2 = await summarizeNow(summarizer);
+                const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+                const dsCTime2 = timestamps2.get(dataStoreC._context.id);
+                assert(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+            });
+
+            /*
+            * Validates that we can detect references that were added transitively via new data stores before they are
+            * references themselves, and then the reference from the new data store is removed.
+            * 1. Summary 1 at t1. V = [A*, D]. E = []. D has unreferenced time t1.
+            * 2. Data stores B and C are created. E = [].
+            * 3. Add reference from B to C. E = [].
+            * 4. Add reference from C to D. E = [].
+            * 5. Op adds reference from A to B. E = [A -> B, B -> C, C -> D].
+            * 6. Op removes reference from C to D. E = [A -> B, B -> C].
+            * 7. Summary 2 at t2. V = [A*, B, C]. E = [A -> B, B -> C]. D has unreferenced time t2.
+            * Validates that the unreferenced time for D is t2 which is > t1.
+            *
+            * This difference from the previous test case is that there is another level of indirection here that
+            * references the node which was unreferenced in previous summary.
+            */
+            it(`Scenario 7 - Reference added transitively via new nodes and removed`, async () => {
+                const summarizer = await createSummarizer(provider, mainContainer);
+
+                // Create data store D and mark it referenced by storing its handle in data store A.
+                const dataStoreD = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                dataStoreA._root.set("dataStoreD", dataStoreD.handle);
+
+                // Remove the reference to D which marks it as unreferenced.
+                dataStoreA._root.delete("dataStoreD");
+
+                // 1. Get summary 1 and validate that D is has unreferenced timestamp. E = [].
+                await provider.ensureSynchronized();
+                const summaryResult1 = await summarizeNow(summarizer);
+                const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
+                const dsDTime1 = timestamps1.get(dataStoreD._context.id);
+                assert(dsDTime1 !== undefined, `D should have unreferenced timestamp`);
+
+                // 2. Create data stores B and C. E = [].
+                const dataStoreB = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                const dataStoreC = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+
+                // 3. Add reference from B to C. E = [].
+                dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+
+                // 4. Add reference from C to D. E = [].
+                dataStoreC._root.set("dataStoreD", dataStoreD.handle);
+
+                // 5. Add reference from A to B. E = [A -> B, B -> C, C -> D].
+                dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+
+                // 6. Remove reference from C to D. E = [A -> B, B -> C].
+                dataStoreC._root.delete("dataStoreD");
+
+                // 7. Get summary 2 and validate that D's unreferenced timestamps updated. E = [A -> B, B -> C].
+                await provider.ensureSynchronized();
+                const summaryResult2 = await summarizeNow(summarizer);
+                const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+                const dsDTime2 = timestamps2.get(dataStoreD._context.id);
+                assert(dsDTime2 !== undefined && dsDTime2 > dsDTime1, `D's timestamp should have updated`);
+            });
+
+            /*
+            * Validates that DDSes are referenced even though we don't detect their referenced between summaries. Once we
+            * do GC at DDS level, this test will fail - https://github.com/microsoft/FluidFramework/issues/8470.
+            * 1. Summary 1 at t1. V = [A*]. E = [].
+            * 2. DDS B is created. No reference is added to it.
+            * 3. Summary 2 at t2. V = [A*, B]. E = []. B is still referenced.
+            */
+            it(`Scenario 8 - Reference to DDS not added`, async () => {
+                const summarizer = await createSummarizer(provider, mainContainer);
+
+                // 1. Get summary 1 and validate that A is referenced. E = [].
+                await provider.ensureSynchronized();
+                const summaryResult1 = await summarizeNow(summarizer);
+                const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
+                assert(timestamps1.get(dataStoreA._context.id) === undefined, "A should be referenced");
+
+                // 2. Create a DDS B and don't mark it as referenced (by adding its handle in another DDS).
+                const ddsB = SharedMap.create(dataStoreA._runtime);
+                ddsB.bindToContext();
+
+                // 3. Get summary 2 and validate that B still does not have unreferenced timestamp. E = [].
+                await provider.ensureSynchronized();
+                const summaryResult2 = await summarizeNow(summarizer);
+                const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+                const ddsBUrl = `/${dataStoreA._context.id}/${ddsB.id}`;
+                const ddsBTime1 = timestamps2.get(ddsBUrl.slice(1));
+                assert(
+                    ddsBTime1 === undefined,
+                    `B should not have unreferenced timestamp since we do not have GC at DDS level yet`,
+                );
+            });
         });
 
-        /*
-         * Validates that we can detect references that were added transitively and then removed.
-         * 1. Summary 1 at t1. V = [A*, B, C]. E = [B -> C]. B and C have unreferenced time t2.
-         * 2. Op adds reference from A to B. E = [A -> B, B -> C].
-         * 3. Op removes reference from B to C. E = [A -> B].
-         * 4. Op removes reference from A to B. E = [].
-         * 5. Summary 2 at t2. V = [A*, B, C]. E = []. B and C have unreferenced time t2.
-         * Validates that the unreferenced time for B and C is t2 which is > t1.
-         */
-        it(`Scenario 2 - Reference transitively added and removed`, async () => {
-            const summarizer = await createSummarizer(provider, mainContainer);
+        describe("References to unreferenced nodes from another unreferenced node", () => {
+            /**
+             * Function that asserts the given value is not true. Used in these tests to demonstrate that because of
+             * a bug we are not getting the expected results. Once the bug is fixed, these asserts should start working
+             * as expected.
+             */
+            function assertNotTrue(value: boolean, message: string) {
+                assert(!value, message);
+            }
 
-            // Create data stores B and C and mark them referenced as follows by storing their handles as follows:
-            // dataStoreA -> dataStoreB -> dataStoreC
-            const dataStoreB = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-            const dataStoreC = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-            dataStoreB._root.set("dataStoreC", dataStoreC.handle);
-            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+            /*
+             * Validates that we can detect references that are added from an unreferenced node to another.
+             * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
+             * 2. Op adds reference from B to C. E = [B -> C].
+             * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. C has unreferenced time t2.
+             * Validates that the unreferenced time for C is t2 which is > t1.
+             */
+            it(`Scenario 1 - Reference added to an unreferenced node`, async () => {
+                const summarizer = await createSummarizer(provider, mainContainer);
 
-            // Remove the reference to B which marks both B and C as unreferenced.
-            dataStoreA._root.delete("dataStoreB");
+                // Create data stores B and C and mark them referenced as follows by storing their handles as follows:
+                // dataStoreA -> dataStoreB -> dataStoreC.
+                const dataStoreB = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                const dataStoreC = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+                dataStoreA._root.set("dataStoreB", dataStoreB.handle);
 
-            // 1. Get summary 1 and validate that both B and C have unreferenced timestamps. E = [B -> C].
-            await provider.ensureSynchronized();
-            const summaryResult1 = await summarizeNow(summarizer);
-            const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
-            const dsBTime1 = timestamps1.get(dataStoreB._context.id);
-            const dsCTime1 = timestamps1.get(dataStoreC._context.id);
-            assert(dsBTime1 !== undefined, `B should have unreferenced timestamp`);
-            assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+                // Remove the reference from A to B and B to C which marks both B and C as unreferenced.
+                dataStoreA._root.delete("dataStoreB");
+                dataStoreB._root.delete("dataStoreC");
 
-            // 2. Add reference from A to B. E = [A -> B, B -> C].
-            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+                // 1. Get summary 1 and validate that both B and C have unreferenced timestamps. E = [B -> C].
+                await provider.ensureSynchronized();
+                const summaryResult1 = await summarizeNow(summarizer);
+                const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
+                const dsBTime1 = timestamps1.get(dataStoreB._context.id);
+                const dsCTime1 = timestamps1.get(dataStoreC._context.id);
+                assert(dsBTime1 !== undefined, `B should have unreferenced timestamp`);
+                assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
 
-            // 3. Remove reference from B to C. E = [A -> B].
-            dataStoreB._root.delete("dataStoreC");
+                // 2. Add reference from B to C. E = [B -> C].
+                dataStoreB._root.set("dataStoreC", dataStoreC.handle);
 
-            // 4. Remove reference from A to B. E = [].
-            dataStoreA._root.delete("dataStoreB");
+                // 3. Get summary 2 and validate that both C's unreferenced timestamp has updated. E = [B -> C].
+                await provider.ensureSynchronized();
+                const summaryResult2 = await summarizeNow(summarizer);
+                const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+                const dsBTime2 = timestamps2.get(dataStoreB._context.id);
+                const dsCTime2 = timestamps2.get(dataStoreC._context.id);
+                assert(dsBTime2 === dsBTime1, `B's timestamp should be the same`);
 
-            // 5. Get summary 2 and validate that both B and C's unreferenced timestamps updated. E = [].
-            await provider.ensureSynchronized();
-            const summaryResult2 = await summarizeNow(summarizer);
-            const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
-            const dsBTime2 = timestamps2.get(dataStoreB._context.id);
-            const dsCTime2 = timestamps2.get(dataStoreC._context.id);
-            assert(dsBTime2 !== undefined && dsBTime2 > dsBTime1, `B's timestamp should have updated`);
-            assert(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
-        });
+                // The following assert is currently not true due to a bug. Will be updated when the bug is fixed.
+                assertNotTrue(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+            });
 
-        /*
-         * Validates that we can detect chain of references in which the first reference was added and then removed.
-         * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [B -> C, C -> D]. B, C and D have unreferenced time t2.
-         * 2. Op adds reference from A to B. E = [A -> B, B -> C, C -> D].
-         * 3. Op removes reference from A to B. E = [B -> C, C -> D].
-         * 4. Summary 2 at t2. V = [A*, B, C, D]. E = [B -> C, C -> D]. B, C and D have unreferenced time t2.
-         * Validates that the unreferenced time for B, C and D is t2 which is > t1.
-         */
-        it(`Scenario 3 - Reference added through chain of references and removed`, async () => {
-            const summarizer = await createSummarizer(provider, mainContainer);
+            /*
+             * Validates that we can detect references that are added from an unreferenced node to a list of
+             * unreferenced nodes, i.e., nodes with references to each other but are overall unreferenced.
+             * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [C -> D]. B, C and D have unreferenced time t1.
+             * 2. Op adds reference from B to C. E = [B -> C, C -> D].
+             * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -> C, C -> D]. C and D have unreferenced time t2.
+             * Validates that the unreferenced time for C and D is t2 which is > t1.
+             */
+            it(`Scenario 2 - Reference added to a list of unreferenced nodes`, async () => {
+                const summarizer = await createSummarizer(provider, mainContainer);
 
-            // Create data stores B, C and D and mark them referenced as follows by storing their handles as follows:
-            // dataStoreA -> dataStoreB -> dataStoreC -> dataStoreD
-            const dataStoreB = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-            const dataStoreC = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-            const dataStoreD = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-            dataStoreB._root.set("dataStoreC", dataStoreC.handle);
-            dataStoreC._root.set("dataStoreD", dataStoreD.handle);
-            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+                // Create data stores B, C and D mark them referenced as follows by storing their handles as follows:
+                // dataStoreA -> dataStoreB -> dataStoreC -> dataStoreD.
+                const dataStoreB = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                const dataStoreC = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                const dataStoreD = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                dataStoreC._root.set("dataStoreD", dataStoreD.handle);
+                dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+                dataStoreA._root.set("dataStoreB", dataStoreB.handle);
 
-            // Remove the reference to B which marks B, C and D as unreferenced.
-            dataStoreA._root.delete("dataStoreB");
+                // Remove the reference from A to B and B to C which marks B, C and D as unreferenced.
+                dataStoreA._root.delete("dataStoreB");
+                dataStoreB._root.delete("dataStoreC");
 
-            // 1. Get summary 1 and validate that B, C and D have unreferenced timestamps. E = [B -> C, C -> D].
-            await provider.ensureSynchronized();
-            const summaryResult1 = await summarizeNow(summarizer);
-            const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
-            const dsBTime1 = timestamps1.get(dataStoreB._context.id);
-            const dsCTime1 = timestamps1.get(dataStoreC._context.id);
-            const dsDTime1 = timestamps1.get(dataStoreD._context.id);
-            assert(dsBTime1 !== undefined, `B should have unreferenced timestamp`);
-            assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
-            assert(dsDTime1 !== undefined, `D should have unreferenced timestamp`);
+                // 1. Get summary 1 and validate that B, C and D have unreferenced timestamps. E = [C -> D].
+                await provider.ensureSynchronized();
+                const summaryResult1 = await summarizeNow(summarizer);
+                const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
+                const dsBTime1 = timestamps1.get(dataStoreB._context.id);
+                const dsCTime1 = timestamps1.get(dataStoreC._context.id);
+                const dsDTime1 = timestamps1.get(dataStoreD._context.id);
+                assert(dsBTime1 !== undefined, `B should have unreferenced timestamp`);
+                assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+                assert(dsDTime1 !== undefined, `D should have unreferenced timestamp`);
 
-            // 2. Add reference from A to B. E = [A -> B, B -> C, C -> D].
-            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+                // 2. Add reference from B to C. E = [B -> C, C -> D].
+                dataStoreB._root.set("dataStoreC", dataStoreC.handle);
 
-            // 3. Remove reference from A to B. E = [B -> C, C -> D].
-            dataStoreA._root.delete("dataStoreB");
+                // 3. Get summary 2 and validate that C and D's unreferenced timestamps updated. E = [B -> C, C -> D].
+                await provider.ensureSynchronized();
+                const summaryResult2 = await summarizeNow(summarizer);
+                const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+                const dsBTime2 = timestamps2.get(dataStoreB._context.id);
+                const dsCTime2 = timestamps2.get(dataStoreC._context.id);
+                const dsDTime2 = timestamps2.get(dataStoreD._context.id);
+                assert(dsBTime2 === dsBTime1, `B's timestamp should be the same`);
 
-            // 4. Get summary 2 and validate that B, C and D's unreferenced timestamps updated. E = [B -> C, C -> D].
-            await provider.ensureSynchronized();
-            const summaryResult2 = await summarizeNow(summarizer);
-            const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
-            const dsBTime2 = timestamps2.get(dataStoreB._context.id);
-            const dsCTime2 = timestamps2.get(dataStoreC._context.id);
-            const dsDTime2 = timestamps2.get(dataStoreD._context.id);
-            assert(dsBTime2 !== undefined && dsBTime2 > dsBTime1, `B's timestamp should have updated`);
-            assert(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
-            assert(dsDTime2 !== undefined && dsDTime2 > dsDTime1, `D's timestamp should have updated`);
-        });
+                // The following asserts are currently not true due to a bug. Will be updated when the bug is fixed.
+                assertNotTrue(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+                assertNotTrue(dsDTime2 !== undefined && dsDTime2 > dsDTime1, `D's timestamp should have updated`);
+            });
 
-        /*
-         * Validates that we can detect references that were added and removed via new data stores.
-         * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
-         * 2. Data store B is created. E = [].
-         * 3. Op adds reference from A to B. E = [A -> B].
-         * 4. Op adds reference from B to C. E = [A -> B, B -> C].
-         * 5. Op removes reference from B to C. E = [A -> B].
-         * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -> B]. C has unreferenced time t2.
-         * Validates that the unreferenced time for C is t2 which is > t1.
-         */
-        it(`Scenario 4 - Reference added and removed via new nodes`, async () => {
-            const summarizer = await createSummarizer(provider, mainContainer);
+            /*
+             * Validates that we can detect references that are added from an unreferenced node to a list of
+             * unreferenced nodes, i.e., nodes with references to each other but are overall unreferenced. Then
+             * a reference between the list is removed
+             * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [C -> D]. B, C and D have unreferenced time t1.
+             * 2. Op adds reference from B to C. E = [B -> C, C -> D].
+             * 3. Op removes reference from C to D. E = [B -> C].
+             * 4. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. C and D have unreferenced time t2.
+             * Validates that the unreferenced time for C and D is t2 which is > t1.
+             */
+            it(`Scenario 2 - Reference added to a list of unreferenced nodes and a reference is removed`, async () => {
+                const summarizer = await createSummarizer(provider, mainContainer);
 
-            // Create data store C and mark it referenced by storing its handle in data store A.
-            const dataStoreC = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-            dataStoreA._root.set("dataStoreC", dataStoreC.handle);
+                // Create data stores B, C and D mark them referenced as follows by storing their handles as follows:
+                // dataStoreA -> dataStoreB -> dataStoreC -> dataStoreD.
+                const dataStoreB = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                const dataStoreC = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                const dataStoreD = await requestFluidObject<ITestDataObject>(
+                    await containerRuntime.createDataStore(TestDataObjectType), "");
+                dataStoreC._root.set("dataStoreD", dataStoreD.handle);
+                dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+                dataStoreA._root.set("dataStoreB", dataStoreB.handle);
 
-            // Remove the reference to C to make it unreferenced.
-            dataStoreA._root.delete("dataStoreC");
+                // Remove the reference from A to B and B to C which marks B, C and D as unreferenced.
+                dataStoreA._root.delete("dataStoreB");
+                dataStoreB._root.delete("dataStoreC");
 
-            // 1. Get summary 1 and validate that C is has unreferenced timestamp. E = [].
-            await provider.ensureSynchronized();
-            const summaryResult1 = await summarizeNow(summarizer);
-            const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
-            const dsCTime1 = timestamps1.get(dataStoreC._context.id);
-            assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+                // 1. Get summary 1 and validate that B, C and D have unreferenced timestamps. E = [B -> C, C -> D].
+                await provider.ensureSynchronized();
+                const summaryResult1 = await summarizeNow(summarizer);
+                const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
+                const dsBTime1 = timestamps1.get(dataStoreB._context.id);
+                const dsCTime1 = timestamps1.get(dataStoreC._context.id);
+                const dsDTime1 = timestamps1.get(dataStoreD._context.id);
+                assert(dsBTime1 !== undefined, `B should have unreferenced timestamp`);
+                assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+                assert(dsDTime1 !== undefined, `D should have unreferenced timestamp`);
 
-            // 2. Create data store B. E = [].
-            const dataStoreB = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
+                // 2. Add reference from B to C. E = [B -> C].
+                dataStoreB._root.set("dataStoreC", dataStoreC.handle);
 
-            // 3. Add reference from A to B. E = [A -> B].
-            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+                // 3. Remove reference from C to D. E = [B -> C].
+                dataStoreC._root.delete("dataStoreD");
 
-            // 4. Add reference from B to C. E = [A -> B, B -> C].
-            dataStoreB._root.set("dataStoreC", dataStoreC.handle);
+                // 4. Get summary 2 and validate that C and D's unreferenced timestamps updated. E = [B -> C].
+                await provider.ensureSynchronized();
+                const summaryResult2 = await summarizeNow(summarizer);
+                const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+                const dsBTime2 = timestamps2.get(dataStoreB._context.id);
+                const dsCTime2 = timestamps2.get(dataStoreC._context.id);
+                const dsDTime2 = timestamps2.get(dataStoreD._context.id);
+                assert(dsBTime2 === dsBTime1, `B's timestamp should be the same`);
 
-            // 5. Remove reference from B to C. E = [A -> B].
-            dataStoreB._root.delete("dataStoreC");
-
-            // 6. Get summary 2 and validate that C's unreferenced timestamps updated. E = [A -> B].
-            await provider.ensureSynchronized();
-            const summaryResult2 = await summarizeNow(summarizer);
-            const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
-            const dsCTime2 = timestamps2.get(dataStoreC._context.id);
-            assert(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
-        });
-
-        /*
-         * Validates that we can detect references that were added and removed via new aliased data stores.
-         * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
-         * 2. Root data store B is created. E = [].
-         * 3. Op adds reference from A to B. E = [A -> B].
-         * 4. Op adds reference from B to C. E = [A -> B, B -> C].
-         * 5. Op removes reference from B to C. E = [A -> B].
-         * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -> B]. C has unreferenced time t2.
-         * Validates that the unreferenced time for C is t2 which is > t1.
-         *
-         * The difference from the previous tests is that the new data stores is a root data store. So, this validates
-         * that we can detect new root data stores and outbound references from them.
-         */
-        it(`Scenario 5 - Reference added via new root nodes and removed`, async () => {
-            const summarizer = await createSummarizer(provider, mainContainer);
-
-            // Create data store C and mark it referenced by storing its handle in data store A.
-            const dataStoreC = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-            dataStoreA._root.set("dataStoreC", dataStoreC.handle);
-
-            // Remove the reference to C to make it unreferenced.
-            dataStoreA._root.delete("dataStoreC");
-
-            // 1. Get summary 1 and validate that C is has unreferenced timestamp. E = [].
-            await provider.ensureSynchronized();
-            const summaryResult1 = await summarizeNow(summarizer);
-            const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
-            const dsCTime1 = timestamps1.get(dataStoreC._context.id);
-            assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
-
-            // 2. Create data store B. E = [].
-            const dataStore = await containerRuntime.createDataStore(TestDataObjectType);
-            await dataStore.trySetAlias("dataStoreA");
-            const dataStoreB = await requestFluidObject<ITestDataObject>(dataStore, "");
-
-            // 4. Add reference from B to C. E = [A -> B, B -> C].
-            dataStoreB._root.set("dataStoreC", dataStoreC.handle);
-
-            // 5. Remove reference from B to C. E = [A -> B].
-            dataStoreB._root.delete("dataStoreC");
-
-            // 6. Get summary 2 and validate that C's unreferenced timestamps updated. E = [A -> B].
-            await provider.ensureSynchronized();
-            const summaryResult2 = await summarizeNow(summarizer);
-            const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
-            const dsCTime2 = timestamps2.get(dataStoreC._context.id);
-            assert(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
-        });
-
-        /*
-         * Validates that we can detect references that were added via new data stores before they are referenced
-         * themselves, and then the reference from the new data store is removed.
-         * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
-         * 2. Data store B is created. E = [].
-         * 3. Add reference from B to C. E = [].
-         * 4. Op adds reference from A to B. E = [A -> B, B -> C].
-         * 5. Op removes reference from B to C. E = [A -> B].
-         * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -> B]. C has unreferenced time t2.
-         * Validates that the unreferenced time for C is t2 which is > t1.
-         *
-         * The difference from previous test case is that the reference from B to C is added before B is referenced and
-         * observed by summarizer. So, the summarizer does not see this reference directly but only when B is realized.
-         */
-        it(`Scenario 6 - Reference added via new unreferenced nodes and removed`, async () => {
-            const summarizer = await createSummarizer(provider, mainContainer);
-
-            // Create data store C and mark it referenced by storing its handle in data store A.
-            const dataStoreC = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-            dataStoreA._root.set("dataStoreC", dataStoreC.handle);
-
-            // Remove the reference to C to make it unreferenced.
-            dataStoreA._root.delete("dataStoreC");
-
-            // 1. Get summary 1 and validate that C is has unreferenced timestamp. E = [].
-            await provider.ensureSynchronized();
-            const summaryResult1 = await summarizeNow(summarizer);
-            const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
-            const dsCTime1 = timestamps1.get(dataStoreC._context.id);
-            assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
-
-            // 2. Create data store B. E = [].
-            const dataStoreB = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-
-            // 3. Add reference from B to C. E = [].
-            dataStoreB._root.set("dataStoreC", dataStoreC.handle);
-
-            // 4. Add reference from A to B. E = [A -> B, B -> C].
-            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
-
-            // 5. Remove reference from B to C. E = [A -> B].
-            dataStoreB._root.delete("dataStoreC");
-
-            // 6. Get summary 2 and validate that C's unreferenced timestamps updated. E = [A -> B].
-            await provider.ensureSynchronized();
-            const summaryResult2 = await summarizeNow(summarizer);
-            const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
-            const dsCTime2 = timestamps2.get(dataStoreC._context.id);
-            assert(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
-        });
-
-        /*
-         * Validates that we can detect references that were added transitively via new data stores before they are
-         * references themselves, and then the reference from the new data store is removed.
-         * 1. Summary 1 at t1. V = [A*, D]. E = []. D has unreferenced time t1.
-         * 2. Data stores B and C are created. E = [].
-         * 3. Add reference from B to C. E = [].
-         * 4. Add reference from C to D. E = [].
-         * 5. Op adds reference from A to B. E = [A -> B, B -> C, C -> D].
-         * 6. Op removes reference from C to D. E = [A -> B, B -> C].
-         * 7. Summary 2 at t2. V = [A*, B, C]. E = [A -> B, B -> C]. D has unreferenced time t2.
-         * Validates that the unreferenced time for D is t2 which is > t1.
-         *
-         * This difference from the previous test case is that there is another level of indirection here that
-         * references the node which was unreferenced in previous summary.
-         */
-        it(`Scenario 7 - Reference added transitively via new nodes and removed`, async () => {
-            const summarizer = await createSummarizer(provider, mainContainer);
-
-            // Create data store D and mark it referenced by storing its handle in data store A.
-            const dataStoreD = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-            dataStoreA._root.set("dataStoreD", dataStoreD.handle);
-
-            // Remove the reference to D which marks it as unreferenced.
-            dataStoreA._root.delete("dataStoreD");
-
-            // 1. Get summary 1 and validate that D is has unreferenced timestamp. E = [].
-            await provider.ensureSynchronized();
-            const summaryResult1 = await summarizeNow(summarizer);
-            const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
-            const dsDTime1 = timestamps1.get(dataStoreD._context.id);
-            assert(dsDTime1 !== undefined, `D should have unreferenced timestamp`);
-
-            // 2. Create data stores B and C. E = [].
-            const dataStoreB = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-            const dataStoreC = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-
-            // 3. Add reference from B to C. E = [].
-            dataStoreB._root.set("dataStoreC", dataStoreC.handle);
-
-            // 4. Add reference from C to D. E = [].
-            dataStoreC._root.set("dataStoreD", dataStoreD.handle);
-
-            // 5. Add reference from A to B. E = [A -> B, B -> C, C -> D].
-            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
-
-            // 6. Remove reference from C to D. E = [A -> B, B -> C].
-            dataStoreC._root.delete("dataStoreD");
-
-            // 7. Get summary 2 and validate that D's unreferenced timestamps updated. E = [A -> B, B -> C].
-            await provider.ensureSynchronized();
-            const summaryResult2 = await summarizeNow(summarizer);
-            const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
-            const dsDTime2 = timestamps2.get(dataStoreD._context.id);
-            assert(dsDTime2 !== undefined && dsDTime2 > dsDTime1, `D's timestamp should have updated`);
-        });
-
-        /*
-         * Validates that references added by unreferences nodes do not show up as references.
-         * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
-         * 2. Op adds reference from B to C. E = [B -> C].
-         * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. B and C have unreferenced time t1.
-         * Validates that the unreferenced time for B and C is still t1.
-         */
-        it(`Scenario 8 - Reference added via unreferenced nodes`, async () => {
-            const summarizer = await createSummarizer(provider, mainContainer);
-
-            // Create data stores B and C and mark them referenced.
-            const dataStoreB = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-            const dataStoreC = await requestFluidObject<ITestDataObject>(
-                await containerRuntime.createDataStore(TestDataObjectType), "");
-            dataStoreA._root.set("dataStoreB", dataStoreB.handle);
-            dataStoreA._root.set("dataStoreC", dataStoreC.handle);
-
-            // Mark B and C as unreferenced for the first summary.
-            dataStoreA._root.delete("dataStoreB");
-            dataStoreA._root.delete("dataStoreC");
-
-            // 1. Get summary 1 and validate that both B and C have unreferenced timestamps. E = [].
-            await provider.ensureSynchronized();
-            const summaryResult1 = await summarizeNow(summarizer);
-            const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
-            const dsBTime1 = timestamps1.get(dataStoreB._context.id);
-            const dsCTime1 = timestamps1.get(dataStoreC._context.id);
-            assert(dsBTime1 !== undefined, `B should have unreferenced timestamp`);
-            assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
-
-            // 2. Add reference from B to C. E = [B -> C].
-            dataStoreB._root.set("dataStoreC", dataStoreC.handle);
-
-            // 3. Get summary 2 and validate that both B and C's unreferenced timestamps haven't changed. E = [B -> C].
-            await provider.ensureSynchronized();
-            const summaryResult2 = await summarizeNow(summarizer);
-            const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
-            const dsBTime2 = timestamps2.get(dataStoreB._context.id);
-            const dsCTime2 = timestamps2.get(dataStoreC._context.id);
-            assert(dsBTime2 === dsBTime1, `B's unreferenced timestamp should be unchanged`);
-            assert(dsCTime2 === dsCTime1, `C's unreferenced timestamp should be unchanged`);
-        });
-
-        /*
-         * Validates that DDSes are referenced even though we don't detect their referenced between summaries. Once we
-         * do GC at DDS level, this test will fail - https://github.com/microsoft/FluidFramework/issues/8470.
-         * 1. Summary 1 at t1. V = [A*]. E = [].
-         * 2. DDS B is created. No reference is added to it.
-         * 3. Summary 2 at t2. V = [A*, B]. E = []. B is still referenced.
-         */
-        it(`Scenario 9 - Reference to DDS not added`, async () => {
-            const summarizer = await createSummarizer(provider, mainContainer);
-
-            // 1. Get summary 1 and validate that A is referenced. E = [].
-            await provider.ensureSynchronized();
-            const summaryResult1 = await summarizeNow(summarizer);
-            const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
-            assert(timestamps1.get(dataStoreA._context.id) === undefined, "A should be referenced");
-
-            // 2. Create a DDS B and don't mark it as referenced (by adding its handle in another DDS).
-            const ddsB = SharedMap.create(dataStoreA._runtime);
-            ddsB.bindToContext();
-
-            // 3. Get summary 2 and validate that B still does not have unreferenced timestamp. E = [].
-            await provider.ensureSynchronized();
-            const summaryResult2 = await summarizeNow(summarizer);
-            const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
-            const ddsBUrl = `/${dataStoreA._context.id}/${ddsB.id}`;
-            const ddsBTime1 = timestamps2.get(ddsBUrl.slice(1));
-            assert(
-                ddsBTime1 === undefined,
-                `B should not have unreferenced timestamp since we do not have GC at DDS level yet`,
-            );
+                // The following asserts are currently not true due to a bug. Will be updated when the bug is fixed.
+                assertNotTrue(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+                assertNotTrue(dsDTime2 !== undefined && dsDTime2 > dsDTime1, `D's timestamp should have updated`);
+            });
         });
     });
 });


### PR DESCRIPTION
Currently, when an unreferenced node adds reference to other unreferenced nodes, their unreferenced timestamps are not updated. However, this is incorrect because any client can retrieve the objects for the nodes whose references are added and then they have until session expiry to reference it back. So, the unreferenced timestamp needs to be updated to give enough time for these sessions to expire and we can safely delete these objects.

This PR adds tests for these scenarios and validates that they are failing currently. Once the bug is fixed, the tests will be updated so that they pass.

Bug for the above scenario - [AB#2801](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2801).

