### PR TITLE
Make main the default branch for artifacts downloaded by test pipelines

### DIFF
--- a/tools/pipelines/test-dds-stress.yml
+++ b/tools/pipelines/test-dds-stress.yml
@@ -12,6 +12,7 @@ resources:
   pipelines:
   - pipeline: client   # Name of the pipeline resource
     source: Build - client packages
+    branch: main # Default branch for manual/scheduled triggers if none is selected
     trigger:
       branches:
       - release/*

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -10,6 +10,7 @@ resources:
   pipelines:
   - pipeline: client   # Name of the pipeline resource
     source: Build - client packages
+    branch: main # Default branch for manual/scheduled triggers if none is selected
     trigger:
       branches:
       - release/*

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -12,6 +12,7 @@ resources:
   pipelines:
   - pipeline: client   # Name of the pipeline resource
     source: Build - client packages
+    branch: main # Default branch for manual/scheduled triggers if none is selected
     trigger:
       branches:
       - release/*

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -12,6 +12,7 @@ resources:
   pipelines:
   - pipeline: client   # Name of the pipeline resource
     source: Build - client packages
+    branch: main # Default branch for manual/scheduled triggers if none is selected
     trigger:
       branches:
       - release/*


### PR DESCRIPTION
## Description

Right now, when we manually trigger a pipeline that would normally trigger in response to a run of the `Build - client packages` pipeline, it will download artifacts from the _latest_ run of `Build - client packages`, which might be for a branch that does not match the one for which the manual pipeline run is being done. Example, [116565](https://dev.azure.com/fluidframework/internal/_build/results?buildId=116565) (msft internal), a manual run of e2e tests for the `main` branch, used artifacts from [116553](https://dev.azure.com/fluidframework/internal/_build/results?buildId=116553&view=results) (see [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=116565&view=logs&j=5d40b943-5a8e-529c-ed4b-95198832abfc&t=94686312-f0f5-5668-54c3-251134305c69&l=9) in the logs) (msft internal), which was a `Build - client packages` run for branch `release/1.3`, not `main`.

Making `main` the default for this scenario seems like a reasonable thing to do, since most of the time manual runs of pipelines probably want to work off of that. Manual runs that need to target builds for other branches should be doing it explicitly anyway.

[AB#2950](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2950)