### PR TITLE
Remove colorization from t9s log file during CI runs

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -88,6 +88,7 @@ stages:
         testCommand: start:t9s
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+          logger__colorize: false
         additionalSteps:
 
         # Publish the tinylicious log

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -88,7 +88,9 @@ stages:
         testCommand: start:t9s
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+          # Disable colorization for tinylicious logs (not useful when printing to a file)
           logger__colorize: false
+          logger__morganFormat: tiny
         additionalSteps:
 
         # Publish the tinylicious log

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -58,7 +58,9 @@ stages:
         testCommand: test:realsvc:tinylicious:report
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+          # Disable colorization for tinylicious logs (not useful when printing to a file)
           logger__colorize: false
+          logger__morganFormat: tiny
         additionalSteps:
 
         # Publish the tinylicious log

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -58,6 +58,7 @@ stages:
         testCommand: test:realsvc:tinylicious:report
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+          logger__colorize: false
         additionalSteps:
 
         # Publish the tinylicious log


### PR DESCRIPTION
## Description

The t9s log files we publish from our CI pipeline runs are always looked at in an editor, not the console, so color codes meant for consoles to interpret are just noise and increase the file size unnecessarily. This PR makes it the t9s log file doesn't have color codes when generated in the e2e or stress tests pipelines.

The `logger__colorize: false` env variable disables colorization by winston (the general logger). The `logger__morganFormat: tiny` env variable changes the template used by [morgan](https://github.com/expressjs/morgan) in the contents of log messages it generates, to one that does not use color codes for console output.

I confirmed the two variables have the intended effect when applied locally to tinylicious, while running stress tests.
