### PR TITLE
Create SharedMap editor string control

### DIFF
--- a/packages/tools/client-debugger/client-debugger-view/src/components/data-object-views/SharedStringView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/data-object-views/SharedStringView.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Stack, StackItem } from "@fluentui/react";
+import { IStackProps, IStackStyles, PrimaryButton, Stack, TextField } from "@fluentui/react";
 import React from "react";
 
 import { SharedString } from "@fluidframework/sequence";
@@ -25,9 +25,12 @@ export function SharedStringView(props: SharedStringViewProps): React.ReactEleme
 
 	const [text, setText] = React.useState<string>(sharedString.getText());
 
+	const [deltaText, setDeltaText] = React.useState("");
+
 	React.useEffect(() => {
 		function updateText(): void {
 			const newText = sharedString.getText();
+			setDeltaText(newText);
 			setText(newText);
 		}
 
@@ -38,12 +41,41 @@ export function SharedStringView(props: SharedStringViewProps): React.ReactEleme
 		};
 	}, []);
 
+	const stackStyles: Partial<IStackStyles> = { root: { width: 650 } };
+	const stackTokens = { childrenGap: 50 };
+	const columnProps: Partial<IStackProps> = {
+		tokens: { childrenGap: 15 },
+		styles: { root: { width: 300 } },
+	};
+
+	function updateText(): void {
+		sharedString.replaceText(0, text.length, deltaText);
+		sharedString.emit("sequenceDelta");
+		setDeltaText("");
+	}
+
+	const updateDeltaText = (
+		event: React.FormEvent<HTMLTextAreaElement | HTMLInputElement>,
+		newValue?: string | undefined,
+	): void => {
+		setDeltaText(newValue ?? "");
+	};
+
 	return (
-		<Stack>
-			<StackItem>
-				<b>SharedString</b>
-			</StackItem>
-			<StackItem>{text}</StackItem>
+		<Stack horizontal tokens={stackTokens} styles={stackStyles}>
+			<Stack {...columnProps}>
+				<TextField
+					id="sharedStringDebuggerEditorId"
+					label="SharedString"
+					multiline
+					rows={3}
+					defaultValue={text}
+					onChange={updateDeltaText}
+				/>
+				<PrimaryButton disabled={deltaText === ""} onClick={updateText}>
+					Submit Text
+				</PrimaryButton>
+			</Stack>
 		</Stack>
 	);
 }


### PR DESCRIPTION
This will be the first step in creating the SharedMap view. To start, we can just display a readonly table view that lists the keys (always strings) and the values if they are primitive data only. For non-primitives, we can just display the kind of data found (if known). 

![1](https://user-images.githubusercontent.com/114451900/209026095-86c89be2-62fd-4d05-b219-f4a852dd28d1.png)
![2](https://user-images.githubusercontent.com/114451900/209026102-9391b1be-3a87-47be-8d0f-d8d6d2e2eee6.png)
![3](https://user-images.githubusercontent.com/114451900/209026104-75c4cc16-e96c-4688-9396-69dca0ed910e.png)
