### PR TITLE
Add logging for when the connection mode granted is different than th…

### DIFF
--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -507,8 +507,6 @@ export class ConnectionManager implements IConnectionManager {
                     // Nobody observed this connection, so drop it on the floor and retry.
                     this.logger.sendTelemetryEvent({ eventName: "ReceivedClosedConnection" });
                     connection = undefined;
-                } else if (connection.mode !== requestedMode) {
-                    this.logger.sendTelemetryEvent({ eventName: "ConnectionModeMismatch", requestedMode, mode: connection.mode });
                 }
             } catch (origError: any) {
                 if (typeof origError === "object" && origError !== null &&
@@ -667,6 +665,9 @@ export class ConnectionManager implements IConnectionManager {
         // But if we ask read, server can still give us write.
         const readonly = !connection.claims.scopes.includes(ScopeType.DocWrite);
 
+        if (connection.mode !== requestedMode) {
+            this.logger.sendTelemetryEvent({ eventName: "ConnectionModeMismatch", requestedMode, mode: connection.mode });
+        }
         // This connection mode validation logic is moving to the driver layer in 0.44.  These two asserts can be
         // removed after those packages have released and become ubiquitous.
         assert(requestedMode === "read" || readonly === (this.connectionMode === "read"),

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -507,6 +507,8 @@ export class ConnectionManager implements IConnectionManager {
                     // Nobody observed this connection, so drop it on the floor and retry.
                     this.logger.sendTelemetryEvent({ eventName: "ReceivedClosedConnection" });
                     connection = undefined;
+                } else if (connection.mode !== requestedMode) {
+                    this.logger.sendTelemetryEvent({ eventName: "ConnectionModeMismatch", requestedMode, mode: connection.mode });
                 }
             } catch (origError: any) {
                 if (typeof origError === "object" && origError !== null &&


### PR DESCRIPTION
While investigating [Task 2342](https://dev.azure.com/fluidframework/internal/_workitems/edit/2342) we've realized that we request a connection mode to the server and if it does not grant it, we do not log at all. That makes it much harder to understand why the summarizer was being connected in read mode instead of write. Adding a telemetry event to catch these cases. 