### PR TITLE
Tree: no superfluous peer change rebasing

### DIFF
--- a/packages/dds/tree/src/core/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/core/edit-manager/editManager.ts
@@ -198,6 +198,9 @@ export class EditManager<
                 branch.localChanges.length === 0,
                 "A branch whose latest commit is in line with the trunk should be empty",
             );
+            // We record that the peer session's commits are up to date with the current trunk tip.
+            // This will be leveraged to compute `effectiveNewCommitRef` when receiving the next change from
+            // that same peer session.
             branch.refSeq = newCommit.seqNumber;
         }
 

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -150,6 +150,15 @@ describe("EditManager", () => {
             { seq: 3, type: "Ack" },
         ]);
 
+        runUnitTestScenario("Can handle non-concurrent local changes partially sequenced later", [
+            { seq: 1, type: "Push" },
+            { seq: 2, type: "Push" },
+            { seq: 1, type: "Ack" },
+            { seq: 3, type: "Push" },
+            { seq: 2, type: "Ack" },
+            { seq: 3, type: "Ack" },
+        ]);
+
         runUnitTestScenario("Can handle non-concurrent peer changes sequenced immediately", [
             { seq: 1, type: "Pull", ref: 0, from: peer1 },
             { seq: 2, type: "Pull", ref: 1, from: peer1 },
@@ -160,6 +169,12 @@ describe("EditManager", () => {
             { seq: 1, type: "Pull", ref: 0, from: peer1 },
             { seq: 2, type: "Pull", ref: 0, from: peer1 },
             { seq: 3, type: "Pull", ref: 0, from: peer1 },
+        ]);
+
+        runUnitTestScenario("Can handle non-concurrent peer changes partially sequenced later", [
+            { seq: 1, type: "Pull", ref: 0, from: peer1 },
+            { seq: 2, type: "Pull", ref: 0, from: peer1 },
+            { seq: 3, type: "Pull", ref: 1, from: peer1 },
         ]);
 
         runUnitTestScenario("Can rebase a single peer change over multiple peer changes", [
@@ -317,15 +332,17 @@ describe("EditManager", () => {
         for (const scenario of buildScenario([], meta)) {
             // Uncomment the code below to log the titles of generated scenarios.
             // This is helpful for creating a unit test out of a generated scenario that fails.
-            // const title = scenario.map((s) => {
-            //     if (s.type === "Pull") {
-            //         return `Pull(${s.seq}) from:${s.from} ref:${s.ref}`;
-            //     } else if (s.type === "Ack") {
-            //         return `Ack(${s.seq})`;
-            //     }
-            //     return s.type;
-            // }).join("|");
-            // console.debug(title);
+            const title = scenario
+                .map((s) => {
+                    if (s.type === "Pull") {
+                        return `Pull(${s.seq}) from:${s.from} ref:${s.ref}`;
+                    } else if (s.type === "Ack") {
+                        return `Ack(${s.seq})`;
+                    }
+                    return `Push(${s.seq})`;
+                })
+                .join("|");
+            console.debug(title);
             runUnitTestScenario(undefined, scenario);
         }
     });

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -24,6 +24,7 @@ import {
     TestChangeRebaser,
     TestChange,
     UnrebasableTestChangeRebaser,
+    ConstrainedTestChangeRebaser,
 } from "../testChange";
 
 const rootKey: FieldKey = brand("root");
@@ -286,12 +287,12 @@ describe("EditManager", () => {
                 { seq: 3, type: "Pull", ref: 2, from: peer2 },
                 { seq: 4, type: "Ack" },
             ],
-            new UnrebasableTestChangeRebaser(
-                (change: TestChange, over: TaggedChange<TestChange>): TestChange => {
+            new ConstrainedTestChangeRebaser(
+                (change: TestChange, over: TaggedChange<TestChange>): boolean => {
                     // This is the only rebase that should happen
                     assert.deepEqual(change.intentions, [4]);
                     assert.deepEqual(over.change.intentions, [3]);
-                    return TestChange.rebase(change, over.change);
+                    return true;
                 },
             ),
         );
@@ -303,12 +304,12 @@ describe("EditManager", () => {
                 { seq: 3, type: "Pull", ref: 2, from: peer2 },
                 { seq: 4, type: "Pull", ref: 0, from: peer1 },
             ],
-            new UnrebasableTestChangeRebaser(
-                (change: TestChange, over: TaggedChange<TestChange>): TestChange => {
+            new ConstrainedTestChangeRebaser(
+                (change: TestChange, over: TaggedChange<TestChange>): boolean => {
                     // This is the only rebase that should happen
                     assert.deepEqual(change.intentions, [4]);
                     assert.deepEqual(over.change.intentions, [3]);
-                    return TestChange.rebase(change, over.change);
+                    return true;
                 },
             ),
         );

--- a/packages/dds/tree/src/test/testChange.ts
+++ b/packages/dds/tree/src/test/testChange.ts
@@ -236,17 +236,24 @@ export class TestChangeRebaser implements ChangeRebaser<TestChange> {
 }
 
 export class UnrebasableTestChangeRebaser extends TestChangeRebaser {
+    public rebase(change: TestChange, over: TaggedChange<TestChange>): TestChange {
+        assert.fail("Unexpected call to rebase");
+    }
+}
+
+export class ConstrainedTestChangeRebaser extends TestChangeRebaser {
     public constructor(
-        private readonly delegate?: (
+        private readonly constraint: (
             change: TestChange,
             over: TaggedChange<TestChange>,
-        ) => TestChange,
+        ) => boolean,
     ) {
         super();
     }
 
     public rebase(change: TestChange, over: TaggedChange<TestChange>): TestChange {
-        return (this.delegate ?? assert.fail("Unexpected call to rebase"))(change, over);
+        assert(this.constraint(change, over));
+        return super.rebase(change, over);
     }
 }
 

--- a/packages/dds/tree/src/test/testChange.ts
+++ b/packages/dds/tree/src/test/testChange.ts
@@ -236,8 +236,17 @@ export class TestChangeRebaser implements ChangeRebaser<TestChange> {
 }
 
 export class UnrebasableTestChangeRebaser extends TestChangeRebaser {
+    public constructor(
+        private readonly delegate?: (
+            change: TestChange,
+            over: TaggedChange<TestChange>,
+        ) => TestChange,
+    ) {
+        super();
+    }
+
     public rebase(change: TestChange, over: TaggedChange<TestChange>): TestChange {
-        assert.fail("Unexpected call to rebase");
+        return (this.delegate ?? assert.fail("Unexpected call to rebase"))(change, over);
     }
 }
 


### PR DESCRIPTION
There was a discrepancy between the rebase flow that local and peer edits go through. IOW, the same edit was rebased differently (though typically with the same result) depending on whether it was produced by the local session or not.

For example, in the right-to-left insertion interleaving test (see src\test\shared-tree\editing.spec.ts), the edit for the insertion of Y was...
rebased over [T, C, S, B] on the local client
rebased over [Z⁻¹, Z, T, C, S, B] on peers (as part of `rebaseChangeFromBranchToTrunk`)
This should be fine because Y ↷ [Z⁻¹, Z] === Y should hold, but we want to avoid relying on this axiom if we don't have to.
There are two reasons for this:
Not relying on the axiom means we are less vulnerable to decoherence bugs.
We can save processing time by avoiding the extra rebase over [Z⁻¹, Z].

This PR removes this discrepancy by avoiding the extra rebase.