### PR TITLE
Render the deletion of the task from the list in external-data example app

### DIFF
--- a/examples/hosts/app-integration/external-data/src/model/taskList.ts
+++ b/examples/hosts/app-integration/external-data/src/model/taskList.ts
@@ -130,7 +130,7 @@ export class TaskList extends DataObject implements ITaskList {
     };
 
     public readonly deleteTask = (id: string): void => {
-        this.root.delete(id);
+        this.handleTaskDeleted(id);
     };
 
     public readonly getTasks = (): Task[] => {


### PR DESCRIPTION
Currently external-data app does not react when the delete button is pressed. This is because `this.root` no longer contains the data after [the separate storage PR](https://github.com/microsoft/FluidFramework/pull/13066/files) was merged in. This PR simply hooks up the delete button to work again.