### PR TITLE
Increase timeout for test which needs to install packages

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
@@ -24,7 +24,8 @@ const versionWithChunking = "0.56.0";
 describeInstallVersions(
     {
         requestAbsoluteVersions: [versionWithChunking],
-    }
+    },
+    /* timeoutMs */ 50000,
 )(
     "Legacy chunking",
     (getTestObjectProvider) => {


### PR DESCRIPTION
The CI fails as the test is sometimes timing out. The test needs to install older package versions.