### PR TITLE
build: Bump deps on `@fluidframework/eslint-config-fluid` to `2.0.0` in server packages

### DIFF
--- a/server/gitrest/lerna-package-lock.json
+++ b/server/gitrest/lerna-package-lock.json
@@ -347,9 +347,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "2.0.0-115036",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0-115036.tgz",
-			"integrity": "sha512-hOvlE0B3hsShc744aRM9sYCADVVeXbNAbgjZQtDwk03KrWHQ//1f6JgODBr6FopCcWg6/J6prjy82ufAPl+gjg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
+			"integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
 			"dev": true,
 			"requires": {
 				"@rushstack/eslint-patch": "~1.1.0",

--- a/server/gitrest/lerna-package-lock.json
+++ b/server/gitrest/lerna-package-lock.json
@@ -347,9 +347,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.2.0.tgz",
-			"integrity": "sha512-l1EPPfDfGoTU7dxo6K0JBRoKkTVRmJWT0Ri5wmjma/vnZoDAQ3GFrq5DpUMwFWV9VhLrPd3/Qr07W5YvbLPpRw==",
+			"version": "2.0.0-115036",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0-115036.tgz",
+			"integrity": "sha512-hOvlE0B3hsShc744aRM9sYCADVVeXbNAbgjZQtDwk03KrWHQ//1f6JgODBr6FopCcWg6/J6prjy82ufAPl+gjg==",
 			"dev": true,
 			"requires": {
 				"@rushstack/eslint-patch": "~1.1.0",
@@ -8887,7 +8887,7 @@
 		"clean-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
-			"integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
+			"integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
@@ -10011,7 +10011,7 @@
 				"yallist": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
 					"dev": true
 				}
 			}
@@ -10824,9 +10824,9 @@
 					"dev": true
 				},
 				"ci-info": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-					"integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
+					"version": "3.7.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+					"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
 					"dev": true
 				},
 				"semver": {
@@ -16343,7 +16343,7 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
 			"dev": true
 		},
 		"psl": {
@@ -17111,7 +17111,7 @@
 		"sigmund": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+			"integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
 			"dev": true
 		},
 		"signal-exit": {
@@ -17745,7 +17745,7 @@
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
 			"dev": true
 		},
 		"to-readable-stream": {

--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -315,9 +315,9 @@
 			"dev": true
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "2.0.0-115036",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0-115036.tgz",
-			"integrity": "sha512-hOvlE0B3hsShc744aRM9sYCADVVeXbNAbgjZQtDwk03KrWHQ//1f6JgODBr6FopCcWg6/J6prjy82ufAPl+gjg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
+			"integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
 			"dev": true,
 			"requires": {
 				"@rushstack/eslint-patch": "~1.1.0",

--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -315,9 +315,9 @@
 			"dev": true
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.2.0.tgz",
-			"integrity": "sha512-l1EPPfDfGoTU7dxo6K0JBRoKkTVRmJWT0Ri5wmjma/vnZoDAQ3GFrq5DpUMwFWV9VhLrPd3/Qr07W5YvbLPpRw==",
+			"version": "2.0.0-115036",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0-115036.tgz",
+			"integrity": "sha512-hOvlE0B3hsShc744aRM9sYCADVVeXbNAbgjZQtDwk03KrWHQ//1f6JgODBr6FopCcWg6/J6prjy82ufAPl+gjg==",
 			"dev": true,
 			"requires": {
 				"@rushstack/eslint-patch": "~1.1.0",
@@ -4080,7 +4080,7 @@
 		"clean-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
-			"integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
+			"integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
@@ -4998,7 +4998,7 @@
 				"yallist": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
 					"dev": true
 				}
 			}
@@ -5716,9 +5716,9 @@
 					"dev": true
 				},
 				"ci-info": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-					"integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
