### PR TITLE
Changed gcUnknownOutboundReferences to error and added test to validate GC's  refresh from snapshot is correct

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryLogger, ITelemetryPerformanceEvent } from "@fluidframework/common-definitions";
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert, LazyPromise, Timer } from "@fluidframework/common-utils";
 import { ICriticalContainerError } from "@fluidframework/container-definitions";
 import { ClientSessionExpiredError, DataProcessingError, UsageError } from "@fluidframework/container-utils";
@@ -1243,12 +1243,11 @@ export class GarbageCollector implements IGarbageCollector {
 
         if (missingExplicitReferences.length > 0) {
             missingExplicitReferences.forEach((missingExplicitReference) => {
-                const event: ITelemetryPerformanceEvent = {
+                logger.sendErrorEvent({
                     eventName: "gcUnknownOutboundReferences",
                     gcNodeId: missingExplicitReference[0],
                     gcRoutes: JSON.stringify(missingExplicitReference[1]),
-                };
-                logger.sendPerformanceEvent(event);
+                });
             });
         }
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
@@ -15,7 +15,7 @@ import {
     summarizeNow,
     waitForContainerConnection,
 } from "@fluidframework/test-utils";
-import { describeNoCompat, ITestDataObject, TestDataObjectType } from "@fluidframework/test-version-utils";
+import { describeNoCompat, ITestDataObject, itExpects, TestDataObjectType } from "@fluidframework/test-version-utils";
 import { defaultGCConfig } from "./gcTestConfigs";
 import {
     getGCStateFromSummary,
@@ -32,7 +32,7 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
     let dataStoreA: ITestDataObject;
 
     /**
-     * Submits a summary and returns the reference state for all the nodes in the container.
+     * Returns the reference state for all the nodes in the given summary tree.
      * If a node is referenced, its value is true. If it's unreferenced, its value is false.
      * @returns a map of nodePath to its unreferenced timestamp.
      */
@@ -47,6 +47,22 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         return nodeIsReferencedMap;
     }
 
+    /**
+     * Returns the unreferenced timestamp for all the nodes in the given summary tree.
+     * If a node is referenced, the unreferenced timestamp is undefined.
+     * @returns a map of nodePath to its unreferenced timestamp.
+     */
+    async function getUnreferencedTimestamps(summaryTree: ISummaryTree) {
+        const gcState = getGCStateFromSummary(summaryTree);
+        assert(gcState !== undefined, "GC tree is not available in the summary");
+
+        const nodeTimestamps: Map<string, number | undefined> = new Map();
+        for (const [nodePath, nodeData] of Object.entries(gcState.gcNodes)) {
+            nodeTimestamps.set(nodePath.slice(1), nodeData.unreferencedTimestampMs);
+        }
+        return nodeTimestamps;
+    }
+
     /*
      * Utility function that returns the sequence number of a summary from the summary metadata.
      */
@@ -55,7 +71,16 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         assert(metadataBlob.type === SummaryType.Blob, "Container runtime metadata is not a blob");
         const metadata = JSON.parse(metadataBlob.content as string) as Record<string, unknown>;
         return (metadata.message as ISequencedDocumentMessage).sequenceNumber;
-    };
+    }
+
+    /**
+     * Function that asserts the given value is not true. Used in these tests to demonstrate that because of
+     * a bug we are not getting the expected results. Once the bug is fixed, these asserts should start working
+     * as expected.
+     */
+    function assertNotTrue(value: boolean, message: string) {
+        assert(!value, message);
+    }
 
     beforeEach(async function() {
         provider = getTestObjectProvider({ syncSummarizer: true });
@@ -65,7 +90,11 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         await waitForContainerConnection(mainContainer);
     });
 
