### PR TITLE
Make various improvements to SharedTree events

### DIFF
--- a/packages/dds/tree/README.md
+++ b/packages/dds/tree/README.md
@@ -315,8 +315,7 @@ flowchart
             dependency-tracking
             forest-->tree
         end
-        core-->events
-        core-->util
+        core-->events-->util
         id-compressor-->util
         feature-->shared-tree-core
         shared-tree-core-->core

--- a/packages/dds/tree/src/events/events.ts
+++ b/packages/dds/tree/src/events/events.ts
@@ -60,9 +60,8 @@ export type TransformEvents<E extends Events<E>, Target extends IEvent = IEvent>
 
 /**
  * An object which allows the registration of listeners so that subscribers can be notified when an event happens.
- * Clients can subscribe to events via the `on` method and unsubscribe by invoking the return value of `on`.
- * Classes wishing to emit events via this interface may implement this interface by creating a private {@link EventEmitter}
- * or by extending {@link EventEmitter} directly.
+ *
+ * {@link EventEmitter} can help implement this interface via delegation or extension.
  * @param E - All the events that this emitter supports
  * @example
  * ```ts
@@ -74,7 +73,7 @@ export type TransformEvents<E extends Events<E>, Target extends IEvent = IEvent>
  */
 export interface IEventEmitter<E extends Events<E>> {
     /**
-     * Register an event listener
+     * Register an event listener.
      * @param eventName - the name of the event
      * @param listener - the handler to run when the event is fired by the emitter
      * @returns a function which will deregister the listener when run
@@ -107,10 +106,7 @@ export interface IEventEmitter<E extends Events<E>> {
  *     this.events.emit("loaded");
  *   }
  *
- *   public on<K extends keyof MyEvents>(
- *     eventName: K,
- *     listener: MyEvents[K],
- *   ): () => void {
+ *   public on<K extends keyof MyEvents>(eventName: K, listener: MyEvents[K]): () => void {
  *     return this.events.on(eventName, listener);
  *   }
  * }
@@ -133,7 +129,7 @@ export class EventEmitter<E extends Events<E>> implements IEventEmitter<E> {
     protected constructor() {}
 
     /**
-     * Fire the given event, notifying all subscribers by calling their registered listener functions
+     * Fire the given event, notifying all subscribers by calling their registered listener functions.
      * @param eventName - the name of the event to fire
      * @param args - the arguments passed to the event listener functions
      */
@@ -147,12 +143,6 @@ export class EventEmitter<E extends Events<E>> implements IEventEmitter<E> {
         }
     }
 
