### PR TITLE
r11s-driver: properly reset discovery refresh flags (#12993)

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -240,7 +240,6 @@ export class DocumentService implements api.IDocumentService {
         this.storageUrl = fluidResolvedUrl.endpoints.storageUrl;
         this.ordererUrl = fluidResolvedUrl.endpoints.ordererUrl;
         this.deltaStorageUrl = fluidResolvedUrl.endpoints.deltaStorageUrl;
-        this.lastDiscoveredAt = Date.now();
     }
 
     /**
@@ -256,6 +255,15 @@ export class DocumentService implements api.IDocumentService {
         // Disconnect event is not so reliable in local testing. To ensure re-discovery when necessary,
         // re-discover if enough time has passed since last discovery.
         const pastLastDiscoveryTimeThreshold = (now - this.lastDiscoveredAt) > RediscoverAfterTimeSinceDiscoveryMs;
+        if (pastLastDiscoveryTimeThreshold) {
+            // Reset discover promise and refresh discovery.
+            this.lastDiscoveredAt = Date.now();
+            this.discoverP = undefined;
+            this.refreshDiscovery().catch(() => {
+                // Undo discovery time set on failure, so that next check refreshes.
+                this.lastDiscoveredAt = 0;
+            });
+        }
         return pastLastDiscoveryTimeThreshold;
     }
 }


### PR DESCRIPTION
cherry picked commit from routerlicious driver fix: https://github.com/microsoft/FluidFramework/pull/12993