### PR TITLE
Disable op reentry for stress tests

### DIFF
--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -81,7 +81,7 @@ export function generateRuntimeOptions(
         flushMode: [undefined],
         compressionOptions: [{ minimumBatchSizeInBytes: 500, compressionAlgorithm: CompressionAlgorithms.lz4 }],
         maxBatchSizeInBytes: [undefined],
-        enableOpReentryCheck: [true],
+        enableOpReentryCheck: [undefined],
         chunkSizeInBytes: [undefined],
     };
 


### PR DESCRIPTION
We've acquired the relevant logs for the errors brought up by this check in the stress tests, disabling this for now, until the problem is fixed, to reduce OCE noise.