### PR TITLE
Tree: tests and partial fix for revive ordering

### DIFF
--- a/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
@@ -227,6 +227,42 @@ class RebaseQueue<T> {
             ) {
                 return dequeueRelatedReattaches(this.newMarks, this.baseMarks);
             }
+            if (isReattach(baseMark)) {
+                const offset = getOffsetAtRevision(
+                    newMark.lineage,
+                    baseMark.lastDetachedBy ?? baseMark.detachedBy,
+                );
+                if (offset !== undefined) {
+                    // WARNING: the offset is based on the first node detached whereas the detachIndex is based on the
+                    // first node in the field.
+                    // The comparison below is the only valid one we can make at the moment.
+                    // TODO: find a way to make the lineage and detachIndex info more comparable so we can correctly
+                    // handle scenarios where either all or some fraction of newMark should come first.
+                    if (offset >= baseMark.detachIndex + baseMark.count) {
+                        return {
+                            baseMark: this.baseMarks.dequeue(),
+                        };
+                    }
+                }
+            }
+            if (isReattach(newMark)) {
+                const offset = getOffsetAtRevision(
+                    baseMark.lineage,
+                    newMark.lastDetachedBy ?? newMark.detachedBy,
+                );
+                if (offset !== undefined) {
+                    // WARNING: the offset is based on the first node detached whereas the detachIndex is based on the
+                    // first node in the field.
+                    // The comparison below is the only valid one we can make at the moment.
+                    // TODO: find a way to make the lineage and detachIndex info more comparable so we can correctly
+                    // handle scenarios where either all or some fraction of baseMark should come first.
+                    if (offset >= newMark.detachIndex + newMark.count) {
+                        return {
+                            newMark: this.newMarks.dequeue(),
+                        };
+                    }
+                }
+            }
             const revision = baseMark.revision ?? this.baseMarks.revision;
             const reattachOffset = getOffsetAtRevision(newMark.lineage, revision);
             if (reattachOffset !== undefined) {

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.spec.ts
@@ -597,13 +597,58 @@ describe("SequenceField - Compose", () => {
         assert.deepEqual(actual, expected);
     });
 
-    it("revive ○ revive", () => {
-        const reviveA = Change.revive(0, 2, tag1, 0);
-        const reviveB = Change.revive(0, 3, tag2, 0);
-        // TODO: test with merge-right policy as well
+    it("reviveAA ○ reviveB => BAA", () => {
+        const reviveAA = Change.revive(0, 2, tag1, 1, undefined, [{ revision: tag2, offset: 1 }]);
+        const reviveB = Change.revive(0, 1, tag2, 0);
         const expected: SF.Changeset = [
-            { type: "Revive", count: 3, detachedBy: tag2, detachIndex: 0 },
-            { type: "Revive", count: 2, detachedBy: tag1, detachIndex: 0 },
+            { type: "Revive", count: 1, detachedBy: tag2, detachIndex: 0 },
+            {
+                type: "Revive",
+                count: 2,
+                detachedBy: tag1,
+                detachIndex: 1,
+                lineage: [{ revision: tag2, offset: 1 }],
+            },
+        ];
+        const actual = shallowCompose([makeAnonChange(reviveAA), makeAnonChange(reviveB)]);
+        assert.deepEqual(actual, expected);
+    });
+
+    it("reviveA ○ reviveBB => BAB", () => {
+        const reviveA = Change.revive(0, 1, tag1, 1, undefined, [{ revision: tag2, offset: 1 }]);
+        const reviveB1 = Change.revive(0, 1, tag2, 0);
+        const reviveB2 = Change.revive(2, 1, tag2, 1);
+        const expected: SF.Changeset = [
+            { type: "Revive", count: 1, detachedBy: tag2, detachIndex: 0 },
+            {
+                type: "Revive",
+                count: 1,
+                detachedBy: tag1,
+                detachIndex: 1,
+                lineage: [{ revision: tag2, offset: 1 }],
+            },
+            { type: "Revive", count: 1, detachedBy: tag2, detachIndex: 1 },
+        ];
+        const actual = shallowCompose([
+            makeAnonChange(reviveA),
+            makeAnonChange(reviveB1),
+            makeAnonChange(reviveB2),
+        ]);
+        assert.deepEqual(actual, expected);
+    });
+
+    it("reviveAA ○ reviveB => AAB", () => {
+        const reviveA = Change.revive(0, 2, tag1, 0, undefined, [{ revision: tag2, offset: 0 }]);
+        const reviveB = Change.revive(2, 1, tag2, 0);
+        const expected: SF.Changeset = [
+            {
+                type: "Revive",
+                count: 2,
+                detachedBy: tag1,
+                detachIndex: 0,
+                lineage: [{ revision: tag2, offset: 0 }],
+            },
+            { type: "Revive", count: 1, detachedBy: tag2, detachIndex: 0 },
         ];
         const actual = shallowCompose([makeAnonChange(reviveA), makeAnonChange(reviveB)]);
         assert.deepEqual(actual, expected);

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/rebase.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/rebase.spec.ts
@@ -398,20 +398,47 @@ describe("SequenceField - Rebase", () => {
         assert.deepEqual(actual, expected);
     });
 
-    it("revive ↷ different revive", () => {
-        const reviveA = composeAnonChanges([
-            Change.revive(0, 1, tag1, 0),
-            Change.revive(3, 2, tag1, 1),
-            Change.revive(7, 1, tag1, 3),
-        ]);
-        const reviveB = Change.revive(2, 1, tag2, 0);
-        const actual = rebase(reviveA, reviveB);
-        // TODO: test cases for both ordering of revived data
-        const expected = composeAnonChanges([
-            Change.revive(0, 1, tag1, 0),
-            Change.revive(3, 2, tag1, 1),
-            Change.revive(8, 1, tag1, 3),
-        ]);
+    it("reviveAA ↷ reviveB => BAA", () => {
+        const reviveAA = Change.revive(0, 2, tag1, 1, undefined, [{ revision: tag2, offset: 1 }]);
+        const reviveB = Change.revive(0, 1, tag2, 0);
+        const expected = Change.revive(1, 2, tag1, 1, undefined, [{ revision: tag2, offset: 1 }]);
+        const actual = rebase(reviveAA, reviveB);
+        assert.deepEqual(actual, expected);
+    });
+
+    it("reviveAA ↷ reviveB => AAB", () => {
+        const reviveAA = Change.revive(0, 2, tag1, 0, undefined, [{ revision: tag2, offset: 0 }]);
+        const reviveB = Change.revive(0, 1, tag2, 0);
+        const expected = Change.revive(0, 2, tag1, 0, undefined, [{ revision: tag2, offset: 0 }]);
+        const actual = rebase(reviveAA, reviveB);
+        assert.deepEqual(actual, expected);
+    });
+
+    it("reviveBB ↷ reviveA => BBA", () => {
+        const reviveBB = Change.revive(0, 2, tag2, 0);
+        const reviveA = Change.revive(0, 1, tag1, 2, undefined, [{ revision: tag2, offset: 2 }]);
+        const expected = Change.revive(0, 2, tag2, 0);
+        const actual = rebase(reviveBB, reviveA);
+        assert.deepEqual(actual, expected);
+    });
+
+    // To fix this test we need to be able to compare lineage entries with detach indices.
+    // See comments in RebaseQueue.pop
+    it.skip("reviveBB ↷ reviveA => ABB", () => {
+        const reviveBB = Change.revive(0, 2, tag2, 1);
+        const reviveA = Change.revive(0, 1, tag1, 0, undefined, [{ revision: tag2, offset: 0 }]);
+        const expected = Change.revive(1, 2, tag2, 1);
+        const actual = rebase(reviveBB, reviveA);
+        assert.deepEqual(actual, expected);
+    });
+
+    // To fix this test we need to be able to compare lineage entries with detach indices.
+    // See comments in RebaseQueue.pop
+    it.skip("reviveA ↷ reviveBB => BAB", () => {
+        const reviveA = Change.revive(0, 1, tag1, 1, undefined, [{ revision: tag2, offset: 1 }]);
+        const reviveBB = Change.revive(0, 2, tag2, 0);
+        const expected = Change.revive(1, 1, tag1, 1, undefined, [{ revision: tag2, offset: 1 }]);
+        const actual = rebase(reviveA, reviveBB);
         assert.deepEqual(actual, expected);
     });
 


### PR DESCRIPTION
This PR adds more test cases for the rebasing and compositions of revive marks in the name gap.
Some of the tests elicited some changes to the rebasing code in order to pass.
Some of the tests are skipped because the required changes to the rebasing code is beyond the scope of this investigation.