### PR TITLE
Always report "WaitOps" and "WaitOpProcessing"

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1226,14 +1226,16 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             if (opsBeforeReturnP !== undefined) {
                 this._deltaManager.inbound.resume();
 
-                await ReportIfTooLong(
+                await PerformanceEvent.timedExecAsync(
                     this.mc.logger,
-                    "WaitOps",
-                    async () => { await opsBeforeReturnP; return {}; });
-                await ReportIfTooLong(
+                    { eventName:  "WaitOps" },
+                    async () => opsBeforeReturnP
+                );
+                await PerformanceEvent.timedExecAsync(
                     this.mc.logger,
-                    "WaitOpProcessing",
-                    async () => this._deltaManager.inbound.waitTillProcessingDone());
+                    { eventName:  "WaitOpProcessing" },
+                    async () => this._deltaManager.inbound.waitTillProcessingDone()
+                );
 
                 // eslint-disable-next-line @typescript-eslint/no-floating-promises
                 this._deltaManager.inbound.pause();


### PR DESCRIPTION
## Description

Per discussion with @vladsud, moving the "WaitOps" and "WaitOpProcessing" events to always be reported, rather than only being reported if they took a long time.

This will allow us to track these metrics more easily in telemetry, e.g., to determine p95 distributions, etc.

Tested that this works by manually applying a similar change to a demo app, and seeing the two events in the profiler:

![image](https://user-images.githubusercontent.com/2230453/208797470-bc640750-ff49-4fa2-895d-7cefd9dae558.png)
