### PR TITLE
Add label 'area: dds: tree' to shared tree PRs

### DIFF
--- a/.github/actions-labeler.yml
+++ b/.github/actions-labeler.yml
@@ -13,6 +13,10 @@
   - experimental/dds/**
   - packages/dds/**
 
+"area: dds: tree":
+  - experimental/dds/tree/**
+  - packages/dds/tree/**
+
 "area: dds: propertydds":
   - experimental/PropertyDDS/**
 


### PR DESCRIPTION
## Description

Adding the label 'area: dds: tree' to all shared tree PRs in order to be able to post a notification to a Team Channel every time a new PR is created for these directories.
