### PR TITLE
Typetests for v2int2.1

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -1987,18 +1987,25 @@
 			}
 		},
 		"@fluid-experimental/property-changeset": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-changeset/-/property-changeset-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-ecUYd2RTHT1J8UmYvdNLjSZWDAmGQRQSTlMfRfokhAPsdLNMnfTvSwhUppUsXtnnvXRJ42vweVSpQ8ieW8c48g==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-changeset/-/property-changeset-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-PEI+qNJEDOijy8gKO8cTOY6WO79cAgK5mlD+g9eMslRiYnb8XUtC5o5HlaE2/bxs2482T2TbSuxvAg2udnIhTw==",
 			"requires": {
-				"@fluid-experimental/property-common": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-common": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"ajv": "7.1.1",
 				"ajv-keywords": "4.0.0",
-				"async": "^3.2.0",
+				"async": "^3.2.2",
 				"fastest-json-copy": "^1.0.1",
 				"lodash": "^4.17.21",
 				"semver": "^7.3.4",
 				"traverse": "0.6.6"
+			},
+			"dependencies": {
+				"async": {
+					"version": "3.2.4",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+					"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+				}
 			}
 		},
 		"@fluid-experimental/property-changeset-previous": {
@@ -2017,12 +2024,12 @@
 			}
 		},
 		"@fluid-experimental/property-common": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-common/-/property-common-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-c5yyVIjY08PecArJ7slZHm5eWIkf4BeKksAjXnMjjuzJtCxIzZ4pUtahdVFF3VVKKpXB3x6xEPV73IGx5M2E6g==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-common/-/property-common-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-hIJNenPxo58wCN2esX5PkAn4gwwiCiCeBWZQSJJwogbBk4U9/t9UalXO0QvHA9GKimFtD+yx0CYd7jOJ78tGFw==",
 			"requires": {
 				"ajv": "7.1.1",
-				"async": "^3.2.0",
+				"async": "^3.2.2",
 				"base64-js": "1.3.0",
 				"events": "^3.1.0",
 				"fastest-json-copy": "^1.0.1",
@@ -2030,6 +2037,13 @@
 				"murmurhash3js": "3.0.1",
 				"semver": "^7.3.4",
 				"traverse": "0.6.6"
+			},
+			"dependencies": {
+				"async": {
+					"version": "3.2.4",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+					"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+				}
 			}
 		},
 		"@fluid-experimental/property-common-previous": {
@@ -2049,20 +2063,20 @@
 			}
 		},
 		"@fluid-experimental/property-dds": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-dds/-/property-dds-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-PaNtohuioQ/jpYcFwVu5t302AdeYmlaU2kfhEDoLGTqmRx3GNW1NemyV8cB2isXlZODeJGVOnu697pQf3Rq++w==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-dds/-/property-dds-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-Kk6Xn3wG2GnStKetUiY2apbD7qu8C4fYKLoZc7IuYDEm4LB2oDI4iOpkCmIEE6W38iMw+/HMYiscLLLTiBlUEg==",
 			"requires": {
-				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluid-experimental/property-properties": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-properties": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"fastest-json-copy": "^1.0.1",
 				"lodash": "^4.17.21",
@@ -2116,19 +2130,26 @@
 			}
 		},
 		"@fluid-experimental/property-properties": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-properties/-/property-properties-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-Mn3fgQoPOiTqswCeqUEaDGCkvLSlgCiBArG2k/Fz4vHdGVLna88/iL42fJmX+TNBVYoLQsmLf8UEBDLfSzNX4g==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/property-properties/-/property-properties-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-2qNQZiIHCxMMirQA5bpGBe1JNHDCM7MhW+kW0TvZyjdsGFYayTXDOIdv8syPV0mlj9cjDGOrpZJM80Sd7BtVzw==",
 			"requires": {
-				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluid-experimental/property-common": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-changeset": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluid-experimental/property-common": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"ajv": "7.1.1",
-				"async": "^3.2.0",
+				"async": "^3.2.2",
 				"fastest-json-copy": "^1.0.1",
 				"lodash": "^4.17.21",
 				"semver": "^7.3.4",
 				"traverse": "0.6.6",
 				"underscore": "^1.12.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "3.2.4",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+					"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+				}
 			}
 		},
 		"@fluid-experimental/property-properties-previous": {
@@ -2176,16 +2197,16 @@
 			}
 		},
 		"@fluid-experimental/sequence-deprecated": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-OFMBwKut7k6RbTDPTyF5hIXoeJ2EynoWcOWJfnpKWRnQ58YK7C5ds6b1lo2HKM16ZeXfGye6a4Dc8fFzwzH7bg==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-fniPcWnMyshl+iIo1BuBlNdVPe9+FpmCh3/K5TXe2dx8Ht2DsZ51ycT/qes49eA8VL9/1cZtZ9fqtdsMzdY25w==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/sequence": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/sequence": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluid-experimental/sequence-deprecated-previous": {
