### PR TITLE
(pipelines) Only trigger test-azure-frs in response to other pipelines

### DIFF
--- a/tools/pipelines/build-azure.yml
+++ b/tools/pipelines/build-azure.yml
@@ -49,6 +49,14 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
+    # Relevant to the test-azure-frs pipeline
+    - packages/dds/map
+    - packages/drivers/routerlicious-driver
+    - packages/framework/fluid-static
+    - packages/framework/loader/container-loader
+    - packages/test/test-end-to-end-tests
+    - tools/pipelines/test-azure-frs.yml
+    - tools/pipelines/templates/include-test-real-service.yml
 
 pr:
   branches:
@@ -68,6 +76,14 @@ pr:
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
+    # Relevant to the test-azure-frs pipeline
+    - packages/dds/map
+    - packages/drivers/routerlicious-driver
+    - packages/framework/fluid-static
+    - packages/framework/loader/container-loader
+    - packages/test/test-end-to-end-tests
+    - tools/pipelines/test-azure-frs.yml
+    - tools/pipelines/templates/include-test-real-service.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -5,31 +5,24 @@
 
 name: $(Build.BuildId)
 
-trigger:
-  branches:
-    include:
-    - main
-    - next
-    - lts
-    - release/*
-  paths:
-    include:
-    - azure/packages/azure-client
-    - packages/framework/loader/container-loader
-    - packages/framework/fluid-static
-    - packages/drivers/routerlicious-driver
-    - packages/dds/map
-    - tools/pipelines/test-azure-frs.yml
-    - tools/pipelines/templates/include-test-real-service.yml
-
+trigger: none
 pr: none
 
 resources:
   pipelines:
   - pipeline: client
     source: Build - client packages
+    branch: main # Default to using the latest build of the main branch instead of from any branch
+    trigger:
+      branches:
+        include:
+        - releases/*
+        - main
+        - next
+        - lts
   - pipeline: azure
     source: Build - azure
+    branch: main # Default to using the latest build of the main branch instead of from any branch
     trigger:
       branches:
         include:


### PR DESCRIPTION
## Description

Make it so test-azure-frs only triggers in response to successful builds of either of its build-type pipeline resources, not on its own in response to commits to the main branches.

Adding `branch: main` so that the artifacts that the pipeline downloads are from that branch by default, even if there are more recent builds from other branches. This is particularly noticeable when the latest build of one of the build-type pipelines is for a test branch, and CI runs of the test-azure-frs start trying to use those artifacts instead of the ones from main.

And I think it only affects this pipeline because it has two resource pipelines that can trigger it. Pipelines with a single resource pipeline that triggers them will always be able to download artifacts exactly from the specific run that triggered them.

It does mean that when test-azure-frs triggers in response to a build for next/lts/release* from one of its two resource pipelines, it might try to use artifacts from `main` from the other one. Not sure how we can best address that, or if it's even relevant...? I think it only uses artifacts from Build - azure no matter who triggered it.

The one scenario that might still behave weirdly in that case is in runs of test-azure-frs triggered by runs of Build - client packages _for branches other than main_, because in that case the artifacts downloaded from Build - Azure would be the ones from its latest run for `main`, not the branch for which Build - client packages triggered.