### PR TITLE
Add testing for tombstone revived logs

### DIFF
--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -69,13 +69,13 @@ export const createDocumentId: () => string;
 export function createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>, documentServiceFactory: IDocumentServiceFactory, urlResolver: IUrlResolver, logger?: ITelemetryBaseLogger, options?: ILoaderOptions): IHostLoader;
 
 // @public (undocumented)
-export function createSummarizer(provider: ITestObjectProvider, container: IContainer, summaryVersion?: string, gcOptions?: IGCRuntimeOptions, configProvider?: IConfigProviderBase): Promise<ISummarizer>;
+export function createSummarizer(provider: ITestObjectProvider, container: IContainer, summaryVersion?: string, gcOptions?: IGCRuntimeOptions, configProvider?: IConfigProviderBase, logger?: ITelemetryBaseLogger): Promise<ISummarizer>;
 
 // @public (undocumented)
 export function createSummarizerFromFactory(provider: ITestObjectProvider, container: IContainer, dataStoreFactory: IFluidDataStoreFactory, summaryVersion?: string, containerRuntimeFactoryType?: typeof ContainerRuntimeFactoryWithDefaultDataStore, registryEntries?: NamedFluidDataStoreRegistryEntries): Promise<ISummarizer>;
 
 // @public (undocumented)
-export function createSummarizerWithContainer(provider: ITestObjectProvider, absoluteUrl: string | undefined, summaryVersion?: string, gcOptions?: IGCRuntimeOptions, configProvider?: IConfigProviderBase): Promise<{
+export function createSummarizerWithContainer(provider: ITestObjectProvider, absoluteUrl: string | undefined, summaryVersion?: string, gcOptions?: IGCRuntimeOptions, configProvider?: IConfigProviderBase, logger?: ITelemetryBaseLogger): Promise<{
     container: IContainer;
     summarizer: ISummarizer;
 }>;

--- a/packages/runtime/container-runtime/src/garbageCollectionTombstoneUtils.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionTombstoneUtils.ts
@@ -26,11 +26,6 @@ export function sendGCTombstoneEvent(
     if(throwOnTombstoneUsage) {
         mc.logger.sendErrorEvent(event, error);
     } else {
-        mc.logger.sendTelemetryEvent(
-            {
-                ...event,
-                ...error,
-            }
-        );
+        mc.logger.sendTelemetryEvent(event, error);
     }
 }

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -844,7 +844,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             mainDataStore._root.set("newDataStore", newDataStore.handle);
             mainDataStore._root.set("blob", blobHandle);
             await provider.ensureSynchronized();
-            mockLogger.matchEvents([
+            mockLogger.assertMatch([
                 { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived" },
                 { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived" },
             ]);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -25,13 +25,14 @@ import { IRequest } from "@fluidframework/core-interfaces";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { getGCStateFromSummary, getGCTombstoneStateFromSummary } from "./gcTestSummaryUtils";
 
 /**
  * These tests validate that SweepReady data stores are correctly marked as tombstones. Tombstones should be added
  * to the summary and changing them (sending / receiving ops, loading, etc.) is not allowed.
  */
-describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
+describeNoCompat.only("GC data store tombstone tests", (getTestObjectProvider) => {
     const remainingTimeUntilSweepMs = 100;
     const sweepTimeoutMs = 200;
     assert(remainingTimeUntilSweepMs < sweepTimeoutMs, "remainingTimeUntilSweepMs should be < sweepTimeoutMs");
@@ -772,6 +773,8 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 
         itExpects("removes un-tombstoned data store and attachment blob from tombstone blob in summary",
         [
+            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived" },
+            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived" },
             { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived", type: "DataStore" },
             { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived", type: "Blob" },
         ],
@@ -781,12 +784,15 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             const mainDataStoreUrl = `/${mainDataStore._context.id}`;
             await waitForContainerConnection(mainContainer);
 
+            const mockLogger = new MockLogger();
+
             const summarizer = await createSummarizer(
                 provider,
                 mainContainer,
                 undefined /* summaryVersion */,
                 gcOptions,
                 mockConfigProvider(settings),
+                mockLogger,
             );
 
             // Create couple of data stores.
@@ -829,10 +835,19 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             validateTombstoneState(
                 summary2.summaryTree, [newDataStoreUrl, newDataStore2Url, blobHandle.absolutePath], [mainDataStoreUrl]);
 
+            mockLogger.assertMatchNone([
+                { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived" },
+                { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived" },
+            ]);
+
             // Mark one of the data stores and attachment blob as referenced so that they are not tombstones anymore.
             mainDataStore._root.set("newDataStore", newDataStore.handle);
             mainDataStore._root.set("blob", blobHandle);
             await provider.ensureSynchronized();
+            mockLogger.matchEvents([
+                { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived" },
+                { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived" },
+            ]);
 
             // Summarize. The un-tombstoned data store and attachment blob should not be part of the tombstone blob.
             const summary3 = await summarizeNow(summarizer);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -32,7 +32,7 @@ import { getGCStateFromSummary, getGCTombstoneStateFromSummary } from "./gcTestS
  * These tests validate that SweepReady data stores are correctly marked as tombstones. Tombstones should be added
  * to the summary and changing them (sending / receiving ops, loading, etc.) is not allowed.
  */
-describeNoCompat.only("GC data store tombstone tests", (getTestObjectProvider) => {
+describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
     const remainingTimeUntilSweepMs = 100;
     const sweepTimeoutMs = 200;
     assert(remainingTimeUntilSweepMs < sweepTimeoutMs, "remainingTimeUntilSweepMs should be < sweepTimeoutMs");

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -21,6 +21,7 @@ import {
 } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { IConfigProviderBase } from "@fluidframework/telemetry-utils";
+import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { ITestContainerConfig, ITestObjectProvider } from "./testObjectProvider";
 import { mockConfigProvider } from "./TestConfigs";
 
@@ -104,6 +105,7 @@ export async function createSummarizer(
     summaryVersion?: string,
     gcOptions?: IGCRuntimeOptions,
     configProvider: IConfigProviderBase = mockConfigProvider(),
+    logger?: ITelemetryBaseLogger,
 ): Promise<ISummarizer> {
     const absoluteUrl = await container.getAbsoluteUrl("");
     return (await createSummarizerWithContainer(
@@ -112,6 +114,7 @@ export async function createSummarizer(
         summaryVersion,
         gcOptions,
         configProvider,
+        logger,
     )).summarizer;
 }
 
@@ -121,13 +124,14 @@ export async function createSummarizerWithContainer(
     summaryVersion?: string,
     gcOptions?: IGCRuntimeOptions,
     configProvider: IConfigProviderBase = mockConfigProvider(),
+    logger?: ITelemetryBaseLogger,
 ): Promise<{ container: IContainer; summarizer: ISummarizer; }> {
     const testContainerConfig: ITestContainerConfig = {
         runtimeOptions: {
             summaryOptions: defaultSummaryOptions,
             gcOptions,
         },
-        loaderProps: { configProvider },
+        loaderProps: { configProvider, logger },
     };
     const loader = provider.makeTestLoader(testContainerConfig);
     return createSummarizerCore(absoluteUrl, loader, summaryVersion);


### PR DESCRIPTION
[AB#2961](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2961)

Add tombstoned revived logs testing. Fixes generic telemetry logging information for other tombstone events.