### PR TITLE
Remove partial lengths debug-only code from bundle

### DIFF
--- a/packages/dds/merge-tree/src/partialLengths.ts
+++ b/packages/dds/merge-tree/src/partialLengths.ts
@@ -186,6 +186,11 @@ interface LocalPartialSequenceLength extends PartialSequenceLength {
     localSeq: number;
 }
 
+export interface PartialSequenceLengthsOptions {
+    verifier?: (partialLengths: PartialSequenceLengths) => void;
+    zamboni: boolean;
+}
+
 /**
  * Keeps track of partial sums of segment lengths for all sequence numbers in the current collaboration window.
  * Only used during active collaboration.
@@ -232,8 +237,7 @@ interface LocalPartialSequenceLength extends PartialSequenceLength {
  * concurrently removing the same segment. See the field's documentation for more details.
  */
 export class PartialSequenceLengths {
-    public static options = {
-        verify: false,
+    public static options: PartialSequenceLengthsOptions = {
         zamboni: true,
     };
 
@@ -318,10 +322,7 @@ export class PartialSequenceLengths {
             combinedPartialLengths.zamboni(collabWindow);
         }
 
-        if (PartialSequenceLengths.options.verify) {
-            verify(combinedPartialLengths);
-        }
-
+        PartialSequenceLengths.options.verifier?.(combinedPartialLengths);
         return combinedPartialLengths;
     }
 
@@ -382,9 +383,7 @@ export class PartialSequenceLengths {
             }
         }
 
-        if (PartialSequenceLengths.options.verify) {
-            verify(combinedPartialLengths);
-        }
+        PartialSequenceLengths.options.verifier?.(combinedPartialLengths);
         return combinedPartialLengths;
     }
 
@@ -649,9 +648,8 @@ export class PartialSequenceLengths {
         if (PartialSequenceLengths.options.zamboni) {
             this.zamboni(collabWindow);
         }
-        if (PartialSequenceLengths.options.verify) {
-            verify(this);
-        }
+
+        PartialSequenceLengths.options.verifier?.(this);
     }
 
     /**
@@ -875,7 +873,7 @@ function verifyPartialLengths(
     return count;
 }
 
-function verify(partialSeqLengths: PartialSequenceLengths) {
+export function verify(partialSeqLengths: PartialSequenceLengths) {
     if (partialSeqLengths["clientSeqNumbers"]) {
         let cliCount = 0;
         for (const cliSeq of partialSeqLengths["clientSeqNumbers"]) {

--- a/packages/dds/merge-tree/src/test/obliterate.partialLength.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.partialLength.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { MergeTreeDeltaType } from "../ops";
-import { PartialSequenceLengths } from "../partialLengths";
+import { PartialSequenceLengths, verify } from "../partialLengths";
 import { TestClient } from "./testClient";
 import { insertText, validatePartialLengths } from "./testUtils";
 
@@ -16,7 +16,7 @@ describe("obliterate partial lengths", () => {
     const remoteClientId = 18;
 
     beforeEach(() => {
-        PartialSequenceLengths.options.verify = true;
+        PartialSequenceLengths.options.verifier = verify;
         client = new TestClient();
         client.startOrUpdateCollaboration("local");
         for (const char of "hello world") {
@@ -32,7 +32,7 @@ describe("obliterate partial lengths", () => {
     });
 
     afterEach(() => {
-        PartialSequenceLengths.options.verify = false;
+        PartialSequenceLengths.options.verifier = undefined;
     });
 
     it("removes text", () => {

--- a/packages/dds/merge-tree/src/test/partialLength.spec.ts
+++ b/packages/dds/merge-tree/src/test/partialLength.spec.ts
@@ -6,7 +6,7 @@
 import { UnassignedSequenceNumber } from "../constants";
 import { MergeTree } from "../mergeTree";
 import { MergeTreeDeltaType } from "../ops";
-import { PartialSequenceLengths } from "../partialLengths";
+import { PartialSequenceLengths, verify } from "../partialLengths";
 import { TextSegment } from "../textSegment";
 import {
     insertSegments,
@@ -22,7 +22,7 @@ describe("partial lengths", () => {
     const refSeq = 0;
 
     beforeEach(() => {
-        PartialSequenceLengths.options.verify = true;
+        PartialSequenceLengths.options.verifier = verify;
         mergeTree = new MergeTree();
         insertSegments({
             mergeTree,
@@ -41,7 +41,7 @@ describe("partial lengths", () => {
     });
 
     afterEach(() => {
-        PartialSequenceLengths.options.verify = false;
+        PartialSequenceLengths.options.verifier = undefined;
     });
 
     it("passes with no additional ops", () => {


### PR DESCRIPTION
The pattern used previously causes debug-only code to be included in the bundle. We don't export `PartialSequenceLengths` from the package, so there's no way consumers can (or should) turn this verification on. This adjusts the options object to take in a verify callback instead, which enables tree-shaking of those functions.