### PR TITLE
Fix for refreshSummaryFromAck not always downloading latest summary as expected

### DIFF
--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -235,10 +235,11 @@ export const mockConfigProvider: (settings?: Record<string, ConfigTypes>) => ICo
 // @public
 export const retryWithEventualValue: <T>(callback: () => Promise<T>, check: (value: T) => boolean, defaultValue: T, maxTries?: number, backOffMs?: number) => Promise<T>;
 
-// @public (undocumented)
+// @public
 export function summarizeNow(summarizer: ISummarizer, reason?: string): Promise<{
     summaryTree: ISummaryTree;
     summaryVersion: string;
+    summaryRefSeq: number;
 }>;
 
 // @public (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2772,7 +2772,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             /**
              * If the fetched snapshot is older than the one for which the ack was received, close the container.
              * This should never happen because an ack should be sent after the latest summary is updated in the server.
-             * However, there are couple of scenarios it's possible:
+             * However, there are couple of scenarios where it's possible:
              * 1. A file was modified externally resulting in modifying the snapshot's sequence number. This can lead to
              * the document being unusable and we should not proceed.
              * 2. The server DB failed after the ack was sent which may delete the corresponding snapshot. Ideally, in

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -132,7 +132,10 @@ export async function createSummarizerWithContainer(
     const loader = provider.makeTestLoader(testContainerConfig);
     return createSummarizerCore(absoluteUrl, loader, summaryVersion);
 }
-
+/**
+ * Summarizes on demand and returns the summary tree, the version number and the reference sequence number of the
+ * submitted summary.
+*/
 export async function summarizeNow(summarizer: ISummarizer, reason: string = "end-to-end test") {
     const result = summarizer.summarizeOnDemand({ reason });
 
@@ -153,6 +156,7 @@ export async function summarizeNow(summarizer: ISummarizer, reason: string = "en
     return {
         summaryTree: submitResult.data.summaryTree,
         summaryVersion: ackNackResult.data.summaryAckOp.contents.handle,
+        summaryRefSeq: submitResult.data.referenceSequenceNumber,
     };
 }
 


### PR DESCRIPTION
## Bug
When refereshSummaryFromAck is called, if the ack is newer that the currently tracked latest summary, it attempts to download the latest snapshot from the server and update state from it. However, its possible that the snapshot that is downloaded is older than the one corresponding to the received ack because the its downloaded from the cache. The latest summary state will be incorrectly updated from an older summary leading to inconsistent state.

## Fix
When fetching the latest version via getVersions API, pass the `FetchSource.NoCache` parameter which will ensure that the snapshot is always downloaded via a network call and never from cache. If the downloaded snapshot is still older that the received ack, throw an error because this will lead to inconsistent state.

[AB#3139](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3139)