+					"version": "3.7.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+					"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
 					"dev": true
 				},
 				"semver": {
@@ -10046,7 +10046,7 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
 			"dev": true
 		},
 		"punycode": {
@@ -10617,7 +10617,7 @@
 		"sigmund": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+			"integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
 			"dev": true
 		},
 		"signal-exit": {

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/async": "^3.2.9",
     "@types/cors": "^2.8.4",

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/async": "^3.2.9",
     "@types/cors": "^2.8.4",

--- a/server/gitrest/packages/gitrest-base/.eslintrc.js
+++ b/server/gitrest/packages/gitrest-base/.eslintrc.js
@@ -5,7 +5,8 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid", "prettier")
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
+        "prettier"
     ],
     "parserOptions": {
         "project": ["./tsconfig.json", "./src/test/tsconfig.json"]

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/async": "^3.2.9",
     "@types/cors": "^2.8.4",

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/async": "^3.2.9",
     "@types/cors": "^2.8.4",

--- a/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
@@ -34,7 +34,6 @@ export interface IRepositoryManager {
     getRefs(): Promise<git.IRef[]>;
     getRef(ref: string, externalWriterConfig?: IExternalWriterConfig): Promise<git.IRef>;
     createRef(createRefParams: git.ICreateRefParams, externalWriterConfig?: IExternalWriterConfig): Promise<git.IRef>;
-    // eslint-disable-next-line max-len
     patchRef(refId: string, patchRefParams: git.IPatchRefParams, externalWriterConfig?: IExternalWriterConfig): Promise<git.IRef>;
     deleteRef(refId: string): Promise<void>;
     getTag(tagId: string): Promise<git.ITag>;

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerBase.ts
@@ -15,7 +15,6 @@ export abstract class RepositoryManagerBase implements IRepositoryManager {
         private readonly enableRepositoryManagerMetrics: boolean = false,
     ) {}
 
-    /* eslint-disable max-len */
     protected abstract getCommitCore(sha: string): Promise<git.ICommit>;
     protected abstract getCommitsCore(sha: string, count: number, externalWriterConfig?: IExternalWriterConfig): Promise<git.ICommitDetails[]>;
     protected abstract getTreeCore(root: string, recursive: boolean): Promise<git.ITree>;
@@ -31,7 +30,6 @@ export abstract class RepositoryManagerBase implements IRepositoryManager {
     protected abstract deleteRefCore(refId: string): Promise<void>;
     protected abstract getTagCore(tagId: string): Promise<git.ITag>;
     protected abstract createTagCore(tagParams: git.ICreateTagParams): Promise<git.ITag>;
-    /* eslint-enable max-len */
 
     public get path(): string {
         return this.directory;

--- a/server/gitrest/packages/gitrest/.eslintrc.js
+++ b/server/gitrest/packages/gitrest/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "parserOptions": {

--- a/server/gitrest/packages/gitrest/package.json
+++ b/server/gitrest/packages/gitrest/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/async": "^3.2.9",
     "@types/cors": "^2.8.4",

--- a/server/gitrest/packages/gitrest/package.json
+++ b/server/gitrest/packages/gitrest/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/async": "^3.2.9",
     "@types/cors": "^2.8.4",

--- a/server/historian/lerna-package-lock.json
+++ b/server/historian/lerna-package-lock.json
@@ -496,9 +496,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.2.0.tgz",
-			"integrity": "sha512-l1EPPfDfGoTU7dxo6K0JBRoKkTVRmJWT0Ri5wmjma/vnZoDAQ3GFrq5DpUMwFWV9VhLrPd3/Qr07W5YvbLPpRw==",
+			"version": "2.0.0-115036",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0-115036.tgz",
+			"integrity": "sha512-hOvlE0B3hsShc744aRM9sYCADVVeXbNAbgjZQtDwk03KrWHQ//1f6JgODBr6FopCcWg6/J6prjy82ufAPl+gjg==",
 			"dev": true,
 			"requires": {
 				"@rushstack/eslint-patch": "~1.1.0",
@@ -4816,9 +4816,9 @@
 					},
 					"dependencies": {
 						"ignore": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-							"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
+							"integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
 							"dev": true
 						}
 					}
@@ -4947,9 +4947,9 @@
 					}
 				},
 				"ignore": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-					"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
+					"integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
 					"dev": true
 				},
 				"is-glob": {
@@ -5085,9 +5085,9 @@
 					}
 				},
 				"ignore": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-					"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
+					"integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
 					"dev": true
 				},
 				"is-glob": {
@@ -5168,9 +5168,9 @@
 					}
 				},
 				"ignore": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-					"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
+					"integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
 					"dev": true
 				},
 				"is-glob": {

--- a/server/historian/lerna-package-lock.json
+++ b/server/historian/lerna-package-lock.json
@@ -496,9 +496,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "2.0.0-115036",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0-115036.tgz",
-			"integrity": "sha512-hOvlE0B3hsShc744aRM9sYCADVVeXbNAbgjZQtDwk03KrWHQ//1f6JgODBr6FopCcWg6/J6prjy82ufAPl+gjg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
+			"integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
 			"dev": true,
 			"requires": {
 				"@rushstack/eslint-patch": "~1.1.0",

--- a/server/historian/package-lock.json
+++ b/server/historian/package-lock.json
@@ -413,9 +413,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.2.0.tgz",
-      "integrity": "sha512-l1EPPfDfGoTU7dxo6K0JBRoKkTVRmJWT0Ri5wmjma/vnZoDAQ3GFrq5DpUMwFWV9VhLrPd3/Qr07W5YvbLPpRw==",
+      "version": "2.0.0-115036",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0-115036.tgz",
+      "integrity": "sha512-hOvlE0B3hsShc744aRM9sYCADVVeXbNAbgjZQtDwk03KrWHQ//1f6JgODBr6FopCcWg6/J6prjy82ufAPl+gjg==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",
@@ -4247,9 +4247,9 @@
           },
           "dependencies": {
             "ignore": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-              "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
+              "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
               "dev": true
             }
           }
@@ -4378,9 +4378,9 @@
           }
         },
         "ignore": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
+          "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
           "dev": true
         },
         "is-glob": {
@@ -4516,9 +4516,9 @@
           }
         },
         "ignore": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
+          "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
           "dev": true
         },
         "is-glob": {
@@ -4599,9 +4599,9 @@
           }
         },
         "ignore": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
