### PR TITLE
Tree: Interleaving tests

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -47,7 +47,7 @@ describe("Editing", () => {
             expectJsonTree([tree1, tree2], ["w", "x"]);
         });
 
-        it("does not interleave concurrent left to right inserts", () => {
+        it("merge-left tie-breaking does not interleave concurrent left to right inserts", () => {
             const sequencer = new Sequencer();
             const tree1 = TestTree.fromJson([]);
             const tree2 = tree1.fork();
@@ -79,8 +79,11 @@ describe("Editing", () => {
         });
 
         // The current implementation orders the letters from inserted last to inserted first.
-        // TODO: address this scenario.
-        it.skip("does not interleave concurrent right to left inserts", () => {
+        // This is due to the hard-coded merge-left policy.
+        // Having merge-right tie-breaking does preserve groupings but in a first-to-last order
+        // which is the desired outcome for RTL text.
+        // TODO: update and activate this test once merge-right is supported.
+        it("merge-right tie-breaking does not interleave concurrent right to left inserts", () => {
             const sequencer = new Sequencer();
             const tree1 = TestTree.fromJson([]);
             const tree2 = tree1.fork();

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -47,6 +47,29 @@ describe("Editing", () => {
             expectJsonTree([tree1, tree2], ["w", "x"]);
         });
 
+        it("inserts that concurrently target the same insertion point do not interleave their contents", () => {
+            const sequencer = new Sequencer();
+            const tree1 = TestTree.fromJson([]);
+            const tree2 = tree1.fork();
+            const tree3 = tree1.fork();
+            const tree4 = tree1.fork();
+
+            const abc = insert(tree1, 0, "a", "b", "c");
+            const rst = insert(tree2, 0, "r", "s", "t");
+            const xyz = insert(tree3, 0, "x", "y", "z");
+
+            const sequenced = sequencer.sequence([xyz, rst, abc]);
+            tree1.receive(sequenced);
+            tree2.receive(sequenced);
+            tree3.receive(sequenced);
+            tree4.receive(sequenced);
+
+            expectJsonTree(
+                [tree1, tree2, tree3, tree4],
+                ["a", "b", "c", "r", "s", "t", "x", "y", "z"],
+            );
+        });
+
         it("merge-left tie-breaking does not interleave concurrent left to right inserts", () => {
             const sequencer = new Sequencer();
             const tree1 = TestTree.fromJson([]);
@@ -83,7 +106,7 @@ describe("Editing", () => {
         // Having merge-right tie-breaking does preserve groupings but in a first-to-last order
         // which is the desired outcome for RTL text.
         // TODO: update and activate this test once merge-right is supported.
-        it("merge-right tie-breaking does not interleave concurrent right to left inserts", () => {
+        it.skip("merge-right tie-breaking does not interleave concurrent right to left inserts", () => {
             const sequencer = new Sequencer();
             const tree1 = TestTree.fromJson([]);
             const tree2 = tree1.fork();


### PR DESCRIPTION
This PR adds an interleaving test and adds comments to document the reason one of the interleaving tests is failing.