### PR TITLE
Increase timeout for Matrix memory tests

### DIFF
--- a/packages/dds/matrix/src/test/memory/.mocharc.js
+++ b/packages/dds/matrix/src/test/memory/.mocharc.js
@@ -16,5 +16,5 @@
     reporterOptions: ["reportDir=.memoryTestsOutput/"],
     require: ["node_modules/@fluidframework/mocha-test-setup"],
     spec: ["dist/test/memory/**/*.spec.js", "--perfMode"],
-    timeout: "60000"
+    timeout: "90000"
 }


### PR DESCRIPTION
## Description

Increase the timeout for memory tests in @fluidframework/matrix. We have some flaky tests whose execution time seems to be very close to the current timeout.

[AB#2963](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2963)

Created [AB#3137](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3137) for improvements that could let us address these scenarios without increasing the global mocha timeout.