### PR TITLE
Add strong typing to TypedEventEmitter.emit

### DIFF
--- a/common/lib/common-utils/src/eventForwarder.ts
+++ b/common/lib/common-utils/src/eventForwarder.ts
@@ -87,7 +87,9 @@ export class EventForwarder<TEvent = IEvent>
                     this.forwardingEvents.set(event, sources);
                 }
                 if (!sources.has(source)) {
-                    const listener = (...args: any[]): boolean => this.emit(event, ...args);
+                    // Event forwarding doesn't include type safety on the event names forwarded,
+                    // so we opt out of TypedEventEmitter.emit strong typing here.
+                    const listener = (...args: any[]): boolean => (this as EventEmitter).emit(event, ...args);
                     sources.set(source, () => source.off(event, listener));
                     source.on(event, listener);
                 }

--- a/common/lib/common-utils/src/eventForwarder.ts
+++ b/common/lib/common-utils/src/eventForwarder.ts
@@ -89,7 +89,8 @@ export class EventForwarder<TEvent = IEvent>
                 if (!sources.has(source)) {
                     // Event forwarding doesn't include type safety on the event names forwarded,
                     // so we opt out of TypedEventEmitter.emit strong typing here.
-                    const listener = (...args: any[]): boolean => (this as EventEmitter).emit(event, ...args);
+                    const listener = (...args: any[]): boolean =>
+                        (this as EventEmitter).emit(event, ...args);
                     sources.set(source, () => source.off(event, listener));
                     source.on(event, listener);
                 }

--- a/common/lib/common-utils/src/index.ts
+++ b/common/lib/common-utils/src/index.ts
@@ -43,5 +43,12 @@ export {
     Timer,
 } from "./timer";
 export { ITraceEvent, Trace } from "./trace";
-export { EventEmitterEventType, TypedEventEmitter, TypedEventTransform } from "./typedEventEmitter";
+export {
+    EventEmitterEventType,
+    TypedEventEmitter,
+    TypedEventTransform,
+    EventArgsMapping,
+    SingleEventArgsMapping,
+    TypedEmit
+} from "./typedEventEmitter";
 export { unreachableCase } from "./unreachable";

--- a/common/lib/common-utils/src/index.ts
+++ b/common/lib/common-utils/src/index.ts
@@ -49,6 +49,6 @@ export {
     TypedEventTransform,
     EventArgsMapping,
     SingleEventArgsMapping,
-    TypedEmit
+    TypedEmit,
 } from "./typedEventEmitter";
 export { unreachableCase } from "./unreachable";

--- a/common/lib/common-utils/src/test/mocha/eventForwarder.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/eventForwarder.spec.ts
@@ -41,15 +41,6 @@ describe("Loader", () => {
                     assert(emitted);
                 });
 
-                it("Should forward events 2", () => {
-                    let emitted = false;
-                    forwarder.on(testEvent, () => {
-                        emitted = true;
-                    });
-                    source.emit(testEvent);
-                    assert(emitted);
-                });
-
                 it("Should forward events in correct order", () => {
                     let emitCount = 0;
                     forwarder.on(testEvent, () => {

--- a/common/lib/common-utils/src/test/mocha/eventForwarder.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/eventForwarder.spec.ts
@@ -198,11 +198,14 @@ describe("Loader", () => {
                     class Forwarder extends EventForwarder<ITestEvents> {
                         testing(): void {
                             // forwardEvent allows any event names to be specified, even ones not declared on source or this
-                            this.forwardEvent(new TypedEventEmitter<ITestEvents>(), "unknownEventName");
+                            this.forwardEvent(
+                                new TypedEventEmitter<ITestEvents>(),
+                                "unknownEventName",
+                            );
                         }
                     }
                     new Forwarder();
-                })
+                });
             });
         });
     });

