### PR TITLE
Added tests for attachment blobs uploaded when container is disconnected

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
@@ -11,7 +11,7 @@ import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
-import { ITestContainerConfig, ITestObjectProvider } from "@fluidframework/test-utils";
+import { ITestContainerConfig, ITestObjectProvider, waitForContainerConnection } from "@fluidframework/test-utils";
 import { describeNoCompat, ITestDataObject } from "@fluidframework/test-version-utils";
 import { getUrlFromItemId, MockDetachedBlobStorage } from "../mockDetachedBlobStorage";
 import { getGCStateFromSummary } from "./gcTestSummaryUtils";
@@ -33,6 +33,11 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
     const tests = (deleteUnreferencedContent: boolean = false) => {
         const gcContainerConfig: ITestContainerConfig = {
             runtimeOptions: {
+                summaryOptions: {
+                    summaryConfigOverrides: {
+                        state: "disabled",
+                    },
+                },
                 gcOptions: {
                     gcAllowed: true, runGCInTestMode: deleteUnreferencedContent,
                 },
@@ -41,15 +46,14 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 
         let provider: ITestObjectProvider;
         let container: IContainer;
-        let containerRuntime: ContainerRuntime;
         let defaultDataStore: ITestDataObject;
 
         /**
-         * Returns the referenced / unreferenced state of each node if the GC state in summary.
+         * Summarizes and returns the referenced / unreferenced state of each node if the GC state in summary.
          */
-        async function getUnreferencedNodeStates() {
+        async function summarizeAndGetUnreferencedNodeStates(summarizerRuntime: ContainerRuntime) {
             await provider.ensureSynchronized();
-            const { summary } = await containerRuntime.summarize({
+            const { summary } = await summarizerRuntime.summarize({
                 runGC: true,
                 fullTree: true,
                 trackState: false,
@@ -66,6 +70,26 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             return nodeTimestamps;
         }
 
+        /**
+         * Loads a container from the itemId of the container. We need to do this instead of loading a container
+         * normally because - When a detached container is attached after attachment blobs have been added, a .tmp
+         * extension is added to the end of the filename. Since the ODSP test driver assumes the filename will always
+         * be <fileName>.fluid, it does not correctly return the url for a container that was attached with attachment
+         * blobs when createContainerUrl() is called, instead creating a new file.
+         */
+        async function loadContainer() {
+            const url = getUrlFromItemId((container.resolvedUrl as IOdspResolvedUrl).itemId, provider);
+            const newContainer = await provider.makeTestLoader(gcContainerConfig).resolve({ url });
+            await waitForContainerConnection(newContainer);
+            return newContainer;
+        }
+
+        async function createSummarizerRuntime() {
+            const summarizerContainer = await loadContainer();
+            const summarizerDefaultDataStore = await requestFluidObject<ITestDataObject>(summarizerContainer, "/");
+            return summarizerDefaultDataStore._context.containerRuntime as ContainerRuntime;
+        }
+
         beforeEach(async function() {
             provider = getTestObjectProvider();
             if (provider.driver.type !== "odsp") {
@@ -75,30 +99,31 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             const loader = provider.makeTestLoader({ ...gcContainerConfig, loaderProps: { detachedBlobStorage } });
             container = await loader.createDetachedContainer(provider.defaultCodeDetails);
             defaultDataStore = await requestFluidObject<ITestDataObject>(container, "/");
-            containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
         });
 
         it("collects blobs uploaded in attached container", async () => {
             // Attach the container.
             await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
 
+            const summarizerRuntime = await createSummarizerRuntime();
+
             // Upload an attachment blob and mark it referenced by storing its handle in a DDS.
             const blobContents = "Blob contents";
             const blobHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
             defaultDataStore._root.set("blob", blobHandle);
 
-            const s1 = await getUnreferencedNodeStates();
+            const s1 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             assert(s1.get(blobHandle.absolutePath) === "referenced", "blob should be referenced");
 
             // Remove the blob's handle and verify its marked as unreferenced.
             defaultDataStore._root.delete("blob");
-            const s2 = await getUnreferencedNodeStates();
+            const s2 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             assert(s2.get(blobHandle.absolutePath) === "unreferenced", "blob should be unreferenced");
 
             // Add the blob's handle back. If deleteUnreferencedContent is true, the blob's node would have been
             // deleted from the GC state. Else, it would be referenced.
             defaultDataStore._root.set("blob", blobHandle);
-            const s3 = await getUnreferencedNodeStates();
+            const s3 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             if (deleteUnreferencedContent) {
                 assert(s3.get(blobHandle.absolutePath) === undefined, "blob should not have a GC entry");
             } else {
@@ -115,13 +140,14 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             // Attach the container after the blob is uploaded.
             await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
 
+            const summarizerRuntime = await createSummarizerRuntime();
+
             // GC requires at least one op to have been processed. It needs a server timestamp and
             // uses the timestamp of the op.
             defaultDataStore._root.set("make container connect in", "write mode");
 
             // Load a second container.
-            const url = getUrlFromItemId((container.resolvedUrl as IOdspResolvedUrl).itemId, provider);
-            const container2 = await provider.makeTestLoader(gcContainerConfig).resolve({ url });
+            const container2 = await loadContainer();
             const defaultDataStore2 = await requestFluidObject<ITestDataObject>(container2, "/");
 
             // Validate the blob handle's path is the same as the one in the first container. This is to validate that
@@ -130,18 +156,18 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             assert.strictEqual(blobHandle.absolutePath, blobHandle2?.absolutePath,
                     "The blob handle has a different path in remote container.");
 
-            const s1 = await getUnreferencedNodeStates();
+            const s1 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             assert(s1.get(blobHandle.absolutePath) === "referenced", "blob should be referenced");
 
             // Remove the blob's handle and verify its marked as unreferenced.
             defaultDataStore._root.delete("blob");
-            const s2 = await getUnreferencedNodeStates();
+            const s2 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             assert(s2.get(blobHandle.absolutePath) === "unreferenced", "blob should be unreferenced");
 
             // Add the blob's handle in second container. If deleteUnreferencedContent is true, the blob's node would
             // have been deleted from the GC state. Else, it would be referenced.
             defaultDataStore2._root.set("blobContainer2", blobHandle2);
-            const s3 = await getUnreferencedNodeStates();
+            const s3 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             if (deleteUnreferencedContent) {
                 assert(s3.get(blobHandle.absolutePath) === undefined, "blob should not have a GC entry");
             } else {
@@ -159,19 +185,21 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             // Attach the container after the blob is uploaded.
             await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
 
+            const summarizerRuntime = await createSummarizerRuntime();
+
             // GC requires at least one op to have been processed. It needs a server timestamp and
             // uses the timestamp of the op.
             defaultDataStore._root.set("make container connect in", "write mode");
             // Make sure we are connected or we may get a local ID handle
             await ensureContainerConnectedWriteMode(container as Container);
 
-            // Upload the same blob. This will get de-duped and we will get back a handle with the stoageId instead of
+            // Upload the same blob. This will get de-duped and we will get back a handle with the storageId instead of
             // the localId that we got when uploading in detached container.
             const storageHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
 
             // Validate that storing the localId handle makes both the localId and storageId nodes as referenced since
             // localId is simply an alias to the storageId.
-            const s1 = await getUnreferencedNodeStates();
+            const s1 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             assert(s1.get(localHandle.absolutePath) === "referenced", "local id blob should be referenced");
             assert(s1.get(storageHandle.absolutePath) === "referenced",
                 "storage id blob should also be referenced (1)");
@@ -179,7 +207,7 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             // Replace the localId handle with the storageId handle. The storageId node should be referenced but the
             // localId node should be unreferenced. Basically, the alias is deleted.
             defaultDataStore._root.set("blob", storageHandle);
-            const s2 = await getUnreferencedNodeStates();
+            const s2 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             assert(s2.get(localHandle.absolutePath) === "unreferenced", "local id blob should still be unreferenced");
             assert(s2.get(storageHandle.absolutePath) === "referenced",
                 "storage id blob should also be referenced (2)");
@@ -187,7 +215,7 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             // Delete the storageId handle. The storageId node should be unreferenced. If deleteUnreferencedContent is
             // true, the localId node should be deleted from the GC state. Else, it would be unreferenced.
             defaultDataStore._root.delete("blob");
-            const s3 = await getUnreferencedNodeStates();
+            const s3 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             assert(s3.get(storageHandle.absolutePath) === "unreferenced", "storage id blob should be unreferenced");
             if (deleteUnreferencedContent) {
                 assert(s3.get(localHandle.absolutePath) === undefined, "local id blob should not have a GC entry");
@@ -198,7 +226,7 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             // Add the localId handle back. If deleteUnreferencedContent is true, both the nodes would have been
             // deleted from the GC state. Else, they would both be referenced.
             defaultDataStore._root.set("blob", localHandle);
-            const s4 = await getUnreferencedNodeStates();
+            const s4 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             if (deleteUnreferencedContent) {
                 assert(s4.get(localHandle.absolutePath) === undefined, "local id blob should not have a GC entry");
                 assert(s4.get(storageHandle.absolutePath) === undefined, "storage id blob should not have a GC entry");
@@ -218,6 +246,8 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             // Attach the container after the blob is uploaded.
             await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
 
+            const summarizerRuntime = await createSummarizerRuntime();
+
             // GC requires at least one op to have been processed. It needs a server timestamp and
             // uses the timestamp of the op.
             defaultDataStore._root.set("make container connect in", "write mode");
@@ -231,14 +261,14 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             // Store the localId1 and localId2 handles. This would make the localId nodes and storageId node referenced.
             defaultDataStore._root.set("local1", localHandle1);
             defaultDataStore._root.set("local2", localHandle2);
-            const s1 = await getUnreferencedNodeStates();
+            const s1 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             assert(s1.get(localHandle1.absolutePath) === "referenced", "local id 1 blob should be referenced");
             assert(s1.get(localHandle2.absolutePath) === "referenced", "local id 2 blob should be referenced");
             assert(s1.get(storageHandle.absolutePath) === "referenced", "storage id blob should be referenced (1)");
 
             // Delete the localId1 handle. This would make localId1 node unreferenced.
             defaultDataStore._root.delete("local1");
-            const s2 = await getUnreferencedNodeStates();
+            const s2 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             assert(s2.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should be unreferenced");
             assert(s2.get(localHandle2.absolutePath) === "referenced", "local id 2 blob should be referenced");
             assert(s2.get(storageHandle.absolutePath) === "referenced", "storage id blob should be referenced (2)");
@@ -247,7 +277,7 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             // is true, localId2 node would be deleted from GC state. Store the storageId handle to keep it referenced.
             defaultDataStore._root.delete("local2");
             defaultDataStore._root.set("storage", storageHandle);
-            const s3 = await getUnreferencedNodeStates();
+            const s3 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             assert(s3.get(localHandle2.absolutePath) === "unreferenced", "local id 2 blob should be unreferenced");
             assert(s3.get(storageHandle.absolutePath) === "referenced", "storage id blob should be referenced (3)");
             if (deleteUnreferencedContent) {
@@ -258,7 +288,7 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 
             // Delete the storageId handle. It should now be unreferenced.
             defaultDataStore._root.delete("storage");
-            const s4 = await getUnreferencedNodeStates();
+            const s4 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             assert(s4.get(storageHandle.absolutePath) === "unreferenced", "storage id blob should be unreferenced");
             if (deleteUnreferencedContent) {
                 assert(s4.get(localHandle1.absolutePath) === undefined, "local id blob 1 should not have a GC entry");
@@ -266,6 +296,62 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             } else {
                 assert(s4.get(localHandle1.absolutePath) === "unreferenced", "local id blob 1 should be unreferenced");
                 assert(s4.get(localHandle2.absolutePath) === "unreferenced", "local id blob 2 should be unreferenced");
+            }
+        });
+
+        it("collects blobs uploaded in disconnected and de-duped in connected container", async () => {
+            // Attach the main container.
+            await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+            // GC requires at least one op to have been processed. It needs a server timestamp and
+            // uses the timestamp of the op.
+            defaultDataStore._root.set("make container connect in", "write mode");
+            await ensureContainerConnectedWriteMode(container as Container);
+
+            // Summarize once before uploading the blob in disconnected container. This will make sure that when GC
+            // runs next, it has GC data from previous run to do reference validation.
+            const summarizerRuntime = await createSummarizerRuntime();
+            await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
+
+            // Load a new container and disconnect it.
+            const container2 = await loadContainer();
+            const container2DataStore = await requestFluidObject<ITestDataObject>(container2, "/");
+            container2.disconnect();
+
+            // Upload an attachment blob when disconnected. We should get a handle with a localId for the blob. Mark it
+            // referenced by storing its handle in a DDS.
+            const blobContents = "Blob contents";
+            const localHandle = await container2DataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            container2DataStore._root.set("local", localHandle);
+
+            // Connect the container and wait for it to be connected.
+            container2.connect();
+            await waitForContainerConnection(container2);
+
+            // Validate that the localId is referenced. This should not log any gcUnknownOutboundReferences error as a
+            // reference from localId to storageId would be created.
+            const s1 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
+            assert(s1.get(localHandle.absolutePath) === "referenced", "local id blob should be referenced");
+
+            // Upload the same blob. This will get de-duped and we will get back a handle with the storageId instead of
+            // the localId that we got when uploading in disconnected container.
+            const storageHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            assert(s1.get(storageHandle.absolutePath) === "referenced", "storage id blob should be referenced");
+
+            // Delete the localId handle. The localId and storageId nodes should both be unreferenced. They will be
+            // be deleted locally in this summary. In the next summary, they will be deleted.
+            container2DataStore._root.delete("local");
+            const s2 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
+            assert(s2.get(localHandle.absolutePath) === "unreferenced", "local id blob should be unreferenced");
+            assert(s2.get(storageHandle.absolutePath) === "unreferenced", "storage id blob should be unreferenced");
+
+            // In this summary, unreferenced nodes will be deleted if deleteUnreferencedContent is set.
+            const s3 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
+            if (deleteUnreferencedContent) {
+                assert(s3.get(localHandle.absolutePath) === undefined, "local id blob should not have a GC entry");
+                assert(s3.get(storageHandle.absolutePath) === undefined, "storage id blob should not have a GC entry");
+            } else {
+                assert(s3.get(localHandle.absolutePath) === "unreferenced", "local id blob should be unreferenced");
+                assert(s3.get(storageHandle.absolutePath) === "unreferenced", "storage id blob should be unreferenced");
             }
         });
     };

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { strict as assert } from "assert";
+import { Container } from "@fluidframework/container-loader";
 import { IGCRuntimeOptions } from "@fluidframework/container-runtime";
 import {
     requestFluidObject } from "@fluidframework/runtime-utils";
@@ -17,7 +18,7 @@ import {
 } from "@fluidframework/test-utils";
 import { describeNoCompat, ITestDataObject, itExpects } from "@fluidframework/test-version-utils";
 import { delay, stringToBuffer } from "@fluidframework/common-utils";
-import { LoaderHeader } from "@fluidframework/container-definitions";
+import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
 import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
 import { getUrlFromItemId, MockDetachedBlobStorage } from "../mockDetachedBlobStorage";
 
@@ -345,19 +346,22 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
     });
 
     describe("Attachment blobs in detached container", () => {
-        async function createContainerAndDataStore() {
+        /**
+         * Creates a detached container and returns it along with the default data store.
+         */
+        async function createDetachedContainerAndDataStore() {
             const detachedBlobStorage = new MockDetachedBlobStorage();
             const loader = provider.makeTestLoader({
                 ...testContainerConfig,
                 loaderProps: { ...testContainerConfig.loaderProps, detachedBlobStorage },
             });
-            const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
-            const dataStore = await requestFluidObject<ITestDataObject>(container, "/");
-            return { container, dataStore };
+            const mainContainer = await loader.createDetachedContainer(provider.defaultCodeDetails);
+            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "/");
+            return { mainContainer, mainDataStore };
         }
 
         beforeEach(async function() {
-            provider = getTestObjectProvider();
+            provider = getTestObjectProvider({ syncSummarizer: true });
             if (provider.driver.type !== "odsp") {
                 this.skip();
             }
@@ -373,7 +377,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
             },
         ],
         async () => {
-            const { container: mainContainer, dataStore: mainDataStore } = await createContainerAndDataStore();
+            const { mainContainer, mainDataStore } = await createDetachedContainerAndDataStore();
 
             // Upload an attachment blob and mark it referenced by storing its handle in a DDS.
             const blobContents = "Blob contents";
@@ -437,7 +441,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
             }
         ],
         async () => {
-            const { container: mainContainer, dataStore: mainDataStore } = await createContainerAndDataStore();
+            const { mainContainer, mainDataStore } = await createDetachedContainerAndDataStore();
 
             // Upload an attachment blob. We should get a handle with a localId for the blob. Mark it referenced by
             // storing its handle in a DDS.
@@ -516,7 +520,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
             }
         ],
         async () => {
-            const { container: mainContainer, dataStore: mainDataStore } = await createContainerAndDataStore();
+            const { mainContainer, mainDataStore } = await createDetachedContainerAndDataStore();
 
             // Upload couple of attachment blobs with the same content. When these blobs are uploaded to the server,
             // they will be de-duped and redirect to the same storageId.
@@ -573,6 +577,246 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
                 url,
                 headers: { [LoaderHeader.version]: summary2.summaryVersion },
             });
+
+            // Retrieving the blob via any of the handles should fail. Note that the blob is requested via its url since
+            // this container does not have access to the blob's handle.
+            const localResponse1 = await container2.request({ url: localHandle1.absolutePath });
+            assert.strictEqual(localResponse1?.status, 404, `Expecting a 404 response for local handle 1`);
+            assert(localResponse1.value.startsWith("Blob removed by gc:"), `Unexpected value for local handle 1`);
+
+            const localResponse2 = await container2.request({ url: localHandle2.absolutePath });
+            assert.strictEqual(localResponse2?.status, 404, `Expecting a 404 response for local handle 2`);
+            assert(localResponse2.value.startsWith("Blob removed by gc:"), `Unexpected value for local handle 2`);
+
+            const storageResponse = await container2.request({ url: storageHandle.absolutePath });
+            assert.strictEqual(storageResponse?.status, 404, `Expecting a 404 response for storage handle`);
+            assert(storageResponse.value.startsWith("Blob removed by gc:"), `Unexpected value for storage handle`);
+        });
+    });
+
+    describe("Attachment blobs in disconnected container", () => {
+        /**
+         * Creates a container and returns it along with the default data store.
+         */
+        async function createContainerAndDataStore() {
+            const mainContainer = await provider.makeTestContainer(testContainerConfig);
+            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "/");
+            await waitForContainerConnection(mainContainer);
+            return { mainContainer, mainDataStore };
+        }
+
+        /**
+         * Creates a summarizer, does an initial summary and returns the summarizer. The initial summary is done so
+         * that GarbageCollector has initial GC data. When GC runs next with the attachment blobs, it has a previous
+         * GC data to validate references against and ensure that gcUnknownOutboundReferences error is not logged.
+         */
+        async function createSummarizerWithInitialSummary(container: IContainer) {
+            const summarizer = await createSummarizer(
+                provider,
+                container,
+                undefined /* summaryVersion */,
+                gcOptions,
+                mockConfigProvider(settings),
+            );
+            await provider.ensureSynchronized();
+            await summarizeNow(summarizer);
+            return summarizer;
+        }
+
+        const ensureContainerConnectedWriteMode = async (container: IContainer) => {
+            const resolveIfActive = (res: () => void) => { if (container.deltaManager.active) { res(); } };
+            if (!container.deltaManager.active) {
+                await new Promise<void>((resolve) => container.on("connected", () => resolveIfActive(resolve)));
+                (container as Container).off("connected", resolveIfActive);
+            }
+        };
+
+        beforeEach(async function() {
+            provider = getTestObjectProvider({ syncSummarizer: true });
+            if (provider.driver.type !== "local") {
+                this.skip();
+            }
+
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
+            settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
+        });
+
+        itExpects("tombstones blobs uploaded in disconnected container",
+        [
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            },
+        ],
+        async () => {
+            const { mainContainer, mainDataStore } = await createContainerAndDataStore();
+
+            // Create a summarizer which does an initial summary.
+            const summarizer = await createSummarizerWithInitialSummary(mainContainer);
+
+            // Disconnect the main container, upload an attachment blob and mark it referenced.
+            mainContainer.disconnect();
+            const blobContents = "Blob contents";
+            const blobHandle = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            mainDataStore._root.set("blob", blobHandle);
+
+            // Connect the container after the blob is uploaded. Send an op to transition it to write mode.
+            mainContainer.connect();
+            mainDataStore._root.set("transition to write", "true");
+            await ensureContainerConnectedWriteMode(mainContainer);
+
+            // Remove the blob's handle to unreference it.
+            mainDataStore._root.delete("blob");
+
+            // Summarize so that the above attachment blob is marked unreferenced.
+            await provider.ensureSynchronized();
+            await summarizeNow(summarizer);
+
+            // Wait for sweep timeout so that the blob is tombstoned.
+            await delay(sweepTimeoutMs + 10);
+
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize so that the tombstoned blob should are now part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+
+            // Load a new container from the above summary which should have the blob tombstoned.
+            const container2 = await loadContainer(summary2.summaryVersion);
+
+            // Retrieving the blob should fail. Note that the blob is requested via its url since this container does
+            // not have access to the blob's handle.
+            const response = await container2.request({ url: blobHandle.absolutePath });
+            assert.strictEqual(response?.status, 404, `Expecting a 404 response`);
+            assert(response.value.startsWith("Blob removed by gc:"), `Unexpected response value`);
+            assert(container2.closed !== true, "Container should not have closed");
+        });
+
+        itExpects("tombstones blobs uploaded in disconnected and de-duped in connected container",
+        [
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            },
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            }
+        ],
+        async () => {
+            const { mainContainer, mainDataStore } = await createContainerAndDataStore();
+
+            // Create a summarizer which does an initial summary.
+            const summarizer = await createSummarizerWithInitialSummary(mainContainer);
+
+            // Disconnect the main container, upload an attachment blob and mark it referenced. We should get a handle
+            // with a localId for the blob.
+            mainContainer.disconnect();
+            const blobContents = "Blob contents";
+            const localHandle = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            mainDataStore._root.set("localBlob", localHandle);
+
+            // Connect the container after the blob is uploaded. Send an op to transition the container to write mode.
+            mainContainer.connect();
+            mainDataStore._root.set("transition to write", "true");
+            await ensureContainerConnectedWriteMode(mainContainer);
+
+            // Upload the same blob. This will get de-duped and we will get back a handle with the storageId instead of
+            // the localId that we got when uploading in detached container.
+            const storageHandle = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            assert.notStrictEqual(
+                localHandle.absolutePath, storageHandle.absolutePath, "local and storage handles should be different");
+
+            // Remove the blob's handle to unreference it.
+            mainDataStore._root.delete("localBlob");
+
+            // Summarize so that the above attachment blob is marked unreferenced.
+            await provider.ensureSynchronized();
+            await summarizeNow(summarizer);
+
+            // Wait for sweep timeout so that the blob is tombstoned.
+            await delay(sweepTimeoutMs + 10);
+
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize so that the tombstoned blob is now  part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+
+            // Load a new container from the above summary which should have the blob tombstoned.
+            const container2 = await loadContainer(summary2.summaryVersion);
+
+            // Retrieving the blob via any of the handles should fail. Note that the blob is requested via its url since
+            // this container does not have access to the blob's handle.
+            const localResponse = await container2.request({ url: localHandle.absolutePath });
+            assert.strictEqual(localResponse?.status, 404, `Expecting a 404 response for local handle`);
+            assert(localResponse.value.startsWith("Blob removed by gc:"), `Unexpected value for local handle 1`);
+
+            // Retrieving the blob via the storage handle should fail as well.
+            const storageResponse = await container2.request({ url: storageHandle.absolutePath });
+            assert.strictEqual(storageResponse?.status, 404, `Expecting a 404 response for storage handle`);
+            assert(storageResponse.value.startsWith("Blob removed by gc:"), `Unexpected value for local handle 2`);
+        });
+
+        itExpects("tombstones blobs uploaded and de-duped in disconnected container",
+        [
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            },
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            },
+            {
+                eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested",
+            }
+        ],
+        async () => {
+            const { mainContainer, mainDataStore } = await createContainerAndDataStore();
+
+            const summarizer = await createSummarizerWithInitialSummary(mainContainer);
+
+            // Disconnect the main container, upload couple of attachment blobs with same content and mark them
+            // referenced. We should get a handle. When these blobs are uploaded to the server, they will be
+            // de-duped and redirect to the same storageId.
+            mainContainer.disconnect();
+            const blobContents = "Blob contents";
+            const localHandle1 = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            const localHandle2 = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+
+            // Connect the container after the blob is uploaded. Send an op to transition the container to write mode.
+            mainContainer.connect();
+            mainDataStore._root.set("transition to write", "true");
+            await ensureContainerConnectedWriteMode(mainContainer);
+
+            // Add the blob's local handles to reference them.
+            mainDataStore._root.set("localBlob1", localHandle1);
+            mainDataStore._root.set("localBlob2", localHandle2);
+
+            // Upload the same blob. This will get de-duped and we will get back a handle with the storageId instead of
+            // the localId that we got when uploading in detached container.
+            const storageHandle = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            assert.notStrictEqual(
+                localHandle1.absolutePath, storageHandle.absolutePath, "local and storage handles should be different");
+
+            // Remove the blob's local handles to unreference them.
+            mainDataStore._root.delete("localBlob1");
+            mainDataStore._root.delete("localBlob2");
+
+            // Summarize so that the above attachment blobs are marked unreferenced.
+            await provider.ensureSynchronized();
+            await summarizeNow(summarizer);
+
+            // Wait for sweep timeout so that the blob is tombstoned.
+            await delay(sweepTimeoutMs + 10);
+
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize so that the tombstoned blobs are now part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+
+            // Load a new container from the above summary which should have the blobs tombstoned.
+            const container2 = await loadContainer(summary2.summaryVersion);
 
             // Retrieving the blob via any of the handles should fail. Note that the blob is requested via its url since
             // this container does not have access to the blob's handle.


### PR DESCRIPTION
Added tests for scenarios where attachment blobs are uploaded when container is disconnected. When such a container is connected, the blobs are uploaded to the server and a local to storage id mapping is created. The code path is different from when blobs are uploaded in detached container and the container is attached later. We need tests that cover both these scenarios.
These tests also ensure that "gcUnknownOutboundReferences" errors are not thrown for the local to storage id mapping.