### PR TITLE
[GC-stress] Reduced the total send count by half in CI config.

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -33,7 +33,7 @@
             "opRatePerMin": 800,
             "progressIntervalMs": 5000,
             "numClients": 10,
-            "totalSendCount": 48000,
+            "totalSendCount": 24000,
             "optionOverrides":{
                 "tinylicious":{
                     "comment": "SessionExpiry: 15 mins. Inactive Timeout: 16 mins. Sweep Timeout: 17 mins.",


### PR DESCRIPTION
## Reviewer Guidance
This is in a test branch (test/gc-stress) and not in the main branch. This is an experimental stress test that we eventually plan to get into main. For now, it lives and runs in the test branch so we can make quick progress :-).

## Description
The tests are currently failing due to timeout of 150 mins. They work fine for me locally. Reducing the number of ops required to complete the test by half to see if it helps.