### PR TITLE
build: Bump deps on `@fluidframework/eslint-config-fluid` to `2.0.0` in independently-published packages

### DIFF
--- a/common/lib/common-definitions/package-lock.json
+++ b/common/lib/common-definitions/package-lock.json
@@ -308,9 +308,9 @@
             "dev": true
         },
         "@fluidframework/eslint-config-fluid": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.2.1.tgz",
-            "integrity": "sha512-jOt6rWtg4Zigz33hv42hg/y8CUWXp6J+0Jn4ub0Bo/0H58agHD2XWfD0RAOD5bOtNxBLPAhsSUHD4XN7SCct+w==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
+            "integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
             "dev": true,
             "requires": {
                 "@rushstack/eslint-patch": "~1.1.0",
@@ -2441,21 +2441,31 @@
             "dev": true
         },
         "array.prototype.flat": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-            "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+            "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.19.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4",
                 "es-shim-unscopables": "^1.0.0"
             },
             "dependencies": {
+                "define-properties": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                    "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                    "dev": true,
+                    "requires": {
+                        "has-property-descriptors": "^1.0.0",
+                        "object-keys": "^1.1.1"
+                    }
+                },
                 "es-abstract": {
-                    "version": "1.20.4",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-                    "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+                    "version": "1.20.5",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+                    "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
@@ -2464,6 +2474,7 @@
                         "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.3",
                         "get-symbol-description": "^1.0.0",
+                        "gopd": "^1.0.1",
                         "has": "^1.0.3",
                         "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
@@ -2479,8 +2490,8 @@
                         "object.assign": "^4.1.4",
                         "regexp.prototype.flags": "^1.4.3",
                         "safe-regex-test": "^1.0.0",
-                        "string.prototype.trimend": "^1.0.5",
-                        "string.prototype.trimstart": "^1.0.5",
+                        "string.prototype.trimend": "^1.0.6",
+                        "string.prototype.trimstart": "^1.0.6",
                         "unbox-primitive": "^1.0.2"
                     }
                 },
@@ -2553,18 +2564,6 @@
                         "define-properties": "^1.1.4",
                         "has-symbols": "^1.0.3",
                         "object-keys": "^1.1.1"
-                    },
-                    "dependencies": {
-                        "define-properties": {
-                            "version": "1.1.4",
-                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-                            "dev": true,
-                            "requires": {
-                                "has-property-descriptors": "^1.0.0",
-                                "object-keys": "^1.1.1"
-                            }
-                        }
                     }
                 },
                 "regexp.prototype.flags": {
@@ -2579,49 +2578,25 @@
                     }
                 },
                 "string.prototype.trimend": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+                    "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "define-properties": "^1.1.4",
-                        "es-abstract": "^1.19.5"
-                    },
-                    "dependencies": {
-                        "define-properties": {
-                            "version": "1.1.4",
-                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-                            "dev": true,
-                            "requires": {
-                                "has-property-descriptors": "^1.0.0",
-                                "object-keys": "^1.1.1"
-                            }
-                        }
+                        "es-abstract": "^1.20.4"
                     }
                 },
                 "string.prototype.trimstart": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+                    "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "define-properties": "^1.1.4",
