### PR TITLE
Update client lock file for 2.0.0-internal.2.2.1 release

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2392,11 +2392,11 @@
       }
     },
     "@fluid-experimental/property-changeset": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-changeset/-/property-changeset-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-cjePMCuwVFTClaVsZMP+SMhY9/D50HkgY73E6Iau2tkLQAIzY8A3UVCwSUIwCbxy/jB29fzuv9ZPMAMOLhFWlw==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-changeset/-/property-changeset-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-PEI+qNJEDOijy8gKO8cTOY6WO79cAgK5mlD+g9eMslRiYnb8XUtC5o5HlaE2/bxs2482T2TbSuxvAg2udnIhTw==",
       "requires": {
-        "@fluid-experimental/property-common": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-common": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "ajv": "7.1.1",
         "ajv-keywords": "4.0.0",
         "async": "^3.2.2",
@@ -2422,9 +2422,9 @@
       }
     },
     "@fluid-experimental/property-common": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-common/-/property-common-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-Tttwf50SEQctfasZrPDCGVQj2Z5lVZHCHFSiowj3p1m1M4Ayb6ERVeqkcJCHtRFMK3IctIDi6T5G9VhADJjeUQ==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-common/-/property-common-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-hIJNenPxo58wCN2esX5PkAn4gwwiCiCeBWZQSJJwogbBk4U9/t9UalXO0QvHA9GKimFtD+yx0CYd7jOJ78tGFw==",
       "requires": {
         "ajv": "7.1.1",
         "async": "^3.2.2",
@@ -2454,20 +2454,20 @@
       }
     },
     "@fluid-experimental/property-dds": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-dds/-/property-dds-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-9Y2CVp4g7Vgm3sqKShxQNWMEwW7UY7d0+sti0ly8lRJSGr4A+oAHUEJJBRdWeHtIrOYdgTybS29UTGAxCAwP2A==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-dds/-/property-dds-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-Kk6Xn3wG2GnStKetUiY2apbD7qu8C4fYKLoZc7IuYDEm4LB2oDI4iOpkCmIEE6W38iMw+/HMYiscLLLTiBlUEg==",
       "requires": {
-        "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluid-experimental/property-properties": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-properties": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "axios": "^0.26.0",
         "fastest-json-copy": "^1.0.1",
         "lodash": "^4.17.21",
@@ -2521,12 +2521,12 @@
       }
     },
     "@fluid-experimental/property-properties": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-properties/-/property-properties-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-Fhohi2FnSboF1/unVkAyZ6VeiM4yr1/leXZmeu1eEY14yOedsH00I7yy8ucfa5GaFJ4iNXSrznGnDluHP452Ng==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-properties/-/property-properties-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-2qNQZiIHCxMMirQA5bpGBe1JNHDCM7MhW+kW0TvZyjdsGFYayTXDOIdv8syPV0mlj9cjDGOrpZJM80Sd7BtVzw==",
       "requires": {
-        "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluid-experimental/property-common": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-common": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "ajv": "7.1.1",
         "async": "^3.2.2",
         "fastest-json-copy": "^1.0.1",
@@ -2565,16 +2565,16 @@
       }
     },
     "@fluid-experimental/sequence-deprecated": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-UPzhbLJc/XcaXUvMEghaB/6RtJnr70bXFkeKQAaH5ZxF0mCrFzugSU2g9besVshJbWzT6od9Qu3J8Qd33rW9Qg==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-fniPcWnMyshl+iIo1BuBlNdVPe9+FpmCh3/K5TXe2dx8Ht2DsZ51ycT/qes49eA8VL9/1cZtZ9fqtdsMzdY25w==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/sequence": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/sequence": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluid-experimental/sequence-deprecated-previous": {