@@ -3102,25 +3123,25 @@
 			}
 		},
 		"@fluidframework/aqueduct": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-l4HzHKijGzufCK2I8m4TlBNefTHfH/rqRYQMG8nqTcyottQS3ug6R8Q7HlSXiL9uMmpLW91sD5FULXd/L9G47A==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-iI43c+FrJVd3sqPdN7sadcQ+gb13F83K0GxV/wIL0HwsErHqfQaIb2ZmY+nCY5IehuWu35do8RI9YG2v/nYzlA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/map": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/synthesize": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/map": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/synthesize": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -3868,17 +3889,17 @@
 			}
 		},
 		"@fluidframework/cell": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-ihREKG2pCmxsU9oesPkx1yMkpeKuQ9gRd4+e4qZw9jrhSZC5JfFt5sTfqMydISkIdsZR4gXWUx0+OYmZSGNZFQ==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-ZmoXkZBxtLyYBNnEXeycPjr/ZvpmvDpQa9JwHbJ0LwE7B6Dbu5dI7kzpP0ScgD2No4GnNPpnj4Ng/+3I3vQi9w==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/cell-previous": {
@@ -3922,13 +3943,13 @@
 			}
 		},
 		"@fluidframework/container-definitions": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-C8j/3UDqSvZks/3ylUS35rC9wUeiHNgJPIdCdSgS+V+sQu7V+wIVfiwq+Mju8d+jPonBhonO1MUEQmcDIK3Jtw==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-rNHJh5366x0DCIbxohCtIaLEeluII5lTLDr+kdbHv98slHaNh9vmeQ1rhOVTmDWNNXcKmy0/sZ/NE0AN+mO4oQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0"
 			}
 		},
@@ -3944,20 +3965,20 @@
 			}
 		},
 		"@fluidframework/container-loader": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-K6yqOHwTbtDeUbBQodHkFIIt1BiFKSp+P79SyAwTmbtDPKEN36C5X2BBuzqiSYJTRj4kgS3/67JjFwEyLBcP9w==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-Woyt7ztxjHsnk1v8FkrK0zuXxj1CC+XZv1ocN77sIR6m43WPfOCjDE53TT/uylr5ppCFa7lLALm+FH9AD9z3Og==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"abort-controller": "^3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lodash": "^4.17.21",
@@ -3988,41 +4009,41 @@
 			}
 		},
 		"@fluidframework/container-runtime": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-ELsn/AxCQDd19HTlmfLYY9fphzSn19uRXX9VmWr5PEUT6/A/B7HDRdvub65ZzU2YVHwMo+t35VCGb10ejAdj4g==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-qyYbAKF6bDK7MpLp198rxsTJlzY7qihY73jtBO+K6th8/mFSwUWzovzkV3cLtsrhwYjbMSa2KfIc/H5kEVwZJg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lz4js": "^0.2.0",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/container-runtime-definitions": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-ADUYqfrWkP5j1Lt82hX6a0LHvTGqSurv3wuliQpmVicxnzX78wrssvycEoLvlc9BCKRjs/+NX5o1PfQFU0nnyQ==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-tLf6BuIWkf5PudxPEMwq5rsFhGQhAurQoxHCrTAwOQsQVG0MXCLU6iTz64XuNhtazozAZmdOVvI1UVRUfhggUQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@types/node": "^14.18.0"
 			}
 		},
