### PR TITLE
Tree: compose fixes

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -726,7 +726,7 @@ interface Modify<TTree = ProtoNode> {
 }
 
 // @public (undocumented)
-interface Modify_2<TNodeChange = NodeChangeType> extends HasChanges<TNodeChange>, HasRevisionTag {
+interface Modify_2<TNodeChange = NodeChangeType> extends HasChanges<TNodeChange> {
     // (undocumented)
     tomb?: RevisionTag;
     // (undocumented)

--- a/packages/dds/tree/src/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/edit-manager/editManager.ts
@@ -232,6 +232,8 @@ export class EditManager<
             inverses.unshift(tagInverse(inverse, localChange.revision));
         }
 
+        // This approach can lead to non-minimal changesets (and therefore deltas) for local inserts because
+        // the rebased local insert does not cancel out with its inverse during composition.
         const netChange = this.changeFamily.rebaser.compose([
             ...inverses,
             trunkChange,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/format.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/format.ts
@@ -24,9 +24,7 @@ export type SizedObjectMark<TNodeChange = NodeChangeType> =
     | Detach
     | ModifyDetach<TNodeChange>;
 
-export interface Modify<TNodeChange = NodeChangeType>
-    extends HasChanges<TNodeChange>,
-        HasRevisionTag {
+export interface Modify<TNodeChange = NodeChangeType> extends HasChanges<TNodeChange> {
     type: "Modify";
     tomb?: RevisionTag;
 }

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -8,6 +8,7 @@ import { fail } from "../../util";
 import {
     Attach,
     Detach,
+    HasRevisionTag,
     HasTiebreakPolicy,
     Insert,
     LineageEvent,
@@ -295,10 +296,14 @@ export function isObjMark<TNodeChange>(
  * When `false` is returned, `lhs` is left untouched.
  */
 export function tryExtendMark(lhs: ObjectMark, rhs: Readonly<ObjectMark>): boolean {
-    if (rhs.type !== lhs.type || rhs.revision !== lhs.revision) {
+    if (rhs.type !== lhs.type) {
         return false;
     }
     const type = rhs.type;
+    if (type !== "Modify" && rhs.revision !== (lhs as HasRevisionTag).revision) {
+        return false;
+    }
+
     switch (type) {
         case "Insert":
         case "MoveIn": {

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { RevisionTag } from "../../../core";
 import { SequenceField as SF } from "../../../feature-libraries";
-import { makeAnonChange, TaggedChange } from "../../../rebase";
+import { makeAnonChange, tagChange, TaggedChange } from "../../../rebase";
 import { TreeSchemaIdentifier } from "../../../schema-stored";
 import { brand } from "../../../util";
 import { TestChange } from "../../testChange";
@@ -14,12 +14,10 @@ import { deepFreeze } from "../../utils";
 import { cases, ChangeMaker as Change, TestChangeset } from "./testEdits";
 
 const type: TreeSchemaIdentifier = brand("Node");
-const tag0: RevisionTag = brand(0);
 const tag1: RevisionTag = brand(1);
 const tag2: RevisionTag = brand(2);
 const tag3: RevisionTag = brand(3);
 const tag4: RevisionTag = brand(4);
-const tag5: RevisionTag = brand(5);
 
 function compose(changes: TaggedChange<TestChangeset>[]): TestChangeset {
     changes.forEach(deepFreeze);
@@ -152,7 +150,6 @@ describe("SequenceField - Compose", () => {
         const revive: TestChangeset = [
             {
                 type: "MRevive",
-                revision: tag1,
                 detachedBy: tag1,
                 detachIndex: 0,
                 changes: childChangeA,
@@ -167,7 +164,6 @@ describe("SequenceField - Compose", () => {
         const expected: TestChangeset = [
             {
                 type: "MRevive",
-                revision: tag1,
                 detachedBy: tag1,
                 detachIndex: 0,
                 changes: childChangeAB,
@@ -232,7 +228,7 @@ describe("SequenceField - Compose", () => {
             },
             {
                 type: "Insert",
-                revision: tag3,
+                revision: tag1,
                 content: [
                     { type, value: 5 },
                     { type, value: 6 },
@@ -242,8 +238,14 @@ describe("SequenceField - Compose", () => {
         const deletion = Change.delete(1, 4);
         const actual = shallowCompose([makeAnonChange(insert), makeAnonChange(deletion)]);
         const expected: SF.Changeset = [
-            { type: "Insert", revision: tag1, content: [{ type, value: 1 }] },
-            { type: "Insert", revision: tag3, content: [{ type, value: 6 }] },
+            {
+                type: "Insert",
+                revision: tag1,
+                content: [
+                    { type, value: 1 },
+                    { type, value: 6 },
+                ],
+            },
         ];
         assert.deepEqual(actual, expected);
     });
@@ -258,25 +260,25 @@ describe("SequenceField - Compose", () => {
     it("delete ○ delete", () => {
         // Deletes ABC-----IJKLM
         const deleteA: SF.Changeset = [
-            { type: "Delete", revision: tag1, count: 3 },
+            { type: "Delete", count: 3 },
             5,
-            { type: "Delete", revision: tag2, count: 5 },
+            { type: "Delete", count: 5 },
         ];
         // Deletes DEFG--OP
         const deleteB: SF.Changeset = [
-            { type: "Delete", revision: tag3, count: 4 },
+            { type: "Delete", count: 4 },
             2,
-            { type: "Delete", revision: tag4, count: 2 },
+            { type: "Delete", count: 2 },
         ];
-        const actual = shallowCompose([makeAnonChange(deleteA), makeAnonChange(deleteB)]);
+        const actual = shallowCompose([tagChange(deleteA, tag1), tagChange(deleteB, tag2)]);
         // Deletes ABCDEFG-IJKLMNOP
         const expected: SF.Changeset = [
             { type: "Delete", revision: tag1, count: 3 },
-            { type: "Delete", revision: tag3, count: 4 },
+            { type: "Delete", revision: tag2, count: 4 },
             1,
-            { type: "Delete", revision: tag2, count: 5 },
+            { type: "Delete", revision: tag1, count: 5 },
             1,
-            { type: "Delete", revision: tag4, count: 2 },
+            { type: "Delete", revision: tag2, count: 2 },
         ];
         assert.deepEqual(actual, expected);
     });
@@ -285,15 +287,15 @@ describe("SequenceField - Compose", () => {
         const revive = Change.revive(0, 5, 0, tag1);
         const deletion: SF.Changeset = [
             1,
-            { type: "Delete", revision: tag3, count: 1 },
+            { type: "Delete", count: 1 },
             1,
-            { type: "Delete", revision: tag4, count: 3 },
+            { type: "Delete", count: 3 },
         ];
         const actual = shallowCompose([makeAnonChange(revive), makeAnonChange(deletion)]);
         const expected: SF.Changeset = [
             { type: "Revive", count: 1, detachedBy: tag1, detachIndex: 0 },
             { type: "Revive", count: 1, detachedBy: tag1, detachIndex: 2 },
-            { type: "Delete", revision: tag4, count: 1 },
+            { type: "Delete", count: 1 },
         ];
         assert.deepEqual(actual, expected);
     });

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
@@ -123,8 +123,7 @@ describe("SequenceField - Rebaser Axioms", () => {
             if (name === "Insert" || name === "MInsert") {
                 // A⁻¹ ○ A === ε cannot be true for Insert/MInsert:
                 // Re-inserting nodes after deleting them is different from not having deleted them in the first place.
-                // We may reconsider this in the future in order to minimize the deltas produced when sequencing peer
-                // change in the presence of local changes.
+                // We may reconsider this in the future in order to minimize the deltas produced when rebasing local changes.
             } else {
                 it(`${name}⁻¹ ○ ${name} === ε`, () => {
                     const change = [mark];

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
@@ -120,17 +120,24 @@ describe("SequenceField - Rebaser Axioms", () => {
 
     describe("A⁻¹ ○ A === ε", () => {
         for (const [name, mark] of testMarks) {
-            it(`${name}⁻¹ ○ ${name} === ε`, () => {
-                const change = [mark];
-                const taggedChange = tagChange(change, brand(1));
-                const inv = SF.invert(taggedChange, TestChange.invert);
-                const actual = SF.compose(
-                    [tagInverse(inv, taggedChange.revision), taggedChange],
-                    TestChange.compose,
-                );
-                const delta = SF.sequenceFieldToDelta(actual, TestChange.toDelta, fakeRepair);
-                assert.deepEqual(delta, []);
-            });
+            if (name === "Insert" || name === "MInsert") {
+                // A⁻¹ ○ A === ε cannot be true for Insert/MInsert:
+                // Re-inserting nodes after deleting them is different from not having deleted them in the first place.
+                // We may reconsider this in the future in order to minimize the deltas produced when sequencing peer
+                // change in the presence of local changes.
+            } else {
+                it(`${name}⁻¹ ○ ${name} === ε`, () => {
+                    const change = [mark];
+                    const taggedChange = tagChange(change, brand(1));
+                    const inv = SF.invert(taggedChange, TestChange.invert);
+                    const actual = SF.compose(
+                        [tagInverse(inv, taggedChange.revision), taggedChange],
+                        TestChange.compose,
+                    );
+                    const delta = SF.sequenceFieldToDelta(actual, TestChange.toDelta, fakeRepair);
+                    assert.deepEqual(delta, []);
+                });
+            }
         }
     });
 });

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -11,7 +11,7 @@ import { Sequencer, TestTree, TestTreeEdit } from "./testTree";
 
 describe("Editing", () => {
     describe("Sequence Field", () => {
-        it("can rebase local dependent inserts", () => {
+        it.only("can rebase local dependent inserts", () => {
             const sequencer = new Sequencer();
             const tree1 = TestTree.fromJson("y");
             const tree2 = tree1.fork();

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -11,7 +11,7 @@ import { Sequencer, TestTree, TestTreeEdit } from "./testTree";
 
 describe("Editing", () => {
     describe("Sequence Field", () => {
-        it.only("can rebase local dependent inserts", () => {
+        it("can rebase local dependent inserts", () => {
             const sequencer = new Sequencer();
             const tree1 = TestTree.fromJson("y");
             const tree2 = tree1.fork();
@@ -47,8 +47,7 @@ describe("Editing", () => {
             expectJsonTree([tree1, tree2], ["w", "x"]);
         });
 
-        // TODO: investigate. It seems PR13079 may have broken this.
-        it.skip("does not interleave concurrent left to right inserts", () => {
+        it("does not interleave concurrent left to right inserts", () => {
             const sequencer = new Sequencer();
             const tree1 = TestTree.fromJson([]);
             const tree2 = tree1.fork();


### PR DESCRIPTION
Based on #13173.

This PR fixes some issues in compose and updates some of its tests.

**This PR also introduces a performance regression**: the delta generated when rebasing local changes over a sequenced peer change are no longer as minimal as they used to be (though they are still expected to lead to the correct state).
Generating minimal deltas will be tackled later (priority is given to fixing and expanding our tests).