### PR TITLE
Log when mismatched `referenceSequenceNumber` messages are detected by the batch manager

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1038,7 +1038,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.validateSummaryHeuristicConfiguration(this.summaryConfiguration);
         }
 
-        this.enableOpReentryCheck = runtimeOptions.enableOpReentryCheck === true
+        this.enableOpReentryCheck = (runtimeOptions.enableOpReentryCheck === true
+            // If compression is enabled, we need to disallow op reentry as it is required that
+            // ops within the same batch have the same reference sequence number.
+            || runtimeOptions.compressionOptions.minimumBatchSizeInBytes !== Number.POSITIVE_INFINITY)
             // Allow for a break-glass config to override the options
             && this.mc.config.getBoolean("Fluid.ContainerRuntime.DisableOpReentryCheck") !== true;
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1176,6 +1176,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 maxBatchSizeInBytes: runtimeOptions.maxBatchSizeInBytes,
                 enableOpReentryCheck: this.enableOpReentryCheck,
             },
+            logger: this.mc.logger,
         });
 
         this.context.quorum.on("removeMember", (clientId: string) => {

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert } from "@fluidframework/common-utils";
 import { IContainerContext } from "@fluidframework/container-definitions";
 import { GenericError } from "@fluidframework/container-utils";
@@ -26,6 +27,7 @@ export interface IOutboxParameters {
     readonly containerContext: IContainerContext,
     readonly config: IOutboxConfig,
     readonly compressor: OpCompressor;
+    readonly logger: ITelemetryLogger;
 }
 
 export class Outbox {
@@ -43,11 +45,11 @@ export class Outbox {
             hardLimit,
             softLimit,
             enableOpReentryCheck: params.config.enableOpReentryCheck,
-        });
+        }, params.logger);
         this.mainBatch = new BatchManager({
             hardLimit,
             enableOpReentryCheck: params.config.enableOpReentryCheck,
-        });
+        }, params.logger);
     }
 
     public get isEmpty(): boolean {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
@@ -170,15 +170,23 @@ describe("BatchManager", () => {
         assert.equal(batchManager.contentSizeInBytes, smallMessageSize * batchManager.length);
     });
 
-    it("Don't verify op ordering by default", () => {
+    it("Don't verify op ordering by default, but log at most 5 events when it occurs", () => {
         const batchManager = new BatchManager({ hardLimit }, mockLogger);
         assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 0 }), true);
         assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 0 }), true);
+
+        assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 1 }), true);
+        assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 1 }), true);
+        assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 2 }), true);
         assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 1 }), true);
         assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 1 }), true);
         assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 2 }), true);
 
         mockLogger.assertMatchStrict([{
+            eventName: "BatchManager:Submission of an out of order message",
+        }, {
+            eventName: "BatchManager:Submission of an out of order message",
+        }, {
             eventName: "BatchManager:Submission of an out of order message",
         }, {
             eventName: "BatchManager:Submission of an out of order message",

--- a/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
@@ -4,20 +4,30 @@
  */
 
 import { strict as assert } from "assert";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { BatchManager, BatchMessage } from "../../opLifecycle";
+import { ContainerMessageType } from "../../containerRuntime";
 
 describe("BatchManager", () => {
+    const mockLogger = new MockLogger();
     const softLimit = 1024;
     const hardLimit = 950 * 1024;
     const smallMessageSize = 10;
 
+    beforeEach(() => {
+        mockLogger.clear();
+    });
+
     const generateStringOfSize = (sizeInBytes: number): string => new Array(sizeInBytes + 1).join("0");
 
-    const smallMessage = (): BatchMessage => ({ contents: generateStringOfSize(smallMessageSize) } as any as BatchMessage);
+    const smallMessage = (): BatchMessage => ({
+        contents: generateStringOfSize(smallMessageSize),
+        deserializedContent: { type: ContainerMessageType.FluidDataStoreOp }
+    } as any as BatchMessage);
 
     it("BatchManager's soft limit: a bunch of small messages", () => {
         const message = { contents: generateStringOfSize(softLimit / 2) } as any as BatchMessage;
-        const batchManager = new BatchManager({ hardLimit, softLimit });
+        const batchManager = new BatchManager({ hardLimit, softLimit }, mockLogger);
 
         // Can push one large message
         assert.equal(batchManager.push(message), true);
@@ -46,7 +56,7 @@ describe("BatchManager", () => {
 
     it("BatchManager's soft limit: single large message", () => {
         const message = { contents: generateStringOfSize(softLimit * 2) } as any as BatchMessage;
-        const batchManager = new BatchManager({ hardLimit, softLimit });
+        const batchManager = new BatchManager({ hardLimit, softLimit }, mockLogger);
 
         // Can push one large message, even above soft limit
         assert.equal(batchManager.push(message), true);
@@ -70,7 +80,7 @@ describe("BatchManager", () => {
     });
 
     it("BatchManager: no soft limit", () => {
-        const batchManager = new BatchManager({ hardLimit });
+        const batchManager = new BatchManager({ hardLimit }, mockLogger);
         const third = Math.floor(hardLimit / 3) + 1;
         const message = { contents: generateStringOfSize(third) } as any as BatchMessage;
 
@@ -102,7 +112,7 @@ describe("BatchManager", () => {
     });
 
     it("BatchManager: soft limit is higher than hard limit", () => {
-        const batchManager = new BatchManager({ hardLimit, softLimit: hardLimit * 2 });
+        const batchManager = new BatchManager({ hardLimit, softLimit: hardLimit * 2 }, mockLogger);
         const twoThird = Math.floor(hardLimit * 2 / 3);
         const message = { contents: generateStringOfSize(twoThird) } as any as BatchMessage;
         const largeMessage = { contents: generateStringOfSize(hardLimit + 1) } as any as BatchMessage;
@@ -126,7 +136,7 @@ describe("BatchManager", () => {
 
     it("BatchManager: 'infinity' hard limit allows everything", () => {
         const message = { contents: generateStringOfSize(softLimit) } as any as BatchMessage;
-        const batchManager = new BatchManager({ hardLimit: Infinity });
+        const batchManager = new BatchManager({ hardLimit: Infinity }, mockLogger);
 
         for (let i = 1; i <= 10; i++) {
             assert.equal(batchManager.push(message), true);
@@ -135,7 +145,7 @@ describe("BatchManager", () => {
     });
 
     it("Batch metadata is set correctly", () => {
-        const batchManager = new BatchManager({ hardLimit });
+        const batchManager = new BatchManager({ hardLimit }, mockLogger);
         assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 0 }), true);
         assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 1 }), true);
         assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 2 }), true);
@@ -151,7 +161,7 @@ describe("BatchManager", () => {
     });
 
     it("Batch content size is tracked correctly", () => {
-        const batchManager = new BatchManager({ hardLimit });
+        const batchManager = new BatchManager({ hardLimit }, mockLogger);
         assert.equal(batchManager.push(smallMessage()), true);
         assert.equal(batchManager.contentSizeInBytes, smallMessageSize * batchManager.length);
         assert.equal(batchManager.push(smallMessage()), true);
@@ -161,16 +171,29 @@ describe("BatchManager", () => {
     });
 
     it("Don't verify op ordering by default", () => {
-        const batchManager = new BatchManager({ hardLimit });
+        const batchManager = new BatchManager({ hardLimit }, mockLogger);
         assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 0 }), true);
         assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 0 }), true);
         assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 1 }), true);
+        assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 1 }), true);
+        assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 2 }), true);
+
+        mockLogger.assertMatchStrict([{
+            eventName: "BatchManager:Submission of an out of order message",
+        }, {
+            eventName: "BatchManager:Submission of an out of order message",
+        }, {
+            eventName: "BatchManager:Submission of an out of order message",
+        }]);
     });
 
     it("Verify op ordering if requested", () => {
-        const batchManager = new BatchManager({ enableOpReentryCheck: true, hardLimit });
+        const batchManager = new BatchManager({ enableOpReentryCheck: true, hardLimit }, mockLogger);
         assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 0 }), true);
         assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 0 }), true);
         assert.throws(() => batchManager.push({ ...smallMessage(), referenceSequenceNumber: 1 }));