@@ -4066,15 +4087,15 @@
 			}
 		},
 		"@fluidframework/container-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-ckkoAwajI+xPbOMNJhBiYhsPKBqtGJ65+/AnMdLrp3AsYLcIt70eg0FDjS7pcjf/wFMvVgWOPr2BeW3nVOaDWw==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-r12L0SFVhcQ7cUHMetKSHtHbPIAJrcgAUc1N+0vgb3OZ6PRmuFkAT9HRhpT7SorIXohHuqQ5BgsP+8KX4U35Jw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/container-utils-previous": {
@@ -4090,9 +4111,9 @@
 			}
 		},
 		"@fluidframework/core-interfaces": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-Tg0lBCiJvsW1sNWpnTXU/tM+gPHCwUDOWcbUVibLKd1/KdL5SU8y+YwWJ7JD7O6h4xbf/Pukb5Rp3//2e6x75A=="
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-lctB4yMaykYK40W8oUkfC4OHLEiwPgFzATYnS8vfDMmz+EHL0RvzI5+LQO9T2WiXAaKvAlxHgYA1OvzCkOmXtw=="
 		},
 		"@fluidframework/core-interfaces-previous": {
 			"version": "npm:@fluidframework/core-interfaces@2.0.0-internal.2.1.1",
@@ -4100,17 +4121,17 @@
 			"integrity": "sha512-2eEwtkOVMPEN2TH33ZamM84n1t7shkPrq/KQcn/PcFlrwXVJB9odPd7B2V0H59PmVIZjPHVgisxdQIGmG29xwg=="
 		},
 		"@fluidframework/counter": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-n04tH3hkV7o++W316/BPYvflg8lKzMUxMUb+jV7064yKsXL/Y3NdLpzrkLriSXR6zk4fkqAD6px5e8PlmD9VxA==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-O+ivnEnYrv38eIwoXYgAo3U4yoQuHUIAYi7JmJ6ZJ6O3h8DVu7iJIve+jxd8B++ntfS0VkQebQI7AgYgc7ucjQ==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/counter-previous": {
@@ -4146,39 +4167,39 @@
 			}
 		},
 		"@fluidframework/datastore": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-WHNHJU+kmx792YfdMn1FuqtuQYsfwcfpwGz8gFkm5VNmyR5i+4DRHdgXus60+GEHptFmBZ8moLrW/jOGBrxTjg==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-3AECXMJu4v0Zhh8759Ve5ohne2bXjQOvMFUUHksIXihabViUwz5/4ZkgaPZF1YBXeAzFVSYdSsdD6cdpbeynnQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"lodash": "^4.17.21",
 				"uuid": "^8.3.1"
 			}
 		},
 		"@fluidframework/datastore-definitions": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-VyPI3ncceK01jHgfqR+ycDPC1c7XMdaV6GyrAXXQCLtd7DX/phAi/WLAgtUBkDY2m3YXY2p4J3+FUICxgx6Jtg==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-InmktQyhLODak0j3bAFOUEDtO0KRVUecOTjwk44qYIWXEGP2Q7qo6Zl+Lrey6G08FCMHzaajVjyvRksJypMW1g==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@types/node": "^14.18.0"
 			}
 		},
@@ -4245,16 +4266,16 @@
 			}
 		},
 		"@fluidframework/driver-base": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-aHv5MKYcoRMza0janatTyYGFCsz3of+solrl6/XcW9m4Ah5CCMbm05fsWuRNj4lQ5zMnyzpDynjMm0a/IUWgeA==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-5O2Euvxhsl/oeQjIZ3aCVRCiDfJ8yBqeNMTFhh21xJMYfJILJg4MB2B4HCasCOLpr5ODiNCCYNtIMV2e3EmbxA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/driver-base-previous": {
@@ -4271,12 +4292,12 @@
 			}
 		},
 		"@fluidframework/driver-definitions": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-GmBJknNN0gAvC8+JHTBJrATn/wW09MRMbBkPQ6C9OIS6n51gfbyTW97nc/9TnM7O5Bf5z2R3GZcJ/YljhDI3dA==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-uLfyuq78VPWmMDZpFyFq6Uwjer0G9N8CkVWiUAnfy4Txl2ZSyDyps23LY1K4//reVzOVX/FHI1QlCUSUicDtZA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0"
 			}
 		},
@@ -4291,18 +4312,18 @@
 			}
 		},
 		"@fluidframework/driver-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-tv9AD1Y0ZyFGcK/HHXZbHCQaWd6ljt9WUihpcKGvKHd2GCQDnbbB28hXhzCcXkyRvgWh/6GdGad4gXbGjBfgVw==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-ZC7lpf7O2tICxGvZpcvgoDGqSGC2nEE+aX0UuKzHNmPXzLbC2oB4xDijGwE9vFN91YyihaDRTFF2TcXIkvoGAw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"url": "^0.11.0",
 				"uuid": "^8.3.1"