--- a/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
@@ -84,13 +84,14 @@ describe("TypedEventEmitter", () => {
         // @ts-expect-error This shouldn't be emitted manually
         tee.emit("removeListener", "asdf", () => {});
 
-        // Even if typing is violated, events are still emitted as written
         assert.deepStrictEqual(eventArgsEmitted, [
             [],
             [true, "hello"],
             [tee],
+            // Below: Even if typing is violated, events are still emitted as written
             [],
             ["bogus"],
+            [true],
             ["wrongType", 123],
             [plainTee],
         ]);

--- a/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "assert";
-import { IErrorEvent } from "@fluidframework/common-definitions";
+import { IErrorEvent, IEvent, IEventThisPlaceHolder } from "@fluidframework/common-definitions";
 import { TypedEventEmitter } from "../..";
 
 export interface NewEventSpec {

--- a/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "assert";
-import { IErrorEvent, IEvent, IEventThisPlaceHolder } from "@fluidframework/common-definitions";
+import { IErrorEvent } from "@fluidframework/common-definitions";
 import { TypedEventEmitter } from "../..";
 
 export interface NewEventSpec {

--- a/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
@@ -82,6 +82,7 @@ describe("TypedEventEmitter", () => {
         // @ts-expect-error This shouldn't be emitted manually
         tee.emit("removeListener", "asdf", () => {});
 
+        // Even if typing is violated, events are still emitted as written
         assert.deepStrictEqual(eventArgsEmitted, [
             [],
             [true, "hello"],

--- a/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
@@ -96,7 +96,7 @@ describe("TypedEventEmitter", () => {
         ]);
     });
 
-    it("emit not supported for ivalid event type", () => {
+    it("emit not supported for invalid event type", () => {
         const tee = new TypedEventEmitter<IInvalidEvents>();
 
         // @ts-expect-error any invalid signatures invalidate the type altogether (even though noArgs is on there)

--- a/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
@@ -51,8 +51,12 @@ describe("TypedEventEmitter", () => {
 
     it("Validate emit typing for valid event type", () => {
         const eventArgsEmitted: any[] = [];
-        const handler = (...args): void => { eventArgsEmitted.push(args); }
-        const tee = new (class SomeClass extends TypedEventEmitter<ISampleEvents>{ someMember: 0 = 0; })();
+        const handler = (...args): void => {
+            eventArgsEmitted.push(args);
+        };
+        const tee = new (class SomeClass extends TypedEventEmitter<ISampleEvents> {
+            someMember: 0 = 0;
+        })();
         const plainTee = new TypedEventEmitter();
 
         tee.on("noArgs", handler);
@@ -86,7 +90,7 @@ describe("TypedEventEmitter", () => {
             ["bogus"],
             ["wrongType", 123],
             [plainTee],
-        ])
+        ]);
     });
 
     it("emit not supported for ivalid event type", () => {
@@ -104,7 +108,7 @@ describe("TypedEventEmitter", () => {
 interface ISampleEvents extends IEvent {
     (event: "noArgs", listener: () => void);
     (event: "twoArgs", listener: (y: boolean, z: string) => void);
-    (event: "useThis", listener: (y: IEventThisPlaceHolder) => void)
+    (event: "useThis", listener: (y: IEventThisPlaceHolder) => void);
 }
 
 interface IInvalidEvents extends IEvent {

--- a/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
@@ -72,6 +72,8 @@ describe("TypedEventEmitter", () => {
         tee.emit("somethingElse");
         // @ts-expect-error Unknown event
         tee.emit("noArgs", "bogus");
+        // @ts-expect-error Missing arg
+        tee.emit("twoArgs", true);
         // @ts-expect-error Wrong arg types
         tee.emit("twoArgs", "wrongType", 123);
         // @ts-expect-error Wrong arg type for "this"-typed arg

--- a/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/typedEventEmitter.spec.ts
@@ -1,10 +1,57 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
 /*!
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
 import { strict as assert } from "assert";
-import { IErrorEvent } from "@fluidframework/common-definitions";
+import { IErrorEvent, IEvent, IEventProvider, IEventThisPlaceHolder } from "@fluidframework/common-definitions";
 import { TypedEventEmitter } from "../..";
+import { IBaseEventSpec, IEventProvider2, TypedEventEmitter2 } from "../../typedEventEmitter";
+
+export interface ISampleEvents extends IEvent {
+    (event: "something", listener: (x: number) => void);
+    (event: "useThis", listener: (y: IEventThisPlaceHolder) => void)
+}
+
+export interface ISampleEventSpec extends IBaseEventSpec {
+    something: (x: number) => void;
+    useThis: (y: IEventThisPlaceHolder) => void;
+}
+
+export interface ISample extends IEventProvider<ISampleEvents> {
+    dummy: number;
+}
+
+export class Sample extends TypedEventEmitter<ISampleEvents> implements ISample {
+    dummy = 4;
+
+    someCode(): void {
+        this.emit("something", this.dummy);
+    }
+}
+
+export interface ISample2 extends IEventProvider2<ISampleEventSpec> {
+    dummy: number;
+}
+
+export class Sample2 extends TypedEventEmitter2<ISampleEventSpec> implements ISample2 {
+    dummy = 4;
+
+    someCode(): void {
+        this.emit("something", this.dummy);
+        this.emit("useThis", this);
+    }
+}
+
+function takeOld(oldIep: ISample) {
+}
+
+function takeNew(newIep: ISample2) {
+}
+
+takeOld(new Sample2());
+takeNew(new Sample()); // This one still works even if event specs don't match. I think that's ok though
+
 
 describe("TypedEventEmitter", () => {
     it("Validate Function proxies", () => {
@@ -49,3 +96,39 @@ describe("TypedEventEmitter", () => {
         assert.equal(removeListenerCalls, 1);
     });
 });
+
+// ////
+// This section was where I learned that IEventProvider<IEvents<Spec>> doesn't work
+// It matches with multiple event signatures (e.g. E0, E1, E2) and results in a case
+// with unknown that breaks type compatibility
+
+// export type IdmEvents = IEvents<ISampleEventSpec>;
+// export type IdmEventProvider = IEventProvider<IdmEvents>;
+
+// declare const e1: IdmEvents;
+// declare const e2: ISampleEvents;
+// declare const p1: IdmEventProvider;
+// declare const p2: IEventProvider<ISampleEvents>;
+
+// declare const newThing: IEventProvider2<ISampleEventSpec>;
+// takeOld(newThing);
+
+// e1()
+// e2()
+
+// p1.on();
+// p2.on();
+
+// type Testing<TThis, T> = T extends
+// {
+//     (event: infer E0, listener: (...args: infer A0) => void),
+//     (event: infer E1, listener: (...args: infer A1) => void),
+//     (event: infer E2, listener: (...args: infer A2) => void),
+//     (event: string, listener: (...args: any[]) => void),
+// }
+// ? true
+// : false
+
+// type Testing1 = IEventTransformer<ISample, IdmEvents>
+// type Testing2 = Testing<ISample, IdmEvents>
+// type Testing3 = Testing<ISample, ISampleEvents>

--- a/common/lib/common-utils/src/typedEventEmitter.ts
+++ b/common/lib/common-utils/src/typedEventEmitter.ts
@@ -76,11 +76,7 @@ export type ToEventArgsMappingCore<TEvent extends IEvent> =
     ;
 
 export type ToEventArgsMapping<TEvent> =
-    ToEventArgsMappingCore<TEvent & IEvent> &
-    SingleEventArgsMapping<"addListener", [event: string, listener: (...args: any[]) => void]> &
-    SingleEventArgsMapping<"removeListener", [event: string, listener: (...args: any[]) => void]>;
-    //* Uncomment this to allow emitting anything. But themn emit loses intellisense for event keys
-    // & EventSpecEntry<string, any[]>;
+    ToEventArgsMappingCore<TEvent & IEvent>;
 
 export type SingleEventArgsMapping<TEventKey, TListenerArgs extends any[]> =
     TEventKey extends string ?
@@ -89,7 +85,7 @@ export type SingleEventArgsMapping<TEventKey, TListenerArgs extends any[]> =
     }
     : never;
 
-type StringKeys<TEventSpec> =
+export type StringKeys<TEventSpec> =
     keyof TEventSpec extends string ?
             keyof TEventSpec
  : never

--- a/common/lib/common-utils/src/typedEventEmitter.ts
+++ b/common/lib/common-utils/src/typedEventEmitter.ts
@@ -40,63 +40,56 @@ export type TypedEventTransform<TThis, TEvent> =
         TransformedEvent<TThis, EventEmitterEventType, any[]>;
 
 /** Converting from IEvent shape to EventSpec shape. Might allow for easier transition to EventSpec */
-export type ToEventArgsMappingCore<TEvent extends IEvent> =
-    // ...Start with all 15 like IEventTransformer
-    TEvent extends
-    {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: infer E3, listener: (...args: infer A3) => void),
-        (event: string, listener: (...args: any[]) => void),
-    }
-    ? SingleEventArgsMapping<E0, A0> & SingleEventArgsMapping<E1, A1> & SingleEventArgsMapping<E2, A2> & SingleEventArgsMapping<E3, A3>
-    : TEvent extends
-    {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: string, listener: (...args: any[]) => void),
-    }
-    ? SingleEventArgsMapping<E0, A0> & SingleEventArgsMapping<E1, A1> & SingleEventArgsMapping<E2, A2>
-    : TEvent extends
-    {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: string, listener: (...args: any[]) => void),
-    }
-    ? SingleEventArgsMapping<E0, A0> & SingleEventArgsMapping<E1, A1>
-    : TEvent extends
-    {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: string, listener: (...args: any[]) => void),
-    }
-    ? SingleEventArgsMapping<E0, A0>
-    : SingleEventArgsMapping<string, any[]>
-    ;
-
 export type ToEventArgsMapping<TEvent> =
-    ToEventArgsMappingCore<TEvent & IEvent>;
-
-export type SingleEventArgsMapping<TEventKey, TListenerArgs extends any[]> =
-    TEventKey extends string ?
-    {
-        [TK in TEventKey]: TListenerArgs;
+    //* TODO: ...Start with all 15 like IEventTransformer
+    TEvent extends {
+        (event: infer E0, listener: (...args: infer A0) => void);
+        (event: infer E1, listener: (...args: infer A1) => void);
+        (event: infer E2, listener: (...args: infer A2) => void);
+        (event: infer E3, listener: (...args: infer A3) => void);
+        (event: string, listener: (...args: any[]) => void);
     }
+        ? SingleEventArgsMapping<E0, A0> &
+              SingleEventArgsMapping<E1, A1> &
+              SingleEventArgsMapping<E2, A2> &
+              SingleEventArgsMapping<E3, A3>
+        : TEvent extends {
+              (event: infer E0, listener: (...args: infer A0) => void);
+              (event: infer E1, listener: (...args: infer A1) => void);
+              (event: infer E2, listener: (...args: infer A2) => void);
+              (event: string, listener: (...args: any[]) => void);
+          }
+        ? SingleEventArgsMapping<E0, A0> &
+              SingleEventArgsMapping<E1, A1> &
+              SingleEventArgsMapping<E2, A2>
+        : TEvent extends {
+              (event: infer E0, listener: (...args: infer A0) => void);
+              (event: infer E1, listener: (...args: infer A1) => void);
+              (event: string, listener: (...args: any[]) => void);
+          }
+        ? SingleEventArgsMapping<E0, A0> & SingleEventArgsMapping<E1, A1>
+        : TEvent extends {
+              (event: infer E0, listener: (...args: infer A0) => void);
+              (event: string, listener: (...args: any[]) => void);
+          }
+        ? SingleEventArgsMapping<E0, A0>
+        : SingleEventArgsMapping<string, any[]>;
+
+type SingleEventArgsMapping<TEventKey, TListenerArgs extends any[]> = TEventKey extends string
+    ? {
+          [TK in TEventKey]: TListenerArgs;
+      }
     : never;
 
-export type StringKeys<TEventSpec> =
-    keyof TEventSpec extends string ?
-            keyof TEventSpec
- : never
-;
+type RequireAllStringKeys<TEventSpec> = keyof TEventSpec extends string ? keyof TEventSpec : never;
 
 /** Signature for emit */
-type EventEmitSignatures<TThis, TEvent> =
-    <TEventKey extends StringKeys<ToEventArgsMapping<TEvent>>>(
-        event: TEventKey,
-        ...args: ReplaceIEventThisPlaceHolder<ToEventArgsMapping<TEvent>[TEventKey], TThis>
-    ) => boolean;
+type EventEmitSignatures<TThis, TEvent> = <
+    TEventKey extends RequireAllStringKeys<ToEventArgsMapping<TEvent>>,
+>(
+    event: TEventKey,
+    ...args: ReplaceIEventThisPlaceHolder<ToEventArgsMapping<TEvent>[TEventKey], TThis>
+) => boolean;
 
 /**
  * Event Emitter helper class the supports emitting typed events

--- a/common/lib/common-utils/src/typedEventEmitter.ts
+++ b/common/lib/common-utils/src/typedEventEmitter.ts
@@ -69,7 +69,7 @@ export type EventSpecEntry<TEventKey, TListenerArgs extends any[]> =
 
 
 /** These events are always supported due to base EventEmitter implementation */
-export interface IBaseEventSpec {
+export interface BaseEventSpec {
     newListener: (event: string, listener: (...args: any[]) => void) => void;
     removeListener: (event: string, listener: (...args: any[]) => void) => void;
 }
@@ -109,7 +109,7 @@ export interface IEventProvider2<TEventSpec> {
     off: EventHandlerRegistrationSignatures<this, TEventSpec>;
 }
 
-export class TypedEventEmitter2<TEventSpec extends IBaseEventSpec> extends EventEmitter implements IEventProvider2<TEventSpec> {
+export class TypedEventEmitter2<TEventSpec extends BaseEventSpec> extends EventEmitter implements IEventProvider2<TEventSpec> {
     constructor() {
         super();
         this.addListener = super.addListener.bind(this) as EventHandlerRegistrationSignatures<this, TEventSpec>;
@@ -165,7 +165,7 @@ export class TypedEventEmitter<TEvent>
     readonly off: TypedEventTransform<this, TEvent>;
 }
 
-export interface ISampleEventSpec extends IBaseEventSpec {
+export interface SampleEventSpec extends BaseEventSpec {
     foo: (x: number, y: string) => void;
     bar: () => void;
     baz: (options: { a: string; b: boolean; }) => void;
@@ -173,7 +173,7 @@ export interface ISampleEventSpec extends IBaseEventSpec {
     // BOOM: number;
 }
 
-class MyTee extends TypedEventEmitter2<ISampleEventSpec> {}
+class MyTee extends TypedEventEmitter2<SampleEventSpec> {}
 const sample = new MyTee();
 
 // These are strongly typed
@@ -193,7 +193,7 @@ sample.on("useThis", (x: MyTee) => {});
 sample.emit("unspecified", 123);
 sample.on("unspecified", () => {});
 
-export interface INewEvents {
+export interface NewEventSpec {
     something: (x: number) => void;
     useThis1: (y: IEventThisPlaceHolder) => void;
 }

--- a/common/lib/common-utils/src/typedEventEmitter.ts
+++ b/common/lib/common-utils/src/typedEventEmitter.ts
@@ -96,79 +96,11 @@ type StringKeys<TEventSpec> =
 ;
 
 /** Signature for emit */
-export type EventEmitSignatures_Orig<TThis, TEvent> =
+type EventEmitSignatures<TThis, TEvent> =
     <TEventKey extends StringKeys<ToEventArgsMapping<TEvent>>>(
         event: TEventKey,
         ...args: ReplaceIEventThisPlaceHolder<ToEventArgsMapping<TEvent>[TEventKey], TThis>
     ) => boolean;
-
-    export type ToEventArgsArrayCore<TEvent extends IEvent> =
-    // ...Start with all 15 like IEventTransformer
-    TEvent extends
-    {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: infer E3, listener: (...args: infer A3) => void),
-        (event: string, listener: (...args: any[]) => void),
-    }
-    ? SingleEventArgsArray<E0, A0> | SingleEventArgsArray<E1, A1> | SingleEventArgsArray<E2, A2> | SingleEventArgsArray<E3, A3>
-    : TEvent extends
-    {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: infer E2, listener: (...args: infer A2) => void),
-        (event: string, listener: (...args: any[]) => void),
-    }
-    ? SingleEventArgsArray<E0, A0> | SingleEventArgsArray<E1, A1> | SingleEventArgsArray<E2, A2>
-    : TEvent extends
-    {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: infer E1, listener: (...args: infer A1) => void),
-        (event: string, listener: (...args: any[]) => void),
-    }
-    ? SingleEventArgsArray<E0, A0> | SingleEventArgsArray<E1, A1>
-    : TEvent extends
-    {
-        (event: infer E0, listener: (...args: infer A0) => void),
-        (event: string, listener: (...args: any[]) => void),
-    }
-    ? SingleEventArgsArray<E0, A0>
-    : SingleEventArgsArray<string, any[]>
-    ;
-
-export type ToEventArgsArray<TEvent> =
-    ToEventArgsArrayCore<TEvent & IEvent> |
-    SingleEventArgsArray<"addListener", [event: string, listener: (...args: any[]) => void]> |
-    SingleEventArgsArray<"removeListener", [event: string, listener: (...args: any[]) => void]>;
-    //* Uncomment this to allow emitting anything. But themn emit loses intellisense for event keys
-    // & EventSpecEntry<string, any[]>;
-
-type AM =
-    SingleEventArgsMapping<"removeListener", [event: string, listener: (...args: any[]) => void]>;
-
-
-type AA =
-    SingleEventArgsArray<"removeListener", [event: string, listener: (...args: any[]) => void]>;
-
-type B =
-    ToEventArgsArray<IOldEvents>;
-
-export type SingleEventArgsArray<TEventKey, TListenerArgs extends any[]> =
-    TEventKey extends string ?
-    [TEventKey, TListenerArgs] //* ORiginally tried spreading [TEventKey, ...TListenerArgs] but this loses the named tuple members
-    : never;
-
-type EventEmitSignatures<TThis, TEvent> =
-    ToEventArgsArray<TEvent> extends [event: infer TKey, args: [...rest: infer TRest]]
-    ?
-    <TKey2 extends TKey>(
-        event: TKey2,
-        ...args: TRest
-        // ...args: ReplaceIEventThisPlaceHolder<ToEventArgsArray<TEvent>, TThis>
-    ) => boolean
-    :
-    never;
 
 /**
  * Event Emitter helper class the supports emitting typed events
@@ -205,12 +137,3 @@ export class TypedEventEmitter<TEvent>
 
     readonly emit: EventEmitSignatures<this, TEvent>;
 }
-
-export interface IOldEvents extends IEvent {
-    (event: "asdf", listener: (y: boolean, z: string) => void);
-    (event: "qwer", listener: () => void);
-}
-
-const tee1: TypedEventEmitter<IOldEvents> = new TypedEventEmitter();
-
-tee1.emit("asdf", )

--- a/common/lib/common-utils/src/typedEventEmitter.ts
+++ b/common/lib/common-utils/src/typedEventEmitter.ts
@@ -75,20 +75,21 @@ export type EventArgsMapping<TEvent> =
         ? SingleEventArgsMapping<E0, A0>
         : SingleEventArgsMapping<string, any[]>;
 
-export type SingleEventArgsMapping<TEventKey, TListenerArgs extends any[]> = TEventKey extends string
+export type SingleEventArgsMapping<
+    TEventKey,
+    TListenerArgs extends any[],
+> = TEventKey extends string
     ? {
           [TK in TEventKey]: TListenerArgs;
       }
     : never;
 
 export type TypedEmit<TThis, TEvent> = keyof EventArgsMapping<TEvent> extends string
-? <
-    TEventKey extends keyof EventArgsMapping<TEvent>,
->(
-    event: TEventKey,
-    ...args: ReplaceIEventThisPlaceHolder<EventArgsMapping<TEvent>[TEventKey], TThis>
-) => boolean
-: never;
+    ? <TEventKey extends keyof EventArgsMapping<TEvent>>(
+          event: TEventKey,
+          ...args: ReplaceIEventThisPlaceHolder<EventArgsMapping<TEvent>[TEventKey], TThis>
+      ) => boolean
+    : never;
 
 /**
  * Event Emitter helper class the supports emitting typed events

--- a/common/lib/common-utils/src/typedEventEmitter.ts
+++ b/common/lib/common-utils/src/typedEventEmitter.ts
@@ -102,6 +102,10 @@ type EventEmitSignatures<TThis, TEventSpec> =
         ...args: Parameters<ListenerSignature<TThis, TEventSpec, TEventKey>>
     ) => boolean;
 
+/** Also includes (event: string, ...) signature */
+type EventEmitSignaturesLoose<TThis, TEventSpec> =
+    EventEmitSignatures<TThis, TEventSpec> & {(event: string, ...args: any[])};
+
 /** Interface exposed to consumers who will listen to events */
 export interface IEventProvider2<TEventSpec> {
     on: EventHandlerRegistrationSignatures<this, TEventSpec>;
@@ -155,6 +159,8 @@ export class TypedEventEmitter<TEvent>
         >;
         this.removeListener = super.removeListener.bind(this) as TypedEventTransform<this, TEvent>;
         this.off = super.off.bind(this) as TypedEventTransform<this, TEvent>;
+
+        this.emit = super.emit.bind(this) as EventEmitSignaturesLoose<this, ToEventSpec<TEvent & IEvent>>;
     }
     readonly addListener: TypedEventTransform<this, TEvent>;
     readonly on: TypedEventTransform<this, TEvent>;
@@ -163,6 +169,8 @@ export class TypedEventEmitter<TEvent>
     readonly prependOnceListener: TypedEventTransform<this, TEvent>;
     readonly removeListener: TypedEventTransform<this, TEvent>;
     readonly off: TypedEventTransform<this, TEvent>;
+
+    readonly emit: EventEmitSignaturesLoose<this, ToEventSpec<TEvent & IEvent>>;
 }
 
 export interface SampleEventSpec extends BaseEventSpec {
@@ -204,6 +212,8 @@ export interface IOldEvents extends IEvent {
 }
 
 const sampleOld = new TypedEventEmitter<IOldEvents>();
+
+sampleOld.emit("something", 54);
 
 // Notice these are acceptable
 sampleOld.emit("unspecified", () => {});

--- a/common/lib/common-utils/src/typedEventEmitter.ts
+++ b/common/lib/common-utils/src/typedEventEmitter.ts
@@ -96,11 +96,79 @@ type StringKeys<TEventSpec> =
 ;
 
 /** Signature for emit */
-type EventEmitSignatures<TThis, TEvent> =
+export type EventEmitSignatures_Orig<TThis, TEvent> =
     <TEventKey extends StringKeys<ToEventArgsMapping<TEvent>>>(
         event: TEventKey,
         ...args: ReplaceIEventThisPlaceHolder<ToEventArgsMapping<TEvent>[TEventKey], TThis>
     ) => boolean;
+
+    export type ToEventArgsArrayCore<TEvent extends IEvent> =
+    // ...Start with all 15 like IEventTransformer
+    TEvent extends
+    {
+        (event: infer E0, listener: (...args: infer A0) => void),
+        (event: infer E1, listener: (...args: infer A1) => void),
+        (event: infer E2, listener: (...args: infer A2) => void),
+        (event: infer E3, listener: (...args: infer A3) => void),
+        (event: string, listener: (...args: any[]) => void),
+    }
+    ? SingleEventArgsArray<E0, A0> | SingleEventArgsArray<E1, A1> | SingleEventArgsArray<E2, A2> | SingleEventArgsArray<E3, A3>
+    : TEvent extends
+    {
+        (event: infer E0, listener: (...args: infer A0) => void),
+        (event: infer E1, listener: (...args: infer A1) => void),
+        (event: infer E2, listener: (...args: infer A2) => void),
+        (event: string, listener: (...args: any[]) => void),
+    }
+    ? SingleEventArgsArray<E0, A0> | SingleEventArgsArray<E1, A1> | SingleEventArgsArray<E2, A2>
+    : TEvent extends
+    {
+        (event: infer E0, listener: (...args: infer A0) => void),
+        (event: infer E1, listener: (...args: infer A1) => void),
+        (event: string, listener: (...args: any[]) => void),
+    }
+    ? SingleEventArgsArray<E0, A0> | SingleEventArgsArray<E1, A1>
+    : TEvent extends
+    {
+        (event: infer E0, listener: (...args: infer A0) => void),
+        (event: string, listener: (...args: any[]) => void),
+    }
+    ? SingleEventArgsArray<E0, A0>
+    : SingleEventArgsArray<string, any[]>
+    ;
+
+export type ToEventArgsArray<TEvent> =
+    ToEventArgsArrayCore<TEvent & IEvent> |
+    SingleEventArgsArray<"addListener", [event: string, listener: (...args: any[]) => void]> |
+    SingleEventArgsArray<"removeListener", [event: string, listener: (...args: any[]) => void]>;
+    //* Uncomment this to allow emitting anything. But themn emit loses intellisense for event keys
+    // & EventSpecEntry<string, any[]>;
+
+type AM =
+    SingleEventArgsMapping<"removeListener", [event: string, listener: (...args: any[]) => void]>;
+
+
+type AA =
+    SingleEventArgsArray<"removeListener", [event: string, listener: (...args: any[]) => void]>;
+
+type B =
+    ToEventArgsArray<IOldEvents>;
+
+export type SingleEventArgsArray<TEventKey, TListenerArgs extends any[]> =
+    TEventKey extends string ?
+    [TEventKey, TListenerArgs] //* ORiginally tried spreading [TEventKey, ...TListenerArgs] but this loses the named tuple members
+    : never;
+
+type EventEmitSignatures<TThis, TEvent> =
+    ToEventArgsArray<TEvent> extends [event: infer TKey, args: [...rest: infer TRest]]
+    ?
+    <TKey2 extends TKey>(
+        event: TKey2,
+        ...args: TRest
+        // ...args: ReplaceIEventThisPlaceHolder<ToEventArgsArray<TEvent>, TThis>
+    ) => boolean
+    :
+    never;
 
 /**
  * Event Emitter helper class the supports emitting typed events
@@ -137,3 +205,12 @@ export class TypedEventEmitter<TEvent>
 
     readonly emit: EventEmitSignatures<this, TEvent>;
 }
+
+export interface IOldEvents extends IEvent {
+    (event: "asdf", listener: (y: boolean, z: string) => void);
+    (event: "qwer", listener: () => void);
+}
+
+const tee1: TypedEventEmitter<IOldEvents> = new TypedEventEmitter();
+
+tee1.emit("asdf", )


### PR DESCRIPTION
## Description

TypedEventEmitter implements IEventProvider which gives strong typing on the `on` and related functions for registering listeners, but the emitters themselves don't get type safety on the `emit` function.

This is a developer pain point, and even has resulted in release-blocking bugs slipping through unnoticed until a partner shipped to dogfood and users starting hitting crashes.

One important difference in typings between this and what `IEventProvider` uses is that _only events explicitly specified via `TEvent` can be emitted_, whereas `IEventProvider` also includes the general `string`/`any[]` base.  I couldn't figure out how to support unspecified events while still getting intellisense, for some reason.  I believe this is fine because the most common case is calling `emit` from within the class itself for one of the events declared in the `TEvent` type.  But for cases where you need to emit something not declared in the `TEvent` type, you can cast to `EventEmitter` first.

## Reviewer Guidance

* I still need to do a symlink:full and see what pops up
* I tried many variations on this approach looking for something simpler or more streamlined, but came up empty. Suggestions welcome!
* I wish I didn't need to export the helper types but I believe I do, right?
* Major design point is getting intellisense to pop up valid event names, and then match the signatures.  Can't write tests for this unfortunately but I'm checking manually whenever I make a change
