### PR TITLE
[GC-stress] Disabling ODSP tests until we figure out throttling of attachment blobs

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -225,7 +225,7 @@ jobs:
         inputs:
           command: 'custom'
           workingDir: ${{ parameters.testWorkspace }}
-          customCommand: 'install $(Initialize.testPackageTgz) ${{ parameters.loggerPackage }}'
+          customCommand: 'install $(Initialize.testPackageTgz)' # ${{ parameters.loggerPackage }}'
           customRegistry: 'useNpmrc'
 
       # Download Test Files & Install Extra Dependencies

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -35,24 +35,24 @@ variables:
 lockBehavior: sequential
 stages:
   # stress tests odsp
-  - stage:
-    displayName:  Stress tests - Odsp
-    dependsOn: []
-    # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
-    variables:
-    - group: stress-odsp-lock
-    jobs:
-    - template: templates/include-test-real-service.yml
-      parameters:
-        poolBuild: Large
-        testPackage: "@fluid-internal/test-service-load"
-        testWorkspace: ${{ variables.testWorkspace }}
-        timeoutInMinutes: 150
-        testCommand: start:odsp:gc:ci
-        env:
-          login__microsoft__clientId: $(login-microsoft-clientId)
-          login__microsoft__secret: $(login-microsoft-secret)
-          login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
+  # - stage:
+  #   displayName:  Stress tests - Odsp
+  #   dependsOn: []
+  #   # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
+  #   variables:
+  #   - group: stress-odsp-lock
+  #   jobs:
+  #   - template: templates/include-test-real-service.yml
+  #     parameters:
+  #       poolBuild: Large
+  #       testPackage: "@fluid-internal/test-service-load"
+  #       testWorkspace: ${{ variables.testWorkspace }}
+  #       timeoutInMinutes: 150
+  #       testCommand: start:odsp:gc:ci
+  #       env:
+  #         login__microsoft__clientId: $(login-microsoft-clientId)
+  #         login__microsoft__secret: $(login-microsoft-secret)
+  #         login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
           #FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
 
   # stress tests tinylicious


### PR DESCRIPTION
@markfields I am disabling ODSP test for now. Will update the tests to not run attachment blobs for ODSP Monday since it requires non-trivial work.