### PR TITLE
fix(pipelines) Fix bash script condition syntax

### DIFF
--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -454,7 +454,7 @@ stages:
                 echo "##vso[task.logissue type=error]Exit code for runtime tests execution = $executionTimeTestsExitCode"
               fi
 
-              if [[ $memoryTestsExitCode -ne 0]]; then
+              if [[ $memoryTestsExitCode -ne 0 ]]; then
                 echo "##vso[task.logissue type=error]Exit code for memory tests execution = $memoryTestsExitCode"
               fi
 


### PR DESCRIPTION
## Description

Fix the syntax on a condition in a bash script. `]]` needs to be preceded by a space. The perf benchmarks pipeline already failed when it hit this line.
