### PR TITLE
Log more information in version utils

### DIFF
--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -115,7 +115,7 @@ export function resolveVersion(requested: string, installed: boolean) {
         if (found) {
             return found;
         }
-        throw new Error(`No matching version found in ${baseModulePath}`);
+        throw new Error(`No matching version found in ${baseModulePath} (requested: ${requested})`);
     } else {
         const result = execSync(
             `npm v @fluidframework/container-loader@"${requested}" version --json`,
@@ -140,7 +140,7 @@ export function resolveVersion(requested: string, installed: boolean) {
 async function ensureModulePath(version: string, modulePath: string) {
     const release = await lock(baseModulePath, { retries: { forever: true } });
     try {
-        console.log(`Installing version ${version}`);
+        console.log(`Installing version ${version} at ${modulePath}`);
         if (!existsSync(modulePath)) {
             // Create the under the baseModulePath lock
             mkdirSync(modulePath, { recursive: true });
@@ -223,7 +223,7 @@ export function checkInstalled(requested: string) {
         // assume it is valid if it exists
         return { version, modulePath };
     }
-    throw new Error(`Requested version ${requested} resolved to ${version} is not installed`);
+    throw new Error(`Requested version ${requested} resolved to ${version} is not installed at ${modulePath}`);
 }
 
 export const loadPackage = (modulePath: string, pkg: string) =>


### PR DESCRIPTION
## Description

Adding a bit of extra context to some log messages / errors in version utils. One of them motivated by [AB#2951](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2951), for which I can't find a good explanation. This extra context might shed some light on it. The others seem to make sense too to help troubleshoot issues if they arise at some point.