### PR TITLE
Always report  "InstantiateRuntime" event to telemetry

### DIFF
--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -46,7 +46,7 @@ import {
     ISummaryContent,
 } from "@fluidframework/protocol-definitions";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
-import { Container, ReportIfTooLong } from "./container";
+import { Container } from "./container";
 
 const PackageNotFactoryError = "Code package does not implement IRuntimeFactory";
 

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -324,13 +324,10 @@ export class ContainerContext implements IContainerContext {
 
     private async instantiateRuntime(existing: boolean) {
         const runtimeFactory = await this.getRuntimeFactory();
-        await ReportIfTooLong(
-            this.taggedLogger,
-            "instantiateRuntime",
-            async () => {
-                this._runtime = await runtimeFactory.instantiateRuntime(this, existing);
-                return {};
-            });
+        this._runtime = await PerformanceEvent.timedExecAsync(
+			this.taggedLogger,
+			{ eventName: "InstantiateRuntime" },
+			() => runtimeFactory.instantiateRuntime(this, existing));
     }
 
     private attachListener() {

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -327,7 +327,7 @@ export class ContainerContext implements IContainerContext {
         this._runtime = await PerformanceEvent.timedExecAsync(
 			this.taggedLogger,
 			{ eventName: "InstantiateRuntime" },
-			() => runtimeFactory.instantiateRuntime(this, existing));
+			async () => runtimeFactory.instantiateRuntime(this, existing));
     }
 
     private attachListener() {


### PR DESCRIPTION
## Description

In PR #13305, @vladsud added telemetry to the runtime-instantiation event, but wrapped it in a `ReportIfTooLong` call.

I think it would be best to always report the instantiation duration. That way we can always rely on it for telemetry (today, we instead have some of our containers add the telemetry, but not all containers do -- so it would be great to be able to standardize our telemetry to always use the Fluid Framework's reported duration).

Here's an example of what the event looks like, compared with the existing event from one of the containers. The top one is the new one, the bottom one is the one that the container reported today (so by having the framework report it, we'd also eliminate the slight gap):
![image](https://user-images.githubusercontent.com/2230453/208329169-e653a6fb-f986-45ac-9498-670f6ef8a916.png)

## Reviewer Guidance

@vladsud , note that for consistency with other event names, I also changed the capitalization of `instantiateRuntime` to `InstantiateRuntime`. To my knowledge, none of our main hosts have picked up the latest FF version yet, so it's unlikely we'll need to worry about the old name. But if you'd rather me keep the old capitalization, let me know.