@@ -2853,25 +2853,25 @@
       }
     },
     "@fluidframework/aqueduct": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-PAEnL928V5eJH3Z8A2GBMRe5OMQ4gYmlBxJvL5NBX7xKoyEmFPvfMQi8qfGYWQAQRKJN3+r+U+z2QUlQGHkHPA==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-iI43c+FrJVd3sqPdN7sadcQ+gb13F83K0GxV/wIL0HwsErHqfQaIb2ZmY+nCY5IehuWu35do8RI9YG2v/nYzlA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/synthesize": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/map": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/request-handler": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/synthesize": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -3014,17 +3014,17 @@
       }
     },
     "@fluidframework/cell": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-/UxOkxbM26bpZeqFNGZRDAD7p7foUH84yFC/ZUxLvzSUDVEA59Torefe9hjwWEBuny06qdI4eFkHX47A+zKtNQ==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-ZmoXkZBxtLyYBNnEXeycPjr/ZvpmvDpQa9JwHbJ0LwE7B6Dbu5dI7kzpP0ScgD2No4GnNPpnj4Ng/+3I3vQi9w==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/cell-previous": {
@@ -3068,13 +3068,13 @@
       }
     },
     "@fluidframework/container-definitions": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-Y+BXNRQ8cS9X4f0EwdtiLqGICVKV6m4xGqSAfhzVJh/3UrfbzIzp00/MbogCjHZnwb9QHUxPD2CacsrY2V/kSQ==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-rNHJh5366x0DCIbxohCtIaLEeluII5lTLDr+kdbHv98slHaNh9vmeQ1rhOVTmDWNNXcKmy0/sZ/NE0AN+mO4oQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0"
       }
     },
@@ -3090,20 +3090,20 @@
       }
     },
     "@fluidframework/container-loader": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-rgIl4qBK0R86lvx3nVvPfgvw6onzORkGVbOimuzk9ePoX0Er7KKF3qAcVMfL7+LWwllHF2dFzyMRv7OtKfTxxQ==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-Woyt7ztxjHsnk1v8FkrK0zuXxj1CC+XZv1ocN77sIR6m43WPfOCjDE53TT/uylr5ppCFa7lLALm+FH9AD9z3Og==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "abort-controller": "^3.0.0",
         "double-ended-queue": "^2.1.0-0",
         "lodash": "^4.17.21",
@@ -3134,41 +3134,41 @@
       }
     },
     "@fluidframework/container-runtime": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-5g3ZwBf2K/D95DXx+kfOKg1gCWYp5aIDtiqg7F4+JJFsdt2Vit42D35WBJBPyZ/P8eHy1fYA/Jm/zAJ7nwZXYQ==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-qyYbAKF6bDK7MpLp198rxsTJlzY7qihY73jtBO+K6th8/mFSwUWzovzkV3cLtsrhwYjbMSa2KfIc/H5kEVwZJg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "double-ended-queue": "^2.1.0-0",
         "lz4js": "^0.2.0",
         "uuid": "^8.3.1"
       }
     },
     "@fluidframework/container-runtime-definitions": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-aUewKYpnWP2SlZClPd/GXft+he8RBPwb5bL4E/9cJRCbyuaUGyW7zuFVKfiiLSbNYBF4wtJBBU5WqNRw1DV0YQ==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-tLf6BuIWkf5PudxPEMwq5rsFhGQhAurQoxHCrTAwOQsQVG0MXCLU6iTz64XuNhtazozAZmdOVvI1UVRUfhggUQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@types/node": "^14.18.0"
       }
     },
@@ -3212,15 +3212,15 @@
       }
     },
     "@fluidframework/container-utils": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-PpT2bBBl8CmQnsgQrNKWzI2GmDG0S3IZt6LTsXu/OLj+OkjXW+xDFzmuaguZn0gCmrvOvr0vSz23/w3F4QaMjg==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-r12L0SFVhcQ7cUHMetKSHtHbPIAJrcgAUc1N+0vgb3OZ6PRmuFkAT9HRhpT7SorIXohHuqQ5BgsP+8KX4U35Jw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/container-utils-previous": {