+        mockLogger.assertMatchNone([{
+            eventName: "BatchManager:Submission of an out of order message",
+        }]);
     });
 });

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -14,6 +14,7 @@ import {
     ContainerRuntimeMessage,
     ICompressionRuntimeOptions,
 } from "../../containerRuntime";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 
 describe("Outbox", () => {
     const maxBatchSizeInBytes = 1024;
@@ -141,7 +142,8 @@ describe("Outbox", () => {
         config: {
             maxBatchSizeInBytes: maxBatchSize,
             compressionOptions,
-        }
+        },
+        logger: new MockLogger(),
     });
 
     beforeEach(() => {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "assert";
 import { IBatchMessage, IContainerContext, IDeltaManager } from "@fluidframework/container-definitions";
 import { IDocumentMessage, ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { PendingStateManager } from "../../pendingStateManager";
 import { BatchMessage, IBatch, OpCompressor, Outbox } from "../../opLifecycle";
 import {
@@ -14,7 +15,6 @@ import {
     ContainerRuntimeMessage,
     ICompressionRuntimeOptions,
 } from "../../containerRuntime";
-import { MockLogger } from "@fluidframework/telemetry-utils";
 
 describe("Outbox", () => {
     const maxBatchSizeInBytes = 1024;

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -7,9 +7,9 @@ import assert from "assert";
 import { ICriticalContainerError } from "@fluidframework/container-definitions";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import { DataProcessingError } from "@fluidframework/container-utils";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { PendingStateManager } from "../pendingStateManager";
 import { BatchManager, BatchMessage } from "../opLifecycle";
-import { MockLogger } from "@fluidframework/telemetry-utils";
 
 describe("Pending State Manager", () => {
     describe("Rollback", () => {

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -9,6 +9,7 @@ import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol
 import { DataProcessingError } from "@fluidframework/container-utils";
 import { PendingStateManager } from "../pendingStateManager";
 import { BatchManager, BatchMessage } from "../opLifecycle";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 
 describe("Pending State Manager", () => {
     describe("Rollback", () => {
@@ -34,7 +35,7 @@ describe("Pending State Manager", () => {
             rollbackContent = [];
             rollbackShouldThrow = false;
 
-            batchManager = new BatchManager({ hardLimit: 950 * 1024 });
+            batchManager = new BatchManager({ hardLimit: 950 * 1024 }, new MockLogger());
         });
 
         it("should do nothing when rolling back empty pending stack", () => {


### PR DESCRIPTION
The feature is disabled, but it would be beneficial to know when/if it happens.

This change (along with the feature gate) will be ported to `main`, as https://github.com/microsoft/FluidFramework/pull/13329 requires it.