### PR TITLE
GC: Add gc aliased datastore tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -4,12 +4,12 @@
  */
 
 import { strict as assert } from "assert";
-import { IContainer } from "@fluidframework/container-definitions";
+import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { ITestObjectProvider, waitForContainerConnection } from "@fluidframework/test-utils";
-import { describeFullCompat, ITestDataObject, TestDataObjectType } from "@fluidframework/test-version-utils";
+import { createSummarizer, ITestObjectProvider, summarizeNow, waitForContainerConnection } from "@fluidframework/test-utils";
+import { describeFullCompat, describeNoCompat, ITestDataObject, TestDataObjectType } from "@fluidframework/test-version-utils";
 import { defaultGCConfig } from "./gcTestConfigs";
 import { getGCStateFromSummary } from "./gcTestSummaryUtils";
 
@@ -18,27 +18,25 @@ import { getGCStateFromSummary } from "./gcTestSummaryUtils";
  */
 describeFullCompat("GC Data Store Aliased", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
-    let container1: IContainer;
-    let container2: IContainer;
-    let mainDataStore1: ITestDataObject;
-    let mainDataStore2: ITestDataObject;
+
+    beforeEach(async () => {
+        provider = getTestObjectProvider({ syncSummarizer: true });
+    });
 
     async function waitForSummary(container: IContainer) {
         const dataStore = await requestFluidObject<ITestDataObject>(container, "default");
         return (dataStore._context.containerRuntime as ContainerRuntime).summarize({ runGC: true, trackState: false });
     }
 
-    beforeEach(async () => {
-        provider = getTestObjectProvider({ syncSummarizer: true });
-        container1 = await provider.makeTestContainer(defaultGCConfig);
-        container2 = await provider.loadTestContainer(defaultGCConfig);
-        mainDataStore1 = await requestFluidObject<ITestDataObject>(container1, "default");
-        mainDataStore2 = await requestFluidObject<ITestDataObject>(container2, "default");
+    // Note: this is an edge case.
+    it("GC aliased datastore is still aliased when initially summarized as non-aliased datastore", async () => {
+        const container1 = await provider.makeTestContainer(defaultGCConfig);
+        const container2 = await provider.loadTestContainer(defaultGCConfig);
+        const mainDataStore1 = await requestFluidObject<ITestDataObject>(container1, "default");
+        const mainDataStore2 = await requestFluidObject<ITestDataObject>(container2, "default");
         await waitForContainerConnection(container1);
         await waitForContainerConnection(container2);
-    });
 
-    it("GC is notified when datastores are aliased.", async () => {
         const aliasableDataStore1 = await mainDataStore1._context.containerRuntime.createDataStore(TestDataObjectType);
         const ds1 = await requestFluidObject<ITestDataObject>(aliasableDataStore1, "");
 
@@ -48,8 +46,8 @@ describeFullCompat("GC Data Store Aliased", (getTestObjectProvider) => {
         // We run the summary so await this.getInitialSnapshotDetails() is called before the datastore is aliased
         // and after the datastore is attached. This sets the isRootDataStore to false.
         let summaryWithStats = await waitForSummary(container2);
-        let gcState = getGCStateFromSummary(summaryWithStats.summary);
-        assert(gcState?.gcNodes[ds1.handle.absolutePath].unreferencedTimestampMs !== undefined,
+        const gcStatePreAlias = getGCStateFromSummary(summaryWithStats.summary);
+        assert(gcStatePreAlias?.gcNodes[ds1.handle.absolutePath].unreferencedTimestampMs !== undefined,
             "AliasableDataStore1 should be unreferenced as it is not aliased and not root!");
 
         // Alias a datastore
@@ -59,12 +57,41 @@ describeFullCompat("GC Data Store Aliased", (getTestObjectProvider) => {
         await provider.ensureSynchronized();
 
         // Should be able to retrieve root datastore from remote
-        const containerRuntime2 = mainDataStore2._context.containerRuntime as IContainerRuntime;
+        const containerRuntime2 = mainDataStore2._context.containerRuntime as unknown as IContainerRuntime;
         assert.doesNotThrow(async () => containerRuntime2.getRootDataStore(alias),
             "Aliased datastore should be root as it is aliased!");
         summaryWithStats = await waitForSummary(container2);
-        gcState = getGCStateFromSummary(summaryWithStats.summary);
-        assert(gcState?.gcNodes[ds1.handle.absolutePath].unreferencedTimestampMs === undefined,
+        const gcStatePostAlias = getGCStateFromSummary(summaryWithStats.summary);
+        assert(gcStatePostAlias?.gcNodes[ds1.handle.absolutePath].unreferencedTimestampMs === undefined,
             "AliasableDataStore1 should be referenced as it is aliased and thus a root datastore!");
+    });
+});
+
+describeNoCompat("GC aliased datastore is always referenced", async (getTestObjectProvider) => {
+    let provider: ITestObjectProvider;
+
+    beforeEach(async () => {
+        provider = getTestObjectProvider({ syncSummarizer: true });
+    });
+
+    it("GC aliased datastore is always referenced", async () => {
+        const container = await provider.makeTestContainer(defaultGCConfig);
+        const remoteContainer = await provider.loadTestContainer(defaultGCConfig);
+        await waitForContainerConnection(container);
+        await waitForContainerConnection(remoteContainer);
+
+        // Create and alias datastore
+        const mainDatastore = await requestFluidObject<ITestDataObject>(container, "default");
+        const aliasedDataStore = await mainDatastore._context.containerRuntime.createDataStore(TestDataObjectType);
+        const alias = "alias";
+        await aliasedDataStore.trySetAlias(alias);
+
+        // summarize
+        const summarizer = await createSummarizer(provider, container)
+        const { summaryTree } = await summarizeNow(summarizer);
+        const gcState = getGCStateFromSummary(summaryTree);
+        assert(aliasedDataStore.entryPoint !== undefined, "Expecting an entrypoint handle in a non-compat test!");
+        assert(gcState?.gcNodes[aliasedDataStore.entryPoint.absolutePath].unreferencedTimestampMs === undefined,
+            "Aliased datastores should always be referenced!");
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -69,7 +69,7 @@ describeFullCompat("GC Data Store Aliased", (getTestObjectProvider) => {
     });
 });
 
-describeNoCompat("GC aliased datastore is always referenced", async (getTestObjectProvider) => {
+describeNoCompat("GC aliased datastore is always referenced", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;
 
     beforeEach(async () => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
+import { IContainer } from "@fluidframework/container-definitions";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
@@ -47,7 +47,8 @@ describeFullCompat("GC Data Store Aliased", (getTestObjectProvider) => {
         // and after the datastore is attached. This sets the isRootDataStore to false.
         let summaryWithStats = await waitForSummary(container2);
         const gcStatePreAlias = getGCStateFromSummary(summaryWithStats.summary);
-        assert(gcStatePreAlias?.gcNodes[ds1.handle.absolutePath].unreferencedTimestampMs !== undefined,
+        assert(gcStatePreAlias !== undefined, "Should get gc pre state from summary!");
+        assert(gcStatePreAlias.gcNodes[ds1.handle.absolutePath].unreferencedTimestampMs !== undefined,
             "AliasableDataStore1 should be unreferenced as it is not aliased and not root!");
 
         // Alias a datastore
@@ -62,7 +63,8 @@ describeFullCompat("GC Data Store Aliased", (getTestObjectProvider) => {
             "Aliased datastore should be root as it is aliased!");
         summaryWithStats = await waitForSummary(container2);
         const gcStatePostAlias = getGCStateFromSummary(summaryWithStats.summary);
-        assert(gcStatePostAlias?.gcNodes[ds1.handle.absolutePath].unreferencedTimestampMs === undefined,
+        assert(gcStatePostAlias !== undefined, "Should get gc post state from summary!");
+        assert(gcStatePostAlias.gcNodes[ds1.handle.absolutePath].unreferencedTimestampMs === undefined,
             "AliasableDataStore1 should be referenced as it is aliased and thus a root datastore!");
     });
 });


### PR DESCRIPTION
[AB#2393](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2393)

Create missing aliased datastores are always referenced in GC tests