### PR TITLE
Fix event deps on main

### DIFF
--- a/experimental/PropertyDDS/examples/partial-checkout/.eslintrc.js
+++ b/experimental/PropertyDDS/examples/partial-checkout/.eslintrc.js
@@ -25,7 +25,7 @@ module.exports = {
             // Rules only for test files
             files: ["*.spec.ts", "src/test/**"],
             rules: {
-                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                // Test files are run in node only so additional node libraries can be used.
                 "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
 
             },

--- a/experimental/PropertyDDS/examples/partial-checkout/.eslintrc.js
+++ b/experimental/PropertyDDS/examples/partial-checkout/.eslintrc.js
@@ -5,6 +5,7 @@
 
 module.exports = {
     extends: ["@fluidframework/eslint-config-fluid/minimal"],
+
     parserOptions: {
         project: ["./tsconfig.json"],
     },
@@ -14,7 +15,6 @@ module.exports = {
         "unicorn/filename-case": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/unbound-method": "off",
-        "@typescript-eslint/prefer-nullish-coalescing": "off",
 
         // This library is used in the browser, so we don't want dependencies on most node libraries.
         "import/no-nodejs-modules": ["error", { allow: ["events"] }],
@@ -26,6 +26,7 @@ module.exports = {
             rules: {
                 // This library is used in the browser, so we don't want dependencies on most node libraries.
                 "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+
             },
         },
     ],

--- a/experimental/PropertyDDS/examples/partial-checkout/.eslintrc.js
+++ b/experimental/PropertyDDS/examples/partial-checkout/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
         "unicorn/filename-case": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/unbound-method": "off",
+        "@typescript-eslint/prefer-nullish-coalescing": "off",
 
         // This library is used in the browser, so we don't want dependencies on most node libraries.
         "import/no-nodejs-modules": ["error", { allow: ["events"] }],

--- a/experimental/PropertyDDS/examples/partial-checkout/.eslintrc.js
+++ b/experimental/PropertyDDS/examples/partial-checkout/.eslintrc.js
@@ -4,16 +4,29 @@
  */
 
 module.exports = {
-	extends: ["@fluidframework/eslint-config-fluid/minimal"],
-    "parserOptions": {
-        "project": ["./tsconfig.json"]
+    extends: ["@fluidframework/eslint-config-fluid/minimal"],
+    parserOptions: {
+        project: ["./tsconfig.json"],
     },
-	rules: {
-		"@typescript-eslint/strict-boolean-expressions": "off",
+    rules: {
+        "@typescript-eslint/strict-boolean-expressions": "off",
         "import/no-internal-modules": "off",
         "unicorn/filename-case": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/unbound-method": "off",
         "@typescript-eslint/prefer-nullish-coalescing": "off",
-	},
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+            },
+        },
+    ],
 };

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -71,6 +71,7 @@
     "@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/view-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@types/uuid": "^8.3.0",
+    "events": "^3.1.0",
     "jsonwebtoken": "^8.4.0",
     "lodash": "^4.17.21",
     "react": "^17.0.1",

--- a/experimental/PropertyDDS/examples/property-inspector/.eslintrc.js
+++ b/experimental/PropertyDDS/examples/property-inspector/.eslintrc.js
@@ -5,6 +5,7 @@
 
 module.exports = {
     extends: ["@fluidframework/eslint-config-fluid/minimal"],
+
     parserOptions: {
         project: ["./tsconfig.json"],
     },

--- a/experimental/PropertyDDS/examples/property-inspector/.eslintrc.js
+++ b/experimental/PropertyDDS/examples/property-inspector/.eslintrc.js
@@ -5,8 +5,8 @@
 
 module.exports = {
     extends: ["@fluidframework/eslint-config-fluid/minimal"],
-    "parserOptions": {
-        "project": ["./tsconfig.json"]
+    parserOptions: {
+        project: ["./tsconfig.json"],
     },
     rules: {
         "@typescript-eslint/strict-boolean-expressions": "off",
@@ -14,6 +14,9 @@ module.exports = {
         "unicorn/filename-case": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/unbound-method": "off",
-        "import/no-unassigned-import": "off"
+        "import/no-unassigned-import": "off",
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
     },
 };

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -73,6 +73,7 @@
     "@material-ui/lab": "4.0.0-alpha.61",
     "@material-ui/styles": "4.11.5",
     "@types/uuid": "^8.3.0",
+    "events": "^3.1.0",
     "jsonwebtoken": "^8.4.0",
     "lodash": "^4.17.21",
     "react": "^17.0.1",

--- a/experimental/framework/data-objects/.eslintrc.js
+++ b/experimental/framework/data-objects/.eslintrc.js
@@ -4,13 +4,24 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+    parserOptions: {
+        project: ["./tsconfig.json"],
     },
-    "rules": {
-        "@typescript-eslint/strict-boolean-expressions": "off"
-    }
-}
+    rules: {
+        "@typescript-eslint/strict-boolean-expressions": "off",
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+            },
+        },
+    ],
+};