@@ -4391,22 +4412,22 @@
 			}
 		},
 		"@fluidframework/fluid-static": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-C5EB4gy7mKEzNUm+JjBvqJgnmqsoArmTLjQywM1um/j8FaAb5JqD9jQ7KR++9JXxSIVQHJTNXLBtCOYdM9nW1g==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-rFOx5Lda/Izsi2U/NFX7vefIEfwPmG44Ca8KUFGmXSfhcctxQPuRXJCirGKUYAU59KAJsyKvMXXb0a49Yh9leA==",
 			"requires": {
-				"@fluidframework/aqueduct": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/fluid-static-previous": {
@@ -4429,13 +4450,13 @@
 			}
 		},
 		"@fluidframework/garbage-collector": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-D/mlJBMex3TBO1+5+FVgV6MNE1A9tfUrXJkE6UGe2Hu1d8yvY/lJKeQpFzPrWVvrBguJ7fpEuv7iRm/yMgbv8g==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-LC/S0E/pgtPur+aKFOUHBzYOCvSaCH0rHxqJ4a6L3nF0cBjWKl3gS7uGVl9tDLuupCQei1nBcRb4kyVetomQLg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/garbage-collector-previous": {
@@ -4469,17 +4490,17 @@
 			}
 		},
 		"@fluidframework/ink": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-CMHFi1OZmsAEaynRSd9lSX9t0r9Y8eT+FLf9XeQdnuaYIJNNKMwPG3dg/hJ9z3GAv+spPFFWAaeGQHnkOXw13w==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-/wcLSjnyyEzbnlVnNNC3Hc82zzDH2JOfsbRrbXZ3W6P7nD92vheLq2tw1kp4aUzPPcHXWpniB+/XSGQzK+zXWw==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -4499,24 +4520,24 @@
 			}
 		},
 		"@fluidframework/local-driver": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-2jf6CWEMpmTjho4X3Qen1zfoge2Rh+kSiyuyiCbwf0RdxAFDl861sFYsYQDMke64aqMIP1Sx6/ob1EIBAIqMhw==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-yfIZAZ6s1gnUwYQkgtd2S6fjHgcsxwyozCHB70Ona8/inVF+iuDaTQAnzYp7ZJJpanqXD8UhaXf49AJDsQan/w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-local-server": "^0.1038.2000",
 				"@fluidframework/server-services-client": "^0.1038.2000",
 				"@fluidframework/server-services-core": "^0.1038.2000",
 				"@fluidframework/server-test-utils": "^0.1038.2000",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"jsrsasign": "^10.5.25",
 				"url": "^0.11.0",
 				"uuid": "^8.3.1"
@@ -4558,20 +4579,20 @@
 			}
 		},
 		"@fluidframework/map": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-2QuJS7GBrlWX51Fn/KQrZzXAg1O8bmRVjfOfbdYf3ExmpRVDzRYsiPGkktgF15TLgX36zScwLQ2SBuK/HWx+mA==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-XPC+P1skPGnAiTlcm7pYT9JXI1c1fngzaQjGoPR6Xnwjq46OO7fMTBGG9q7a07+nTLkxvNMpsnSyzz2EhYb7XA==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
@@ -4594,21 +4615,21 @@
 			}
 		},
 		"@fluidframework/matrix": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-76JBu+w+Xxfd7j4UoBmg3LVAwxSgiJTLazAhGzoFQ4K64wTQMqoUK0YZtZ5bHwwVKmk63jT8GIQyU25qlwVXgA==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-4GZIsk5JEyyqcrG3iASlB3PJTF2hZma6LZc8NfPvOnavbZmk4GFBjXUa4unBr7gp0HUVYoI0V/GeKO/fmSf5tQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@tiny-calc/nano": "0.0.0-alpha.5",
 				"tslib": "^1.10.0"
 			}
@@ -4634,21 +4655,21 @@
 			}
 		},
 		"@fluidframework/merge-tree": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-uiGV2MYjhJ/hP9S24Amtjby6twe9eA7/SIlwUDdWsFPCWgy7I/3hZl5HnsEV/phsbQfaRKulUHpVyDQGnC2HrQ==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-jSh/9UKr7I6oQUi1dUrJtCpUzrJEcsYUPFs2G7xRNVyBgSCORqh483gG1up50Ro1X6vEXe0e3682nYUIC6DpFw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/merge-tree-previous": {