+          "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
           "dev": true
         },
         "is-glob": {

--- a/server/historian/package-lock.json
+++ b/server/historian/package-lock.json
@@ -413,9 +413,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "2.0.0-115036",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0-115036.tgz",
-      "integrity": "sha512-hOvlE0B3hsShc744aRM9sYCADVVeXbNAbgjZQtDwk03KrWHQ//1f6JgODBr6FopCcWg6/J6prjy82ufAPl+gjg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
+      "integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-tools": "^0.4.4000",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/compression": "0.0.36",
     "@types/cors": "^2.8.4",

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-tools": "^0.4.4000",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/compression": "0.0.36",
     "@types/cors": "^2.8.4",

--- a/server/historian/packages/historian-base/.eslintrc.js
+++ b/server/historian/packages/historian-base/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "parserOptions": {

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@fluidframework/server-test-utils": "^0.1038.3000-107897",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/compression": "0.0.36",

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/server-test-utils": "^0.1038.3000-107897",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/compression": "0.0.36",

--- a/server/historian/packages/historian-base/src/utils.ts
+++ b/server/historian/packages/historian-base/src/utils.ts
@@ -108,9 +108,7 @@ export function getRequestErrorTranslator(
             // BasicRestWrapper throws NetworkErrors that describe the error details associated with the network call.
             // Here, we log information associated with the error for debugging purposes, and re-throw.
             const networkError = error as NetworkError;
-            // eslint-disable-next-line max-len
             winston.error(`${standardLogErrorMessage}: [statusCode: ${networkError.code}], [details: ${safeStringify(networkError.details) ?? "undefined"}]`);
-            // eslint-disable-next-line max-len
             Lumberjack.error(`${standardLogErrorMessage}: [statusCode: ${networkError.code}], [details: ${safeStringify(networkError.details) ?? "undefined"}]`, lumberProperties);
             throw error;
         } else if (typeof error === "number" || !Number.isNaN(Number.parseInt(error, 10))) {

--- a/server/historian/packages/historian/.eslintrc.js
+++ b/server/historian/packages/historian/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "parserOptions": {

--- a/server/historian/packages/historian/package.json
+++ b/server/historian/packages/historian/package.json
@@ -42,7 +42,7 @@
     "winston": "^3.6.0"
   },
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/compression": "0.0.36",
     "@types/cors": "^2.8.4",

--- a/server/historian/packages/historian/package.json
+++ b/server/historian/packages/historian/package.json
@@ -42,7 +42,7 @@
     "winston": "^3.6.0"
   },
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/compression": "0.0.36",
     "@types/cors": "^2.8.4",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -587,9 +587,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "2.0.0-115036",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0-115036.tgz",
-			"integrity": "sha512-hOvlE0B3hsShc744aRM9sYCADVVeXbNAbgjZQtDwk03KrWHQ//1f6JgODBr6FopCcWg6/J6prjy82ufAPl+gjg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
+			"integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
 			"requires": {
 				"@rushstack/eslint-patch": "~1.1.0",
 				"@rushstack/eslint-plugin": "~0.8.5",

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -587,9 +587,9 @@
 			}
 		},
 		"@fluidframework/eslint-config-fluid": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.2.0.tgz",
-			"integrity": "sha512-l1EPPfDfGoTU7dxo6K0JBRoKkTVRmJWT0Ri5wmjma/vnZoDAQ3GFrq5DpUMwFWV9VhLrPd3/Qr07W5YvbLPpRw==",
+			"version": "2.0.0-115036",
+			"resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0-115036.tgz",
+			"integrity": "sha512-hOvlE0B3hsShc744aRM9sYCADVVeXbNAbgjZQtDwk03KrWHQ//1f6JgODBr6FopCcWg6/J6prjy82ufAPl+gjg==",
 			"requires": {
 				"@rushstack/eslint-patch": "~1.1.0",
 				"@rushstack/eslint-plugin": "~0.8.5",
@@ -6066,9 +6066,9 @@
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.20.4",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-					"integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+					"version": "1.20.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+					"integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
 					"requires": {
 						"call-bind": "^1.0.2",
 						"es-to-primitive": "^1.2.1",
@@ -6076,6 +6076,7 @@
 						"function.prototype.name": "^1.1.5",
 						"get-intrinsic": "^1.1.3",
 						"get-symbol-description": "^1.0.0",
+						"gopd": "^1.0.1",
 						"has": "^1.0.3",
 						"has-property-descriptors": "^1.0.0",
 						"has-symbols": "^1.0.3",
@@ -6091,8 +6092,8 @@
 						"object.assign": "^4.1.4",
 						"regexp.prototype.flags": "^1.4.3",
 						"safe-regex-test": "^1.0.0",
-						"string.prototype.trimend": "^1.0.5",
-						"string.prototype.trimstart": "^1.0.5",
+						"string.prototype.trimend": "^1.0.6",
+						"string.prototype.trimstart": "^1.0.6",
 						"unbox-primitive": "^1.0.2"
 					}
 				},
@@ -9272,9 +9273,9 @@
 					"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
 				},
 				"ci-info": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-					"integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw=="
+					"version": "3.7.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+					"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog=="
 				},
 				"semver": {
 					"version": "7.3.8",
@@ -10584,6 +10585,26 @@
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 					"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+				}
+			}
+		},
+		"gopd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"requires": {
+				"get-intrinsic": "^1.1.3"
+			},
+			"dependencies": {
+				"get-intrinsic": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+					"integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.3"
+					}
 				}
 			}
 		},
@@ -17359,9 +17380,9 @@
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.20.4",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-					"integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+					"version": "1.20.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+					"integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
 					"requires": {
 						"call-bind": "^1.0.2",
 						"es-to-primitive": "^1.2.1",
@@ -17369,6 +17390,7 @@
 						"function.prototype.name": "^1.1.5",
 						"get-intrinsic": "^1.1.3",
 						"get-symbol-description": "^1.0.0",
+						"gopd": "^1.0.1",
 						"has": "^1.0.3",
 						"has-property-descriptors": "^1.0.0",
 						"has-symbols": "^1.0.3",
@@ -17384,8 +17406,8 @@
 						"object.assign": "^4.1.4",
 						"regexp.prototype.flags": "^1.4.3",
 						"safe-regex-test": "^1.0.0",
-						"string.prototype.trimend": "^1.0.5",
-						"string.prototype.trimstart": "^1.0.5",
+						"string.prototype.trimend": "^1.0.6",
+						"string.prototype.trimstart": "^1.0.6",
 						"unbox-primitive": "^1.0.2"
 					}
 				},
