### PR TITLE
Mitigate typetests issue in next by adding fallback to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,8 @@
       "main": "minor",
       "lts": "minor",
       "release/**": "patch",
-      "next": "major"
+      "next": "major",
+      "*": "major"
     }
   }
 }


### PR DESCRIPTION
## Description

Some recent changes to typetests result in them not correctly generating on feature branches. This mitigates the issue by adding a fallback configuration. We will want a better solution long-term though (hopefully in the tool itself), as this is a per-branch cost.

## Reviewer Guidance

I verified this results in typetests generating correctly again on a feature branch, and also verified that the logic to select from this config runs through the options in order (iterates `Object.entries(branchReleaseTypes)`) so this shouldn't affect other config. Open to further suggestions to validate this fix doesn't break other behavior.