@@ -4680,16 +4701,16 @@
 			}
 		},
 		"@fluidframework/odsp-doclib-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-/ojG/zz6h+St3KIhyS8G+aVAJTj+sbGNAX4yCxgbFIPL9AizCimJLDn/rb3xHsrF4BZVy6kW7P/hLUTeLd3CoA==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-S289cQ/9BqVbRECGhzhIs4x/MkpRgyghBsuMnxlLbZEdz7qP0id7Vy1a92dIBP5ZsObXtSb4Ypl+rQU3/BmP/Q==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"node-fetch": "^2.6.1"
 			}
 		},
@@ -4708,22 +4729,22 @@
 			}
 		},
 		"@fluidframework/odsp-driver": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-SmqeqKZCIUADjOe4gPZ9erhyypCNUAz2MWPPUmj91PHsv3lQhNwnLQ9P9vMC3EttGWxjXVKv3wXbv3RH7lRK3w==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-MQRUR6zvI/u2pv9oeR9k8Y9olh0nhAs2mjGM+0Tf/blduRyiK2H1+F5J45ph/wxykHw1oquZyF5DQraAdPlImQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"abort-controller": "^3.0.0",
 				"node-fetch": "^2.6.1",
 				"socket.io-client": "^4.4.1",
@@ -4731,11 +4752,11 @@
 			}
 		},
 		"@fluidframework/odsp-driver-definitions": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-iJjSI9c/dXI4dcWeZbb+CQv5svZOzcQhRCeBM6XRf5xuiv2bz52E0ld+ZhigM33PmqG2HnPz3J9515M8rYvHqw==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-nBLW0hBtPOCe8juIPFcAUVswbnWZT/wFBesaeOiUUjt9slPMy5SY66RGo2tYFWcIMOVW2Cs8bljDQi/KRsbnNQ==",
 			"requires": {
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/odsp-driver-definitions-previous": {
@@ -4770,14 +4791,14 @@
 			}
 		},
 		"@fluidframework/odsp-urlresolver": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-SDqu09paHxGLgiSh0YC9Wqj6FyvMJvAcRstUFxNeQrPQT41KCEqDC3tfvxni6qKLx6k6yb4VrEtEQUUmMlgORA==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-8LQlDA++uuUoOvayAj+7zs8790/B45D1DRhydpVnit68Ch7bK2hbDQMUL4w08OrxGHLSNd6W8Ryni+nA3Kd47A==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/odsp-urlresolver-previous": {
@@ -4792,17 +4813,17 @@
 			}
 		},
 		"@fluidframework/ordered-collection": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-11IlfnNyQE2Sv4pXt6xtFK7s3HEBSVazNLBb8m4E88XRZwZ5q8r6FYsgZsuTGBu7nxS3N0OJdsFTuUxKmNWFyQ==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-jYoLfT1HguxUOs4JLGc+fXOGihB6D4ClTTMUZtyjBHyw7rLTOXxa0Vc1n3QoMXk3eSCb1lpcWB9R1k1qJU7Yww==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -4841,17 +4862,17 @@
 			}
 		},
 		"@fluidframework/register-collection": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-S3b7hsFIxkAiCBe4HqSw5ZV82YrF6pjfPriC6M8mMOxC9pFx+iD2nwl75oLo/6EjYuYLgUcbvpUu71gQBixXJQ==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-tI9VtpHpqWO1Dh5f6+Hs4Nl0Vr22EypMGncoRmv0PsfTdy8YBrdlhxESl3vmAWX2tQlaboVE8Qi5OGO0HpspDw==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/register-collection-previous": {
@@ -4869,16 +4890,16 @@
 			}
 		},
 		"@fluidframework/replay-driver": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-riBUWeScvUOSVxJkLcJi3Fc10vcT5IR1MQOH+YxWNnotVa4OKJFG1g6VQaJHTk5WbLx+DFFAlZqdbcx7Jl/2Rw==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-rofaaxxoTdmLf1/kxVP91e+R+ZDnN1rIXIY0DO/SKpZa0E4kmT61y1eiC4IlEyEJk3tpuAf1b0Jzg6hf34mi6w==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/replay-driver-previous": {