-                        "es-abstract": "^1.19.5"
-                    },
-                    "dependencies": {
-                        "define-properties": {
-                            "version": "1.1.4",
-                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-                            "dev": true,
-                            "requires": {
-                                "has-property-descriptors": "^1.0.0",
-                                "object-keys": "^1.1.1"
-                            }
-                        }
+                        "es-abstract": "^1.20.4"
                     }
                 },
                 "unbox-primitive": {
@@ -2844,9 +2819,9 @@
             "dev": true
         },
         "ci-info": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-            "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+            "integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
             "dev": true
         },
         "clean-regexp": {
@@ -4472,6 +4447,34 @@
                 "ignore": "^5.1.4",
                 "merge2": "^1.3.0",
                 "slash": "^3.0.0"
+            }
+        },
+        "gopd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.1.3"
+            },
+            "dependencies": {
+                "get-intrinsic": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+                    "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+                    "dev": true,
+                    "requires": {
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.3"
+                    }
+                },
+                "has-symbols": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+                    "dev": true
+                }
             }
         },
         "graceful-fs": {
@@ -6418,7 +6421,7 @@
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
             "dev": true
         },
         "pump": {
@@ -6969,7 +6972,7 @@
         "sigmund": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+            "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
             "dev": true
         },
         "signal-exit": {
@@ -7860,7 +7863,7 @@
         "yallist": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
             "dev": true
         },
         "yaml": {

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.6.0-109663",
     "@fluidframework/common-definitions-previous": "npm:@fluidframework/common-definitions@0.20.1",
-    "@fluidframework/eslint-config-fluid": "^1.2.1",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",

--- a/common/lib/common-utils/.eslintrc.js
+++ b/common/lib/common-utils/.eslintrc.js
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-    extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
+    extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
     parserOptions: {
         project: [
             "./tsconfig.json",

--- a/common/lib/common-utils/package-lock.json
+++ b/common/lib/common-utils/package-lock.json
@@ -681,9 +681,9 @@
             }
         },
         "@fluidframework/eslint-config-fluid": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.2.1.tgz",
-            "integrity": "sha512-jOt6rWtg4Zigz33hv42hg/y8CUWXp6J+0Jn4ub0Bo/0H58agHD2XWfD0RAOD5bOtNxBLPAhsSUHD4XN7SCct+w==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
+            "integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
             "dev": true,
             "requires": {
                 "@rushstack/eslint-patch": "~1.1.0",
@@ -3379,15 +3379,6 @@
                         "tsutils": "^3.21.0"
                     }
                 },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
                 "semver": {
                     "version": "7.3.8",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -3396,12 +3387,6 @@
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true
                 }
             }
         },
@@ -3474,15 +3459,6 @@
                         "tsutils": "^3.21.0"
                     }
                 },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
                 "semver": {
                     "version": "7.3.8",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -3491,12 +3467,6 @@
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true
                 }
             }
         },
@@ -3564,15 +3534,6 @@
                         "tsutils": "^3.21.0"
                     }
                 },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
                 "semver": {
                     "version": "7.3.8",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -3581,12 +3542,6 @@
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true
                 }
             }
         },
@@ -4052,21 +4007,31 @@
             "dev": true
         },
         "array.prototype.flat": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-            "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+            "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.19.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4",
                 "es-shim-unscopables": "^1.0.0"
             },
             "dependencies": {
+                "define-properties": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                    "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                    "dev": true,
+                    "requires": {
+                        "has-property-descriptors": "^1.0.0",
+                        "object-keys": "^1.1.1"
+                    }
+                },
                 "es-abstract": {
-                    "version": "1.20.4",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-                    "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+                    "version": "1.20.5",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+                    "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
@@ -4075,6 +4040,7 @@
                         "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.3",
                         "get-symbol-description": "^1.0.0",
+                        "gopd": "^1.0.1",
                         "has": "^1.0.3",
                         "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
@@ -4090,8 +4056,8 @@
                         "object.assign": "^4.1.4",
                         "regexp.prototype.flags": "^1.4.3",
                         "safe-regex-test": "^1.0.0",
-                        "string.prototype.trimend": "^1.0.5",
-                        "string.prototype.trimstart": "^1.0.5",
+                        "string.prototype.trimend": "^1.0.6",
+                        "string.prototype.trimstart": "^1.0.6",
                         "unbox-primitive": "^1.0.2"
                     }
                 },
@@ -4149,18 +4115,6 @@
                         "define-properties": "^1.1.4",
                         "has-symbols": "^1.0.3",
                         "object-keys": "^1.1.1"
-                    },
-                    "dependencies": {
-                        "define-properties": {
-                            "version": "1.1.4",
-                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-                            "dev": true,
-                            "requires": {
-                                "has-property-descriptors": "^1.0.0",
-                                "object-keys": "^1.1.1"
-                            }
-                        }
                     }
                 },
                 "regexp.prototype.flags": {
@@ -4175,49 +4129,25 @@
                     }
                 },
                 "string.prototype.trimend": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+                    "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "define-properties": "^1.1.4",
