### PR TITLE
tools(eslint-config): Disable prefer node import

### DIFF
--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -1440,7 +1440,7 @@
             "error"
         ],
         "unicorn/prefer-node-protocol": [
-            "error"
+            "off"
         ],
         "unicorn/prefer-number-properties": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -1440,7 +1440,7 @@
             "error"
         ],
         "unicorn/prefer-node-protocol": [
-            "error"
+            "off"
         ],
         "unicorn/prefer-number-properties": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -1485,7 +1485,7 @@
             "error"
         ],
         "unicorn/prefer-node-protocol": [
-            "error"
+            "off"
         ],
         "unicorn/prefer-number-properties": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -1440,7 +1440,7 @@
             "error"
         ],
         "unicorn/prefer-node-protocol": [
-            "error"
+            "off"
         ],
         "unicorn/prefer-number-properties": [
             "error"

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -34,7 +34,7 @@ module.exports = {
 
         /**
          * "node:" imports are not supported prior to Node.js v16.
-         * TODO: re-enable this (remove override) once the repo has been migrated.
+         * TODO: re-enable this (remove override) once the repo has been updated to v16.
          */
         "unicorn/prefer-node-protocol": "off",
 

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -33,6 +33,12 @@ module.exports = {
         "unicorn/prevent-abbreviations": "off",
 
         /**
+         * "node:" imports are not supported prior to Node.js v16.
+         * TODO: re-enable this (remove override) once the repo has been migrated.
+         */
+        "unicorn/prefer-node-protocol": "off",
+
+        /**
          * Disallows the `any` type.
          * Using the `any` type defeats the purpose of using TypeScript.
          * When `any` is used, all compiler type checks around that value are ignored.


### PR DESCRIPTION
Rule documentation: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md

Disabling rule as support for its recommended syntax was not added until Node.js v16.

Relevant Stack Overflow article: https://stackoverflow.com/questions/67263317/how-to-fix-eslint-error-when-using-the-node-protocol-when-importing-node-js-bui

- Note: As far as I can tell, the back-port of support for this protocol to Node.js v14 is only supported for `require` syntax, not `import`.