@@ -3236,9 +3236,9 @@
       }
     },
     "@fluidframework/core-interfaces": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-B7JNJWkR/0y6CJn90Kk8vTMmZDRKR81OEd82a3CUuYbfAJBsVcMeTPFdh9obrLiH7FS9/f1MxQHFXy7zLOAOWw=="
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-lctB4yMaykYK40W8oUkfC4OHLEiwPgFzATYnS8vfDMmz+EHL0RvzI5+LQO9T2WiXAaKvAlxHgYA1OvzCkOmXtw=="
     },
     "@fluidframework/core-interfaces-previous": {
       "version": "npm:@fluidframework/core-interfaces@2.0.0-internal.2.2.0",
@@ -3246,17 +3246,17 @@
       "integrity": "sha512-B7JNJWkR/0y6CJn90Kk8vTMmZDRKR81OEd82a3CUuYbfAJBsVcMeTPFdh9obrLiH7FS9/f1MxQHFXy7zLOAOWw=="
     },
     "@fluidframework/counter": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-jUIWY63RZvMrP+o3HcjBtovbji2HTo3W8M8lPD13taoI6XBmzo619mG7PLmGtCMl7eQ6+hJ++nOvenP4uGWOKQ==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-O+ivnEnYrv38eIwoXYgAo3U4yoQuHUIAYi7JmJ6ZJ6O3h8DVu7iJIve+jxd8B++ntfS0VkQebQI7AgYgc7ucjQ==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/counter-previous": {
@@ -3292,39 +3292,39 @@
       }
     },
     "@fluidframework/datastore": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-cbQHCNWoTNVDOOZX5Oq9pni0KgYSN5zAnGoYr5YTON3D+tGKPTIShp75UHyIzsWWFEYZrg/ybvqCMRAfPuoeoQ==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-3AECXMJu4v0Zhh8759Ve5ohne2bXjQOvMFUUHksIXihabViUwz5/4ZkgaPZF1YBXeAzFVSYdSsdD6cdpbeynnQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "lodash": "^4.17.21",
         "uuid": "^8.3.1"
       }
     },
     "@fluidframework/datastore-definitions": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-46x/eiFnbBRdUMmPkHaI/Znar7Uxr5dSdgw6p7Zi1dvr+3l9F0ZZ0d92FdBcyk4EJlRJlqbZLq4I7Wv7k9hJog==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-InmktQyhLODak0j3bAFOUEDtO0KRVUecOTjwk44qYIWXEGP2Q7qo6Zl+Lrey6G08FCMHzaajVjyvRksJypMW1g==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@types/node": "^14.18.0"
       }
     },
@@ -3391,16 +3391,16 @@
       }
     },
     "@fluidframework/driver-base": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-3bFBZGjtF0saMia4EeLzjpbT3MURCwyLpDN72Bc6DeelmcRXsr+kOriwk/9PV6AyO7Yjyk7y5fCTTQJSjFO3/w==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-5O2Euvxhsl/oeQjIZ3aCVRCiDfJ8yBqeNMTFhh21xJMYfJILJg4MB2B4HCasCOLpr5ODiNCCYNtIMV2e3EmbxA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/driver-base-previous": {
@@ -3417,12 +3417,12 @@
       }
     },
     "@fluidframework/driver-definitions": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-XaS/93Quwm8mbRF/cE6O+mE8vr9s4vwv4H4DGqNQiitGfPEu4l/4BrzHWNmlpJTENu5LZfWY1q/7CDw0nRov5Q==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-uLfyuq78VPWmMDZpFyFq6Uwjer0G9N8CkVWiUAnfy4Txl2ZSyDyps23LY1K4//reVzOVX/FHI1QlCUSUicDtZA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0"
       }
     },
@@ -3437,18 +3437,18 @@
       }
     },
     "@fluidframework/driver-utils": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-x0cIgwWETVttS5BxEYWBRsV6JiFWRnOzuWsBAtuFrhkRZO04d4hobEc/UWgJgcZaBrtqY7ba4fMmAwU5cWPFSA==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-ZC7lpf7O2tICxGvZpcvgoDGqSGC2nEE+aX0UuKzHNmPXzLbC2oB4xDijGwE9vFN91YyihaDRTFF2TcXIkvoGAw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/gitresources": "^0.1038.2000",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "axios": "^0.26.0",
         "url": "^0.11.0",
         "uuid": "^8.3.1"