-                        "es-abstract": "^1.19.5"
-                    },
-                    "dependencies": {
-                        "define-properties": {
-                            "version": "1.1.4",
-                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-                            "dev": true,
-                            "requires": {
-                                "has-property-descriptors": "^1.0.0",
-                                "object-keys": "^1.1.1"
-                            }
-                        }
+                        "es-abstract": "^1.20.4"
                     }
                 },
                 "string.prototype.trimstart": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+                    "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "define-properties": "^1.1.4",
-                        "es-abstract": "^1.19.5"
-                    },
-                    "dependencies": {
-                        "define-properties": {
-                            "version": "1.1.4",
-                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-                            "dev": true,
-                            "requires": {
-                                "has-property-descriptors": "^1.0.0",
-                                "object-keys": "^1.1.1"
-                            }
-                        }
+                        "es-abstract": "^1.20.4"
                     }
                 },
                 "unbox-primitive": {
@@ -5678,10 +5608,26 @@
                 "sigmund": "^1.0.1"
             },
             "dependencies": {
+                "lru-cache": {
+                    "version": "4.1.5",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+                    "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
                 "semver": {
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
                     "dev": true
                 }
             }
@@ -6302,15 +6248,6 @@
                     "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
                     "dev": true
                 },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
                 "semver": {
                     "version": "7.3.8",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -6319,12 +6256,6 @@
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true
                 }
             }
         },
@@ -6417,19 +6348,10 @@
             },
             "dependencies": {
                 "ci-info": {
-                    "version": "3.5.0",
-                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-                    "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
+                    "version": "3.7.0",
+                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+                    "integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
                     "dev": true
-                },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
                 },
                 "semver": {
                     "version": "7.3.8",
@@ -6439,12 +6361,6 @@
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true
                 }
             }
         },
@@ -7527,6 +7443,34 @@
                 "ignore": "^5.1.4",
                 "merge2": "^1.3.0",
                 "slash": "^3.0.0"
+            }
+        },
+        "gopd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.1.3"
+            },
+            "dependencies": {
+                "get-intrinsic": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+                    "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+                    "dev": true,
+                    "requires": {
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.3"
+                    }
+                },
+                "has-symbols": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+                    "dev": true
+                }
             }
         },
         "graceful-fs": {
@@ -11075,13 +11019,12 @@
             }
         },
         "lru-cache": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
             "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
+                "yallist": "^4.0.0"
             }
         },
         "macos-release": {
@@ -12834,7 +12777,7 @@
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
             "dev": true
         },
         "psl": {
@@ -14009,7 +13952,7 @@
         "sigmund": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+            "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
             "dev": true
         },
         "signal-exit": {
@@ -15753,9 +15696,9 @@
             "dev": true
         },
         "yallist": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
         "yaml": {

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -89,7 +89,7 @@
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.6.0-109663",
     "@fluidframework/common-utils-previous": "npm:@fluidframework/common-utils@1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.1",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/base64-js": "^1.3.0",

--- a/common/lib/protocol-definitions/package-lock.json
+++ b/common/lib/protocol-definitions/package-lock.json
@@ -277,9 +277,9 @@
             "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
         },
         "@fluidframework/eslint-config-fluid": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.2.1.tgz",
-            "integrity": "sha512-jOt6rWtg4Zigz33hv42hg/y8CUWXp6J+0Jn4ub0Bo/0H58agHD2XWfD0RAOD5bOtNxBLPAhsSUHD4XN7SCct+w==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
+            "integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
             "dev": true,
             "requires": {
                 "@rushstack/eslint-patch": "~1.1.0",
@@ -2384,21 +2384,31 @@
             "dev": true
         },
         "array.prototype.flat": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-            "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+            "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.19.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4",
                 "es-shim-unscopables": "^1.0.0"
             },
             "dependencies": {
+                "define-properties": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                    "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                    "dev": true,
+                    "requires": {
+                        "has-property-descriptors": "^1.0.0",
+                        "object-keys": "^1.1.1"
+                    }
+                },
                 "es-abstract": {
-                    "version": "1.20.4",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-                    "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+                    "version": "1.20.5",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+                    "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
@@ -2407,6 +2417,7 @@
                         "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.3",
                         "get-symbol-description": "^1.0.0",
+                        "gopd": "^1.0.1",
                         "has": "^1.0.3",
                         "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
@@ -2422,8 +2433,8 @@
                         "object.assign": "^4.1.4",
                         "regexp.prototype.flags": "^1.4.3",
                         "safe-regex-test": "^1.0.0",
-                        "string.prototype.trimend": "^1.0.5",
-                        "string.prototype.trimstart": "^1.0.5",
+                        "string.prototype.trimend": "^1.0.6",
+                        "string.prototype.trimstart": "^1.0.6",
                         "unbox-primitive": "^1.0.2"
                     }
                 },
