### PR TITLE
Update type tests for 2.0.0-internal.2.2.0 release

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1987,14 +1987,14 @@
 			}
 		},
 		"@fluid-experimental/property-changeset": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-changeset/-/property-changeset-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-ecUYd2RTHT1J8UmYvdNLjSZWDAmGQRQSTlMfRfokhAPsdLNMnfTvSwhUppUsXtnnvXRJ42vweVSpQ8ieW8c48g==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-changeset/-/property-changeset-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-cjePMCuwVFTClaVsZMP+SMhY9/D50HkgY73E6Iau2tkLQAIzY8A3UVCwSUIwCbxy/jB29fzuv9ZPMAMOLhFWlw==",
 			"requires": {
-				"@fluid-experimental/property-common": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-common": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"ajv": "7.1.1",
 				"ajv-keywords": "4.0.0",
-				"async": "^3.2.0",
+				"async": "^3.2.2",
 				"fastest-json-copy": "^1.0.1",
 				"lodash": "^4.17.21",
 				"semver": "^7.3.4",
@@ -2017,12 +2017,12 @@
 			}
 		},
 		"@fluid-experimental/property-common": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-common/-/property-common-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-c5yyVIjY08PecArJ7slZHm5eWIkf4BeKksAjXnMjjuzJtCxIzZ4pUtahdVFF3VVKKpXB3x6xEPV73IGx5M2E6g==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-common/-/property-common-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-Tttwf50SEQctfasZrPDCGVQj2Z5lVZHCHFSiowj3p1m1M4Ayb6ERVeqkcJCHtRFMK3IctIDi6T5G9VhADJjeUQ==",
 			"requires": {
 				"ajv": "7.1.1",
-				"async": "^3.2.0",
+				"async": "^3.2.2",
 				"base64-js": "1.3.0",
 				"events": "^3.1.0",
 				"fastest-json-copy": "^1.0.1",
@@ -2049,20 +2049,20 @@
 			}
 		},
 		"@fluid-experimental/property-dds": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-dds/-/property-dds-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-PaNtohuioQ/jpYcFwVu5t302AdeYmlaU2kfhEDoLGTqmRx3GNW1NemyV8cB2isXlZODeJGVOnu697pQf3Rq++w==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-dds/-/property-dds-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-9Y2CVp4g7Vgm3sqKShxQNWMEwW7UY7d0+sti0ly8lRJSGr4A+oAHUEJJBRdWeHtIrOYdgTybS29UTGAxCAwP2A==",
 			"requires": {
-				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluid-experimental/property-properties": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-properties": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"fastest-json-copy": "^1.0.1",
 				"lodash": "^4.17.21",
@@ -2116,14 +2116,14 @@
 			}
 		},
 		"@fluid-experimental/property-properties": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-properties/-/property-properties-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-Mn3fgQoPOiTqswCeqUEaDGCkvLSlgCiBArG2k/Fz4vHdGVLna88/iL42fJmX+TNBVYoLQsmLf8UEBDLfSzNX4g==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-properties/-/property-properties-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-Fhohi2FnSboF1/unVkAyZ6VeiM4yr1/leXZmeu1eEY14yOedsH00I7yy8ucfa5GaFJ4iNXSrznGnDluHP452Ng==",
 			"requires": {
-				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluid-experimental/property-common": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-common": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"ajv": "7.1.1",
-				"async": "^3.2.0",
+				"async": "^3.2.2",
 				"fastest-json-copy": "^1.0.1",
 				"lodash": "^4.17.21",
 				"semver": "^7.3.4",
@@ -2160,16 +2160,16 @@
 			}
 		},
 		"@fluid-experimental/sequence-deprecated": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-OFMBwKut7k6RbTDPTyF5hIXoeJ2EynoWcOWJfnpKWRnQ58YK7C5ds6b1lo2HKM16ZeXfGye6a4Dc8fFzwzH7bg==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-UPzhbLJc/XcaXUvMEghaB/6RtJnr70bXFkeKQAaH5ZxF0mCrFzugSU2g9besVshJbWzT6od9Qu3J8Qd33rW9Qg==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/sequence": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/sequence": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluid-experimental/sequence-deprecated-previous": {
@@ -2667,15 +2667,15 @@
 			}
 		},
 		"@fluid-tools/fluidapp-odsp-urlresolver-previous": {
-			"version": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-jJAiGlxeizCDsr3E/UIWlRKglvCtiKqLPmwq9cHeX8CkYn8x0PGwzt6xtELWLJTSHMjfwT+HqFF+RTbpO4ixYQ==",
+			"version": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-+3jP5hGxHlMsoI0Be0JGW1PZBMeb9tvxImMTDCotYQujPkBEEkrg/XSr8hIbBG3+Dc++UUyNquNJNS2kmXZ0TA==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluid-tools/version-tools": {
@@ -2728,170 +2728,101 @@
 			}
 		},
 		"@fluid-tools/webpack-fluid-loader-previous": {
-			"version": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-y5gBnXW2VOcywKmFJ3Zdt0+ZvCnw/ZNHufhVuZtGzoJUPLQpqvfe0VVyanWFlHiypNddgX4ozHxKcLFJr8GNCg==",
+			"version": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-8qXfA+nGBqZ+BAxTC10jpoBfhBPhM5uiirwmqU3t+iNWzH8/x1/q9gULem1OcZ/NGfETjCYG6GXSSw8/jb9KeA==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/local-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/local-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-local-server": "^0.1038.2000",
 				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/tool-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/view-adapters": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/web-code-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/tool-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/view-adapters": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/web-code-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
+				"buffer": "^6.0.3",
 				"express": "^4.16.3",
-				"nconf": "^0.11.4",
+				"nconf": "^0.12.0",
 				"sillyname": "^0.1.0",
 				"uuid": "^8.3.1",
 				"webpack-dev-server": "~4.6.0"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-				},
-				"ini": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-					"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				},
-				"nconf": {
-					"version": "0.11.4",
-					"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.11.4.tgz",
-					"integrity": "sha512-YaDR846q11JnG1vTrhJ0QIlhiGY6+W1bgWtReG9SS3vkTl3AoNwFvUItdhG6/ZjGCfWpUVuRTNEBTDAQ3nWhGw==",
-					"requires": {
-						"async": "^1.4.0",
-						"ini": "^2.0.0",
-						"secure-keys": "^1.0.0",
-						"yargs": "^16.1.1"
-					}
-				},
-				"string-width": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-					"requires": {
-						"ansi-regex": "^5.0.1"
-					}
-				},
-				"y18n": {
-					"version": "5.0.8",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-				},
-				"yargs": {
-					"version": "16.2.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-					"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-					"requires": {
-						"cliui": "^7.0.2",
-						"escalade": "^3.1.1",
-						"get-caller-file": "^2.0.5",
-						"require-directory": "^2.1.1",
-						"string-width": "^4.2.0",
-						"y18n": "^5.0.5",
-						"yargs-parser": "^20.2.2"
-					}
-				}
 			}
 		},
 		"@fluidframework/agent-scheduler-previous": {
-			"version": "npm:@fluidframework/agent-scheduler@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-P6Ab5WEpRpzWVxqqAvBjgdhnWUQkod4DdODa24pJ6giGIkZrKvsmtZTWXkKiCugr36dYdSyviPCTn0hFGjAfoA==",
+			"version": "npm:@fluidframework/agent-scheduler@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-4z/LuZbszW5+muRQiwQs9OTGziy/j/KGI968JXVb1AlELmvYpsetvK855GrS8dHyvOjdK967IpQW+nhZYWp6uw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/map": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/register-collection": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/register-collection": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-l4HzHKijGzufCK2I8m4TlBNefTHfH/rqRYQMG8nqTcyottQS3ug6R8Q7HlSXiL9uMmpLW91sD5FULXd/L9G47A==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-PAEnL928V5eJH3Z8A2GBMRe5OMQ4gYmlBxJvL5NBX7xKoyEmFPvfMQi8qfGYWQAQRKJN3+r+U+z2QUlQGHkHPA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/map": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/synthesize": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/synthesize": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/aqueduct-previous": {
-			"version": "npm:@fluidframework/aqueduct@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-HctjLrNjCMb7YkVN9C0DxrhTbFBXKuq6Af309yecyUMl/jI1w9BmabZih3wBLQz64PbZhR0pHhSiYPddE1lZ/w==",
+			"version": "npm:@fluidframework/aqueduct@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-PAEnL928V5eJH3Z8A2GBMRe5OMQ4gYmlBxJvL5NBX7xKoyEmFPvfMQi8qfGYWQAQRKJN3+r+U+z2QUlQGHkHPA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/map": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/synthesize": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/synthesize": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -3302,31 +3233,31 @@
 			}
 		},
 		"@fluidframework/cell": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-ihREKG2pCmxsU9oesPkx1yMkpeKuQ9gRd4+e4qZw9jrhSZC5JfFt5sTfqMydISkIdsZR4gXWUx0+OYmZSGNZFQ==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-/UxOkxbM26bpZeqFNGZRDAD7p7foUH84yFC/ZUxLvzSUDVEA59Torefe9hjwWEBuny06qdI4eFkHX47A+zKtNQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/cell-previous": {