@@ -4895,15 +4916,15 @@
 			}
 		},
 		"@fluidframework/request-handler": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-sTtCiH3ijNR1C6Ln8Vqf+UQjjyqRu43swkAvpQUut1t5B3umpt2+V4KNMnISyvI7jky+XJPi/S97K4INuYNwmw==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-pY2zZ0fWa6phEgraRGQggzxgLZ46D0WpKA9gdV++hKOnib3PyrRoRGZ9F2TxSzUWQkuOE5l3y/y7Rz7DBstIKg==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/request-handler-previous": {
@@ -4919,20 +4940,20 @@
 			}
 		},
 		"@fluidframework/routerlicious-driver": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-hiDwst2RZJsx9aC9KvrHxVULWFgif51gxNsggJnRVkWfVXg3D3kml6u3ljrljHZcmbWIer+fUtMaWAn+8gEKkw==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-zHHsqY5pHydkFaVlOCEi1hQ/07Le78FcIzEBActrr+/CgWluxrQmeiFLEub/ZCcT+RkuRAnGxTxLoMdT4vOjgg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/driver-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/gitresources": "^0.1038.2000",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"@fluidframework/server-services-client": "^0.1038.2000",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -4978,15 +4999,15 @@
 			}
 		},
 		"@fluidframework/runtime-definitions": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-MzR66Gn2DAUS6FFfvz9jISLV863bjAwevEwZoiJ099pOkMRtKpcYqnDz3UpXN9gkfbhPqSDAJzof/51sZb4NQA==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-If4I4HWOdiV0iOr/DSwUk1kEdnjoz02JJUMEu2iXotvGQYuGofkpZBfNr6+Xw4k2pVUbIWqpZIsm9kIJhVPVWQ==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"@types/node": "^14.18.0"
 			}
@@ -5006,21 +5027,21 @@
 			}
 		},
 		"@fluidframework/runtime-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-QcRqKRAuQmtkeWs1cFwtltIltgi9qRV+i+Np9mLl1GzgzgzAsiClB5D9FmubJV9FbSsLuwP35w/ROCPtFoj1Cg==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-iKS5kAGvwCVM4+4IeANIC8dEhPSzcd3z6OnWeQxnoXG3+vNtaEj9TjyipIZIC3aNqJdWO2+pRaoBJP9NHmECMg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/runtime-utils-previous": {
@@ -5042,21 +5063,21 @@
 			}
 		},
 		"@fluidframework/sequence": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-NATc3D7wKopoq/Eu8t3y/t9g3OTEAfG5RTD3IlQqrUQYs5ef3cfIhawp7W5nOidXDek5/3vGXG0NKmnC3ti4RA==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-MuRGzr4ebZmSa5rP6LJ8jU3exEk43N+5TBTEuam8QSaFPw7eZ7S1+DBU2V+7SZZFoM4m1cdmj14OEHGMbTeQxg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/merge-tree": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/merge-tree": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -5832,22 +5853,22 @@
 			}
 		},
 		"@fluidframework/shared-object-base": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-sGLyROiubr76aY9+JfnUPZm1+B6Jyf36739MUhgwKCOiH0LGwzl33DQusMBgxkaKliwy9suMU9dWd8uJDd1/fA==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-qAc7yLJSMtPV86YYioRyVjJpi0TlHzd45wVm9fsU8eEuvzMH7l3sNo3Dl6iIzMGNhwv/IWaoIa4ZJ56rmGydOw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -5886,9 +5907,9 @@
 			}
 		},
 		"@fluidframework/synthesize": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-RghjXkF0bAdvjsSKzDlo89ATN2jAV2nWl/42v8uMKxiryjjqgWFkJdyGcMLGtj82mz/qyaH26Xi/eNuN1A3Qdg=="
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-R8k/rkkhqg5c7LMAt7ewS6wAecGQoAkdzkgXLV5QLGKeJptPNq88m9KhzIGFwMs3HpIhG0671PfhBlg39Hw9SQ=="
 		},
 		"@fluidframework/synthesize-previous": {
 			"version": "npm:@fluidframework/synthesize@2.0.0-internal.2.1.1",
@@ -5896,9 +5917,9 @@
 			"integrity": "sha512-Prgl2msLRsOyV7cixHRT0yA/tAyUqaUEsJrcLMbyexG8uWzYjtlyUY6g8+nVnMOHMXWjYTmhOx4D80MYro0OQA=="
 		},
 		"@fluidframework/telemetry-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-oGvjk4CXLs1ShSfDLiz9xw71/NmJGkyHxAOe8/NCli14FRE5wI84ymtfcuXBEk5O6FFR9BwvWnTzkFOIJlwnEA==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-eEvSxKX4BlU3pxRMwhLHwxDR4t4waw7ddHJgF12ra3BLQn9L3meiKO/gxC9p4CAzlLbw6yLJXGqnw4NUpp0cfg==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
