### PR TITLE
Add SharedCounter editor control to client-debug-visualizer package

### DIFF
--- a/packages/tools/client-debug-view/src/components/data-object-views/SharedCounterView.tsx
+++ b/packages/tools/client-debug-view/src/components/data-object-views/SharedCounterView.tsx
@@ -91,7 +91,7 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
                     content="Enter the delta value of your choice"
                     id={inputFieldTooltipId}
                 >
-                    <input onChange={inputSetValue} placeholder="Enter Delta" value={deltaValue}/>
+                    <input type="number" onChange={inputSetValue} placeholder="Enter Delta" value={deltaValue}/>
                 </TooltipHost>
 
                 <TooltipHost

--- a/packages/tools/client-debug-view/src/components/data-object-views/SharedCounterView.tsx
+++ b/packages/tools/client-debug-view/src/components/data-object-views/SharedCounterView.tsx
@@ -40,7 +40,7 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
 	const { sharedCounter } = props;
 
 	const [value, setValue] = React.useState<number>(sharedCounter.value);
-    const [deltaValue, setDeltaValue] = React.useState(1);
+    const [deltaValue, setDeltaValue] = React.useState("");
 
 	React.useEffect(() => {
 		function updateValue(delta: number, newValue: number): void {
@@ -54,27 +54,18 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
 		};
 	}, [sharedCounter, setValue]);
 
-
     function decrementCounter(): void {
-        sharedCounter.increment(-deltaValue);
+        sharedCounter.increment(-Number.parseInt(deltaValue, 10));
+        setDeltaValue("");
 	}
 
     function incrementCounter(): void {
-		sharedCounter.increment(deltaValue);
+		sharedCounter.increment(Number.parseInt(deltaValue, 10));
+        setDeltaValue("");
 	}
 
     const inputSetValue = (e: React.ChangeEvent<HTMLInputElement>): void => {
-        numberFormatCheck(e.target.value);
-    }
-
-    const numberFormatCheck = (val: string): void => {
-        const num = Number.parseInt(val, 10) || value;
-
-        if (!Number.isFinite(num) || num[0] === '-') {
-            return
-        }
-
-        setDeltaValue(num);
+        setDeltaValue(e.target.value);
     }
 
 	return (
@@ -85,29 +76,31 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
 			<StackItem>Value: {value} </StackItem>
             <StackItem>
                 <TooltipHost
-					content="Decrement counter by 1 (min 0)."
+					content="Decrememt counter by the delta-value."
 					id={decrementButtonTooltipId}
 				>
                     <IconButton
                             onClick={decrementCounter}
+                            disabled={deltaValue === ""}
                             menuIconProps={{ iconName: "CalculatorSubtract" }}
                             aria-describedby={decrementButtonTooltipId}
                     />
                 </TooltipHost>
 
                 <TooltipHost
-                    content="Change the counter value by passing the number in input field"
+                    content="Enter the delta value of your choice"
                     id={inputFieldTooltipId}
                 >
-                    <input type="number" onChange={inputSetValue}/>
+                    <input onChange={inputSetValue} placeholder="Enter Delta" value={deltaValue}/>
                 </TooltipHost>
 
                 <TooltipHost
-					content="Increment counter by 1."
+					content="Increment counter by the delta-value."
 					id={incrementButtonTooltipId}
 				>
                     <IconButton
                             onClick={incrementCounter}
+                            disabled={deltaValue === ""}
                             menuIconProps={{ iconName: "CalculatorAddition" }}
                             aria-describedby={incrementButtonTooltipId}
                     />

--- a/packages/tools/client-debug-view/src/components/data-object-views/SharedCounterView.tsx
+++ b/packages/tools/client-debug-view/src/components/data-object-views/SharedCounterView.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IconButton, Stack, StackItem, TooltipHost } from "@fluentui/react";
+import { IconButton, IStackStyles, Stack, StackItem, TooltipHost } from "@fluentui/react";
 import React from "react";
 
 import { SharedCounter } from "@fluidframework/counter";
@@ -68,13 +68,26 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
         setDeltaValue(e.target.value);
     }
 
