### PR TITLE
Publish tinylicious logs in more pipelines

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -339,8 +339,6 @@ stages:
                 mkdir $(Build.ArtifactStagingDirectory)/pack/
                 mkdir $(Build.ArtifactStagingDirectory)/pack/scoped/
                 mkdir $(Build.ArtifactStagingDirectory)/test-files/
-                mkdir $(Build.ArtifactStagingDirectory)/logs/
-                mv ${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log $(Build.ArtifactStagingDirectory)/logs/
                 if [[ "${{ variables.publishNonScopedPackages }}" == "True" ]]; then
                   mkdir $(Build.ArtifactStagingDirectory)/pack/non-scoped/
                 fi
@@ -381,12 +379,23 @@ stages:
               artifactName: 'test-files'
               publishLocation: 'pipeline'
 
-          - task: PublishPipelineArtifact@1
-            displayName: Publish Artifact - Tinylicious Log
-            inputs:
-              targetPath: '$(Build.ArtifactStagingDirectory)/logs'
-              artifactName: 'tinyliciousLog'
-              publishLocation: 'pipeline'
+        # Publish logs for other components that ran in this pipeline
+        # Right now this is only tinylicious but we could add logs for other things in the same artifact.
+        - task: Bash@3
+          displayName:
+          inputs:
+            targetType: 'inline'
+            workingDirectory: ${{ parameters.buildDirectory }}
+            script: |
+              mkdir -p $(Build.ArtifactStagingDirectory)/logs/
+              mv ${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log $(Build.ArtifactStagingDirectory)/logs/
+
+        - task: PublishPipelineArtifact@1
+          displayName: Publish Artifact - Tinylicious Log
+          inputs:
+            targetPath: '$(Build.ArtifactStagingDirectory)/logs'
+            artifactName: 'tinyliciousLog'
+            publishLocation: 'pipeline'
 
         # Collect/publish/run bundle analysis
         - ${{ if eq(parameters.taskBundleAnalysis, true) }}:

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -66,6 +66,12 @@ parameters:
   type: string
   default: '@ff-internal/aria-logger'
 
+# Custom steps specified by the "caller" of this template, for any additional things that need to be done
+# after the steps in this template complete.
+- name: additionalSteps
+  type: stepList
+  default: []
+
 jobs:
   - ${{ each variant in parameters.splitTestVariants }}:
     - job:
@@ -318,3 +324,5 @@ jobs:
           searchFolder: ${{ variables.testPackageDir }}/nyc
           mergeTestResults: false
         condition: succeededOrFailed()
+
+      - ${{ parameters.additionalSteps }}

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -23,6 +23,9 @@ variables:
 - group: prague-key-vault
 - name: testWorkspace
   value: $(Pipeline.Workspace)/test
+- name: testPackage
+  value: "@fluid-internal/test-service-load"
+  readonly: true
 
 lockBehavior: sequential
 stages:
@@ -37,7 +40,7 @@ stages:
     - template: templates/include-test-real-service.yml
       parameters:
         poolBuild: Large
-        testPackage: "@fluid-internal/test-service-load"
+        testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 120
@@ -59,7 +62,7 @@ stages:
     - template: templates/include-test-real-service.yml
       parameters:
         poolBuild: Large
-        testPackage: "@fluid-internal/test-service-load"
+        testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 120
@@ -78,13 +81,24 @@ stages:
     - template: templates/include-test-real-service.yml
       parameters:
         poolBuild: Large
-        testPackage: "@fluid-internal/test-service-load"
+        testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 120
         testCommand: start:t9s
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+        additionalSteps:
+
+        # Publish the tinylicious log
+        - task: PublishPipelineArtifact@1
+          displayName: Publish Artifact - Tinylicious Log
+          inputs:
+            # NOTE: this depends on knowledge of what the template does and where it puts things.
+            # If the template changes its logic, we might need to adjust this path.
+            targetPath: '${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}/tinylicious.log'
+            artifactName: 'tinyliciousLog'
+            publishLocation: 'pipeline'
 
   # stress tests frs
   - stage:
@@ -97,7 +111,7 @@ stages:
     - template: templates/include-test-real-service.yml
       parameters:
         poolBuild: Large
-        testPackage: "@fluid-internal/test-service-load"
+        testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 120

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -23,6 +23,9 @@ variables:
 - group: prague-key-vault
 - name: testWorkspace
   value: $(Pipeline.Workspace)/test
+- name: testPackage
+  value: "@fluidframework/test-end-to-end-tests"
+  readonly: true
 
 lockBehavior: sequential
 stages:
@@ -34,7 +37,7 @@ stages:
     - template: templates/include-test-real-service.yml
       parameters:
         poolBuild: Small
-        testPackage: "@fluidframework/test-end-to-end-tests"
+        testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         testCommand: test:realsvc:local:report
@@ -49,12 +52,23 @@ stages:
     - template: templates/include-test-real-service.yml
       parameters:
         poolBuild: Small
-        testPackage: "@fluidframework/test-end-to-end-tests"
+        testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         testCommand: test:realsvc:tinylicious:report
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+        additionalSteps:
+
+        # Publish the tinylicious log
+        - task: PublishPipelineArtifact@1
+          displayName: Publish Artifact - Tinylicious Log
+          inputs:
+            # NOTE: this depends on knowledge of what the template does and where it puts things.
+            # If the template changes its logic, we might need to adjust this path.
+            targetPath: '${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}/tinylicious.log'
+            artifactName: 'tinyliciousLog'
+            publishLocation: 'pipeline'
 
   # end-to-end tests routerlicious
   - stage:
@@ -67,7 +81,7 @@ stages:
     - template: templates/include-test-real-service.yml
       parameters:
         poolBuild: Small
-        testPackage: "@fluidframework/test-end-to-end-tests"
+        testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         testCommand: test:realsvc:routerlicious:report
@@ -95,7 +109,7 @@ stages:
     - template: templates/include-test-real-service.yml
       parameters:
         poolBuild: Small
-        testPackage: "@fluidframework/test-end-to-end-tests"
+        testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 360
@@ -123,7 +137,7 @@ stages:
     - template: templates/include-test-real-service.yml
       parameters:
         poolBuild: Small
-        testPackage: "@fluidframework/test-end-to-end-tests"
+        testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 360


### PR DESCRIPTION
## Description

- Publish artifact with tinylicious logs from e2e and stress tests pipelines.
- For the Build - client packages pipeline, extract it from inside conditionals so it always gets published.