### PR TITLE
remove maxBatchWaitTime event

### DIFF
--- a/packages/runtime/container-runtime/src/scheduleManager.ts
+++ b/packages/runtime/container-runtime/src/scheduleManager.ts
@@ -16,7 +16,6 @@ import {
 } from "@fluidframework/container-utils";
 import { DeltaScheduler } from "./deltaScheduler";
 import { pkgVersion } from "./packageVersion";
-import { latencyThreshold } from "./connectionTelemetry";
 
 type IRuntimeMessageMetadata = undefined | {
     batch?: boolean;

--- a/packages/runtime/container-runtime/src/scheduleManager.ts
+++ b/packages/runtime/container-runtime/src/scheduleManager.ts
@@ -212,16 +212,6 @@ class ScheduleManagerCore {
 
         this.localPaused = false;
 
-        // Random round number - we want to know when batch waiting paused op processing.
-        if (duration !== undefined && duration > latencyThreshold) {
-            this.logger.sendErrorEvent({
-                eventName: "MaxBatchWaitTimeExceeded",
-                duration,
-                sequenceNumber: endBatch,
-                length: endBatch - startBatch,
-            });
-        }
-
         this.deltaManager.inbound.resume();
     }
 


### PR DESCRIPTION


## Description

remove the error event as it produced noise in stress tests and prod, we already have opRoundTripTime for tracking latency.