### PR TITLE
Resolve incorrect partial lengths state that prevented insert operation

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -388,29 +388,29 @@ export interface IMergeTreeOptions {
     /**
      * Whether to enable the length calculations implemented in
      * https://github.com/microsoft/FluidFramework/pull/11678
-     *
+     * 
      * These calculations resolve bugginess that causes eventual consistency issues in certain conflicting
      * removal cases, but regress some index-based undo-redo implementations. The suggested path for
-     * consumers is to switch to LocalReference-based undo-redo implementation (see
+     * consumers is to switch to LocalReference-based undo-redo implementation (see 
      * https://github.com/microsoft/FluidFramework/pull/11899) and enable this feature flag.
-     *
+     * 
      * default: false
      */
     mergeTreeUseNewLengthCalculations?: boolean;
     mergeTreeSnapshotChunkSize?: number;
     /**
      * Whether to use the SnapshotV1 format over SnapshotLegacy.
-     *
+     * 
      * SnapshotV1 stores a view of the merge-tree at the current sequence number, preserving merge metadata
      * (e.g. clientId, seq, etc.) only for segment changes within the collab window.
-     *
+     * 
      * SnapshotLegacy stores a view of the merge-tree at the minimum sequence number along with the ops between
      * the minimum sequence number and the current sequence number.
-     *
+     * 
      * Both formats merge segments where possible (see {@link ISegment.canAppend})
-     *
+     * 
      * default: false
-     *
+     * 
      * @remarks
      * Despite the "legacy"/"V1" naming, both formats are actively used at the time of writing. SharedString
      * uses legacy and Matrix uses V1.
@@ -427,10 +427,10 @@ export interface IMergeTreeAttributionOptions {
     /**
      * If enabled, segments will store attribution keys which can be used with the runtime to determine
      * attribution information (i.e. who created the content and when it was created).
-     *
+     * 
      * This flag only applied to new documents: if a snapshot is loaded, whether or not attribution keys
      * are tracked is determined by the presence of existing attribution keys in the snapshot.
-     *
+     * 
      * default: false
      */
     track?: boolean;
@@ -1294,7 +1294,7 @@ export class MergeTree {
                         pendingSegment.cachedLength
                     );
                 }
