### PR TITLE
Fix rollback farm by clearing properties if empty

### DIFF
--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -384,7 +384,7 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
         if (!this.properties) {
             this.properties = createMap<any>();
         }
-        return this.propertyManager.addProperties(
+        const result = this.propertyManager.addProperties(
             this.properties,
             newProps,
             op,
@@ -392,6 +392,10 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
             collabWindow && collabWindow.collaborating,
             rollback,
         );
+        if (Object.entries(this.properties).length === 0) {
+            this.properties = undefined;
+        }
+        return result;
     }
 
     public hasProperty(key: string): boolean {

--- a/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
@@ -7,7 +7,7 @@
 
 import random from "random-js";
 import {
-    // annotateRange,
+    annotateRange,
     applyMessages,
     doOverRange,
     generateOperationMessagesForClients,
@@ -19,12 +19,12 @@ import { createClientsAtInitialState, TestClientLogger } from "./testClientLogge
 
 const allOperations: TestOperation[] = [
     removeRange,
-    // annotateRange, // Bug AB2724: properties in rollback client don't match oracle
+    annotateRange,
     insertAtRefPos,
 ];
 
 const defaultOptions = {
-    minLength: { min: 1, max: 32 },
+    minLength: { min: 1, max: 16 /* 32 */ },
     opsPerRollbackRange: { min: 1, max: 16 /* 32 */ }, // Bug AB1809: fail to insert in rollback client after many ops
     rounds: 10,
     opsPerRound: 10,
@@ -65,7 +65,7 @@ describe("MergeTree.Client", () => {
                     const rollbackMsgs = generateOperationMessagesForClients(
                         mt,
                         seq,
-                        [clients.A, clients.B, clients.C ],
+                        [clients.A, clients.B, clients.C],
                         logger,
                         opsPerRollback,
                         minLength,


### PR DESCRIPTION
## Description

The rollback farm for mergeTree fails with annotateRange because setting and rolling back properties results in empty propertySets which do not compare as equal to undefined propertySets. This fix sets properties on segments back to undefined if they become empty.

I had previously tried to address this in #11264 by changing the matchProperties function to treat undefined and {} as equivalent, but that broke snapshot tests in a way I was uncertain was safe, so I had to revert.

## Breaking Changes

If segment properties become empty through clearing properties, it used to remain empty. Now properties is set to undefined, the same as if properties were never set.