--- a/experimental/framework/data-objects/.eslintrc.js
+++ b/experimental/framework/data-objects/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
             // Rules only for test files
             files: ["*.spec.ts", "src/test/**"],
             rules: {
-                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                // Test files are run in node only so additional node libraries can be used.
                 "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
             },
         },

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -37,7 +37,8 @@
     "@fluidframework/common-utils": "^1.0.0",
     "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/map": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+    "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+    "events": "^3.1.0"
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.7.0",

--- a/packages/common/container-definitions/.eslintrc.js
+++ b/packages/common/container-definitions/.eslintrc.js
@@ -4,12 +4,22 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
-        "prettier"
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/types/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/types/tsconfig.json"],
     },
-    "rules": {}
-}
+    rules: {
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+            },
+        },
+    ],
+};

--- a/packages/common/container-definitions/.eslintrc.js
+++ b/packages/common/container-definitions/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
             // Rules only for test files
             files: ["*.spec.ts", "src/test/**"],
             rules: {
-                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                // Test files are run in node only so additional node libraries can be used.
                 "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
 
             },

--- a/packages/common/container-definitions/.eslintrc.js
+++ b/packages/common/container-definitions/.eslintrc.js
@@ -5,6 +5,7 @@
 
 module.exports = {
     extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+
     parserOptions: {
         project: ["./tsconfig.json", "./src/test/types/tsconfig.json"],
     },
@@ -19,6 +20,7 @@ module.exports = {
             rules: {
                 // This library is used in the browser, so we don't want dependencies on most node libraries.
                 "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+
             },
         },
     ],

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -43,7 +43,8 @@
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/protocol-definitions": "^1.1.0"
+    "@fluidframework/protocol-definitions": "^1.1.0",
+    "events": "^3.1.0"
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.7.0",

--- a/packages/dds/matrix/.eslintrc.js
+++ b/packages/dds/matrix/.eslintrc.js
@@ -5,6 +5,7 @@
 
 module.exports = {
     extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+
     parserOptions: {
         project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
@@ -22,6 +23,7 @@ module.exports = {
             rules: {
                 // Test files are run in node only so additional node libraries can be used.
                 "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+
             },
         },
     ],

--- a/packages/dds/matrix/.eslintrc.js
+++ b/packages/dds/matrix/.eslintrc.js
@@ -4,14 +4,25 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    "rules": {
+    rules: {
         "@typescript-eslint/no-shadow": "off",
         "space-before-function-paren": "off", // Off because it conflicts with typescript-formatter
-    }
-}
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // Test files are run in node only so additional node libraries can be used.
+                "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+            },
+        },
+    ],
+};

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -76,6 +76,7 @@
     "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@tiny-calc/nano": "0.0.0-alpha.5",
+    "events": "^3.1.0",
     "tslib": "^1.10.0"
   },
   "devDependencies": {

--- a/packages/dds/quorum/.eslintrc.js
+++ b/packages/dds/quorum/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
             // Rules only for test files
             files: ["*.spec.ts", "src/test/**"],
             rules: {
-                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                // Test files are run in node only so additional node libraries can be used.
                 "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
 
             },

--- a/packages/dds/quorum/.eslintrc.js
+++ b/packages/dds/quorum/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
             rules: {
                 // This library is used in the browser, so we don't want dependencies on most node libraries.
                 "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+
             },
         },
     ],

--- a/packages/dds/quorum/.eslintrc.js
+++ b/packages/dds/quorum/.eslintrc.js
@@ -4,12 +4,22 @@
  */
 
 module.exports = {
-    "extends": [
-        "@fluidframework/eslint-config-fluid/strict",
-        "prettier"
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: ["@fluidframework/eslint-config-fluid/strict", "prettier"],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    "rules": { }
-}
+    rules: {
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+            },
+        },
+    ],
+};

