### PR TITLE
Prevent scribe from creating summaries for incorrect states

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -200,7 +200,8 @@ export class ScribeLambda implements IPartitionLambda {
                 if (value.operation.type === MessageType.Summarize && !value.operation.serverMetadata?.deliAcked) {
                     // ensure the client is requesting a summary for a state that scribe can achieve
                     // the clients summary state (ref seq num) must be at least as high as scribes (protocolHandler.sequenceNumber)
-                    if (!this.summaryWriter.isExternal || value.operation.referenceSequenceNumber >= this.protocolHandler.sequenceNumber) {
+                    if (!this.summaryWriter.isExternal ||
+                        value.operation.referenceSequenceNumber >= this.protocolHandler.sequenceNumber) {
                         // Process up to the summary op ref seq to get the protocol state at the summary op.
                         // Capture state first in case the summary is nacked.
                         const prevState = {

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -198,86 +198,90 @@ export class ScribeLambda implements IPartitionLambda {
 
                 // skip summarize messages that deli already acked
                 if (value.operation.type === MessageType.Summarize && !value.operation.serverMetadata?.deliAcked) {
-                    // Process up to the summary op ref seq to get the protocol state at the summary op.
-                    // Capture state first in case the summary is nacked.
-                    const prevState = {
-                        protocolState: this.protocolHandler.getProtocolState(),
-                        pendingOps: this.pendingMessages.toArray(),
-                    };
-                    this.processFromPending(value.operation.referenceSequenceNumber);
+                    // ensure the client is requesting a summary for a state that scribe can achieve
+                    // the clients summary state (ref seq num) must be at least as high as scribes (protocolHandler.sequenceNumber)
+                    if (value.operation.referenceSequenceNumber >= this.protocolHandler.sequenceNumber) {
+                        // Process up to the summary op ref seq to get the protocol state at the summary op.
+                        // Capture state first in case the summary is nacked.
+                        const prevState = {
+                            protocolState: this.protocolHandler.getProtocolState(),
+                            pendingOps: this.pendingMessages.toArray(),
+                        };
+                        this.processFromPending(value.operation.referenceSequenceNumber);
 
-                    // Only process the op if the protocol state advances. This eliminates the corner case where we have
-                    // already captured this summary and are processing this message due to a replay of the stream.
-                    if (this.protocolHead < this.protocolHandler.sequenceNumber) {
-                        try {
-                            const scribeCheckpoint = this.generateScribeCheckpoint(this.lastOffset);
-                            const operation = value.operation as ISequencedDocumentAugmentedMessage;
-                            const summaryResponse = await this.summaryWriter.writeClientSummary(
-                                operation,
-                                this.lastClientSummaryHead,
-                                scribeCheckpoint,
-                                this.pendingCheckpointMessages.toArray(),
-                            );
-
-                            // This block is only executed if the writer is not external. For an external writer,
-                            // (e.g., job queue) the responsibility of sending ops to the stream is up to the
-                            // external writer.
-                            if (!this.summaryWriter.isExternal) {
-                                // On a successful write, send an ack message to clients and a control message to deli.
-                                // Otherwise send a nack and revert the protocol state back to pre summary state.
-                                if (summaryResponse.status) {
-                                    await this.sendSummaryAck(summaryResponse.message as ISummaryAck);
-                                    await this.sendSummaryConfirmationMessage(operation.sequenceNumber, true, false);
-                                    this.updateProtocolHead(this.protocolHandler.sequenceNumber);
-                                    this.updateLastSummarySequenceNumber(this.protocolHandler.sequenceNumber);
-                                    const summaryResult = `Client summary success @${value.operation.sequenceNumber}`;
-                                    this.context.log?.info(
-                                        summaryResult,
-                                        {
-                                            messageMetaData: {
-                                                documentId: this.documentId,
-                                                tenantId: this.tenantId,
-                                            },
-                                        },
-                                    );
-                                    Lumberjack.info(summaryResult,
-                                        getLumberBaseProperties(this.documentId, this.tenantId));
-                                } else {
-                                    const nackMessage = summaryResponse.message as ISummaryNack;
-                                    await this.sendSummaryNack(nackMessage);
-                                    const errorMsg = `Client summary failure @${value.operation.sequenceNumber}. `
-                                        + `Error: ${nackMessage.message}`;
-                                    this.context.log?.error(
-                                        errorMsg,
-                                        {
-                                            messageMetaData: {
-                                                documentId: this.documentId,
-                                                tenantId: this.tenantId,
-                                            },
-                                        },
-                                    );
-                                    Lumberjack.error(errorMsg, getLumberBaseProperties(this.documentId, this.tenantId));
-                                    this.revertProtocolState(prevState.protocolState, prevState.pendingOps);
-                                }
-                            }
-                        } catch (ex) {
-                            const errorMsg = `Client summary failure @${value.operation.sequenceNumber}`;
-                            this.context.log?.error(`${errorMsg} Exception: ${inspect(ex)}`);
-                            Lumberjack.error(errorMsg, getLumberBaseProperties(this.documentId, this.tenantId), ex);
-                            this.revertProtocolState(prevState.protocolState, prevState.pendingOps);
-                            // If this flag is set, we should ignore any storage specific error and move forward
-                            // to process the next message.
-                            if (this.serviceConfiguration.scribe.ignoreStorageException) {
-                                await this.sendSummaryNack(
-                                    {
-                                        message: "Failed to summarize the document.",
-                                        summaryProposal: {
-                                            summarySequenceNumber: value.operation.sequenceNumber,
-                                        },
-                                    },
+                        // Only process the op if the protocol state advances. This eliminates the corner case where we have
+                        // already captured this summary and are processing this message due to a replay of the stream.
+                        if (this.protocolHead < this.protocolHandler.sequenceNumber) {
+                            try {
+                                const scribeCheckpoint = this.generateScribeCheckpoint(this.lastOffset);
+                                const operation = value.operation as ISequencedDocumentAugmentedMessage;
+                                const summaryResponse = await this.summaryWriter.writeClientSummary(
+                                    operation,
+                                    this.lastClientSummaryHead,
+                                    scribeCheckpoint,
+                                    this.pendingCheckpointMessages.toArray(),
                                 );
-                            } else {
-                                throw ex;
+
+                                // This block is only executed if the writer is not external. For an external writer,
+                                // (e.g., job queue) the responsibility of sending ops to the stream is up to the
+                                // external writer.
+                                if (!this.summaryWriter.isExternal) {
+                                    // On a successful write, send an ack message to clients and a control message to deli.
+                                    // Otherwise send a nack and revert the protocol state back to pre summary state.
+                                    if (summaryResponse.status) {
+                                        await this.sendSummaryAck(summaryResponse.message as ISummaryAck);
+                                        await this.sendSummaryConfirmationMessage(operation.sequenceNumber, true, false);
+                                        this.updateProtocolHead(this.protocolHandler.sequenceNumber);
+                                        this.updateLastSummarySequenceNumber(this.protocolHandler.sequenceNumber);
+                                        const summaryResult = `Client summary success @${value.operation.sequenceNumber}`;
+                                        this.context.log?.info(
+                                            summaryResult,
+                                            {
+                                                messageMetaData: {
+                                                    documentId: this.documentId,
+                                                    tenantId: this.tenantId,
+                                                },
+                                            },
+                                        );
+                                        Lumberjack.info(summaryResult,
+                                            getLumberBaseProperties(this.documentId, this.tenantId));
+                                    } else {
+                                        const nackMessage = summaryResponse.message as ISummaryNack;
+                                        await this.sendSummaryNack(nackMessage);
+                                        const errorMsg = `Client summary failure @${value.operation.sequenceNumber}. `
+                                            + `Error: ${nackMessage.message}`;
+                                        this.context.log?.error(
+                                            errorMsg,
+                                            {
+                                                messageMetaData: {
+                                                    documentId: this.documentId,
+                                                    tenantId: this.tenantId,
+                                                },
+                                            },
+                                        );
+                                        Lumberjack.error(errorMsg, getLumberBaseProperties(this.documentId, this.tenantId));
+                                        this.revertProtocolState(prevState.protocolState, prevState.pendingOps);
+                                    }
+                                }
+                            } catch (ex) {
+                                const errorMsg = `Client summary failure @${value.operation.sequenceNumber}`;
+                                this.context.log?.error(`${errorMsg} Exception: ${inspect(ex)}`);
+                                Lumberjack.error(errorMsg, getLumberBaseProperties(this.documentId, this.tenantId), ex);
+                                this.revertProtocolState(prevState.protocolState, prevState.pendingOps);
+                                // If this flag is set, we should ignore any storage specific error and move forward
+                                // to process the next message.
+                                if (this.serviceConfiguration.scribe.ignoreStorageException) {
+                                    await this.sendSummaryNack(
+                                        {
+                                            message: "Failed to summarize the document.",
+                                            summaryProposal: {
+                                                summarySequenceNumber: value.operation.sequenceNumber,
+                                            },
+                                        },
+                                    );
+                                } else {
+                                    throw ex;
+                                }
                             }
                         }
                     }

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -209,9 +209,10 @@ export class ScribeLambda implements IPartitionLambda {
                         };
                         this.processFromPending(value.operation.referenceSequenceNumber);
 
-                        // Only process the op if the protocol state advances. This eliminates the corner case where we have
+                        // When external, only process the op if the protocol state advances.
+                        // This eliminates the corner case where we have
                         // already captured this summary and are processing this message due to a replay of the stream.
-                        if (this.protocolHead < this.protocolHandler.sequenceNumber) {
+                        if (!this.summaryWriter.isExternal || this.protocolHead < this.protocolHandler.sequenceNumber) {
                             try {
                                 const scribeCheckpoint = this.generateScribeCheckpoint(this.lastOffset);
                                 const operation = value.operation as ISequencedDocumentAugmentedMessage;


### PR DESCRIPTION
The following sequence of events causes corruption when scribe is configured for an external summarizer (`isExternal` is set to true)
1. Summarizer1 sent a summary op with ref seq # 2057
2. Summarizer2 sent a summary op with ref seq # 2056
3. Server processes summary op for ref seq # 2057 and sends a summaryNack
4. Server processes summary op for ref seq # 2056 and sends a summayAck

When a new client connects and downloads the summary for ref seq # 2056, the data in the summary has seq#2057 (it should be seq#2056).

This happens because:
1. Scribe does not revert the state for summary failures when an external summarizer is enabled. 
2. Scribe does not have any checks regarding the summary ref sequence number. Scribe is very good at ensuring it processes ops in order, but it has no such checks for the summary ref seq num vs scribe's protocol state.

This PR adds a check for number 2 - it will ensure that scribe will not make summaries when the summarize op ref sequence number is behind its current state. Scribe will simply ignore summary ops for this case. We cannot make it nack for this case due to the potential of kafka message replays.