### PR TITLE
Fix for GC tests that load from old summaries not working for ODSP

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
@@ -11,8 +11,8 @@ import { IContainerRuntime } from "@fluidframework/container-runtime-definitions
 import { SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
+    createSummarizerWithContainer,
     ITestObjectProvider,
-    createSummarizer,
     summarizeNow,
     waitForContainerConnection,
 } from "@fluidframework/test-utils";
@@ -32,6 +32,14 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
     let mainContainer: IContainer;
     let containerRuntime: IContainerRuntime;
     let dataStoreA: ITestDataObject;
+
+    /**
+     * Creates a summarizer with the given summary version and returns the IContainer along with the ISummarizer.
+     */
+    async function createSummarizerAndContainer(summaryVersion?: string) {
+        const url = await mainContainer.getAbsoluteUrl("");
+        return createSummarizerWithContainer(provider, url, summaryVersion);
+    }
 
     /**
      * Returns the reference state for all the nodes in the given summary tree.
@@ -75,6 +83,21 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         return (metadata.message as ISequencedDocumentMessage).sequenceNumber;
     }
 
+    /**
+     * Reconnects the summarizer so that it is elected as the current summarizer. This is needed for two reasons:
+     * 1. In ODSP, when a summary is submitted, the previous one may be deleted based on heuristics. Since these tests
+     * need to load a container from an older summary, we need to load a summarizer with the old summary before a new
+     * one is generated. This poses problem with summarizer election because of the second reason below.
+     * 2. In these tests, summarization is disabled on the main container. However, when the first summarizer container
+     * is closed, the main container is still chosen as the summarizer due to a bug. If we reconnect a new summarizer
+     * after this happens, it will be chosen as the summarizer client and can do on-demand summaries.
+     */
+    async function reconnectSummarizerToBeElected(container: IContainer) {
+        container.disconnect();
+        container.connect();
+        await waitForContainerConnection(container);
+    }
+
     beforeEach(async function() {
         provider = getTestObjectProvider({ syncSummarizer: true });
         mainContainer = await provider.makeTestContainer(defaultGCConfig);
@@ -95,7 +118,7 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
     });
 
     it("updates referenced nodes correctly when loading from an older summary", async () => {
-        const summarizer1 = await createSummarizer(provider, mainContainer);
+        const { summarizer: summarizer1 } = await createSummarizerAndContainer();
 
         // Create a data store and mark it unreferenced to begin with.
         const dataStoreBHandle =
@@ -115,6 +138,11 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         const dsBReferenceState1 = referenceState1.get(dataStoreB._context.id);
         assert(dsBReferenceState1 === false, `dataStoreB should be unreferenced`);
 
+        // Create a second summarizer with summary1. Note that this is done before posting another summary because ODSP
+        // may delete this summary when a new one is posted.
+        const { container: container2, summarizer: summarizer2 } =
+            await createSummarizerAndContainer(summaryResult1.summaryVersion);
+
         // Reference dataStoreB now.
         dataStoreA._root.set("dataStoreB", dataStoreB.handle);
 
@@ -123,23 +151,25 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         const summaryResult2 = await summarizeNow(summarizer1);
         const referenceState2 = await getReferenceState(summaryResult2.summaryTree);
         const dsAReferenceState2 = referenceState2.get(dataStoreA._context.id);
-        assert(dsAReferenceState2 === true, `dataStoreA should still be referenced`);
+        assert(dsAReferenceState2 === true, `dataStoreA should still be referenced (1)`);
         const dsBReferenceState2 = referenceState2.get(dataStoreB._context.id);
         assert(dsBReferenceState2 === true, `dataStoreB should be referenced now`);
 
-        // Load a new summarizer from the summary1 and summarize - summary3. Before it summarizes, it will catch up
-        // to latest and so the reference state of the data stores should be the same as in summary2.
-        // Also, note that while catching up, it will download summary2 and update state from it.
+        // Close the first summarizer and reconnect the second one. The reconnection is necessary so that it is elected
+        // as the new summarizer.
         summarizer1.close();
-        const summarizer2 = await createSummarizer(provider, mainContainer, summaryResult1.summaryVersion);
+        await reconnectSummarizerToBeElected(container2);
 
         // Create a new alias data store so that the GC data changes without changing the GC state of existing data
         // stores. This is to write the GC tree in summary (instead of handle) which is used for validation.
         const ds2 = await containerRuntime.createDataStore(TestDataObjectType);
         const aliasResult = await ds2.trySetAlias("root2");
         assert.strictEqual(aliasResult, "Success", "Failed to alias data store");
-
         await provider.ensureSynchronized();
+
+        // Summarize - summary3 with the new summarizer. Before it summarizes, it will catch up to latest and so the
+        // reference state of the data stores should be the same as in summary2.
+        // Also, note that while catching up, it will download summary2 and update state from it.
         const summaryResult3 = await summarizeNow(summarizer2);
 
         // Validate that summary3 is same or newer than summary2. This is to ensure that it has the latest GC state.
@@ -150,13 +180,13 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         // Validate that dataStoreB is still referenced in this summary.
         const referenceState3 = await getReferenceState(summaryResult3.summaryTree);
         const dsAReferenceState3 = referenceState3.get(dataStoreA._context.id);
-        assert(dsAReferenceState3 === true, `dataStoreA should still be referenced`);
+        assert(dsAReferenceState3 === true, `dataStoreA should still be referenced (2)`);
         const dsBReferenceState3 = referenceState3.get(dataStoreB._context.id);
         assert(dsBReferenceState3 === true, `dataStoreB should still be referenced on loading from old summary`);
     });
 
     it("updates unreferenced nodes correctly when loading from an older summary", async () => {
-        const summarizer1 = await createSummarizer(provider, mainContainer);
+        const { summarizer: summarizer1 } = await createSummarizerAndContainer();
 
         // Create a data store and mark it referenced to begin with.
         const dataStoreBHandle =
@@ -175,6 +205,11 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         const dsBReferenceState1 = referenceState1.get(dataStoreB._context.id);
         assert(dsBReferenceState1 === true, `dataStoreB should be referenced`);
 
+        // Create a second summarizer with summary1. Note that this is done before posting another summary because ODSP
+        // may delete this summary when a new one is posted.
+        const { container: container2, summarizer: summarizer2 } =
+            await createSummarizerAndContainer(summaryResult1.summaryVersion);
+
         // Unreference dataStoreB now.
         dataStoreA._root.delete("dataStoreB");
 
@@ -183,23 +218,25 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         const summaryResult2 = await summarizeNow(summarizer1);
         const referenceState2 = await getReferenceState(summaryResult2.summaryTree);
         const dsAReferenceState2 = referenceState2.get(dataStoreA._context.id);
-        assert(dsAReferenceState2 === true, `dataStoreA should still be referenced`);
+        assert(dsAReferenceState2 === true, `dataStoreA should still be referenced (1)`);
         const dsBReferenceState2 = referenceState2.get(dataStoreB._context.id);
         assert(dsBReferenceState2 === false, `dataStoreB should be unreferenced now`);
 
-        // Load a new summarizer from the summary1 and summarize - summary3. Before it summarizes, it will catch up
-        // to latest and so the reference state of the data stores should be the same as in summary2.
-        // Also, note that while catching up, it will download summary2 and update state from it.
+        // Close the first summarizer and reconnect the second one. The reconnection is necessary so that it is elected
+        // as the new summarizer.
         summarizer1.close();
-        const summarizer2 = await createSummarizer(provider, mainContainer, summaryResult1.summaryVersion);
+        await reconnectSummarizerToBeElected(container2);
 
         // Create a new alias data store so that the GC data changes without changing the GC state of existing data
         // stores. This is to write the GC tree in summary (instead of handle) which is used for validation.
         const ds2 = await containerRuntime.createDataStore(TestDataObjectType);
         const aliasResult = await ds2.trySetAlias("root2");
         assert.strictEqual(aliasResult, "Success", "Failed to alias data store");
-
         await provider.ensureSynchronized();
+
+        // Summarize - summary3 with the new summarizer. Before it summarizes, it will catch up to latest and so the
+        // reference state of the data stores should be the same as in summary2.
+        // Also, note that while catching up, it will download summary2 and update state from it.
         const summaryResult3 = await summarizeNow(summarizer2);
 
         // Validate that summary3 is same or newer than summary2. This is to ensure that it has the latest GC state.
@@ -210,7 +247,7 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         // Validate that dataStoreB is still unreferenced in this summary.
         const referenceState3 = await getReferenceState(summaryResult3.summaryTree);
         const dsAReferenceState3 = referenceState3.get(dataStoreA._context.id);
-        assert(dsAReferenceState3 === true, `dataStoreA should still be referenced`);
+        assert(dsAReferenceState3 === true, `dataStoreA should still be referenced (2)`);
         const dsBReferenceState3 = referenceState3.get(dataStoreB._context.id);
         assert(
             dsBReferenceState3 === false, `dataStoreB should still be unreferenced on loading from old summary`);
@@ -222,7 +259,7 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
      * in older summary is correctly propagated to DDS as well.
      */
     it("updates unreferenced nodes correctly when DDS is unchanged after loading from older summary", async () => {
-        const summarizer1 = await createSummarizer(provider, mainContainer);
+        const { summarizer: summarizer1 } = await createSummarizerAndContainer();
 
         // Create a second DDS in dataStoreA. This will be changed after loading from old summary so that the data store
         // changes but the root DDS containing references is unchanged.
@@ -246,6 +283,11 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         const dsBReferenceState1 = referenceState1.get(dataStoreB._context.id);
         assert(dsBReferenceState1 === false, `dataStoreB should be unreferenced`);
 
+        // Create a second summarizer with summary1. Note that this is done before posting another summary because ODSP
+        // may delete this summary when a new one is posted.
+        const { container: container2, summarizer: summarizer2 } =
+            await createSummarizerAndContainer(summaryResult1.summaryVersion);
+
         // Reference dataStoreB now.
         dataStoreA._root.set("dataStoreB", dataStoreB.handle);
 
@@ -254,15 +296,14 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         const summaryResult2 = await summarizeNow(summarizer1);
         const referenceState2 = await getReferenceState(summaryResult2.summaryTree);
         const dsAReferenceState2 = referenceState2.get(dataStoreA._context.id);
-        assert(dsAReferenceState2 === true, `dataStoreA should still be referenced`);
+        assert(dsAReferenceState2 === true, `dataStoreA should still be referenced (1)`);
         const dsBReferenceState2 = referenceState2.get(dataStoreB._context.id);
         assert(dsBReferenceState2 === true, `dataStoreB should now be referenced`);
 
-        // Load a new summarizer from the summary1 and summarize - summary3. Before it summarizes, it will catch up
-        // to latest and so the reference state of the data stores should be the same as in summary2.
-        // Also, note that while catching up, it will download summary2 and update state from it.
+        // Close the first summarizer and reconnect the second one. The reconnection is necessary so that it is elected
+        // as the new summarizer.
         summarizer1.close();
-        const summarizer2 = await createSummarizer(provider, mainContainer, summaryResult1.summaryVersion);
+        await reconnectSummarizerToBeElected(container2);
 
         // Create a new alias data store so that the GC data changes without changing the GC state of existing data
         // stores. This is to write the GC tree in summary (instead of handle) which is used for validation.
@@ -273,8 +314,11 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         // Change the second DDS in dataStoreA. This will change dataStoreA but the root DDS that contains references
         // to dataStoreB is unchanged.
         dataStoreAdds2.set("key", "value");
-
         await provider.ensureSynchronized();
+
+        // Summarize - summary3 with the new summarizer. Before it summarizes, it will catch up to latest and so the
+        // reference state of the data stores should be the same as in summary2.
+        // Also, note that while catching up, it will download summary2 and update state from it.
         const summaryResult3 = await summarizeNow(summarizer2);
 
         // Validate that summary3 is same or newer than summary2. This is to ensure that it has the latest GC state.
@@ -285,13 +329,13 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         // Validate that dataStoreB is still referenced in this summary.
         const referenceState3 = await getReferenceState(summaryResult3.summaryTree);
         const dsAReferenceState3 = referenceState3.get(dataStoreA._context.id);
-        assert(dsAReferenceState3 === true, `dataStoreA should still be referenced`);
+        assert(dsAReferenceState3 === true, `dataStoreA should still be referenced (2)`);
         const dsBReferenceState3 = referenceState3.get(dataStoreB._context.id);
         assert(dsBReferenceState3 === true, `dataStoreB should still be referenced on loading from old summary`);
     });
 
     it("updates unreferenced timestamps correctly when loading from an older summary", async () => {
-        const summarizer1 = await createSummarizer(provider, mainContainer);
+        const { summarizer: summarizer1 } = await createSummarizerAndContainer();
 
         // Create a data store and mark it unreferenced to begin with.
         const dataStoreBHandle =
@@ -309,6 +353,11 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         const dsBTime1 = unreferencedTimestamps1.get(dataStoreB._context.id);
         assert(dsBTime1 !== undefined, `dataStoreB should have unreferenced timestamp`);
 
+        // Create a second summarizer with summary1. Note that this is done before posting another summary because ODSP
+        // may delete this summary when a new one is posted.
+        const { container: container2, summarizer: summarizer2 } =
+            await createSummarizerAndContainer(summaryResult1.summaryVersion);
+
         // Reference and unreference dataStoreB.
         dataStoreA._root.set("dataStoreB", dataStoreB.handle);
         dataStoreA._root.delete("dataStoreB");
@@ -320,19 +369,21 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         const dsBTime2 = unreferencedTimestamps2.get(dataStoreB._context.id);
         assert(dsBTime2 !== undefined && dsBTime2 > dsBTime1, `dataStoreB's time should have updated`);
 
-        // Load a new summarizer from the summary1 and summarize - summary3. Before it summarizes, it will catch up
-        // to latest and so the reference state of the data stores should be the same as in summary2.
-        // Also, note that while catching up, it will download summary2 and update state from it.
+        // Close the first summarizer and reconnect the second one. The reconnection is necessary so that it is elected
+        // as the new summarizer.
         summarizer1.close();
-        const summarizer2 = await createSummarizer(provider, mainContainer, summaryResult1.summaryVersion);
+        await reconnectSummarizerToBeElected(container2);
 
         // Create a new alias data store so that the GC data changes without changing the GC state of existing data
         // stores. This is to write the GC tree in summary (instead of handle) which is used for validation.
         const ds2 = await containerRuntime.createDataStore(TestDataObjectType);
         const aliasResult = await ds2.trySetAlias("root2");
         assert.strictEqual(aliasResult, "Success", "Failed to alias data store");
-
         await provider.ensureSynchronized();
+
+        // Summarize - summary3 with the new summarizer. Before it summarizes, it will catch up to latest and so the
+        // reference state of the data stores should be the same as in summary2.
+        // Also, note that while catching up, it will download summary2 and update state from it.
         const summaryResult3 = await summarizeNow(summarizer2);
 
         // Validate that summary3 is same or newer than summary2. This is to ensure that it has the latest GC state.
@@ -347,7 +398,7 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
     });
 
     it("does not log gcUnknownOutboundReferences errors when loading from an older summary", async () => {
-        const summarizer1 = await createSummarizer(provider, mainContainer);
+        const { summarizer: summarizer1 } = await createSummarizerAndContainer();
 
         // Create a data store and mark it unreferenced to begin with.
         const dataStoreBHandle =
@@ -367,6 +418,11 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         const dsBReferenceState1 = referenceState1.get(dataStoreB._context.id);
         assert(dsBReferenceState1 === false, `dataStoreB should be unreferenced`);
 
+        // Create a second summarizer with summary1. Note that this is done before posting another summary because ODSP
+        // may delete this summary when a new one is posted.
+        const { container: container2, summarizer: summarizer2 } =
+            await createSummarizerAndContainer(summaryResult1.summaryVersion);
+
         // Reference dataStoreB. This should result in an explicit reference from dataStoreA -> dataStoreB.
         dataStoreA._root.set("dataStoreB", dataStoreB.handle);
 
@@ -377,13 +433,15 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
         const dsBTime2 = unreferencedTimestamps2.get(dataStoreB._context.id);
         assert(dsBTime2 === undefined, `dataStoreB's time should have updated`);
 
-        // Load a new summarizer from the summary1 and summarize - summary3. Before it summarizes, it will catch up
-        // to latest and so the reference state of the data stores should be the same as in summary2.
-        // Also, note that while catching up, it will download summary2 and update state from it.
+        // Close the first summarizer and reconnect the second one. The reconnection is necessary so that it is elected
+        // as the new summarizer.
         summarizer1.close();
-        const summarizer2 = await createSummarizer(provider, mainContainer, summaryResult1.summaryVersion);
+        await reconnectSummarizerToBeElected(container2);
         await provider.ensureSynchronized();
 
+        // Summarize - summary3 with the new summarizer. Before it summarizes, it will catch up to latest and so the
+        // reference state of the data stores should be the same as in summary2.
+        // Also, note that while catching up, it will download summary2 and update state from it.
         // When GC runs as part of this summarize, it should not throw "gcUnknownOutboundReferences" error for the
         // dataStoreA -> dataStoreB route.
         const summaryResult3 = await summarizeNow(summarizer2);

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -40,7 +40,6 @@ async function createSummarizerCore(absoluteUrl: string | undefined, loader: IHo
                 type: summarizerClientType,
             },
             [DriverHeader.summarizingClient]: true,
-            [LoaderHeader.reconnect]: false,
             [LoaderHeader.version]: summaryVersion,
         },
         url: absoluteUrl,


### PR DESCRIPTION
## Bug
The GC tests in `gcLoadingFromOlderSummaries.spec.ts` validate that when summarizer loads from an older summary and refreshing is state from a later summary ack, things work as expected. In ODSP, when a summary is uploaded the previous summary may get deleted as they only keep around 2 summaries for a document.
The tests generated 2 summaries (s1 and s2) and then loaded a summarizer container from the s1. ODSP deletes s1 when s2 is submitted so the container loads fails.

## Fix
Load the container from a summary before submitting another summary. In the above scenario, load the summarizer container from s1 before s2 is submitted. However, this results in another problem where the new summarizer container is not chosen as the summarizer due to another bug. To work around this issue, after the first summarizer is closed, disconnect and reconnect the new summarizer. This adds the summarizer to the quorum which results in summarizer election where its elected.

[AB#3103](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3103)