### PR TITLE
fix(api-markdown-documenter): Newline and path handling on Windows

### DIFF
--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.api.md
@@ -229,7 +229,7 @@ export function getExampleBlocks(apiItem: ApiItem): DocSection[] | undefined;
 export function getFileNameForApiItem(apiItem: ApiItem, config: Required<MarkdownDocumenterConfiguration>, includeExtension: boolean): string;
 
 // @public
-export function getFilePathForApiItem(apiItem: ApiItem, config: Required<MarkdownDocumenterConfiguration>, includeExtension: boolean): string;
+export function getFilePathForApiItem(apiItem: ApiItem, config: Required<MarkdownDocumenterConfiguration>): string;
 
 // @public
 export function getFilteredParent(apiItem: ApiItem): ApiItem | undefined;

--- a/tools/api-markdown-documenter/src/Configuration.ts
+++ b/tools/api-markdown-documenter/src/Configuration.ts
@@ -32,7 +32,8 @@ export interface MarkdownDocumenterConfiguration extends PolicyOptions, Renderin
 
     /**
      * Specifies what type of newlines API Documenter should use when writing output files.
-     * By default, the output files will be written with Windows-style newlines.
+     *
+     * @defaultValue {@link @rushstack/node-core-library#NewlineKind.OsDefault}
      */
     readonly newlineKind?: NewlineKind;
 

--- a/tools/api-markdown-documenter/src/rendering/Rendering.ts
+++ b/tools/api-markdown-documenter/src/rendering/Rendering.ts
@@ -189,7 +189,7 @@ function createMarkdownDocument(
     return {
         contents,
         apiItem,
-        path: getFilePathForApiItem(apiItem, config, /* includeExtension: */ true),
+        path: getFilePathForApiItem(apiItem, config),
     };
 }
 

--- a/tools/api-markdown-documenter/src/test/MarkdownDocumenter.test.ts
+++ b/tools/api-markdown-documenter/src/test/MarkdownDocumenter.test.ts
@@ -5,7 +5,7 @@
 import * as Path from "node:path";
 
 import { ApiItem, ApiItemKind, ApiModel } from "@microsoft/api-extractor-model";
-import { FileSystem } from "@rushstack/node-core-library";
+import { FileSystem, NewlineKind } from "@rushstack/node-core-library";
 import { expect } from "chai";
 import { compare } from "dir-compare";
 import { Suite } from "mocha";
@@ -188,6 +188,7 @@ describe("api-markdown-documenter full-suite tests", () => {
      */
     const defaultConfig: Omit<MarkdownDocumenterConfiguration, "apiModel"> = {
         uriRoot: ".",
+        newlineKind: NewlineKind.Lf,
     };
 
     /**
@@ -195,6 +196,7 @@ describe("api-markdown-documenter full-suite tests", () => {
      */
     const flatConfig: Omit<MarkdownDocumenterConfiguration, "apiModel"> = {
         uriRoot: "docs",
+        newlineKind: NewlineKind.Lf,
         includeBreadcrumb: true,
         includeTopLevelDocumentHeading: false,
         documentBoundaries: [], // Render everything to package documents
@@ -207,6 +209,7 @@ describe("api-markdown-documenter full-suite tests", () => {
      */
     const sparseConfig: Omit<MarkdownDocumenterConfiguration, "apiModel"> = {
         uriRoot: "docs",
+        newlineKind: NewlineKind.Lf,
         includeBreadcrumb: false,
         includeTopLevelDocumentHeading: true,
         // Render everything to its own document

--- a/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
@@ -242,7 +242,7 @@ export function getFilePathForApiItem(
  * @param config - See {@link MarkdownDocumenterConfiguration}.
  * @param includeExtension - Whether or not to include the `.md` file extension at the end of the path.
  */
-export function getApiItemPath(
+function getApiItemPath(
     apiItem: ApiItem,
     config: Required<MarkdownDocumenterConfiguration>,
     includeExtension: boolean,

--- a/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
@@ -187,7 +187,7 @@ export function getLinkUrlForApiItem(
     config: Required<MarkdownDocumenterConfiguration>,
 ): string {
     const uriBase = config.uriBaseOverridePolicy(apiItem) ?? config.uriRoot;
-    let documentPath = getFilePathForApiItem(apiItem, config, /* includeExtension: */ false);
+    let documentPath = getApiItemPath(apiItem, config, /* includeExtension: */ false).join("/");
 
     // Omit "index" file name from path generated in links.
     // This can be considered an optimization in most cases, but some documentation systems also special-case
@@ -225,14 +225,28 @@ export function getUnscopedPackageName(apiPackage: ApiPackage): string {
  * The generated path is relative to {@link MarkdownDocumenterConfiguration.uriRoot}.
  *
  * @param apiItem - The API item for which we are generating a file path.
- * @param config - See {@link MarkdownDocumenterConfiguration}
- * @param includeExtension - Whether or not to include the `.md` file extension at the end of the path.
+ * @param config - See {@link MarkdownDocumenterConfiguration}.
  */
 export function getFilePathForApiItem(
     apiItem: ApiItem,
     config: Required<MarkdownDocumenterConfiguration>,
-    includeExtension: boolean,
 ): string {
+    const pathSegments = getApiItemPath(apiItem, config, true);
+    return Path.join(...pathSegments);
+}
+
+/**
+ * Gets the path to the specified API item, represented as an ordered list of path segments.
+ *
+ * @param apiItem - The API item for which we are generating a file path.
+ * @param config - See {@link MarkdownDocumenterConfiguration}.
+ * @param includeExtension - Whether or not to include the `.md` file extension at the end of the path.
+ */
+export function getApiItemPath(
+    apiItem: ApiItem,
+    config: Required<MarkdownDocumenterConfiguration>,
+    includeExtension: boolean,
+): string[] {
     const targetDocumentItem = getFirstAncestorWithOwnDocument(apiItem, config.documentBoundaries);
 
     const fileName = getFileNameForApiItem(apiItem, config, includeExtension);
@@ -242,12 +256,10 @@ export function getFilePathForApiItem(
         doesItemGenerateHierarchy(hierarchyItem, config.hierarchyBoundaries),
     );
 
-    let path = fileName;
-    for (const hierarchyItem of documentAncestry) {
-        const segmentName = config.fileNamePolicy(hierarchyItem);
-        path = Path.join(segmentName, path);
-    }
-    return path;
+    return [
+        fileName,
+        ...documentAncestry.map((hierarchyItem) => config.fileNamePolicy(hierarchyItem)),
+    ].reverse();
 }
 
 /**


### PR DESCRIPTION
Includes the following fixes:
- Link paths are always generated using forward slashes, regardless of platform
- Default newline policy was documented to be Windows-style, but was implemented using OS-default.
    - Docs have been updated to match implementation
    - Tests have been updated to specify a non-OS-dependent newline configuration to ensure correct functionality regardless of platform.

BREAKING CHANGE: `getFilePathForApiItem` no longer accepts the `includeExtension` argument - it will *always* include the file extension in its output.