### PR TITLE
Attachment blobs - Always return local ID and send blob attach op for all blob uploads including de-dupe scenarios

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -467,7 +467,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
          * storageId may be undefined but since we are not connected we will have a chance to add it when reSubmit()
          * is called on reconnection.
          */
-        if (entry.status !== PendingBlobStatus.OnlinePendingOp && entry.status !== PendingBlobStatus.OfflinePendingOp) {
+        if (entry.status !== PendingBlobStatus.OnlinePendingOp) {
             this.sendBlobAttachOp(localId, entry.storageId);
         }
 

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -461,8 +461,8 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 
         /**
          * If we haven't already submitted a BlobAttach op for this entry, send it before returning the blob handle.
-         * This will make sure that the BlobAttach op is sequenced prior to any ops referencing the handle, otherwise
-         * otherwise, an invalid handle could be added to the document.
+         * This will make sure that the BlobAttach op is sequenced prior to any ops referencing the handle. Otherwise,
+         * an invalid handle could be added to the document.
          * storageId may be undefined but since we are not connected we will have a chance to add it when reSubmit()
          * is called on reconnection.
          */

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -121,7 +121,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
     private readonly mc: MonitoringContext;
 
     /**
-     * Map of local IDs to storage IDs. Contains identity entries (id → id) for storage IDs. All request3ed IDs should
+     * Map of local IDs to storage IDs. Contains identity entries (id → id) for storage IDs. All requested IDs should
      * be a key in this map. Blobs created while the container is detached are stored in IDetachedBlobStorage which
      * gives local IDs; the storage IDs are filled in at attach time.
      */
@@ -500,7 +500,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
             this.setRedirection(message.metadata.localId, message.metadata.blobId);
         }
         // set identity (id -> id) entry
-        this.setRedirection(blobId, message.metadata.blobId);
+        this.setRedirection(blobId, blobId);
 
         if (local) {
             assert(message.metadata?.localId !== undefined, "local ID not present in blob attach message");

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -180,7 +180,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
         // To be called when a blob node is requested. blobPath is the path of the blob's node in GC's graph. It's
         // of the format `/<BlobManager.basePath>/<blobId>`.
         private readonly blobRequested: (blobPath: string) => void,
-        private readonly addedBlobReference: (fromId: string, toId: string) => void,
+        private readonly addedBlobReference: (fromNodePath: string, toNodePath: string) => void,
         private readonly runtime: IBlobManagerRuntime,
         stashedBlobs: IPendingBlobs = {},
     ) {
@@ -377,7 +377,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
     private setRedirection(fromId: string, toId: string | undefined) {
         this.redirectTable.set(fromId, toId);
         if (toId !== undefined) {
-            this.addedBlobReference(fromId, toId);
+            this.addedBlobReference(this.getBlobGCNodePath(fromId), this.getBlobGCNodePath(toId));
         }
     }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1134,12 +1134,13 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.handleContext,
             blobManagerSnapshot,
             () => this.storage,
-            (blobId, localId) => {
+            (localId: string, blobId?: string) => {
                 if (!this.disposed) {
-                    this.submit(ContainerMessageType.BlobAttach, undefined, undefined, { blobId, localId });
+                    this.submit(ContainerMessageType.BlobAttach, undefined, undefined, { localId, blobId });
                 }
             },
             (blobPath: string) => this.garbageCollector.nodeUpdated(blobPath, "Loaded"),
+            (fromId: string, toId: string) => this.garbageCollector.addedOutboundReference(fromId, toId),
             this,
             pendingRuntimeState?.pendingAttachmentBlobs,
         );

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1140,7 +1140,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 }
             },
             (blobPath: string) => this.garbageCollector.nodeUpdated(blobPath, "Loaded"),