@@ -5930,13 +5951,13 @@
 			}
 		},
 		"@fluidframework/test-driver-definitions": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-BJS3OE0+wCxVTypSRLU7xzi8J3ELGPUkoVId3hdXf2Sh+Fr9HQyPzSykReCLPFaEd7XZCT4RjVP4x/mlwF3Z7w==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-1Q5IFUy2eZlFU9NHDwoGhXiLU3jVjbSHPz9YDA4+TeJSlrIp9HSalTIaUsKGVu1cFXtSDrj0I7K16Idz61JEmw==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"uuid": "^8.3.1"
 			}
@@ -5954,27 +5975,27 @@
 			}
 		},
 		"@fluidframework/test-drivers": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-SwcbymAmGhVYQSrf9x2YQ2fKjR4mzCOzWT/B4MRSWnP8PPpIvKpKYzAOHMaHrvqfWTJnt7y/WwqqRFH0KniUvg==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-a41i8MsuXT0JoeMDz8lFYWhzjk+aP+oNbito1djMkh2WLGwWvhJtGZfT3gxsMQbYk7fzUYmouLBNYZ5De9MySg==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/local-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/local-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-local-server": "^0.1038.2000",
-				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/tool-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/tool-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"semver": "^7.3.4",
 				"uuid": "^8.3.1"
@@ -6020,9 +6041,9 @@
 			}
 		},
 		"@fluidframework/test-pairwise-generator": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-NJN29fYIdUE30Da84JnOwWv2J2sIOZyrDoQTz5ihcDfGkcl4HlpT+yH9QxerJ4rjTAwha8xaXIiPf6Zmi9h4qg==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-ekwbM+l6e5fXKQM/CtwqQfkQ/QIN7RDAblUeYcvjCkrjgaz7GmBbxYEM23Q4Q9n7W941AioydKZuUtJmPff4/w==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
 				"random-js": "^1.0.8"
@@ -6038,22 +6059,22 @@
 			}
 		},
 		"@fluidframework/test-runtime-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-lhqgziVd1hBOVz8sQfBmsYlh7G1bITsremlutWnupTbS7/M//tvsK9bZ+/mcMghbK+uyL4GRKF4Iyyw+SalauA==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-WGSpjgoGOWdEOLyf7KZUgWuOVfxsIgU4b4jbJiW+vTqXtzOcZebzmgGeavruel2k1VuZH2nP1l+y6M1TA2i02A==",
 			"requires": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"axios": "^0.26.0",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -6088,32 +6109,32 @@
 			"dev": true
 		},
 		"@fluidframework/test-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-iG+Emrq7A07rZw0hSgpnU/8mP/0WOLpiwhpYqeavdUp3JJuX+OT+1qmK0/IHiTHqlNSNm7mwzwDZxKvp8izScg==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-/B5Frfd86Lz7/uop7oAowowKI9rDW9U6fvFoR5/FDXEQrXOff8ocOw3n6ZogoehqEvloMEraD66vFwQny3N1kA==",
 			"requires": {
-				"@fluidframework/aqueduct": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/aqueduct": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-loader": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/local-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/map": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-loader": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/local-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/map": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/request-handler": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/request-handler": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"best-random": "^1.0.0",
 				"debug": "^4.1.1",
 				"uuid": "^8.3.1"
@@ -6206,15 +6227,15 @@
 			}
 		},
 		"@fluidframework/tinylicious-driver": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-/7aC4JvtEsiPivoeIcaMQrnfQroxiFVdAk1uPWBlELcK/AIuv2r26f1zgIv4FG92nYaV8cuQwIW8phSMxdT0yQ==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-Cqe/sgoJtRoi5uYuCk+Z01kh2dLhCmfDv3Jx3WWl5StTd9u/6J6WxODjr3sGR/ftHiBzNOmk0xm5QNSPwIfcMw==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/driver-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-definitions": "^1.1.0",