-    /**
-     * Register an event listener
-     * @param eventName - the name of the event
-     * @param listener - the handler to run when the event is fired by the emitter
-     * @returns a function which will deregister the listener when run
-     */
     public on<K extends keyof Events<E>>(eventName: K, listener: E[K]): () => void {
         const listeners = this.listeners.get(eventName);
         if (listeners !== undefined) {

--- a/packages/dds/tree/src/events/fence.json
+++ b/packages/dds/tree/src/events/fence.json
@@ -1,5 +1,5 @@
 {
   "tags": ["events"],
   "exports": ["index"],
-  "imports": []
+  "imports": ["util"]
 }

--- a/packages/dds/tree/src/events/index.ts
+++ b/packages/dds/tree/src/events/index.ts
@@ -6,7 +6,7 @@
 export {
     EventEmitter,
     Events,
-    IEventEmitter,
+    ISubscribable,
     IsEvent,
     TransformEvents,
     UnionToIntersection,

--- a/packages/dds/tree/src/events/index.ts
+++ b/packages/dds/tree/src/events/index.ts
@@ -4,6 +4,7 @@
  */
 
 export {
+    createEmitter,
     EventEmitter,
     Events,
     ISubscribable,

--- a/packages/dds/tree/src/feature-libraries/forestIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/forestIndex.ts
@@ -33,7 +33,7 @@ import {
     SummaryElementStringifier,
     IndexEvents,
 } from "../shared-tree-core";
-import { IEventEmitter } from "../events";
+import { ISubscribable } from "../events";
 import { jsonableTreeFromCursor, singleTextCursor } from "./treeTextCursor";
 import { afterChangeForest } from "./object-forest";
 
@@ -63,7 +63,7 @@ export class ForestIndex implements Index, SummaryElement {
 
     public constructor(
         private readonly runtime: IFluidDataStoreRuntime,
-        events: IEventEmitter<IndexEvents<unknown>>,
+        events: ISubscribable<IndexEvents<unknown>>,
         private readonly forest: IEditableForest,
     ) {
         this.cursor = this.forest.allocateCursor();

--- a/packages/dds/tree/src/feature-libraries/schemaIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/schemaIndex.ts
@@ -44,7 +44,7 @@ import {
     SummaryElementStringifier,
 } from "../shared-tree-core";
 import { brand, isJsonObject, JsonCompatibleReadOnly } from "../util";
-import { IEventEmitter } from "../events";
+import { ISubscribable } from "../events";
 
 /**
  * The storage key for the blob in the summary containing schema data
@@ -223,7 +223,7 @@ export class SchemaIndex implements Index, SummaryElement {
 
     public constructor(
         private readonly runtime: IFluidDataStoreRuntime,
-        events: IEventEmitter<IndexEvents<unknown>>,
+        events: ISubscribable<IndexEvents<unknown>>,
         private readonly schema: StoredSchemaRepository,
     ) {
         this.schemaBlob = cachedValue(async (observer) => {

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -28,7 +28,7 @@ import {
 import { v4 as uuid } from "uuid";
 import { ChangeFamily, Commit, EditManager, SeqNumber, AnchorSet, Delta } from "../core";
 import { brand, isReadonlyArray, JsonCompatibleReadOnly } from "../util";
-import { EventEmitter, IEventEmitter, TransformEvents } from "../events";
+import { EventEmitter, ISubscribable, TransformEvents } from "../events";
 
 /**
  * The events emitted by a {@link SharedTreeCore}
@@ -117,7 +117,7 @@ export class SharedTreeCore<
      * @param telemetryContextPrefix - the context for any telemetry logs/errors emitted
      */
     public constructor(
-        indexes: TIndexes | ((events: IEventEmitter<IndexEvents<TChange>>) => TIndexes),
+        indexes: TIndexes | ((events: ISubscribable<IndexEvents<TChange>>) => TIndexes),
         public readonly changeFamily: TChangeFamily,
         public readonly editManager: EditManager<TChange, TChangeFamily>,
         anchors: AnchorSet,

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -28,7 +28,7 @@ import {
 import { v4 as uuid } from "uuid";
 import { ChangeFamily, Commit, EditManager, SeqNumber, AnchorSet, Delta } from "../core";
 import { brand, isReadonlyArray, JsonCompatibleReadOnly } from "../util";
-import { EventEmitter, ISubscribable, TransformEvents } from "../events";
+import { createEmitter, ISubscribable, TransformEvents } from "../events";
 
 /**
  * The events emitted by a {@link SharedTreeCore}
@@ -104,7 +104,7 @@ export class SharedTreeCore<
     /**
      * Provides events that indexes can subscribe to
      */
-    private readonly indexEventEmitter = EventEmitter.create<IndexEvents<TChange>>();
+    private readonly indexEventEmitter = createEmitter<IndexEvents<TChange>>();
 
     /**
      * @param indexes - A list of indexes, either as an array or as a factory function

--- a/packages/dds/tree/src/test/events/eventEmitter.spec.ts
+++ b/packages/dds/tree/src/test/events/eventEmitter.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { EventEmitter } from "../../events";
+import { EventEmitter, IEventEmitter } from "../../events";
 
 interface TestEvents {
     open: () => void;
@@ -93,3 +93,27 @@ describe("EventEmitter", () => {
         assert.strictEqual(count, 1);
     });
 });
+
+interface MyEvents {
+    loaded: () => void;
+}
+
+// The below classes correspond to the examples given in the doc comment of `EventEmitter` to ensure that they compile
+
+class MyInheritanceClass extends EventEmitter<MyEvents> {
+    private load() {
+        this.emit("loaded");
+    }
+}
+
+class MyCompositionClass implements IEventEmitter<MyEvents> {
+    private readonly events = EventEmitter.create<MyEvents>();
+
+    private load() {
+        this.events.emit("loaded");
+    }
+
+    public on<K extends keyof MyEvents>(eventName: K, listener: MyEvents[K]): () => void {
+        return this.events.on(eventName, listener);
+    }
+}

--- a/packages/dds/tree/src/test/events/eventEmitter.spec.ts
+++ b/packages/dds/tree/src/test/events/eventEmitter.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
-import { EventEmitter, ISubscribable } from "../../events";
+import { createEmitter, EventEmitter, ISubscribable } from "../../events";
 
 interface TestEvents {
     open: () => void;
@@ -14,7 +14,7 @@ interface TestEvents {
 
 describe("EventEmitter", () => {
     it("emits events", () => {
-        const emitter = EventEmitter.create<TestEvents>();
+        const emitter = createEmitter<TestEvents>();
         let opened = false;
         emitter.on("open", () => {
             assert(!opened, "Event should only be fired once");
@@ -25,7 +25,7 @@ describe("EventEmitter", () => {
     });
 
     it("passes arguments to events", () => {
-        const emitter = EventEmitter.create<TestEvents>();
+        const emitter = createEmitter<TestEvents>();
         let error = false;
         emitter.on("close", (e: boolean) => {
             error = e;
@@ -35,7 +35,7 @@ describe("EventEmitter", () => {
     });
 
     it("emits multiple events", () => {
-        const emitter = EventEmitter.create<TestEvents>();
+        const emitter = createEmitter<TestEvents>();
         let opened = false;
         let closed = false;
         emitter.on("open", () => {
@@ -53,7 +53,7 @@ describe("EventEmitter", () => {
     });
 
     it("deregisters events", () => {
-        const emitter = EventEmitter.create<TestEvents>();
+        const emitter = createEmitter<TestEvents>();
         let error = false;
         const deregister = emitter.on("close", (e: boolean) => {
             error = e;
@@ -64,7 +64,7 @@ describe("EventEmitter", () => {
     });
 
     it("deregisters multiple events", () => {
-        const emitter = EventEmitter.create<TestEvents>();
+        const emitter = createEmitter<TestEvents>();
         let opened = false;
         let closed = false;
         const deregisterOpen = emitter.on("open", () => {
@@ -84,7 +84,7 @@ describe("EventEmitter", () => {
     });
 
     it("ignores duplicate events", () => {
-        const emitter = EventEmitter.create<TestEvents>();
+        const emitter = createEmitter<TestEvents>();
         let count = 0;
         const listener = () => (count += 1);
         emitter.on("open", listener);
@@ -95,7 +95,7 @@ describe("EventEmitter", () => {
     });
 
     it("fails on duplicate deregistrations", () => {
-        const emitter = EventEmitter.create<TestEvents>();
+        const emitter = createEmitter<TestEvents>();
         const deregister = emitter.on("open", () => {});
         const deregisterB = emitter.on("open", () => {});
         deregister();
@@ -132,7 +132,7 @@ class MyInheritanceClass extends EventEmitter<MyEvents> {
 }
 
 class MyCompositionClass implements ISubscribable<MyEvents> {
-    private readonly events = EventEmitter.create<MyEvents>();
+    private readonly events = createEmitter<MyEvents>();
 
     private load() {
         this.events.emit("loaded");


### PR DESCRIPTION
* Improve documentation and discoverability
* Fix errors in documentation examples
* Use a Map instead of an object to store events to avoid prototype pollution
* Export creation function for event emitter rather than using a static method