### PR TITLE
--use-openssl-ca for r11s tests - port to release/1.3

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -32,7 +32,7 @@
     "test:realsvc:local:report": "cross-env FLUID_TEST_REPORT=1 npm run test:realsvc:local --",
     "test:realsvc:odsp": "npm run test:realsvc:run -- --driver=odsp --timeout=20s",
     "test:realsvc:odsp:report": "cross-env FLUID_TEST_REPORT=1 npm run test:realsvc:odsp --",
-    "test:realsvc:r11s": "npm run test:realsvc:run -- --driver=r11s --timeout=5s",
+    "test:realsvc:r11s": "npm run test:realsvc:run -- --driver=r11s --timeout=5s --use-openssl-ca",
     "test:realsvc:report": "cross-env FLUID_TEST_REPORT=1 npm run test:realsvc",
     "test:realsvc:routerlicious": "npm run test:realsvc:r11s",
     "test:realsvc:routerlicious:report": "cross-env FLUID_TEST_REPORT=1 npm run test:realsvc:r11s --",


### PR DESCRIPTION
## Description

Add `--use-openssl-ca` flag so the r11s end-to-end tests trust the self-signed cert we install in the build agents.

[AB#2949](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2949)