-            (fromId: string, toId: string) => this.garbageCollector.addedOutboundReference(fromId, toId),
+            (fromPath: string, toPath: string) => this.garbageCollector.addedOutboundReference(fromPath, toPath),
             this,
             pendingRuntimeState?.pendingAttachmentBlobs,
         );

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -1425,7 +1425,8 @@ export class GarbageCollector implements IGarbageCollector {
              * explicit routes to them.
              */
             currentOutboundRoutes.forEach((route) => {
-                if (this.runtime.getNodeType(route) === GCNodeType.DataStore
+                const nodeType = this.runtime.getNodeType(route);
+                if ((nodeType === GCNodeType.DataStore || nodeType === GCNodeType.Blob)
                     && !nodeId.startsWith(route)
                     && (!previousRoutes.includes(route) && !explicitRoutes.includes(route))) {
                     missingExplicitRoutes.push(route);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
@@ -298,9 +298,9 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             defaultDataStore._root.delete("local3");
             const s2 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             assert(s2.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should be unreferenced");
-            assert(s2.get(localHandle2.absolutePath) === "unreferenced", "local id 2 blob should be referenced (2)");
-            assert(s2.get(localHandle3.absolutePath) === "unreferenced", "local id 3 blob should be referenced (2)");
-            assert(s2.get(storageId) === "unreferenced", "storage id blob should be referenced (2)");
+            assert(s2.get(localHandle2.absolutePath) === "unreferenced", "local id 2 blob should be unreferenced");
+            assert(s2.get(localHandle3.absolutePath) === "unreferenced", "local id 3 blob should be unreferenced");
+            assert(s2.get(storageId) === "unreferenced", "storage id blob should be unreferenced");
 
             // Add the localId1 handle back. If deleteUnreferencedContent is true, all the nodes would have been
             // deleted from the GC state. Else, localId1 and storageId nodes will be referenced and others unreferenced.
@@ -309,12 +309,12 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             if (deleteUnreferencedContent) {
                 assert(s3.get(localHandle1.absolutePath) === undefined, "local id 1 blob should not have a GC entry");
                 assert(s3.get(localHandle2.absolutePath) === undefined, "local id 2 blob should not have a GC entry");
-                assert(s3.get(localHandle3.absolutePath) === undefined, "local id 2 blob should not have a GC entry");
+                assert(s3.get(localHandle3.absolutePath) === undefined, "local id 3 blob should not have a GC entry");
                 assert(s3.get(storageId) === undefined, "storage id blob should not have a GC entry");
             } else {
                 assert(s3.get(localHandle1.absolutePath) === "referenced", "local id 1 blob should be re-referenced");
                 assert(s3.get(localHandle2.absolutePath) === "unreferenced", "local id 2 blob should still be unreferenced");
-                assert(s3.get(localHandle3.absolutePath) === "unreferenced", "local id 2 blob should still be unreferenced");
+                assert(s3.get(localHandle3.absolutePath) === "unreferenced", "local id 3 blob should still be unreferenced");
                 assert(s3.get(storageId) === "referenced", "storage id blob should be re-referenced");
             }
         });
@@ -364,9 +364,9 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             defaultDataStore._root.set("local2", localHandle2);
             defaultDataStore._root.delete("local1");
             const s2 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
-            assert(s2.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should be referenced");
+            assert(s2.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should be unreferenced");
             assert(s2.get(localHandle2.absolutePath) === "referenced", "local id 2 blob should be referenced");
-            assert(s2.get(storageId) === "referenced", "storage id blob should also be referenced (1)");
+            assert(s2.get(storageId) === "referenced", "storage id blob should also be referenced");
 
             // Remove the localId2 handle. Validate that localId2 and storageId nodes are now unreferenced. Also, if
             // deleteUnreferencedContent is true, localId1 node would have been deleted.
@@ -375,10 +375,10 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             if (deleteUnreferencedContent) {
                 assert(s3.get(localHandle1.absolutePath) === undefined, "local id 1 blob should not have a GC entry");
             } else {
-                assert(s3.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should be re-referenced");
+                assert(s3.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should still be unreferenced");
             }
             assert(s3.get(localHandle2.absolutePath) === "unreferenced", "local id 2 blob should still be unreferenced");
-            assert(s3.get(storageId) === "unreferenced", "storage id blob should be re-referenced");
+            assert(s3.get(storageId) === "unreferenced", "storage id blob should still be unreferenced");
         });
     };
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
@@ -13,6 +13,8 @@ import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestContainerConfig, ITestObjectProvider, waitForContainerConnection } from "@fluidframework/test-utils";
 import { describeNoCompat, ITestDataObject } from "@fluidframework/test-version-utils";
+// eslint-disable-next-line import/no-internal-modules
+import { BlobManager } from "@fluidframework/container-runtime/dist/blobManager";
 import { getUrlFromItemId, MockDetachedBlobStorage } from "../mockDetachedBlobStorage";
 import { getGCStateFromSummary } from "./gcTestSummaryUtils";
 
@@ -49,7 +51,7 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
         let defaultDataStore: ITestDataObject;
 
         /**
-         * Summarizes and returns the referenced / unreferenced state of each node if the GC state in summary.
+         * Summarizes and returns the referenced / unreferenced state of each blob node if the GC state in summary.
          */
         async function summarizeAndGetUnreferencedNodeStates(summarizerRuntime: ContainerRuntime) {
             await provider.ensureSynchronized();
@@ -64,8 +66,11 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 
             const nodeTimestamps: Map<string, "referenced" | "unreferenced"> = new Map();
             for (const [nodePath, nodeData] of Object.entries(gcState.gcNodes)) {
-                // Unreferenced nodes have unreferenced timestamp associated with them.
-                nodeTimestamps.set(nodePath, nodeData.unreferencedTimestampMs ? "unreferenced" : "referenced");
+                // Filter blob nodes.
+                if (nodePath.slice(1).startsWith(BlobManager.basePath)) {
+                    // Unreferenced nodes have unreferenced timestamp associated with them.
+                    nodeTimestamps.set(nodePath, nodeData.unreferencedTimestampMs ? "unreferenced" : "referenced");
+                }
             }
             return nodeTimestamps;
         }
@@ -88,6 +93,22 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             const summarizerContainer = await loadContainer();
             const summarizerDefaultDataStore = await requestFluidObject<ITestDataObject>(summarizerContainer, "/");
             return summarizerDefaultDataStore._context.containerRuntime as ContainerRuntime;
+        }
+
+        function getStorageIdFromReferenceMap(
+            referenceNodeStateMap: Map<string, "referenced" | "unreferenced">,
+            localBlobIds: string[],
+        ): string {
+            let storageId: string | undefined;
+            referenceNodeStateMap.forEach((state, nodePath) => {
+                if (localBlobIds.includes(nodePath)) {
+                    return;
+                }
+                assert(storageId === undefined, "Unexpected blob node in reference state map");
+                storageId = nodePath;
+            });
+            assert(storageId !== undefined, "No storage id node in reference state map");
+            return storageId;
         }
 
         beforeEach(async function() {
@@ -179,8 +200,8 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             // Upload an attachment blob. We should get a handle with a localId for the blob. Mark it referenced by
             // storing its handle in a DDS.
             const blobContents = "Blob contents";
-            const localHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
-            defaultDataStore._root.set("blob", localHandle);
+            const localHandle1 = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            defaultDataStore._root.set("local1", localHandle1);
 
             // Attach the container after the blob is uploaded.
             await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
@@ -195,44 +216,39 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 
             // Upload the same blob. This will get de-duped and we will get back a handle with the storageId instead of
             // the localId that we got when uploading in detached container.
-            const storageHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            const localHandle2 = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            defaultDataStore._root.set("local2", localHandle2);
 
             // Validate that storing the localId handle makes both the localId and storageId nodes as referenced since
             // localId is simply an alias to the storageId.
             const s1 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
-            assert(s1.get(localHandle.absolutePath) === "referenced", "local id blob should be referenced");
-            assert(s1.get(storageHandle.absolutePath) === "referenced",
-                "storage id blob should also be referenced (1)");
+            assert.strictEqual(s1.size, 3, "There should be 3 blob entries in GC data");
+            const storageId = getStorageIdFromReferenceMap(s1, [localHandle1.absolutePath, localHandle2.absolutePath]);
+            assert(s1.get(localHandle1.absolutePath) === "referenced", "local id 1 blob should be referenced");
+            assert(s1.get(localHandle2.absolutePath) === "referenced", "local id 2 blob should be referenced");
+            assert(s1.get(storageId) === "referenced", "storage id blob should also be referenced (1)");
 
             // Replace the localId handle with the storageId handle. The storageId node should be referenced but the
             // localId node should be unreferenced. Basically, the alias is deleted.
-            defaultDataStore._root.set("blob", storageHandle);
+            defaultDataStore._root.delete("local1");
+            defaultDataStore._root.delete("local2");
             const s2 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
-            assert(s2.get(localHandle.absolutePath) === "unreferenced", "local id blob should still be unreferenced");
-            assert(s2.get(storageHandle.absolutePath) === "referenced",
-                "storage id blob should also be referenced (2)");
-
-            // Delete the storageId handle. The storageId node should be unreferenced. If deleteUnreferencedContent is
-            // true, the localId node should be deleted from the GC state. Else, it would be unreferenced.
-            defaultDataStore._root.delete("blob");
-            const s3 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
-            assert(s3.get(storageHandle.absolutePath) === "unreferenced", "storage id blob should be unreferenced");
-            if (deleteUnreferencedContent) {
-                assert(s3.get(localHandle.absolutePath) === undefined, "local id blob should not have a GC entry");
-            } else {
-                assert(s3.get(localHandle.absolutePath) === "unreferenced", "local id blob should be unreferenced");
-            }
+            assert(s2.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should be unreferenced");
+            assert(s2.get(localHandle2.absolutePath) === "unreferenced", "local id 2 blob should be unreferenced");
+            assert(s2.get(storageId) === "unreferenced", "storage id blob should be unreferenced");
 
             // Add the localId handle back. If deleteUnreferencedContent is true, both the nodes would have been
             // deleted from the GC state. Else, they would both be referenced.
-            defaultDataStore._root.set("blob", localHandle);
-            const s4 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
+            defaultDataStore._root.set("local1", localHandle1);
+            const s3 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             if (deleteUnreferencedContent) {
-                assert(s4.get(localHandle.absolutePath) === undefined, "local id blob should not have a GC entry");
-                assert(s4.get(storageHandle.absolutePath) === undefined, "storage id blob should not have a GC entry");
+                assert(s3.get(localHandle1.absolutePath) === undefined, "local id 1 blob should not have a GC entry");
+                assert(s3.get(localHandle2.absolutePath) === undefined, "local id 2 blob should not have a GC entry");
+                assert(s3.get(storageId) === undefined, "storage id blob should not have a GC entry");
             } else {
-                assert(s4.get(localHandle.absolutePath) === "referenced", "local id blob should be re-referenced");
-                assert(s4.get(storageHandle.absolutePath) === "referenced", "storage id blob should be re-referenced");
+                assert(s3.get(localHandle1.absolutePath) === "referenced", "local id 1 blob should be re-referenced");
+                assert(s3.get(localHandle2.absolutePath) === "unreferenced", "local id 2 blob should still be unreferenced");
+                assert(s3.get(storageId) === "referenced", "storage id blob should be re-referenced");
             }
         });
 
@@ -256,46 +272,47 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 
             // Upload the same blob. This will get de-duped and we will get back a handle with the storageId instead of
             // the localId that we got when uploading in detached container.
-            const storageHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            const localHandle3 = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
 
             // Store the localId1 and localId2 handles. This would make the localId nodes and storageId node referenced.
             defaultDataStore._root.set("local1", localHandle1);
             defaultDataStore._root.set("local2", localHandle2);
+            defaultDataStore._root.set("local3", localHandle3);
             const s1 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
-            assert(s1.get(localHandle1.absolutePath) === "referenced", "local id 1 blob should be referenced");
-            assert(s1.get(localHandle2.absolutePath) === "referenced", "local id 2 blob should be referenced");
-            assert(s1.get(storageHandle.absolutePath) === "referenced", "storage id blob should be referenced (1)");
+            assert.strictEqual(s1.size, 4, "There should be 4 blob entries in GC data");
+            const storageId = getStorageIdFromReferenceMap(
+                s1,
+                [localHandle1.absolutePath, localHandle2.absolutePath, localHandle3.absolutePath],
+            );
+            assert(s1.get(localHandle1.absolutePath) === "referenced", "local id 1 blob should be referenced (1)");
+            assert(s1.get(localHandle2.absolutePath) === "referenced", "local id 2 blob should be referenced (1)");
+            assert(s1.get(localHandle3.absolutePath) === "referenced", "local id 3 blob should be referenced (1)");
+            assert(s1.get(storageId) === "referenced", "storage id blob should be referenced (1)");
 
             // Delete the localId1 handle. This would make localId1 node unreferenced.
             defaultDataStore._root.delete("local1");
+            defaultDataStore._root.delete("local2");
+            defaultDataStore._root.delete("local3");
             const s2 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             assert(s2.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should be unreferenced");
-            assert(s2.get(localHandle2.absolutePath) === "referenced", "local id 2 blob should be referenced");
-            assert(s2.get(storageHandle.absolutePath) === "referenced", "storage id blob should be referenced (2)");
+            assert(s2.get(localHandle2.absolutePath) === "unreferenced", "local id 2 blob should be referenced (2)");
+            assert(s2.get(localHandle3.absolutePath) === "unreferenced", "local id 3 blob should be referenced (2)");
+            assert(s2.get(storageId) === "unreferenced", "storage id blob should be referenced (2)");
 
-            // Delete the localId2 handle. This would make the localId2 node referenced. If deleteUnreferencedContent
-            // is true, localId2 node would be deleted from GC state. Store the storageId handle to keep it referenced.
-            defaultDataStore._root.delete("local2");
-            defaultDataStore._root.set("storage", storageHandle);
+            // Add the localId handle back. If deleteUnreferencedContent is true, both the nodes would have been
+            // deleted from the GC state. Else, they would both be referenced.
+            defaultDataStore._root.set("local1", localHandle1);
             const s3 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
-            assert(s3.get(localHandle2.absolutePath) === "unreferenced", "local id 2 blob should be unreferenced");
-            assert(s3.get(storageHandle.absolutePath) === "referenced", "storage id blob should be referenced (3)");
             if (deleteUnreferencedContent) {
                 assert(s3.get(localHandle1.absolutePath) === undefined, "local id 1 blob should not have a GC entry");
+                assert(s3.get(localHandle2.absolutePath) === undefined, "local id 2 blob should not have a GC entry");
+                assert(s3.get(localHandle3.absolutePath) === undefined, "local id 2 blob should not have a GC entry");
+                assert(s3.get(storageId) === undefined, "storage id blob should not have a GC entry");
             } else {
-                assert(s3.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should be unreferenced");
-            }
-
-            // Delete the storageId handle. It should now be unreferenced.
-            defaultDataStore._root.delete("storage");
-            const s4 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
-            assert(s4.get(storageHandle.absolutePath) === "unreferenced", "storage id blob should be unreferenced");
-            if (deleteUnreferencedContent) {
-                assert(s4.get(localHandle1.absolutePath) === undefined, "local id blob 1 should not have a GC entry");
-                assert(s4.get(localHandle2.absolutePath) === undefined, "local id blob 2 should not have a GC entry");
-            } else {
-                assert(s4.get(localHandle1.absolutePath) === "unreferenced", "local id blob 1 should be unreferenced");
-                assert(s4.get(localHandle2.absolutePath) === "unreferenced", "local id blob 2 should be unreferenced");
+                assert(s3.get(localHandle1.absolutePath) === "referenced", "local id 1 blob should be re-referenced");
+                assert(s3.get(localHandle2.absolutePath) === "unreferenced", "local id 2 blob should still be unreferenced");
+                assert(s3.get(localHandle3.absolutePath) === "unreferenced", "local id 2 blob should still be unreferenced");
+                assert(s3.get(storageId) === "referenced", "storage id blob should be re-referenced");
             }
         });
 
@@ -320,8 +337,8 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             // Upload an attachment blob when disconnected. We should get a handle with a localId for the blob. Mark it
             // referenced by storing its handle in a DDS.
             const blobContents = "Blob contents";
-            const localHandle = await container2DataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
-            container2DataStore._root.set("local", localHandle);
+            const localHandle1 = await container2DataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            container2DataStore._root.set("local1", localHandle1);
 
             // Connect the container and wait for it to be connected.
             container2.connect();
@@ -330,37 +347,44 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
             // Validate that the localId is referenced. This should not log any gcUnknownOutboundReferences error as a
             // reference from localId to storageId would be created.
             const s1 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
-            assert(s1.get(localHandle.absolutePath) === "referenced", "local id blob should be referenced");
+            assert.strictEqual(s1.size, 2, "There should be 2 blob entries in GC data");
+            const storageId = getStorageIdFromReferenceMap(s1, [localHandle1.absolutePath]);
+            assert(s1.get(localHandle1.absolutePath) === "referenced", "local id blob should be referenced");
+            assert(s1.get(storageId) === "referenced", "storage id blob should be referenced");
 
             // Upload the same blob. This will get de-duped and we will get back a handle with the storageId instead of
             // the localId that we got when uploading in disconnected container.
-            const storageHandle = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
-            assert(s1.get(storageHandle.absolutePath) === "referenced", "storage id blob should be referenced");
+            const localHandle2 = await defaultDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            defaultDataStore._root.set("local2", localHandle2);
 
-            // Delete the localId handle. The localId and storageId nodes should both be unreferenced. They will be
-            // be deleted locally in this summary. In the next summary, they will be deleted.
-            container2DataStore._root.delete("local");
+            defaultDataStore._root.delete("local1");
+
+            // Validate that storing the localId handle makes both the localId and storageId nodes as referenced since
+            // localId is simply an alias to the storageId.
             const s2 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
-            assert(s2.get(localHandle.absolutePath) === "unreferenced", "local id blob should be unreferenced");
-            assert(s2.get(storageHandle.absolutePath) === "unreferenced", "storage id blob should be unreferenced");
+            assert(s2.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should be referenced");
+            assert(s2.get(localHandle2.absolutePath) === "referenced", "local id 2 blob should be referenced");
+            assert(s2.get(storageId) === "referenced", "storage id blob should also be referenced (1)");
 
-            // In this summary, unreferenced nodes will be deleted if deleteUnreferencedContent is set.
+            // Replace the localId handle with the storageId handle. The storageId node should be referenced but the
+            // localId node should be unreferenced. Basically, the alias is deleted.
+            defaultDataStore._root.delete("local2");
             const s3 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
             if (deleteUnreferencedContent) {
-                assert(s3.get(localHandle.absolutePath) === undefined, "local id blob should not have a GC entry");
-                assert(s3.get(storageHandle.absolutePath) === undefined, "storage id blob should not have a GC entry");
+                assert(s3.get(localHandle1.absolutePath) === undefined, "local id 1 blob should not have a GC entry");
             } else {
-                assert(s3.get(localHandle.absolutePath) === "unreferenced", "local id blob should be unreferenced");
-                assert(s3.get(storageHandle.absolutePath) === "unreferenced", "storage id blob should be unreferenced");
+                assert(s3.get(localHandle1.absolutePath) === "unreferenced", "local id 1 blob should be re-referenced");
             }
+            assert(s3.get(localHandle2.absolutePath) === "unreferenced", "local id 2 blob should still be unreferenced");
+            assert(s3.get(storageId) === "unreferenced", "storage id blob should be re-referenced");
         });
     };
 
-    describe("Verify data store state when unreferenced content is marked", () => {
+    describe("Verify attachment blob state when unreferenced content is marked", () => {
         tests();
     });
 
-    describe("Verify data store state when unreferenced content is deleted", () => {
+    describe("Verify attachment blob state when unreferenced content is deleted", () => {
         tests(true /* deleteUnreferencedContent */);
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
@@ -83,15 +83,15 @@ describeNoCompat("Garbage Collection Stats", (getTestObjectProvider) => {
         const dataStore2 = await requestFluidObject<ITestDataObject>(
             await containerRuntime.createDataStore(TestDataObjectType), "");
         const expectedGCStats: IGCStats = {
-            nodeCount: 9,
+            nodeCount: 11,
             unrefNodeCount: 0,
-            updatedNodeCount: 9,
+            updatedNodeCount: 11,
             dataStoreCount: 3,
             unrefDataStoreCount: 0,
             updatedDataStoreCount: 3,
-            attachmentBlobCount: 2,
+            attachmentBlobCount: 4,
             unrefAttachmentBlobCount: 0,
-            updatedAttachmentBlobCount: 2,
+            updatedAttachmentBlobCount: 4,
         };
 
         // Add both data store handles in default data store to mark them referenced.
@@ -124,15 +124,15 @@ describeNoCompat("Garbage Collection Stats", (getTestObjectProvider) => {
         const dataStore2 = await requestFluidObject<ITestDataObject>(
             await containerRuntime.createDataStore(TestDataObjectType), "");
         const expectedGCStats: IGCStats = {
-            nodeCount: 9,
+            nodeCount: 11,
             unrefNodeCount: 0,
-            updatedNodeCount: 9,
+            updatedNodeCount: 11,
             dataStoreCount: 3,
             unrefDataStoreCount: 0,
             updatedDataStoreCount: 3,
-            attachmentBlobCount: 2,
+            attachmentBlobCount: 4,
             unrefAttachmentBlobCount: 0,
-            updatedAttachmentBlobCount: 2,
+            updatedAttachmentBlobCount: 4,
         };
 
         // Add both data store handles in default data store to mark them referenced.
@@ -161,12 +161,12 @@ describeNoCompat("Garbage Collection Stats", (getTestObjectProvider) => {
 
         // dataStore1, its DDS and blob1 should be now unreferenced. Also, their reference state updated from referenced
         // to unreferenced.
-        expectedGCStats.unrefNodeCount = 3;
-        expectedGCStats.updatedNodeCount = 3;
+        expectedGCStats.unrefNodeCount = 4;
+        expectedGCStats.updatedNodeCount = 4;
         expectedGCStats.unrefDataStoreCount = 1;
         expectedGCStats.updatedDataStoreCount = 1;
-        expectedGCStats.unrefAttachmentBlobCount = 1;
-        expectedGCStats.updatedAttachmentBlobCount = 1;
+        expectedGCStats.unrefAttachmentBlobCount = 2;
+        expectedGCStats.updatedAttachmentBlobCount = 2;
 
         gcStats = await containerRuntime.collectGarbage({});
         assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
@@ -186,12 +186,12 @@ describeNoCompat("Garbage Collection Stats", (getTestObjectProvider) => {
 
         // dataStore1, dataStore2, their DDS and blob2 should be now unreferenced. Also, dataStore2, its DDS and blob2's
         // reference state updated from referenced to unreferenced.
-        expectedGCStats.unrefNodeCount = 6;
-        expectedGCStats.updatedNodeCount = 3;
+        expectedGCStats.unrefNodeCount = 8;
+        expectedGCStats.updatedNodeCount = 4;
         expectedGCStats.unrefDataStoreCount = 2;
         expectedGCStats.updatedDataStoreCount = 1;
-        expectedGCStats.unrefAttachmentBlobCount = 2;
-        expectedGCStats.updatedAttachmentBlobCount = 1;
+        expectedGCStats.unrefAttachmentBlobCount = 4;
+        expectedGCStats.updatedAttachmentBlobCount = 2;
 
         gcStats = await containerRuntime.collectGarbage({});
         assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
@@ -212,15 +212,15 @@ describeNoCompat("Garbage Collection Stats", (getTestObjectProvider) => {
         const dataStore2 = await requestFluidObject<ITestDataObject>(
             await containerRuntime.createDataStore(TestDataObjectType), "");
         const expectedGCStats: IGCStats = {
-            nodeCount: 9,
+            nodeCount: 11,
             unrefNodeCount: 0,
-            updatedNodeCount: 9,
+            updatedNodeCount: 11,
             dataStoreCount: 3,
             unrefDataStoreCount: 0,
             updatedDataStoreCount: 3,
-            attachmentBlobCount: 2,
+            attachmentBlobCount: 4,
             unrefAttachmentBlobCount: 0,
-            updatedAttachmentBlobCount: 2,
+            updatedAttachmentBlobCount: 4,
         };
 
         // Add both data store handles in default data store to mark them referenced.

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -270,14 +270,6 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
         });
 
         /**
-         * Function that rejects instead of not rejecting. Used in these tests to demonstrate that because of a bug we
-         * are not getting the expected results. Once the bug is fixed, these asserts should start working as expected.
-         */
-        async function assertWronglyRejects(block: Promise<any>, message?: string | Error) {
-            return assert.doesNotReject(block, message);
-        };
-
-        /**
          * This test validates that when blobs are de-duped in different containers, these containers can use these
          * blobs irrespective of whether the original blob is tombstoned. Basically, after uploading a blob, a container
          * should be able to use it the same way whether it was de-duped or not.
@@ -327,7 +319,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
                 await container3MainDataStore._runtime.uploadBlob(stringToBuffer(blobContents, "utf-8"));
             // Ideally, this should not reject but currently it will because of a bug with how blob de-dup interacts
             // with GC.
-            await assertWronglyRejects(container3BlobHandle.get(), "Container3 should be able to get the blob");
+            await assert.doesNotReject(container3BlobHandle.get(), "Container3 should be able to get the blob");
 
             // Reference the blob in container2 and container3 which should be valid. There should not be any asserts
             // or errors logged in any container because of this.

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -137,7 +137,6 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 
             // Upload another blob with the same content so that it is de-duped.
             const blobHandle2 = await mainDataStore._runtime.uploadBlob(stringToBuffer(blobContents, "utf-8"));
-            assert.strictEqual(blobHandle1.absolutePath, blobHandle2.absolutePath, "Blobs are not de-duped");
 
             // Reference and then unreference the blob via one of the handles so that it's unreferenced in next summary.
             mainDataStore._root.set("blob1", blobHandle1);
@@ -275,7 +274,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
          * are not getting the expected results. Once the bug is fixed, these asserts should start working as expected.
          */
         async function assertWronglyRejects(block: Promise<any>, message?: string | Error) {
-            return assert.rejects(block, message);
+            return assert.doesNotReject(block, message);
         };
 
         /**
@@ -283,11 +282,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
          * blobs irrespective of whether the original blob is tombstoned. Basically, after uploading a blob, a container
          * should be able to use it the same way whether it was de-duped or not.
          */
-        itExpects("should allow access to blobs that are de-duped in different containers",
-        [
-            { eventName: "fluid:telemetry:BlobManager:GC_Tombstone_Blob_Requested" }
-        ],
-        async () => {
+        it("should allow access to blobs that are de-duped in different containers", async () => {
             const { dataStore: mainDataStore, summarizer } = await createDataStoreAndSummarizer();
 
             // Upload an attachment blob.


### PR DESCRIPTION
## Problem
There are 2 main reasons for adding this change and both are because of GC:
1. The main reason this change is added because of the way blob de-dupe interacts with GC. If a blob that has been unreferenced for a long time (almost ready for deletion) is de-duped, the server returns the same storage ID for it as the unreferenced blob. GC doesn't know about that the blob was de-duped and will proceed to delete the blob shortly. However, the client that got the de-duped storage ID can still refer to the blob leading to data loss.
The behavior in the case of blob de-dup should be the same as a brand new blob upload since from the users perspective thqat is the case. So, when the blob is de-duped, the time to delete it should be reset giving the user the same amount of time to re-use the blob as with a brand new blob upload.

2. The other reason is that GC validates all references from a node to another are explicitly notified. In case of blobs, a mapping from local ID to storage ID is essentially a reference and GC should be notified of it.

## Solution
The high level solution is that when a blob is de-duped, notify GC so that it resets the unreferenced timestamp. Here is how this PR achieves that:
- It always returns local IDs when a blob creation is completed. Currently, local IDs are only returned in detached / disconnected mode. This makes the creation flow consistent and easy to reason about - When a blob creation is complete, a local ID to storage ID mapping is created and the local ID is returned to users.
- Whenever a local ID to storage ID mapping is created, notify GC that a reference is added. This will fix problem 2 above and since a mapping is created in blob de-dupe scenario as well, it will fix problem 1 as well.

## Reviewer Guidance
Couple of key changes to note:
- When container is online and a blob upload is completed, before the local ID is returned, a blob attach op is sent so that all clients can create a local ID to storage ID mapping on receiving it. This will ensure that any op containing this local ID is sequenced after the blob attach op and clients can retrieve the blob successfully.
- When a blob is de-duped and the original blob is already ack'd, the blob is returned via the local ID as soon as the upload completes and the blob attach op is sent. Since the blob is already present, we don't need to wait for the op to be ack'd as the server will keep it alive.
- When one or more blobs are de-duped and the original blob is not yet ack'd, these ops are added to a local queue (opsInFlight). As soon as one of the ops is ack'd, all the blobs are resolved and returned since this op will keep all of them alive as they have the same storage ID. 


[AB#2745](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2745)