### PR TITLE
Fix build - Update tsc script

### DIFF
--- a/packages/tools/client-debugger/client-debugger-chrome-extension/package.json
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/package.json
@@ -37,7 +37,7 @@
     "test:realsvc:coverage": "npm run test:realsvc:run:coverage",
     "test:realsvc:run": "jest --detectOpenHandles",
     "test:realsvc:run:coverage": "jest  --detectOpenHandles --coverage --ci --reporters=default --reporters=jest-junit",
-    "tsc": "tsc --pretty",
+    "tsc": "tsc",
     "webpack": "webpack --env production",
     "webpack:dev": "webpack --env development"
   },

--- a/packages/tools/client-debugger/client-debugger-view/package.json
+++ b/packages/tools/client-debugger/client-debugger-view/package.json
@@ -43,7 +43,7 @@
     "test:realsvc:coverage": "npm run test:realsvc:run:coverage",
     "test:realsvc:run": "jest --detectOpenHandles",
     "test:realsvc:run:coverage": "jest  --detectOpenHandles --coverage --ci --reporters=default --reporters=jest-junit",
-    "tsc": "tsc --pretty",
+    "tsc": "tsc",
     "webpack": "webpack --env production",
     "webpack:dev": "webpack --env development"
   },

--- a/packages/tools/client-debugger/client-debugger/package.json
+++ b/packages/tools/client-debugger/client-debugger/package.json
@@ -40,7 +40,7 @@
     "test:realsvc:coverage": "npm run test:realsvc:run:coverage",
     "test:realsvc:run": "mocha dist/**/*.test.js --unhandled-rejections=strict --exit",
     "test:realsvc:run:coverage": "nyc npm run mocha -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
-    "tsc": "tsc --pretty"
+    "tsc": "tsc"
   },
   "nyc": {
     "all": true,


### PR DESCRIPTION
## Description

Updates the `tsc` npm script in 3 new packages to match the standard one expected by some of our checks, to unblock the (local) build of the `main` branch which currently fails with this error:

```console
INFO: ERROR: Unexpected error. @fluid-tools/client-debugger-view: Unable to find tsc task for dependent task api-extractor run --local
INFO: Error: @fluid-tools/client-debugger-view: Unable to find tsc task for dependent task api-extractor run --local
```

We'll investigate why CI didn't catch this in the first place, and adjust the checks if necessary to support the `--pretty` flag.