@@ -2487,18 +2498,6 @@
                         "define-properties": "^1.1.4",
                         "has-symbols": "^1.0.3",
                         "object-keys": "^1.1.1"
-                    },
-                    "dependencies": {
-                        "define-properties": {
-                            "version": "1.1.4",
-                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-                            "dev": true,
-                            "requires": {
-                                "has-property-descriptors": "^1.0.0",
-                                "object-keys": "^1.1.1"
-                            }
-                        }
                     }
                 },
                 "regexp.prototype.flags": {
@@ -2513,49 +2512,25 @@
                     }
                 },
                 "string.prototype.trimend": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+                    "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "define-properties": "^1.1.4",
-                        "es-abstract": "^1.19.5"
-                    },
-                    "dependencies": {
-                        "define-properties": {
-                            "version": "1.1.4",
-                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-                            "dev": true,
-                            "requires": {
-                                "has-property-descriptors": "^1.0.0",
-                                "object-keys": "^1.1.1"
-                            }
-                        }
+                        "es-abstract": "^1.20.4"
                     }
                 },
                 "string.prototype.trimstart": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+                    "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "define-properties": "^1.1.4",
-                        "es-abstract": "^1.19.5"
-                    },
-                    "dependencies": {
-                        "define-properties": {
-                            "version": "1.1.4",
-                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-                            "dev": true,
-                            "requires": {
-                                "has-property-descriptors": "^1.0.0",
-                                "object-keys": "^1.1.1"
-                            }
-                        }
+                        "es-abstract": "^1.20.4"
                     }
                 },
                 "unbox-primitive": {
@@ -2778,9 +2753,9 @@
             "dev": true
         },
         "ci-info": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-            "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+            "integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
             "dev": true
         },
         "clean-regexp": {
@@ -4463,6 +4438,34 @@
                 "ignore": "^5.1.4",
                 "merge2": "^1.3.0",
                 "slash": "^3.0.0"
+            }
+        },
+        "gopd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.1.3"
+            },
+            "dependencies": {
+                "get-intrinsic": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+                    "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+                    "dev": true,
+                    "requires": {
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.3"
+                    }
+                },
+                "has-symbols": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+                    "dev": true
+                }
             }
         },
         "graceful-fs": {

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.6.0-109663",
-    "@fluidframework/eslint-config-fluid": "^1.2.1",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/protocol-definitions-previous": "npm:@fluidframework/protocol-definitions@1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/tools/api-markdown-documenter/package-lock.json
+++ b/tools/api-markdown-documenter/package-lock.json
@@ -1013,9 +1013,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.2.1.tgz",
-      "integrity": "sha512-jOt6rWtg4Zigz33hv42hg/y8CUWXp6J+0Jn4ub0Bo/0H58agHD2XWfD0RAOD5bOtNxBLPAhsSUHD4XN7SCct+w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
+      "integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",
@@ -4187,9 +4187,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-      "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+      "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -4198,6 +4198,7 @@
         "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.3",
         "get-symbol-description": "^1.0.0",
+        "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
@@ -4213,8 +4214,8 @@
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
         "unbox-primitive": "^1.0.2"
       },
       "dependencies": {
@@ -5390,6 +5391,28 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "dependencies": {
+        "get-intrinsic": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+          "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.3"
+          }
+        }
       }
     },
     "graceful-fs": {

--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
     "@fluidframework/build-tools": "^0.6.0-109663",
-    "@fluidframework/eslint-config-fluid": "^1.2.1",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": "^1.2.5",
     "@fluidframework/test-utils": "^1.2.5",
     "@microsoft/api-extractor": "^7.22.2",

--- a/tools/benchmark/.eslintrc.js
+++ b/tools/benchmark/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     extends: [
-        require.resolve("@fluidframework/eslint-config-fluid"), "prettier"
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"
     ],
     parserOptions: {
         project: ["./tsconfig.json", "./src/test/tsconfig.json"]

--- a/tools/benchmark/package-lock.json
+++ b/tools/benchmark/package-lock.json
@@ -432,9 +432,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.2.1.tgz",
-      "integrity": "sha512-jOt6rWtg4Zigz33hv42hg/y8CUWXp6J+0Jn4ub0Bo/0H58agHD2XWfD0RAOD5bOtNxBLPAhsSUHD4XN7SCct+w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
+      "integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",
@@ -1755,9 +1755,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.20.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-          "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+          "version": "1.20.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+          "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
@@ -1766,6 +1766,7 @@
             "function.prototype.name": "^1.1.5",
             "get-intrinsic": "^1.1.3",
             "get-symbol-description": "^1.0.0",
+            "gopd": "^1.0.1",
             "has": "^1.0.3",
             "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
@@ -1781,8 +1782,8 @@
             "object.assign": "^4.1.4",
             "regexp.prototype.flags": "^1.4.3",
             "safe-regex-test": "^1.0.0",
-            "string.prototype.trimend": "^1.0.5",
-            "string.prototype.trimstart": "^1.0.5",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
             "unbox-primitive": "^1.0.2"
           }
         },