@@ -3537,22 +3537,22 @@
       }
     },
     "@fluidframework/fluid-static": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-v3//RQ8c+Fjzymz7f8XWx8iolXwLYAwI9KqWYvybfcZIV/gnGrWssJ93K72CUeYOZqGe/XKbJyPl6e43PJjQWA==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-rFOx5Lda/Izsi2U/NFX7vefIEfwPmG44Ca8KUFGmXSfhcctxQPuRXJCirGKUYAU59KAJsyKvMXXb0a49Yh9leA==",
       "requires": {
-        "@fluidframework/aqueduct": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/aqueduct": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/request-handler": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/fluid-static-previous": {
@@ -3575,13 +3575,13 @@
       }
     },
     "@fluidframework/garbage-collector": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-6ZHbBEIbljtMqAjnP/R3MP7MyrPfyWut2q84mKeX8XymXHQoq3S8ApHUyso3NEBTfTxn1hkXvqLq86eumCwqxw==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-LC/S0E/pgtPur+aKFOUHBzYOCvSaCH0rHxqJ4a6L3nF0cBjWKl3gS7uGVl9tDLuupCQei1nBcRb4kyVetomQLg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/garbage-collector-previous": {
@@ -3615,17 +3615,17 @@
       }
     },
     "@fluidframework/ink": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-E+1pBFwK2H+w61wENQG+GyvX9ud/AcsU7wFFvYiJcGSxr9HizEwD03CSK2lhOjyklMc+WG5xNkpMDEOe5PoAtg==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-/wcLSjnyyEzbnlVnNNC3Hc82zzDH2JOfsbRrbXZ3W6P7nD92vheLq2tw1kp4aUzPPcHXWpniB+/XSGQzK+zXWw==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -3645,24 +3645,24 @@
       }
     },
     "@fluidframework/local-driver": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-Y72ZLmFtRxsraymJWhedtE6iJ9lsH02PcsrsqpQcqEYD9I4o3mdVCaJFCGNpgKjYgc3ljPjou4IXHYqTsiJ2NA==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-yfIZAZ6s1gnUwYQkgtd2S6fjHgcsxwyozCHB70Ona8/inVF+iuDaTQAnzYp7ZJJpanqXD8UhaXf49AJDsQan/w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/server-local-server": "^0.1038.2000",
         "@fluidframework/server-services-client": "^0.1038.2000",
         "@fluidframework/server-services-core": "^0.1038.2000",
         "@fluidframework/server-test-utils": "^0.1038.2000",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "jsrsasign": "^10.5.25",
         "url": "^0.11.0",
         "uuid": "^8.3.1"
@@ -3704,20 +3704,20 @@
       }
     },
     "@fluidframework/map": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-27wFQeJUwwubgUyZMj555q+0LgeNqTI72y8zd5B+RJTBAMDGENY2ZK/vjZkTFBIHFrEpvHFmF+ZmzN6W0P35mQ==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-XPC+P1skPGnAiTlcm7pYT9JXI1c1fngzaQjGoPR6Xnwjq46OO7fMTBGG9q7a07+nTLkxvNMpsnSyzz2EhYb7XA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "path-browserify": "^1.0.1"
       }
     },
@@ -3740,21 +3740,21 @@
       }
     },
     "@fluidframework/matrix": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-dLeh+0Q1SL9c7dwbNTOyfgxsOVB7GdL3dReLqf3Md6eiT1wwMu7wAOgIq7gfc49P3GHRLjMlGseIV3ccrxezBQ==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-4GZIsk5JEyyqcrG3iASlB3PJTF2hZma6LZc8NfPvOnavbZmk4GFBjXUa4unBr7gp0HUVYoI0V/GeKO/fmSf5tQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@tiny-calc/nano": "0.0.0-alpha.5",
         "tslib": "^1.10.0"
       }
@@ -3780,21 +3780,21 @@
       }
     },
     "@fluidframework/merge-tree": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-MRjHrDRQbUY44v1WzJL49pbdivvb+BvB36bWEs8HT0pGJahPrWSCBahf8771rvfd2G7Yvl9uUSueMDSmzOwgkw==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-jSh/9UKr7I6oQUi1dUrJtCpUzrJEcsYUPFs2G7xRNVyBgSCORqh483gG1up50Ro1X6vEXe0e3682nYUIC6DpFw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/merge-tree-previous": {
