### PR TITLE
feat: [HACK]: Create POST route to enable triggering webhook in alfred

### DIFF
--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import EventEmitter from "events";
 import {
     ConnectionMode,
     IClient,
@@ -215,6 +216,7 @@ export function configureWebSocketServices(
     throttleAndUsageStorageManager?: core.IThrottleAndUsageStorageManager,
     verifyMaxMessageSize?: boolean,
     httpServer?: core.IHttpServer,
+    eventEmitter?: EventEmitter,
 ) {
     webSocketServer.on("connection", (socket: core.IWebSocket) => {
         // Map from client IDs on this connection to the object ID and user info.
@@ -458,7 +460,7 @@ export function configureWebSocketServices(
             (connectedMessage as any).timestamp = connectedTimestamp;
 
             // TODO: KLUDGE webhook connection
-            if(httpServer !== undefined) {
+            if(httpServer !== undefined && eventEmitter !== undefined) {
                 const customerServicePort = 5237;
 
                 const url = `http://localhost:${httpServer.address().port}/task-list-hook`; // TODO: verify this
@@ -482,7 +484,7 @@ export function configureWebSocketServices(
                     }
                 });
 
-                httpServer.on("task-list-hook", () => {
+                eventEmitter.on("task-list-hook", () => {
                     // Only for debugging purposes
                     const signalMessageRuntimeMessage : ISignalMessage = {
                         clientId: null, // system signal

--- a/server/tinylicious/src/app.ts
+++ b/server/tinylicious/src/app.ts
@@ -78,7 +78,7 @@ export function create(
     app.use(Router().get("/", (req, res) => {
         res.status(200).send("This is Tinylicious. Learn more at https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious");
     }));
-    app.use(Router().post("/task-list-hook", (req, res) = {
+    app.use(Router().post("/task-list-hook", (req, res) => {
         eventEmitter.emit('task-list-hook');
         res.status(200).send("Triggering debug signal from tinylicious");
     }));

--- a/server/tinylicious/src/app.ts
+++ b/server/tinylicious/src/app.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import EventEmitter from "events";
 import {
     IDocumentStorage,
     MongoManager,
@@ -33,6 +34,7 @@ export function create(
     config: Provider,
     storage: IDocumentStorage,
     mongoManager: MongoManager,
+    eventEmitter: EventEmitter,
 ) {
     // Maximum REST request size
     const requestSize = config.get("alfred:restJsonSize");
@@ -75,6 +77,10 @@ export function create(
     // Basic Help Message
     app.use(Router().get("/", (req, res) => {
         res.status(200).send("This is Tinylicious. Learn more at https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious");
+    }));
+    app.use(Router().post("/task-list-hook", (req, res) = {
+        eventEmitter.emit('task-list-hook');
+        res.status(200).send("Triggering debug signal from tinylicious");
     }));
 
     // Catch 404 and forward to error handler

--- a/server/tinylicious/src/app.ts
+++ b/server/tinylicious/src/app.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import EventEmitter from "events";
+import { EventEmitter } from "events";
 import {
     IDocumentStorage,
     MongoManager,

--- a/server/tinylicious/src/runner.ts
+++ b/server/tinylicious/src/runner.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import EventEmitter from "events";
+import { EventEmitter } from "events";
 import {
     IDocumentStorage,
     IOrdererManager,

--- a/server/tinylicious/src/runner.ts
+++ b/server/tinylicious/src/runner.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-
+import EventEmitter from "events";
 import {
     IDocumentStorage,
     IOrdererManager,
@@ -52,7 +52,8 @@ export class TinyliciousRunner implements IRunner {
             throw e;
         }
 
-        const alfred = app.create(this.config, this.storage, this.mongoManager);
+        const eventEmitter = new EventEmitter();
+        const alfred = app.create(this.config, this.storage, this.mongoManager, eventEmitter);
         alfred.set("port", this.port);
 
         this.server = this.serverFactory.create(alfred);
@@ -78,6 +79,7 @@ export class TinyliciousRunner implements IRunner {
             undefined,
             undefined,
             httpServer,
+            eventEmitter,
         );
 
         // Listen on provided port, on all network interfaces.


### PR DESCRIPTION
**Note: This PR is targeting a shared dev branch, not main. These changes are strictly a hack for prototyping, and will not be merged into main 🙂**

https://github.com/microsoft/FluidFramework/pull/13428 introduced a webhook as a hack in alfred but this webhook was not reachable from an external server. This PR creates a POST route to enable triggering the webhook from outside the fluid framework ecosystem.