### PR TITLE
docs: Add comments to each of the eslint configs explaining their intended use cases

### DIFF
--- a/common/build/eslint-config-fluid/README.md
+++ b/common/build/eslint-config-fluid/README.md
@@ -4,11 +4,35 @@ This package contains a shared ESLint config used by all the packages in the Flu
 
 It exports the following shared ESLint configs:
 
--   `minimal`: The minimal config for Fluid Framework packages.
-    Only intended for internal-only packages, test libraries, etc.
-    Whenever possible, the `recommended` or `strict` configs should be used instead.
--   `recommended`: (default) The recommended config for Fluid Framework packages.
--   `strict`: The strictest config; intended for packages with public facing APIs, and those used as external-facing examples (e.g. those mentioned on `fluidframework.com`).
+## Configurations
+
+### Minimal
+
+This is the minimal config for use in Fluid Framework libraries, only intended for internal-only packages, test libraries, etc.
+Whenever possible, the [recommended](#recommended) or [strict](#strict) configs should be used instead.
+
+This configuration should never be used in published packages.
+It is only suitable for early prototyping and repository-internal testing libraries.
+
+Imported via `@fluidframework/eslint-config-fluid/minimal`.
+
+### Recommended
+
+This is the standard config for use in Fluid Framework libraries.
+It is also the default library export.
+
+This configuration is recommended for all libraries in the repository, though use of the [strict](#strict) config is preferred whenever reasonable.
+
+Imported via `@fluidframework/eslint-config-fluid` (or `@fluidframework/eslint-config-fluid/recommended`).
+
+### Strict
+
+The strictest config for use in Fluid Framework libraries.
+Recommended for highest code quality enforcement.
+
+In particular, use of this config is encouraged for libraries with public facing APIs, and those used as external-facing examples (e.g. those mentioned on `fluidframework.com`).
+
+Imported via `@fluidframework/eslint-config-fluid/strict`.
 
 ## Changing the lint config
 

--- a/common/build/eslint-config-fluid/README.md
+++ b/common/build/eslint-config-fluid/README.md
@@ -5,8 +5,10 @@ This package contains a shared ESLint config used by all the packages in the Flu
 It exports the following shared ESLint configs:
 
 -   `minimal`: The minimal config for Fluid Framework packages.
+    Only intended for internal-only packages, test libraries, etc.
+    Whenever possible, the `recommended` or `strict` configs should be used instead.
 -   `recommended`: (default) The recommended config for Fluid Framework packages.
--   `strict`: The strictest config; intended for packages with public facing APIs.
+-   `strict`: The strictest config; intended for packages with public facing APIs, and those used as external-facing examples (e.g. those mentioned on `fluidframework.com`).
 
 ## Changing the lint config
 

--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -3,6 +3,15 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * "Minimal" eslint configuration.
+ *
+ * This configuration is primarily intended for use in packages during prototyping / initial setup.
+ * Ideally, all of packages in the fluid-framework repository should derive from either the "Recommended" or
+ * "Strict" configuration.
+ *
+ * Production packages **should not** use this configuration.
+ */
 module.exports = {
     env: {
         browser: true,

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -3,6 +3,14 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * "Recommended" eslint configuration.
+ *
+ * This is the fluid-framework repository's default configuration.
+ * Recommended for use production packages whose APIs we do not expect the majority of our customers to use directly.
+ *
+ * For packages whose APIs are intended for wide use, the "Strict" configuration should be used instead.
+ */
 module.exports = {
     extends: ["./minimal.js", "plugin:unicorn/recommended", "plugin:editorconfig/all"],
     plugins: ["editorconfig", "eslint-plugin-tsdoc"],

--- a/common/build/eslint-config-fluid/strict.js
+++ b/common/build/eslint-config-fluid/strict.js
@@ -3,6 +3,16 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * "Strict" eslint configuration.
+ *
+ * This configuration is recommended, in particular, for packages whose APIs are expected to be used externally.
+ * It is additionally recommended for the following scenarios:
+ *
+ * * Critical libraries - those where particular attention to code quality might prevent severe issues.
+ *
+ * * Publicized examples - any libraries, sample applications, etc. we expect external consumers to use for reference.
+ */
 module.exports = {
     extends: ["./recommended.js"],
     rules: {


### PR DESCRIPTION
Currently, there is not concrete guidance on where each of our config variants is intended to be used. This PR attempts to formalize this. Additional documentation will be added to the wiki once we are happy with the breakdown here.