### PR TITLE
Remove side effect of coupling op reentry and compression configs, revert stress tests changes - next

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1053,10 +1053,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             this.validateSummaryHeuristicConfiguration(this.summaryConfiguration);
         }
 
-        this.enableOpReentryCheck = (runtimeOptions.enableOpReentryCheck === true
-            // If compression is enabled, we need to disallow op reentry as it is required that
-            // ops within the same batch have the same reference sequence number.
-            || runtimeOptions.compressionOptions.minimumBatchSizeInBytes !== Number.POSITIVE_INFINITY)
+        this.enableOpReentryCheck = runtimeOptions.enableOpReentryCheck === true
             // Allow for a break-glass config to override the options
             && this.mc.config.getBoolean("Fluid.ContainerRuntime.DisableOpReentryCheck") !== true;
 

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -225,16 +225,8 @@ export class LoadTestDataStoreModel {
         this.partnerId = (this.config.runId + halfClients) % this.config.testConfig.numClients;
         const changed = (taskId) => {
             if (taskId === this.taskId && this.taskStartTime !== 0) {
-                Promise.resolve().then(() => {
-                    if (!this.runtime.disposed) {
-                        this.dir.set(taskTimeKey, this.totalTaskTime);
-                        this.taskStartTime = 0;
-                    }
-                }).catch((error) => {
-                    this.logger.sendErrorEvent({
-                        eventName: "TaskManager_OnValueChanged",
-                    }, error);
-                });
+                this.dir.set(taskTimeKey, this.totalTaskTime);
+                this.taskStartTime = 0;
             }
         };
         this.taskManager.on("lost", changed);
@@ -264,14 +256,7 @@ export class LoadTestDataStoreModel {
                     : Math.trunc(value * blobsPerOp - this.blobCount);
 
                 if (newBlobs > 0) {
-                    Promise.resolve().then(() => {
-                        if (!this.runtime.disposed) {
-                            this.blobUploads.push(...[...Array(newBlobs)].map(async () => this.writeBlob(this.blobCount++)));
-                        }
-                    }).catch((error) => this.logger.sendErrorEvent({
-                        eventName: "WriteBlobFailed_OnCounterChanged",
-                        count: this.blobCount,
-                    }, error));
+                    this.blobUploads.push(...[...Array(newBlobs)].map(async () => this.writeBlob(this.blobCount++)));
                 }
             });
         }

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -78,7 +78,7 @@ export function generateRuntimeOptions(
         flushMode: [undefined],
         compressionOptions: [{ minimumBatchSizeInBytes: 500, compressionAlgorithm: CompressionAlgorithms.lz4 }],
         maxBatchSizeInBytes: [undefined],
-        enableOpReentryCheck: [true],
+        enableOpReentryCheck: [undefined],
         chunkSizeInBytes: [undefined],
     };
 


### PR DESCRIPTION
OP Reentry in the stress tests is still causing test incidents due to the lifecycle of the container. This requires more refactoring of the stress tests. Until then, these configs should be decoupled and the reentry feature disabled in the stress tests in order to continue having test coverage for compression.