### PR TITLE
Tree: avoid using cursors during test enumeration

### DIFF
--- a/packages/dds/tree/src/test/cursorTestSuite.ts
+++ b/packages/dds/tree/src/test/cursorTestSuite.ts
@@ -149,7 +149,7 @@ export function testGeneralPurposeTreeCursor<TData, TCursor extends ITreeCursor>
         dataFromCursor,
         testData: testTrees.map(([name, data]) => ({
             name,
-            data: () => dataFromJsonableTree(data),
+            dataFactory: () => dataFromJsonableTree(data),
             expected: data,
         })),
         extraRoot,
@@ -174,7 +174,7 @@ export interface SpecialCaseBuilder<TData> {
 
 export interface TestTree<TData> {
     readonly name: string;
-    readonly data: () => TData;
+    readonly dataFactory: () => TData;
     readonly reference?: JsonableTree;
     readonly path?: UpPath;
 }
@@ -290,7 +290,7 @@ function testTreeCursor<TData, TCursor extends ITreeCursor>(config: {
 
     return describe(`${cursorName} cursor implementation`, () => {
         describe("test trees", () => {
-            for (const { name, data: dataFactory, reference, path } of testData) {
+            for (const { name, dataFactory, reference, path } of testData) {
                 describe(name, () => {
                     let data: TData;
                     before(() => {

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
@@ -46,13 +46,13 @@ const testCases: readonly [string, readonly JsonCompatible[]][] = [
     ],
 ];
 
-const cursors: { name: string; data: JsonCompatible }[] = [];
+const cursors: { name: string; data: () => JsonCompatible }[] = [];
 
 for (const [name, testValues] of testCases) {
     for (const data of testValues) {
         cursors.push({
             name: `${name}: ${JSON.stringify(data)}`,
-            data,
+            data: () => data,
         });
     }
 }

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.spec.ts
@@ -46,13 +46,13 @@ const testCases: readonly [string, readonly JsonCompatible[]][] = [
     ],
 ];
 
-const cursors: { name: string; data: () => JsonCompatible }[] = [];
+const cursors: { name: string; dataFactory: () => JsonCompatible }[] = [];
 
 for (const [name, testValues] of testCases) {
     for (const data of testValues) {
         cursors.push({
             name: `${name}: ${JSON.stringify(data)}`,
-            data: () => data,
+            dataFactory: () => data,
         });
     }
 }

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/uniformChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/uniformChunk.spec.ts
@@ -11,6 +11,7 @@ import {
     dummyRoot,
     ChunkShape,
     UniformChunk,
+    TreeChunk,
     // eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/chunked-forest/uniformChunk";
 import { testSpecializedCursor, TestTree } from "../../cursorTestSuite";
@@ -31,7 +32,6 @@ import {
     mapTreeFromCursor,
     singleMapTreeCursor,
     singleTextCursor,
-    TreeChunk,
 } from "../../../feature-libraries";
 
 const xField: FieldKey = brand("x");

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/uniformChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/uniformChunk.spec.ts
@@ -7,7 +7,6 @@ import { strict as assert } from "assert";
 import { benchmark, BenchmarkType } from "@fluid-tools/benchmark";
 import {
     uniformChunk,
-    TreeChunk,
     TreeShape,
     dummyRoot,
     ChunkShape,
@@ -32,6 +31,7 @@ import {
     mapTreeFromCursor,
     singleMapTreeCursor,
     singleTextCursor,
+    TreeChunk,
 } from "../../../feature-libraries";
 
 const xField: FieldKey = brand("x");
@@ -52,10 +52,11 @@ const polygon = new TreeShape(jsonArray.name, false, [
 
 const polygonTree: TestTree<TreeChunk> = {
     name: "polygon",
-    data: uniformChunk(
-        polygon,
-        makeArray(sides * 2, (index) => index),
-    ),
+    data: () =>
+        uniformChunk(
+            polygon,
+            makeArray(sides * 2, (index) => index),
+        ),
     reference: {
         type: jsonArray.name,
         fields: {
@@ -73,12 +74,12 @@ const polygonTree: TestTree<TreeChunk> = {
 const testTrees = [
     {
         name: "number",
-        data: uniformChunk(numberShape.withTopLevelLength(1), [5]),
+        data: () => uniformChunk(numberShape.withTopLevelLength(1), [5]),
         reference: [{ type: jsonNumber.name, value: 5 }],
     },
     {
         name: "root sequence",
-        data: uniformChunk(numberShape.withTopLevelLength(3), [1, 2, 3]),
+        data: () => uniformChunk(numberShape.withTopLevelLength(3), [1, 2, 3]),
         reference: [
             { type: jsonNumber.name, value: 1 },
             { type: jsonNumber.name, value: 2 },
@@ -87,12 +88,13 @@ const testTrees = [
     },
     {
         name: "child sequence",
-        data: uniformChunk(
-            new TreeShape(jsonArray.name, false, [[EmptyKey, numberShape, 3]]).withTopLevelLength(
-                1,
+        data: () =>
+            uniformChunk(
+                new TreeShape(jsonArray.name, false, [
+                    [EmptyKey, numberShape, 3],
+                ]).withTopLevelLength(1),
+                [1, 2, 3],
             ),
-            [1, 2, 3],
-        ),
         reference: [
             {
                 type: jsonArray.name,
@@ -108,7 +110,7 @@ const testTrees = [
     },
     {
         name: "withChild",
-        data: uniformChunk(withChildShape.withTopLevelLength(1), [1]),
+        data: () => uniformChunk(withChildShape.withTopLevelLength(1), [1]),
         reference: [
             {
                 type: jsonObject.name,
@@ -120,7 +122,7 @@ const testTrees = [
     },
     {
         name: "point",
-        data: uniformChunk(pointShape.withTopLevelLength(1), [1, 2]),
+        data: () => uniformChunk(pointShape.withTopLevelLength(1), [1, 2]),
         reference: [
             {
                 type: jsonObject.name,
@@ -165,7 +167,7 @@ const testData: TestTree<[number, TreeChunk]>[] = testTrees.flatMap(({ name, dat
     for (let index = 0; index < reference.length; index++) {
         out.push({
             name: reference.length > 1 ? `${name} part ${index + 1}` : name,
-            data: [index, data],
+            data: () => [index, data()],
             reference: reference[index],
             path: { parent: undefined, parentIndex: index, parentField: dummyRoot },
         });
@@ -177,7 +179,7 @@ describe("uniformChunk", () => {
     describe("shapes", () => {
         for (const tree of testTrees) {
             it(`validate shape for ${tree.name}`, () => {
-                validateShape((tree.data as UniformChunk).shape);
+                validateShape((tree.data() as UniformChunk).shape);
             });
         }
     });
@@ -227,7 +229,7 @@ describe("uniformChunk", () => {
                     type: BenchmarkType.Measurement,
                     title: `Sum: '${name}'`,
                     before: () => {
-                        cursor = factory(data);
+                        cursor = factory(data());
                     },
                     benchmarkFn: () => {
                         sum(cursor);
@@ -239,7 +241,7 @@ describe("uniformChunk", () => {
                 type: BenchmarkType.Measurement,
                 title: "Polygon access",
                 before: () => {
-                    cursor = polygonTree.data.cursor();
+                    cursor = polygonTree.data().cursor();
                 },
                 benchmarkFn: () => {
                     let x = 0;

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/uniformChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/uniformChunk.spec.ts
@@ -52,7 +52,7 @@ const polygon = new TreeShape(jsonArray.name, false, [
 
 const polygonTree: TestTree<TreeChunk> = {
     name: "polygon",
-    data: () =>
+    dataFactory: () =>
         uniformChunk(
             polygon,
             makeArray(sides * 2, (index) => index),
@@ -74,12 +74,12 @@ const polygonTree: TestTree<TreeChunk> = {
 const testTrees = [
     {
         name: "number",
-        data: () => uniformChunk(numberShape.withTopLevelLength(1), [5]),
+        dataFactory: () => uniformChunk(numberShape.withTopLevelLength(1), [5]),
         reference: [{ type: jsonNumber.name, value: 5 }],
     },
     {
         name: "root sequence",
-        data: () => uniformChunk(numberShape.withTopLevelLength(3), [1, 2, 3]),
+        dataFactory: () => uniformChunk(numberShape.withTopLevelLength(3), [1, 2, 3]),
         reference: [
             { type: jsonNumber.name, value: 1 },
             { type: jsonNumber.name, value: 2 },
@@ -88,7 +88,7 @@ const testTrees = [
     },
     {
         name: "child sequence",
-        data: () =>
+        dataFactory: () =>
             uniformChunk(
                 new TreeShape(jsonArray.name, false, [
                     [EmptyKey, numberShape, 3],
@@ -110,7 +110,7 @@ const testTrees = [
     },
     {
         name: "withChild",
-        data: () => uniformChunk(withChildShape.withTopLevelLength(1), [1]),
+        dataFactory: () => uniformChunk(withChildShape.withTopLevelLength(1), [1]),
         reference: [
             {
                 type: jsonObject.name,
@@ -122,7 +122,7 @@ const testTrees = [
     },
     {
         name: "point",
-        data: () => uniformChunk(pointShape.withTopLevelLength(1), [1, 2]),
+        dataFactory: () => uniformChunk(pointShape.withTopLevelLength(1), [1, 2]),
         reference: [
             {
                 type: jsonObject.name,
@@ -162,24 +162,26 @@ function validateShape(shape: ChunkShape): void {
 }
 
 // testing is per node, and our data can have multiple nodes at the root, so split tests as needed:
-const testData: TestTree<[number, TreeChunk]>[] = testTrees.flatMap(({ name, data, reference }) => {
-    const out: TestTree<[number, TreeChunk]>[] = [];
-    for (let index = 0; index < reference.length; index++) {
-        out.push({
-            name: reference.length > 1 ? `${name} part ${index + 1}` : name,
-            data: () => [index, data()],
-            reference: reference[index],
-            path: { parent: undefined, parentIndex: index, parentField: dummyRoot },
-        });
-    }
-    return out;
-});
+const testData: TestTree<[number, TreeChunk]>[] = testTrees.flatMap(
+    ({ name, dataFactory, reference }) => {
+        const out: TestTree<[number, TreeChunk]>[] = [];
+        for (let index = 0; index < reference.length; index++) {
+            out.push({
+                name: reference.length > 1 ? `${name} part ${index + 1}` : name,
+                dataFactory: () => [index, dataFactory()],
+                reference: reference[index],
+                path: { parent: undefined, parentIndex: index, parentField: dummyRoot },
+            });
+        }
+        return out;
+    },
+);
 
 describe("uniformChunk", () => {
     describe("shapes", () => {
         for (const tree of testTrees) {
             it(`validate shape for ${tree.name}`, () => {
-                validateShape((tree.data() as UniformChunk).shape);
+                validateShape((tree.dataFactory() as UniformChunk).shape);
             });
         }
     });
@@ -224,7 +226,7 @@ describe("uniformChunk", () => {
     for (const { name: cursorName, factory } of cursorSources) {
         describe(`${cursorName} bench`, () => {
             let cursor: ITreeCursorSynchronous;
-            for (const { name, data } of testTrees) {
+            for (const { name, dataFactory: data } of testTrees) {
                 benchmark({
                     type: BenchmarkType.Measurement,
                     title: `Sum: '${name}'`,
@@ -241,7 +243,7 @@ describe("uniformChunk", () => {
                 type: BenchmarkType.Measurement,
                 title: "Polygon access",
                 before: () => {
-                    cursor = polygonTree.data().cursor();
+                    cursor = polygonTree.dataFactory().cursor();
                 },
                 benchmarkFn: () => {
                     let x = 0;


### PR DESCRIPTION
## Description

This change shifts some cursor related test setup to happen either in a "before" block, or in the tests themselves.
This was done when debugging a crash accidentally introduced to StackCursor which crashed test enumeration preventing use of the cursor tests suite to debug it.

Running complex code during test enumeration is bad for a couple of reasons:
1. It slows down test enumeration. This means the cost is paid even if just running a single test, and thus it slows down things like developer workflows for debugging tests and separate process performance testing mode.
2. If it Errors, it breaks test enumeration, which makes locating the error annoying and prevents running any tests until its fixed (which might have helped isolate the bug).

## Reviewer Guidance

One issue that this could introduce is an overall testing slowdown for the case of running all the tests but duplicateing data initialization thats needed for multiple tests. I think my use of "before" block should cover the cases where it might be a real perf issue but keep a look out for ways that could be improved.