@@ -3337,6 +3338,34 @@
         "ignore": "^5.1.4",
         "merge2": "^1.3.0",
         "slash": "^3.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "dependencies": {
+        "get-intrinsic": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+          "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.3"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.1",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": "^1.3.1",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",

--- a/tools/getkeys/package-lock.json
+++ b/tools/getkeys/package-lock.json
@@ -186,9 +186,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.2.1.tgz",
-      "integrity": "sha512-jOt6rWtg4Zigz33hv42hg/y8CUWXp6J+0Jn4ub0Bo/0H58agHD2XWfD0RAOD5bOtNxBLPAhsSUHD4XN7SCct+w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
+      "integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",
@@ -787,9 +787,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.20.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-          "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+          "version": "1.20.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+          "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
@@ -798,6 +798,7 @@
             "function.prototype.name": "^1.1.5",
             "get-intrinsic": "^1.1.3",
             "get-symbol-description": "^1.0.0",
+            "gopd": "^1.0.1",
             "has": "^1.0.3",
             "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
@@ -813,8 +814,8 @@
             "object.assign": "^4.1.4",
             "regexp.prototype.flags": "^1.4.3",
             "safe-regex-test": "^1.0.0",
-            "string.prototype.trimend": "^1.0.5",
-            "string.prototype.trimstart": "^1.0.5",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
             "unbox-primitive": "^1.0.2"
           }
         },
@@ -928,9 +929,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.20.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-          "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+          "version": "1.20.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+          "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
@@ -939,6 +940,7 @@
             "function.prototype.name": "^1.1.5",
             "get-intrinsic": "^1.1.3",
             "get-symbol-description": "^1.0.0",
+            "gopd": "^1.0.1",
             "has": "^1.0.3",
             "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
@@ -954,8 +956,8 @@
             "object.assign": "^4.1.4",
             "regexp.prototype.flags": "^1.4.3",
             "safe-regex-test": "^1.0.0",
-            "string.prototype.trimend": "^1.0.5",
-            "string.prototype.trimstart": "^1.0.5",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
             "unbox-primitive": "^1.0.2"
           }
         },
@@ -1063,9 +1065,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.20.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-          "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+          "version": "1.20.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+          "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
@@ -1074,6 +1076,7 @@
             "function.prototype.name": "^1.1.5",
             "get-intrinsic": "^1.1.3",
             "get-symbol-description": "^1.0.0",
