### PR TITLE
initial random tree generator

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/generator.ts
+++ b/packages/dds/tree/src/test/shared-tree/generator.ts
@@ -1,0 +1,102 @@
+import {
+    AsyncGenerator,
+    BaseFuzzTestState,
+    createWeightedAsyncGenerator,
+} from "@fluid-internal/stochastic-test-utils";
+import { FieldKey, UpPath } from "../../tree";
+import { ITestTreeProvider } from "../utils";
+import { getRandomNodePosition } from "./treeGenerator";
+
+type Operation = TreeEdit;
+
+export interface TreeEdit {
+    type: "edit";
+    contents: FuzzChange;
+    /** index of the tree to apply the edit to. */
+    index: number;
+}
+
+export interface FuzzInsert {
+    fuzzType: "insert";
+    path: UpPath | undefined;
+    field: FieldKey | undefined;
+    index: number | undefined;
+    value: number | undefined;
+    treeIndex: number;
+}
+
+export interface FuzzDelete {
+    fuzzType: "delete";
+    path: UpPath | undefined;
+    field: FieldKey | undefined;
+    index: number | undefined;
+    treeIndex: number;
+}
+
+export type FuzzChange = FuzzInsert | FuzzDelete;
+
+export interface FuzzTestState extends BaseFuzzTestState {
+    testTreeProvider: ITestTreeProvider;
+}
+
+export const makeEditGenerator = (): AsyncGenerator<Operation, FuzzTestState> => {
+    async function insertGenerator(state: FuzzTestState): Promise<FuzzInsert> {
+        // randomly select a tree in the testTreeProvider
+        const trees = state.testTreeProvider.trees;
+        const treeIndex = state.random.integer(0, trees.length - 1);
+        const tree = trees[treeIndex];
+
+        // generate edit for that specific tree
+        const {
+            path,
+            nodeField,
+            nodeIndex,
+            isNewPath: newPath,
+        } = getRandomNodePosition(tree, state.random);
+        const insert: FuzzInsert = {
+            fuzzType: "insert",
+            path,
+            field: nodeField,
+            index: nodeIndex,
+            value: state.random.integer(Number.MIN_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
+            treeIndex,
+        };
+        return insert;
+    }
+
+    async function deleteGenerator(state: FuzzTestState): Promise<FuzzDelete> {
+        // randomly select a tree in the testTreeProvider
+        const trees = state.testTreeProvider.trees;
+        const treeIndex = state.random.integer(0, trees.length - 1);
+        const tree = trees[treeIndex];
+
+        // generate edit for that specific tree
+        const {
+            path,
+            nodeField,
+            nodeIndex,
+            isNewPath: newPath,
+        } = getRandomNodePosition(tree, state.random);
+        const fuzzDelete: FuzzDelete = {
+            fuzzType: "delete",
+            path,
+            field: nodeField,
+            index: nodeIndex,
+            treeIndex,
+        };
+        return fuzzDelete;
+    }
+
+    const baseEditGenerator = createWeightedAsyncGenerator<FuzzChange, FuzzTestState>([
+        [insertGenerator, 1, (state: FuzzTestState) => state !== undefined],
+        [deleteGenerator, 1, (state: FuzzTestState) => state !== undefined],
+    ]);
+
+    return async (state: FuzzTestState): Promise<Operation> => {
+        const trees = state.testTreeProvider.trees;
+        const treeIndex = state.random.integer(0, trees.length - 1);
+        const tree = trees[treeIndex];
+        const contents = (await baseEditGenerator(state)) as FuzzChange;
+        return { type: "edit", contents, index: treeIndex };
+    };
+};

--- a/packages/dds/tree/src/test/shared-tree/generator.ts
+++ b/packages/dds/tree/src/test/shared-tree/generator.ts
@@ -42,14 +42,14 @@ export interface FuzzSetPayload {
     path: UpPath | undefined;
     field: FieldKey | undefined;
     index: number | undefined;
-    value: number
+    value: number;
     treeIndex: number;
 }
 
 export type FuzzChange = FuzzInsert | FuzzDelete | FuzzSetPayload;
 
 export interface Synchronize {
-	type: 'synchronize';
+    type: "synchronize";
 }
 
 export interface FuzzTestState extends BaseFuzzTestState {
@@ -59,7 +59,7 @@ export interface FuzzTestState extends BaseFuzzTestState {
 }
 
 export interface TreeContext {
-	treeIndex: number;
+    treeIndex: number;
 }
 
 export const makeEditGenerator = (): AsyncGenerator<Operation, FuzzTestState> => {
@@ -70,12 +70,8 @@ export const makeEditGenerator = (): AsyncGenerator<Operation, FuzzTestState> =>
         const tree = trees[state.treeIndex];
 
         // generate edit for that specific tree
-        const {
-            path,
-            nodeField,
-            nodeIndex,
-        } = getRandomNodePosition(tree, state.random);
-        assert(typeof(nodeField) !== 'object')
+        const { path, nodeField, nodeIndex } = getRandomNodePosition(tree, state.random);
+        assert(typeof nodeField !== "object");
         const insert: FuzzInsert = {
             fuzzType: "insert",
             path,
@@ -93,25 +89,26 @@ export const makeEditGenerator = (): AsyncGenerator<Operation, FuzzTestState> =>
         const tree = trees[state.treeIndex];
 
         // generate edit for that specific tree
-        const {
-            path,
-            nodeField,
-            nodeIndex,
-            onlyRootNode
-        } = getRandomNodePosition(tree, state.random, true);
-        return onlyRootNode ? {
-                fuzzType: "delete",
-                path: undefined,
-                field: undefined,
-                index: undefined,
-                treeIndex: state.treeIndex,
-            } : {
-                fuzzType: "delete",
-                path,
-                field: nodeField,
-                index: nodeIndex,
-                treeIndex: state.treeIndex,
-            };
+        const { path, nodeField, nodeIndex, onlyRootNode } = getRandomNodePosition(
+            tree,
+            state.random,
+            true,
+        );
+        return onlyRootNode
+            ? {
+                  fuzzType: "delete",
+                  path: undefined,
+                  field: undefined,
+                  index: undefined,
+                  treeIndex: state.treeIndex,
+              }
+            : {
+                  fuzzType: "delete",
+                  path,
+                  field: nodeField,
+                  index: nodeIndex,
+                  treeIndex: state.treeIndex,
+              };
     }
 
     async function setPayloadGenerator(state: EditState): Promise<FuzzSetPayload> {
@@ -120,13 +117,9 @@ export const makeEditGenerator = (): AsyncGenerator<Operation, FuzzTestState> =>
         const tree = trees[state.treeIndex];
 
         // generate edit for that specific tree
-        const {
-            path,
-            nodeField,
-            nodeIndex,
-        } = getRandomNodePosition(tree, state.random, true);
+        const { path, nodeField, nodeIndex } = getRandomNodePosition(tree, state.random, true);
         const fuzzSetPayload: FuzzSetPayload = {
-            fuzzType: 'setPayload',
+            fuzzType: "setPayload",
             path,
             field: nodeField,
             index: nodeIndex,
@@ -144,7 +137,7 @@ export const makeEditGenerator = (): AsyncGenerator<Operation, FuzzTestState> =>
     const baseEditGenerator = createWeightedAsyncGenerator<FuzzChange, EditState>([
         [insertGenerator, 5, (state: EditState) => state.numberOfEdits < 3000],
         [deleteGenerator, 1, (state: EditState) => state.numberOfEdits < 3000],
-        [setPayloadGenerator, 1, (state: EditState) => state.numberOfEdits < 3000]
+        [setPayloadGenerator, 1, (state: EditState) => state.numberOfEdits < 3000],
     ]);
 
     return async (state: FuzzTestState): Promise<Operation | typeof done> => {
@@ -156,18 +149,18 @@ export const makeEditGenerator = (): AsyncGenerator<Operation, FuzzTestState> =>
         });
         state.numberOfEdits += 1;
         if (contents === done) {
-			return done;
-		}
+            return done;
+        }
         return { type: "edit", contents, index: treeIndex };
     };
 };
 
 export function makeOpGenerator(): AsyncGenerator<Operation, FuzzTestState> {
     const maximumEdits: AcceptanceCondition<FuzzTestState> = ({ numberOfEdits }) =>
-		numberOfEdits < 4000;
-	const opWeights: AsyncWeights<Operation, FuzzTestState> = [
-		[makeEditGenerator(), 3, maximumEdits],
-        [{ type: 'synchronize' }, 1, maximumEdits]
-	];
-	return createWeightedAsyncGenerator(opWeights);
+        numberOfEdits < 4000;
+    const opWeights: AsyncWeights<Operation, FuzzTestState> = [
+        [makeEditGenerator(), 3, maximumEdits],
+        [{ type: "synchronize" }, 1, maximumEdits],
+    ];
+    return createWeightedAsyncGenerator(opWeights);
 }

--- a/packages/dds/tree/src/test/shared-tree/generator.ts
+++ b/packages/dds/tree/src/test/shared-tree/generator.ts
@@ -1,13 +1,16 @@
 import {
+    AcceptanceCondition,
     AsyncGenerator,
+    AsyncWeights,
     BaseFuzzTestState,
     createWeightedAsyncGenerator,
+    done,
 } from "@fluid-internal/stochastic-test-utils";
 import { FieldKey, UpPath } from "../../tree";
 import { ITestTreeProvider } from "../utils";
 import { getRandomNodePosition } from "./treeGenerator";
 
-type Operation = TreeEdit;
+export type Operation = TreeEdit;
 
 export interface TreeEdit {
     type: "edit";
@@ -37,21 +40,25 @@ export type FuzzChange = FuzzInsert | FuzzDelete;
 
 export interface FuzzTestState extends BaseFuzzTestState {
     testTreeProvider: ITestTreeProvider;
+    numberOfEdits: number;
+}
+
+export interface TreeContext {
+	treeIndex: number;
 }
 
 export const makeEditGenerator = (): AsyncGenerator<Operation, FuzzTestState> => {
-    async function insertGenerator(state: FuzzTestState): Promise<FuzzInsert> {
+    type EditState = FuzzTestState & TreeContext;
+    async function insertGenerator(state: EditState): Promise<FuzzInsert> {
         // randomly select a tree in the testTreeProvider
         const trees = state.testTreeProvider.trees;
-        const treeIndex = state.random.integer(0, trees.length - 1);
-        const tree = trees[treeIndex];
+        const tree = trees[state.treeIndex];
 
         // generate edit for that specific tree
         const {
             path,
             nodeField,
             nodeIndex,
-            isNewPath: newPath,
         } = getRandomNodePosition(tree, state.random);
         const insert: FuzzInsert = {
             fuzzType: "insert",
@@ -59,16 +66,15 @@ export const makeEditGenerator = (): AsyncGenerator<Operation, FuzzTestState> =>
             field: nodeField,
             index: nodeIndex,
             value: state.random.integer(Number.MIN_SAFE_INTEGER, Number.MIN_SAFE_INTEGER),
-            treeIndex,
+            treeIndex: state.treeIndex,
         };
         return insert;
     }
 
-    async function deleteGenerator(state: FuzzTestState): Promise<FuzzDelete> {
+    async function deleteGenerator(state: EditState): Promise<FuzzDelete> {
         // randomly select a tree in the testTreeProvider
         const trees = state.testTreeProvider.trees;
-        const treeIndex = state.random.integer(0, trees.length - 1);
-        const tree = trees[treeIndex];
+        const tree = trees[state.treeIndex];
 
         // generate edit for that specific tree
         const {
@@ -76,27 +82,42 @@ export const makeEditGenerator = (): AsyncGenerator<Operation, FuzzTestState> =>
             nodeField,
             nodeIndex,
             isNewPath: newPath,
-        } = getRandomNodePosition(tree, state.random);
+        } = getRandomNodePosition(tree, state.random, true);
         const fuzzDelete: FuzzDelete = {
             fuzzType: "delete",
             path,
             field: nodeField,
             index: nodeIndex,
-            treeIndex,
+            treeIndex: state.treeIndex,
         };
         return fuzzDelete;
     }
 
-    const baseEditGenerator = createWeightedAsyncGenerator<FuzzChange, FuzzTestState>([
-        [insertGenerator, 1, (state: FuzzTestState) => state !== undefined],
-        [deleteGenerator, 1, (state: FuzzTestState) => state !== undefined],
+    const baseEditGenerator = createWeightedAsyncGenerator<FuzzChange, EditState>([
+        [insertGenerator, 2, (state: EditState) => state.numberOfEdits < 10],
+        [deleteGenerator, 1, (state: EditState) => state.numberOfEdits < 10]
     ]);
 
-    return async (state: FuzzTestState): Promise<Operation> => {
+    return async (state: FuzzTestState): Promise<Operation | typeof done> => {
         const trees = state.testTreeProvider.trees;
         const treeIndex = state.random.integer(0, trees.length - 1);
-        const tree = trees[treeIndex];
-        const contents = (await baseEditGenerator(state)) as FuzzChange;
+        const contents = await baseEditGenerator({
+            ...state,
+            treeIndex,
+        });
+        state.numberOfEdits += 1;
+        if (contents === done) {
+			return done;
+		}
         return { type: "edit", contents, index: treeIndex };
     };
 };
+
+export function makeOpGenerator(): AsyncGenerator<Operation, FuzzTestState> {
+    const atLeastOneActiveClient: AcceptanceCondition<FuzzTestState> = ({ numberOfEdits }) =>
+		numberOfEdits > -1;
+	const opWeights: AsyncWeights<Operation, FuzzTestState> = [
+		[makeEditGenerator(), 1, atLeastOneActiveClient],
+	];
+	return createWeightedAsyncGenerator(opWeights);
+}

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeFuzzTests.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeFuzzTests.ts
@@ -206,30 +206,14 @@ function abortFuzzChange(tree: ISharedTree, contents: FuzzChange): void {
     switch (contents.fuzzType) {
         case "insert":
             if (index !== undefined && nodeField !== undefined) {
-                try {
-                    tree.runTransaction((forest, editor) => {
-                        const field = editor.sequenceField(contents.path, nodeField);
-                        field.insert(
-                            index,
-                            singleTextCursor({ type: brand("Test"), value: contents.value }),
-                        );
-                        return TransactionResult.Abort;
-                    });
-                } catch (error) {
-                    const testPath = topDownPath(contents.path);
-                    const readCursor = tree.forest.allocateCursor();
-                    moveToDetachedField(tree.forest, readCursor);
-                    const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
-                    const jsonData = JSON.stringify(actual);
-                    readCursor.free();
-                    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-                    const fs = require("fs");
-                    fs.writeFile("invalidInsert.txt", jsonData, (err: any) => {
-                        if (err) {
-                            console.log(err);
-                        }
-                    });
-                }
+                tree.runTransaction((forest, editor) => {
+                    const field = editor.sequenceField(contents.path, nodeField);
+                    field.insert(
+                        index,
+                        singleTextCursor({ type: brand("Test"), value: contents.value }),
+                    );
+                    return TransactionResult.Abort;
+                });
             }
             break;
         case "delete":
@@ -237,24 +221,16 @@ function abortFuzzChange(tree: ISharedTree, contents: FuzzChange): void {
                 const parent = contents.path?.parent;
                 const delField = contents.path?.parentField;
                 if (delField !== undefined && parent !== undefined) {
-                    try {
-                        const testPath = topDownPath(contents.path);
-                        const readCursor = tree.forest.allocateCursor();
-                        moveToDetachedField(tree.forest, readCursor);
-                        const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
-                        readCursor.free();
-                        tree.runTransaction((forest, editor) => {
-                            const field = editor.sequenceField(parent, delField);
-                            field.delete(index, 1); // set index to 0 for now for testing purposes.
-                            return TransactionResult.Abort;
-                        });
-                    } catch (error) {
-                        const testPath = topDownPath(contents.path);
-                        const readCursor = tree.forest.allocateCursor();
-                        moveToDetachedField(tree.forest, readCursor);
-                        const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
-                        readCursor.free();
-                    }
+                    const testPath = topDownPath(contents.path);
+                    const readCursor = tree.forest.allocateCursor();
+                    moveToDetachedField(tree.forest, readCursor);
+                    const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
+                    readCursor.free();
+                    tree.runTransaction((forest, editor) => {
+                        const field = editor.sequenceField(parent, delField);
+                        field.delete(index, 1); // set index to 0 for now for testing purposes.
+                        return TransactionResult.Abort;
+                    });
                 }
             }
             break;
@@ -262,27 +238,15 @@ function abortFuzzChange(tree: ISharedTree, contents: FuzzChange): void {
             if (index !== undefined && nodeField !== undefined) {
                 const path = contents.path;
                 if (path !== undefined) {
-                    try {
-                        const testPath = topDownPath(contents.path);
-                        const readCursor = tree.forest.allocateCursor();
-                        moveToDetachedField(tree.forest, readCursor);
-                        const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
-                        readCursor.free();
-                        tree.runTransaction((forest, editor) => {
-                            editor.setValue(path, contents.value);
-                            return TransactionResult.Abort;
-                        });
-                        const readCursor2 = tree.forest.allocateCursor();
-                        moveToDetachedField(tree.forest, readCursor2);
-                        const actual2 = mapCursorField(readCursor2, jsonableTreeFromCursor);
-                        readCursor2.free();
-                    } catch (error) {
-                        const testPath = topDownPath(contents.path);
-                        const readCursor = tree.forest.allocateCursor();
-                        moveToDetachedField(tree.forest, readCursor);
-                        const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
-                        readCursor.free();
-                    }
+                    const testPath = topDownPath(contents.path);
+                    const readCursor = tree.forest.allocateCursor();
+                    moveToDetachedField(tree.forest, readCursor);
+                    const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
+                    readCursor.free();
+                    tree.runTransaction((forest, editor) => {
+                        editor.setValue(path, contents.value);
+                        return TransactionResult.Abort;
+                    });
                 }
             }
             break;
@@ -297,42 +261,19 @@ async function applyFuzzChange(tree: ISharedTree, contents: FuzzChange): Promise
     switch (contents.fuzzType) {
         case "insert":
             if (index !== undefined && nodeField !== undefined) {
-                try {
-                    const testPath = topDownPath(contents.path);
-                    const readCursor = tree.forest.allocateCursor();
-                    moveToDetachedField(tree.forest, readCursor);
-                    const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
-                    readCursor.free();
-                    tree.runTransaction((forest, editor) => {
-                        const field = editor.sequenceField(contents.path, nodeField);
-                        field.insert(
-                            index,
-                            singleTextCursor({ type: brand("Test"), value: contents.value }),
-                        );
-                        return TransactionResult.Apply;
-                    });
-                } catch (error) {
-                    const testPath = topDownPath(contents.path);
-                    const readCursor = tree.forest.allocateCursor();
-                    moveToDetachedField(tree.forest, readCursor);
-                    const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
-                    const actualData = JSON.stringify(actual);
-                    const pathData = {
-                        path: testPath,
-                        field: nodeField,
+                const testPath = topDownPath(contents.path);
+                const readCursor = tree.forest.allocateCursor();
+                moveToDetachedField(tree.forest, readCursor);
+                const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
+                readCursor.free();
+                tree.runTransaction((forest, editor) => {
+                    const field = editor.sequenceField(contents.path, nodeField);
+                    field.insert(
                         index,
-                    };
-                    const jsonData = JSON.stringify([pathData, actualData]);
-                    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-                    const fs = require("fs");
-                    fs.writeFile("invalidInsert.txt", jsonData, (err: any) => {
-                        if (err) {
-                            console.log(err);
-                        }
-                    });
-                    readCursor.free();
-                    throw error;
-                }
+                        singleTextCursor({ type: brand("Test"), value: contents.value }),
+                    );
+                    return TransactionResult.Apply;
+                });
             }
             break;
         case "delete":
@@ -341,28 +282,16 @@ async function applyFuzzChange(tree: ISharedTree, contents: FuzzChange): Promise
                 const delField = contents.path?.parentField;
                 const parentIndex = contents.path?.parentIndex;
                 if (delField !== undefined && parent !== undefined && parentIndex !== undefined) {
-                    try {
-                        const testPath = topDownPath(contents.path);
-                        const readCursor = tree.forest.allocateCursor();
-                        moveToDetachedField(tree.forest, readCursor);
-                        const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
-                        readCursor.free();
-                        tree.runTransaction((forest, editor) => {
-                            const field = editor.sequenceField(parent, delField);
-                            field.delete(parentIndex, 1); // set index to 0 for now for testing purposes.
-                            return TransactionResult.Apply;
-                        });
-                        const readCursor2 = tree.forest.allocateCursor();
-                        moveToDetachedField(tree.forest, readCursor2);
-                        const actual2 = mapCursorField(readCursor2, jsonableTreeFromCursor);
-                        readCursor2.free();
-                    } catch (error) {
-                        const testPath = topDownPath(contents.path);
-                        const readCursor = tree.forest.allocateCursor();
-                        moveToDetachedField(tree.forest, readCursor);
-                        const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
-                        readCursor.free();
-                    }
+                    const testPath = topDownPath(contents.path);
+                    const readCursor = tree.forest.allocateCursor();
+                    moveToDetachedField(tree.forest, readCursor);
+                    const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
+                    readCursor.free();
+                    tree.runTransaction((forest, editor) => {
+                        const field = editor.sequenceField(parent, delField);
+                        field.delete(parentIndex, 1); // set index to 0 for now for testing purposes.
+                        return TransactionResult.Apply;
+                    });
                 }
             }
             break;
@@ -370,27 +299,15 @@ async function applyFuzzChange(tree: ISharedTree, contents: FuzzChange): Promise
             if (index !== undefined && nodeField !== undefined) {
                 const path = contents.path;
                 if (path !== undefined) {
-                    try {
-                        const testPath = topDownPath(contents.path);
-                        const readCursor = tree.forest.allocateCursor();
-                        moveToDetachedField(tree.forest, readCursor);
-                        const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
-                        readCursor.free();
-                        tree.runTransaction((forest, editor) => {
-                            editor.setValue(path, contents.value);
-                            return TransactionResult.Apply;
-                        });
-                        const readCursor2 = tree.forest.allocateCursor();
-                        moveToDetachedField(tree.forest, readCursor2);
-                        const actual2 = mapCursorField(readCursor2, jsonableTreeFromCursor);
-                        readCursor2.free();
-                    } catch (error) {
-                        const testPath = topDownPath(contents.path);
-                        const readCursor = tree.forest.allocateCursor();
-                        moveToDetachedField(tree.forest, readCursor);
-                        const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
-                        readCursor.free();
-                    }
+                    const testPath = topDownPath(contents.path);
+                    const readCursor = tree.forest.allocateCursor();
+                    moveToDetachedField(tree.forest, readCursor);
+                    const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
+                    readCursor.free();
+                    tree.runTransaction((forest, editor) => {
+                        editor.setValue(path, contents.value);
+                        return TransactionResult.Apply;
+                    });
                 }
             }
             break;

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeFuzzTests.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeFuzzTests.ts
@@ -1,0 +1,200 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import {
+	AsyncGenerator,
+    makeRandom,
+	describeFuzz,
+	performFuzzActionsAsync as performFuzzActionsBase,
+} from '@fluid-internal/stochastic-test-utils';
+import {
+    FieldKinds,
+    singleTextCursor,
+    namedTreeSchema,
+} from "../../feature-libraries";
+import { brand, fail } from "../../util";
+import { TestTreeProvider } from "../utils";
+import { ISharedTree } from "../../shared-tree";
+import {
+    JsonableTree,
+    rootFieldKey,
+    rootFieldKeySymbol,
+    TreeValue,
+    moveToDetachedField,
+    TransactionResult,
+    fieldSchema,
+    GlobalFieldKey,
+    SchemaData,
+} from "../../core";
+import { FuzzChange, FuzzTestState, makeEditGenerator, Operation } from "./generator";
+
+export async function performFuzzActions(
+	generator: AsyncGenerator<Operation, FuzzTestState>,
+	seed: number,
+	saveInfo?: { saveAt?: number; saveOnFailure: boolean; filepath: string }
+): Promise<Required<FuzzTestState>> {
+	const random = makeRandom(seed);
+    const provider = await TestTreeProvider.create(1)
+
+    const initialTreeState: JsonableTree = {
+        type: brand("Node"),
+        fields: {
+            foo: [
+                { type: brand("Number"), value: 0 },
+                { type: brand("Number"), value: 1 },
+                { type: brand("Number"), value: 2 },
+            ],
+            foo2: [
+                { type: brand("Number"), value: 0 },
+                { type: brand("Number"), value: 1 },
+                { type: brand("Number"), value: 2 },
+            ],
+        },
+    };
+    initializeTestTree(provider.trees[0], initialTreeState);
+	const initialState: FuzzTestState = {
+        random,
+        testTreeProvider: provider,
+        numberOfEdits: 0
+    };
+	const finalState = await performFuzzActionsBase(
+		generator,
+		{
+			edit: async (state, operation) => {
+				const { index, contents } = operation;
+                const tree = state.testTreeProvider.trees[index]
+				applyFuzzChange(tree, contents);
+				return state;
+			}
+		},
+		initialState,
+		saveInfo
+	);
+
+	return finalState as Required<FuzzTestState>;
+}
+
+function applyFuzzChange(tree: ISharedTree, contents: FuzzChange): void {
+    const index = contents.index;
+    const nodeField = contents.field;
+	switch (contents.fuzzType) {
+		case 'insert':
+            if (index !== undefined && nodeField !== undefined) {
+                tree.runTransaction((forest, editor) => {
+                    const field = editor.sequenceField(contents.path, nodeField);
+                    field.insert(
+                        index,
+                        singleTextCursor({ type: brand("Test"), value: contents.value }),
+                    );
+                    return TransactionResult.Apply;
+                });
+            }
+			break;
+        case 'delete':
+            if (index !== undefined && nodeField !== undefined) {
+                const parent = contents.path?.parent;
+                const delField = contents.path?.parentField
+                if(delField !== undefined){
+                    tree.runTransaction((forest, editor) => {
+                        const field = editor.sequenceField(parent, delField);
+                        field.delete(index, 1);
+                        return TransactionResult.Apply;
+                    });
+                }
+            }
+            break;
+		default:
+			fail('Invalid edit.');
+	}
+}
+
+export function runSharedTreeFuzzTests(title: string): void {
+	describeFuzz(title, ({ testCount }) => {
+		function runTest(
+			generatorFactory: () => AsyncGenerator<Operation, FuzzTestState>,
+			seed: number,
+			saveOnFailure?: boolean
+		): void {
+			it(`with seed ${seed}`, async () => {
+				await performFuzzActions(generatorFactory(), seed);
+			}).timeout(10000);
+		}
+        describe('with no-history summarization', () => {
+            const generatorFactory = () => makeEditGenerator()
+
+            describe('using only version 0.1.1', () => {
+				for (let seed = 0; seed < 1; seed++) {
+					runTest(generatorFactory, seed);
+				}
+			});
+        });
+	});
+}
+
+const globalFieldKey: GlobalFieldKey = brand("globalFieldKey");
+
+describe("SharedTreeFuzz", () => {
+    runSharedTreeFuzzTests("test shared tree fuzz")
+});
+
+const rootFieldSchema = fieldSchema(FieldKinds.value);
+const globalFieldSchema = fieldSchema(FieldKinds.value);
+const rootNodeSchema = namedTreeSchema({
+    name: brand("TestValue"),
+    localFields: {
+        optionalChild: fieldSchema(FieldKinds.optional, [brand("TestValue")]),
+    },
+    extraLocalFields: fieldSchema(FieldKinds.sequence),
+    globalFields: [globalFieldKey],
+});
+const testSchema: SchemaData = {
+    treeSchema: new Map([[rootNodeSchema.name, rootNodeSchema]]),
+    globalFieldSchema: new Map([
+        [rootFieldKey, rootFieldSchema],
+        [globalFieldKey, globalFieldSchema],
+    ]),
+};
+
+/**
+ * Updates the given `tree` to the given `schema` and inserts `state` as its root.
+ */
+function initializeTestTree(
+    tree: ISharedTree,
+    state: JsonableTree,
+    schema: SchemaData = testSchema,
+): void {
+    tree.storedSchema.update(schema);
+
+    // Apply an edit to the tree which inserts a node with a value
+    tree.runTransaction((forest, editor) => {
+        const writeCursor = singleTextCursor(state);
+        const field = editor.sequenceField(undefined, rootFieldKeySymbol);
+        field.insert(0, writeCursor);
+
+        return TransactionResult.Apply;
+    });
+}
+
+/**
+ * Inserts a single node under the root of the tree with the given value.
+ * Use {@link getTestValue} to read the value.
+ */
+function initializeTestTreeWithValue(tree: ISharedTree, value: TreeValue): void {
+    initializeTestTree(tree, { type: brand("TestValue"), value });
+}
+
+/**
+ * Reads a value in a tree set by {@link initializeTestTreeWithValue} if it exists.
+ */
+function getTestValue({ forest }: ISharedTree): TreeValue | undefined {
+    const readCursor = forest.allocateCursor();
+    moveToDetachedField(forest, readCursor);
+    if (!readCursor.firstNode()) {
+        readCursor.free();
+        return undefined;
+    }
+    const { value } = readCursor;
+    readCursor.free();
+    return value;
+}

--- a/packages/dds/tree/src/test/shared-tree/treeGenerator.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeGenerator.ts
@@ -13,7 +13,11 @@ export interface NodeLocation {
     onlyRootNode: boolean;
 }
 
-export function getRandomNodePosition(tree: ISharedTree, random: IRandom, existingPath = false): NodeLocation {
+export function getRandomNodePosition(
+    tree: ISharedTree,
+    random: IRandom,
+    existingPath = false,
+): NodeLocation {
     const moves = {
         field: ["enterNode", "nextField"],
         nodes: ["stop", "firstField"],
@@ -30,7 +34,7 @@ export function getRandomNodePosition(tree: ISharedTree, random: IRandom, existi
 
     let currentMove = "firstField";
     const testerKey: FieldKey = brand("Test");
-    assert(cursor.mode === CursorLocationType.Nodes)
+    assert(cursor.mode === CursorLocationType.Nodes);
 
     while (currentMove !== "stop") {
         switch (currentMove) {
@@ -40,8 +44,7 @@ export function getRandomNodePosition(tree: ISharedTree, random: IRandom, existi
                     // assert(cursor.mode === CursorLocationType.Fields, "must be in fields mode");
                     cursor.enterNode(nodeIndex);
                     path = cursor.getPath();
-                    // nodeField = cursor.getFieldKey();
-                    if (typeof(nodeField) === 'object') {
+                    if (typeof nodeField === "object") {
                         const readCursor = tree.forest.allocateCursor();
                         moveToDetachedField(tree.forest, readCursor);
                         const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
@@ -66,8 +69,13 @@ export function getRandomNodePosition(tree: ISharedTree, random: IRandom, existi
                     }
                 } else {
                     // This means no
-                    cursor.free()
-                    return { path:undefined, nodeField:undefined, nodeIndex:undefined, onlyRootNode: firstPath === path}
+                    cursor.free();
+                    return {
+                        path: undefined,
+                        nodeField: undefined,
+                        nodeIndex: undefined,
+                        onlyRootNode: firstPath === path,
+                    };
                     currentMove = random.pick(moves.nodes);
                 }
                 break;
@@ -93,7 +101,6 @@ export function getRandomNodePosition(tree: ISharedTree, random: IRandom, existi
             case "nextField":
                 if (cursor.nextField()) {
                     currentMove = random.pick(moves.field);
-                    // assert(cursor.mode === CursorLocationType.Fields, "must be in fields mode");
                     fieldNodes = cursor.getFieldLength();
                     nodeField = cursor.getFieldKey();
                 } else {
@@ -109,5 +116,5 @@ export function getRandomNodePosition(tree: ISharedTree, random: IRandom, existi
         }
     }
     cursor.free();
-    return { path, nodeField, nodeIndex, onlyRootNode: firstPath === path};
+    return { path, nodeField, nodeIndex, onlyRootNode: firstPath === path };
 }

--- a/packages/dds/tree/src/test/shared-tree/treeGenerator.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeGenerator.ts
@@ -1,0 +1,274 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IRandom, makeRandom } from "@fluid-internal/stochastic-test-utils";
+import { TransactionResult } from "../../checkout";
+import { FieldKinds, namedTreeSchema, singleTextCursor } from "../../feature-libraries";
+import { fieldSchema, GlobalFieldKey, SchemaData } from "../../schema-stored";
+import { ISharedTree } from "../../shared-tree";
+import {
+    FieldKey,
+    JsonableTree,
+    rootFieldKey,
+    rootFieldKeySymbol,
+    TreeValue,
+    UpPath,
+} from "../../tree";
+import { brand, fail } from "../../util";
+
+export type TreeNodePaths = Map<string, PathInfo>;
+
+export interface TreeEdit {
+    editType: string;
+    path: string;
+    index: number;
+    value: number;
+    field: string;
+}
+
+export type NodeValues = Map<number, number>;
+
+export type PathInfo = Map<string, NodeValues>;
+
+const rootPath = {
+    parent: "undefined",
+    parentField: "rootFieldKeySymbol",
+    parentIndex: 0,
+};
+
+const fooKey: FieldKey = brand("foo");
+const fooKey2: FieldKey = brand("foo2");
+
+type FieldKeyTypes = GlobalFieldKey | FieldKey;
+const fieldsPool = new Map<string, FieldKeyTypes>();
+fieldsPool.set("rootFieldKeySymbol", rootFieldKeySymbol);
+fieldsPool.set("fooKey", fooKey);
+fieldsPool.set("fooKey2", fooKey2);
+
+const rootValue = makeRandom(0).integer(Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
+const initialPaths: TreeNodePaths = new Map<string, PathInfo>();
+const rootPathInfo: PathInfo = new Map<string, NodeValues>();
+const rootNodeValues: NodeValues = new Map<number, number>();
+rootNodeValues.set(0, rootValue);
+rootPathInfo.set("rootFieldKeySymbol", rootNodeValues);
+initialPaths.set(JSON.stringify(rootPath), rootPathInfo);
+
+const initialEdits: TreeEdit[] = [];
+const rootEdit: TreeEdit = {
+    editType: "insert",
+    path: JSON.stringify(rootPath),
+    index: 0,
+    value: rootValue,
+    field: "rootFieldKeySymbol",
+};
+initialEdits.push(rootEdit);
+
+export function treeGenerator(
+    state: TreeNodePaths = initialPaths,
+    edits: TreeEdit[] = initialEdits,
+    seed: number,
+): any {
+    const random = makeRandom(seed);
+    const treeType = random.pick(["leaf", "stick", "balanced"]);
+    const path = selectRandomPath(state, random);
+    const field = random.pick(Array.from(fieldsPool.keys()));
+    switch (treeType) {
+        case "leaf":
+            addLeaf(state, path, field, edits, random);
+            return { state, edits };
+        case "stick":
+            addStick(state, path, edits, random);
+            return { state, edits };
+        case "balanced":
+            addBalanced(state, path, edits, random);
+            return { state, edits };
+        default:
+            fail(`Unexpected treeType ${treeType}`);
+    }
+}
+
+function selectRandomPath(state: TreeNodePaths, random: IRandom): string {
+    const paths = Array.from(state.keys());
+    const path = random.pick(paths);
+    return path;
+}
+
+function addLeaf(
+    state: TreeNodePaths,
+    path: string,
+    field: string,
+    edits: TreeEdit[],
+    random: IRandom,
+) {
+    const pathInfo = state.get(path);
+    const fieldData = pathInfo?.get(field);
+    const indices = fieldData !== undefined ? Array.from(fieldData.keys()) : [];
+    const index = getMaxIndex(indices);
+    const value = random.integer(0, Number.MAX_SAFE_INTEGER);
+    const nodeValue: NodeValues = new Map<number, number>();
+    nodeValue.set(index, value);
+    if (pathInfo === undefined) {
+        const newPathInfo: PathInfo = new Map<string, NodeValues>();
+        newPathInfo.set(field, nodeValue);
+        state.set(path, newPathInfo);
+    } else {
+        pathInfo.set(field, nodeValue);
+        state.set(path, pathInfo);
+    }
+    const edit = {
+        editType: "insert",
+        path,
+        index,
+        value,
+        field,
+    };
+    edits.push(edit);
+}
+
+function addStick(state: TreeNodePaths, path: string, edits: TreeEdit[], random: IRandom) {
+    const parentPath = parseParentPath(JSON.parse(path));
+    const pathInfo = state.get(path);
+    const availableFields = pathInfo !== undefined ? Array.from(pathInfo.keys()) : [];
+    const parentField = random.pick(availableFields);
+    const availableIndices = getCurrentIndices(state, path, parentField);
+    const index = random.pick(availableIndices);
+    const newPath = {
+        parent: parentPath,
+        parentField,
+        parentIndex: index,
+    };
+    const newPathKey = JSON.stringify(newPath);
+    const nodeField = random.pick(Array.from(fieldsPool.keys()));
+    if (state.has(newPathKey)) {
+        addLeaf(state, newPathKey, nodeField, edits, random);
+    } else {
+        const value = random.integer(0, Number.MAX_SAFE_INTEGER);
+        const newPathInfo: PathInfo = new Map<string, NodeValues>();
+        const newNodeValues: NodeValues = new Map<number, number>();
+        newNodeValues.set(0, value);
+        newPathInfo.set(nodeField, newNodeValues);
+        state.set(newPathKey, newPathInfo);
+        const edit = {
+            editType: "insert",
+            path: newPathKey,
+            index,
+            value,
+            field: nodeField,
+        };
+        edits.push(edit);
+    }
+}
+
+function addBalanced(state: TreeNodePaths, path: string, edits: TreeEdit[], random: IRandom): any {
+    addStick(state, path, edits, random);
+    addStick(state, path, edits, random);
+}
+
+function parseParentPath(path: any): any {
+    const parsedPath = {
+        parent: path.parent,
+        parentField: path.parentField,
+        parentIndex: path.parentIndex,
+    };
+    return parsedPath;
+}
+
+function getMaxIndex(indices: number[]): number {
+    if (indices.length === 0) {
+        return 0;
+    }
+    return Math.max(...indices) + 1;
+}
+
+function getCurrentIndices(state: TreeNodePaths, path: string, field: string) {
+    const nodeInfo = state.get(path)?.get(field);
+    const indices = nodeInfo !== undefined ? Array.from(nodeInfo.keys()) : [];
+    return indices;
+}
+
+const globalFieldKey: GlobalFieldKey = brand("globalFieldKey");
+const rootFieldSchema = fieldSchema(FieldKinds.value);
+const globalFieldSchema = fieldSchema(FieldKinds.value);
+const rootNodeSchema = namedTreeSchema({
+    name: brand("TestValue"),
+    localFields: {
+        optionalChild: fieldSchema(FieldKinds.optional, [brand("TestValue")]),
+    },
+    extraLocalFields: fieldSchema(FieldKinds.sequence),
+    globalFields: [globalFieldKey],
+});
+const testSchema: SchemaData = {
+    treeSchema: new Map([[rootNodeSchema.name, rootNodeSchema]]),
+    globalFieldSchema: new Map([
+        [rootFieldKey, rootFieldSchema],
+        [globalFieldKey, globalFieldSchema],
+    ]),
+};
+
+const convertToUpPath = (obj: { [x: string]: any }) => {
+    Object.keys(obj).forEach((key) => {
+        console.log(`key: ${key}, value: ${obj[key]}`);
+        if (key === "parentField") {
+            obj[key] = fieldsPool.get(obj[key]);
+        } else if (key === "parent" && obj[key] === "undefined") {
+            obj[key] = undefined;
+        }
+
+        if (typeof obj[key] === "object" && obj[key] !== null) {
+            convertToUpPath(obj[key]);
+        }
+    });
+    return obj;
+};
+
+export function applyTreeEdits(tree: ISharedTree, edits: TreeEdit[]): void {
+    initializeTestTreeWithValue(tree, 42);
+    for (const edit of edits) {
+        const editPath = convertToUpPath(JSON.parse(edit.path));
+        const path: UpPath = {
+            parent: editPath.parent,
+            parentField: editPath.parentField,
+            parentIndex: editPath.parentIndex,
+        };
+        const index = edit.index;
+        const value = edit.value;
+        const editField = fieldsPool.get(edit.field);
+
+        tree.runTransaction((forest, editor) => {
+            const writeCursor = singleTextCursor({ type: brand("TestValue"), value });
+            const field = editor.sequenceField(path, editField as FieldKey);
+            field.insert(index, writeCursor);
+            return TransactionResult.Apply;
+        });
+    }
+}
+
+/**
+ * Updates the given `tree` to the given `schema` and inserts `state` as its root.
+ */
+function initializeTestTree(
+    tree: ISharedTree,
+    state: JsonableTree,
+    schema: SchemaData = testSchema,
+): void {
+    tree.storedSchema.update(schema);
+
+    // Apply an edit to the tree which inserts a node with a value
+    tree.runTransaction((forest, editor) => {
+        const writeCursor = singleTextCursor(state);
+        const field = editor.sequenceField(undefined, rootFieldKeySymbol);
+        field.insert(0, writeCursor);
+
+        return TransactionResult.Apply;
+    });
+}
+
+/**
+ * Inserts a single node under the root of the tree with the given value.
+ * Use {@link getTestValue} to read the value.
+ */
+function initializeTestTreeWithValue(tree: ISharedTree, value: TreeValue): void {
+    initializeTestTree(tree, { type: brand("TestValue"), value });
+}

--- a/packages/dds/tree/src/test/shared-tree/treeGenerator.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeGenerator.ts
@@ -2,14 +2,15 @@ import { strict as assert } from "assert";
 import { IRandom } from "@fluid-internal/stochastic-test-utils";
 import { moveToDetachedField } from "../../forest";
 import { ISharedTree } from "../../shared-tree";
-import { FieldKey, UpPath } from "../../tree";
+import { CursorLocationType, FieldKey, mapCursorField, UpPath } from "../../tree";
 import { brand, fail } from "../../util";
+import { jsonableTreeFromCursor } from "../../feature-libraries";
 
 export interface NodeLocation {
     path: UpPath | undefined;
     nodeField: FieldKey | undefined;
     nodeIndex: number | undefined;
-    isNewPath: boolean;
+    onlyRootNode: boolean;
 }
 
 export function getRandomNodePosition(tree: ISharedTree, random: IRandom, existingPath = false): NodeLocation {
@@ -20,63 +21,86 @@ export function getRandomNodePosition(tree: ISharedTree, random: IRandom, existi
     const cursor = tree.forest.allocateCursor();
     moveToDetachedField(tree.forest, cursor);
     const firstNode = cursor.firstNode();
-    cursor.firstField();
-    const firstField = cursor.getFieldKey();
-    const firstFieldNodes = cursor.getFieldLength();
+    assert(firstNode, "tree must contain at least one node");
+    const firstPath = cursor.getPath();
+    let path: UpPath | undefined = cursor.getPath();
+    let fieldNodes: number = 0;
+    let nodeField: FieldKey | undefined;
+    let nodeIndex: number | undefined;
 
-    assert(firstNode !== undefined, "tree must contain at least one node");
-    assert(firstField !== undefined);
-    assert(firstFieldNodes > 0);
-
-    let fieldNodes: number = firstFieldNodes;
-    let path: UpPath | undefined;
-    let nodeField: FieldKey = firstField;
-    let nodeIndex: number = fieldNodes;
-    let isNewPath: boolean = false;
-
-    let currentMove = "enterNode";
+    let currentMove = "firstField";
     const testerKey: FieldKey = brand("Test");
+    assert(cursor.mode === CursorLocationType.Nodes)
 
     while (currentMove !== "stop") {
         switch (currentMove) {
             case "enterNode":
                 if (fieldNodes > 0) {
                     nodeIndex = random.integer(0, fieldNodes - 1);
+                    // assert(cursor.mode === CursorLocationType.Fields, "must be in fields mode");
                     cursor.enterNode(nodeIndex);
                     path = cursor.getPath();
-                    nodeField = cursor.getFieldKey();
+                    // nodeField = cursor.getFieldKey();
+                    if (typeof(nodeField) === 'object') {
+                        const readCursor = tree.forest.allocateCursor();
+                        moveToDetachedField(tree.forest, readCursor);
+                        const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
+                        readCursor.free();
+                    }
                     currentMove = random.pick(moves.nodes);
                     if (currentMove === "stop") {
-                        cursor.enterField(nodeField);
-                        nodeIndex = cursor.getFieldLength();
+                        if (cursor.firstField()) {
+                            // assert(cursor.mode === CursorLocationType.Fields, "must be in fields mode");
+                            fieldNodes = cursor.getFieldLength();
+                            nodeField = cursor.getFieldKey();
+                            nodeIndex = fieldNodes !== 0 ? random.integer(0, fieldNodes - 1) : 0;
+                            cursor.free();
+                            return { path, nodeField, nodeIndex, onlyRootNode: firstPath === path };
+                        } else {
+                            if (!existingPath) {
+                                nodeField = testerKey;
+                                nodeIndex = 0;
+                            }
+                        }
+                        break;
                     }
                 } else {
+                    // This means no
+                    cursor.free()
+                    return { path:undefined, nodeField:undefined, nodeIndex:undefined, onlyRootNode: firstPath === path}
                     currentMove = random.pick(moves.nodes);
                 }
                 break;
             case "firstField":
-                if (cursor.firstField()) {
-                    currentMove = random.pick(moves.field);
-                    fieldNodes = cursor.getFieldLength();
-                } else {
-                    currentMove = "stop";
-                    if (!existingPath) {
-                        nodeField = testerKey;
-                        nodeIndex = 0;
-                        isNewPath = true;
+                try {
+                    if (cursor.firstField()) {
+                        currentMove = random.pick(moves.field);
+                        fieldNodes = cursor.getFieldLength();
+                        nodeField = cursor.getFieldKey();
+                    } else {
+                        currentMove = "stop";
+                        if (!existingPath) {
+                            nodeField = testerKey;
+                            nodeIndex = 0;
+                        }
                     }
+                    break;
+                } catch (error) {
+                    cursor.free();
+                    return { path, nodeField, nodeIndex, onlyRootNode: firstPath === path };
                 }
-                break;
+
             case "nextField":
                 if (cursor.nextField()) {
                     currentMove = random.pick(moves.field);
+                    // assert(cursor.mode === CursorLocationType.Fields, "must be in fields mode");
                     fieldNodes = cursor.getFieldLength();
+                    nodeField = cursor.getFieldKey();
                 } else {
                     currentMove = "stop";
                     if (!existingPath) {
                         nodeField = testerKey;
                         nodeIndex = 0;
-                        isNewPath = true;
                     }
                 }
                 break;
@@ -85,5 +109,5 @@ export function getRandomNodePosition(tree: ISharedTree, random: IRandom, existi
         }
     }
     cursor.free();
-    return { path, nodeField, nodeIndex, isNewPath };
+    return { path, nodeField, nodeIndex, onlyRootNode: firstPath === path};
 }

--- a/packages/dds/tree/src/test/shared-tree/treeGenerator.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeGenerator.ts
@@ -4,72 +4,72 @@ import { ISharedTree } from "../../shared-tree";
 import { FieldKey, UpPath } from "../../tree";
 import { brand, fail } from "../../util";
 
-interface NodeLocation {
-    path: UpPath | undefined,
-    nodeField: FieldKey | undefined,
-    nodeIndex: number | undefined,
-    newPath: boolean,
+export interface NodeLocation {
+    path: UpPath | undefined;
+    nodeField: FieldKey | undefined;
+    nodeIndex: number | undefined;
+    isNewPath: boolean;
 }
 
-function getRandomNodePosition(tree:ISharedTree, random:IRandom): NodeLocation{
+export function getRandomNodePosition(tree: ISharedTree, random: IRandom): NodeLocation {
     const moves = {
-        "field": ["enterNode", "nextField"],
-        "nodes": ["stop", "firstField"]
-    }
+        field: ["enterNode", "nextField"],
+        nodes: ["stop", "firstField"],
+    };
     const cursor = tree.forest.allocateCursor();
-    moveToDetachedField(tree.forest, cursor)
+    moveToDetachedField(tree.forest, cursor);
 
-    let currentMove = "enterNode"
+    let currentMove = "enterNode";
     let path: UpPath | undefined;
     let nodeField: FieldKey | undefined;
     let nodeIndex: number | undefined;
     let fieldNodes: number = cursor.getFieldLength();
-    let newPath: boolean = false;
+    let isNewPath: boolean = false;
     const testerKey: FieldKey = brand("Test");
 
-    while (currentMove !== 'stop') {
+    while (currentMove !== "stop") {
         switch (currentMove) {
             case "enterNode":
                 if (fieldNodes > 0) {
-                    nodeIndex = random.integer(0, fieldNodes-1)
-                    cursor.enterNode(nodeIndex)
-                    path = cursor.getPath()
-                    nodeField = cursor.getFieldKey()
-                    currentMove = random.pick(moves.nodes)
-                    if (currentMove === 'stop'){
-                        cursor.enterField(nodeField)
-                        nodeIndex = cursor.getFieldLength()
+                    nodeIndex = random.integer(0, fieldNodes - 1);
+                    cursor.enterNode(nodeIndex);
+                    path = cursor.getPath();
+                    nodeField = cursor.getFieldKey();
+                    currentMove = random.pick(moves.nodes);
+                    if (currentMove === "stop") {
+                        cursor.enterField(nodeField);
+                        nodeIndex = cursor.getFieldLength();
                     }
                 } else {
-                    currentMove = random.pick(moves.nodes)
+                    currentMove = random.pick(moves.nodes);
                 }
-                break
+                break;
             case "firstField":
                 if (cursor.firstField()) {
-                    currentMove = random.pick(moves.field)
-                    fieldNodes = cursor.getFieldLength()
+                    currentMove = random.pick(moves.field);
+                    fieldNodes = cursor.getFieldLength();
                 } else {
-                    currentMove = 'stop';
-                    nodeField = testerKey
-                    nodeIndex = 0
-                    newPath = true;
+                    currentMove = "stop";
+                    nodeField = testerKey;
+                    nodeIndex = 0;
+                    isNewPath = true;
                 }
-                break
+                break;
             case "nextField":
                 if (cursor.nextField()) {
-                    currentMove = random.pick(moves.field)
-                    fieldNodes = cursor.getFieldLength()
+                    currentMove = random.pick(moves.field);
+                    fieldNodes = cursor.getFieldLength();
                 } else {
-                    currentMove = 'stop';
-                    nodeField = testerKey
-                    nodeIndex = 0
-                    newPath = true;
+                    currentMove = "stop";
+                    nodeField = testerKey;
+                    nodeIndex = 0;
+                    isNewPath = true;
                 }
-                break
+                break;
             default:
                 fail(`Unexpected move ${currentMove}`);
         }
     }
-    cursor.free()
-    return { path, nodeField, nodeIndex, newPath}
+    cursor.free();
+    return { path, nodeField, nodeIndex, isNewPath };
 }

--- a/packages/dds/tree/src/test/shared-tree/treeGenerator.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeGenerator.ts
@@ -1,274 +1,75 @@
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
-
-import { IRandom, makeRandom } from "@fluid-internal/stochastic-test-utils";
-import { TransactionResult } from "../../checkout";
-import { FieldKinds, namedTreeSchema, singleTextCursor } from "../../feature-libraries";
-import { fieldSchema, GlobalFieldKey, SchemaData } from "../../schema-stored";
+import { IRandom } from "@fluid-internal/stochastic-test-utils";
+import { moveToDetachedField } from "../../forest";
 import { ISharedTree } from "../../shared-tree";
-import {
-    FieldKey,
-    JsonableTree,
-    rootFieldKey,
-    rootFieldKeySymbol,
-    TreeValue,
-    UpPath,
-} from "../../tree";
+import { FieldKey, UpPath } from "../../tree";
 import { brand, fail } from "../../util";
 
-export type TreeNodePaths = Map<string, PathInfo>;
-
-export interface TreeEdit {
-    editType: string;
-    path: string;
-    index: number;
-    value: number;
-    field: string;
+interface NodeLocation {
+    path: UpPath | undefined,
+    nodeField: FieldKey | undefined,
+    nodeIndex: number | undefined,
+    newPath: boolean,
 }
 
-export type NodeValues = Map<number, number>;
-
-export type PathInfo = Map<string, NodeValues>;
-
-const rootPath = {
-    parent: "undefined",
-    parentField: "rootFieldKeySymbol",
-    parentIndex: 0,
-};
-
-const fooKey: FieldKey = brand("foo");
-const fooKey2: FieldKey = brand("foo2");
-
-type FieldKeyTypes = GlobalFieldKey | FieldKey;
-const fieldsPool = new Map<string, FieldKeyTypes>();
-fieldsPool.set("rootFieldKeySymbol", rootFieldKeySymbol);
-fieldsPool.set("fooKey", fooKey);
-fieldsPool.set("fooKey2", fooKey2);
-
-const rootValue = makeRandom(0).integer(Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
-const initialPaths: TreeNodePaths = new Map<string, PathInfo>();
-const rootPathInfo: PathInfo = new Map<string, NodeValues>();
-const rootNodeValues: NodeValues = new Map<number, number>();
-rootNodeValues.set(0, rootValue);
-rootPathInfo.set("rootFieldKeySymbol", rootNodeValues);
-initialPaths.set(JSON.stringify(rootPath), rootPathInfo);
-
-const initialEdits: TreeEdit[] = [];
-const rootEdit: TreeEdit = {
-    editType: "insert",
-    path: JSON.stringify(rootPath),
-    index: 0,
-    value: rootValue,
-    field: "rootFieldKeySymbol",
-};
-initialEdits.push(rootEdit);
-
-export function treeGenerator(
-    state: TreeNodePaths = initialPaths,
-    edits: TreeEdit[] = initialEdits,
-    seed: number,
-): any {
-    const random = makeRandom(seed);
-    const treeType = random.pick(["leaf", "stick", "balanced"]);
-    const path = selectRandomPath(state, random);
-    const field = random.pick(Array.from(fieldsPool.keys()));
-    switch (treeType) {
-        case "leaf":
-            addLeaf(state, path, field, edits, random);
-            return { state, edits };
-        case "stick":
-            addStick(state, path, edits, random);
-            return { state, edits };
-        case "balanced":
-            addBalanced(state, path, edits, random);
-            return { state, edits };
-        default:
-            fail(`Unexpected treeType ${treeType}`);
+function getRandomNodePosition(tree:ISharedTree, random:IRandom): NodeLocation{
+    const moves = {
+        "field": ["enterNode", "nextField"],
+        "nodes": ["stop", "firstField"]
     }
-}
+    const cursor = tree.forest.allocateCursor();
+    moveToDetachedField(tree.forest, cursor)
 
-function selectRandomPath(state: TreeNodePaths, random: IRandom): string {
-    const paths = Array.from(state.keys());
-    const path = random.pick(paths);
-    return path;
-}
+    let currentMove = "enterNode"
+    let path: UpPath | undefined;
+    let nodeField: FieldKey | undefined;
+    let nodeIndex: number | undefined;
+    let fieldNodes: number = cursor.getFieldLength();
+    let newPath: boolean = false;
+    const testerKey: FieldKey = brand("Test");
 
-function addLeaf(
-    state: TreeNodePaths,
-    path: string,
-    field: string,
-    edits: TreeEdit[],
-    random: IRandom,
-) {
-    const pathInfo = state.get(path);
-    const fieldData = pathInfo?.get(field);
-    const indices = fieldData !== undefined ? Array.from(fieldData.keys()) : [];
-    const index = getMaxIndex(indices);
-    const value = random.integer(0, Number.MAX_SAFE_INTEGER);
-    const nodeValue: NodeValues = new Map<number, number>();
-    nodeValue.set(index, value);
-    if (pathInfo === undefined) {
-        const newPathInfo: PathInfo = new Map<string, NodeValues>();
-        newPathInfo.set(field, nodeValue);
-        state.set(path, newPathInfo);
-    } else {
-        pathInfo.set(field, nodeValue);
-        state.set(path, pathInfo);
-    }
-    const edit = {
-        editType: "insert",
-        path,
-        index,
-        value,
-        field,
-    };
-    edits.push(edit);
-}
-
-function addStick(state: TreeNodePaths, path: string, edits: TreeEdit[], random: IRandom) {
-    const parentPath = parseParentPath(JSON.parse(path));
-    const pathInfo = state.get(path);
-    const availableFields = pathInfo !== undefined ? Array.from(pathInfo.keys()) : [];
-    const parentField = random.pick(availableFields);
-    const availableIndices = getCurrentIndices(state, path, parentField);
-    const index = random.pick(availableIndices);
-    const newPath = {
-        parent: parentPath,
-        parentField,
-        parentIndex: index,
-    };
-    const newPathKey = JSON.stringify(newPath);
-    const nodeField = random.pick(Array.from(fieldsPool.keys()));
-    if (state.has(newPathKey)) {
-        addLeaf(state, newPathKey, nodeField, edits, random);
-    } else {
-        const value = random.integer(0, Number.MAX_SAFE_INTEGER);
-        const newPathInfo: PathInfo = new Map<string, NodeValues>();
-        const newNodeValues: NodeValues = new Map<number, number>();
-        newNodeValues.set(0, value);
-        newPathInfo.set(nodeField, newNodeValues);
-        state.set(newPathKey, newPathInfo);
-        const edit = {
-            editType: "insert",
-            path: newPathKey,
-            index,
-            value,
-            field: nodeField,
-        };
-        edits.push(edit);
-    }
-}
-
-function addBalanced(state: TreeNodePaths, path: string, edits: TreeEdit[], random: IRandom): any {
-    addStick(state, path, edits, random);
-    addStick(state, path, edits, random);
-}
-
-function parseParentPath(path: any): any {
-    const parsedPath = {
-        parent: path.parent,
-        parentField: path.parentField,
-        parentIndex: path.parentIndex,
-    };
-    return parsedPath;
-}
-
-function getMaxIndex(indices: number[]): number {
-    if (indices.length === 0) {
-        return 0;
-    }
-    return Math.max(...indices) + 1;
-}
-
-function getCurrentIndices(state: TreeNodePaths, path: string, field: string) {
-    const nodeInfo = state.get(path)?.get(field);
-    const indices = nodeInfo !== undefined ? Array.from(nodeInfo.keys()) : [];
-    return indices;
-}
-
-const globalFieldKey: GlobalFieldKey = brand("globalFieldKey");
-const rootFieldSchema = fieldSchema(FieldKinds.value);
-const globalFieldSchema = fieldSchema(FieldKinds.value);
-const rootNodeSchema = namedTreeSchema({
-    name: brand("TestValue"),
-    localFields: {
-        optionalChild: fieldSchema(FieldKinds.optional, [brand("TestValue")]),
-    },
-    extraLocalFields: fieldSchema(FieldKinds.sequence),
-    globalFields: [globalFieldKey],
-});
-const testSchema: SchemaData = {
-    treeSchema: new Map([[rootNodeSchema.name, rootNodeSchema]]),
-    globalFieldSchema: new Map([
-        [rootFieldKey, rootFieldSchema],
-        [globalFieldKey, globalFieldSchema],
-    ]),
-};
-
-const convertToUpPath = (obj: { [x: string]: any }) => {
-    Object.keys(obj).forEach((key) => {
-        console.log(`key: ${key}, value: ${obj[key]}`);
-        if (key === "parentField") {
-            obj[key] = fieldsPool.get(obj[key]);
-        } else if (key === "parent" && obj[key] === "undefined") {
-            obj[key] = undefined;
+    while (currentMove !== 'stop') {
+        switch (currentMove) {
+            case "enterNode":
+                if (fieldNodes > 0) {
+                    nodeIndex = random.integer(0, fieldNodes-1)
+                    cursor.enterNode(nodeIndex)
+                    path = cursor.getPath()
+                    nodeField = cursor.getFieldKey()
+                    currentMove = random.pick(moves.nodes)
+                    if (currentMove === 'stop'){
+                        cursor.enterField(nodeField)
+                        nodeIndex = cursor.getFieldLength()
+                    }
+                } else {
+                    currentMove = random.pick(moves.nodes)
+                }
+                break
+            case "firstField":
+                if (cursor.firstField()) {
+                    currentMove = random.pick(moves.field)
+                    fieldNodes = cursor.getFieldLength()
+                } else {
+                    currentMove = 'stop';
+                    nodeField = testerKey
+                    nodeIndex = 0
+                    newPath = true;
+                }
+                break
+            case "nextField":
+                if (cursor.nextField()) {
+                    currentMove = random.pick(moves.field)
+                    fieldNodes = cursor.getFieldLength()
+                } else {
+                    currentMove = 'stop';
+                    nodeField = testerKey
+                    nodeIndex = 0
+                    newPath = true;
+                }
+                break
+            default:
+                fail(`Unexpected move ${currentMove}`);
         }
-
-        if (typeof obj[key] === "object" && obj[key] !== null) {
-            convertToUpPath(obj[key]);
-        }
-    });
-    return obj;
-};
-
-export function applyTreeEdits(tree: ISharedTree, edits: TreeEdit[]): void {
-    initializeTestTreeWithValue(tree, 42);
-    for (const edit of edits) {
-        const editPath = convertToUpPath(JSON.parse(edit.path));
-        const path: UpPath = {
-            parent: editPath.parent,
-            parentField: editPath.parentField,
-            parentIndex: editPath.parentIndex,
-        };
-        const index = edit.index;
-        const value = edit.value;
-        const editField = fieldsPool.get(edit.field);
-
-        tree.runTransaction((forest, editor) => {
-            const writeCursor = singleTextCursor({ type: brand("TestValue"), value });
-            const field = editor.sequenceField(path, editField as FieldKey);
-            field.insert(index, writeCursor);
-            return TransactionResult.Apply;
-        });
     }
-}
-
-/**
- * Updates the given `tree` to the given `schema` and inserts `state` as its root.
- */
-function initializeTestTree(
-    tree: ISharedTree,
-    state: JsonableTree,
-    schema: SchemaData = testSchema,
-): void {
-    tree.storedSchema.update(schema);
-
-    // Apply an edit to the tree which inserts a node with a value
-    tree.runTransaction((forest, editor) => {
-        const writeCursor = singleTextCursor(state);
-        const field = editor.sequenceField(undefined, rootFieldKeySymbol);
-        field.insert(0, writeCursor);
-
-        return TransactionResult.Apply;
-    });
-}
-
-/**
- * Inserts a single node under the root of the tree with the given value.
- * Use {@link getTestValue} to read the value.
- */
-function initializeTestTreeWithValue(tree: ISharedTree, value: TreeValue): void {
-    initializeTestTree(tree, { type: brand("TestValue"), value });
+    cursor.free()
+    return { path, nodeField, nodeIndex, newPath}
 }


### PR DESCRIPTION
## Description

This PR adds a random tree generator, which will be used as the starting state for our upcoming fuzz testing suite.

The method `treeGenerator()` returns a `state` , which represents the state of the tree using a Map of the node paths, fields, indices and values. Also returns `edits` which are a list of randomly generated edits that can be applied to the tree to get it's initial state. For now, the `applyTreeEdits()` function can be used to make sure these inserts can be applied to the tree, but this will eventually be replaced with a `reducer` function that will be used for the upcoming fuzz testing suite.
