### PR TITLE
Change eslint test 

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -561,7 +561,7 @@ export class FluidPackageCheck {
                     this.checkChildrenScripts(
                         pkg,
                         "lint:fix",
-                        lintFixChildren?.map((value) => `${value}:fix`),
+                        lintFixChildren?.map((e) => `${e}:fix`),
                         false,
                         fix,
                     )

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -501,7 +501,7 @@ export class FluidPackageCheck {
                 const lintChildren = lintPackages?.map((x) => x.trim().split(" ")[1]); // regex to create a list of ["foo", "bar"]
 
                 if (lintChildren !== undefined) {
-                    const hasEslint = lintChildren.some(elem => /eslint/.test(elem)); // regex to check if "eslint" exists
+                    const hasEslint = lintChildren.some((elem) => /eslint/.test(elem)); // regex to check if "eslint" exists
 
                     if (!hasEslint) {
                         lintChildren?.push("eslint"); // push "eslint" to lintChildren as expected package
@@ -517,12 +517,11 @@ export class FluidPackageCheck {
             const lintFixScript = pkg.getScript("lint:fix");
             const lintFixPackages = lintFixScript?.match(/run\s*([^&]*)\s*/g);
 
-
             if (lintFixPackages !== null) {
                 const lintFixChildren = lintFixPackages?.map((x) => x.trim().split(" ")[1]);
 
                 if (lintFixChildren !== undefined) {
-                    const hasEslint = lintFixChildren.some(elem => /eslint/.test(elem));
+                    const hasEslint = lintFixChildren.some((elem) => /eslint/.test(elem));
 
                     if (!hasEslint) {
                         lintFixChildren?.push("eslint");

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -169,10 +169,6 @@ export class FluidPackageCheck {
         concurrent: boolean,
         fix: boolean,
     ) {
-        /**
-        const expectedScript = expected ? concurrent ? `concurrently ${expected.map((value) => `npm:${value}`).join(" ")}` : expected.map((value) => `npm run ${value}`).join(" && ") : undefined;
-         */
-
         const expectedScript = expected
             ? concurrent
                 ? `concurrently ${expected.map((value) => `npm:${value}`).join(" ")}`

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -178,7 +178,7 @@ export class FluidPackageCheck {
         const actual = pkg.getScript(name);
 
         if (expected !== actual) {
-            this.logWarn(pkg, `${name} should contain: ${expectedPackages}`, fix);
+            this.logWarn(pkg, `${name} should only contain: ${expectedPackages}`, fix);
 
             if (fix) {
                 pkg.packageJson.scripts[name] = expected;
@@ -188,20 +188,20 @@ export class FluidPackageCheck {
         return fixed;
     }
 
-    private static checkChildrenScripts(
-        pkg: Package,
-        name: string,
-        expected: string[] | undefined,
-        concurrent: boolean,
-        fix: boolean,
-    ) {
-        const expectedScript = expected
-            ? concurrent
-                ? `concurrently ${expected.map((value) => `npm:${value}`).join(" ")}`
-                : expected.map((value) => `npm run ${value}`).join(" && ")
-            : undefined;
-        return this.checkScript(pkg, name, expectedScript, fix);
-    }
+    // private static checkChildrenScripts(
+    //     pkg: Package,
+    //     name: string,
+    //     expected: string[] | undefined,
+    //     concurrent: boolean,
+    //     fix: boolean,
+    // ) {
+    //     const expectedScript = expected
+    //         ? concurrent
+    //             ? `concurrently ${expected.map((value) => `npm:${value}`).join(" ")}`
+    //             : expected.map((value) => `npm run ${value}`).join(" && ")
+    //         : undefined;
+    //     return this.checkScript(pkg, name, expectedScript, fix);
+    // }
 
     /**
      * checkChildrenScripts for "lint" && "lint:fix"
@@ -563,16 +563,19 @@ export class FluidPackageCheck {
 
             // Check "lint"
             if (lintScript) {
-                const lintChildren = lintScript
+                let lintChildren = lintScript
                     ?.match(lintRegex)
                     ?.map((name) => name.replace("npm run ", ""))
                     .map((name) => name.split(":")[0]);
 
                 if (lintChildren !== undefined) {
                     const hasEslint = lintChildren.some((e) => /eslint/.test(e));
+                    const checkEslintPrettier = /^(eslint|prettier)(,(eslint|prettier))*$/.test(
+                        lintChildren.toString(),
+                    );
 
-                    if (!hasEslint) {
-                        lintChildren?.push("eslint");
+                    if (!(hasEslint && checkEslintPrettier)) {
+                        lintChildren = ["eslint", "prettier"];
                     }
                 }
 
@@ -583,16 +586,19 @@ export class FluidPackageCheck {
 
             // Check "lint:fix"
             if (lintFixScript) {
-                const lintFixChildren = lintFixScript
+                let lintFixChildren = lintFixScript
                     ?.match(lintRegex)
                     ?.map((name) => name.replace("npm run ", ""))
                     .map((name) => name.split(":")[0]);
 
                 if (lintFixChildren !== undefined) {
                     const hasEslint = lintFixChildren.some((e) => /eslint/.test(e));
+                    const checkEslintPrettier = /^(eslint|prettier)(,(eslint|prettier))*$/.test(
+                        lintFixChildren.toString(),
+                    );
 
-                    if (!hasEslint) {
-                        lintFixChildren?.push("eslint");
+                    if (!(hasEslint && checkEslintPrettier)) {
+                        lintFixChildren = ["eslint", "prettier"];
                     }
                 }
 

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { fail } from "assert";
 import chalk from "chalk";
 import fs from "fs";
 import isEqual from "lodash.isequal";
@@ -521,7 +520,7 @@ export class FluidPackageCheck {
                 const lintFixChildren = lintFixPackages?.map((x) => x.trim().split(" ")[1]);
 
                 if (lintFixChildren !== undefined) {
-                    const hasEslint = lintFixChildren.some((elem) => /eslint/.test(elem));
+                    const hasEslint = lintFixChildren.some((elem) => /eslint:fix/.test(elem));
 
                     if (!hasEslint) {
                         lintFixChildren?.push("eslint");

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -152,10 +152,20 @@ export class FluidPackageCheck {
 
         if (expected !== actual) {
             if (name === "lint" || name === "lint:fix") {
-                const lintRegex = /npm run (\w+)(?::fix)?/g;
+                /* Regular Expression
+                    lintRegex is a regex to extract expected lint-packages from the expected string value
+
+                    if expected = "npm run foo && npm run bar && npm run baz-qux:fix"
+                    lintPackages = ["foo", "bar", "baz-qux"]
+
+                    `/run (.*?)(?= &&|:|$)/g` : matches text between "run" and ("&&" or ":")
+                    `map` : extract the text from lintMatch by replacing `run` and `\s` with ""
+                */
+
+                const lintRegex = /run (.*?)(?= &&|:|$)/g;
                 const lintMatch = expected?.match(lintRegex);
 
-                const lintPackages = lintMatch?.map((e) => e.replace(/npm run |:fix/g, ""));
+                const lintPackages = lintMatch?.map((e) => e.replace(/run |\s/g, ""));
 
                 this.logWarn(pkg, `${name} should contain: ${lintPackages}`, fix);
             } else {
@@ -522,10 +532,10 @@ export class FluidPackageCheck {
                 const lintChildren = lintMatch?.map((e) => e.replace(/npm run |:fix/g, ""));
 
                 if (lintChildren !== undefined) {
-                    const hasEslint = lintChildren.some((e) => /eslint/.test(e)); // regex to check if "eslint" exists
+                    const hasEslint = lintChildren.some((e) => /eslint/.test(e));
 
                     if (!hasEslint) {
-                        lintChildren?.push("eslint"); // push "eslint" to lintChildren as expected package
+                        lintChildren?.push("eslint");
                     }
                 }
 


### PR DESCRIPTION
### Description
https://dev.azure.com/fluidframework/internal/_workitems/edit/3087/

Remove unnecessary warning logs from `lint` and `lint:fix` when running `npm run build:fast` on root directory

#### Before 
![Screenshot 2023-01-10 232913](https://user-images.githubusercontent.com/111468570/211962616-4093f46b-02df-462f-8c8a-e40561248eea.png)


#### After 
<img width="903" alt="after" src="https://user-images.githubusercontent.com/111468570/211962709-5ffa6901-ba64-4052-9ab1-c75d42f25f44.png">

### Error Filtering If Missing Packages
<img width="765" alt="image" src="https://user-images.githubusercontent.com/111468570/212152640-60dde222-e49f-4709-8c48-3798749e015f.png">


### Objective 
- Removing approximately 1000 warnings and make easier developing experience to find meaningful error / warning logs 

### Changes
- The order of the package in script is no longer enforced (i.e., `eslint` does not have to be the last package in `lint` and `lint:fix` packages)
- Introduces a new `logWarn()` by filtering out the case triggered by `lint` and `lint:fix to tell which packages are missing

#### Locally Test the Changes 
- Even if changes are made to the local package, `npm run build:fast` makes use of globally installed `build-tools` package. Therefore, we must first install `build-tools` locally 

Reference: https://docs.npmjs.com/cli/v6/commands/npm-link

- Install `pnpm` in `build-tools` by `npm i -g pnpm`
- Build in `build-tools/packages/build-tools` by `pnpm run prettier:fix` and `pnpm run build`
- In the root directory, run `npm link` to link the local version of `build-tools`