-				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/server-services-client": "^0.1038.2000",
 				"jsrsasign": "^10.5.25",
 				"uuid": "^8.3.1"
@@ -6236,12 +6257,12 @@
 			}
 		},
 		"@fluidframework/tool-utils": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-Svw/m5OSRS4jYi9TUasyKRB/GDNCO8MMkfmYnIgtRVCyvvJeIJgpLmJjYHAJRKBqQf2cVvC6dbCK81O1mBT8nA==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-BOXjO/kS7s7aLHz3zhMMkFNqKlgV0Skm3U6VcurILVKCOLF5y+muNyhtYkeUNq0wrEEyQu5Y3U8aOuFmgbLypw==",
 			"requires": {
 				"@fluidframework/common-utils": "^1.0.0",
-				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"@fluidframework/protocol-base": "^0.1038.2000",
 				"@fluidframework/protocol-definitions": "^1.1.0",
 				"async-mutex": "^0.3.1",
@@ -6277,12 +6298,12 @@
 			}
 		},
 		"@fluidframework/view-adapters": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-Ze84PP1AozmMWp6qKHNVDZRMFeLm5Fc0o6axgmJsS8VQYzepbBJC4RKGQnEz06AZyOVP96rUkN0pir3sqXuVIA==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-BNgtHYUiHu/+usW2uz9wKfQQGnImL3M6mt409Bhke8p7Lrmwjwde3DKSmYCkXrHP0DFQoSeG+K2WJey49g6j3g==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"react": "^17.0.1",
 				"react-dom": "^17.0.1"
 			}
@@ -6299,11 +6320,11 @@
 			}
 		},
 		"@fluidframework/view-interfaces": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-mehNznfHr7AqPn5/u5n9NF5iDyLBn48CjXBQwKQydYJH3v6jJB+I2BzVaW2Rw0y3pz8jbhd1xbUcjDI5X+elUg==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-EPsNvDvtEa4x1QHAsfIx9sqSMb5EcaAeV8NMq28seuvb93f9Yzdior8dd2/knmgrgxMIq15LQWUBz2EF3ULTeg==",
 			"requires": {
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
 			}
 		},
 		"@fluidframework/view-interfaces-previous": {
@@ -6315,12 +6336,12 @@
 			}
 		},
 		"@fluidframework/web-code-loader": {
-			"version": "2.0.0-internal.2.1.2",
-			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.1.2.tgz",
-			"integrity": "sha512-GcwuPMGE6c2OidL5lSwlRTFXXJBFofC7K3J7+NoFjAmto8lsm7nRVQpC94G+/h3U+s0uzTHVuxnvTLGMcSJonw==",
+			"version": "2.0.0-internal.2.2.1",
+			"resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.2.1.tgz",
+			"integrity": "sha512-gHUb94qdfFZmK26/a/FDf16B0WRJr0KFadE9iOytBF4ncWxRufTYWeeJGuZ0Bt3WK/dx2vmwvwcx5ah3jawi+g==",
 			"requires": {
-				"@fluidframework/container-definitions": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
-				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.2 <2.0.0-internal.3.0.0",
+				"@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+				"@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
 				"isomorphic-fetch": "^3.0.0"
 			}
 		},

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -105,6 +105,8 @@
   "typeValidation": {
     "version": "2.0.0-internal.2.1.2",
     "baselineRange": "2.0.0-internal.2.1.1",
-    "broken": {}
+    "broken": {
+      "InterfaceDeclaration_ITestContainerConfig": { "forwardCompat": false }
+    }
   }
 }

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -407,6 +407,7 @@ declare function get_old_InterfaceDeclaration_ITestContainerConfig():
 declare function use_current_InterfaceDeclaration_ITestContainerConfig(
     use: TypeOnly<current.ITestContainerConfig>);
 use_current_InterfaceDeclaration_ITestContainerConfig(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ITestContainerConfig());
 
 /*


### PR DESCRIPTION
## Description

Trying to follow steps on https://github.com/microsoft/FluidFramework/pull/13340 to update type tests on a release branch so that I can cherry-pick a fix onto it

1. npm run typetests:prepare
2. npm install
3. remove old "broken" annotations in package.json files from previous type tests.
4. npm run typetests:gen
