### PR TITLE
GC: Fix for unreferenced timestamp not always reset when reference is added between summaries

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -1235,8 +1235,13 @@ export class GarbageCollector implements IGarbageCollector {
 
     /**
      * Since GC runs periodically, the GC data that is generated only tells us the state of the world at that point in
-     * time. It's possible that nodes transition from `unreferenced -> referenced -> unreferenced` between two runs. The
-     * unreferenced timestamp of such nodes needs to be reset as they may have been accessed when they were referenced.
+     * time. There can be nodes that were referenced in between two runs and their unreferenced state needs to be
+     * updated. For example, in the following scenarios not updating the unreferenced timestamp can lead to deletion of
+     * these objects while there can be in-memory referenced to it:
+     * 1. A node transitions from `unreferenced -> referenced -> unreferenced` between two runs. When the reference is
+     * added, the object may have been accessed and in-memory reference to it added.
+     * 2. A reference is added from one unreferenced node to one or more unreferenced nodes. Even though the node[s] were
+     * unreferenced, they could have been accessed and in-memory reference to them added.
      *
      * This function identifies nodes that were referenced since last run and removes their unreferenced state, if any.
      * If these nodes are currently unreferenced, they will be assigned new unreferenced state by the current run.
@@ -1277,41 +1282,41 @@ export class GarbageCollector implements IGarbageCollector {
          * run, and then add the references since last run.
          *
          * Note on why we need to combine the data from previous run, current run and all references in between -
-         *
          * 1. We need data from last run because some of its references may have been deleted since then. If those
-         * references added new outbound references before getting deleted, we need to detect them.
+         * references added new outbound references before they were deleted, we need to detect them.
          *
          * 2. We need new outbound references since last run because some of them may have been deleted later. If those
-         * references added new outbound references before getting deleted, we need to detect them.
+         * references added new outbound references before they were deleted, we need to detect them.
          *
          * 3. We need data from the current run because currently we may not detect when DDSes are referenced:
-         *
-         * - We don't require DDSes handles to be stored in a referenced DDS. For this, we need GC at DDS level
-         * which is tracked by https://github.com/microsoft/FluidFramework/issues/8470.
-         *
+         * - We don't require DDSes handles to be stored in a referenced DDS.
          * - A new data store may have "root" DDSes already created and we don't detect them today.
          */
         const gcDataSuperSet = concatGarbageCollectionData(this.previousGCDataFromLastRun, currentGCData);
+        const newOutboundRoutesSinceLastRun: string[] = [];
         this.newReferencesSinceLastRun.forEach((outboundRoutes: string[], sourceNodeId: string) => {
             if (gcDataSuperSet.gcNodes[sourceNodeId] === undefined) {
                 gcDataSuperSet.gcNodes[sourceNodeId] = outboundRoutes;
             } else {
                 gcDataSuperSet.gcNodes[sourceNodeId].push(...outboundRoutes);
             }
+            newOutboundRoutesSinceLastRun.push(...outboundRoutes);
         });
 
         /**
-         * Run GC on the above reference graph to find all nodes that are referenced. For each one, if they are
+         * Run GC on the above reference graph starting with root and all new outbound routes. This will generate a
+         * list of all nodes that could have been referenced since the last run. If any of these nodes are unreferenced,
          * unreferenced, stop tracking them and remove from unreferenced list.
-         * Some of these nodes may be unreferenced now and if so, the current run will add unreferenced state for them.
+         * Note that some of these nodes may be unreferenced now and if so, the current run will mark them as
+         * unreferenced and add unreferenced state.
          */
-        const gcResult = runGarbageCollection(gcDataSuperSet.gcNodes, ["/"]);
+        const gcResult = runGarbageCollection(gcDataSuperSet.gcNodes, ["/", ...newOutboundRoutesSinceLastRun]);
         for (const nodeId of gcResult.referencedNodeIds) {
             const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
             if (nodeStateTracker !== undefined) {
                 // Stop tracking so as to clear out any running timers.
                 nodeStateTracker.stopTracking();
-                // Delete the node as we don't need to track it any more.
+                // Delete the unreferenced state as we don't need to track it any more.
                 this.unreferencedNodesState.delete(nodeId);
             }
         }

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -1460,15 +1460,6 @@ describe("Garbage Collection Tests", () => {
 
         describe("References to unreferenced nodes", () => {
             /**
-             * Function that asserts the given value is not true. Used in these tests to demonstrate that because of
-             * a bug we are not getting the expected results. Once the bug is fixed, these asserts should start working
-             * as expected.
-             */
-            function assertNotTrue(value: boolean, message: string) {
-                assert(!value, message);
-            }
-
-            /**
              * Validates that we can detect references that are added from an unreferenced node to another.
              * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
              * 2. Reference from B to C. E = [B -\> C].
@@ -1502,7 +1493,7 @@ describe("Garbage Collection Tests", () => {
                 const nodeBTime2 = timestamps2.get(nodeB);
                 const nodeCTime2 = timestamps2.get(nodeC);
                 assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
-                assertNotTrue(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
             });
 
             /*
@@ -1544,8 +1535,8 @@ describe("Garbage Collection Tests", () => {
                 const nodeCTime2 = timestamps2.get(nodeC);
                 const nodeDTime2 = timestamps2.get(nodeD);
                 assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
-                assertNotTrue(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
-                assertNotTrue(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
+                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+                assert(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
             });
 
             /*
@@ -1558,7 +1549,7 @@ describe("Garbage Collection Tests", () => {
              * 4. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. C and D have unreferenced time t2.
              * Validates that the unreferenced time for C and D is t2 which is > t1.
              */
-            it(`Scenario 2 - Reference added to a list of unreferenced nodes and a reference is removed`, async () => {
+            it(`Scenario 3 - Reference added to a list of unreferenced nodes and a reference is removed`, async () => {
                 // Initialize nodes A, B and C.
                 defaultGCData.gcNodes["/"] = [nodeA];
                 defaultGCData.gcNodes[nodeA] = [];
@@ -1592,8 +1583,8 @@ describe("Garbage Collection Tests", () => {
                 const nodeCTime2 = timestamps2.get(nodeC);
                 const nodeDTime2 = timestamps2.get(nodeD);
                 assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
-                assertNotTrue(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
-                assertNotTrue(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
+                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+                assert(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
             });
         });
     });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -605,15 +605,6 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
         });
 
         describe("References to unreferenced nodes from another unreferenced node", () => {
-            /**
-             * Function that asserts the given value is not true. Used in these tests to demonstrate that because of
-             * a bug we are not getting the expected results. Once the bug is fixed, these asserts should start working
-             * as expected.
-             */
-            function assertNotTrue(value: boolean, message: string) {
-                assert(!value, message);
-            }
-
             /*
              * Validates that we can detect references that are added from an unreferenced node to another.
              * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
@@ -621,7 +612,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
              * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. C has unreferenced time t2.
              * Validates that the unreferenced time for C is t2 which is > t1.
              */
-            it(`Scenario 5 - Reference added to unreferenced node`, async () => {
+            it(`Scenario 1 - Reference added to unreferenced node`, async () => {
                 const summarizer = await createSummarizer(provider, mainContainer);
 
                 // Create data stores B and C and mark them referenced as follows by storing their handles as follows:
@@ -658,7 +649,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
                 assert(dsBTime2 === dsBTime1, `B's timestamp should be the same`);
 
                 // The following assert is currently not true due to a bug. Will be updated when the bug is fixed.
-                assertNotTrue(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+                assert(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
             });
 
             /*
@@ -712,8 +703,8 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
                 assert(dsBTime2 === dsBTime1, `B's timestamp should be the same`);
 
                 // The following asserts are currently not true due to a bug. Will be updated when the bug is fixed.
-                assertNotTrue(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
-                assertNotTrue(dsDTime2 !== undefined && dsDTime2 > dsDTime1, `D's timestamp should have updated`);
+                assert(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+                assert(dsDTime2 !== undefined && dsDTime2 > dsDTime1, `D's timestamp should have updated`);
             });
 
             /*
@@ -726,7 +717,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
              * 4. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. C and D have unreferenced time t2.
              * Validates that the unreferenced time for C and D is t2 which is > t1.
              */
-            it(`Scenario 2 - Reference added to a list of unreferenced nodes and a reference is removed`, async () => {
+            it(`Scenario 3 - Reference added to a list of unreferenced nodes and a reference is removed`, async () => {
                 const summarizer = await createSummarizer(provider, mainContainer);
 
                 // Create data stores B, C and D mark them referenced as follows by storing their handles as follows:
@@ -772,8 +763,8 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
                 assert(dsBTime2 === dsBTime1, `B's timestamp should be the same`);
 
                 // The following asserts are currently not true due to a bug. Will be updated when the bug is fixed.
-                assertNotTrue(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
-                assertNotTrue(dsDTime2 !== undefined && dsDTime2 > dsDTime1, `D's timestamp should have updated`);
+                assert(dsCTime2 !== undefined && dsCTime2 > dsCTime1, `C's timestamp should have updated`);
+                assert(dsDTime2 !== undefined && dsDTime2 > dsDTime1, `D's timestamp should have updated`);
             });
         });
     });


### PR DESCRIPTION
## Bug
When a reference is added to unreferenced objects between two summaries, their unreferenced timestamp is reset only if the reference is added from another referenced object. See https://github.com/microsoft/FluidFramework/blob/3cd0cd0618b2963b2e24261da9a4ae6794c90d4e/packages/runtime/container-runtime/src/garbageCollection.ts#L1309.
However, the unreferenced timestamp of such objects (say objA) should be reset irrespective of whether the object that adds the reference (say objB) is itself referenced or not. That's because objB can be in memory of certain clients even if it is unreferenced and such clients could then access objA and store an in-memory reference to it. The session for these clients can last upto the session expiry timeout and so, their unreference timestamp needs to be reset.

## Fix
When updating the unreferenced timestamp of references between summaries, do it for all all references irrespective of whether the node that added the reference was referenced or not.

[AB#2801](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2801)