### PR TITLE
Disable op reentry for stress tests - next

### DIFF
--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -78,7 +78,7 @@ export function generateRuntimeOptions(
         flushMode: [undefined],
         compressionOptions: [{ minimumBatchSizeInBytes: 500, compressionAlgorithm: CompressionAlgorithms.lz4 }],
         maxBatchSizeInBytes: [undefined],
-        enableOpReentryCheck: [true],
+        enableOpReentryCheck: [undefined],
         chunkSizeInBytes: [undefined],
     };
 


### PR DESCRIPTION
Porting https://github.com/microsoft/FluidFramework/pull/13509 to `next` faster than the `main->next` integration so that OCEs don't get continuously spammed with incidents.