### PR TITLE
Fix deletions in external-data example app

### DIFF
--- a/examples/hosts/app-integration/external-data/src/model/taskList.ts
+++ b/examples/hosts/app-integration/external-data/src/model/taskList.ts
@@ -130,7 +130,7 @@ export class TaskList extends DataObject implements ITaskList {
     };
 
     public readonly deleteTask = (id: string): void => {
-        this.handleTaskDeleted(id);
+        this.draftData.delete(id);
     };
 
     public readonly getTasks = (): Task[] => {
@@ -318,13 +318,13 @@ export class TaskList extends DataObject implements ITaskList {
         }
         this._draftData = await draft.get();
 
-        this.root.on("valueChanged", (changed) => {
+        this._draftData.on("valueChanged", (changed) => {
             if (changed.previousValue === undefined) {
                 // Must be from adding a new task
                 this.handleTaskAdded(changed.key).catch((error) => {
                     console.error(error);
                 });
-            } else if (this.root.get(changed.key) === undefined) {
+            } else if (this.draftData.get(changed.key) === undefined) {
                 // Must be from a deletion
                 this.handleTaskDeleted(changed.key);
             } else {


### PR DESCRIPTION
This PR fixes the deletion behavior, so that two clients will have deletion synced. It does the delete on the draftdata instead of on the root, like this PR incorrectly did: https://github.com/microsoft/FluidFramework/pull/13435