### PR TITLE
GC: Added test where a DDS's summarizer node is created after refreshLatestFromSnapshot completes

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
@@ -74,6 +74,15 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         return (metadata.message as ISequencedDocumentMessage).sequenceNumber;
     }
 
+    /**
+     * Function that asserts the given value is not true. Used in these tests to demonstrate that because of
+     * a bug we are not getting the expected results. Once the bug is fixed, these asserts should start working
+     * as expected.
+     */
+    function assertNotTrue(value: boolean, message: string) {
+        assert(!value, message);
+    }
+
     beforeEach(async function() {
         provider = getTestObjectProvider({ syncSummarizer: true });
         mainContainer = await provider.makeTestContainer(defaultGCConfig);
@@ -286,7 +295,7 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         const dsAReferenceState3 = referenceState3.get(dataStoreA._context.id);
         assert(dsAReferenceState3 === true, `dataStoreA should still be referenced`);
         const dsBReferenceState3 = referenceState3.get(dataStoreB._context.id);
-        assert(dsBReferenceState3 === true, `dataStoreB should still be referenced on loading from old summary`);
+        assertNotTrue(dsBReferenceState3 === true, `dataStoreB should still be referenced on loading from old summary`);
     });
 
     it("updates unreferenced timestamps correctly when loading from an older summary", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
@@ -8,6 +8,7 @@ import { IContainer } from "@fluidframework/container-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISequencedDocumentMessage, ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
+import { SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     ITestObjectProvider,
@@ -76,8 +77,19 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
     beforeEach(async function() {
         provider = getTestObjectProvider({ syncSummarizer: true });
         mainContainer = await provider.makeTestContainer(defaultGCConfig);
-        dataStoreA = await requestFluidObject<ITestDataObject>(mainContainer, "default");
-        containerRuntime = dataStoreA._context.containerRuntime as IContainerRuntime;
+        const defaultDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
+        containerRuntime = defaultDataStore._context.containerRuntime as IContainerRuntime;
+
+        // Create data store B and mark it referenced. This will be used to manage reference of another data store.
+        // We create a new data store because the default data store and is always realized by the test infrastructure.
+        // In these tests, the data store managing referencing should not be realized by default.
+        const dataStoreAHandle =
+            (await containerRuntime.createDataStore(TestDataObjectType)).entryPoint as IFluidHandle<ITestDataObject>;
+        assert(dataStoreAHandle !== undefined, "data store does not have a handle");
+        dataStoreA = await dataStoreAHandle.get();
+        defaultDataStore._root.set("dataStoreA", dataStoreAHandle);
+
+        await provider.ensureSynchronized();
         await waitForContainerConnection(mainContainer);
     });
 
@@ -201,6 +213,80 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         const dsBReferenceState3 = referenceState3.get(dataStoreB._context.id);
         assert(
             dsBReferenceState3 === false, `dataStoreB should still be unreferenced on loading from old summary`);
+    });
+
+    /**
+     * In this test, the data store containing references to another data store is changed after loading from an older
+     * summary. But the DDS in the data store containing the references is not changed. This validates that the GC data
+     * in older summary is correctly propagated to DDS as well.
+     */
+    it("updates unreferenced nodes correctly when DDS is unchanged after loading from older summary", async () => {
+        const summarizer1 = await createSummarizer(provider, mainContainer);
+
+        // Create a second DDS in dataStoreA. This will be changed after loading from old summary so that the data store
+        // changes but the root DDS containing references is unchanged.
+        const dataStoreAdds2 = SharedMap.create(dataStoreA._runtime);
+        dataStoreA._root.set("dds2", dataStoreAdds2.handle);
+
+        const dataStoreBHandle =
+            (await containerRuntime.createDataStore(TestDataObjectType)).entryPoint as IFluidHandle<ITestDataObject>;
+        assert(dataStoreBHandle !== undefined, "New data store does not have a handle");
+        const dataStoreB = await dataStoreBHandle.get();
+        dataStoreA._root.set("dataStoreB", dataStoreBHandle);
+        dataStoreA._root.delete("dataStoreB");
+
+        await provider.ensureSynchronized();
+
+        // Summarize - summary1. dataStoreB should be unreferenced.
+        const summaryResult1 = await summarizeNow(summarizer1);
+        const referenceState1 = await getReferenceState(summaryResult1.summaryTree);
+        const dsAReferenceState1 = referenceState1.get(dataStoreA._context.id);
+        assert(dsAReferenceState1 === true, `dataStoreA should be referenced`);
+        const dsBReferenceState1 = referenceState1.get(dataStoreB._context.id);
+        assert(dsBReferenceState1 === false, `dataStoreB should be unreferenced`);
+
+        // Reference dataStoreB now.
+        dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+
+        // Summarize - summary2. dataStoreB should now be referenced.
+        await provider.ensureSynchronized();
+        const summaryResult2 = await summarizeNow(summarizer1);
+        const referenceState2 = await getReferenceState(summaryResult2.summaryTree);
+        const dsAReferenceState2 = referenceState2.get(dataStoreA._context.id);
+        assert(dsAReferenceState2 === true, `dataStoreA should still be referenced`);
+        const dsBReferenceState2 = referenceState2.get(dataStoreB._context.id);
+        assert(dsBReferenceState2 === true, `dataStoreB should now be referenced`);
+
+        // Load a new summarizer from the summary1 and summarize - summary3. Before it summarizes, it will catch up
+        // to latest and so the reference state of the data stores should be the same as in summary2.
+        // Also, note that while catching up, it will download summary2 and update state from it.
+        summarizer1.close();
+        const summarizer2 = await createSummarizer(provider, mainContainer, summaryResult1.summaryVersion);
+
+        // Create a new alias data store so that the GC data changes without changing the GC state of existing data
+        // stores. This is to write the GC tree in summary (instead of handle) which is used for validation.
+        const ds2 = await containerRuntime.createDataStore(TestDataObjectType);
+        const aliasResult = await ds2.trySetAlias("root2");
+        assert.strictEqual(aliasResult, "Success", "Failed to alias data store");
+
+        // Change the second DDS in dataStoreA. This will change dataStoreA but the root DDS that contains references
+        // to dataStoreB is unchanged.
+        dataStoreAdds2.set("key", "value");
+
+        await provider.ensureSynchronized();
+        const summaryResult3 = await summarizeNow(summarizer2);
+
+        // Validate that summary3 is same or newer than summary2. This is to ensure that it has the latest GC state.
+        const summary2SequenceNumber = getSummarySequenceNumber(summaryResult2.summaryTree);
+        const summary3SequenceNumber = getSummarySequenceNumber(summaryResult3.summaryTree);
+        assert(summary3SequenceNumber >= summary2SequenceNumber, "Summary 3 should be same or newer than summary 2");
+
+        // Validate that dataStoreB is still referenced in this summary.
+        const referenceState3 = await getReferenceState(summaryResult3.summaryTree);
+        const dsAReferenceState3 = referenceState3.get(dataStoreA._context.id);
+        assert(dsAReferenceState3 === true, `dataStoreA should still be referenced`);
+        const dsBReferenceState3 = referenceState3.get(dataStoreB._context.id);
+        assert(dsBReferenceState3 === true, `dataStoreB should still be referenced on loading from old summary`);
     });
 
     it("updates unreferenced timestamps correctly when loading from an older summary", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
@@ -23,8 +23,9 @@ import {
 } from "./gcTestSummaryUtils";
 
 /**
- * Validates that that reference state of nodes is correct irrespective of whether a summarizer loads from the
- * latest summary or an older summary.
+ * Validates that that reference state of nodes is correct irrespective of whether a summarizer loads from the latest
+ * summary or an older summary. When a summarizer loads from an older summary, it gets the ack for newer summaries and
+ * refreshes its state from the newer summary. These tests validates that the GC state is correctly refreshed.
  */
 describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
     let provider: ITestObjectProvider;


### PR DESCRIPTION
Added a test that repros the following bug:
When a DDS's summarizer node is created after the container refreshes its state from a snapshot, the DDS's GC data may be incorrect. Here is a scenario where this can happen:
1. Container loads from base snapshot - snapshot1. The GC data for dataStore1 is set to dsGCData1. It has a map DDS but the data store hasn't been realized yet so the map's summarizer node is not created. The map DDS's GC data at this point is mapGCData1.
2. Container gets an ack for snapshot2 and refreshes its state from this snapshot. The GC data for dataStore1 is updated to dsGCData2. The map DDS's GC data at this point is mapGCData2.
3. dataStore1 is now realized and the summarizer node for map DDS is created. Currently, the map's GC data is initialized from the base snapshot's GC data, i.e., mapGCData1.
4. The map DDS does not change and GC runs. The GC data returned in mapGCData1 which is incorrect. In step 3, the map's GC data should have been updated to mapGCData2.

Repros this bug - [AB#2962](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2962)