### PR TITLE
Tree: Make consumed Deltas readonly

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -22,7 +22,7 @@ export interface AnchorLocator {
 
 // @public @sealed
 export class AnchorSet {
-    applyDelta(delta: Delta.Root): void;
+    applyDelta(delta: RecursiveReadonly<Delta.Root>): void;
     // (undocumented)
     forget(anchor: Anchor): void;
     isEmpty(): boolean;
@@ -503,7 +503,7 @@ export interface IDefaultEditBuilder {
 // @public
 export interface IEditableForest extends IForestSubscription {
     readonly anchors: AnchorSet;
-    applyDelta(delta: Delta.Root): void;
+    applyDelta(delta: RecursiveReadonly<Delta.Root>): void;
 }
 
 // @public
@@ -1095,8 +1095,13 @@ function rebase<TNodeChange>(change: Changeset<TNodeChange>, base: TaggedChange<
 export function recordDependency(dependent: ObservingDependent | undefined, dependee: Dependee): void;
 
 // @public
+export type RecursiveReadonly<T> = T extends undefined | null | boolean | string | number | Function | Symbol ? T : T extends Opaque<Brand<any, string>> ? T : T extends Map<infer K, infer V> ? ReadonlyMap<RecursiveReadonly<K>, RecursiveReadonly<V>> : T extends Set<infer K> ? ReadonlySet<RecursiveReadonly<K>> : T extends (infer V)[] ? readonly RecursiveReadonly<V>[] : {
+    readonly [K in keyof T]: RecursiveReadonly<T[K]>;
+};
+
+// @public
 export interface RepairDataStore<TTree = Delta.ProtoNode> extends ReadonlyRepairDataStore<TTree> {
-    capture(change: Delta.Root, revision: RevisionTag): void;
+    capture(change: RecursiveReadonly<Delta.Root>, revision: RevisionTag): void;
 }
 
 // @public

--- a/packages/dds/tree/src/core/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/core/edit-manager/editManager.ts
@@ -123,8 +123,8 @@ export class EditManager<
         writer({ trunk: this.trunk, branches: this.branches });
     }
 
-    public getTrunk(): readonly RecursiveReadonly<Commit<RecursiveReadonly<TChangeset>>>[] {
-        return this.trunk as RecursiveReadonly<Commit<RecursiveReadonly<TChangeset>>>[];
+    public getTrunk(): readonly RecursiveReadonly<Commit<TChangeset>>[] {
+        return this.trunk as RecursiveReadonly<Commit<TChangeset>>[];
     }
 
     public getLastSequencedChange(): TChangeset {

--- a/packages/dds/tree/src/core/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/core/edit-manager/editManager.ts
@@ -123,8 +123,8 @@ export class EditManager<
         writer({ trunk: this.trunk, branches: this.branches });
     }
 
-    public getTrunk(): readonly RecursiveReadonly<Commit<TChangeset>>[] {
-        return this.trunk;
+    public getTrunk(): readonly RecursiveReadonly<Commit<RecursiveReadonly<TChangeset>>>[] {
+        return this.trunk as RecursiveReadonly<Commit<RecursiveReadonly<TChangeset>>>[];
     }
 
     public getLastSequencedChange(): TChangeset {
@@ -136,7 +136,7 @@ export class EditManager<
     }
 
     public getLocalChanges(): readonly RecursiveReadonly<TChangeset>[] {
-        return this.localChanges.map((change) => change.change);
+        return this.localChanges.map((change) => change.change) as RecursiveReadonly<TChangeset>[];
     }
 
     public addSequencedChange(newCommit: Commit<TChangeset>): Delta.Root {

--- a/packages/dds/tree/src/core/forest/editableForest.ts
+++ b/packages/dds/tree/src/core/forest/editableForest.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { RecursiveReadonly } from "../../util";
 import { InvalidationToken } from "../dependency-tracking";
 import {
     AnchorSet,
@@ -33,7 +34,7 @@ export interface IEditableForest extends IForestSubscription {
      * Applies the supplied Delta to the forest.
      * Does NOT update anchors.
      */
-    applyDelta(delta: Delta.Root): void;
+    applyDelta(delta: RecursiveReadonly<Delta.Root>): void;
 }
 
 /**

--- a/packages/dds/tree/src/core/repair/repairDataStore.ts
+++ b/packages/dds/tree/src/core/repair/repairDataStore.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { RecursiveReadonly } from "../../util";
 import { RevisionTag } from "../rebase";
 import { Value, Delta, UpPath, FieldKey } from "../tree";
 
@@ -50,5 +51,5 @@ export interface RepairDataStore<TTree = Delta.ProtoNode> extends ReadonlyRepair
      * @param change - A change that may be deleting document data that this store should retain.
      * @param revision - The revision associated with the change.
      */
-    capture(change: Delta.Root, revision: RevisionTag): void;
+    capture(change: RecursiveReadonly<Delta.Root>, revision: RevisionTag): void;
 }

--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
-import { brand, Brand, fail } from "../../util";
+import { brand, Brand, fail, RecursiveReadonly } from "../../util";
 import { FieldKey, EmptyKey, Delta, visitDelta } from "../tree";
 import { UpPath } from "./pathTree";
 import { Value } from "./types";
@@ -299,7 +299,7 @@ export class AnchorSet {
     /**
      * Updates the anchors according to the changes described in the given delta
      */
-    public applyDelta(delta: Delta.Root): void {
+    public applyDelta(delta: RecursiveReadonly<Delta.Root>): void {
         let parentField: FieldKey | undefined;
         let parent: UpPath | undefined;
         const moveTable = new Map<Delta.MoveId, UpPath>();

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
@@ -25,6 +25,7 @@ import {
     afterChangeToken,
     SchemaDataAndPolicy,
 } from "../../core";
+import { RecursiveReadonly } from "../../util";
 import { DefaultChangeset, DefaultEditBuilder } from "../defaultChangeFamily";
 import { runSynchronousTransaction } from "../defaultTransaction";
 import { singleMapTreeCursor } from "../mapTreeCursor";
@@ -143,7 +144,7 @@ export class ProxyContext implements EditableTreeContext {
         >,
     ) {
         this.observer = new SimpleObservingDependent(
-            (token?: InvalidationToken, delta?: Delta.Root): void => {
+            (token?: InvalidationToken, delta?: RecursiveReadonly<Delta.Root>): void => {
                 if (token === afterChangeToken) {
                     this.handleAfterChange();
                 } else {

--- a/packages/dds/tree/src/feature-libraries/forestRepairDataStore.ts
+++ b/packages/dds/tree/src/feature-libraries/forestRepairDataStore.ts
@@ -20,7 +20,7 @@ import {
     UpPath,
     Value,
 } from "../core";
-import { unreachableCase } from "../util";
+import { RecursiveReadonly, unreachableCase } from "../util";
 import { mapTreeFromCursor, singleMapTreeCursor } from "./mapTreeCursor";
 
 interface RepairData {
@@ -41,11 +41,14 @@ export class ForestRepairDataStore implements RepairDataStore {
         this.root = new SparseNode<RepairData | undefined>(EmptyKey, 0, undefined, undefined);
     }
 
-    public capture(change: Delta.Root, revision: RevisionTag): void {
+    public capture(change: RecursiveReadonly<Delta.Root>, revision: RevisionTag): void {
         const forest = this.forestProvider(revision);
         const cursor = forest.allocateCursor();
 
-        const visitFieldMarks = (fields: Delta.FieldMarks, parent: RepairDataNode): void => {
+        const visitFieldMarks = (
+            fields: RecursiveReadonly<Delta.FieldMarks>,
+            parent: RepairDataNode,
+        ): void => {
             for (const [key, field] of fields) {
                 if (parent !== this.root) {
                     cursor.enterField(key);
@@ -59,7 +62,11 @@ export class ForestRepairDataStore implements RepairDataStore {
             }
         };
 
-        function visitField(delta: Delta.MarkList, parent: RepairDataNode, key: FieldKey): void {
+        function visitField(
+            delta: RecursiveReadonly<Delta.MarkList>,
+            parent: RepairDataNode,
+            key: FieldKey,
+        ): void {
             let index = 0;
             for (const mark of delta) {
                 if (typeof mark === "number") {
@@ -103,7 +110,7 @@ export class ForestRepairDataStore implements RepairDataStore {
             }
         }
 
-        function visitModify(modify: ModifyLike, node: RepairDataNode): void {
+        function visitModify(modify: RecursiveReadonly<ModifyLike>, node: RepairDataNode): void {
             // Note that the `in` operator return true for properties that are present on the object even if they
             // are set to `undefined. This is leveraged here to represent the fact that the value should be set to
             // `undefined` as opposed to leaving the value untouched.

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -32,7 +32,7 @@ import {
     afterChangeToken,
     FieldUpPath,
 } from "../../core";
-import { brand, fail } from "../../util";
+import { brand, fail, RecursiveReadonly } from "../../util";
 import { CursorWithNode, SynchronousCursor } from "../treeCursorUtils";
 import { mapTreeFromCursor, singleMapTreeCursor } from "../mapTreeCursor";
 
@@ -84,7 +84,7 @@ class ObjectForest extends SimpleDependee implements IEditableForest {
         this.anchors.forget(anchor);
     }
 
-    applyDelta(delta: Delta.Root): void {
+    applyDelta(delta: RecursiveReadonly<Delta.Root>): void {
         this.beforeChange();
 
         // Note: This code uses cursors, however it also modifies the tree.

--- a/packages/dds/tree/src/feature-libraries/schemaIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/schemaIndex.ts
@@ -43,7 +43,7 @@ import {
     SummaryElementParser,
     SummaryElementStringifier,
 } from "../shared-tree-core";
-import { brand, isJsonObject, JsonCompatibleReadOnly } from "../util";
+import { brand, isJsonObject, JsonCompatibleReadOnly, RecursiveReadonly } from "../util";
 import { IEventEmitter } from "../events";
 
 /**
@@ -239,7 +239,7 @@ export class SchemaIndex implements Index, SummaryElement {
         });
     }
 
-    newLocalState(changeDelta: Delta.Root): void {
+    newLocalState(changeDelta: RecursiveReadonly<Delta.Root>): void {
         // TODO: apply schema changes.
         // Extend delta to include them, or maybe have some higher level edit type that includes them and deltas?
     }

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -95,6 +95,7 @@ export {
     JsonCompatibleReadOnly,
     JsonCompatible,
     JsonCompatibleObject,
+    RecursiveReadonly,
 } from "./util";
 
 export {

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -27,7 +27,7 @@ import {
 } from "@fluidframework/shared-object-base";
 import { v4 as uuid } from "uuid";
 import { ChangeFamily, Commit, EditManager, SeqNumber, AnchorSet, Delta } from "../core";
-import { brand, isReadonlyArray, JsonCompatibleReadOnly } from "../util";
+import { brand, isReadonlyArray, JsonCompatibleReadOnly, RecursiveReadonly } from "../util";
 import { EventEmitter, IEventEmitter, TransformEvents } from "../events";
 
 /**
@@ -61,7 +61,7 @@ export interface IndexEvents<TChangeset> {
      * May involve effects of a new sequenced change (including rebasing of local changes onto it),
      * or a new local change. Called after either sequencedChange or newLocalChange.
      */
-    newLocalState: (changeDelta: Delta.Root) => void;
+    newLocalState: (changeDelta: RecursiveReadonly<Delta.Root>) => void;
 }
 
 /**

--- a/packages/dds/tree/src/test/util/recursiveReadonly.spec.ts
+++ b/packages/dds/tree/src/test/util/recursiveReadonly.spec.ts
@@ -1,0 +1,144 @@
+import {
+    areSafelyAssignable,
+    Brand,
+    isAssignableTo,
+    Opaque,
+    RecursiveReadonly,
+    requireFalse,
+    requireTrue,
+} from "../../util";
+
+// Type tests for RecursiveReadonly
+{
+    type TestInner = Set<number>;
+    type TestInnerString = Set<string>;
+    type TestInnerReadonly = ReadonlySet<number>;
+    // Checks assignability of equivalent types
+    {
+        type _basic = requireTrue<areSafelyAssignable<RecursiveReadonly<number>, number>>;
+        type _union = requireTrue<
+            areSafelyAssignable<RecursiveReadonly<number | string>, number | string>
+        >;
+        type _intersection = requireTrue<
+            areSafelyAssignable<RecursiveReadonly<number & string>, number & string>
+        >;
+        type _brand = requireTrue<
+            areSafelyAssignable<RecursiveReadonly<Brand<number, string>>, Brand<number, string>>
+        >;
+        type _brandNested = requireTrue<
+            areSafelyAssignable<
+                RecursiveReadonly<Brand<TestInner, string>>,
+                Brand<TestInnerReadonly, string>
+            >
+        >;
+        type _opaque = requireTrue<
+            areSafelyAssignable<
+                RecursiveReadonly<Opaque<Brand<number, string>>>,
+                Opaque<Brand<number, string>>
+            >
+        >;
+        type _opaqueNested = requireTrue<
+            areSafelyAssignable<
+                RecursiveReadonly<Opaque<Brand<TestInner, string>>>,
+                // Opaque already makes the inner type unmutable
+                Opaque<Brand<TestInner, string>>
+            >
+        >;
+        type _set = requireTrue<
+            areSafelyAssignable<RecursiveReadonly<Set<number>>, ReadonlySet<number>>
+        >;
+        type _setNested = requireTrue<
+            areSafelyAssignable<RecursiveReadonly<Set<TestInner>>, ReadonlySet<TestInnerReadonly>>
+        >;
+        type _map = requireTrue<
+            areSafelyAssignable<RecursiveReadonly<Map<number, string>>, ReadonlyMap<number, string>>
+        >;
+        type _mapNestedKey = requireTrue<
+            areSafelyAssignable<
+                RecursiveReadonly<Map<TestInner, string>>,
+                ReadonlyMap<TestInnerReadonly, string>
+            >
+        >;
+        type _mapNestedValue = requireTrue<
+            areSafelyAssignable<
+                RecursiveReadonly<Map<string, TestInner>>,
+                ReadonlyMap<string, TestInnerReadonly>
+            >
+        >;
+        type _array = requireTrue<
+            areSafelyAssignable<RecursiveReadonly<number[]>, readonly number[]>
+        >;
+        type _arrayNested = requireTrue<
+            areSafelyAssignable<RecursiveReadonly<TestInner[]>, readonly TestInnerReadonly[]>
+        >;
+        type _obj = requireTrue<
+            areSafelyAssignable<RecursiveReadonly<{ a: number }>, { readonly a: number }>
+        >;
+        type _objNested = requireTrue<
+            areSafelyAssignable<
+                RecursiveReadonly<{ a: TestInner }>,
+                { readonly a: TestInnerReadonly }
+            >
+        >;
+    }
+    // Check non-assignability of non-equivalent types
+    {
+        type _basic = requireFalse<isAssignableTo<RecursiveReadonly<string>, number>>;
+        type _union = requireFalse<
+            isAssignableTo<RecursiveReadonly<number | boolean>, symbol | string>
+        >;
+        type _intersection = requireFalse<
+            isAssignableTo<RecursiveReadonly<number & boolean>, number & string>
+        >;
+        type _brand = requireFalse<
+            isAssignableTo<RecursiveReadonly<Brand<string, string>>, Brand<number, string>>
+        >;
+        type _brandNested = requireFalse<
+            isAssignableTo<
+                RecursiveReadonly<Brand<TestInnerString, string>>,
+                Brand<TestInnerReadonly, string>
+            >
+        >;
+        type _opaque = requireFalse<
+            isAssignableTo<
+                RecursiveReadonly<Opaque<Brand<string, string>>>,
+                Opaque<Brand<number, string>>
+            >
+        >;
+        type _opaqueNested = requireFalse<
+            isAssignableTo<
+                RecursiveReadonly<Opaque<Brand<TestInnerString, string>>>,
+                // Opaque already makes the inner type unmutable
+                Opaque<Brand<TestInner, string>>
+            >
+        >;
+        type _set = requireFalse<isAssignableTo<RecursiveReadonly<Set<number>>, Set<number>>>;
+        type _setNested = requireFalse<
+            isAssignableTo<RecursiveReadonly<Set<TestInner>>, ReadonlySet<TestInner>>
+        >;
+        type _map = requireFalse<
+            isAssignableTo<RecursiveReadonly<Map<number, string>>, Map<number, string>>
+        >;
+        type _mapNestedKey = requireFalse<
+            isAssignableTo<
+                RecursiveReadonly<Map<TestInner, string>>,
+                ReadonlyMap<TestInner, string>
+            >
+        >;
+        type _mapNestedValue = requireFalse<
+            isAssignableTo<
+                RecursiveReadonly<Map<string, TestInner>>,
+                ReadonlyMap<string, TestInner>
+            >
+        >;
+        type _array = requireFalse<isAssignableTo<RecursiveReadonly<number[]>, number[]>>;
+        type _arrayNested = requireFalse<
+            isAssignableTo<RecursiveReadonly<TestInner[]>, readonly TestInner[]>
+        >;
+        // Why does this fail? The whole point is to ensure this.
+        type _obj = requireFalse<isAssignableTo<RecursiveReadonly<{ a: number }>, { a: number }>>;
+        type _objNested = requireFalse<
+            isAssignableTo<RecursiveReadonly<{ a: TestInner }>, { readonly a: TestInner }>
+        >;
+    }
+}

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -4,13 +4,34 @@
  */
 
 import structuredClone from "@ungap/structured-clone";
+import { Brand, Opaque } from "./brand";
 
 /**
  * Make all transitive properties in T readonly
  */
-export type RecursiveReadonly<T> = {
-    readonly [P in keyof T]: RecursiveReadonly<T[P]>;
-};
+export type RecursiveReadonly<T> = T extends
+    | undefined
+    // eslint-disable-next-line @rushstack/no-new-null
+    | null
+    | boolean
+    | string
+    | number
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    | Function
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    | Symbol
+    ? T
+    : T extends Opaque<Brand<any, string>>
+    ? T
+    : T extends Map<infer K, infer V>
+    ? ReadonlyMap<RecursiveReadonly<K>, RecursiveReadonly<V>>
+    : T extends Set<infer K>
+    ? ReadonlySet<RecursiveReadonly<K>>
+    : T extends (infer V)[]
+    ? readonly RecursiveReadonly<V>[]
+    : {
+          readonly [K in keyof T]: RecursiveReadonly<T[K]>;
+      };
 
 /**
  * Remove `readonly` from all fields.

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -21,6 +21,8 @@ export type RecursiveReadonly<T> = T extends
     // eslint-disable-next-line @typescript-eslint/ban-types
     | Symbol
     ? T
+    : T extends Brand<infer V, string>
+    ? Brand<RecursiveReadonly<V>, string>
     : T extends Opaque<Brand<any, string>>
     ? T
     : T extends Map<infer K, infer V>


### PR DESCRIPTION
This prevents consumers of Deltas from mutating them when they shouldn't.

## Reviewer Guidance

I encountered some typing issues. See the comments on the PR.