--- a/packages/dds/quorum/package.json
+++ b/packages/dds/quorum/package.json
@@ -68,7 +68,8 @@
     "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/protocol-definitions": "^1.1.0",
     "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+    "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+    "events": "^3.1.0"
   },
   "devDependencies": {
     "@fluid-internal/test-dds-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",

--- a/packages/dds/task-manager/.eslintrc.js
+++ b/packages/dds/task-manager/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
             files: ["*.spec.ts", "src/test/**"],
             rules: {
                 // This library is used in the browser, so we don't want dependencies on most node libraries.
-                "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+                "import/no-nodejs-modules": ["error", { allow: ["assert", "events", "fs", "path"] }],
             },
         },
     ],

--- a/packages/dds/task-manager/.eslintrc.js
+++ b/packages/dds/task-manager/.eslintrc.js
@@ -4,11 +4,22 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
-        "prettier"
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-}
+    rules: {
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+            },
+        },
+    ],
+};

--- a/packages/dds/task-manager/.eslintrc.js
+++ b/packages/dds/task-manager/.eslintrc.js
@@ -5,6 +5,7 @@
 
 module.exports = {
     extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+
     parserOptions: {
         project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },

--- a/packages/dds/task-manager/.eslintrc.js
+++ b/packages/dds/task-manager/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
             // Rules only for test files
             files: ["*.spec.ts", "src/test/**"],
             rules: {
-                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                // Test files are run in node only so additional node libraries can be used.
                 "import/no-nodejs-modules": ["error", { allow: ["assert", "events", "fs", "path"] }],
             },
         },

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -71,7 +71,8 @@
     "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/protocol-definitions": "^1.1.0",
     "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+    "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+    "events": "^3.1.0"
   },
   "devDependencies": {
     "@fluid-experimental/task-manager-previous": "npm:@fluid-experimental/task-manager@2.0.0-internal.2.1.0",

--- a/packages/drivers/iframe-driver/.eslintrc.js
+++ b/packages/drivers/iframe-driver/.eslintrc.js
@@ -4,11 +4,18 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid/minimal"),
-        "prettier"
-    ],
-    "rules": {
+    extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+    rules: {
         "@typescript-eslint/strict-boolean-expressions": "off",
-    }
-}
+    },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+            },
+        },
+    ],
+};

--- a/packages/drivers/iframe-driver/.eslintrc.js
+++ b/packages/drivers/iframe-driver/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
     extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
     rules: {
         "@typescript-eslint/strict-boolean-expressions": "off",
+
     },
     overrides: [
         {
@@ -15,6 +16,7 @@ module.exports = {
             rules: {
                 // This library is used in the browser, so we don't want dependencies on most node libraries.
                 "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+
             },
         },
     ],

--- a/packages/drivers/iframe-driver/.eslintrc.js
+++ b/packages/drivers/iframe-driver/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
             // Rules only for test files
             files: ["*.spec.ts", "src/test/**"],
             rules: {
-                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                // Test files are run in node only so additional node libraries can be used.
                 "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
 
             },

--- a/packages/drivers/iframe-driver/package.json
+++ b/packages/drivers/iframe-driver/package.json
@@ -43,7 +43,8 @@
     "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/protocol-definitions": "^1.1.0",
     "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "comlink": "^4.3.0"
+    "comlink": "^4.3.0",
+    "events": "^3.1.0"
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.7.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -71,6 +71,7 @@
     "@fluidframework/server-services-core": "^0.1038.2000",
     "@fluidframework/server-test-utils": "^0.1038.2000",
     "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+    "events": "^3.1.0",
     "jsrsasign": "^10.5.25",
     "url": "^0.11.0",
     "uuid": "^8.3.1"

--- a/packages/framework/undo-redo/.eslintrc.js
+++ b/packages/framework/undo-redo/.eslintrc.js
@@ -5,6 +5,7 @@
 
 module.exports = {
     extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+
     parserOptions: {
         project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
@@ -22,6 +23,7 @@ module.exports = {
             rules: {
                 // Test files are run in node only so additional node libraries can be used.
                 "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+
             },
         },
     ],

--- a/packages/framework/undo-redo/.eslintrc.js
+++ b/packages/framework/undo-redo/.eslintrc.js
@@ -4,14 +4,25 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    "rules": {
+    rules: {
         "@typescript-eslint/no-use-before-define": "off",
-        "no-case-declarations": "off"
-    }
-}
+        "no-case-declarations": "off",
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // Test files are run in node only so additional node libraries can be used.
+                "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+            },
+        },
+    ],
+};

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -65,7 +65,8 @@
     "@fluidframework/map": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/matrix": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/merge-tree": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/sequence": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+    "@fluidframework/sequence": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+    "events": "^3.1.0"
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.7.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -75,8 +75,8 @@
     "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "abort-controller": "^3.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "lodash": "^4.17.21",
     "events": "^3.1.0",