-    it("updates referenced nodes correctly when loading from an older summary", async () => {
+    itExpects("updates referenced nodes correctly when loading from an older summary",
+    [
+        { eventName: "fluid:telemetry:Summarizer:Running:gcUnknownOutboundReferences" }
+    ],
+    async () => {
         const summarizer1 = await createSummarizer(provider, mainContainer);
 
         // Create a data store and mark it unreferenced to begin with.
@@ -185,5 +214,113 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         const dsBReferenceState3 = referenceState3.get(dataStoreB._context.id);
         assert(
             dsBReferenceState3 === false, `dataStoreB should still be unreferenced on loading from old summary`);
+    });
+
+    it("updates unreferenced timestamps correctly when loading from an older summary", async () => {
+        const summarizer1 = await createSummarizer(provider, mainContainer);
+
+        // Create a data store and mark it unreferenced to begin with.
+        const dataStoreBHandle =
+            (await containerRuntime.createDataStore(TestDataObjectType)).entryPoint as IFluidHandle<ITestDataObject>;
+        assert(dataStoreBHandle !== undefined, "New data store does not have a handle");
+        const dataStoreB = await dataStoreBHandle.get();
+        dataStoreA._root.set("dataStoreB", dataStoreBHandle);
+        dataStoreA._root.delete("dataStoreB");
+
+        await provider.ensureSynchronized();
+
+        // Summarize - summary1. dataStoreB should have unreferenced timestamp.
+        const summaryResult1 = await summarizeNow(summarizer1);
+        const unreferencedTimestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
+        const dsBTime1 = unreferencedTimestamps1.get(dataStoreB._context.id);
+        assert(dsBTime1 !== undefined, `dataStoreB should have unreferenced timestamp`);
+
+        // Reference and unreference dataStoreB.
+        dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+        dataStoreA._root.delete("dataStoreB");
+
+        // Summarize - summary2. dataStoreB's unreferenced timestamp should have updated.
+        await provider.ensureSynchronized();
+        const summaryResult2 = await summarizeNow(summarizer1);
+        const unreferencedTimestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+        const dsBTime2 = unreferencedTimestamps2.get(dataStoreB._context.id);
+        assert(dsBTime2 !== undefined && dsBTime2 > dsBTime1, `dataStoreB's time should have updated`);
+
+        // Load a new summarizer from the summary1 and summarize - summary3. Before it summarizes, it will catch up
+        // to latest and so the reference state of the data stores should be the same as in summary2.
+        // Also, note that while catching up, it will download summary2 and update state from it.
+        summarizer1.close();
+        const summarizer2 = await createSummarizer(provider, mainContainer, summaryResult1.summaryVersion);
+
+        // Create a new alias data store so that the GC data changes without changing the GC state of existing data
+        // stores. This is to write the GC tree in summary (instead of handle) which is used for validation.
+        const ds2 = await containerRuntime.createDataStore(TestDataObjectType);
+        const aliasResult = await ds2.trySetAlias("root2");
+        assert.strictEqual(aliasResult, "Success", "Failed to alias data store");
+
+        await provider.ensureSynchronized();
+        const summaryResult3 = await summarizeNow(summarizer2);
+
+        // Validate that summary3 is same or newer than summary2. This is to ensure that it has the latest GC state.
+        const summary2SequenceNumber = getSummarySequenceNumber(summaryResult2.summaryTree);
+        const summary3SequenceNumber = getSummarySequenceNumber(summaryResult3.summaryTree);
+        assert(summary3SequenceNumber >= summary2SequenceNumber, "Summary 3 should be same or newer than summary 2");
+
+        // Validate that dataStoreB's unreferenced timestamp is the same as from summary2.
+        const unreferencedTimestamps3 = await getUnreferencedTimestamps(summaryResult3.summaryTree);
+        const dsBTime3 = unreferencedTimestamps3.get(dataStoreB._context.id);
+        assertNotTrue(dsBTime3 === dsBTime2, `dataStoreB's time should be same as in summary2`);
+    });
+
+    itExpects("does not log gcUnknownOutboundReferences errors when loading from an older summary",
+    [
+        { eventName: "fluid:telemetry:Summarizer:Running:gcUnknownOutboundReferences" }
+    ],
+    async () => {
+        const summarizer1 = await createSummarizer(provider, mainContainer);
+
+        // Create a data store and mark it unreferenced to begin with.
+        const dataStoreBHandle =
+            (await containerRuntime.createDataStore(TestDataObjectType)).entryPoint as IFluidHandle<ITestDataObject>;
+        assert(dataStoreBHandle !== undefined, "New data store does not have a handle");
+        const dataStoreB = await dataStoreBHandle.get();
+        dataStoreA._root.set("dataStoreB", dataStoreBHandle);
+        dataStoreA._root.delete("dataStoreB");
+
+        await provider.ensureSynchronized();
+
+        // Summarize - summary1. dataStoreB should be unreferenced.
+        const summaryResult1 = await summarizeNow(summarizer1);
+        const referenceState1 = await getReferenceState(summaryResult1.summaryTree);
+        const dsAReferenceState1 = referenceState1.get(dataStoreA._context.id);
+        assert(dsAReferenceState1 === true, `dataStoreA should be referenced`);
+        const dsBReferenceState1 = referenceState1.get(dataStoreB._context.id);
+        assert(dsBReferenceState1 === false, `dataStoreB should be unreferenced`);
+
+        // Reference dataStoreB. This should result in an explicit reference from dataStoreA -> dataStoreB.
+        dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+
+        // Summarize - summary2. dataStoreB should now be referenced.
+        await provider.ensureSynchronized();
+        const summaryResult2 = await summarizeNow(summarizer1);
+        const unreferencedTimestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+        const dsBTime2 = unreferencedTimestamps2.get(dataStoreB._context.id);
+        assert(dsBTime2 === undefined, `dataStoreB's time should have updated`);
+
+        // Load a new summarizer from the summary1 and summarize - summary3. Before it summarizes, it will catch up
+        // to latest and so the reference state of the data stores should be the same as in summary2.
+        // Also, note that while catching up, it will download summary2 and update state from it.
+        summarizer1.close();
+        const summarizer2 = await createSummarizer(provider, mainContainer, summaryResult1.summaryVersion);
+        await provider.ensureSynchronized();
+
+        // When GC runs as part of this summarize, it should not throw "gcUnknownOutboundReferences" error for the
+        // dataStoreA -> dataStoreB route.
+        const summaryResult3 = await summarizeNow(summarizer2);
+
+        // Validate that summary3 is same or newer than summary2. This is to ensure that it has the latest GC state.
+        const summary2SequenceNumber = getSummarySequenceNumber(summaryResult2.summaryTree);
+        const summary3SequenceNumber = getSummarySequenceNumber(summaryResult3.summaryTree);
+        assert(summary3SequenceNumber >= summary2SequenceNumber, "Summary 3 should be same or newer than summary 2");
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -540,9 +540,10 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
         });
 
         // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-        itExpects("Can untombstone datastores by storing a handle",
+        itExpects("Can un-tombstone datastores by storing a handle",
         [
             { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested" },
+            { eventName: "fluid:telemetry:Summarizer:Running:gcUnknownOutboundReferences" },
             { eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" },
             {
                 eventName: "fluid:telemetry:Container:ContainerClose",
@@ -578,15 +579,17 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
                 `Should not be able to retrieve a tombstoned datastore.`,
             );
 
-            // Normally on non-summarizer clients we would see a SweepReady_Revived error, but because this is the
-            // summarizer client, we do not as we do not decode the handle on the summarizer. We only encode it.
+            // Normally, there should be a SweepReady_Revived error when referencing a SweepReady data store. However,
+            // since the summarizer client is the one that is created and adding the handle, the handle is not decoded
+            // and it will not result in GC detecting the reference. Also, a "gcUnknownOutboundReferences" error will
+            // be logged for the same reason.
             const mainDataObject = await requestFluidObject<ITestDataObject>(summarizingContainer, "default");
             mainDataObject._root.set("store", dataObject.handle);
 
-            // This container closes as we submit ops and signals in the untombstoned container
+            // This container closes as we submit ops and signals in the un-tombstoned container
             setupContainerCloseErrorValidation(tombstoneContainer, "processSignal");
 
-            // The datastore should be untombstoned now
+            // The datastore should be un-tombstoned now
             const { summaryVersion: revivalVersion } = await summarize(summarizer);
             const revivalContainer = await loadContainer(revivalVersion);
             const revivedObject = await requestFluidObject<ITestDataObject>(revivalContainer, unreferencedId);
@@ -601,17 +604,30 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             sendDataObject._runtime.submitSignal("can receive", "a signal");
             await provider.ensureSynchronized();
             assert(tombstoneContainer.closed === true, `Container receiving messages to a tombstoned datastore should close.`);
-            assert(revivalContainer.closed !== true, `Revived datastore should not close a container when requested, sending/receiving signals/ops.`);
-            assert(sendingContainer.closed !== true, `Revived datastore should not close a container when sending signals and ops.`);
+            assert(revivalContainer.closed !== true,
+                `Revived datastore should not close a container when requested, sending/receiving signals/ops.`);
+            assert(sendingContainer.closed !== true,
+                `Revived datastore should not close a container when sending signals and ops.`);
         });
 
         itExpects("does not throw tombstone errors when ThrowOnTombstoneUsage setting is not enabled",
         [
             { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested" },
             { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
-            { eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed", callSite: "submitMessage" },
-            { eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed", callSite: "process", clientType: "noninteractive/summarizer" },
-            { eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed", callSite: "process", clientType: "interactive" },
+            {
+                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+                callSite: "submitMessage",
+            },
+            {
+                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+                callSite: "process",
+                clientType: "noninteractive/summarizer",
+            },
+            {
+                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+                callSite: "process",
+                clientType: "interactive",
+            },
         ],
         async () => {
             settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;


### PR DESCRIPTION
Updated "gcUnknownOutboundReferences" to be logged as an error - It should have been an error to begin with since its not expected.
Added couple of tests that show the bug where GC state is not updated correctly in GarbageCollector on refreshing state from a snapshot. Basically, the gc data from last run and tombstone state should also be updated when refereshing state from a snapshot. Otherwise, there are couple of things that can go wrong:
- The unreferenced timestamp of nodes is not updated in certain scenarios when it goes from unreferenced -> referenced -> unreferenced between summaries. Added a test for this scenario.
- "gcUnknownOutboundReferences" error can be logged in certain scenarios. Added a test for this scenario.

These tests repro the issues in bugs [AB#2940](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2940) and [AB#2945](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2945)