### PR TITLE
refactor: Update client-debugger tests to not require background Tinylicious service

### DIFF
--- a/packages/tools/client-debugger/client-debugger/package.json
+++ b/packages/tools/client-debugger/client-debugger/package.json
@@ -33,13 +33,10 @@
     "lint:fix": "npm run prettier:fix && npm run eslint:fix",
     "prettier": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "start:tinylicious": "tinylicious",
-    "test": "npm run test:realsvc",
-    "test:coverage": "start-server-and-test start:tinylicious 7070 test:realsvc:coverage",
-    "test:realsvc": "start-server-and-test start:tinylicious 7070 test:realsvc:run",
-    "test:realsvc:coverage": "npm run test:realsvc:run:coverage",
-    "test:realsvc:run": "mocha dist/**/*.test.js --unhandled-rejections=strict --exit",
-    "test:realsvc:run:coverage": "nyc npm run mocha -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
+    "test": "npm run test:mocha",
+    "test:coverage": "npm run test:mocha:coverage",
+    "test:mocha": "mocha dist/**/*.test.js --unhandled-rejections=strict --exit",
+    "test:mocha:coverage": "nyc npm run mocha -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
     "tsc": "tsc"
   },
   "nyc": {
@@ -73,8 +70,8 @@
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
+    "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/fluid-static": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@types/chai": "^4.0.0",
@@ -91,7 +88,6 @@
     "rimraf": "^2.6.2",
     "start-server-and-test": "^1.11.7",
     "style-loader": "^1.0.0",
-    "tinylicious": "0.5.0",
     "typescript": "~4.5.5"
   }
 }

--- a/packages/tools/client-debugger/client-debugger/package.json
+++ b/packages/tools/client-debugger/client-debugger/package.json
@@ -68,18 +68,14 @@
     "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/container-loader": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/protocol-definitions": "^1.1.0"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.7.0",
-    "@fluidframework/counter": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/fluid-static": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/test-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-    "@fluidframework/tinylicious-client": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@types/chai": "^4.0.0",
     "@types/mocha": "^9.1.1",

--- a/packages/tools/client-debugger/client-debugger/package.json
+++ b/packages/tools/client-debugger/client-debugger/package.json
@@ -86,8 +86,6 @@
     "nyc": "^15.0.0",
     "prettier": "~2.6.2",
     "rimraf": "^2.6.2",
-    "start-server-and-test": "^1.11.7",
-    "style-loader": "^1.0.0",
     "typescript": "~4.5.5"
   }
 }

--- a/packages/tools/client-debugger/client-debugger/src/test/ClientDebugger.test.ts
+++ b/packages/tools/client-debugger/client-debugger/src/test/ClientDebugger.test.ts
@@ -2,112 +2,52 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
 import { expect } from "chai";
 
-import { SharedCounter } from "@fluidframework/counter";
-import { ContainerSchema, FluidContainer, IFluidContainer } from "@fluidframework/fluid-static";
-import {
-    TinyliciousClient,
-    TinyliciousContainerServices,
-} from "@fluidframework/tinylicious-client";
+import { IContainer } from "@fluidframework/container-definitions";
 
 import { IFluidClientDebugger } from "../IFluidClientDebugger";
 import {
-    FluidClientDebuggerProps,
     clearDebuggerRegistry,
     closeFluidClientDebugger,
     getDebuggerRegistry,
     getFluidClientDebugger,
     initializeFluidClientDebugger,
 } from "../Registry";