+    "lodash": "^4.17.21",
     "url": "^0.11.0",
     "uuid": "^8.3.1"
   },

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -76,6 +76,7 @@
     "abort-controller": "^3.0.0",
     "double-ended-queue": "^2.1.0-0",
     "lodash": "^4.17.21",
+    "events": "^3.1.0",
     "url": "^0.11.0",
     "uuid": "^8.3.1"
   },

--- a/packages/runtime/container-runtime/.eslintrc.js
+++ b/packages/runtime/container-runtime/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
             // Rules only for test files
             files: ["*.spec.ts", "src/test/**"],
             rules: {
-                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                // Test files are run in node only so additional node libraries can be used.
                 "import/no-nodejs-modules": ["error", { allow: ["assert", "crypto", "events"] }],
             },
         },

--- a/packages/runtime/container-runtime/.eslintrc.js
+++ b/packages/runtime/container-runtime/.eslintrc.js
@@ -4,13 +4,24 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"
-    ],
-    "parserOptions": {
-        "project": ["./tsconfig.json", "./src/test/tsconfig.json"]
+    extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+    parserOptions: {
+        project: ["./tsconfig.json", "./src/test/tsconfig.json"],
     },
-    "rules": {
+    rules: {
         "@typescript-eslint/strict-boolean-expressions": "off",
-    }
-}
+
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+            },
+        },
+    ],
+};

--- a/packages/runtime/container-runtime/.eslintrc.js
+++ b/packages/runtime/container-runtime/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
             files: ["*.spec.ts", "src/test/**"],
             rules: {
                 // This library is used in the browser, so we don't want dependencies on most node libraries.
-                "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+                "import/no-nodejs-modules": ["error", { allow: ["assert", "crypto", "events"] }],
             },
         },
     ],

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -79,6 +79,7 @@
     "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "double-ended-queue": "^2.1.0-0",
+    "events": "^3.1.0",
     "lz4js": "^0.2.0",
     "uuid": "^8.3.1"
   },

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -73,6 +73,7 @@
     "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "axios": "^0.26.0",
+    "events": "^3.1.0",
     "jsrsasign": "^10.5.25",
     "uuid": "^8.3.1"
   },

--- a/packages/test/functional-tests/.eslintrc.js
+++ b/packages/test/functional-tests/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
             // Rules only for test files
             files: ["*.spec.ts", "src/test/**"],
             rules: {
-                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                // Test files are run in node only so additional node libraries can be used.
                 "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
             },
         },

--- a/packages/test/functional-tests/.eslintrc.js
+++ b/packages/test/functional-tests/.eslintrc.js
@@ -4,10 +4,19 @@
  */
 
 module.exports = {
-    "extends": [
-        require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"
+    extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+    rules: {
+        // This library is used in the browser, so we don't want dependencies on most node libraries.
+        "import/no-nodejs-modules": ["error", { allow: ["events"] }],
+    },
+    overrides: [
+        {
+            // Rules only for test files
+            files: ["*.spec.ts", "src/test/**"],
+            rules: {
+                // This library is used in the browser, so we don't want dependencies on most node libraries.
+                "import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+            },
+        },
     ],
-    "rules": {
-        "import/no-nodejs-modules": "off",
-    }
-}
+};

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -56,6 +56,9 @@
     ],
     "temp-directory": "nyc/.nyc_output"
   },
+  "dependencies": {
+    "events": "^3.1.0"
+  },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.7.0",
     "@fluidframework/build-common": "^1.1.0",


### PR DESCRIPTION
Affects the following packages:

@fluid-experimental/partial-checkout
@fluid-experimental/property-inspector
@fluid-experimental/data-objects
@fluidframework/container-definitions
@fluidframework/matrix
@fluid-experimental/quorum
@fluid-experimental/task-manager
@fluidframework/iframe-driver
@fluidframework/local-driver
@fluidframework/undo-redo
@fluidframework/container-loader
@fluidframework/container-runtime
@fluidframework/test-runtime-utils - already has import/no-nodejs-modules rule
@fluid-internal/functional-tests