### PR TITLE
feat: Add `readOnly` prop to react-input types and update docs

### DIFF
--- a/experimental/framework/react-inputs/src/CollaborativeCheckbox.tsx
+++ b/experimental/framework/react-inputs/src/CollaborativeCheckbox.tsx
@@ -10,10 +10,18 @@ export interface ICollaborativeCheckboxProps {
      * The SharedCell that will store the checkbox value.
      */
     data: SharedCell<boolean>;
+
     /**
      * The value for the "name" property of the checkbox input
      */
     id: string;
+
+    /**
+     * Whether or not the control should be {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#readonly | read-only}.
+     * @defaultValue `false`
+     */
+    readOnly?: boolean;
+
     className?: string;
     style?: React.CSSProperties;
 }
@@ -55,6 +63,7 @@ export class CollaborativeCheckbox
                 aria-checked={this.state.checked}
                 name={this.props.id}
                 checked={this.state.checked}
+                readOnly={this.props.readOnly ?? false}
                 onChange={this.updateCheckbox} />
         );
     }

--- a/experimental/framework/react-inputs/src/CollaborativeInput.tsx
+++ b/experimental/framework/react-inputs/src/CollaborativeInput.tsx
@@ -10,8 +10,16 @@ export interface ICollaborativeInputProps {
      * The SharedString that will store the input value.
      */
     sharedString: SharedString;
+
     /**
-     * Whether spellCheck should be enabled.  Defaults to true.
+     * Whether or not the control should be {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#readonly | read-only}.
+     * @defaultValue `false`
+     */
+    readOnly?: boolean;
+
+    /**
+     * Whether spellCheck should be enabled.
+     * @defaultValue `true`
      */
     spellCheck?: boolean;
     className?: string;
@@ -72,6 +80,7 @@ export class CollaborativeInput
             <input
                 className={this.props.className}
                 style={this.props.style}
+                readOnly={this.props.readOnly ?? false}
                 spellCheck={this.props.spellCheck ? this.props.spellCheck : true}
                 ref={this.inputElementRef}
                 disabled={this.props.disabled}

--- a/experimental/framework/react-inputs/src/CollaborativeTextArea.tsx
+++ b/experimental/framework/react-inputs/src/CollaborativeTextArea.tsx
@@ -11,10 +11,19 @@ export interface ICollaborativeTextAreaProps {
      * The SharedString that will store the text from the textarea.
      */
     sharedStringHelper: SharedStringHelper;
+
     /**
-     * Whether spellCheck should be enabled.  Defaults to false.
+     * Whether or not the control should be {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-readonly | read-only}.
+     * @defaultValue `false`
+     */
+    readOnly?: boolean;
+
+    /**
+     * Whether `spellCheck` should be enabled.
+     * @defaultValue `false`
      */
     spellCheck?: boolean;
+
     className?: string;
     style?: React.CSSProperties;
 }
@@ -22,6 +31,7 @@ export interface ICollaborativeTextAreaProps {
 export const CollaborativeTextArea: React.FC<ICollaborativeTextAreaProps> = (props: ICollaborativeTextAreaProps) => {
     const {
         sharedStringHelper,
+        readOnly,
         spellCheck,
         className,
         style,
@@ -149,7 +159,8 @@ export const CollaborativeTextArea: React.FC<ICollaborativeTextAreaProps> = (pro
             ref={textareaRef}
             className={className}
             style={style}
-            spellCheck={spellCheck ? spellCheck : false}
+            spellCheck={spellCheck ?? false}
+            readOnly={readOnly ?? false}
             onBeforeInput={storeSelectionInReact}
             onKeyDown={storeSelectionInReact}
             onClick={storeSelectionInReact}


### PR DESCRIPTION
Intended to be used in some client debugger views.