### PR TITLE
Fix json syntax in ConfigMap

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -135,7 +135,7 @@ data:
             "checkpointTimeIntervalMsec": 1000
         },
         "scribe": {
-            "kafkaClientId": "{{ template "scribe.fullname" . }}"
+            "kafkaClientId": "{{ template "scribe.fullname" . }}",
             "checkpointHeuristics": {
                 "enable": {{ .Values.scribe.checkpointHeuristics.enable }},
                 "idleTime": {{ .Values.scribe.checkpointHeuristics.idleTime }},


### PR DESCRIPTION
## Description

Add missing comma to JSON string in ConfigMap. Missed in [this PR](https://github.com/microsoft/FluidFramework/pull/12736).

Noticed it because several pods in our internal r11s deployment for tests were stuck in CrashLoopBackoff.