### PR TITLE
gitrest: Add createRepo and openRepo metrics

### DIFF
--- a/server/gitrest/lerna-package-lock.json
+++ b/server/gitrest/lerna-package-lock.json
@@ -642,7 +642,7 @@
 				"@fluidframework/server-services-core": "0.1038.3000-107897",
 				"@fluidframework/server-services-telemetry": "0.1038.3000-107897",
 				"debug": "^4.1.1",
-				"express": "^4.17.3",
+				"express": "^4.16.3",
 				"ioredis": "^4.24.2",
 				"json-stringify-safe": "^5.0.1",
 				"jsonwebtoken": "^8.4.0",
@@ -17758,7 +17758,7 @@
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
 			"dev": true
 		},
 		"to-readable-stream": {

--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -11134,7 +11134,7 @@
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
 			"dev": true
 		},
 		"to-regex-range": {

--- a/server/gitrest/packages/gitrest-base/src/utils/gitrestTelemetryDefinitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/gitrestTelemetryDefinitions.ts
@@ -28,6 +28,13 @@ export enum GitRestLumberEventName {
     GetTag = "GetTag",
     GetTree = "GetTree",
     PatchRef = "PatchRef",
+
+    // RepoManagerFactory
+    OpenRepo = "OpenRepo",
+    CreateRepo = "CreateRepo",
+
+    // Misc
+    CheckSoftDeleted = "CheckSoftDeleted",
 }
 
 // List of properties used in telemetry throughout GitRest

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -254,12 +254,35 @@ export async function checkSoftDeleted(
     const lumberjackProperties = {
         ...getLumberjackBasePropertiesFromRepoManagerParams(repoManagerParams),
     };
+    const metric = Lumberjack.newLumberMetric(
+        GitRestLumberEventName.CheckSoftDeleted,
+        lumberjackProperties);
     const softDeletedMarkerPath = getSoftDeletedMarkerPath(repoPath);
     const softDeleteBlobExists = await exists(fileSystemManager, softDeletedMarkerPath);
     const softDeleted = softDeleteBlobExists !== false && softDeleteBlobExists.isFile();
+    metric.setProperties({ softDeleted });
+    metric.success("Checked if document is soft-deleted.");
     if (softDeleted) {
         const error = new NetworkError(410, "The requested resource has been deleted.");
         Lumberjack.error("Attempted to retrieve soft-deleted document.", lumberjackProperties, error);
+        throw error;
+    }
+}
+
+export async function executeApiWithMetric<U>(
+    api: () => Promise<U>,
+    apiName: string,
+    telemetryProperties: Record<string, any>,
+): Promise<U> {
+    const metric = Lumberjack.newLumberMetric(
+        apiName,
+        telemetryProperties);
+    try {
+        const result = await api();
+        metric.success(`RepositoryManager: ${apiName} success`);
+        return result;
+    } catch (error: any) {
+        metric.error(`RepositoryManager: ${apiName} error`, error);
         throw error;
     }
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -258,14 +258,19 @@ export async function checkSoftDeleted(
         GitRestLumberEventName.CheckSoftDeleted,
         lumberjackProperties);
     const softDeletedMarkerPath = getSoftDeletedMarkerPath(repoPath);
-    const softDeleteBlobExists = await exists(fileSystemManager, softDeletedMarkerPath);
-    const softDeleted = softDeleteBlobExists !== false && softDeleteBlobExists.isFile();
-    metric.setProperties({ softDeleted });
-    metric.success("Checked if document is soft-deleted.");
-    if (softDeleted) {
-        const error = new NetworkError(410, "The requested resource has been deleted.");
-        Lumberjack.error("Attempted to retrieve soft-deleted document.", lumberjackProperties, error);
-        throw error;
+    try {
+        const softDeleteBlobExists = await exists(fileSystemManager, softDeletedMarkerPath);
+        const softDeleted = softDeleteBlobExists !== false && softDeleteBlobExists.isFile();
+        metric.setProperties({ softDeleted });
+        metric.success("Checked if document is soft-deleted.");
+        if (softDeleted) {
+            const error = new NetworkError(410, "The requested resource has been deleted.");
+            Lumberjack.error("Attempted to retrieve soft-deleted document.", lumberjackProperties, error);
+            throw error;
+        }
+    } catch (e) {
+        metric.error("Failed to check if document is soft-deleted.", e);
+        throw e;
     }
 }
 

--- a/server/gitrest/packages/gitrest-base/src/utils/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/index.ts
@@ -44,6 +44,7 @@ export {
 	retrieveLatestFullSummaryFromStorage,
 	validateBlobContent,
 	validateBlobEncoding,
+	executeApiWithMetric,
 } from "./helpers";
 export { IsomorphicGitManagerFactory, IsomorphicGitRepositoryManager } from "./isomorphicgitManager";
 export { NodeFsManagerFactory, MemFsManagerFactory } from "./filesystems";

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
@@ -17,7 +17,7 @@ import {
     IStorageDirectoryConfig,
     Constants,
 } from "./definitions";
-import { BaseGitRestTelemetryProperties } from "./gitrestTelemetryDefinitions";
+import { BaseGitRestTelemetryProperties, GitRestLumberEventName } from "./gitrestTelemetryDefinitions";
 
 type RepoOperationType = "create" | "open";
 
@@ -78,7 +78,13 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
                 });
         };
 
-        return this.internalHandler(params, onRepoNotExists, "create");
+        return this.enableRepositoryManagerMetrics
+            ? helpers.executeApiWithMetric(
+                async () => this.internalHandler(params, onRepoNotExists, "create"),
+                GitRestLumberEventName.CreateRepo,
+                helpers.getLumberjackBasePropertiesFromRepoManagerParams(params),
+            )
+            : this.internalHandler(params, onRepoNotExists, "create");
     }
 
     public async open(params: IRepoManagerParams): Promise<IRepositoryManager> {
@@ -98,7 +104,13 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
             throw new NetworkError(400, `Repo does not exist ${gitdir}`);
         };
 
-        return this.internalHandler(params, onRepoNotExists, "open");
+        return this.enableRepositoryManagerMetrics
+            ? helpers.executeApiWithMetric(
+                async () => this.internalHandler(params, onRepoNotExists, "open"),
+                GitRestLumberEventName.OpenRepo,
+                helpers.getLumberjackBasePropertiesFromRepoManagerParams(params),
+            )
+            : this.internalHandler(params, onRepoNotExists, "open");
     }
 
     private async repoPerDocInternalHandler(


### PR DESCRIPTION
## Description

When writing a whole summary in gitrest (particularly the initial one for a new document), ~1/3 of the time spent processing the request happens outside of the summary write method. This PR adds performance metrics to a couple other key storage access points in the summary read/write flows.