@@ -3826,16 +3826,16 @@
       }
     },
     "@fluidframework/odsp-doclib-utils": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-94eIjEythnG8/OI9PIMaA2Jd3VyUa6m2TOW+KwtHENVqBTa4/ZEDpWkVc39rRv1VKU4GEvx4V1+lRjhzN17j5Q==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-S289cQ/9BqVbRECGhzhIs4x/MkpRgyghBsuMnxlLbZEdz7qP0id7Vy1a92dIBP5ZsObXtSb4Ypl+rQU3/BmP/Q==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "node-fetch": "^2.6.1"
       }
     },
@@ -3854,22 +3854,22 @@
       }
     },
     "@fluidframework/odsp-driver": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-zYqiXUcxQYGlobKLPNS2WdpSrK/1PB/cimitqWQ9yh66dY/p0z2qG2xdKfm2FWNew7k9pnJbCkZzxqR3NQ5G/w==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-MQRUR6zvI/u2pv9oeR9k8Y9olh0nhAs2mjGM+0Tf/blduRyiK2H1+F5J45ph/wxykHw1oquZyF5DQraAdPlImQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/gitresources": "^0.1038.2000",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.1",
         "socket.io-client": "^4.4.1",
@@ -3877,11 +3877,11 @@
       }
     },
     "@fluidframework/odsp-driver-definitions": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-8O683idVdX+0FCDXuwdoAF50TGKr/SgEgngHjcWOfkSLlXBx8OkbPfypBJ+lsYSE6aVvOjzVxNN6Od72KnCDrQ==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-nBLW0hBtPOCe8juIPFcAUVswbnWZT/wFBesaeOiUUjt9slPMy5SY66RGo2tYFWcIMOVW2Cs8bljDQi/KRsbnNQ==",
       "requires": {
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/odsp-driver-definitions-previous": {
@@ -3916,14 +3916,14 @@
       }
     },
     "@fluidframework/odsp-urlresolver": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-FBaxclM18yqbPjhXuozqsQCkf6OvPySfxw2tEUDnLS0xxuOHv/g/HiCiDdVVbCosytFVRKTrNIbJGY9HGSFBHg==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-8LQlDA++uuUoOvayAj+7zs8790/B45D1DRhydpVnit68Ch7bK2hbDQMUL4w08OrxGHLSNd6W8Ryni+nA3Kd47A==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/odsp-urlresolver-previous": {
@@ -3938,17 +3938,17 @@
       }
     },
     "@fluidframework/ordered-collection": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-uVwA9R3Zrp1BHU4QKDF91eKYeAq7HpKE7BSGdbAzpdibHknCx6fad5TKW9rgB5/CYRXiTpR77X07cY59KG7GFg==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-jYoLfT1HguxUOs4JLGc+fXOGihB6D4ClTTMUZtyjBHyw7rLTOXxa0Vc1n3QoMXk3eSCb1lpcWB9R1k1qJU7Yww==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -3987,17 +3987,17 @@
       }
     },
     "@fluidframework/register-collection": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-8gBxZCeO0T+X9Jd9FBIjyvbb38a29jialMewljjp1HmvYY9mq0hczkOsqdDGkX7mEXJjKFh0t3FNL8aXD1SOkA==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-tI9VtpHpqWO1Dh5f6+Hs4Nl0Vr22EypMGncoRmv0PsfTdy8YBrdlhxESl3vmAWX2tQlaboVE8Qi5OGO0HpspDw==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/register-collection-previous": {
@@ -4015,16 +4015,16 @@
       }
     },
     "@fluidframework/replay-driver": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-9PoxCnCuVvwuB1MI+GP+0bDfBNpdW4Hc/8Q4QDVYLvKsMtzd03W4TmmGJkglzjGj/MgR6WlU2jRATECnqXbc3g==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-rofaaxxoTdmLf1/kxVP91e+R+ZDnN1rIXIY0DO/SKpZa0E4kmT61y1eiC4IlEyEJk3tpuAf1b0Jzg6hf34mi6w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/replay-driver-previous": {