@@ -17428,9 +17450,9 @@
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.20.4",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-					"integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+					"version": "1.20.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+					"integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
 					"requires": {
 						"call-bind": "^1.0.2",
 						"es-to-primitive": "^1.2.1",
@@ -17438,6 +17460,7 @@
 						"function.prototype.name": "^1.1.5",
 						"get-intrinsic": "^1.1.3",
 						"get-symbol-description": "^1.0.0",
+						"gopd": "^1.0.1",
 						"has": "^1.0.3",
 						"has-property-descriptors": "^1.0.0",
 						"has-symbols": "^1.0.3",
@@ -17453,8 +17476,8 @@
 						"object.assign": "^4.1.4",
 						"regexp.prototype.flags": "^1.4.3",
 						"safe-regex-test": "^1.0.0",
-						"string.prototype.trimend": "^1.0.5",
-						"string.prototype.trimstart": "^1.0.5",
+						"string.prototype.trimend": "^1.0.6",
+						"string.prototype.trimstart": "^1.0.6",
 						"unbox-primitive": "^1.0.2"
 					}
 				},

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@rushstack/eslint-config": "^2.6.1",
     "concurrently": "^7.5.0",
     "eslint": "~8.27.0",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@rushstack/eslint-config": "^2.6.1",
     "concurrently": "^7.5.0",
     "eslint": "~8.27.0",

--- a/server/routerlicious/packages/kafka-orderer/.eslintrc.js
+++ b/server/routerlicious/packages/kafka-orderer/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "rules": {

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/node": "^14.18.0",
     "concurrently": "^7.5.0",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/node": "^14.18.0",
     "concurrently": "^7.5.0",

--- a/server/routerlicious/packages/lambdas-driver/.eslintrc.js
+++ b/server/routerlicious/packages/lambdas-driver/.eslintrc.js
@@ -5,12 +5,13 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid")
+        require.resolve("@fluidframework/eslint-config-fluid/minimal")
     ],
     "parserOptions": {
         "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
     },
     "rules": {
-        "@typescript-eslint/strict-boolean-expressions": "off"
+        "@typescript-eslint/strict-boolean-expressions": "off",
+        "import/no-nodejs-modules": "off",
     }
 }

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/async": "^3.2.9",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/async": "^3.2.9",

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
@@ -158,9 +158,7 @@ export class PartitionManager extends EventEmitter {
                 continue;
             }
 
-            // eslint-disable-next-line max-len
             this.logger?.info(`Creating ${partition.topic}: Partition ${partition.partition}, Epoch ${partition.leaderEpoch}, Offset ${partition.offset} due to rebalance`);
