### PR TITLE
Deduplicate some common tracing code in merge-tree Client

### DIFF
--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -245,23 +245,23 @@ export class Client {
             segment);
 
         const opArgs = { op };
+        this.traceOp(
+            opArgs, 
+            () => this._mergeTree.insertAtReferencePosition(refPos, segment, opArgs)
+        );
+
+        return op;
+    }
+
+    private traceOp(opArgs: IMergeTreeDeltaOpArgs, applyOp: () => void): void {
         let traceStart: Trace | undefined;
         if (this.measureOps) {
             traceStart = Trace.start();
         }
 
-        this._mergeTree.insertAtReferencePosition(
-            refPos,
-            segment,
-            opArgs);
+        applyOp();
 
-        this.completeAndLogOp(
-            opArgs,
-            this.getClientSequenceArgs(opArgs),
-            { start: op.pos1 },
-            traceStart);
-
-        return op;
+        this.completeAndLogOp(opArgs, traceStart);
     }
 
     public walkSegments<TClientData>(
@@ -407,22 +407,18 @@ export class Client {
         const op = opArgs.op;
         const clientArgs = this.getClientSequenceArgs(opArgs);
         const range = this.getValidOpRange(op, clientArgs);
-
-        let traceStart: Trace | undefined;
-        if (this.measureOps) {
-            traceStart = Trace.start();
-        }
-
-        this._mergeTree.markRangeRemoved(
-            range.start,
-            range.end,
-            clientArgs.referenceSequenceNumber,
-            clientArgs.clientId,
-            clientArgs.sequenceNumber,
-            false,
-            opArgs);
-
-        this.completeAndLogOp(opArgs, clientArgs, range, traceStart);
+        this.traceOp(
+            opArgs,
+            () => this._mergeTree.markRangeRemoved(
+                range.start,
+                range.end,
+                clientArgs.referenceSequenceNumber,
+                clientArgs.clientId,
+                clientArgs.sequenceNumber,
+                false,
+                opArgs
+            )
+        );
 
         return true;
     }
@@ -442,22 +438,19 @@ export class Client {
             return false;
         }
 
-        let traceStart: Trace | undefined;
-        if (this.measureOps) {
-            traceStart = Trace.start();
-        }
-
-        this._mergeTree.annotateRange(
-            range.start,
-            range.end,
-            op.props,
-            op.combiningOp,
-            clientArgs.referenceSequenceNumber,
-            clientArgs.clientId,
-            clientArgs.sequenceNumber,
-            opArgs);
-
-        this.completeAndLogOp(opArgs, clientArgs, range, traceStart);
+        this.traceOp(
+            opArgs,
+            () => this._mergeTree.annotateRange(
+                range.start,
+                range.end,
+                op.props,
+                op.combiningOp,
+                clientArgs.referenceSequenceNumber,
+                clientArgs.clientId,
+                clientArgs.sequenceNumber,
+                opArgs
+            )
+        );
 
         return true;
     }
@@ -486,20 +479,17 @@ export class Client {
             return false;
         }
 
-        let traceStart: Trace | undefined;
-        if (this.measureOps) {
-            traceStart = Trace.start();
-        }
-
-        this._mergeTree.insertSegments(
-            range.start,
-            segments,
-            clientArgs.referenceSequenceNumber,
-            clientArgs.clientId,
-            clientArgs.sequenceNumber,
-            opArgs);
-
-        this.completeAndLogOp(opArgs, clientArgs, range, traceStart);
+        this.traceOp(
+            opArgs,
+            () => this._mergeTree.insertSegments(
+                range.start,
+                segments!,
+                clientArgs.referenceSequenceNumber,
+                clientArgs.clientId,
+                clientArgs.sequenceNumber,
+                opArgs
+            )
+        );
 
         return true;
     }
@@ -513,8 +503,6 @@ export class Client {
      */
     private completeAndLogOp(
         opArgs: IMergeTreeDeltaOpArgs,
-        clientArgs: IMergeTreeClientSequenceArgs,
-        range: Partial<IIntegerRange>,
         traceStart?: Trace) {
         if (!opArgs.sequencedMessage) {
             if (traceStart) {
@@ -522,9 +510,11 @@ export class Client {
                 this.localOps++;
             }
         } else {
-            assert(this._mergeTree.getCollabWindow().currentSeq < clientArgs.sequenceNumber,
+            const { currentSeq, minSeq } = this.getCollabWindow();
+            const { minimumSequenceNumber, sequenceNumber } = opArgs.sequencedMessage;
+            assert(currentSeq < sequenceNumber,
                 0x030 /* "Incoming remote op sequence# <= local collabWindow's currentSequence#" */);
-            assert(this._mergeTree.getCollabWindow().minSeq <= opArgs.sequencedMessage.minimumSequenceNumber,
+            assert(minSeq <= minimumSequenceNumber,
                 0x031 /* "Incoming remote op minSequence# < local collabWindow's minSequence#" */);
             if (traceStart) {
                 this.accumTime += elapsedMicroseconds(traceStart);


### PR DESCRIPTION
## Description

goal is lower bundle size. We can probably actually deprecate/remove this functionality and make it pay-to-play instead, but that's not a transparent change.