@@ -4041,15 +4041,15 @@
       }
     },
     "@fluidframework/request-handler": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-8fYfd0ZzGhNsXEtXDxKiDQvT1KJzWKt7w7mE8SJQCqJpiZarLfP4m5sCgQ8MflGHokyrdS0HoAff1PUh7Fz/bg==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-pY2zZ0fWa6phEgraRGQggzxgLZ46D0WpKA9gdV++hKOnib3PyrRoRGZ9F2TxSzUWQkuOE5l3y/y7Rz7DBstIKg==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/request-handler-previous": {
@@ -4065,20 +4065,20 @@
       }
     },
     "@fluidframework/routerlicious-driver": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-cAHwV48LFAsONXy+8+CD1wMgM7O0qd24DRBclqOleQzmB7f1lojhcxgSAloeI0busMegb0X3bJ71/jZ5U28JCg==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-zHHsqY5pHydkFaVlOCEi1hQ/07Le78FcIzEBActrr+/CgWluxrQmeiFLEub/ZCcT+RkuRAnGxTxLoMdT4vOjgg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/gitresources": "^0.1038.2000",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "@fluidframework/server-services-client": "^0.1038.2000",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "cross-fetch": "^3.1.5",
         "json-stringify-safe": "5.0.1",
         "querystring": "^0.2.0",
@@ -4124,15 +4124,15 @@
       }
     },
     "@fluidframework/runtime-definitions": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-FEdRUE1PKhv6oRciRP9KPZnm6505b7CzKLOudV8rQtEFKqdD9WODPQAOgOtfZWcKs2ZAoavfowmJ5iJovKT6EA==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-If4I4HWOdiV0iOr/DSwUk1kEdnjoz02JJUMEu2iXotvGQYuGofkpZBfNr6+Xw4k2pVUbIWqpZIsm9kIJhVPVWQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "@types/node": "^14.18.0"
       }
@@ -4152,21 +4152,21 @@
       }
     },
     "@fluidframework/runtime-utils": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-U7LyFfd1RrH/Vzy5rn3aNlFPjway16To/T0ZrrmeoPDnCNP6FBUgdLsZqUGwyaWCTPhNyLy3E8lfzcgecKrGDA==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-iKS5kAGvwCVM4+4IeANIC8dEhPSzcd3z6OnWeQxnoXG3+vNtaEj9TjyipIZIC3aNqJdWO2+pRaoBJP9NHmECMg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/runtime-utils-previous": {
@@ -4188,21 +4188,21 @@
       }
     },
     "@fluidframework/sequence": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-KZASJO8bo6Ksz9enDc+Jl0RkN2wfxV8vEO0j0Zw53VGzskhDV4ZiwOw4t3WUS2QYV3FNLGHttWZWKy3AESEZyw==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-MuRGzr4ebZmSa5rP6LJ8jU3exEk43N+5TBTEuam8QSaFPw7eZ7S1+DBU2V+7SZZFoM4m1cdmj14OEHGMbTeQxg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -4659,22 +4659,22 @@
       }
     },
     "@fluidframework/shared-object-base": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-oZ5S8ZpPHoM0Au0alaXxTD+pqf6MnopDIlQ1ER2dA+MfvGtR3/Rg1jdyOn/dmpx83lXdKA942uQv0zzND0hX7A==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-qAc7yLJSMtPV86YYioRyVjJpi0TlHzd45wVm9fsU8eEuvzMH7l3sNo3Dl6iIzMGNhwv/IWaoIa4ZJ56rmGydOw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -4713,9 +4713,9 @@
       }
     },
     "@fluidframework/synthesize": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-Z1PdSOr9PrpcU8tCG+INGzS5RFMoe9sO+IrGgACJ1tFDpja29gs3su9JfIWcgnDIAtL2lbP/i8ezxBGDbJZPxQ=="
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-R8k/rkkhqg5c7LMAt7ewS6wAecGQoAkdzkgXLV5QLGKeJptPNq88m9KhzIGFwMs3HpIhG0671PfhBlg39Hw9SQ=="
     },
     "@fluidframework/synthesize-previous": {
       "version": "npm:@fluidframework/synthesize@2.0.0-internal.2.2.0",
@@ -4723,9 +4723,9 @@
       "integrity": "sha512-Z1PdSOr9PrpcU8tCG+INGzS5RFMoe9sO+IrGgACJ1tFDpja29gs3su9JfIWcgnDIAtL2lbP/i8ezxBGDbJZPxQ=="
     },
     "@fluidframework/telemetry-utils": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-eERa9i4aAS3dwGxTdkGlkY4GCl9BVufvsGQBC67Pv56N6pVO0HNhiYS1x0vszGA3UZRtjn4NO00PIEP6FQB54g==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-eEvSxKX4BlU3pxRMwhLHwxDR4t4waw7ddHJgF12ra3BLQn9L3meiKO/gxC9p4CAzlLbw6yLJXGqnw4NUpp0cfg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
