### PR TITLE
GC Add Test for Summarizer does not fail when requesting a tombstoned object

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -417,6 +417,10 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
                 eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
                 viaHandle: false,
             },
+            {
+                eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+                viaHandle: false,
+            },
         ],
         async () => {
             const {
@@ -438,7 +442,11 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
                     const correctErrorMessage = error.message.startsWith(`Datastore removed by gc`) === true;
                     return correctErrorType && correctErrorMessage;
                 },
-                `Should not be able to retrieve a tombstoned datastore.`,
+                `Should not be able to retrieve a tombstoned datastore in non-summarizer clients`,
+            );
+            await assert.doesNotReject(
+                async () => requestFluidObject<ITestDataObject>(summarizingContainer, unreferencedId),
+                `Should be able to retrieve a tombstoned datastore in summarizer clients`,
             );
         });
 


### PR DESCRIPTION
[AB#3044](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3044)
Create tests to verify that:
- Summarizers only log when retrieving tombstoned blobs
- Summarizers only log when retrieving tombstoned datastores