### PR TITLE
Improve handling of non-retry-able network errors

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -419,7 +419,7 @@ export class DocumentDeltaConnection
                         }
                     }
                     else if (description && typeof description === "object") {
-                        const errorCode = description.error.code;
+                        const errorCode = description.error?.code;
 
                         // Self-Signed Certificate ErrorCode Found in error.description
                         if (errorCode === "DEPTH_ZERO_SELF_SIGNED_CERT") {

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -406,28 +406,27 @@ export class DocumentDeltaConnection
                 let isWebSocketTransportError = false;
                 try {
                     const description = error?.description;
-                    // const responseText = error?.context?.responseText;
+                    const context = error?.context;
 
-                    if (description.message?.includes("self signed certificate")) {
-                        failAndCloseSocket(this.createErrorObject("connect_error", error, false));
-                        return;
+                    if (context && typeof context === "object") {
+                        const statusText = error.context.statusText.code;
+
+                        // Self-Signed Certificate ErrorCode
+                        if (statusText === "DEPTH_ZERO_SELF_SIGNED_CERT") {
+                            failAndCloseSocket(this.createErrorObject("connect_error", error, false));
+                            return;
+                        }
                     }
+                    else if (description && typeof description === "object") {
+                        if (description.message?.includes("self signed certificate")) {
+                            failAndCloseSocket(this.createErrorObject("connect_error", error, false));
+                            return;
+                        }
 
-                    // console.log('Error: ', error);
-                    // console.log('Description:', description);
-                    // console.log('Description Message: ', description.message);
-                    // console.log("ResponseText:", responseText);
-
-                    // if (responseText?.includes("Error: self signed certificate")) {
-                    //     console.log('RESPONSE TEXT HIT');
-                    //     failAndCloseSocket(this.createErrorObject("connect_error", error, false));
-                    //     return;
-                    // }
-
-                    if (description && typeof description === "object") {
                         if (error.type === "TransportError") {
                             isWebSocketTransportError = true;
                         }
+
                         // That's a WebSocket. Clear it as we can't log it.
                         description.target = undefined;
                     }

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -409,21 +409,20 @@ export class DocumentDeltaConnection
                     const context = error?.context;
 
                     if (context && typeof context === "object") {
-                        const statusText = context.statusText.code;
+                        const statusText = context.statusText?.code;
 
-                        // Instead of string-matching the ErrorMessage, Filter the Error Based on the ErrorCode: "DEPTH_ZERO_SELF_SIGNED_CERT"
                         // Self-Signed Certificate ErrorCode Found in error.context
                         if (statusText === "DEPTH_ZERO_SELF_SIGNED_CERT") {
-                            failAndCloseSocket(this.createErrorObject("connect_error", error, false));
+                            failAndCloseSocket(this.createErrorObject("self_signed_cert_err", error, false));
                             return;
                         }
                     }
                     else if (description && typeof description === "object") {
-                        const errorCode = description.error.code;
+                        const errorCode = description.error?.code;
 
                         // Self-Signed Certificate ErrorCode Found in error.description
                         if (errorCode === "DEPTH_ZERO_SELF_SIGNED_CERT") {
-                            failAndCloseSocket(this.createErrorObject("connect_error", error, false));
+                            failAndCloseSocket(this.createErrorObject("self_signed_cert_err", error, false));
                             return;
                         }
 

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -408,9 +408,20 @@ export class DocumentDeltaConnection
                     const description = error?.description;
                     const responseText = error?.context?.responseText;
 
-                    if (responseText?.includes("Error: self signed certificate")) {
+                    if (description.message?.includes("self signed certificate")) {
                         failAndCloseSocket(this.createErrorObject("connect_error", error, false));
+                        return;
                     }
+
+                    console.log('Error: ', error);
+                    console.log('Description:', description);
+                    console.log('Description Message: ', description.message);
+                    console.log("ResponseText:", responseText);
+
+                    // if (responseText?.includes("Error: self signed certificate")) {
+                    //     failAndCloseSocket(this.createErrorObject("connect_error", error, false));
+                    //     return;
+                    // }
 
                     if (description && typeof description === "object") {
                         if (error.type === "TransportError") {

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -409,7 +409,7 @@ export class DocumentDeltaConnection
                     const context = error?.context;
 
                     if (context && typeof context === "object") {
-                        const statusText = error.context.statusText.code;
+                        const statusText = context.statusText.code;
 
                         // Self-Signed Certificate ErrorCode
                         if (statusText === "DEPTH_ZERO_SELF_SIGNED_CERT") {

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -411,14 +411,18 @@ export class DocumentDeltaConnection
                     if (context && typeof context === "object") {
                         const statusText = context.statusText.code;
 
-                        // Self-Signed Certificate ErrorCode
+                        // Instead of string-matching the ErrorMessage, Filter the Error Based on the ErrorCode: "DEPTH_ZERO_SELF_SIGNED_CERT"
+                        // Self-Signed Certificate ErrorCode Found in error.context
                         if (statusText === "DEPTH_ZERO_SELF_SIGNED_CERT") {
                             failAndCloseSocket(this.createErrorObject("connect_error", error, false));
                             return;
                         }
                     }
                     else if (description && typeof description === "object") {
-                        if (description.message?.includes("self signed certificate")) {
+                        const errorCode = description.error.code;
+
+                        // Self-Signed Certificate ErrorCode Found in error.description
+                        if (errorCode === "DEPTH_ZERO_SELF_SIGNED_CERT") {
                             failAndCloseSocket(this.createErrorObject("connect_error", error, false));
                             return;
                         }

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -413,7 +413,7 @@ export class DocumentDeltaConnection
 
                         // Self-Signed Certificate ErrorCode Found in error.context
                         if (statusText === "DEPTH_ZERO_SELF_SIGNED_CERT") {
-                            failAndCloseSocket(this.createErrorObject("self_signed_cert_err", error, false));
+                            failAndCloseSocket(this.createErrorObject("connect_error", error, false));
                             return;
                         }
                     }
@@ -422,7 +422,7 @@ export class DocumentDeltaConnection
 
                         // Self-Signed Certificate ErrorCode Found in error.description
                         if (errorCode === "DEPTH_ZERO_SELF_SIGNED_CERT") {
-                            failAndCloseSocket(this.createErrorObject("self_signed_cert_err", error, false));
+                            failAndCloseSocket(this.createErrorObject("connect_error", error, false));
                             return;
                         }
 

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -406,6 +406,12 @@ export class DocumentDeltaConnection
                 let isWebSocketTransportError = false;
                 try {
                     const description = error?.description;
+                    const responseText = error?.context?.responseText;
+
+                    if (responseText?.includes("Error: self signed certificate")) {
+                        failAndCloseSocket(this.createErrorObject("connect_error", error, false));
+                    }
+
                     if (description && typeof description === "object") {
                         if (error.type === "TransportError") {
                             isWebSocketTransportError = true;

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -406,19 +406,20 @@ export class DocumentDeltaConnection
                 let isWebSocketTransportError = false;
                 try {
                     const description = error?.description;
-                    const responseText = error?.context?.responseText;
+                    // const responseText = error?.context?.responseText;
 
                     if (description.message?.includes("self signed certificate")) {
                         failAndCloseSocket(this.createErrorObject("connect_error", error, false));
                         return;
                     }
 
-                    console.log('Error: ', error);
-                    console.log('Description:', description);
-                    console.log('Description Message: ', description.message);
-                    console.log("ResponseText:", responseText);
+                    // console.log('Error: ', error);
+                    // console.log('Description:', description);
+                    // console.log('Description Message: ', description.message);
+                    // console.log("ResponseText:", responseText);
 
                     // if (responseText?.includes("Error: self signed certificate")) {
+                    //     console.log('RESPONSE TEXT HIT');
                     //     failAndCloseSocket(this.createErrorObject("connect_error", error, false));
                     //     return;
                     // }

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -66,9 +66,9 @@ export function createR11sNetworkError(
             // If a service is temporarily down or a browser resource limit is reached, RestWrapper will throw
             // a network error with no status code (e.g. err:ERR_CONN_REFUSED or err:ERR_FAILED) and
             // the error message will start with NetworkError as defined in restWrapper.ts
-            // if (errorMessage.includes("failed, reason: self signed certificate")) {
-            //     return new NonRetryableError(errorMessage, R11sErrorType.sslCertError, props);
-            // }
+            if (errorMessage.includes("failed, reason: self signed certificate")) {
+                return new NonRetryableError(errorMessage, R11sErrorType.sslCertError, props);
+            }
             return new GenericNetworkError(errorMessage, errorMessage.startsWith("NetworkError"), props);
         case 401:
             // The first 401 is manually retried in RouterliciousRestWrapper with a refreshed token,

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -14,6 +14,7 @@ import { pkgVersion as driverVersion } from "./packageVersion";
 
 export enum R11sErrorType {
     fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
+    sslCertError = "sslCertError",
 }
 
 /**
@@ -65,8 +66,10 @@ export function createR11sNetworkError(
             // If a service is temporarily down or a browser resource limit is reached, RestWrapper will throw
             // a network error with no status code (e.g. err:ERR_CONN_REFUSED or err:ERR_FAILED) and
             // the error message will start with NetworkError as defined in restWrapper.ts
-            return new GenericNetworkError(
-                errorMessage, errorMessage.startsWith("NetworkError"), props);
+            // if (errorMessage.includes("failed, reason: self signed certificate")) {
+            //     return new NonRetryableError(errorMessage, R11sErrorType.sslCertError, props);
+            // }
+            return new GenericNetworkError(errorMessage, errorMessage.startsWith("NetworkError"), props);
         case 401:
             // The first 401 is manually retried in RouterliciousRestWrapper with a refreshed token,
             // so we treat repeat 401s the same as 403.

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -66,6 +66,7 @@ export function createR11sNetworkError(
             // If a service is temporarily down or a browser resource limit is reached, RestWrapper will throw
             // a network error with no status code (e.g. err:ERR_CONN_REFUSED or err:ERR_FAILED) and
             // the error message will start with NetworkError as defined in restWrapper.ts
+            // If there exists a self-signed SSL certificates error, throw a NonRetryableError
             if (errorMessage.includes("failed, reason: self signed certificate")) {
                 return new NonRetryableError(errorMessage, R11sErrorType.sslCertError, props);
             }

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -67,6 +67,8 @@ export function createR11sNetworkError(
             // a network error with no status code (e.g. err:ERR_CONN_REFUSED or err:ERR_FAILED) and
             // the error message will start with NetworkError as defined in restWrapper.ts
             // If there exists a self-signed SSL certificates error, throw a NonRetryableError
+            // Instead of relying on string matching, filter error based on the error code / ID
+
             if (errorMessage.includes("failed, reason: self signed certificate")) {
                 return new NonRetryableError(errorMessage, R11sErrorType.sslCertError, props);
             }

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -67,8 +67,7 @@ export function createR11sNetworkError(
             // a network error with no status code (e.g. err:ERR_CONN_REFUSED or err:ERR_FAILED) and
             // the error message will start with NetworkError as defined in restWrapper.ts
             // If there exists a self-signed SSL certificates error, throw a NonRetryableError
-            // Instead of relying on string matching, filter error based on the error code / ID
-
+            // TODO: instead of relying on string matching, filter error based on the error code like we do for websocket connections
             if (errorMessage.includes("failed, reason: self signed certificate")) {
                 return new NonRetryableError(errorMessage, R11sErrorType.sslCertError, props);
             }

--- a/packages/tools/fluid-runner/src/test/parseBundleAndExportFile.spec.ts
+++ b/packages/tools/fluid-runner/src/test/parseBundleAndExportFile.spec.ts
@@ -70,7 +70,6 @@ describe("parseBundleAndExportFile", () => {
                 telemetryFile,
             );
 
-            // Instead of relying on string matching, filter error based on the error code / ID
             assert(!result.success, "result should not be successful");
             assert(result.errorMessage.includes("IFluidFileConverter"),
                 `error message does not contain "IFluidFileConverter" [${result.errorMessage}]`);

--- a/packages/tools/fluid-runner/src/test/parseBundleAndExportFile.spec.ts
+++ b/packages/tools/fluid-runner/src/test/parseBundleAndExportFile.spec.ts
@@ -70,6 +70,7 @@ describe("parseBundleAndExportFile", () => {
                 telemetryFile,
             );
 
+            // Instead of relying on string matching, filter error based on the error code / ID
             assert(!result.success, "result should not be successful");
             assert(result.errorMessage.includes("IFluidFileConverter"),
                 `error message does not contain "IFluidFileConverter" [${result.errorMessage}]`);


### PR DESCRIPTION
### Description

https://dev.azure.com/fluidframework/internal/_workitems/edit/2489/

### Objective

This PR solves the problem in FF's end-to-end test triggered by the move to self-signed SSL certificates for the R11s AKS cluster. In contrast to the past error messages, improved logic will instantaneously throw `self signed certificate ERROR` instead of retrying the connection and eventually throwing a `timeout error`. 

### HTTP
<img width="1130" alt="Screenshot 2022-12-22 142948" src="https://user-images.githubusercontent.com/111468570/209238237-155947b0-549b-460f-aad0-9857df3213e2.png">


### Socket 

<img width="1130" alt="Screenshot 2022-12-22 142935" src="https://user-images.githubusercontent.com/111468570/209238150-27632a9f-030b-43b5-b3b4-2c319c0eb6c9.png">