-            // eslint-disable-next-line max-len
             Lumberjack.info(`Creating ${partition.topic}: Partition ${partition.partition}, Epoch ${partition.leaderEpoch}, Offset ${partition.offset} due to rebalance`);
 
             const newPartition = new Partition(

--- a/server/routerlicious/packages/lambdas/.eslintrc.js
+++ b/server/routerlicious/packages/lambdas/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "rules": {

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/async": "^3.2.9",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/async": "^3.2.9",

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -323,7 +323,6 @@ export function configureWebSocketServices(
             if (!version) {
                 throw new NetworkError(
                     400,
-                    // eslint-disable-next-line max-len
                     `Unsupported client protocol. Server: ${protocolVersions}. Client: ${JSON.stringify(connectVersions)}`,
                 );
             }
@@ -395,7 +394,6 @@ export function configureWebSocketServices(
                 connection.once("error", (error) => {
                     const messageMetaData = getMessageMetadata(connection.documentId, connection.tenantId);
 
-                    // eslint-disable-next-line max-len
                     logger.error(`Disconnecting socket on connection error: ${safeStringify(error, undefined, 2)}`, { messageMetaData });
                     Lumberjack.error(
                         `Disconnecting socket on connection error`,
@@ -408,7 +406,6 @@ export function configureWebSocketServices(
 
                 connection.connect()
                     .catch(async (err) => {
-                        // eslint-disable-next-line max-len
                         const errMsg = `Failed to connect to the orderer connection. Error: ${safeStringify(err, undefined, 2)}`;
                         connectDocumentOrdererConnectionMetric.error("Failed to establish orderer connection", err);
                         return handleServerError(logger, errMsg, claims.documentId, claims.tenantId);

--- a/server/routerlicious/packages/lambdas/src/copier/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/copier/lambda.ts
@@ -83,7 +83,6 @@ export class CopierLambda implements IPartitionLambda {
         Promise.all(allProcessed).then(
             () => {
                 this.currentJobs.clear();
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                 this.context.checkpoint(batchOffset as IQueuedMessage);
                 this.sendPending();
             },
@@ -95,7 +94,6 @@ export class CopierLambda implements IPartitionLambda {
     private async processMongoCore(kafkaBatches: IRawOperationMessageBatch[]): Promise<void> {
         await this.rawOpCollection
             .insertMany(kafkaBatches, false)
-            // eslint-disable-next-line @typescript-eslint/promise-function-async
             .catch((error) => {
                 // Duplicate key errors are ignored since a replay may cause us to insert twice into Mongo.
                 // All other errors result in a rejected promise.

--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -31,7 +31,6 @@ export class CheckpointContext {
         }
 
         // Check if a checkpoint is in progress - if so store the pending checkpoint
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         if (this.pendingUpdateP) {
             this.pendingCheckpoint = checkpoint;
             return;
@@ -95,7 +94,6 @@ export class CheckpointContext {
         this.closed = true;
     }
 
-    // eslint-disable-next-line @typescript-eslint/promise-function-async
     private checkpointCore(checkpoint: ICheckpointParams) {
         // Exit early if already closed
         if (this.closed) {

--- a/server/routerlicious/packages/lambdas/src/foreman/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/foreman/lambda.ts
@@ -49,7 +49,6 @@ export class ForemanLambda implements core.IPartitionLambda {
                 const sequencedMessage = baseMessage as core.ISequencedOperationMessage;
                 // Only process "Help" messages.
                 if (sequencedMessage.operation.type === MessageType.RemoteHelp) {
-                    // eslint-disable-next-line max-len
                     const helpMessage: IHelpMessage = JSON.parse((sequencedMessage.operation as ISequencedDocumentSystemMessage).data);
                     // Back-compat to play well with older client.
                     const helpContent = helpMessage.version

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -82,7 +82,6 @@ export class SummaryWriter implements ISummaryWriter {
      * @returns ISummaryWriteResponse; that represents the success or failure of the write, along with an
      * Ack or Nack message
      */
-    /* eslint-disable max-len */
     public async writeClientSummary(
         op: ISequencedDocumentAugmentedMessage,
         lastSummaryHead: string | undefined,
@@ -322,8 +321,6 @@ export class SummaryWriter implements ISummaryWriter {
         }
     }
 
-    /* eslint-enable max-len */
-
     /**
      * Helper function that writes a new summary. Unlike client summaries, service summaries can be
      * triggered at any point in time. At first it fetches the last summary written by client. Once done,
@@ -534,7 +531,6 @@ export class SummaryWriter implements ISummaryWriter {
                 }
             }
             Lumberjack.info(
-                // eslint-disable-next-line max-len
                 `FullLogTail missing ops from: ${from} exclusive, to: ${to} exclusive with sequence numbers: ${JSON.stringify(missingOpsSequenceNumbers)}`
                 , this.lumberProperties);
         }
@@ -554,7 +550,7 @@ export class SummaryWriter implements ISummaryWriter {
         if (fullLogTail.length > 0) {
             Lumberjack.info(`LogTail of length ${fullLogTail.length} generated from seq no ${fullLogTail[0].sequenceNumber} to ${fullLogTail[fullLogTail.length - 1].sequenceNumber}`, this.lumberProperties);
         }
-        
+
         return logTailEntries;
     }
 
@@ -574,7 +570,6 @@ export class SummaryWriter implements ISummaryWriter {
         const missingOpsSN: number[] = [];
         missingOps?.forEach((op) => missingOpsSN.push(op.sequenceNumber));
         if (missingOpsSN.length > 0) {
-            // eslint-disable-next-line max-len
             Lumberjack.info(`Fetched ops gt: ${gt} exclusive, lt: ${lt} exclusive of last summary logtail: ${JSON.stringify(missingOpsSN)}`
                 , this.lumberProperties);
         }

--- a/server/routerlicious/packages/local-server/.eslintrc.js
+++ b/server/routerlicious/packages/local-server/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "parserOptions": {

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^10.0.0",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^10.0.0",

--- a/server/routerlicious/packages/memory-orderer/.eslintrc.js
+++ b/server/routerlicious/packages/memory-orderer/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "rules": {

--- a/server/routerlicious/packages/memory-orderer/.eslintrc.js
+++ b/server/routerlicious/packages/memory-orderer/.eslintrc.js
@@ -11,5 +11,6 @@ module.exports = {
     "rules": {
         "@typescript-eslint/restrict-template-expressions": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
+        "import/no-nodejs-modules": "off",
     }
 }

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -77,7 +77,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/mocha": "^10.0.0",
     "@types/uuid": "^8.3.0",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -77,7 +77,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/mocha": "^10.0.0",
     "@types/uuid": "^8.3.0",

--- a/server/routerlicious/packages/memory-orderer/src/localKafka.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localKafka.ts
@@ -63,7 +63,6 @@ export class LocalKafka implements IProducer {
         this.subscriptions.push(kafkaSubscription);
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
     public async send(messages: object[], topic: string): Promise<any> {
         for (const message of messages) {
             const queuedMessage: IQueuedMessage = {

--- a/server/routerlicious/packages/memory-orderer/src/socket.ts
+++ b/server/routerlicious/packages/memory-orderer/src/socket.ts
@@ -9,7 +9,6 @@ import { IsoBuffer } from "@fluidframework/common-utils";
 import { debug } from "./debug";
 
 export class Socket<T> extends EventEmitter {
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     public static async connect<T>(address: string, path: string): Promise<Socket<T>> {
         const socket = new ws(`ws://${address}/${path}`);
         await new Promise<void>((resolve, reject) => {

--- a/server/routerlicious/packages/protocol-base/.eslintrc.js
+++ b/server/routerlicious/packages/protocol-base/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     extends: [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     rules: {

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/assert": "^1.5.1",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/assert": "^1.5.1",

--- a/server/routerlicious/packages/protocol-base/src/blobs.ts
+++ b/server/routerlicious/packages/protocol-base/src/blobs.ts
@@ -147,7 +147,6 @@ export class AttachmentTreeEntry {
     }
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
 export function addBlobToTree(tree: ITree, blobName: string, content: object) {
     tree.entries.push(
         {

--- a/server/routerlicious/packages/routerlicious-base/.eslintrc.js
+++ b/server/routerlicious/packages/routerlicious-base/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "rules": {

--- a/server/routerlicious/packages/routerlicious-base/.eslintrc.js
+++ b/server/routerlicious/packages/routerlicious-base/.eslintrc.js
@@ -10,5 +10,6 @@ module.exports = {
     ],
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
+        "import/no-nodejs-modules": "off",
     }
 }

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -86,7 +86,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/server-local-server": "^0.1038.3000",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -86,7 +86,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@fluidframework/server-local-server": "^0.1038.3000",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -168,11 +168,14 @@ const verifyRequest = async (
     tenantManager: core.ITenantManager,
     storage: core.IDocumentStorage,
     maxTokenLifetimeSec: number,
-    // eslint-disable-next-line max-len
     isTokenExpiryEnabled: boolean) => Promise.all([verifyToken(request, tenantManager, maxTokenLifetimeSec, isTokenExpiryEnabled), checkDocumentExistence(request, storage)]);
 
-// eslint-disable-next-line max-len
-async function verifyToken(request: Request, tenantManager: core.ITenantManager, maxTokenLifetimeSec: number, isTokenExpiryEnabled: boolean): Promise<void> {
+async function verifyToken(
+    request: Request,
+    tenantManager: core.ITenantManager,
+    maxTokenLifetimeSec: number,
+    isTokenExpiryEnabled: boolean
+): Promise<void> {
     const token = request.headers["access-token"] as string;
     if (!token) {
         return Promise.reject(new Error("Missing access token"));

--- a/server/routerlicious/packages/routerlicious-base/src/utils/documentRouter.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/documentRouter.ts
@@ -23,7 +23,6 @@ export interface IPlugin {
 }
 
 export async function createDocumentRouter(config: nconf.Provider): Promise<IPartitionLambdaFactory<IPartitionConfig>> {
-    // eslint-disable-next-line @typescript-eslint/ban-types
     const pluginConfig = config.get("documentLambda") as string | object;
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const plugin = (typeof pluginConfig === "object" ? pluginConfig : require(pluginConfig)) as IPlugin;

--- a/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
@@ -105,7 +105,6 @@ async function updateExistingSession(
                 ...lumberjackProperties,
                 isSessionSticky,
                 sessionHasLocation,
-                // eslint-disable-next-line max-len
                 oldSessionLocation: { ordererUrl: existingSession.ordererUrl, historianUrl: existingSession.historianUrl, deltaStreamUrl: existingSession.deltaStreamUrl },
                 newSessionLocation: { ordererUrl, historianUrl, deltaStreamUrl },
             });

--- a/server/routerlicious/packages/routerlicious/.eslintrc.js
+++ b/server/routerlicious/packages/routerlicious/.eslintrc.js
@@ -5,10 +5,11 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
+        "import/no-nodejs-modules": "off",
     }
 }

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@fluidframework/server-local-server": "^0.1038.3000",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/server-local-server": "^0.1038.3000",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",

--- a/server/routerlicious/packages/services-client/.eslintrc.js
+++ b/server/routerlicious/packages/services-client/.eslintrc.js
@@ -5,13 +5,14 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "parserOptions": {
         "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
     },
     "rules": {
-        "@typescript-eslint/strict-boolean-expressions": "off"
+        "@typescript-eslint/strict-boolean-expressions": "off",
+        "import/no-nodejs-modules": "off",
     }
 }

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -74,7 +74,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -74,7 +74,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -136,7 +136,6 @@ export class BasicRestWrapper extends RestWrapper {
                     }
 
                     if (error?.config) {
-                        // eslint-disable-next-line max-len
                         debug(`[${error.config.method}] request to [${error.config.baseURL ?? ""}${error.config.url ?? ""}] failed with [${error.response?.status}] [${safeStringify(error.response?.data, undefined, 2)}]`);
                     } else {
                         debug(`request to ${options.url} failed ${error ? error.message : ""}`);

--- a/server/routerlicious/packages/services-core/.eslintrc.js
+++ b/server/routerlicious/packages/services-core/.eslintrc.js
@@ -5,10 +5,11 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
+        "import/no-nodejs-modules": "off",
     }
 }

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@rushstack/eslint-config": "^2.6.1",
     "concurrently": "^7.5.0",
     "eslint": "~8.27.0",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@rushstack/eslint-config": "^2.6.1",
     "concurrently": "^7.5.0",
     "eslint": "~8.27.0",

--- a/server/routerlicious/packages/services-core/src/combinedLambda.ts
+++ b/server/routerlicious/packages/services-core/src/combinedLambda.ts
@@ -16,7 +16,6 @@ export class CombinedLambda implements IPartitionLambda {
 	/**
 	 * Processes an incoming message
 	 */
-	// eslint-disable-next-line @typescript-eslint/promise-function-async
 	public handler(message: IQueuedMessage) {
 		const promises: Promise<void>[] = [];
 

--- a/server/routerlicious/packages/services-ordering-kafkanode/.eslintrc.js
+++ b/server/routerlicious/packages/services-ordering-kafkanode/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "rules": {

--- a/server/routerlicious/packages/services-ordering-kafkanode/.eslintrc.js
+++ b/server/routerlicious/packages/services-ordering-kafkanode/.eslintrc.js
@@ -10,5 +10,6 @@ module.exports = {
     ],
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
+        "import/no-nodejs-modules": "off",
     }
 }

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
+++ b/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
@@ -53,7 +53,7 @@ export class KafkaNodeProducer implements IProducer {
     /**
      * Sends the provided message to Kafka
      */
-    // eslint-disable-next-line @typescript-eslint/ban-types,@typescript-eslint/promise-function-async
+    // eslint-disable-next-line @typescript-eslint/promise-function-async
     public send(messages: object[], tenantId: string, documentId: string): Promise<any> {
         const key = `${tenantId}/${documentId}`;
 
@@ -147,7 +147,6 @@ export class KafkaNodeProducer implements IProducer {
             if (stringifiedMessage.byteLength > this.maxMessageSize) {
                 const error = new NetworkError(
                     413,
-                    // eslint-disable-next-line max-len
                     `Boxcar message size (${stringifiedMessage.byteLength}) exceeded max message size (${this.maxMessageSize})`,
                 );
                 boxcar.deferred.reject(error);

--- a/server/routerlicious/packages/services-ordering-rdkafka/.eslintrc.js
+++ b/server/routerlicious/packages/services-ordering-rdkafka/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "rules": {

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/amqplib": "^0.5.17",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/amqplib": "^0.5.17",

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
@@ -131,7 +131,6 @@ export abstract class RdkafkaBase extends EventEmitter {
         this.emit("error", error, errorData);
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
     protected static isObject(value: any): value is object {
         return value !== null && typeof (value) === "object";
     }

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -232,7 +232,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 	/**
 	 * Sends the provided message to Kafka
 	 */
-	// eslint-disable-next-line @typescript-eslint/ban-types,@typescript-eslint/promise-function-async
+	// eslint-disable-next-line @typescript-eslint/promise-function-async
 	public send(messages: object[], tenantId: string, documentId: string, partitionId?: number): Promise<any> {
 		// createa boxcar for these messages
 		const boxcar = new PendingBoxcar(tenantId, documentId);
@@ -426,7 +426,6 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 	private createMessageSizeTooLargeError(boxcar: IPendingBoxcar, message: Buffer) {
 		return new NetworkError(
 			413,
-			// eslint-disable-next-line max-len
 			`Message size too large. Boxcar message count: ${boxcar.messages.length}, size: ${message.byteLength}, max message size: ${this.producerOptions.maxMessageSize}.`,
 		);
 	}

--- a/server/routerlicious/packages/services-ordering-zookeeper/.eslintrc.js
+++ b/server/routerlicious/packages/services-ordering-zookeeper/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "rules": {

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-shared/.eslintrc.js
+++ b/server/routerlicious/packages/services-shared/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "parserOptions": {

--- a/server/routerlicious/packages/services-shared/.eslintrc.js
+++ b/server/routerlicious/packages/services-shared/.eslintrc.js
@@ -13,5 +13,6 @@ module.exports = {
     },
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
+        "import/no-nodejs-modules": "off",
     }
 }

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/body-parser": "^1.19.2",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/body-parser": "^1.19.2",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-telemetry/.eslintrc.js
+++ b/server/routerlicious/packages/services-telemetry/.eslintrc.js
@@ -5,13 +5,13 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "parserOptions": {
         "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
     },
     "rules": {
-        "@typescript-eslint/strict-boolean-expressions": "off"
+        "@typescript-eslint/strict-boolean-expressions": "off",
     }
 }

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/mocha": "^10.0.0",
     "@types/node": "^14.18.0",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/mocha": "^10.0.0",
     "@types/node": "^14.18.0",

--- a/server/routerlicious/packages/services-utils/.eslintrc.js
+++ b/server/routerlicious/packages/services-utils/.eslintrc.js
@@ -5,10 +5,11 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "rules": {
-        "@typescript-eslint/strict-boolean-expressions": "off"
+        "@typescript-eslint/strict-boolean-expressions": "off",
+        "import/no-nodejs-modules": "off",
     }
 }

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services/.eslintrc.js
+++ b/server/routerlicious/packages/services/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "rules": {

--- a/server/routerlicious/packages/services/.eslintrc.js
+++ b/server/routerlicious/packages/services/.eslintrc.js
@@ -10,5 +10,6 @@ module.exports = {
     ],
     "rules": {
         "@typescript-eslint/strict-boolean-expressions": "off",
+        "import/no-nodejs-modules": "off",
     }
 }

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/amqplib": "^0.5.17",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@fluidframework/server-test-utils": "^0.1038.3000",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/amqplib": "^0.5.17",

--- a/server/routerlicious/packages/services/src/metricClient.ts
+++ b/server/routerlicious/packages/services/src/metricClient.ts
@@ -52,6 +52,7 @@ class TelegrafClient implements IMetricClient {
 }
 
 export function createMetricClient(config: any): IMetricClient {
-    // eslint-disable-next-line max-len
-    return (config !== undefined && config.client === "telegraf") ? new TelegrafClient(config.telegraf) : new DefaultMetricClient();
+    return (config !== undefined && config.client === "telegraf")
+        ? new TelegrafClient(config.telegraf)
+        : new DefaultMetricClient();
 }

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -59,7 +59,6 @@ export class MongoCollection<T> implements core.ICollection<T>, core.IRetryable 
         );
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
     public async update(filter: object, set: any, addToSet: any): Promise<void> {
         const req = async () => this.updateCore(filter, set, addToSet, false);
         return this.requestWithRetry(
@@ -68,7 +67,6 @@ export class MongoCollection<T> implements core.ICollection<T>, core.IRetryable 
         );
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
     public async updateMany(filter: object, set: any, addToSet: any): Promise<void> {
         const req = async () => this.updateManyCore(filter, set, addToSet, false);
         return this.requestWithRetry(
@@ -77,7 +75,6 @@ export class MongoCollection<T> implements core.ICollection<T>, core.IRetryable 
         );
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
     public async upsert(filter: object, set: any, addToSet: any): Promise<void> {
         const req = async () => this.updateCore(filter, set, addToSet, true);
         return this.requestWithRetry(
@@ -148,7 +145,7 @@ export class MongoCollection<T> implements core.ICollection<T>, core.IRetryable 
         }
     }
 
-    // Create index mostly happened at service bootstrap time. If we bubble up at that time, 
+    // Create index mostly happened at service bootstrap time. If we bubble up at that time,
     // service will failed to start. So instead we need catch the exception and log it without bubbling up.
     public async createTTLIndex(index: any, expireAfterSeconds?: number): Promise<void> {
         const req = async () => this.collection.createIndex(index, { expireAfterSeconds });

--- a/server/routerlicious/packages/services/src/nodeCodeLoader.ts
+++ b/server/routerlicious/packages/services/src/nodeCodeLoader.ts
@@ -50,7 +50,6 @@ export class NodeCodeLoader {
     }
 
     private async installOrWaitForPackages(pkg: string): Promise<string> {
-        // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
         const dataStores = pkg.match(/(.*)\/(.*)@(.*)/);
         if (!dataStores) {
             return Promise.reject(new Error("Invalid package"));

--- a/server/routerlicious/packages/test-utils/.eslintrc.js
+++ b/server/routerlicious/packages/test-utils/.eslintrc.js
@@ -5,7 +5,7 @@
 
  module.exports = {
 "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     rules: {
@@ -13,6 +13,7 @@
         "@typescript-eslint/no-unsafe-return": "off",
         "@typescript-eslint/no-use-before-define": "off",
         "@typescript-eslint/strict-boolean-expressions": "off",
+        "import/no-nodejs-modules": "off",
         "no-case-declarations": "off",
     }
 }

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.0",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/lodash": "^4.14.118",
     "@types/mocha": "^10.0.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@rushstack/eslint-config": "^2.6.1",
     "@types/lodash": "^4.14.118",
     "@types/mocha": "^10.0.0",

--- a/server/routerlicious/packages/test-utils/src/testKafka.ts
+++ b/server/routerlicious/packages/test-utils/src/testKafka.ts
@@ -119,7 +119,6 @@ export class TestProducer implements IProducer {
         return true;
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
     public async send(messages: object[], key: string): Promise<any> {
         for (const message of messages) {
             this.kafka.addMessage(message, key);

--- a/server/tinylicious/.eslintrc.js
+++ b/server/tinylicious/.eslintrc.js
@@ -5,7 +5,7 @@
 
  module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"),
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
         "prettier"
     ],
     "parserOptions": {
@@ -16,5 +16,6 @@
         "@typescript-eslint/promise-function-async":"off",
         "@typescript-eslint/strict-boolean-expressions": "off",
         "import/no-internal-modules":"off",
+        "import/no-nodejs-modules": "off",
     }
 }

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -185,9 +185,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.2.1.tgz",
-      "integrity": "sha512-jOt6rWtg4Zigz33hv42hg/y8CUWXp6J+0Jn4ub0Bo/0H58agHD2XWfD0RAOD5bOtNxBLPAhsSUHD4XN7SCct+w==",
+      "version": "2.0.0-115036",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0-115036.tgz",
+      "integrity": "sha512-hOvlE0B3hsShc744aRM9sYCADVVeXbNAbgjZQtDwk03KrWHQ//1f6JgODBr6FopCcWg6/J6prjy82ufAPl+gjg==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",
@@ -1745,9 +1745,9 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.20.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-          "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+          "version": "1.20.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+          "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
@@ -1756,6 +1756,7 @@
             "function.prototype.name": "^1.1.5",
             "get-intrinsic": "^1.1.3",
             "get-symbol-description": "^1.0.0",
+            "gopd": "^1.0.1",
             "has": "^1.0.3",
             "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
@@ -1771,8 +1772,8 @@
             "object.assign": "^4.1.4",
             "regexp.prototype.flags": "^1.4.3",
             "safe-regex-test": "^1.0.0",
-            "string.prototype.trimend": "^1.0.5",
-            "string.prototype.trimstart": "^1.0.5",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
             "unbox-primitive": "^1.0.2"
           }
         },
@@ -1792,6 +1793,28 @@
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
           "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
           "dev": true
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+          "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.20.4"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+          "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.20.4"
+          }
         }
       }
     },
@@ -4411,6 +4434,28 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "dependencies": {
+        "get-intrinsic": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+          "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.3"
+          }
+        }
       }
     },
     "graceful-fs": {

--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -185,9 +185,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "2.0.0-115036",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0-115036.tgz",
-      "integrity": "sha512-hOvlE0B3hsShc744aRM9sYCADVVeXbNAbgjZQtDwk03KrWHQ//1f6JgODBr6FopCcWg6/J6prjy82ufAPl+gjg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
+      "integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.1",
+    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
     "@fluidframework/mocha-test-setup": "^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^2.0.0-115036",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": "^1.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/server/tinylicious/src/app.ts
+++ b/server/tinylicious/src/app.ts
@@ -74,7 +74,6 @@ export function create(
 
     // Basic Help Message
     app.use(Router().get("/", (req, res) => {
-        // eslint-disable-next-line max-len
         res.status(200).send("This is Tinylicious. Learn more at https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious");
     }));
 


### PR DESCRIPTION
Note: `@fluidframework/eslint-config-fluid`'s default export was updated from `minimal` to `recommended`.

Additionally...
- the `@fluidframework/gitresources` package had no violations against the `recommended` config, and so was implicitly upgraded to that configuration.
- removes many unneeded eslint-disable directives