### PR TITLE
refactor(generate:typetests): Print errors during type test generation without need of `--verbose`

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -249,11 +249,11 @@ export default class GenerateTypeTestsCommand extends BaseCommand<
                     } catch (error) {
                         output.push("Error");
                         if (typeof error === "string") {
-                            output.push(chalk.red(error));
+                            this.errorLog(chalk.red(error));
                         } else if (error instanceof Error) {
-                            output.push(chalk.red(error.message), `\n ${error.stack}`);
+                            this.errorLog(`${chalk.red(error.message)}\n ${error.stack}`);
                         } else {
-                            output.push(typeof error, chalk.red(`${error}`));
+                            this.errorLog(`${typeof error} - ${chalk.red(`${error}`)}`);
                         }
 
                         return false;


### PR DESCRIPTION
## Description

Small change so errors during type tests generation are printed immediately even if `--verbose` was not passed. Otherwise we only get a generic error `Some type test generation failed` at the end.  Errors details should always be printed, IMO.

This is particularly inconvenient in our pipelines, where we have to commit and push changes in order to add the `--verbose` flag to the command run in the pipeline.

## Reviewer guidance

I tried to validate this but that led me to realize that type test generation during pipeline runs is actually using the published version of `build-cli` even when told to use the in-repo version (bug reported [here](https://dev.azure.com/fluidframework/internal/_workitems/edit/2941)) so I can't make a pipeline run on a test branch (which is where errors currently happen on every run) reflect these changes to see the output.