### PR TITLE
ci: Make pipelines package r11s and historian Helm charts directly

### DIFF
--- a/tools/pipelines/chart-historian.yml
+++ b/tools/pipelines/chart-historian.yml
@@ -6,13 +6,13 @@ trigger:
   branches:
     include:
     - main
-    - next
-    - lts
   paths:
     include:
     - server/charts/historian
+    - tools/pipelines/chart-historian.yml
+    - tools/pipelines/templates/include-package-chart.yml
 
 extends:
-  template: templates/include-copy-chart.yml
+  template: templates/include-package-chart.yml
   parameters:
     chartPath: server/charts/historian

--- a/tools/pipelines/chart-historian.yml
+++ b/tools/pipelines/chart-historian.yml
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
+name: $(Build.BuildId)
+
 pr: none
 trigger:
   branches:

--- a/tools/pipelines/chart-routerlicious.yml
+++ b/tools/pipelines/chart-routerlicious.yml
@@ -6,13 +6,13 @@ trigger:
   branches:
     include:
     - main
-    - next
-    - lts
   paths:
     include:
     - server/routerlicious/kubernetes/routerlicious
+    - tools/pipelines/chart-routerlicious.yml
+    - tools/pipelines/templates/include-package-chart.yml
 
 extends:
-  template: templates/include-copy-chart.yml
+  template: templates/include-package-chart.yml
   parameters:
     chartPath: server/routerlicious/kubernetes/routerlicious

--- a/tools/pipelines/chart-routerlicious.yml
+++ b/tools/pipelines/chart-routerlicious.yml
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
+name: $(Build.BuildId)
+
 pr: none
 trigger:
   branches:

--- a/tools/pipelines/templates/include-package-chart.yml
+++ b/tools/pipelines/templates/include-package-chart.yml
@@ -10,20 +10,34 @@ variables:
     value: true
 
 jobs:
-- job: Job_1
-  displayName: Agent job 1
+- job: package_chart
+  displayName: Package chart
   pool:
     vmImage: ubuntu-latest
   steps:
   - checkout: self
     clean: true
     fetchDepth: 1
+
   - task: ComponentGovernanceComponentDetection@0
     displayName: Component Detection
     inputs:
       sourceScanPath: ${{ parameters.chartPath }}
-  - task: PublishPipelineArtifact@1
-    displayName: Publish Pipeline Artifact
+
+  - task: HelmInstaller@1
+    displayName: Install Helm
     inputs:
-      targetPath: ${{ parameters.chartPath }}
+      helmVersionToInstall: latest
+
+  - task: HelmDeploy@0
+    displayName: Package Helm chart
+    inputs:
+      command: package
+      chartPath: ${{ parameters.chartPath }}
+      destination: $(Build.ArtifactStagingDirectory)
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish Artifact: chart'
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)
       artifactName: chart

--- a/tools/pipelines/templates/include-package-chart.yml
+++ b/tools/pipelines/templates/include-package-chart.yml
@@ -8,6 +8,9 @@ parameters:
 variables:
   - name: skipComponentGovernanceDetection
     value: true
+  - name: packagedChartFolder
+    value: $(Build.ArtifactStagingDirectory)/chart
+    readonly: true
 
 jobs:
 - job: package_chart
@@ -34,10 +37,10 @@ jobs:
     inputs:
       command: package
       chartPath: ${{ parameters.chartPath }}
-      destination: $(Build.ArtifactStagingDirectory)
+      destination: $(packagedChartFolder)
 
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Artifact: chart'
     inputs:
-      targetPath: $(Build.ArtifactStagingDirectory)
+      targetPath: $(packagedChartFolder)
       artifactName: chart


### PR DESCRIPTION
## Description

Move the steps that package Helm charts for historian and routerlicious from the pipeline definitions in the internal repository to the pipeline definitions here.

These are the steps I'll follow to complete this work once this PR is approved:

- Disable the [`chart copy - historian`](https://dev.azure.com/fluidframework/internal/_build?definitionId=83&_a=summary) and [`chart copy - routerlicious`](https://dev.azure.com/fluidframework/internal/_build?definitionId=82&_a=summary) pipelines, whose definitions come from the pre-rename versions of some files touched in this PR.
- Merge this PR.
- Rename the [`chart - historian`](https://dev.azure.com/fluidframework/internal/_build?definitionId=71&_a=summary) and [`chart - routerlicious`](https://dev.azure.com/fluidframework/internal/_build?definitionId=72) pipelines to `<current name> (old)`, so we can reuse their current names.
  - This because the deployment pipelines in our internal repo declare "dependencies" (ADO pipeline resources) on the `chart - historian` and `chart - routerlicious` pipelines _by name_. We could change that to be by id, or to use new names (for new versions of the pipelines updated in this PR) but I think maintaining the current naming conventions is ok.
- Rename the current `chart copy - historian` and `chart copy - routerlicious` to `chart - historian` and `chart - routerlicious` respectively, update their definition files to be the renamed files in this PR (`tools/pipelines/chart-copy-historian.yml -> tools/pipelines/chart-historian.yml`, and ditto for routerlicious), and re-enable them.

At that point we'll have functioning pipelines named `chart - routerlicious/historian` publishing the same `chart` artifact published by the current pipelines with those names, thus maintaining the "interface" with the deployment pipelines in the internal repo, so those should continue working as usual. And we can effectively archive (move to a separate folder, at least) the `chart - routerlicious/historian (old)` pipelines and clean up their definitions from the internal repo.

## Testing

(msft internal links)

[Artifact published by a test run with the new definition from this PR](https://dev.azure.com/fluidframework/internal/_build/results?buildId=132416&view=artifacts&pathAsName=false&type=publishedArtifacts) and [artifact published by a current run of the existing `chart - _____` pipeline](https://dev.azure.com/fluidframework/internal/_build/results?buildId=123237&view=artifacts&pathAsName=false&type=publishedArtifacts) for comparison.

## Reviewer Guidance

The reason to split the generation of Helm charts into two parts (one here, one in the internal repository) no longer applies so there's no point in having two separate pipelines passing things between them when one suffices.

Open to thoughts around using ids VS names when pipelines reference other pipelines as resources.

[One of the pipelines defined in our internal repo](https://dev.azure.com/fluidframework/internal/_git/ff_internal?path=/devOps/pipelines/chart-historian.yml) (msft internal).

[AB#2970](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2970)