-			"version": "npm:@fluidframework/cell@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-leMU7hUYpK5SA8q7pmF15YpuMX9dGIJaM1RCKm+PVYh1fqh4asXw8LVKlkSDWa4RsITtADRX8XXza2vPdTNeEg==",
+			"version": "npm:@fluidframework/cell@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-/UxOkxbM26bpZeqFNGZRDAD7p7foUH84yFC/ZUxLvzSUDVEA59Torefe9hjwWEBuny06qdI4eFkHX47A+zKtNQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/common-definitions": {
@@ -3356,42 +3287,42 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-C8j/3UDqSvZks/3ylUS35rC9wUeiHNgJPIdCdSgS+V+sQu7V+wIVfiwq+Mju8d+jPonBhonO1MUEQmcDIK3Jtw==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-Y+BXNRQ8cS9X4f0EwdtiLqGICVKV6m4xGqSAfhzVJh/3UrfbzIzp00/MbogCjHZnwb9QHUxPD2CacsrY2V/kSQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0"
 			}
 		},
 		"@fluidframework/container-definitions-previous": {
-			"version": "npm:@fluidframework/container-definitions@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-y822qjw2E19yyixOIpu1KNVzQ6AxS66epQHJCyWpbWR4howmxKZcIGQH1SjmQdemkDhFKpC/V79UmMSx0kGq2Q==",
+			"version": "npm:@fluidframework/container-definitions@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-Y+BXNRQ8cS9X4f0EwdtiLqGICVKV6m4xGqSAfhzVJh/3UrfbzIzp00/MbogCjHZnwb9QHUxPD2CacsrY2V/kSQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0"
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-K6yqOHwTbtDeUbBQodHkFIIt1BiFKSp+P79SyAwTmbtDPKEN36C5X2BBuzqiSYJTRj4kgS3/67JjFwEyLBcP9w==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-rgIl4qBK0R86lvx3nVvPfgvw6onzORkGVbOimuzk9ePoX0Er7KKF3qAcVMfL7+LWwllHF2dFzyMRv7OtKfTxxQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -3400,20 +3331,20 @@
 			}
 		},
 		"@fluidframework/container-loader-previous": {
-			"version": "npm:@fluidframework/container-loader@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-O+g17yxiddhciRlp/Se4RqPl1y0zFWPQcci+l9AjDlTyNaSKXI+89Ev7BCVxb432Fm2JZ5qbHhZbt24V81fU2g==",
+			"version": "npm:@fluidframework/container-loader@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-rgIl4qBK0R86lvx3nVvPfgvw6onzORkGVbOimuzk9ePoX0Er7KKF3qAcVMfL7+LWwllHF2dFzyMRv7OtKfTxxQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -3422,352 +3353,352 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-ELsn/AxCQDd19HTlmfLYY9fphzSn19uRXX9VmWr5PEUT6/A/B7HDRdvub65ZzU2YVHwMo+t35VCGb10ejAdj4g==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-5g3ZwBf2K/D95DXx+kfOKg1gCWYp5aIDtiqg7F4+JJFsdt2Vit42D35WBJBPyZ/P8eHy1fYA/Jm/zAJ7nwZXYQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lz4js": "^0.2.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-ADUYqfrWkP5j1Lt82hX6a0LHvTGqSurv3wuliQpmVicxnzX78wrssvycEoLvlc9BCKRjs/+NX5o1PfQFU0nnyQ==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-aUewKYpnWP2SlZClPd/GXft+he8RBPwb5bL4E/9cJRCbyuaUGyW7zuFVKfiiLSbNYBF4wtJBBU5WqNRw1DV0YQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/container-runtime-definitions-previous": {
-			"version": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-0u1h0chnWgPwBLkUyRe5bCHcyGhpwPWOSFccfEt5xa8YiwNDmj5kSx5dUlVSk1UXJJFWTup6JaqIC8wwFQPNZw==",
+			"version": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-aUewKYpnWP2SlZClPd/GXft+he8RBPwb5bL4E/9cJRCbyuaUGyW7zuFVKfiiLSbNYBF4wtJBBU5WqNRw1DV0YQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/container-runtime-previous": {
-			"version": "npm:@fluidframework/container-runtime@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-wGA/ychiWlPfj+fFUsaIYoTplOMJ1CbA9zjb6zfpBeFqGiqqmTVk8wn6X5G4VNcVoGq6nJZme+TMq7VL7a/K9g==",
+			"version": "npm:@fluidframework/container-runtime@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-5g3ZwBf2K/D95DXx+kfOKg1gCWYp5aIDtiqg7F4+JJFsdt2Vit42D35WBJBPyZ/P8eHy1fYA/Jm/zAJ7nwZXYQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lz4js": "^0.2.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-ckkoAwajI+xPbOMNJhBiYhsPKBqtGJ65+/AnMdLrp3AsYLcIt70eg0FDjS7pcjf/wFMvVgWOPr2BeW3nVOaDWw==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-PpT2bBBl8CmQnsgQrNKWzI2GmDG0S3IZt6LTsXu/OLj+OkjXW+xDFzmuaguZn0gCmrvOvr0vSz23/w3F4QaMjg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/container-utils-previous": {
-			"version": "npm:@fluidframework/container-utils@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-pQ8OmKecWp833+XM8Vm5IvzM/nAAjqbBTA4WA4A39o2VWPiQ/mLnNXtTcLUVVmFYJUD04IxDK7NIMzzYVhB+NQ==",
+			"version": "npm:@fluidframework/container-utils@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-PpT2bBBl8CmQnsgQrNKWzI2GmDG0S3IZt6LTsXu/OLj+OkjXW+xDFzmuaguZn0gCmrvOvr0vSz23/w3F4QaMjg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-Tg0lBCiJvsW1sNWpnTXU/tM+gPHCwUDOWcbUVibLKd1/KdL5SU8y+YwWJ7JD7O6h4xbf/Pukb5Rp3//2e6x75A=="
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-B7JNJWkR/0y6CJn90Kk8vTMmZDRKR81OEd82a3CUuYbfAJBsVcMeTPFdh9obrLiH7FS9/f1MxQHFXy7zLOAOWw=="
 		},
 		"@fluidframework/core-interfaces-previous": {
-			"version": "npm:@fluidframework/core-interfaces@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-ru0WcnuMHeMysngJA0YD3CMwp9cfJCd+JWW2KM77Trtwgz7PJaj9SyGj3190Ceq0HRB6QdPrzM5C5HVzAXZQBg=="
+			"version": "npm:@fluidframework/core-interfaces@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-B7JNJWkR/0y6CJn90Kk8vTMmZDRKR81OEd82a3CUuYbfAJBsVcMeTPFdh9obrLiH7FS9/f1MxQHFXy7zLOAOWw=="
 		},
 		"@fluidframework/counter": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-n04tH3hkV7o++W316/BPYvflg8lKzMUxMUb+jV7064yKsXL/Y3NdLpzrkLriSXR6zk4fkqAD6px5e8PlmD9VxA==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-jUIWY63RZvMrP+o3HcjBtovbji2HTo3W8M8lPD13taoI6XBmzo619mG7PLmGtCMl7eQ6+hJ++nOvenP4uGWOKQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/counter-previous": {
-			"version": "npm:@fluidframework/counter@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-hVTaetymSXpKarVk0/L/RkCtNrrXAmXVFrWZ7n0ozZSBureBOibLOdJuXqkrg3AycnVq9eYZTs53By+xO+08Ow==",
+			"version": "npm:@fluidframework/counter@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-jUIWY63RZvMrP+o3HcjBtovbji2HTo3W8M8lPD13taoI6XBmzo619mG7PLmGtCMl7eQ6+hJ++nOvenP4uGWOKQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/data-object-base-previous": {
-			"version": "npm:@fluidframework/data-object-base@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-u5uweZTlBocZ23C8g6MymsHyHJjsHe6md7Qd0vvbh0CdDwUfKQ94dI7Mrt5v/X2itQVd3bQqtwRvJxhxlh1jtA==",
+			"version": "npm:@fluidframework/data-object-base@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-n2xAF0KBFxk0B+4WNDO3JYwsXS94fVL7KUkkgAzLU7I1rGTkzJ+HhlVO0r4nkKItKH5ZPmmD2CcFPxzoPSytYA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/datastore": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-WHNHJU+kmx792YfdMn1FuqtuQYsfwcfpwGz8gFkm5VNmyR5i+4DRHdgXus60+GEHptFmBZ8moLrW/jOGBrxTjg==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-cbQHCNWoTNVDOOZX5Oq9pni0KgYSN5zAnGoYr5YTON3D+tGKPTIShp75UHyIzsWWFEYZrg/ybvqCMRAfPuoeoQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-VyPI3ncceK01jHgfqR+ycDPC1c7XMdaV6GyrAXXQCLtd7DX/phAi/WLAgtUBkDY2m3YXY2p4J3+FUICxgx6Jtg==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-46x/eiFnbBRdUMmPkHaI/Znar7Uxr5dSdgw6p7Zi1dvr+3l9F0ZZ0d92FdBcyk4EJlRJlqbZLq4I7Wv7k9hJog==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/datastore-definitions-previous": {
-			"version": "npm:@fluidframework/datastore-definitions@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-/pNL61l0olrtRaLzJS+YsjVRJzaYr6zhaqx1S2DKQJjbukGaHYtBwzgNNccj98XueR0A7B4pywCtkz0yalKBfQ==",
+			"version": "npm:@fluidframework/datastore-definitions@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-46x/eiFnbBRdUMmPkHaI/Znar7Uxr5dSdgw6p7Zi1dvr+3l9F0ZZ0d92FdBcyk4EJlRJlqbZLq4I7Wv7k9hJog==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/datastore-previous": {
-			"version": "npm:@fluidframework/datastore@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-YWTiGrJ53sEbNwj2BR/4rVQj6BJD0DZtEE1YyrQG7KXPRVOHr54LPG94BZFcl/U+Hv3PPWgOJYzixtRFIoRuAA==",
+			"version": "npm:@fluidframework/datastore@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-cbQHCNWoTNVDOOZX5Oq9pni0KgYSN5zAnGoYr5YTON3D+tGKPTIShp75UHyIzsWWFEYZrg/ybvqCMRAfPuoeoQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/dds-interceptions-previous": {
-			"version": "npm:@fluidframework/dds-interceptions@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-G5BcJ0V2PPZ2p/ST+vkErJvxYxfTwc5IFOz+5xswv+xZp00mqko1lsUJzRBV/11JB5ZnzZLa+qFi39Er0qQAFQ==",
+			"version": "npm:@fluidframework/dds-interceptions@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-IFIvT/5P8Y6TYm3KbLhNiyCwjIJEMp53QfB7fobchmblHor7/rqoXhAI5BPwwld3+q33BcSBK/bx/x6T3uQXvw==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/map": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/sequence": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/sequence": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/debugger-previous": {
-			"version": "npm:@fluidframework/debugger@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-ONgBfK1qm1J7SJsgX2QW6eNPmNTKnROd1GToZ+IYondTHdZ2oBeEgdktcIpMVCBq94F0MYzk6H9WQ3uaMzybnA==",
+			"version": "npm:@fluidframework/debugger@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-YsTjwLMJnSh9q4QbtIUEOsoRV2Heq1ePQUsrKEnu+wR9HGP5r/pSb1sWrirwMsYeSdHjLdBYMhq67WiCF2IKpQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/replay-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/replay-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"jsonschema": "^1.2.6"
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-aHv5MKYcoRMza0janatTyYGFCsz3of+solrl6/XcW9m4Ah5CCMbm05fsWuRNj4lQ5zMnyzpDynjMm0a/IUWgeA==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-3bFBZGjtF0saMia4EeLzjpbT3MURCwyLpDN72Bc6DeelmcRXsr+kOriwk/9PV6AyO7Yjyk7y5fCTTQJSjFO3/w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/driver-base-previous": {
-			"version": "npm:@fluidframework/driver-base@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-WFjG5CiLCR2WGhZZC1tKXBG1ulPOOnYkijh9C4rfwVK4IvWWiIiuEynGSTgBqpZh+Khlt++HrKx9HCcgpFJ3Vw==",
+			"version": "npm:@fluidframework/driver-base@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-3bFBZGjtF0saMia4EeLzjpbT3MURCwyLpDN72Bc6DeelmcRXsr+kOriwk/9PV6AyO7Yjyk7y5fCTTQJSjFO3/w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-GmBJknNN0gAvC8+JHTBJrATn/wW09MRMbBkPQ6C9OIS6n51gfbyTW97nc/9TnM7O5Bf5z2R3GZcJ/YljhDI3dA==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-XaS/93Quwm8mbRF/cE6O+mE8vr9s4vwv4H4DGqNQiitGfPEu4l/4BrzHWNmlpJTENu5LZfWY1q/7CDw0nRov5Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0"
 			}
 		},
 		"@fluidframework/driver-definitions-previous": {
-			"version": "npm:@fluidframework/driver-definitions@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-Ah8hB6cAx6e46oA5HvZnc8f25CV9xOBxp3pY5adRxKHK+CwGyUVZb/Qe4PFXk1yd3sR4Bm51lJgR6xUyPTKksw==",
+			"version": "npm:@fluidframework/driver-definitions@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-XaS/93Quwm8mbRF/cE6O+mE8vr9s4vwv4H4DGqNQiitGfPEu4l/4BrzHWNmlpJTENu5LZfWY1q/7CDw0nRov5Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0"
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-tv9AD1Y0ZyFGcK/HHXZbHCQaWd6ljt9WUihpcKGvKHd2GCQDnbbB28hXhzCcXkyRvgWh/6GdGad4gXbGjBfgVw==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-x0cIgwWETVttS5BxEYWBRsV6JiFWRnOzuWsBAtuFrhkRZO04d4hobEc/UWgJgcZaBrtqY7ba4fMmAwU5cWPFSA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"url": "^0.11.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/driver-utils-previous": {
-			"version": "npm:@fluidframework/driver-utils@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-y4ATUMFLZgXJfgyy9hjk9+EK8jPOC7aT3c0S77sxUb+HsIhnfq0uZel7GdOvITljqqItXWEa1Hl5tURr9TSTvQ==",
+			"version": "npm:@fluidframework/driver-utils@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-x0cIgwWETVttS5BxEYWBRsV6JiFWRnOzuWsBAtuFrhkRZO04d4hobEc/UWgJgcZaBrtqY7ba4fMmAwU5cWPFSA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"url": "^0.11.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/driver-web-cache-previous": {
-			"version": "npm:@fluidframework/driver-web-cache@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-q6/vC5KoHDeUGXiBXFpMZk2EuBCe7f0bia/Tyv8CVQz25vZeqAk9QZQ2zvKeNEEb6vkwFbT8FYhUR5uryGc5bg==",
+			"version": "npm:@fluidframework/driver-web-cache@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-IfzcYzofia5RBI/PqO8orO9TPA7hYY5NIT+izKE9ZV6BQQnh9Y19LaLxpAAZAiOVllpv/iUd8tLUirahsdl5Fw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"idb": "^6.1.2"
 			}
 		},
@@ -3794,92 +3725,92 @@
 			}
 		},
 		"@fluidframework/file-driver-previous": {
-			"version": "npm:@fluidframework/file-driver@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-rHjPXXfk7PQyd1aLGhaUGS/Gj8LKMlXa56vNLhoBb4omTTIItrgyH0TM8hqQ708YoHlBv3hE6o0F8M8+LvUApw==",
+			"version": "npm:@fluidframework/file-driver@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-nNy7veICX/9RRZPK7wiiotTNEK1KhcVQ+d5cDjplRfOMvEMuDRMnx783Br5mc4O9YLlrbP3YAO+0lI2fd0vrdQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/replay-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/replay-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/fluid-runner-previous": {
-			"version": "npm:@fluidframework/fluid-runner@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-runner/-/fluid-runner-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-QSlRQljbWq322pIYo1yLB3ERyCaGV/sRPK/jPuWMuum8j7qpSAP9y8FfZdtpVF5/8XTLaiG8NP2ClKuS8TY/eA==",
+			"version": "npm:@fluidframework/fluid-runner@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-runner/-/fluid-runner-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-Bdunrbr+dyjJzcjrxCXwjo/rDfaUI8j45VhT9N41QKL+vhOF0C5Ri9WQKwJX2Qr5YWBJwfCHYNj8AnuTJyhv+g==",
 			"requires": {
-				"@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"json2csv": "^5.0.7",
 				"yargs": "13.2.2"
 			}
 		},
 		"@fluidframework/fluid-static": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-C5EB4gy7mKEzNUm+JjBvqJgnmqsoArmTLjQywM1um/j8FaAb5JqD9jQ7KR++9JXxSIVQHJTNXLBtCOYdM9nW1g==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-v3//RQ8c+Fjzymz7f8XWx8iolXwLYAwI9KqWYvybfcZIV/gnGrWssJ93K72CUeYOZqGe/XKbJyPl6e43PJjQWA==",
 			"requires": {
-				"@fluidframework/aqueduct": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
-			"version": "npm:@fluidframework/fluid-static@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-qOZjeOCajk6I3l+Ke5qYnTbeO2XTeWQSb9P6wUNgj3J75ddnbvI2GCuW2s8iatqQYwuP/C2lWlfSvFti28W8oA==",
+			"version": "npm:@fluidframework/fluid-static@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-v3//RQ8c+Fjzymz7f8XWx8iolXwLYAwI9KqWYvybfcZIV/gnGrWssJ93K72CUeYOZqGe/XKbJyPl6e43PJjQWA==",
 			"requires": {
-				"@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-D/mlJBMex3TBO1+5+FVgV6MNE1A9tfUrXJkE6UGe2Hu1d8yvY/lJKeQpFzPrWVvrBguJ7fpEuv7iRm/yMgbv8g==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-6ZHbBEIbljtMqAjnP/R3MP7MyrPfyWut2q84mKeX8XymXHQoq3S8ApHUyso3NEBTfTxn1hkXvqLq86eumCwqxw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
-			"version": "npm:@fluidframework/garbage-collector@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-gxLeyYqB/UE4yBjHzzDj7wS9j/rojvbbTSnLfmogu1Q7RJKsWhI56ZjHD9kyjmumcbXxm58dA4/i9072PpxRkQ==",
+			"version": "npm:@fluidframework/garbage-collector@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-6ZHbBEIbljtMqAjnP/R3MP7MyrPfyWut2q84mKeX8XymXHQoq3S8ApHUyso3NEBTfTxn1hkXvqLq86eumCwqxw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/gitresources": {
@@ -3888,276 +3819,276 @@
 			"integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w=="
 		},
 		"@fluidframework/iframe-driver-previous": {
-			"version": "npm:@fluidframework/iframe-driver@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-uZ5Mxo48npKIs1BIDNYYUeeAY0sVsniq3OsH6EQVkllsky1/oxwUlWRMrJ4vhYch736eL+6LqIv02g+iHtihKA==",
+			"version": "npm:@fluidframework/iframe-driver@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/iframe-driver/-/iframe-driver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-wgQRjN6eLTl4gIU6kgdWeuF/Zho+OMrKCXl5WFBqy+7UJeg8IXt501Mg7FGxDJIg0fVLdXZ7i2tytHHjGL5/cQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"comlink": "^4.3.0"
 			}
 		},
 		"@fluidframework/ink": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-CMHFi1OZmsAEaynRSd9lSX9t0r9Y8eT+FLf9XeQdnuaYIJNNKMwPG3dg/hJ9z3GAv+spPFFWAaeGQHnkOXw13w==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-E+1pBFwK2H+w61wENQG+GyvX9ud/AcsU7wFFvYiJcGSxr9HizEwD03CSK2lhOjyklMc+WG5xNkpMDEOe5PoAtg==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/ink-previous": {
-			"version": "npm:@fluidframework/ink@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-uCicH33IvH1Cnk+InhxQNu8OOFMa4UE1vxUW7PjRF3khLhfETjjyae3ElouzuH/Uf5w27aIZdUFO26DbdjJQzA==",
+			"version": "npm:@fluidframework/ink@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-E+1pBFwK2H+w61wENQG+GyvX9ud/AcsU7wFFvYiJcGSxr9HizEwD03CSK2lhOjyklMc+WG5xNkpMDEOe5PoAtg==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/local-driver": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-2jf6CWEMpmTjho4X3Qen1zfoge2Rh+kSiyuyiCbwf0RdxAFDl861sFYsYQDMke64aqMIP1Sx6/ob1EIBAIqMhw==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-Y72ZLmFtRxsraymJWhedtE6iJ9lsH02PcsrsqpQcqEYD9I4o3mdVCaJFCGNpgKjYgc3ljPjou4IXHYqTsiJ2NA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-local-server": "^0.1038.2000",
 				"@fluidframework/server-services-client": "^0.1038.2000",
 				"@fluidframework/server-services-core": "^0.1038.2000",
 				"@fluidframework/server-test-utils": "^0.1038.2000",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"jsrsasign": "^10.5.25",
 				"url": "^0.11.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/local-driver-previous": {
-			"version": "npm:@fluidframework/local-driver@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-BMGQO0OQbsw18JWDHaogCTzWAkGnK383wlOXCs5mgKKRqruYy2yj+XTMOHkAnrJFnmgIazBeZ56OgHWg/HIoPA==",
+			"version": "npm:@fluidframework/local-driver@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-Y72ZLmFtRxsraymJWhedtE6iJ9lsH02PcsrsqpQcqEYD9I4o3mdVCaJFCGNpgKjYgc3ljPjou4IXHYqTsiJ2NA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-local-server": "^0.1038.2000",
 				"@fluidframework/server-services-client": "^0.1038.2000",
 				"@fluidframework/server-services-core": "^0.1038.2000",
 				"@fluidframework/server-test-utils": "^0.1038.2000",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"jsrsasign": "^10.5.25",
 				"url": "^0.11.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/location-redirection-utils-previous": {
-			"version": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/location-redirection-utils/-/location-redirection-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-JcnHHuF9NA2i3fluH8iuN7y/F+JLfr3rl214suE9u3VkmClOVuvnq5PJhgNM6MgeaHs8lU4EUXrUFXD5jlJNPw==",
+			"version": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/location-redirection-utils/-/location-redirection-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-r+/yKBAzOJwOXGfngB/jw8wap/W2TmelCTB88xAiCigasYbDR+alf7ByhlcD6Xn4mhpaV71IIUYqk91r6t8B8g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/map": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-2QuJS7GBrlWX51Fn/KQrZzXAg1O8bmRVjfOfbdYf3ExmpRVDzRYsiPGkktgF15TLgX36zScwLQ2SBuK/HWx+mA==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-27wFQeJUwwubgUyZMj555q+0LgeNqTI72y8zd5B+RJTBAMDGENY2ZK/vjZkTFBIHFrEpvHFmF+ZmzN6W0P35mQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"@fluidframework/map-previous": {
-			"version": "npm:@fluidframework/map@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-W8+VXlTDwMznxcoz6Ju5wymFosaq3yAqSk7wQqMMxhvOb7mijfLHDmavgV9IcfzXhPlQYNehTj8ys/00/LBRKw==",
+			"version": "npm:@fluidframework/map@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-27wFQeJUwwubgUyZMj555q+0LgeNqTI72y8zd5B+RJTBAMDGENY2ZK/vjZkTFBIHFrEpvHFmF+ZmzN6W0P35mQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"@fluidframework/matrix": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-76JBu+w+Xxfd7j4UoBmg3LVAwxSgiJTLazAhGzoFQ4K64wTQMqoUK0YZtZ5bHwwVKmk63jT8GIQyU25qlwVXgA==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-dLeh+0Q1SL9c7dwbNTOyfgxsOVB7GdL3dReLqf3Md6eiT1wwMu7wAOgIq7gfc49P3GHRLjMlGseIV3ccrxezBQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluidframework/matrix-previous": {
-			"version": "npm:@fluidframework/matrix@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-+pFC6AQ7TQ6IakNPZUSJYmNp1xvpCQ/H49o7OzWBPZvKE6ziGnwkfzBrYbukcSPuduChP1wBiAZTeT2119dfKQ==",
+			"version": "npm:@fluidframework/matrix@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-dLeh+0Q1SL9c7dwbNTOyfgxsOVB7GdL3dReLqf3Md6eiT1wwMu7wAOgIq7gfc49P3GHRLjMlGseIV3ccrxezBQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-uiGV2MYjhJ/hP9S24Amtjby6twe9eA7/SIlwUDdWsFPCWgy7I/3hZl5HnsEV/phsbQfaRKulUHpVyDQGnC2HrQ==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-MRjHrDRQbUY44v1WzJL49pbdivvb+BvB36bWEs8HT0pGJahPrWSCBahf8771rvfd2G7Yvl9uUSueMDSmzOwgkw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
-			"version": "npm:@fluidframework/merge-tree@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-gkMrAeoF3wikJDLg2WakHT7tjXgMiCIljn1ZzSGtUVAFcHoZJIIiIgdJRr+fBsOJDaacpn0fO7qy0xxSp2eOhg==",
+			"version": "npm:@fluidframework/merge-tree@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-MRjHrDRQbUY44v1WzJL49pbdivvb+BvB36bWEs8HT0pGJahPrWSCBahf8771rvfd2G7Yvl9uUSueMDSmzOwgkw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/mocha-test-setup-previous": {
-			"version": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-5TgyUwKO/tRjUbgS1hVzc7jwSDS+VvUBBu5dRqHVcJrAScS6C0qqV6eNV+VVCuOTMMvmTt+GJhR353MtqG90nA==",
+			"version": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-OOZf8cdm3R29cFoBSKWsuQ+/PJpKUxuVzHaeS/Xqkf9HxCOr9Y7XDg5/jVoVLdPcHdNhTwKykSpMOFSCfhTfFQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"mocha": "^10.0.0"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-/ojG/zz6h+St3KIhyS8G+aVAJTj+sbGNAX4yCxgbFIPL9AizCimJLDn/rb3xHsrF4BZVy6kW7P/hLUTeLd3CoA==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-94eIjEythnG8/OI9PIMaA2Jd3VyUa6m2TOW+KwtHENVqBTa4/ZEDpWkVc39rRv1VKU4GEvx4V1+lRjhzN17j5Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"node-fetch": "^2.6.1"
 			}
 		},
 		"@fluidframework/odsp-doclib-utils-previous": {
-			"version": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-EI17vW9cPA/um0KuY/8ec9VjUqxutDX5WMv/Czjbe8oC3ISzAznmMF5ZgaEvtGeyiOiAukX+EI3lkxRd60NWQQ==",
+			"version": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-94eIjEythnG8/OI9PIMaA2Jd3VyUa6m2TOW+KwtHENVqBTa4/ZEDpWkVc39rRv1VKU4GEvx4V1+lRjhzN17j5Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"node-fetch": "^2.6.1"
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-SmqeqKZCIUADjOe4gPZ9erhyypCNUAz2MWPPUmj91PHsv3lQhNwnLQ9P9vMC3EttGWxjXVKv3wXbv3RH7lRK3w==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-zYqiXUcxQYGlobKLPNS2WdpSrK/1PB/cimitqWQ9yh66dY/p0z2qG2xdKfm2FWNew7k9pnJbCkZzxqR3NQ5G/w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -4165,38 +4096,38 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-iJjSI9c/dXI4dcWeZbb+CQv5svZOzcQhRCeBM6XRf5xuiv2bz52E0ld+ZhigM33PmqG2HnPz3J9515M8rYvHqw==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-8O683idVdX+0FCDXuwdoAF50TGKr/SgEgngHjcWOfkSLlXBx8OkbPfypBJ+lsYSE6aVvOjzVxNN6Od72KnCDrQ==",
 			"requires": {
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
-			"version": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-AdHooUBy01IKQTM2HL0+o4ml6dwHeQSpW9Uu3RoDHc73sF+fWS+krBGUlPAOsSDrhCPrv0R4r3yANj/AW9ArUQ==",
+			"version": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-8O683idVdX+0FCDXuwdoAF50TGKr/SgEgngHjcWOfkSLlXBx8OkbPfypBJ+lsYSE6aVvOjzVxNN6Od72KnCDrQ==",
 			"requires": {
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/odsp-driver-previous": {
-			"version": "npm:@fluidframework/odsp-driver@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-XBYGjIEnS33z1s+ETdpw2w61D0OFDtdjiL2S4EOT1c5SRI/OQzPEd9p8BHnklfg+wI9/meM2eZ12t6CRN5iK9g==",
+			"version": "npm:@fluidframework/odsp-driver@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-zYqiXUcxQYGlobKLPNS2WdpSrK/1PB/cimitqWQ9yh66dY/p0z2qG2xdKfm2FWNew7k9pnJbCkZzxqR3NQ5G/w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -4204,54 +4135,54 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-SDqu09paHxGLgiSh0YC9Wqj6FyvMJvAcRstUFxNeQrPQT41KCEqDC3tfvxni6qKLx6k6yb4VrEtEQUUmMlgORA==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-FBaxclM18yqbPjhXuozqsQCkf6OvPySfxw2tEUDnLS0xxuOHv/g/HiCiDdVVbCosytFVRKTrNIbJGY9HGSFBHg==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
-			"version": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-mzBOY17KjNA9Aa4Preh+h5x9GCZmeYLpt8mhFzuYgWlqaJ/7iYvF9T5BmfEifg8mclfORXuGWrkaWizIT+Ve2A==",
+			"version": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-FBaxclM18yqbPjhXuozqsQCkf6OvPySfxw2tEUDnLS0xxuOHv/g/HiCiDdVVbCosytFVRKTrNIbJGY9HGSFBHg==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/ordered-collection": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-11IlfnNyQE2Sv4pXt6xtFK7s3HEBSVazNLBb8m4E88XRZwZ5q8r6FYsgZsuTGBu7nxS3N0OJdsFTuUxKmNWFyQ==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-uVwA9R3Zrp1BHU4QKDF91eKYeAq7HpKE7BSGdbAzpdibHknCx6fad5TKW9rgB5/CYRXiTpR77X07cY59KG7GFg==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/ordered-collection-previous": {
-			"version": "npm:@fluidframework/ordered-collection@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-x4kJlqyrZN5wGvYy6ZXfhG5sTcrPlrvd7GWuK05RXjK0osQJaac1OLeh4n0RhPbi+v1C+CV+MWaGvsWwJOGCMQ==",
+			"version": "npm:@fluidframework/ordered-collection@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-uVwA9R3Zrp1BHU4QKDF91eKYeAq7HpKE7BSGdbAzpdibHknCx6fad5TKW9rgB5/CYRXiTpR77X07cY59KG7GFg==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -4275,98 +4206,98 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-S3b7hsFIxkAiCBe4HqSw5ZV82YrF6pjfPriC6M8mMOxC9pFx+iD2nwl75oLo/6EjYuYLgUcbvpUu71gQBixXJQ==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-8gBxZCeO0T+X9Jd9FBIjyvbb38a29jialMewljjp1HmvYY9mq0hczkOsqdDGkX7mEXJjKFh0t3FNL8aXD1SOkA==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/register-collection-previous": {
-			"version": "npm:@fluidframework/register-collection@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-Vb8IzoTsC2fZOI95TgWC+GOroi6/FowYBKFSz9gIzOO85OFCR52XBYU9b9PktzAa6HVIEKkkyPMW594EBuk1cA==",
+			"version": "npm:@fluidframework/register-collection@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-8gBxZCeO0T+X9Jd9FBIjyvbb38a29jialMewljjp1HmvYY9mq0hczkOsqdDGkX7mEXJjKFh0t3FNL8aXD1SOkA==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/replay-driver": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-riBUWeScvUOSVxJkLcJi3Fc10vcT5IR1MQOH+YxWNnotVa4OKJFG1g6VQaJHTk5WbLx+DFFAlZqdbcx7Jl/2Rw==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-9PoxCnCuVvwuB1MI+GP+0bDfBNpdW4Hc/8Q4QDVYLvKsMtzd03W4TmmGJkglzjGj/MgR6WlU2jRATECnqXbc3g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
-			"version": "npm:@fluidframework/replay-driver@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-dvgzNVyjf/+WcXFGTbgXsZmUFJkzHMw+74b5nEjcyAuSljkdrUS5a/YnXC4khCddOoQ8rOGIReiywIE4ERv8bA==",
+			"version": "npm:@fluidframework/replay-driver@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-9PoxCnCuVvwuB1MI+GP+0bDfBNpdW4Hc/8Q4QDVYLvKsMtzd03W4TmmGJkglzjGj/MgR6WlU2jRATECnqXbc3g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-sTtCiH3ijNR1C6Ln8Vqf+UQjjyqRu43swkAvpQUut1t5B3umpt2+V4KNMnISyvI7jky+XJPi/S97K4INuYNwmw==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-8fYfd0ZzGhNsXEtXDxKiDQvT1KJzWKt7w7mE8SJQCqJpiZarLfP4m5sCgQ8MflGHokyrdS0HoAff1PUh7Fz/bg==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/request-handler-previous": {
-			"version": "npm:@fluidframework/request-handler@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-iZgkhRiJf7C8qCC0opCSxdyxPyWYwWFaht9MsyefyLZEGqPXQkjonHe8AMciMnsR+G5Ygpjql1Uv+SR653AGRQ==",
+			"version": "npm:@fluidframework/request-handler@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-8fYfd0ZzGhNsXEtXDxKiDQvT1KJzWKt7w7mE8SJQCqJpiZarLfP4m5sCgQ8MflGHokyrdS0HoAff1PUh7Fz/bg==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-hiDwst2RZJsx9aC9KvrHxVULWFgif51gxNsggJnRVkWfVXg3D3kml6u3ljrljHZcmbWIer+fUtMaWAn+8gEKkw==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-cAHwV48LFAsONXy+8+CD1wMgM7O0qd24DRBclqOleQzmB7f1lojhcxgSAloeI0busMegb0X3bJ71/jZ5U28JCg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -4376,20 +4307,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver-previous": {
-			"version": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-xrBRWo68ThGsaHynIDo49na36ko+DNm5LzqL9sf74WwtrM6ruuGsv/KUlh1qWCf3ee+ewQI1KZtqKUJvgoXJmg==",
+			"version": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-cAHwV48LFAsONXy+8+CD1wMgM7O0qd24DRBclqOleQzmB7f1lojhcxgSAloeI0busMegb0X3bJ71/jZ5U28JCg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -4399,187 +4330,117 @@
 			}
 		},
 		"@fluidframework/routerlicious-urlresolver-previous": {
-			"version": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-izhFq3PNAR4TjcwdJbWtepYN5+oRjOXUAFPGPYQQFxWTchadnQSHCl/tZXpXosLD87lHy0yrpsGxD+KhnFg+MQ==",
+			"version": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-kI7YPiyGNcBdWi4U00Xr4/hGVV4eystNxsXO0oDHknksukadSzzbDtPlyWQUgR8vRr2SkvuwgTwlHSi38thqPQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"nconf": "^0.11.4",
+				"nconf": "^0.12.0",
 				"url": "^0.11.0"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-				},
-				"ini": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-					"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				},
-				"nconf": {
-					"version": "0.11.4",
-					"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.11.4.tgz",
-					"integrity": "sha512-YaDR846q11JnG1vTrhJ0QIlhiGY6+W1bgWtReG9SS3vkTl3AoNwFvUItdhG6/ZjGCfWpUVuRTNEBTDAQ3nWhGw==",
-					"requires": {
-						"async": "^1.4.0",
-						"ini": "^2.0.0",
-						"secure-keys": "^1.0.0",
-						"yargs": "^16.1.1"
-					}
-				},
-				"string-width": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-					"requires": {
-						"ansi-regex": "^5.0.1"
-					}
-				},
-				"y18n": {
-					"version": "5.0.8",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-				},
-				"yargs": {
-					"version": "16.2.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-					"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-					"requires": {
-						"cliui": "^7.0.2",
-						"escalade": "^3.1.1",
-						"get-caller-file": "^2.0.5",
-						"require-directory": "^2.1.1",
-						"string-width": "^4.2.0",
-						"y18n": "^5.0.5",
-						"yargs-parser": "^20.2.2"
-					}
-				}
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-MzR66Gn2DAUS6FFfvz9jISLV863bjAwevEwZoiJ099pOkMRtKpcYqnDz3UpXN9gkfbhPqSDAJzof/51sZb4NQA==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-FEdRUE1PKhv6oRciRP9KPZnm6505b7CzKLOudV8rQtEFKqdD9WODPQAOgOtfZWcKs2ZAoavfowmJ5iJovKT6EA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/runtime-definitions-previous": {
-			"version": "npm:@fluidframework/runtime-definitions@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-774zXBWdEanxPV0Bz/Fr6w0cutApSnWBIOz2v5v17pO6ACtlMLP/ZZBMQU2TRVxmJltMk1x/av+wOxNV6/8PYw==",
+			"version": "npm:@fluidframework/runtime-definitions@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-FEdRUE1PKhv6oRciRP9KPZnm6505b7CzKLOudV8rQtEFKqdD9WODPQAOgOtfZWcKs2ZAoavfowmJ5iJovKT6EA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"@types/node": "^14.18.0"
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-QcRqKRAuQmtkeWs1cFwtltIltgi9qRV+i+Np9mLl1GzgzgzAsiClB5D9FmubJV9FbSsLuwP35w/ROCPtFoj1Cg==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-U7LyFfd1RrH/Vzy5rn3aNlFPjway16To/T0ZrrmeoPDnCNP6FBUgdLsZqUGwyaWCTPhNyLy3E8lfzcgecKrGDA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
-			"version": "npm:@fluidframework/runtime-utils@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-udPWFNWcPeQLizKy9xAJoyZQjxIxz0HZVDub7Gu5xpRttcFfZ+0H1FDyNJCxsxOFcQ780dQCgv0QHZwXoDdUmg==",
+			"version": "npm:@fluidframework/runtime-utils@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-U7LyFfd1RrH/Vzy5rn3aNlFPjway16To/T0ZrrmeoPDnCNP6FBUgdLsZqUGwyaWCTPhNyLy3E8lfzcgecKrGDA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/sequence": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-NATc3D7wKopoq/Eu8t3y/t9g3OTEAfG5RTD3IlQqrUQYs5ef3cfIhawp7W5nOidXDek5/3vGXG0NKmnC3ti4RA==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-KZASJO8bo6Ksz9enDc+Jl0RkN2wfxV8vEO0j0Zw53VGzskhDV4ZiwOw4t3WUS2QYV3FNLGHttWZWKy3AESEZyw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/sequence-previous": {
-			"version": "npm:@fluidframework/sequence@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-xxypuuIkORnaIdZhXp0Jd0l2Wf+z8rbTw0LLBv2jnFyYEyrs/FIkGP7j+TEpcSFPBXpBjRtBzUqHl74Rstmc2w==",
+			"version": "npm:@fluidframework/sequence@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-KZASJO8bo6Ksz9enDc+Jl0RkN2wfxV8vEO0j0Zw53VGzskhDV4ZiwOw4t3WUS2QYV3FNLGHttWZWKy3AESEZyw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -5336,73 +5197,73 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-sGLyROiubr76aY9+JfnUPZm1+B6Jyf36739MUhgwKCOiH0LGwzl33DQusMBgxkaKliwy9suMU9dWd8uJDd1/fA==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-oZ5S8ZpPHoM0Au0alaXxTD+pqf6MnopDIlQ1ER2dA+MfvGtR3/Rg1jdyOn/dmpx83lXdKA942uQv0zzND0hX7A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/shared-object-base-previous": {
-			"version": "npm:@fluidframework/shared-object-base@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-Tkgl0b5wDECCMr+xsi7rvqzU3yLDDtqj5+ancjqZSjqkwd77XcbblJysZlQLTux36q8lJqhK83/Q8S2PfszXzQ==",
+			"version": "npm:@fluidframework/shared-object-base@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-oZ5S8ZpPHoM0Au0alaXxTD+pqf6MnopDIlQ1ER2dA+MfvGtR3/Rg1jdyOn/dmpx83lXdKA942uQv0zzND0hX7A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/shared-summary-block-previous": {
-			"version": "npm:@fluidframework/shared-summary-block@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-QMfX61VT6fSff2BERzne685wNQdXuOiTf62djMAMIibOxeF7vjjKTteKnoS8JpEfqtexbuPSbNdSK56lxvWibQ==",
+			"version": "npm:@fluidframework/shared-summary-block@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-Tw2nhgazY/M+Y4dmLffffi+GKgWvMbX66yLnI1HYOsHZGXcGGZKORBi1VWQOz5P8cIuX8k8e5bJ05rAU8G239A==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-RghjXkF0bAdvjsSKzDlo89ATN2jAV2nWl/42v8uMKxiryjjqgWFkJdyGcMLGtj82mz/qyaH26Xi/eNuN1A3Qdg=="
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-Z1PdSOr9PrpcU8tCG+INGzS5RFMoe9sO+IrGgACJ1tFDpja29gs3su9JfIWcgnDIAtL2lbP/i8ezxBGDbJZPxQ=="
 		},
 		"@fluidframework/synthesize-previous": {
-			"version": "npm:@fluidframework/synthesize@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-+v+qbTLl9w8zhi3BxrfJfRQBPLousRj4RxjwvDTPtpyHxvzDrvHQJt+z291XNFVS0xBXv7dkjBP4gK5JiOFMEQ=="
+			"version": "npm:@fluidframework/synthesize@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-Z1PdSOr9PrpcU8tCG+INGzS5RFMoe9sO+IrGgACJ1tFDpja29gs3su9JfIWcgnDIAtL2lbP/i8ezxBGDbJZPxQ=="
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-oGvjk4CXLs1ShSfDLiz9xw71/NmJGkyHxAOe8/NCli14FRE5wI84ymtfcuXBEk5O6FFR9BwvWnTzkFOIJlwnEA==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-eERa9i4aAS3dwGxTdkGlkY4GCl9BVufvsGQBC67Pv56N6pVO0HNhiYS1x0vszGA3UZRtjn4NO00PIEP6FQB54g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
@@ -5412,9 +5273,9 @@
 			}
 		},
 		"@fluidframework/telemetry-utils-previous": {
-			"version": "npm:@fluidframework/telemetry-utils@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-VTUFKw6YsHELlRcAhb1m6EqO9hRj1VRFSU9LQwn5qj3C7zJcYdiDwopg4qknlxHrbWWPX1xNlICBMWQrxu4/vg==",
+			"version": "npm:@fluidframework/telemetry-utils@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-eERa9i4aAS3dwGxTdkGlkY4GCl9BVufvsGQBC67Pv56N6pVO0HNhiYS1x0vszGA3UZRtjn4NO00PIEP6FQB54g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
@@ -5424,23 +5285,23 @@
 			}
 		},
 		"@fluidframework/test-client-utils-previous": {
-			"version": "npm:@fluidframework/test-client-utils@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-PCPgxx56JDnBhlJ/KY6qc5O3mC0LTr0Yu0ItIPoy8ir/r3bSNRC2tLNjP2HHGQmNNp5dRCxkKR1Rmc+0yzRrAw==",
+			"version": "npm:@fluidframework/test-client-utils@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-oxotV13eQhNUpZ4iz9UHESjBJYB/Ca7Y4796IC3kCaX49LMjgEMQXiM8sbnOgDt8RkUHE2ZeDTO+QLshPO5myw==",
 			"requires": {
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"sillyname": "^0.1.0"
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-BJS3OE0+wCxVTypSRLU7xzi8J3ELGPUkoVId3hdXf2Sh+Fr9HQyPzSykReCLPFaEd7XZCT4RjVP4x/mlwF3Z7w==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-GmMSQnzCyie9RGWNX/sBn1jXvxgEmJNtJUaxy9MglW6wBFfuHwFwpn9hP7VGn2V24H2fk5Fo33rYJtsa9t9yNw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
@@ -5458,128 +5319,128 @@
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-SwcbymAmGhVYQSrf9x2YQ2fKjR4mzCOzWT/B4MRSWnP8PPpIvKpKYzAOHMaHrvqfWTJnt7y/WwqqRFH0KniUvg==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-8ISe9b8iwcwJVrDZrEsWa/C/0tbNeSozIz2nHuYelFNhDEJMGVCBqxrHT+OL5YODf+ZVKcSAdZY1afiHZJbgAg==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/local-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/local-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-local-server": "^0.1038.2000",
-				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/tool-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/tool-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-drivers-previous": {
-			"version": "npm:@fluidframework/test-drivers@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-USwVl6ybMwXTcVk5nYlDC2QesZSNa9BQQrW+qGj04aGqtDPZzTR5MHmi9uRuYKShE7lM0BPX/cT4VOp7wsH/dA==",
+			"version": "npm:@fluidframework/test-drivers@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-8ISe9b8iwcwJVrDZrEsWa/C/0tbNeSozIz2nHuYelFNhDEJMGVCBqxrHT+OL5YODf+ZVKcSAdZY1afiHZJbgAg==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/local-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/local-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-local-server": "^0.1038.2000",
-				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/tool-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/tool-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-loader-utils-previous": {
-			"version": "npm:@fluidframework/test-loader-utils@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-/Cwjk8EkA+xLBmVMLSDpZW5N4NiQbCo1+sqLhFsEi26PvvojOO5gGFJU+KYWJaDx933dx3WYpvKylB+GSb4kMQ==",
+			"version": "npm:@fluidframework/test-loader-utils@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-MhkIO3fm3EKqlNFiEufRPL5weKnFApnnRRxg23EiddYo1OhAtqqGccf3pTghEQT8EhmscgJmnNMPo1KQb6xW0g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0"
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-NJN29fYIdUE30Da84JnOwWv2J2sIOZyrDoQTz5ihcDfGkcl4HlpT+yH9QxerJ4rjTAwha8xaXIiPf6Zmi9h4qg==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-z+h0VM12B5HESqdr4jfAS7qxzmCUuueoUnH56yztHT+cbgbQrIunN2tTWpog+PCGVx5vMwd7fAo9UNoZDYI/+w==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-pairwise-generator-previous": {
-			"version": "npm:@fluidframework/test-pairwise-generator@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-t/4dtya41PvWk0lu0abYZTXYZHeP/YS5/AvQ3FMB/SVNFefrVsSUy18AsYEhLTtlcqhj3L33fVZP6c1gnksKnA==",
+			"version": "npm:@fluidframework/test-pairwise-generator@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-z+h0VM12B5HESqdr4jfAS7qxzmCUuueoUnH56yztHT+cbgbQrIunN2tTWpog+PCGVx5vMwd7fAo9UNoZDYI/+w==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
 				"random-js": "^1.0.8"
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-lhqgziVd1hBOVz8sQfBmsYlh7G1bITsremlutWnupTbS7/M//tvsK9bZ+/mcMghbK+uyL4GRKF4Iyyw+SalauA==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-nBBuFCLqM6RKylZj1aeEl4XhhwuXTj1PXgfMZJfhHV5pPJ434W6KDFtq2OwXagwLLOsuDfDjBlyppy6P5ByKKg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-runtime-utils-previous": {
-			"version": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-OCV68XMlUBKAhlQJWiEf7roXgSRTKGW6zz1AfHK88ue1TK7iHc5h21N7S7pweadSBYJtg2gU1TJMlntD3Z7cdA==",
+			"version": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-nBBuFCLqM6RKylZj1aeEl4XhhwuXTj1PXgfMZJfhHV5pPJ434W6KDFtq2OwXagwLLOsuDfDjBlyppy6P5ByKKg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -5592,230 +5453,160 @@
 			"dev": true
 		},
 		"@fluidframework/test-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-iG+Emrq7A07rZw0hSgpnU/8mP/0WOLpiwhpYqeavdUp3JJuX+OT+1qmK0/IHiTHqlNSNm7mwzwDZxKvp8izScg==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-3y0WtePiPqQKGIO1VYfQi8jMyhdH92RG5xUPqpYWtAi8pj3456CuVXAOGY7vxEW/unkLCmF/1BIPFk0fA2jLNw==",
 			"requires": {
-				"@fluidframework/aqueduct": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/local-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/map": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/local-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"best-random": "^1.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-utils-previous": {
-			"version": "npm:@fluidframework/test-utils@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-Ex9sGDVnWL/Ii/LVcA7GnrREJSuyaZGfya6I1X9ldsujR0g2EUZFupAmj8InRuUeoa5XdOL53eS+RZ1FHihkew==",
+			"version": "npm:@fluidframework/test-utils@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-3y0WtePiPqQKGIO1VYfQi8jMyhdH92RG5xUPqpYWtAi8pj3456CuVXAOGY7vxEW/unkLCmF/1BIPFk0fA2jLNw==",
 			"requires": {
-				"@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/local-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/map": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/local-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"best-random": "^1.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/test-version-utils-previous": {
-			"version": "npm:@fluidframework/test-version-utils@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-EECkN6Rb7YZL26X3Yd7vowQ88RIvfGiBmxx13PRTuk/Lko8oVlOxfof0TL01HLM9ZnSAlDOxAU2a9qV4wQVZpw==",
+			"version": "npm:@fluidframework/test-version-utils@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-pc6+OdalaX+qmLcTtf+QfZxmqln8xG5yjAsb8goWDnOFk1dsxEtxx9E8m6jj8mmFNa+/vUAQHsNtJJUYOWtd3Q==",
 			"requires": {
-				"@fluid-experimental/sequence-deprecated": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/aqueduct": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/cell": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/sequence-deprecated": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/cell": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/counter": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/ink": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/map": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/matrix": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/ordered-collection": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/counter": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/ink": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/matrix": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/ordered-collection": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/register-collection": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/sequence": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-drivers": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"nconf": "^0.11.4",
+				"@fluidframework/register-collection": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/sequence": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-drivers": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"nconf": "^0.12.0",
 				"proper-lockfile": "^4.1.2",
 				"semver": "^7.3.4"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-				},
-				"ini": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-					"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				},
-				"nconf": {
-					"version": "0.11.4",
-					"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.11.4.tgz",
-					"integrity": "sha512-YaDR846q11JnG1vTrhJ0QIlhiGY6+W1bgWtReG9SS3vkTl3AoNwFvUItdhG6/ZjGCfWpUVuRTNEBTDAQ3nWhGw==",
-					"requires": {
-						"async": "^1.4.0",
-						"ini": "^2.0.0",
-						"secure-keys": "^1.0.0",
-						"yargs": "^16.1.1"
-					}
-				},
-				"string-width": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-					"requires": {
-						"ansi-regex": "^5.0.1"
-					}
-				},
-				"y18n": {
-					"version": "5.0.8",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-				},
-				"yargs": {
-					"version": "16.2.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-					"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-					"requires": {
-						"cliui": "^7.0.2",
-						"escalade": "^3.1.1",
-						"get-caller-file": "^2.0.5",
-						"require-directory": "^2.1.1",
-						"string-width": "^4.2.0",
-						"y18n": "^5.0.5",
-						"yargs-parser": "^20.2.2"
-					}
-				}
 			}
 		},
 		"@fluidframework/tinylicious-client-previous": {
-			"version": "npm:@fluidframework/tinylicious-client@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-lLJryFCzTvKIiCBPMNzo0syLB8jb43C6WmanJ0gN2mTN49afd1qvHb4wnW5eCdtp7KAWloom7FJYUhXov9QHXQ==",
+			"version": "npm:@fluidframework/tinylicious-client@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-HmtW7Tn2Djpw4ZUjMG89IfJotCKf7EJX20XPnCmO3ED5J40L7VZAtL+If/lxaq/9q37IsiQCEOyEX9Ib6YMf6Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/fluid-static": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/map": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/fluid-static": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-/7aC4JvtEsiPivoeIcaMQrnfQroxiFVdAk1uPWBlELcK/AIuv2r26f1zgIv4FG92nYaV8cuQwIW8phSMxdT0yQ==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-CUGTvw2x8N1WQo7EdCcSgUkQnbFHEJlmVeSRVGtOVB+Fb0BiFEbLmfXJEHONXt8IKuQtfw/ZB4UHQL8EF6NoSA==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-services-client": "^0.1038.2000",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/tinylicious-driver-previous": {
-			"version": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-F+eRGnkQNQHcwR4mov1lA+Cb+g5Fx4KMOBG5ykoEMfoPFwXGrPBEZc4upJNpULHNBxJtJgsBJbityEbBNWQ2nQ==",
+			"version": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-CUGTvw2x8N1WQo7EdCcSgUkQnbFHEJlmVeSRVGtOVB+Fb0BiFEbLmfXJEHONXt8IKuQtfw/ZB4UHQL8EF6NoSA==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-services-client": "^0.1038.2000",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-Svw/m5OSRS4jYi9TUasyKRB/GDNCO8MMkfmYnIgtRVCyvvJeIJgpLmJjYHAJRKBqQf2cVvC6dbCK81O1mBT8nA==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-2VYa5c/OQgLzgK2mQw2alIEoqk190KMo2ybQR8UUSAog/AMH96hD/NR3Oj7Kze9fyU0NWzIcXBMIMkQDEZHZfA==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"async-mutex": "^0.3.1",
@@ -5825,12 +5616,12 @@
 			}
 		},
 		"@fluidframework/tool-utils-previous": {
-			"version": "npm:@fluidframework/tool-utils@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-Yj6LWTxeZ3/v0L6jr+CgV/qgfBEbsV/Zw5R6HKCh9RT6iwzHadXH/XBE++avWOQDGylKNdJ26q2grKjrKIbSVw==",
+			"version": "npm:@fluidframework/tool-utils@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-2VYa5c/OQgLzgK2mQw2alIEoqk190KMo2ybQR8UUSAog/AMH96hD/NR3Oj7Kze9fyU0NWzIcXBMIMkQDEZHZfA==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"async-mutex": "^0.3.1",
@@ -5840,71 +5631,71 @@
 			}
 		},
 		"@fluidframework/undo-redo-previous": {
-			"version": "npm:@fluidframework/undo-redo@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-HCON+ZA4DJOLUpIAhEHUPQHGs9MrzRkq/ro/lFjjAoyWcYF7ATJ9poyg/4hrYoNIhzoejAmajbAlAMgegJqhrg==",
+			"version": "npm:@fluidframework/undo-redo@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-avQTBoqLIbGRuY41odSzaFXY3OPsp+fpc72jKRhuikRRwyX3SNJsKs2PevEokH1bYqgw7oIPpjL+f3mtG9BMVw==",
 			"requires": {
-				"@fluidframework/map": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/matrix": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/sequence": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/matrix": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/sequence": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/view-adapters": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-Ze84PP1AozmMWp6qKHNVDZRMFeLm5Fc0o6axgmJsS8VQYzepbBJC4RKGQnEz06AZyOVP96rUkN0pir3sqXuVIA==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-4uJNgrFidEg5310Zy3/ZaHpXMBK13mynQhTnDIQ7PqhnVjy+Jswfz9AcnO1hm/NGdlh2CUC+9GGYGmi8s+QMNA==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"react": "^17.0.1",
 				"react-dom": "^17.0.1"
 			}
 		},
 		"@fluidframework/view-adapters-previous": {
-			"version": "npm:@fluidframework/view-adapters@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-dptqCYkf/YUtOSfC8WaAd6WRPXGMgdD8q09TYEVFX5AlZRoHaumfbC32vzmAVHwQGnAxq704NoHh6HquHtbaOw==",
+			"version": "npm:@fluidframework/view-adapters@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-4uJNgrFidEg5310Zy3/ZaHpXMBK13mynQhTnDIQ7PqhnVjy+Jswfz9AcnO1hm/NGdlh2CUC+9GGYGmi8s+QMNA==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"react": "^17.0.1",
 				"react-dom": "^17.0.1"
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-mehNznfHr7AqPn5/u5n9NF5iDyLBn48CjXBQwKQydYJH3v6jJB+I2BzVaW2Rw0y3pz8jbhd1xbUcjDI5X+elUg==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-AvFzO1VmHH/LJOz3u/c4IoctZ6hr7O7NmsrYsxOBQxynb8IOe7PWVYfEvpX45J3W5KHhbxPMvYKhTh8ovKS2Eg==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
-			"version": "npm:@fluidframework/view-interfaces@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-ko7Kb8QQOaymp+DoMT9wJKNjcF5oOvamheCPv6kwoQEwJo2Q78SgrvHeoQNRxOTAIDf9Sj2PHFIYw+W9z1IHDA==",
+			"version": "npm:@fluidframework/view-interfaces@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-AvFzO1VmHH/LJOz3u/c4IoctZ6hr7O7NmsrYsxOBQxynb8IOe7PWVYfEvpX45J3W5KHhbxPMvYKhTh8ovKS2Eg==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-GcwuPMGE6c2OidL5lSwlRTFXXJBFofC7K3J7+NoFjAmto8lsm7nRVQpC94G+/h3U+s0uzTHVuxnvTLGMcSJonw==",
+			"version": "2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-mmmiCg29wlkN1NYEKYTg+zFSpyCKGS6DeL5UNwMSiJN7kjY0ypRFWTis6WG1mDOSU9qFQBT5eEj/6LA8lTyqaQ==",
 			"requires": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},
 		"@fluidframework/web-code-loader-previous": {
-			"version": "npm:@fluidframework/web-code-loader@2.0.0-internal.2.1.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.1.0.tgz",
-			"integrity": "sha512-eldNOEo7mJ36exkNznPiOqX0D13f7WyMeWZHmnRBNx3h85tK7g4SC7ewONjzNxTJUuLJmmV3I4VKJ8u7AL91Cg==",
+			"version": "npm:@fluidframework/web-code-loader@2.0.0-internal.2.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.2.0.tgz",
+			"integrity": "sha512-mmmiCg29wlkN1NYEKYTg+zFSpyCKGS6DeL5UNwMSiJN7kjY0ypRFWTis6WG1mDOSU9qFQBT5eEj/6LA8lTyqaQ==",
 			"requires": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -49,7 +49,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.2.1.0",
+    "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -62,13 +62,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {
-      "InterfaceDeclaration_IBatchMessage": {
-        "backCompat": false
-      }
     }
   }
 }

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
@@ -275,7 +275,6 @@ declare function get_current_InterfaceDeclaration_IBatchMessage():
 declare function use_old_InterfaceDeclaration_IBatchMessage(
     use: TypeOnly<old.IBatchMessage>);
 use_old_InterfaceDeclaration_IBatchMessage(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IBatchMessage());
 
 /*

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -42,7 +42,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.2.1.0",
+    "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -55,9 +55,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -47,7 +47,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.2.1.0",
+    "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -59,9 +59,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -75,7 +75,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.2.1.0",
+    "@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
@@ -94,9 +94,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -74,7 +74,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.2.1.0",
+    "@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
@@ -93,9 +93,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -76,7 +76,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.2.1.0",
+    "@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.2.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -93,9 +93,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -84,7 +84,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.2.1.0",
+    "@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.2.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -102,9 +102,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -85,7 +85,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.2.1.0",
+    "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.2.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -108,9 +108,9 @@
     "uuid": "^8.3.1"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -81,7 +81,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.2.1.0",
+    "@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.2.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -104,9 +104,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -78,7 +78,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.2.1.0",
+    "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.2.2.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -95,9 +95,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -77,7 +77,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.2.1.0",
+    "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.2.2.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -94,9 +94,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -91,7 +91,7 @@
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/gitresources": "^0.1038.2000",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.2.1.0",
+    "@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.2.2.0",
     "@fluidframework/server-services-client": "^0.1038.2000",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -113,9 +113,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -83,7 +83,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.2.1.0",
+    "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.2.2.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -103,9 +103,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -77,7 +77,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.2.1.0",
+    "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.2.2.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -96,9 +96,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -104,13 +104,6 @@
     "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
     "baselineVersion": "2.0.0-internal.2.1.0",
     "broken": {
-      "ClassDeclaration_TaskManager": {
-        "backCompat": false,
-        "forwardCompat": false
-      },
-      "InterfaceDeclaration_ITaskManager": {
-        "forwardCompat": false
-      }
     }
   }
 }

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -46,7 +46,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.2.1.0",
+    "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -61,9 +61,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.2.1.0",
+    "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -58,9 +58,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -48,7 +48,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.2.1.0",
+    "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -64,9 +64,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.2.1.0",
+    "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.0",
@@ -59,9 +59,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.7.0",
-    "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.2.1.0",
+    "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.2.2.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
@@ -63,9 +63,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -49,7 +49,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/iframe-driver-previous": "npm:@fluidframework/iframe-driver@2.0.0-internal.2.1.0",
+    "@fluidframework/iframe-driver-previous": "npm:@fluidframework/iframe-driver@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -65,9 +65,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -79,7 +79,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.2.1.0",
+    "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.2.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
@@ -96,9 +96,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.2.1.0",
+    "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.2.2.0",
     "@fluidframework/protocol-definitions": "^1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -58,9 +58,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -85,7 +85,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.2.1.0",
+    "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -103,9 +103,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -50,7 +50,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.2.1.0",
+    "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.2.2.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "concurrently": "^6.2.0",
@@ -62,9 +62,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -48,7 +48,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.2.1.0",
+    "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -64,9 +64,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -85,7 +85,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.2.1.0",
+    "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -105,9 +105,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -52,7 +52,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.2.1.0",
+    "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.2.2.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/nconf": "^0.10.0",
@@ -67,9 +67,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.2.1.0",
+    "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.2.2.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^9.1.1",
@@ -62,9 +62,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.7.0",
-    "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.2.1.0",
+    "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.2.2.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
@@ -94,9 +94,9 @@
     }
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.7.0",
-    "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.2.1.0",
+    "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.2.2.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
@@ -105,9 +105,9 @@
   },
   "module:es5": "es5/index.js",
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.2.1.0",
+    "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -93,9 +93,9 @@
   },
   "module:es5": "es5/index.js",
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -73,7 +73,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.2.1.0",
+    "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
@@ -96,9 +96,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -79,7 +79,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.2.1.0",
+    "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.2.2.0",
     "@fluidframework/map": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/sequence": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
@@ -98,9 +98,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -74,7 +74,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.2.1.0",
+    "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.2.2.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -94,9 +94,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/datastore": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.2.1.0",
+    "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -88,9 +88,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -48,7 +48,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@2.0.0-internal.2.1.0",
+    "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
@@ -59,9 +59,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -62,7 +62,7 @@
     "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/test-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.2.1.0",
+    "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -80,9 +80,9 @@
     "fluid-framework": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -74,7 +74,7 @@
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.2.1.0",
+    "@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/diff": "^3.5.1",
@@ -94,9 +94,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -42,7 +42,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.2.1.0",
+    "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^17.0.1",
@@ -54,9 +54,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -39,7 +39,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.2.1.0",
+    "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
@@ -50,9 +50,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -83,7 +83,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.2.1.0",
+    "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-loader-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
@@ -106,9 +106,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -73,7 +73,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.2.1.0",
+    "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
@@ -92,9 +92,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -78,7 +78,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.2.1.0",
+    "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
@@ -97,9 +97,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -73,7 +73,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.2.1.0",
+    "@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.2.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -91,9 +91,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -42,7 +42,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@2.0.0-internal.2.1.0",
+    "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@2.0.0-internal.2.2.0",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
     "eslint": "~8.6.0",
@@ -51,9 +51,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/protocol-definitions": "^1.1.0",
-    "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@2.0.0-internal.2.1.0",
+    "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/isomorphic-fetch": "^0.0.35",
@@ -56,9 +56,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -46,7 +46,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.2.1.0",
+    "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -58,9 +58,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -86,7 +86,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.2.1.0",
+    "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
@@ -108,22 +108,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {
-      "InterfaceDeclaration_ICompressionRuntimeOptions": {
-        "backCompat": false,
-        "forwardCompat": false
-      },
-      "InterfaceDeclaration_IContainerRuntimeOptions": {
-        "backCompat": false,
-        "forwardCompat": false
-      },
-      "ClassDeclaration_ContainerRuntime": {
-        "forwardCompat": false,
-        "backCompat": false
-      }
     }
   }
 }

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -40,6 +40,30 @@ use_old_VariableDeclaration_agentSchedulerId(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "EnumDeclaration_CompressionAlgorithms": {"forwardCompat": false}
+*/
+declare function get_old_EnumDeclaration_CompressionAlgorithms():
+    TypeOnly<old.CompressionAlgorithms>;
+declare function use_current_EnumDeclaration_CompressionAlgorithms(
+    use: TypeOnly<current.CompressionAlgorithms>);
+use_current_EnumDeclaration_CompressionAlgorithms(
+    get_old_EnumDeclaration_CompressionAlgorithms());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "EnumDeclaration_CompressionAlgorithms": {"backCompat": false}
+*/
+declare function get_current_EnumDeclaration_CompressionAlgorithms():
+    TypeOnly<current.CompressionAlgorithms>;
+declare function use_old_EnumDeclaration_CompressionAlgorithms(
+    use: TypeOnly<old.CompressionAlgorithms>);
+use_old_EnumDeclaration_CompressionAlgorithms(
+    get_current_EnumDeclaration_CompressionAlgorithms());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "EnumDeclaration_ContainerMessageType": {"forwardCompat": false}
 */
 declare function get_old_EnumDeclaration_ContainerMessageType():
@@ -71,7 +95,6 @@ declare function get_old_ClassDeclaration_ContainerRuntime():
 declare function use_current_ClassDeclaration_ContainerRuntime(
     use: TypeOnly<current.ContainerRuntime>);
 use_current_ClassDeclaration_ContainerRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_ContainerRuntime());
 
 /*
@@ -84,7 +107,6 @@ declare function get_current_ClassDeclaration_ContainerRuntime():
 declare function use_old_ClassDeclaration_ContainerRuntime(
     use: TypeOnly<old.ContainerRuntime>);
 use_old_ClassDeclaration_ContainerRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_ContainerRuntime());
 
 /*
@@ -457,7 +479,6 @@ declare function get_old_InterfaceDeclaration_ICompressionRuntimeOptions():
 declare function use_current_InterfaceDeclaration_ICompressionRuntimeOptions(
     use: TypeOnly<current.ICompressionRuntimeOptions>);
 use_current_InterfaceDeclaration_ICompressionRuntimeOptions(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ICompressionRuntimeOptions());
 
 /*
@@ -470,7 +491,6 @@ declare function get_current_InterfaceDeclaration_ICompressionRuntimeOptions():
 declare function use_old_InterfaceDeclaration_ICompressionRuntimeOptions(
     use: TypeOnly<old.ICompressionRuntimeOptions>);
 use_old_InterfaceDeclaration_ICompressionRuntimeOptions(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ICompressionRuntimeOptions());
 
 /*
@@ -507,7 +527,6 @@ declare function get_old_InterfaceDeclaration_IContainerRuntimeOptions():
 declare function use_current_InterfaceDeclaration_IContainerRuntimeOptions(
     use: TypeOnly<current.IContainerRuntimeOptions>);
 use_current_InterfaceDeclaration_IContainerRuntimeOptions(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntimeOptions());
 
 /*
@@ -520,7 +539,6 @@ declare function get_current_InterfaceDeclaration_IContainerRuntimeOptions():
 declare function use_old_InterfaceDeclaration_IContainerRuntimeOptions(
     use: TypeOnly<old.IContainerRuntimeOptions>);
 use_old_InterfaceDeclaration_IContainerRuntimeOptions(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IContainerRuntimeOptions());
 
 /*

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -46,7 +46,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.2.1.0",
+    "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -58,9 +58,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -84,7 +84,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.2.1.0",
+    "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.2.2.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
@@ -104,9 +104,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -77,7 +77,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@2.0.0-internal.2.1.0",
+    "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@2.0.0-internal.2.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -94,9 +94,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.2.1.0",
+    "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
@@ -58,9 +58,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -80,7 +80,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.2.1.0",
+    "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -98,9 +98,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
@@ -592,6 +592,30 @@ use_old_ClassDeclaration_ObjectStoragePartition(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_packagePathToTelemetryProperty": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_packagePathToTelemetryProperty():
+    TypeOnly<typeof old.packagePathToTelemetryProperty>;
+declare function use_current_FunctionDeclaration_packagePathToTelemetryProperty(
+    use: TypeOnly<typeof current.packagePathToTelemetryProperty>);
+use_current_FunctionDeclaration_packagePathToTelemetryProperty(
+    get_old_FunctionDeclaration_packagePathToTelemetryProperty());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_packagePathToTelemetryProperty": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_packagePathToTelemetryProperty():
+    TypeOnly<typeof current.packagePathToTelemetryProperty>;
+declare function use_old_FunctionDeclaration_packagePathToTelemetryProperty(
+    use: TypeOnly<typeof old.packagePathToTelemetryProperty>);
+use_old_FunctionDeclaration_packagePathToTelemetryProperty(
+    get_current_FunctionDeclaration_packagePathToTelemetryProperty());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "TypeAliasDeclaration_ReadAndParseBlob": {"forwardCompat": false}
 */
 declare function get_old_TypeAliasDeclaration_ReadAndParseBlob():

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -82,7 +82,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.2.1.0",
+    "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -99,9 +99,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -63,7 +63,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.2.1.0",
+    "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -77,9 +77,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -84,7 +84,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@2.0.0-internal.2.1.0",
+    "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -99,9 +99,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@2.0.0-internal.2.1.0",
+    "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@2.0.0-internal.2.2.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.0",
@@ -75,9 +75,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -88,7 +88,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.2.1.0",
+    "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/diff": "^3.5.1",
@@ -107,13 +107,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {
-      "InterfaceDeclaration_ITestContainerConfig": {
-        "backCompat": false
-      }
     }
   }
 }

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -419,7 +419,6 @@ declare function get_current_InterfaceDeclaration_ITestContainerConfig():
 declare function use_old_InterfaceDeclaration_ITestContainerConfig(
     use: TypeOnly<old.ITestContainerConfig>);
 use_old_InterfaceDeclaration_ITestContainerConfig(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITestContainerConfig());
 
 /*

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -91,7 +91,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@2.0.0-internal.2.1.0",
+    "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@2.0.0-internal.2.2.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/nock": "^9.3.0",
@@ -112,9 +112,9 @@
     "webpack-cli": "^4.9.2"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/test/test-version-utils/src/test/types/validateTestVersionUtilsPrevious.generated.ts
+++ b/packages/test/test-version-utils/src/test/types/validateTestVersionUtilsPrevious.generated.ts
@@ -88,6 +88,30 @@ use_old_VariableDeclaration_describeFullCompat(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_describeInstallVersions": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_describeInstallVersions():
+    TypeOnly<typeof old.describeInstallVersions>;
+declare function use_current_FunctionDeclaration_describeInstallVersions(
+    use: TypeOnly<typeof current.describeInstallVersions>);
+use_current_FunctionDeclaration_describeInstallVersions(
+    get_old_FunctionDeclaration_describeInstallVersions());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_describeInstallVersions": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_describeInstallVersions():
+    TypeOnly<typeof current.describeInstallVersions>;
+declare function use_old_FunctionDeclaration_describeInstallVersions(
+    use: TypeOnly<typeof old.describeInstallVersions>);
+use_old_FunctionDeclaration_describeInstallVersions(
+    get_current_FunctionDeclaration_describeInstallVersions());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "VariableDeclaration_describeLoaderCompat": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_describeLoaderCompat():

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -74,7 +74,7 @@
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
-    "@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.2.1.0",
+    "@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.2.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -89,9 +89,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -95,7 +95,7 @@
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.7.0",
-    "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.2.1.0",
+    "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.2.2.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
@@ -120,9 +120,9 @@
     "webpack-cli": "^4.9.2"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.2.1.0",
+    "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.2.2.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node-fetch": "^2.5.10",
@@ -89,9 +89,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -80,7 +80,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.2.1.0",
+    "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
@@ -99,9 +99,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -78,7 +78,7 @@
     "@fluidframework/build-tools": "^0.7.0",
     "@fluidframework/eslint-config-fluid": "^1.2.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.2.1.0",
+    "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.2.2.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
@@ -96,9 +96,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
+    "version": "2.0.0-internal.2.3.0",
+    "baselineRange": ">=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0",
+    "baselineVersion": "2.0.0-internal.2.2.0",
     "broken": {}
   }
 }


### PR DESCRIPTION
1. `npm run typetests:prepare -- --reset`
2. `npm install`
3. `npm run typetests:gen`

This should fix the build break caused by the 2.0.0-internal.2.2.0. This broke the build because npm pickes up new versions of aliased packages even if the package lock says not to, and is needed as part of every release.