@@ -4757,13 +4757,13 @@
       }
     },
     "@fluidframework/test-driver-definitions": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-GmMSQnzCyie9RGWNX/sBn1jXvxgEmJNtJUaxy9MglW6wBFfuHwFwpn9hP7VGn2V24H2fk5Fo33rYJtsa9t9yNw==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-1Q5IFUy2eZlFU9NHDwoGhXiLU3jVjbSHPz9YDA4+TeJSlrIp9HSalTIaUsKGVu1cFXtSDrj0I7K16Idz61JEmw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "uuid": "^8.3.1"
       }
@@ -4781,27 +4781,27 @@
       }
     },
     "@fluidframework/test-drivers": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-8ISe9b8iwcwJVrDZrEsWa/C/0tbNeSozIz2nHuYelFNhDEJMGVCBqxrHT+OL5YODf+ZVKcSAdZY1afiHZJbgAg==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-a41i8MsuXT0JoeMDz8lFYWhzjk+aP+oNbito1djMkh2WLGwWvhJtGZfT3gxsMQbYk7fzUYmouLBNYZ5De9MySg==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/local-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/local-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/server-local-server": "^0.1038.2000",
-        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/tool-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/tool-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "axios": "^0.26.0",
         "semver": "^7.3.4",
         "uuid": "^8.3.1"
@@ -4847,9 +4847,9 @@
       }
     },
     "@fluidframework/test-pairwise-generator": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-z+h0VM12B5HESqdr4jfAS7qxzmCUuueoUnH56yztHT+cbgbQrIunN2tTWpog+PCGVx5vMwd7fAo9UNoZDYI/+w==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-ekwbM+l6e5fXKQM/CtwqQfkQ/QIN7RDAblUeYcvjCkrjgaz7GmBbxYEM23Q4Q9n7W941AioydKZuUtJmPff4/w==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
         "random-js": "^1.0.8"
@@ -4865,22 +4865,22 @@
       }
     },
     "@fluidframework/test-runtime-utils": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-nBBuFCLqM6RKylZj1aeEl4XhhwuXTj1PXgfMZJfhHV5pPJ434W6KDFtq2OwXagwLLOsuDfDjBlyppy6P5ByKKg==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-WGSpjgoGOWdEOLyf7KZUgWuOVfxsIgU4b4jbJiW+vTqXtzOcZebzmgGeavruel2k1VuZH2nP1l+y6M1TA2i02A==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "axios": "^0.26.0",
         "jsrsasign": "^10.5.25",
         "uuid": "^8.3.1"
