### PR TITLE
Tree: Make Deltas immutable

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -153,9 +153,9 @@ export const defaultSchemaPolicy: FullSchemaPolicy;
 // @public
 interface Delete {
     // (undocumented)
-    count: number;
+    readonly count: number;
     // (undocumented)
-    type: typeof MarkType.Delete;
+    readonly type: typeof MarkType.Delete;
 }
 
 // @public (undocumented)
@@ -371,7 +371,7 @@ export interface FieldLocation {
 }
 
 // @public (undocumented)
-type FieldMap<T> = Map<FieldKey, T>;
+type FieldMap<T> = ReadonlyMap<FieldKey, T>;
 
 // @public
 export interface FieldMapObject<TChild> {
@@ -525,9 +525,9 @@ function inputLength(mark: Mark<unknown>): number;
 // @public
 interface Insert<TTree = ProtoNode> {
     // (undocumented)
-    content: TTree[];
+    readonly content: readonly TTree[];
     // (undocumented)
-    type: typeof MarkType.Insert;
+    readonly type: typeof MarkType.Insert;
 }
 
 // @public (undocumented)
@@ -541,11 +541,11 @@ interface Insert_2<TNodeChange = NodeChangeType> extends HasTiebreakPolicy, HasR
 // @public
 interface InsertAndModify<TTree = ProtoNode> {
     // (undocumented)
-    content: TTree;
+    readonly content: TTree;
     // (undocumented)
-    fields: FieldMarks<TTree>;
+    readonly fields: FieldMarks<TTree>;
     // (undocumented)
-    type: typeof MarkType.InsertAndModify;
+    readonly type: typeof MarkType.InsertAndModify;
 }
 
 // @public
@@ -734,7 +734,7 @@ export interface MarkedArrayLike<T> extends ArrayLike<T> {
 }
 
 // @public
-type MarkList<TTree = ProtoNode> = Mark<TTree>[];
+type MarkList<TTree = ProtoNode> = readonly Mark<TTree>[];
 
 // @public (undocumented)
 type MarkList_2<TNodeChange = NodeChangeType, TMark = Mark_2<TNodeChange>> = TMark[];
@@ -768,11 +768,11 @@ const MarkType: {
 // @public
 interface Modify<TTree = ProtoNode> {
     // (undocumented)
-    fields?: FieldMarks<TTree>;
+    readonly fields?: FieldMarks<TTree>;
     // (undocumented)
-    setValue?: Value;
+    readonly setValue?: Value;
     // (undocumented)
-    type: typeof MarkType.Modify;
+    readonly type: typeof MarkType.Modify;
 }
 
 // @public (undocumented)
@@ -788,20 +788,20 @@ interface Modify_2<TNodeChange = NodeChangeType> {
 // @public
 interface ModifyAndDelete<TTree = ProtoNode> {
     // (undocumented)
-    fields: FieldMarks<TTree>;
+    readonly fields: FieldMarks<TTree>;
     // (undocumented)
-    type: typeof MarkType.ModifyAndDelete;
+    readonly type: typeof MarkType.ModifyAndDelete;
 }
 
 // @public
 interface ModifyAndMoveOut<TTree = ProtoNode> {
     // (undocumented)
-    fields?: FieldMarks<TTree>;
-    moveId: MoveId;
+    readonly fields?: FieldMarks<TTree>;
+    readonly moveId: MoveId;
     // (undocumented)
-    setValue?: Value;
+    readonly setValue?: Value;
     // (undocumented)
-    type: typeof MarkType.ModifyAndMoveOut;
+    readonly type: typeof MarkType.ModifyAndMoveOut;
 }
 
 // @public @sealed
@@ -874,9 +874,9 @@ type MoveId_2 = ChangesetLocalId;
 
 // @public
 interface MoveIn {
-    moveId: MoveId;
+    readonly moveId: MoveId;
     // (undocumented)
-    type: typeof MarkType.MoveIn;
+    readonly type: typeof MarkType.MoveIn;
 }
 
 // @public (undocumented)
@@ -889,10 +889,10 @@ interface MoveIn_2 extends HasMoveId, HasPlaceFields, HasRevisionTag {
 // @public
 interface MoveInAndModify<TTree = ProtoNode> {
     // (undocumented)
-    fields: FieldMarks<TTree>;
-    moveId: MoveId;
+    readonly fields: FieldMarks<TTree>;
+    readonly moveId: MoveId;
     // (undocumented)
-    type: typeof MarkType.MoveInAndModify;
+    readonly type: typeof MarkType.MoveInAndModify;
 }
 
 // @public (undocumented)
@@ -901,10 +901,10 @@ type MoveMark<T> = MoveOut_2<T> | MoveIn_2 | ReturnFrom<T> | ReturnTo;
 // @public
 interface MoveOut {
     // (undocumented)
-    count: number;
-    moveId: MoveId;
+    readonly count: number;
+    readonly moveId: MoveId;
     // (undocumented)
-    type: typeof MarkType.MoveOut;
+    readonly type: typeof MarkType.MoveOut;
 }
 
 // @public (undocumented)

--- a/packages/dds/tree/src/core/tree/delta.ts
+++ b/packages/dds/tree/src/core/tree/delta.ts
@@ -128,6 +128,7 @@ import { FieldKey, Value } from "./types";
 
 /**
  * Represents the change made to a document.
+ * Immutable, therefore safe to retain for async processing.
  */
 export type Root<TTree = ProtoNode> = FieldMarks<TTree>;
 export const empty: Root<any> = new Map();
@@ -157,7 +158,7 @@ export type Mark<TTree = ProtoNode> =
  * applying any of the changes, is not represented explicitly.
  * It corresponds to the sum of `inputLength(mark)` for all previous marks.
  */
-export type MarkList<TTree = ProtoNode> = Mark<TTree>[];
+export type MarkList<TTree = ProtoNode> = readonly Mark<TTree>[];
 
 /**
  * Represents a range of contiguous nodes that is unaffected by changes.
@@ -169,17 +170,17 @@ export type Skip = number;
  * Describes modifications made to a subtree.
  */
 export interface Modify<TTree = ProtoNode> {
-    type: typeof MarkType.Modify;
-    setValue?: Value;
-    fields?: FieldMarks<TTree>;
+    readonly type: typeof MarkType.Modify;
+    readonly setValue?: Value;
+    readonly fields?: FieldMarks<TTree>;
 }
 
 /**
  * Describes the deletion of a contiguous range of node.
  */
 export interface Delete {
-    type: typeof MarkType.Delete;
-    count: number;
+    readonly type: typeof MarkType.Delete;
+    readonly count: number;
 }
 
 /**
@@ -187,20 +188,20 @@ export interface Delete {
  * Includes descriptions of the modifications the node.
  */
 export interface ModifyAndDelete<TTree = ProtoNode> {
-    type: typeof MarkType.ModifyAndDelete;
-    fields: FieldMarks<TTree>;
+    readonly type: typeof MarkType.ModifyAndDelete;
+    readonly fields: FieldMarks<TTree>;
 }
 
 /**
  * Describes the moving out of a contiguous range of node.
  */
 export interface MoveOut {
-    type: typeof MarkType.MoveOut;
-    count: number;
+    readonly type: typeof MarkType.MoveOut;
+    readonly count: number;
     /**
      * The delta should carry exactly one `MoveIn` mark with the same move ID.
      */
-    moveId: MoveId;
+    readonly moveId: MoveId;
 }
 
 /**
@@ -208,24 +209,24 @@ export interface MoveOut {
  * Includes descriptions of the modifications made to the node.
  */
 export interface ModifyAndMoveOut<TTree = ProtoNode> {
-    type: typeof MarkType.ModifyAndMoveOut;
+    readonly type: typeof MarkType.ModifyAndMoveOut;
     /**
      * The delta should carry exactly one `MoveIn` mark with the same move ID.
      */
-    moveId: MoveId;
-    setValue?: Value;
-    fields?: FieldMarks<TTree>;
+    readonly moveId: MoveId;
+    readonly setValue?: Value;
+    readonly fields?: FieldMarks<TTree>;
 }
 
 /**
  * Describes the moving in of a contiguous range of node.
  */
 export interface MoveIn {
-    type: typeof MarkType.MoveIn;
+    readonly type: typeof MarkType.MoveIn;
     /**
      * The delta should carry exactly one `MoveOut` mark with the same move ID.
      */
-    moveId: MoveId;
+    readonly moveId: MoveId;
 }
 
 /**
@@ -233,21 +234,21 @@ export interface MoveIn {
  * Includes descriptions of the modifications made to the node.
  */
 export interface MoveInAndModify<TTree = ProtoNode> {
-    type: typeof MarkType.MoveInAndModify;
+    readonly type: typeof MarkType.MoveInAndModify;
     /**
      * The delta should carry exactly one `MoveOut` mark with the same move ID.
      */
-    moveId: MoveId;
-    fields: FieldMarks<TTree>;
+    readonly moveId: MoveId;
+    readonly fields: FieldMarks<TTree>;
 }
 
 /**
  * Describes the insertion of a contiguous range of node.
  */
 export interface Insert<TTree = ProtoNode> {
-    type: typeof MarkType.Insert;
+    readonly type: typeof MarkType.Insert;
     // TODO: use a single cursor with multiple nodes instead of array of cursors.
-    content: TTree[];
+    readonly content: readonly TTree[];
 }
 
 /**
@@ -255,9 +256,9 @@ export interface Insert<TTree = ProtoNode> {
  * Includes descriptions of the modifications made to the nodes.
  */
 export interface InsertAndModify<TTree = ProtoNode> {
-    type: typeof MarkType.InsertAndModify;
-    content: TTree;
-    fields: FieldMarks<TTree>;
+    readonly type: typeof MarkType.InsertAndModify;
+    readonly content: TTree;
+    readonly fields: FieldMarks<TTree>;
 }
 
 /**
@@ -267,7 +268,7 @@ export interface MoveId extends Opaque<Brand<number, "delta.MoveId">> {}
 
 export type Offset = number;
 
-export type FieldMap<T> = Map<FieldKey, T>;
+export type FieldMap<T> = ReadonlyMap<FieldKey, T>;
 export type FieldMarks<TTree = ProtoNode> = FieldMap<MarkList<TTree>>;
 
 export const MarkType = {

--- a/packages/dds/tree/src/core/tree/visitDelta.ts
+++ b/packages/dds/tree/src/core/tree/visitDelta.ts
@@ -76,7 +76,7 @@ export function visitDelta(delta: Delta.Root, visitor: DeltaVisitor): void {
 
 export interface DeltaVisitor {
     onDelete(index: number, count: number): void;
-    onInsert(index: number, content: Delta.ProtoNode[]): void;
+    onInsert(index: number, content: readonly Delta.ProtoNode[]): void;
     onMoveOut(index: number, count: number, id: Delta.MoveId): void;
     onMoveIn(index: number, count: number, id: Delta.MoveId): void;
     onSetValue(value: Value): void;

--- a/packages/dds/tree/src/feature-libraries/deltaUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/deltaUtils.ts
@@ -22,7 +22,7 @@ export function mapFieldMarks<TIn, TOut>(
     fields: Delta.FieldMarks<TIn>,
     func: (tree: TIn) => TOut,
 ): Delta.FieldMarks<TOut> {
-    const out: Delta.FieldMarks<TOut> = new Map();
+    const out: Map<FieldKey, Delta.MarkList<TOut>> = new Map();
     for (const [k, v] of fields) {
         out.set(k, mapMarkList(v, func));
     }

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -167,7 +167,7 @@ export const genericChangeHandler: FieldChangeHandler<GenericChangeset> = {
     },
     intoDelta: (change: GenericChangeset, deltaFromChild: ToDelta): Delta.MarkList => {
         let nodeIndex = 0;
-        const delta: Delta.MarkList = [];
+        const delta: Delta.Mark[] = [];
         for (const { index, nodeChange } of change) {
             if (nodeIndex < index) {
                 const offset = index - nodeIndex;

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -21,7 +21,7 @@ import {
     RevisionTag,
     tagChange,
 } from "../../core";
-import { brand, clone, getOrAddEmptyToMap, JsonCompatibleReadOnly } from "../../util";
+import { brand, clone, getOrAddEmptyToMap, JsonCompatibleReadOnly, Mutable } from "../../util";
 import { dummyRepairDataStore } from "../fakeRepairDataStore";
 import {
     FieldChangeHandler,
@@ -345,7 +345,7 @@ export class ModularChangeFamily
         repairStore: ReadonlyRepairDataStore,
         path: UpPath | undefined,
     ): Delta.Root {
-        const delta: Delta.Root = new Map();
+        const delta: Map<FieldKey, Delta.MarkList> = new Map();
         for (const [field, fieldChange] of change) {
             const deltaField = getChangeHandler(this.fieldKinds, fieldChange.fieldKind).intoDelta(
                 fieldChange.change,
@@ -374,7 +374,7 @@ export class ModularChangeFamily
         repairStore: ReadonlyRepairDataStore,
         path?: UpPath,
     ): Delta.Modify {
-        const modify: Delta.Modify = {
+        const modify: Mutable<Delta.Modify> = {
             type: Delta.MarkType.Modify,
         };
 

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
@@ -208,7 +208,7 @@ interface DeltaInsertModification {
  * all modifications are applied by the function.
  */
 function applyOrCollectModifications(node: ProtoNode, modify: ChangesetMods): Delta.FieldMarks {
-    const outFieldsMarks: Delta.FieldMarks = new Map();
+    const outFieldsMarks: Map<FieldKey, Delta.MarkList> = new Map();
     if (modify.value !== undefined) {
         node.value = modify.value.value;
     }
@@ -348,7 +348,7 @@ function convertModify(modify: ChangesetMods): DeltaMods {
 }
 
 function convertFieldMarks(fields: T.FieldMarks): Delta.FieldMarks {
-    const outFields: Delta.FieldMarks = new Map();
+    const outFields: Map<FieldKey, Delta.MarkList> = new Map();
     for (const key of Object.keys(fields)) {
         const marks = convertMarkList(fields[key]);
         const brandedKey: FieldKey = brand(key);


### PR DESCRIPTION
## Description

This prevents consumers of Deltas from mutating them when they shouldn't.
It also allows consumers of Deltas to retain them for asynchronous processing if they wish to.

Side note: this is a much easier and safer attempt than making the Delta.Root type immutable through type metaprograms (see https://github.com/microsoft/FluidFramework/pull/13511).