### PR TITLE
Disable one more flaky tinylicious test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -358,7 +358,8 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
                 it("Reconnects while sending compressed batch", async function() {
                     // This is not supported by the local server. See ADO:2690
-                    if (provider.driver.type === "local") {
+                    // This test is flaky on tinylicious. See ADO:2964
+                    if (provider.driver.type === "local" || provider.driver.type === "tinylicious") {
                         this.skip();
                     }
 


### PR DESCRIPTION
## Description
Skipping another test that's been flaky in stability runs (continuation of #13468). There's a work item open for re-enabling these.