+            "gopd": "^1.0.1",
             "has": "^1.0.3",
             "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
@@ -1089,8 +1092,8 @@
             "object.assign": "^4.1.4",
             "regexp.prototype.flags": "^1.4.3",
             "safe-regex-test": "^1.0.0",
-            "string.prototype.trimend": "^1.0.5",
-            "string.prototype.trimstart": "^1.0.5",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
             "unbox-primitive": "^1.0.2"
           }
         },
@@ -2071,9 +2074,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
+      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -2167,9 +2170,9 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.20.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-          "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+          "version": "1.20.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+          "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
@@ -2178,6 +2181,7 @@
             "function.prototype.name": "^1.1.5",
             "get-intrinsic": "^1.1.3",
             "get-symbol-description": "^1.0.0",
+            "gopd": "^1.0.1",
             "has": "^1.0.3",
             "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
@@ -2193,8 +2197,8 @@
             "object.assign": "^4.1.4",
             "regexp.prototype.flags": "^1.4.3",
             "safe-regex-test": "^1.0.0",
-            "string.prototype.trimend": "^1.0.5",
-            "string.prototype.trimstart": "^1.0.5",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
             "unbox-primitive": "^1.0.2"
           }
         },
@@ -2399,6 +2403,34 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "dependencies": {
+        "get-intrinsic": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+          "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.3"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {
@@ -3118,9 +3150,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.20.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-          "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+          "version": "1.20.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+          "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
@@ -3129,6 +3161,7 @@
             "function.prototype.name": "^1.1.5",
             "get-intrinsic": "^1.1.3",
             "get-symbol-description": "^1.0.0",
+            "gopd": "^1.0.1",
             "has": "^1.0.3",
             "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
@@ -3144,8 +3177,8 @@
             "object.assign": "^4.1.4",
             "regexp.prototype.flags": "^1.4.3",
             "safe-regex-test": "^1.0.0",
-            "string.prototype.trimend": "^1.0.5",
-            "string.prototype.trimstart": "^1.0.5",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
             "unbox-primitive": "^1.0.2"
           }
         },
@@ -3252,9 +3285,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.20.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-          "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+          "version": "1.20.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+          "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
@@ -3263,6 +3296,7 @@
             "function.prototype.name": "^1.1.5",
             "get-intrinsic": "^1.1.3",
             "get-symbol-description": "^1.0.0",
+            "gopd": "^1.0.1",
             "has": "^1.0.3",
             "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
@@ -3278,8 +3312,8 @@
             "object.assign": "^4.1.4",
             "regexp.prototype.flags": "^1.4.3",
             "safe-regex-test": "^1.0.0",
-            "string.prototype.trimend": "^1.0.5",
-            "string.prototype.trimstart": "^1.0.5",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
             "unbox-primitive": "^1.0.2"
           }
         },
@@ -3385,9 +3419,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.20.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-          "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+          "version": "1.20.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+          "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
@@ -3396,6 +3430,7 @@
             "function.prototype.name": "^1.1.5",
             "get-intrinsic": "^1.1.3",
             "get-symbol-description": "^1.0.0",
+            "gopd": "^1.0.1",
             "has": "^1.0.3",
             "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
@@ -3411,8 +3446,8 @@
             "object.assign": "^4.1.4",
             "regexp.prototype.flags": "^1.4.3",
             "safe-regex-test": "^1.0.0",
-            "string.prototype.trimend": "^1.0.5",
-            "string.prototype.trimstart": "^1.0.5",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
             "unbox-primitive": "^1.0.2"
           }
         },
@@ -3519,9 +3554,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.20.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-          "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+          "version": "1.20.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+          "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
@@ -3530,6 +3565,7 @@
             "function.prototype.name": "^1.1.5",
             "get-intrinsic": "^1.1.3",
             "get-symbol-description": "^1.0.0",
+            "gopd": "^1.0.1",
             "has": "^1.0.3",
             "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
@@ -3545,8 +3581,8 @@
             "object.assign": "^4.1.4",
             "regexp.prototype.flags": "^1.4.3",
             "safe-regex-test": "^1.0.0",