-
+    
                 overwrite = overlappingRemove || overwrite;
 
                 if (!overlappingRemove && opArgs.op.type === MergeTreeDeltaType.REMOVE) {
@@ -1736,8 +1736,6 @@ export class MergeTree {
                 // if the seg len in undefined, the segment
                 // will be removed, so should just be skipped for now
                 continue;
-            } else {
-                assert(len >= 0, "Length should not be negative");
             }
 
             if ((_pos < len) || ((_pos === len) && this.breakTie(_pos, child, seq))) {
@@ -2046,8 +2044,6 @@ export class MergeTree {
 
                 const start = this.findRollbackPosition(segment);
                 if (op.type === MergeTreeDeltaType.INSERT) {
-                    segment.seq = UniversalSequenceNumber;
-                    segment.localSeq = undefined;
                     const removeOp = createRemoveRangeOp(start, start + segment.cachedLength);
                     this.markRangeRemoved(
                         start,

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -74,6 +74,7 @@ describe("client.rollback", () => {
         client.rollback?.({ type: MergeTreeDeltaType.INSERT }, client.peekPendingSegmentGroups());
 
         assert.equal(client.getText(), "aefg");
+        validatePartialLengths(client.getClientId(), client.mergeTree);
     });
     it("Should zamboni rolled back insert", () => {
         client.insertTextLocal(0, "aefg");

--- a/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
@@ -25,7 +25,7 @@ const allOperations: TestOperation[] = [
 
 const defaultOptions = {
     minLength: { min: 1, max: 32 },
-    opsPerRollbackRange: { min: 1, max: 32 }, // Bug AB1809: fail to insert in rollback client after many ops
+    opsPerRollbackRange: { min: 1, max: 32 },
     rounds: 10,
     opsPerRound: 10,
     operations: allOperations,

--- a/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
@@ -40,7 +40,7 @@ describe("MergeTree.Client", () => {
                 mt.seedWithArray([0xDEADBEEF, 0xFEEDBED, minLength, opsPerRollback]);
 
                 // A: readonly, B: rollback, C: rollback + edit, D: edit
-                const clients = createClientsAtInitialState({ initialState: "", options: {mergeTreeUseNewLengthCalculations: true} }, "A", "B", "C", "D");
+                const clients = createClientsAtInitialState({ initialState: "" }, "A", "B", "C", "D");
                 let seq = 0;
 
                 for (let round = 0; round < defaultOptions.rounds; round++) {

--- a/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
@@ -24,8 +24,8 @@ const allOperations: TestOperation[] = [
 ];
 
 const defaultOptions = {
-    minLength: { min: 1, max: 16 /* 32 */ },
-    opsPerRollbackRange: { min: 1, max: 16 /* 32 */ }, // Bug AB1809: fail to insert in rollback client after many ops
+    minLength: { min: 1, max: 32 },
+    opsPerRollbackRange: { min: 1, max: 32 }, // Bug AB1809: fail to insert in rollback client after many ops
     rounds: 10,
     opsPerRound: 10,
     operations: allOperations,
@@ -40,7 +40,7 @@ describe("MergeTree.Client", () => {
                 mt.seedWithArray([0xDEADBEEF, 0xFEEDBED, minLength, opsPerRollback]);
 
                 // A: readonly, B: rollback, C: rollback + edit, D: edit
-                const clients = createClientsAtInitialState({ initialState: "" }, "A", "B", "C", "D");
+                const clients = createClientsAtInitialState({ initialState: "", options: {mergeTreeUseNewLengthCalculations: true} }, "A", "B", "C", "D");
                 let seq = 0;
 
                 for (let round = 0; round < defaultOptions.rounds; round++) {

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -223,8 +223,9 @@ export function applyMessages(
     let seq = startingSeq;
     try {
         // log and apply all the ops created in the round
-        while (messageData.length > 0) {
-            const [message] = messageData.shift()!;
+        // eslint-disable-next-line @typescript-eslint/prefer-for-of
+        for (let i = 0; i < messageData.length; i++) {
+            const [message] = messageData[i];
             message.sequenceNumber = ++seq;
             clients.forEach((c) => c.applyMsg(message));
         }

--- a/packages/dds/merge-tree/src/test/testUtils.ts
+++ b/packages/dds/merge-tree/src/test/testUtils.ts
@@ -175,7 +175,7 @@ function getPartialLengths(
     seq: number,
     mergeTree: MergeTree,
     localSeq?: number,
-    mergeBlock = mergeTree.root,
+    mergeBlock: IMergeBlock = mergeTree.root,
 ) {
     const partialLen = mergeBlock.partialLengths?.getPartialLength(
         seq,
@@ -219,7 +219,7 @@ export function validatePartialLengths(
     mergeTree: MergeTree,
     expectedValues?: { seq: number; len: number; localSeq?: number; }[],
     localSeq?: number,
-    mergeBlock = mergeTree.root,
+    mergeBlock: IMergeBlock = mergeTree.root,
 ): void {
     mergeTree.computeLocalPartials(0);
     for (let i = mergeTree.collabWindow.minSeq + 1; i <= mergeTree.collabWindow.currentSeq; i++) {
@@ -227,6 +227,9 @@ export function validatePartialLengths(
             clientId, i, mergeTree, localSeq, mergeBlock,
         );
 
+        if (partialLen && partialLen < 0) {
+            assert.fail("Negative partial length returned");
+        }
         assert.equal(partialLen, actualLen);
     }
 


### PR DESCRIPTION
This PR addresses the insert bug that appeared in the rollbackFarm tests. Insert ops that were created to be rolled back were being marked as removed without ever being acked. markRangeRemoved updates the partialLengths by subtracting the length of the node that was inserted, but since the length was never added to the tree in the first place, this resulted in negative node lengths. 

[AB#1809](https://dev.azure.com/fluidframework/internal/_workitems/edit/1809)