### PR TITLE
stress: re-enable offline

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -14,6 +14,16 @@
                 "min": 0,
                 "max": 150000
             },
+            "offline": {
+                "delayMs": {
+                    "min": 0,
+                    "max": 150000
+                },
+                "durationMs": {
+                    "min": 5000,
+                    "max": 15000
+                }
+            },
             "optionOverrides":{
                 "odsp":{
                     "configurations":{
@@ -113,6 +123,16 @@
             "faultInjectionMs": {
                 "min": 0,
                 "max": 10000
+            },
+            "offline": {
+                "delayMs": {
+                    "min": 0,
+                    "max": 150000
+                },
+                "durationMs": {
+                    "min": 5000,
+                    "max": 15000
+                }
             },
             "totalBlobCount": 300,
             "blobSize": 10240,


### PR DESCRIPTION
Re-enable offline in the stress tests, which were disabled due to errors suspected to be caused by offline. I have not been able to reproduce the errors in test branch runs, so I would like to re-enable it and monitor. It's possible that the errors were actually caused by offline, but only occur when the servers are under load.