-            "string.prototype.trimend": "^1.0.5",
-            "string.prototype.trimstart": "^1.0.5",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
             "unbox-primitive": "^1.0.2"
           }
         },
@@ -4148,9 +4184,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.20.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-          "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+          "version": "1.20.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+          "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
@@ -4159,6 +4195,7 @@
             "function.prototype.name": "^1.1.5",
             "get-intrinsic": "^1.1.3",
             "get-symbol-description": "^1.0.0",
+            "gopd": "^1.0.1",
             "has": "^1.0.3",
             "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
@@ -4174,8 +4211,8 @@
             "object.assign": "^4.1.4",
             "regexp.prototype.flags": "^1.4.3",
             "safe-regex-test": "^1.0.0",
-            "string.prototype.trimend": "^1.0.5",
-            "string.prototype.trimstart": "^1.0.5",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
             "unbox-primitive": "^1.0.2"
           }
         },

--- a/tools/getkeys/package.json
+++ b/tools/getkeys/package.json
@@ -30,7 +30,7 @@
     "ms-rest-azure": "^2.6.0"
   },
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^1.2.1",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "eslint": "~8.6.0",
     "prettier": "~2.6.2",
     "typescript": "~4.5.5"

--- a/tools/telemetry-generator/.eslintrc.js
+++ b/tools/telemetry-generator/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid"), "prettier"
+        require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"
     ],
     "parserOptions": {
         project: ["./tsconfig.json"],

--- a/tools/telemetry-generator/package-lock.json
+++ b/tools/telemetry-generator/package-lock.json
@@ -143,9 +143,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.2.1.tgz",
-      "integrity": "sha512-jOt6rWtg4Zigz33hv42hg/y8CUWXp6J+0Jn4ub0Bo/0H58agHD2XWfD0RAOD5bOtNxBLPAhsSUHD4XN7SCct+w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
+      "integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",
@@ -1056,9 +1056,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-      "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+      "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -1067,6 +1067,7 @@
         "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.3",
         "get-symbol-description": "^1.0.0",
+        "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
@@ -1082,8 +1083,8 @@
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
         "unbox-primitive": "^1.0.2"
       }
     },
@@ -1790,6 +1791,15 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
       }
     },
     "graceful-fs": {

--- a/tools/telemetry-generator/package.json
+++ b/tools/telemetry-generator/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
-    "@fluidframework/eslint-config-fluid": "^1.2.1",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@types/node": "^14.18.0",
     "concurrently": "^6.2.0",
     "eslint": "~8.6.0",

--- a/tools/test-tools/package-lock.json
+++ b/tools/test-tools/package-lock.json
@@ -125,9 +125,9 @@
       }
     },
     "@fluidframework/eslint-config-fluid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-1.2.1.tgz",
-      "integrity": "sha512-jOt6rWtg4Zigz33hv42hg/y8CUWXp6J+0Jn4ub0Bo/0H58agHD2XWfD0RAOD5bOtNxBLPAhsSUHD4XN7SCct+w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-2.0.0.tgz",
+      "integrity": "sha512-/az5CybW5XUZUOk9HMH0nUMtKx5AK+CRfHg35UyygTK+V2OmNRes/yCAbmxoQ1J1Vn2iow3Y/Sgw/oJygciugQ==",
       "dev": true,
       "requires": {
         "@rushstack/eslint-patch": "~1.1.0",
@@ -950,9 +950,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-      "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+      "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -961,6 +961,7 @@
         "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.3",
         "get-symbol-description": "^1.0.0",
+        "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
@@ -976,8 +977,8 @@
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
         "unbox-primitive": "^1.0.2"
       }
     },
@@ -1435,9 +1436,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
+      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -1613,6 +1614,15 @@
           "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
           "dev": true
         }
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
       }
     },
     "has": {

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@fluidframework/eslint-config-fluid": "^1.2.1",
+    "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@types/node": "^14.18.0",
     "concurrently": "^6.2.0",
     "eslint": "~8.6.0",


### PR DESCRIPTION
Note: `@fluidframework/eslint-config-fluid`'s default export was updated from `minimal` to `recommended`.