+    const stackStyles: IStackStyles = {
+        root: {
+            padding: 15,
+        }
+    }
+
+    const buttonStyles: IStackStyles = {
+        root: {
+            margin: 20
+        }
+    }
+
+
 	return (
 		<Stack>
 			<StackItem>
 				<b>SharedCounter</b>
 			</StackItem>
 			<StackItem>Value: {value} </StackItem>
-            <StackItem>
+            <StackItem styles={stackStyles}>
                 <TooltipHost
 					content="Decrememt counter by the delta-value."
 					id={decrementButtonTooltipId}
@@ -84,6 +97,7 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
                             disabled={deltaValue === ""}
                             menuIconProps={{ iconName: "CalculatorSubtract" }}
                             aria-describedby={decrementButtonTooltipId}
+                            styles={buttonStyles}
                     />
                 </TooltipHost>
 
@@ -103,6 +117,7 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
                             disabled={deltaValue === ""}
                             menuIconProps={{ iconName: "CalculatorAddition" }}
                             aria-describedby={incrementButtonTooltipId}
+                            styles={buttonStyles}
                     />
                 </TooltipHost>
             </StackItem>

--- a/packages/tools/client-debug-view/src/components/data-object-views/SharedCounterView.tsx
+++ b/packages/tools/client-debug-view/src/components/data-object-views/SharedCounterView.tsx
@@ -44,7 +44,6 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
 
 	React.useEffect(() => {
 		function updateValue(delta: number, newValue: number): void {
-            console.log(newValue);
 			setValue(newValue);
 		}
 
@@ -76,7 +75,6 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
         }
 
         setDeltaValue(num);
-        // sharedCounter.increment(num - value);
     }
 
 	return (
@@ -92,7 +90,6 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
 				>
                     <IconButton
                             onClick={decrementCounter}
-                            // disabled={value === 0}
                             menuIconProps={{ iconName: "CalculatorSubtract" }}
                             aria-describedby={decrementButtonTooltipId}
                     />

--- a/packages/tools/client-debug-view/src/components/data-object-views/SharedCounterView.tsx
+++ b/packages/tools/client-debug-view/src/components/data-object-views/SharedCounterView.tsx
@@ -40,10 +40,12 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
 	const { sharedCounter } = props;
 
 	const [value, setValue] = React.useState<number>(sharedCounter.value);
+    const [deltaValue, setDeltaValue] = React.useState(1);
 
 	React.useEffect(() => {
 		function updateValue(delta: number, newValue: number): void {
-			setValue(Math.max(newValue, 0));
+            console.log(newValue);
+			setValue(newValue);
 		}
 
 		sharedCounter.on("incremented", updateValue);
@@ -55,25 +57,26 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
 
 
     function decrementCounter(): void {
-        sharedCounter.increment(-1);
+        sharedCounter.increment(-deltaValue);
 	}
 
     function incrementCounter(): void {
-		sharedCounter.increment(1);
+		sharedCounter.increment(deltaValue);
 	}
 
-    const inputSetValue = (e: any): void => {
+    const inputSetValue = (e: React.ChangeEvent<HTMLInputElement>): void => {
         numberFormatCheck(e.target.value);
     }
 
-    const numberFormatCheck = (val: number): void => {
-        const num = val ?? value;
+    const numberFormatCheck = (val: string): void => {
+        const num = Number.parseInt(val, 10) || value;
 
-        if (!isFinite(num) || num[0] === '-') {
+        if (!Number.isFinite(num) || num[0] === '-') {
             return
         }
 
-        sharedCounter.increment(num - value);
+        setDeltaValue(num);
+        // sharedCounter.increment(num - value);
     }
 
 	return (
@@ -89,7 +92,7 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
 				>
                     <IconButton
                             onClick={decrementCounter}
-                            disabled={value === 0}
+                            // disabled={value === 0}
                             menuIconProps={{ iconName: "CalculatorSubtract" }}
                             aria-describedby={decrementButtonTooltipId}
                     />
@@ -99,7 +102,7 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
                     content="Change the counter value by passing the number in input field"
                     id={inputFieldTooltipId}
                 >
-                    <input type="number" onChange={inputSetValue} value={value}/>
+                    <input type="number" onChange={inputSetValue}/>
                 </TooltipHost>
 
                 <TooltipHost

--- a/packages/tools/client-debug-view/src/components/data-object-views/SharedCounterView.tsx
+++ b/packages/tools/client-debug-view/src/components/data-object-views/SharedCounterView.tsx
@@ -2,10 +2,26 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Stack, StackItem } from "@fluentui/react";
+import { IconButton, Stack, StackItem, TooltipHost } from "@fluentui/react";
 import React from "react";
 
 import { SharedCounter } from "@fluidframework/counter";
+
+/**
+ * Tooltip element ID used by the widget's decrement button.
+ */
+const decrementButtonTooltipId = "decrement-counter-button";
+
+/**
+ * Tooltip element ID used by the widget's increment button.
+ */
+const incrementButtonTooltipId = "increment-counter-button";
+
+/**
+ * Tooltip element ID used by the widget's input field
+ */
+const inputFieldTooltipId = "change-counter-input";
+
 
 /**
  * {@link SharedCounterView} input props.
@@ -27,7 +43,7 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
 
 	React.useEffect(() => {
 		function updateValue(delta: number, newValue: number): void {
-			setValue(newValue);
+			setValue(Math.max(newValue, 0));
 		}
 
 		sharedCounter.on("incremented", updateValue);
@@ -37,12 +53,66 @@ export function SharedCounterView(props: SharedCounterViewProps): React.ReactEle
 		};
 	}, [sharedCounter, setValue]);
 
+
+    function decrementCounter(): void {
+        sharedCounter.increment(-1);
+	}
+
+    function incrementCounter(): void {
+		sharedCounter.increment(1);
+	}
+
+    const inputSetValue = (e: any): void => {
+        numberFormatCheck(e.target.value);
+    }
+
+    const numberFormatCheck = (val: number): void => {
+        const num = val ?? value;
+
+        if (!isFinite(num) || num[0] === '-') {
+            return
+        }
+
+        sharedCounter.increment(num - value);
+    }
+
 	return (
 		<Stack>
 			<StackItem>
 				<b>SharedCounter</b>
 			</StackItem>
-			<StackItem>Value: {value}</StackItem>
+			<StackItem>Value: {value} </StackItem>
+            <StackItem>
+                <TooltipHost
+					content="Decrement counter by 1 (min 0)."
+					id={decrementButtonTooltipId}
+				>
+                    <IconButton
+                            onClick={decrementCounter}
+                            disabled={value === 0}
+                            menuIconProps={{ iconName: "CalculatorSubtract" }}
+                            aria-describedby={decrementButtonTooltipId}
+                    />
+                </TooltipHost>
+
+                <TooltipHost
+                    content="Change the counter value by passing the number in input field"
+                    id={inputFieldTooltipId}
+                >
+                    <input type="number" onChange={inputSetValue} value={value}/>
+                </TooltipHost>
+
+                <TooltipHost
+					content="Increment counter by 1."
+					id={incrementButtonTooltipId}
+				>
+                    <IconButton
+                            onClick={incrementCounter}
+                            menuIconProps={{ iconName: "CalculatorAddition" }}
+                            aria-describedby={incrementButtonTooltipId}
+                    />
+                </TooltipHost>
+            </StackItem>
 		</Stack>
 	);
 }


### PR DESCRIPTION
#### Description 

https://dev.azure.com/fluidframework/internal/_workitems/edit/2656/

#### Objective 

<img width="911" alt="image" src="https://user-images.githubusercontent.com/111468570/207467001-72a3fbcb-4138-4f4c-9209-86ebdd5fdd0e.png">

This PR aims to add functionality so that the users can freely manipulate the `sharedCounter` values by incrementing, decrementing or by passing an arbitrary integer value in the input field that would function as a delta value. 


#### Notes 
- There should be some CSS works to make the visualization neater after the logic for adding `sharedCounter` editor is approved. 
- The current method of adjusting `sharedCounter.value` is by repeating `sharedCounter.increment` for `num - value` number of times. We might have to think about coming up with a more efficient solution or changing the design of `sharedCounter` to allow applying an arbitrary integer value in the future. 