+import { createMockContainer } from "./Utilities";
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-/**
- * Type returned from when creating / loading the Container.
- */
-interface ContainerLoadResult {
-    container: IFluidContainer;
-    services: TinyliciousContainerServices;
-}
-
-/**
- * Schema used by the app.
- */
-const containerSchema: ContainerSchema = {
-    initialObjects: {
-        counter: SharedCounter,
-    },
-};
-
 describe("ClientDebugger unit tests", () => {
-    let _debuggerProps: FluidClientDebuggerProps | undefined;
+    const containerId = "test-container-id";
+    let container: IContainer | undefined;
 
     beforeEach(async () => {
-        const client = new TinyliciousClient();
-
-        // Create the container
-        console.log("Creating new container...");
-        let createContainerResult: ContainerLoadResult;
-        try {
-            createContainerResult = await client.createContainer(containerSchema);
-        } catch (error) {
-            console.error(`Encountered error creating Fluid container: "${error}".`);
-            throw error;
-        }
-        console.log("Container created!");
-
-        const { container: tinyliciousContainer } = createContainerResult;
-
-        // Attach container
-        let containerId: string;
-        console.log("Awaiting container attach...");
-        try {
-            containerId = await tinyliciousContainer.attach();
-        } catch (error) {
-            console.error(`Encountered error attaching Fluid container: "${error}".`);
-            throw error;
-        }
-        console.log("Fluid container attached!");
-
-        _debuggerProps = {
-            containerId,
-            container: (tinyliciousContainer as FluidContainer).INTERNAL_CONTAINER_DO_NOT_USE!(),
-            containerData: tinyliciousContainer.initialObjects,
-        };
+        container = createMockContainer();
     });
 
     afterEach(() => {
         clearDebuggerRegistry();
     });
 
-    function getDebuggerProps(): FluidClientDebuggerProps {
-        if (_debuggerProps === undefined) {
-            expect.fail("Container initialization failed.");
-        }
-        return _debuggerProps;
-    }
-
-    function initializeDebugger(props: FluidClientDebuggerProps): IFluidClientDebugger {
-        initializeFluidClientDebugger(props);
-        return getFluidClientDebugger(props.containerId)!;
+    function initializeDebugger(): IFluidClientDebugger {
+        initializeFluidClientDebugger({ container: container!, containerId });
+        return getFluidClientDebugger(containerId)!;
     }
 
     it("Initializing debugger populates global (window) registry", () => {
         let debuggerRegistry = getDebuggerRegistry();
         expect(debuggerRegistry.size).to.equal(0); // There should be no registered debuggers yet.
 
-        initializeDebugger(getDebuggerProps());
+        initializeDebugger();
 
         debuggerRegistry = getDebuggerRegistry();
         expect(debuggerRegistry.size).to.equal(1);
     });
 
     it("Closing debugger removes it from global (window) registry and disposes it.", () => {
-        const debuggerProps = getDebuggerProps();
-        const { containerId } = debuggerProps;
-
-        const clientDebugger = initializeDebugger(debuggerProps);
+        const clientDebugger = initializeDebugger();
 
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         expect(clientDebugger.disposed).to.be.false;

--- a/packages/tools/client-debugger/client-debugger/src/test/Utilities.ts
+++ b/packages/tools/client-debugger/client-debugger/src/test/Utilities.ts
@@ -11,32 +11,11 @@ import {
     IAudienceOwner,
     IContainer,
     IContainerEvents,
-    IDeltaManager,
-    IDeltaManagerEvents,
 } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
-import {
-    IClient,
-    IDocumentMessage,
-    ISequencedDocumentMessage,
-} from "@fluidframework/protocol-definitions";
+import { IClient } from "@fluidframework/protocol-definitions";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
-/**
- * Mock {@link @fluidframework/container-definitions#IDeltaManager} for use in tests.
- */
-class MockDeltaManager
-    extends TypedEventEmitter<IDeltaManagerEvents>
-    implements
-        Partial<
-            Omit<IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, "on" | "off" | "once">
-        >
-{
-    public hasCheckpointSequenceNumber = true;
-    public lastKnownSeqNumber = 2;
-    public lastSequenceNumber = 1;
-}
 
 class MockAudience extends EventEmitter implements IAudienceOwner {
     private readonly audienceMembers: Map<string, IClient>;
@@ -91,12 +70,6 @@ class MockContainer
     extends TypedEventEmitter<IContainerEvents>
     implements Partial<Omit<IContainer, "on" | "off" | "once">>
 {
-    public deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> =
-        new MockDeltaManager() as unknown as IDeltaManager<
-            ISequencedDocumentMessage,
-            IDocumentMessage
-        >;
-
     public readonly audience: IAudience = new MockAudience();
 
     private _connectionState: ConnectionState = ConnectionState.Disconnected;
@@ -104,15 +77,6 @@ class MockContainer
     public get connectionState(): ConnectionState {
         return this._connectionState;
     }
-
-    // public resolvedUrl?: IResolvedUrl | undefined;
-    // public attachState?: AttachState | undefined;
-    // public closed?: boolean | undefined = false;
-    // public isDirty?: boolean | undefined;
-    // public connected?: boolean | undefined;
-    // public clientId?: string | undefined;
-    // public readOnlyInfo?: ReadOnlyInfo | undefined;
-    // public IFluidRouter?: IFluidRouter | undefined;
 
     public connect(): void {
         this._connectionState = ConnectionState.Connected;

--- a/packages/tools/client-debugger/client-debugger/src/test/Utilities.ts
+++ b/packages/tools/client-debugger/client-debugger/src/test/Utilities.ts
@@ -1,0 +1,140 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { EventEmitter } from "events";
+
+import { TypedEventEmitter } from "@fluidframework/common-utils";
+import {
+    IAudience,
+    IAudienceOwner,
+    IContainer,
+    IContainerEvents,
+    IDeltaManager,
+    IDeltaManagerEvents,
+} from "@fluidframework/container-definitions";
+import { ConnectionState } from "@fluidframework/container-loader";
+import {
+    IClient,
+    IDocumentMessage,
+    ISequencedDocumentMessage,
+} from "@fluidframework/protocol-definitions";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Mock {@link @fluidframework/container-definitions#IDeltaManager} for use in tests.
+ */
+class MockDeltaManager
+    extends TypedEventEmitter<IDeltaManagerEvents>
+    implements
+        Partial<
+            Omit<IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, "on" | "off" | "once">
+        >
+{
+    public hasCheckpointSequenceNumber = true;
+    public lastKnownSeqNumber = 2;
+    public lastSequenceNumber = 1;
+}
+
+class MockAudience extends EventEmitter implements IAudienceOwner {
+    private readonly audienceMembers: Map<string, IClient>;
+
+    public constructor() {
+        super();
+        this.audienceMembers = new Map<string, IClient>();
+    }
+
+    public on(
+        event: "addMember" | "removeMember",
+        listener: (clientId: string, client: IClient) => void,
+    ): this;
+    public on(event: string, listener: (...args: any[]) => void): this {
+        return super.on(event, listener);
+    }
+    public off(
+        event: "addMember" | "removeMember",
+        listener: (clientId: string, client: IClient) => void,
+    ): this;
+    public off(event: string, listener: (...args: any[]) => void): this {
+        return super.off(event, listener);
+    }
+    public once(
+        event: "addMember" | "removeMember",
+        listener: (clientId: string, client: IClient) => void,
+    ): this;
+    public once(event: string, listener: (...args: any[]) => void): this {
+        return super.once(event, listener);
+    }
+
+    public addMember(clientId: string, member: IClient): void {
+        this.audienceMembers.set(clientId, member);
+    }
+
+    public removeMember(clientId: string): boolean {
+        return this.audienceMembers.delete(clientId);
+    }
+
+    public getMembers(): Map<string, IClient> {
+        return new Map<string, IClient>(this.audienceMembers.entries());
+    }
+    public getMember(clientId: string): IClient | undefined {
+        return this.audienceMembers.get(clientId);
+    }
+}
+
+/**
+ * Mock {@link @fluidframework/container-definitions#IContainer} for use in tests.
+ */
+class MockContainer
+    extends TypedEventEmitter<IContainerEvents>
+    implements Partial<Omit<IContainer, "on" | "off" | "once">>
+{
+    public deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> =
+        new MockDeltaManager() as unknown as IDeltaManager<
+            ISequencedDocumentMessage,
+            IDocumentMessage
+        >;
+
+    public readonly audience: IAudience = new MockAudience();
+
+    private _connectionState: ConnectionState = ConnectionState.Disconnected;
+
+    public get connectionState(): ConnectionState {
+        return this._connectionState;
+    }
+
+    // public resolvedUrl?: IResolvedUrl | undefined;
+    // public attachState?: AttachState | undefined;
+    // public closed?: boolean | undefined = false;
+    // public isDirty?: boolean | undefined;
+    // public connected?: boolean | undefined;
+    // public clientId?: string | undefined;
+    // public readOnlyInfo?: ReadOnlyInfo | undefined;
+    // public IFluidRouter?: IFluidRouter | undefined;
+
+    public connect(): void {
+        this._connectionState = ConnectionState.Connected;
+        this.emit("connected");
+    }
+
+    public disconnect(): void {
+        this._connectionState = ConnectionState.Disconnected;
+        this.emit("disconnected");
+    }
+}
+
+/**
+ * Creates a mock {@link @fluidframework/container-definitions#IContainer} for use in tests.
+ *
+ * @remarks
+ *
+ * Note: the implementation here is incomplete. If a test needs particular functionality, {@link MockContainer}
+ * will need to be updated accordingly.
+ */
+export function createMockContainer(): IContainer {
+    return new MockContainer() as unknown as IContainer;
+}
+
+/* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
Updates the test code to use a mock Container implementation, rather than using Tinylicious.

Also moves test suite from `test:realsvc` to `test:mocha`, and removes a number of unneeded dependencies.