### PR TITLE
odsp-driver: fix bug resource_name.localeCompare is not a function

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -370,7 +370,7 @@ async function fetchLatestSnapshotCore(
                 // Usually the latest fetch call is to the end of resources, so we start from the end.
                 for (let i = resources1.length - 1; i > 0; i--) {
                     const indResTime = resources1[i] as PerformanceResourceTiming;
-                    const resource_name = indResTime.name;
+                    const resource_name = indResTime.name.toString();
                     const resource_initiatortype = indResTime.initiatorType;
                     if ((resource_initiatortype.localeCompare("fetch") === 0)
                         && (resource_name.localeCompare(response.requestUrl) === 0)) {


### PR DESCRIPTION
resource_name is an url here, so fetch call fails "resource_name.localeCompare is not a function" error. Fixing with adding toString()
https://github.com/nodejs/undici/blob/671e05fb90d4e047a3b219d802a8afeeb35ad883/lib/fetch/index.js#L322