### PR TITLE
Removed unrefTimestamp from IGarbageCollectionDetailsBase

### DIFF
--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -246,7 +246,6 @@ export interface IGarbageCollectionData {
 // @public
 export interface IGarbageCollectionDetailsBase {
     gcData?: IGarbageCollectionData;
-    unrefTimestamp?: number;
     usedRoutes?: string[];
 }
 
@@ -262,6 +261,13 @@ export interface IGarbageCollectionState {
     gcNodes: {
         [id: string]: IGarbageCollectionNodeData;
     };
+}
+
+// @public @deprecated (undocumented)
+export interface IGarbageCollectionSummaryDetailsLegacy {
+    gcData?: IGarbageCollectionData;
+    unrefTimestamp?: number;
+    usedRoutes?: string[];
 }
 
 // @public

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -15,6 +15,7 @@ import {
     IGarbageCollectionNodeData,
     IGarbageCollectionState,
     IGarbageCollectionDetailsBase,
+    IGarbageCollectionSummaryDetailsLegacy,
     ISummarizeResult,
 } from "@fluidframework/runtime-definitions";
 import {
@@ -771,7 +772,7 @@ describe("Garbage Collection Tests", () => {
             it("generates events for nodes that time out on load - old snapshot format", async () => {
                 // Create GC details for node 3's GC blob whose unreferenced time was > timeout ms ago.
                 // This means this node should time out as soon as its data is loaded.
-                const node3GCDetails: IGarbageCollectionDetailsBase = {
+                const node3GCDetails: IGarbageCollectionSummaryDetailsLegacy = {
                     gcData: { gcNodes: { "/": [] } },
                     unrefTimestamp: Date.now() - (timeout + 100),
                 };

--- a/packages/runtime/runtime-definitions/src/garbageCollection.ts
+++ b/packages/runtime/runtime-definitions/src/garbageCollection.ts
@@ -29,8 +29,4 @@ export interface IGarbageCollectionDetailsBase {
      * The GC data of this node.
      */
     gcData?: IGarbageCollectionData;
-    /**
-     * If this node is unreferenced, the time when it was marked as such.
-     */
-    unrefTimestamp?: number;
 }

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -34,6 +34,7 @@ export {
 	CreateSummarizerNodeSource,
 	IGarbageCollectionNodeData,
 	IGarbageCollectionState,
+    IGarbageCollectionSummaryDetailsLegacy,
 	ISummarizeInternalResult,
 	ISummarizeResult,
 	ISummarizerNode,

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -98,6 +98,19 @@ export interface IGarbageCollectionState {
     gcNodes: { [ id: string ]: IGarbageCollectionNodeData; };
 }
 
+/**
+ * @deprecated - IGarbageCollectionState is written in the root of the summary now.
+ * Legacy GC details from when the GC details were written at the data store's summary tree.
+ */
+export interface IGarbageCollectionSummaryDetailsLegacy {
+    /** A list of routes to Fluid objects that are used in this node. */
+    usedRoutes?: string[];
+    /** The GC data of this node. */
+    gcData?: IGarbageCollectionData;
+    /** If this node is unreferenced, the time when it was marked as such. */
+    unrefTimestamp?: number;
+}
+
 export type SummarizeInternalFn = (
     fullTree: boolean,
     trackState: boolean,


### PR DESCRIPTION
`unrefTimestamp` is not needed in `IGarbageCollectionDetailsBase` since data stores do not write GC data to summary. However, older documents may still have the GC data in this format in data store's summary tree. So, moved the existing `IGarbageCollectionDetailsBase` interface to a deprecated legacy interface that is only used when reading older summaries.