@@ -5614,32 +5614,32 @@
       },
       "dependencies": {
         "@fluidframework/test-utils": {
-          "version": "2.0.0-internal.2.2.0",
-          "resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.2.0.tgz",
-          "integrity": "sha512-3y0WtePiPqQKGIO1VYfQi8jMyhdH92RG5xUPqpYWtAi8pj3456CuVXAOGY7vxEW/unkLCmF/1BIPFk0fA2jLNw==",
+          "version": "2.0.0-internal.2.2.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.2.1.tgz",
+          "integrity": "sha512-/B5Frfd86Lz7/uop7oAowowKI9rDW9U6fvFoR5/FDXEQrXOff8ocOw3n6ZogoehqEvloMEraD66vFwQny3N1kA==",
           "requires": {
-            "@fluidframework/aqueduct": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+            "@fluidframework/aqueduct": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^1.0.0",
-            "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/local-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/container-loader": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/local-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/map": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
             "@fluidframework/protocol-definitions": "^1.1.0",
-            "@fluidframework/request-handler": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-            "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+            "@fluidframework/request-handler": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+            "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
             "best-random": "^1.0.0",
             "debug": "^4.1.1",
             "uuid": "^8.3.1"
@@ -5668,15 +5668,15 @@
       }
     },
     "@fluidframework/tinylicious-driver": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-CUGTvw2x8N1WQo7EdCcSgUkQnbFHEJlmVeSRVGtOVB+Fb0BiFEbLmfXJEHONXt8IKuQtfw/ZB4UHQL8EF6NoSA==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-Cqe/sgoJtRoi5uYuCk+Z01kh2dLhCmfDv3Jx3WWl5StTd9u/6J6WxODjr3sGR/ftHiBzNOmk0xm5QNSPwIfcMw==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/server-services-client": "^0.1038.2000",
         "jsrsasign": "^10.5.25",
         "uuid": "^8.3.1"
@@ -5698,12 +5698,12 @@
       }
     },
     "@fluidframework/tool-utils": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-2VYa5c/OQgLzgK2mQw2alIEoqk190KMo2ybQR8UUSAog/AMH96hD/NR3Oj7Kze9fyU0NWzIcXBMIMkQDEZHZfA==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-BOXjO/kS7s7aLHz3zhMMkFNqKlgV0Skm3U6VcurILVKCOLF5y+muNyhtYkeUNq0wrEEyQu5Y3U8aOuFmgbLypw==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "async-mutex": "^0.3.1",
@@ -5739,12 +5739,12 @@
       }
     },
     "@fluidframework/view-adapters": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-4uJNgrFidEg5310Zy3/ZaHpXMBK13mynQhTnDIQ7PqhnVjy+Jswfz9AcnO1hm/NGdlh2CUC+9GGYGmi8s+QMNA==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-BNgtHYUiHu/+usW2uz9wKfQQGnImL3M6mt409Bhke8p7Lrmwjwde3DKSmYCkXrHP0DFQoSeG+K2WJey49g6j3g==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "react": "^17.0.1",
         "react-dom": "^17.0.1"
       }
@@ -5761,11 +5761,11 @@
       }
     },
     "@fluidframework/view-interfaces": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-AvFzO1VmHH/LJOz3u/c4IoctZ6hr7O7NmsrYsxOBQxynb8IOe7PWVYfEvpX45J3W5KHhbxPMvYKhTh8ovKS2Eg==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-EPsNvDvtEa4x1QHAsfIx9sqSMb5EcaAeV8NMq28seuvb93f9Yzdior8dd2/knmgrgxMIq15LQWUBz2EF3ULTeg==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/view-interfaces-previous": {
@@ -5777,12 +5777,12 @@
       }
     },
     "@fluidframework/web-code-loader": {
-      "version": "2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-mmmiCg29wlkN1NYEKYTg+zFSpyCKGS6DeL5UNwMSiJN7kjY0ypRFWTis6WG1mDOSU9qFQBT5eEj/6LA8lTyqaQ==",
+      "version": "2.0.0-internal.2.2.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.2.1.tgz",
+      "integrity": "sha512-gHUb94qdfFZmK26/a/FDf16B0WRJr0KFadE9iOytBF4ncWxRufTYWeeJGuZ0Bt3WK/dx2vmwvwcx5ah3jawi+g==",
       "requires": {
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
         "isomorphic-fetch": "^3.0.0"
       }
     },
@@ -42145,7 +42145,7 @@
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
       "requires": {
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
@@ -46892,7 +46892,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
     },
     "strip-bom-buf": {
       "version": "1.0.0",


### PR DESCRIPTION
## Description

This updates the lerna-package-lock.json file for the client release group.

This was generated by running `npm i`.

Relevant npm bugs:
- newly release packages cause changes in the package lock due to handling of aliased packages. This includes those changes.
- package hashes pick up which ever format was present in the user's node_modules folder. Mine has sha512 for a few packages which has sha1 versions currently committed. This is an improvement in security and is the default, so I'm considering this a fix of a previous regression. See https://github.com/microsoft/FluidFramework/pull/13425/files#diff-af7f3050477fb02cc2cd3e3825846a1985372da54ec750a8cd7aea241f15ce8fL45413