### PR TITLE
Fix rollback farm with empty property comparison

### DIFF
--- a/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
@@ -7,7 +7,7 @@
 
 import random from "random-js";
 import {
-    // annotateRange,
+    annotateRange,
     applyMessages,
     doOverRange,
     generateOperationMessagesForClients,
@@ -19,12 +19,12 @@ import { createClientsAtInitialState, TestClientLogger } from "./testClientLogge
 
 const allOperations: TestOperation[] = [
     removeRange,
-    // annotateRange, // Bug AB2724: properties in rollback client don't match oracle
+    annotateRange, // Bug AB2724: properties in rollback client don't match oracle
     insertAtRefPos,
 ];
 
 const defaultOptions = {
-    minLength: { min: 1, max: 32 },
+    minLength: { min: 1, max: 16 /* 32 */ },
     opsPerRollbackRange: { min: 1, max: 16 /* 32 */ }, // Bug AB1809: fail to insert in rollback client after many ops
     rounds: 10,
     opsPerRound: 10,
@@ -65,7 +65,7 @@ describe("MergeTree.Client", () => {
                     const rollbackMsgs = generateOperationMessagesForClients(
                         mt,
                         seq,
-                        [clients.A, clients.B, clients.C ],
+                        [clients.A, clients.B, clients.C],
                         logger,
                         opsPerRollback,
                         minLength,

--- a/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
@@ -19,7 +19,7 @@ import { createClientsAtInitialState, TestClientLogger } from "./testClientLogge
 
 const allOperations: TestOperation[] = [
     removeRange,
-    annotateRange, // Bug AB2724: properties in rollback client don't match oracle
+    annotateRange,
     insertAtRefPos,
 ];
 

--- a/packages/dds/merge-tree/src/test/testClientLogger.ts
+++ b/packages/dds/merge-tree/src/test/testClientLogger.ts
@@ -30,6 +30,17 @@ function getOpString(msg: ISequencedDocumentMessage | undefined) {
     return `${seq}:${ref}:${client}${opType}${opPos}`;
 }
 
+function arePropsEmpty(props: PropertySet | undefined) {
+    return props === undefined || Object.entries(props).length === 0;
+}
+
+/**
+ * Compare properties, allowing empty to match undefined
+ */
+function matchPropertiesHandleEmpty(a: PropertySet | undefined, b: PropertySet | undefined) {
+    return matchProperties(a, b) || (arePropsEmpty(a) && arePropsEmpty(b));
+}
+
 type ClientMap = Partial<Record<"A" | "B" | "C" | "D" | "E", TestClient>>;
 
 export function createClientsAtInitialState<TClients extends ClientMap>(
@@ -197,8 +208,7 @@ export class TestClientLogger {
                         if (toRemovalInfo(seg) === undefined) {
                             const segProps = seg.properties;
                             for (let i = 0; i < seg.cachedLength; i++) {
-                                if (!matchProperties(segProps, properties[pos + i])
-                                    && (!TestClientLogger.arePropsEmpty(segProps) || !TestClientLogger.arePropsEmpty(properties[pos + i]))) {
+                                if (!matchPropertiesHandleEmpty(segProps, properties[pos + i])) {
                                     assert.deepStrictEqual(
                                         segProps,
                                         properties[pos + i],
@@ -218,10 +228,6 @@ export class TestClientLogger {
             this.addNewLogLine(); // capture initial state
         }
         return baseText;
-    }
-
-    private static arePropsEmpty(props: PropertySet | undefined) {
-        return props === undefined || Object.entries(props).length === 0;
     }
 
     static validate(clients: readonly TestClient[], title?: string) {

--- a/packages/dds/merge-tree/src/test/testClientLogger.ts
+++ b/packages/dds/merge-tree/src/test/testClientLogger.ts
@@ -197,7 +197,8 @@ export class TestClientLogger {
                         if (toRemovalInfo(seg) === undefined) {
                             const segProps = seg.properties;
                             for (let i = 0; i < seg.cachedLength; i++) {
-                                if (!matchProperties(segProps, properties[pos + i])) {
+                                if (!matchProperties(segProps, properties[pos + i])
+                                    && (!TestClientLogger.arePropsEmpty(segProps) || !TestClientLogger.arePropsEmpty(properties[pos + i]))) {
                                     assert.deepStrictEqual(
                                         segProps,
                                         properties[pos + i],
@@ -217,6 +218,10 @@ export class TestClientLogger {
             this.addNewLogLine(); // capture initial state
         }
         return baseText;
+    }
+
+    private static arePropsEmpty(props: PropertySet | undefined) {
+        return props === undefined || Object.entries(props).length === 0;
     }
 
     static validate(clients: readonly TestClient[], title?: string) {


### PR DESCRIPTION
## Description

The rollback farm for mergeTree fails with annotateRange because setting and rolling back properties results in empty propertySets which do not compare as equal to undefined propertySets. This change adds another check in the test code to compare {} and undefined property sets as equal.

I had previously tried to address this in #11264 by changing the matchProperties function to treat undefined and {} as equivalent, but that broke snapshot tests in a way I was uncertain was safe, so I reverted. Another possibility is to delete properties when they become empty on the segment (#13400), also a breaking change.