### PR TITLE
Upgrade the GC version as we found some bugs which means current GC data could be incorrect

### DIFF
--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -53,9 +53,9 @@ import {
     currentGCVersion,
     defaultInactiveTimeoutMs,
     defaultSessionExpiryDurationMs,
-    disableGCVersionUpgradeKey,
     disableSweepLogKey,
     disableTombstoneKey,
+    enableGCVersionUpgradeKey,
     gcTestModeKey,
     oneDayMs,
     runGCKey,
@@ -498,9 +498,9 @@ export class GarbageCollector implements IGarbageCollector {
             createParams.baseLogger, "GarbageCollector", { all: { completedGCRuns: () => this.completedRuns } },
         ));
 
-        // If version upgrade is disabled because of issues, fall back to the stable version.
+        // If version upgrade is not enabled, fall back to the stable GC version.
         this.currentGCVersion =
-            this.mc.config.getBoolean(disableGCVersionUpgradeKey) ? stableGCVersion : currentGCVersion;
+            this.mc.config.getBoolean(enableGCVersionUpgradeKey) === true ? currentGCVersion : stableGCVersion;
 
         this.sweepReadyUsageHandler = new SweepReadyUsageDetectionHandler(
             createParams.getContainerDiagnosticId(),

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -55,7 +55,7 @@ import {
     defaultSessionExpiryDurationMs,
     disableSweepLogKey,
     disableTombstoneKey,
-    enableGCVersionUpgradeKey,
+    gcVersionUpgradeToV2Key,
     gcTestModeKey,
     oneDayMs,
     runGCKey,
@@ -500,7 +500,7 @@ export class GarbageCollector implements IGarbageCollector {
 
         // If version upgrade is not enabled, fall back to the stable GC version.
         this.currentGCVersion =
-            this.mc.config.getBoolean(enableGCVersionUpgradeKey) === true ? currentGCVersion : stableGCVersion;
+            this.mc.config.getBoolean(gcVersionUpgradeToV2Key) === true ? currentGCVersion : stableGCVersion;
 
         this.sweepReadyUsageHandler = new SweepReadyUsageDetectionHandler(
             createParams.getContainerDiagnosticId(),

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -50,6 +50,7 @@ import {
 import { IGCRuntimeOptions, RuntimeHeaders } from "./containerRuntime";
 import { getSummaryForDatastores } from "./dataStores";
 import {
+    currentGCVersion,
     defaultInactiveTimeoutMs,
     defaultSessionExpiryDurationMs,
     disableGCVersionUpgradeKey,
@@ -60,6 +61,7 @@ import {
     runGCKey,
     runSessionExpiryKey,
     runSweepKey,
+    stableGCVersion,
     throwOnTombstoneUsageKey,
     trackGCStateKey
 } from "./garbageCollectionConstants";
@@ -74,12 +76,6 @@ import {
     IGCMetadata,
     ICreateContainerMetadata,
 } from "./summaryFormat";
-
-
-/** The stable version of garbage collection in production. */
-const stableGCVersion: GCVersion = 1;
-/** The current version of garbage collection. */
-const currentGCVersion: GCVersion = 2;
 
 /** The statistics of the system state after a garbage collection run. */
 export interface IGCStats {

--- a/packages/runtime/container-runtime/src/garbageCollectionConstants.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionConstants.ts
@@ -19,6 +19,8 @@ export const disableSweepLogKey = "Fluid.GarbageCollection.DisableSweepLog";
 export const disableTombstoneKey = "Fluid.GarbageCollection.DisableTombstone";
 // Feature gate to enable throwing an error when tombstone object is used.
 export const throwOnTombstoneUsageKey = "Fluid.GarbageCollection.ThrowOnTombstoneUsage";
+// Feature gate to disable GC version update if it causes issues.
+export const disableGCVersionUpgradeKey = "Fluid.GarbageCollection.DisableGCVersionUpgrade";
 
 // One day in milliseconds.
 export const oneDayMs = 1 * 24 * 60 * 60 * 1000;

--- a/packages/runtime/container-runtime/src/garbageCollectionConstants.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionConstants.ts
@@ -27,7 +27,7 @@ export const disableTombstoneKey = "Fluid.GarbageCollection.DisableTombstone";
 // Feature gate to enable throwing an error when tombstone object is used.
 export const throwOnTombstoneUsageKey = "Fluid.GarbageCollection.ThrowOnTombstoneUsage";
 // Feature gate to enable GC version upgrade.
-export const enableGCVersionUpgradeKey = "Fluid.GarbageCollection.EnableGCVersionUpgrade";
+export const gcVersionUpgradeToV2Key = "Fluid.GarbageCollection.GCVersionUpgradeToV2";
 
 // One day in milliseconds.
 export const oneDayMs = 1 * 24 * 60 * 60 * 1000;

--- a/packages/runtime/container-runtime/src/garbageCollectionConstants.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionConstants.ts
@@ -26,8 +26,8 @@ export const disableSweepLogKey = "Fluid.GarbageCollection.DisableSweepLog";
 export const disableTombstoneKey = "Fluid.GarbageCollection.DisableTombstone";
 // Feature gate to enable throwing an error when tombstone object is used.
 export const throwOnTombstoneUsageKey = "Fluid.GarbageCollection.ThrowOnTombstoneUsage";
-// Feature gate to disable GC version update if it causes issues.
-export const disableGCVersionUpgradeKey = "Fluid.GarbageCollection.DisableGCVersionUpgrade";
+// Feature gate to enable GC version upgrade.
+export const enableGCVersionUpgradeKey = "Fluid.GarbageCollection.EnableGCVersionUpgrade";
 
 // One day in milliseconds.
 export const oneDayMs = 1 * 24 * 60 * 60 * 1000;

--- a/packages/runtime/container-runtime/src/garbageCollectionConstants.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionConstants.ts
@@ -3,6 +3,13 @@
  * Licensed under the MIT License.
  */
 
+import { GCVersion } from "./summaryFormat";
+
+/** The stable version of garbage collection in production. */
+export const stableGCVersion: GCVersion = 1;
+/** The current version of garbage collection. */
+export const currentGCVersion: GCVersion = 2;
+
 // Feature gate key to turn GC on / off.
 export const runGCKey = "Fluid.GarbageCollection.RunGC";
 // Feature gate key to turn GC sweep on / off.

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -44,6 +44,8 @@ import {
     gcTestModeKey,
     disableSweepLogKey,
     currentGCVersion,
+    stableGCVersion,
+    enableGCVersionUpgradeKey,
 } from "../garbageCollectionConstants";
 
 import { dataStoreAttributesBlobName, GCVersion, IContainerRuntimeMetadata, IGCMetadata } from "../summaryFormat";
@@ -218,6 +220,19 @@ describe("Garbage Collection Tests", () => {
                 };
                 gc = createGcWithPrivateMembers(inputMetadata);
                 const outputMetadata = gc.getMetadata();
+                const expectedOutputMetadata: IGCMetadata = { ...inputMetadata, gcFeature: stableGCVersion };
+                assert.deepEqual(outputMetadata, expectedOutputMetadata, "getMetadata returned different metadata than loaded from");
+            });
+            it("Metadata Roundtrip with GC version upgrade enabled", () => {
+                injectedSettings[enableGCVersionUpgradeKey] = true;
+                const inputMetadata: IGCMetadata = {
+                    sweepEnabled: true,
+                    gcFeature: 1,
+                    sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
+                    sweepTimeoutMs: 123,
+                };
+                gc = createGcWithPrivateMembers(inputMetadata);
+                const outputMetadata = gc.getMetadata();
                 const expectedOutputMetadata: IGCMetadata = { ...inputMetadata, gcFeature: currentGCVersion };
                 assert.deepEqual(outputMetadata, expectedOutputMetadata, "getMetadata returned different metadata than loaded from");
             });
@@ -231,7 +246,7 @@ describe("Garbage Collection Tests", () => {
                 assert(!gc.sweepEnabled, "sweepEnabled incorrect");
                 assert(gc.sessionExpiryTimeoutMs !== undefined, "sessionExpiryTimeoutMs incorrect");
                 assert(gc.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
-                assert.equal(gc.latestSummaryGCVersion, currentGCVersion, "latestSummaryGCVersion incorrect");
+                assert.equal(gc.latestSummaryGCVersion, stableGCVersion, "latestSummaryGCVersion incorrect");
             });
             it("gcAllowed true", () => {
                 gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: true });
@@ -296,6 +311,19 @@ describe("Garbage Collection Tests", () => {
             });
             it("Metadata Roundtrip", () => {
                 injectedSettings[runSessionExpiryKey] = true;
+                const expectedMetadata: IGCMetadata = {
+                    sweepEnabled: true,
+                    gcFeature: 1,
+                    sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
+                    sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
+                };
+                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: true });
+                const outputMetadata = gc.getMetadata();
+                assert.deepEqual(outputMetadata, expectedMetadata, "getMetadata returned different metadata than expected");
+            });
+            it("Metadata Roundtrip with GC version upgrade enabled", () => {
+                injectedSettings[runSessionExpiryKey] = true;
+                injectedSettings[enableGCVersionUpgradeKey] = true;
                 const expectedMetadata: IGCMetadata = {
                     sweepEnabled: true,
                     gcFeature: currentGCVersion,
@@ -375,7 +403,7 @@ describe("Garbage Collection Tests", () => {
 
                 const expectedMetadata: IGCMetadata = {
                     sweepEnabled: false,
-                    gcFeature: currentGCVersion,
+                    gcFeature: 1,
                     sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
                     sweepTimeoutMs: expectedSweepTimeoutMs,
                 };

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -43,6 +43,7 @@ import {
     defaultInactiveTimeoutMs,
     gcTestModeKey,
     disableSweepLogKey,
+    currentGCVersion,
 } from "../garbageCollectionConstants";
 
 import { dataStoreAttributesBlobName, GCVersion, IContainerRuntimeMetadata, IGCMetadata } from "../summaryFormat";
@@ -217,7 +218,8 @@ describe("Garbage Collection Tests", () => {
                 };
                 gc = createGcWithPrivateMembers(inputMetadata);
                 const outputMetadata = gc.getMetadata();
-                assert.deepEqual(outputMetadata, inputMetadata, "getMetadata returned different metadata than loaded from");
+                const expectedOutputMetadata: IGCMetadata = { ...inputMetadata, gcFeature: currentGCVersion };
+                assert.deepEqual(outputMetadata, expectedOutputMetadata, "getMetadata returned different metadata than loaded from");
             });
         });
 
@@ -229,7 +231,7 @@ describe("Garbage Collection Tests", () => {
                 assert(!gc.sweepEnabled, "sweepEnabled incorrect");
                 assert(gc.sessionExpiryTimeoutMs !== undefined, "sessionExpiryTimeoutMs incorrect");
                 assert(gc.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
-                assert.equal(gc.latestSummaryGCVersion, 1, "latestSummaryGCVersion incorrect");
+                assert.equal(gc.latestSummaryGCVersion, currentGCVersion, "latestSummaryGCVersion incorrect");
             });
             it("gcAllowed true", () => {
                 gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: true });
@@ -296,7 +298,7 @@ describe("Garbage Collection Tests", () => {
                 injectedSettings[runSessionExpiryKey] = true;
                 const expectedMetadata: IGCMetadata = {
                     sweepEnabled: true,
-                    gcFeature: 1,
+                    gcFeature: currentGCVersion,
                     sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
                     sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
                 };
@@ -373,7 +375,7 @@ describe("Garbage Collection Tests", () => {
 
                 const expectedMetadata: IGCMetadata = {
                     sweepEnabled: false,
-                    gcFeature: 1,
+                    gcFeature: currentGCVersion,
                     sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
                     sweepTimeoutMs: expectedSweepTimeoutMs,
                 };

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -45,7 +45,7 @@ import {
     disableSweepLogKey,
     currentGCVersion,
     stableGCVersion,
-    enableGCVersionUpgradeKey,
+    gcVersionUpgradeToV2Key,
 } from "../garbageCollectionConstants";
 
 import { dataStoreAttributesBlobName, GCVersion, IContainerRuntimeMetadata, IGCMetadata } from "../summaryFormat";
@@ -223,8 +223,8 @@ describe("Garbage Collection Tests", () => {
                 const expectedOutputMetadata: IGCMetadata = { ...inputMetadata, gcFeature: stableGCVersion };
                 assert.deepEqual(outputMetadata, expectedOutputMetadata, "getMetadata returned different metadata than loaded from");
             });
-            it("Metadata Roundtrip with GC version upgrade enabled", () => {
-                injectedSettings[enableGCVersionUpgradeKey] = true;
+            it("Metadata Roundtrip with GC version upgrade to v2 enabled", () => {
+                injectedSettings[gcVersionUpgradeToV2Key] = true;
                 const inputMetadata: IGCMetadata = {
                     sweepEnabled: true,
                     gcFeature: 1,
@@ -321,9 +321,9 @@ describe("Garbage Collection Tests", () => {
                 const outputMetadata = gc.getMetadata();
                 assert.deepEqual(outputMetadata, expectedMetadata, "getMetadata returned different metadata than expected");
             });
-            it("Metadata Roundtrip with GC version upgrade enabled", () => {
+            it("Metadata Roundtrip with GC version upgrade to v2 enabled", () => {
                 injectedSettings[runSessionExpiryKey] = true;
-                injectedSettings[enableGCVersionUpgradeKey] = true;
+                injectedSettings[gcVersionUpgradeToV2Key] = true;
                 const expectedMetadata: IGCMetadata = {
                     sweepEnabled: true,
                     gcFeature: currentGCVersion,


### PR DESCRIPTION
Recently, the following issues with how GC data is generated and added to the summary were fixed: #13361, #13427 and #13455. This means that the GC data in existing documents could be incorrect. Upgrading the GC version will regenerate the GC data in these documents.
The upgrade is behind a feature flag and can be turned off if needed.