### PR TITLE
GC Tombstone: Separate flags for Load v. Usage (required for recovery)

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -275,11 +275,16 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
         const request = { url: blobId };
         if (this.tombstonedBlobs.has(blobId) ) {
             const error = responseToException(createResponseError(404, "Blob removed by gc", request), request);
-            const event = {
-                eventName: "GC_Tombstone_Blob_Requested",
-                isSummarizerClient: this.runtime.clientDetails.type === summarizerClientType,
-            };
-            sendGCTombstoneEvent(this.mc, event, this.throwOnTombstoneLoad, [BlobManager.basePath], error);
+            sendGCTombstoneEvent(
+                this.mc,
+                {
+                    eventName: "GC_Tombstone_Blob_Requested",
+                    category: this.throwOnTombstoneLoad ? "error" : "generic",
+                    isSummarizerClient: this.runtime.clientDetails.type === summarizerClientType,
+                },
+                [BlobManager.basePath],
+                error,
+            );
             if (this.throwOnTombstoneLoad) {
                 throw error;
             }

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -277,9 +277,9 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
             const error = responseToException(createResponseError(404, "Blob removed by gc", request), request);
             const event = {
                 eventName: "GC_Tombstone_Blob_Requested",
-                url: request.url,
+                isSummarizerClient: this.runtime.clientDetails.type === summarizerClientType,
             };
-            sendGCTombstoneEvent(this.mc, event, this.runtime.clientDetails.type === summarizerClientType, [BlobManager.basePath], error);
+            sendGCTombstoneEvent(this.mc.logger, event, this.throwOnTombstoneLoad, [BlobManager.basePath], error);
             if (this.throwOnTombstoneLoad) {
                 throw error;
             }

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -24,7 +24,7 @@ import {
 } from "@fluidframework/runtime-definitions";
 import { Throttler, formExponentialFn, IThrottler } from "./throttler";
 import { summarizerClientType } from "./summarizerClientElection";
-import { throwOnTombstoneUsageKey } from "./garbageCollectionConstants";
+import { throwOnTombstoneLoadKey } from "./garbageCollectionConstants";
 import { sendGCTombstoneEvent } from "./garbageCollectionTombstoneUtils";
 
 /**
@@ -151,7 +151,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
     ));
 
     /** If true, throw an error when a tombstone attachment blob is retrieved. */
-    private readonly throwOnTombstoneUsage: boolean;
+    private readonly throwOnTombstoneLoad: boolean;
     /**
      * This stores IDs of tombstoned blobs.
      * Tombstone is a temporary feature that imitates a blob getting swept by garbage collection.
@@ -183,8 +183,8 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
         super();
         this.mc = loggerToMonitoringContext(ChildLogger.create(this.runtime.logger, "BlobManager"));
         // Read the feature flag that tells whether to throw when a tombstone blob is requested.
-        this.throwOnTombstoneUsage =
-            this.mc.config.getBoolean(throwOnTombstoneUsageKey) === true &&
+        this.throwOnTombstoneLoad =
+            this.mc.config.getBoolean(throwOnTombstoneLoadKey) === true &&
             this.runtime.clientDetails.type !== summarizerClientType;
 
         this.runtime.on("disconnected", () => this.onDisconnected());
@@ -280,7 +280,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
                 url: request.url,
             };
             sendGCTombstoneEvent(this.mc, event, this.runtime.clientDetails.type === summarizerClientType, [BlobManager.basePath], error);
-            if (this.throwOnTombstoneUsage) {
+            if (this.throwOnTombstoneLoad) {
                 throw error;
             }
         }

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -279,7 +279,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
                 eventName: "GC_Tombstone_Blob_Requested",
                 isSummarizerClient: this.runtime.clientDetails.type === summarizerClientType,
             };
-            sendGCTombstoneEvent(this.mc.logger, event, this.throwOnTombstoneLoad, [BlobManager.basePath], error);
+            sendGCTombstoneEvent(this.mc, event, this.throwOnTombstoneLoad, [BlobManager.basePath], error);
             if (this.throwOnTombstoneLoad) {
                 throw error;
             }

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -787,7 +787,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
                 isSummarizerClient: this.clientDetails.type === summarizerClientType,
                 callSite,
             };
-            sendGCTombstoneEvent(this.mc.logger, event, this.throwOnTombstoneUsage, this.pkg, error);
+            sendGCTombstoneEvent(this.mc, event, this.throwOnTombstoneUsage, this.pkg, error);
             // Always log an error when tombstoned data store is used. However, throw an error only if
             // throwOnTombstoneUsage is set and the client is not a summarizer.
             if (this.throwOnTombstoneUsage) {

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -782,12 +782,17 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
 
             // Always log an error when tombstoned data store is used. However, throw an error only if
             // throwOnTombstoneUsage is set.
-            const event = {
-                eventName: "GC_Tombstone_DataStore_Changed",
-                isSummarizerClient: this.clientDetails.type === summarizerClientType,
-                callSite,
-            };
-            sendGCTombstoneEvent(this.mc, event, this.throwOnTombstoneUsage, this.pkg, error);
+            sendGCTombstoneEvent(
+                this.mc,
+                {
+                    eventName: "GC_Tombstone_DataStore_Changed",
+                    category: this.throwOnTombstoneUsage ? "error" : "generic",
+                    isSummarizerClient: this.clientDetails.type === summarizerClientType,
+                    callSite,
+                },
+                this.pkg,
+                error,
+            );
             // Always log an error when tombstoned data store is used. However, throw an error only if
             // throwOnTombstoneUsage is set and the client is not a summarizer.
             if (this.throwOnTombstoneUsage) {

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -784,9 +784,10 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
             // throwOnTombstoneUsage is set.
             const event = {
                 eventName: "GC_Tombstone_DataStore_Changed",
+                isSummarizerClient: this.clientDetails.type === summarizerClientType,
                 callSite,
             };
-            sendGCTombstoneEvent(this.mc, event, this.clientDetails.type === summarizerClientType, this.pkg, error);
+            sendGCTombstoneEvent(this.mc.logger, event, this.throwOnTombstoneUsage, this.pkg, error);
             // Always log an error when tombstoned data store is used. However, throw an error only if
             // throwOnTombstoneUsage is set and the client is not a summarizer.
             if (this.throwOnTombstoneUsage) {

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -448,7 +448,7 @@ export class DataStores implements IDisposable {
                 viaHandle,
             };
             sendGCTombstoneEvent(
-                this.mc.logger,
+                this.mc,
                 event,
                 this.throwOnTombstoneLoad,
                 context.isLoaded ? context.packagePath : undefined,

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -441,16 +441,14 @@ export class DataStores implements IDisposable {
         if (context.tombstoned) {
             // The requested data store is removed by gc. Create a 404 gc response exception.
             const error = responseToException(createResponseError(404, "Datastore removed by gc", request), request);
-            // Note: if a user writes a request to look like it's viaHandle, we will also send this telemetry event
-            const event = {
-                eventName: "GC_Tombstone_DataStore_Requested",
-                isSummarizerClient: this.runtime.clientDetails.type === summarizerClientType,
-                viaHandle,
-            };
             sendGCTombstoneEvent(
                 this.mc,
-                event,
-                this.throwOnTombstoneLoad,
+                {
+                    eventName: "GC_Tombstone_DataStore_Requested",
+                    category: this.throwOnTombstoneLoad ? "error" : "generic",
+                    isSummarizerClient: this.runtime.clientDetails.type === summarizerClientType,
+                    viaHandle,  // Note: A consumer could easily spoof this header and confuse our telemetry
+                },
                 context.isLoaded ? context.packagePath : undefined,
                 error,
             );

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -54,7 +54,7 @@ import {
 import { IContainerRuntimeMetadata, nonDataStorePaths, rootHasIsolatedChannels } from "./summaryFormat";
 import { IDataStoreAliasMessage, isDataStoreAliasMessage } from "./dataStore";
 import { GCNodeType } from "./garbageCollection";
-import { throwOnTombstoneUsageKey } from "./garbageCollectionConstants";
+import { throwOnTombstoneLoadKey } from "./garbageCollectionConstants";
 import { summarizerClientType } from "./summarizerClientElection";
 import { sendGCTombstoneEvent } from "./garbageCollectionTombstoneUtils";
 
@@ -85,7 +85,7 @@ export class DataStores implements IDisposable {
     // root data stores that are added.
     private dataStoresSinceLastGC: string[] = [];
     /** If true, throw an error when a tombstone data store is retrieved. */
-    private readonly throwOnTombstoneUsage: boolean;
+    private readonly throwOnTombstoneLoad: boolean;
     // The handle to the container runtime. This is used mainly for GC purposes to represent outbound reference from
     // the container runtime to other nodes.
     private readonly containerRuntimeHandle: IFluidHandle;
@@ -118,8 +118,8 @@ export class DataStores implements IDisposable {
             return baseGCDetails.get(dataStoreId);
         };
         // Tombstone should only throw when the feature flag is enabled and the client isn't a summarizer
-        this.throwOnTombstoneUsage =
-            this.mc.config.getBoolean(throwOnTombstoneUsageKey) === true &&
+        this.throwOnTombstoneLoad =
+            this.mc.config.getBoolean(throwOnTombstoneLoadKey) === true &&
             this.runtime.clientDetails.type !== summarizerClientType;
 
         // Extract stores stored inside the snapshot
@@ -455,8 +455,8 @@ export class DataStores implements IDisposable {
                 error,
             );
             // Always log an error when tombstoned data store is used. However, throw an error only if
-            // throwOnTombstoneUsage is set.
-            if (this.throwOnTombstoneUsage) {
+            // throwOnTombstoneLoad is set.
+            if (this.throwOnTombstoneLoad) {
                 throw error;
             }
         }

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -444,13 +444,13 @@ export class DataStores implements IDisposable {
             // Note: if a user writes a request to look like it's viaHandle, we will also send this telemetry event
             const event = {
                 eventName: "GC_Tombstone_DataStore_Requested",
-                url: request.url,
+                isSummarizerClient: this.runtime.clientDetails.type === summarizerClientType,
                 viaHandle,
             };
             sendGCTombstoneEvent(
-                this.mc,
+                this.mc.logger,
                 event,
-                this.runtime.clientDetails.type === summarizerClientType,
+                this.throwOnTombstoneLoad,
                 context.isLoaded ? context.packagePath : undefined,
                 error,
             );

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -62,6 +62,7 @@ import {
     runSessionExpiryKey,
     runSweepKey,
     stableGCVersion,
+    throwOnTombstoneLoadKey,
     throwOnTombstoneUsageKey,
     trackGCStateKey
 } from "./garbageCollectionConstants";
@@ -1248,6 +1249,7 @@ export class GarbageCollector implements IGarbageCollector {
                 isSummarizerClient: this.isSummarizerClient,
                 url: trimLeadingSlashes(toNodePath),
                 nodeType,
+                throwOnTombstoneLoad: this.mc.config.getBoolean(throwOnTombstoneLoadKey) ?? false,
                 throwOnTombstoneUsage: this.mc.config.getBoolean(throwOnTombstoneUsageKey) ?? false,
             });
         }

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -1247,11 +1247,11 @@ export class GarbageCollector implements IGarbageCollector {
                 this.mc,
                 {
                     eventName,
+                    category: "generic",
                     isSummarizerClient: this.isSummarizerClient,
                     url: trimLeadingSlashes(toNodePath),
                     nodeType,
                  },
-                false /* logAsError */,
                 undefined /* packagePath */,
             );
         }

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -62,10 +62,9 @@ import {
     runSessionExpiryKey,
     runSweepKey,
     stableGCVersion,
-    throwOnTombstoneLoadKey,
-    throwOnTombstoneUsageKey,
     trackGCStateKey
 } from "./garbageCollectionConstants";
+import { sendGCTombstoneEvent } from "./garbageCollectionTombstoneUtils";
 import { SweepReadyUsageDetectionHandler } from "./gcSweepReadyUsageDetection";
 import {
     getGCVersion,
@@ -1244,14 +1243,17 @@ export class GarbageCollector implements IGarbageCollector {
                 eventName = "GC_Tombstone_Blob_Revived";
             }
 
-            this.mc.logger.sendTelemetryEvent({
-                eventName,
-                isSummarizerClient: this.isSummarizerClient,
-                url: trimLeadingSlashes(toNodePath),
-                nodeType,
-                throwOnTombstoneLoad: this.mc.config.getBoolean(throwOnTombstoneLoadKey) ?? false,
-                throwOnTombstoneUsage: this.mc.config.getBoolean(throwOnTombstoneUsageKey) ?? false,
-            });
+            sendGCTombstoneEvent(
+                this.mc,
+                {
+                    eventName,
+                    isSummarizerClient: this.isSummarizerClient,
+                    url: trimLeadingSlashes(toNodePath),
+                    nodeType,
+                 },
+                false /* logAsError */,
+                undefined /* packagePath */,
+            );
         }
     }
 

--- a/packages/runtime/container-runtime/src/garbageCollectionConstants.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionConstants.ts
@@ -24,7 +24,9 @@ export const trackGCStateKey = "Fluid.GarbageCollection.TrackGCState";
 export const disableSweepLogKey = "Fluid.GarbageCollection.DisableSweepLog";
 // Feature gate key to disable the tombstone feature, i.e., tombstone information is not read / written into summary.
 export const disableTombstoneKey = "Fluid.GarbageCollection.DisableTombstone";
-// Feature gate to enable throwing an error when tombstone object is used.
+// Feature gate to enable throwing an error when tombstone object is loaded (requested).
+export const throwOnTombstoneLoadKey = "Fluid.GarbageCollection.ThrowOnTombstoneLoad";
+// Feature gate to enable throwing an error when tombstone object is used (e.g. outgoing or incoming ops).
 export const throwOnTombstoneUsageKey = "Fluid.GarbageCollection.ThrowOnTombstoneUsage";
 // Feature gate to enable GC version upgrade.
 export const gcVersionUpgradeToV2Key = "Fluid.GarbageCollection.GCVersionUpgradeToV2";

--- a/packages/runtime/container-runtime/src/garbageCollectionTombstoneUtils.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionTombstoneUtils.ts
@@ -6,7 +6,7 @@
 import { ITelemetryGenericEvent } from "@fluidframework/common-definitions";
 import { packagePathToTelemetryProperty } from "@fluidframework/runtime-utils";
 import { MonitoringContext } from "@fluidframework/telemetry-utils";
-import { throwOnTombstoneLoadKey, throwOnTombstoneUsageKey } from "./garbageCollectionConstants";
+import { disableTombstoneKey, throwOnTombstoneLoadKey, throwOnTombstoneUsageKey } from "./garbageCollectionConstants";
 
 /**
  * Consolidates info / logic for logging when we encounter a Tombstone
@@ -16,13 +16,14 @@ export function sendGCTombstoneEvent(
     event: ITelemetryGenericEvent & { isSummarizerClient: boolean },
     logAsError: boolean,
     packagePath: readonly string[] | undefined,
-    error: unknown,
+    error?: unknown,
 ) {
     event.category = logAsError ? "error" : "generic";
     event.pkg = packagePathToTelemetryProperty(packagePath);
     event.tombstoneFlags = JSON.stringify({
-        throwOnTombstoneUsageKey: mc.config.getBoolean(throwOnTombstoneUsageKey),
-        throwOnTombstoneLoadKey: mc.config.getBoolean(throwOnTombstoneLoadKey),
+        DisableTombstone: mc.config.getBoolean(disableTombstoneKey),
+        ThrowOnTombstoneUsage: mc.config.getBoolean(throwOnTombstoneUsageKey),
+        ThrowOnTombstoneLoad: mc.config.getBoolean(throwOnTombstoneLoadKey),
     });
 
     mc.logger.sendTelemetryEvent(event, error);

--- a/packages/runtime/container-runtime/src/garbageCollectionTombstoneUtils.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionTombstoneUtils.ts
@@ -3,16 +3,16 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryGenericEvent, ITelemetryLogger } from "@fluidframework/common-definitions";
+import { ITelemetryGenericEvent } from "@fluidframework/common-definitions";
 import { packagePathToTelemetryProperty } from "@fluidframework/runtime-utils";
+import { MonitoringContext } from "@fluidframework/telemetry-utils";
+import { throwOnTombstoneLoadKey, throwOnTombstoneUsageKey } from "./garbageCollectionConstants";
 
 /**
- * Decides whether or not to send an error event or a generic event for gc tombstone scenarios
- *
- * Adds isSummarizerClient, packagePath, and error to telemetry properties.
+ * Consolidates info / logic for logging when we encounter a Tombstone
  */
 export function sendGCTombstoneEvent(
-    logger: ITelemetryLogger,
+    mc: MonitoringContext,
     event: ITelemetryGenericEvent & { isSummarizerClient: boolean },
     logAsError: boolean,
     packagePath: readonly string[] | undefined,
@@ -20,6 +20,10 @@ export function sendGCTombstoneEvent(
 ) {
     event.category = logAsError ? "error" : "generic";
     event.pkg = packagePathToTelemetryProperty(packagePath);
+    event.tombstoneFlags = JSON.stringify({
+        throwOnTombstoneUsageKey: mc.config.getBoolean(throwOnTombstoneUsageKey),
+        throwOnTombstoneLoadKey: mc.config.getBoolean(throwOnTombstoneLoadKey),
+    });
 
-    logger.sendTelemetryEvent(event, error);
+    mc.logger.sendTelemetryEvent(event, error);
 }

--- a/packages/runtime/container-runtime/src/garbageCollectionTombstoneUtils.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionTombstoneUtils.ts
@@ -13,12 +13,10 @@ import { disableTombstoneKey, throwOnTombstoneLoadKey, throwOnTombstoneUsageKey 
  */
 export function sendGCTombstoneEvent(
     mc: MonitoringContext,
-    event: ITelemetryGenericEvent & { isSummarizerClient: boolean },
-    logAsError: boolean,
+    event: ITelemetryGenericEvent & { category: "error" | "generic", isSummarizerClient: boolean },
     packagePath: readonly string[] | undefined,
     error?: unknown,
 ) {
-    event.category = logAsError ? "error" : "generic";
     event.pkg = packagePathToTelemetryProperty(packagePath);
     event.tombstoneFlags = JSON.stringify({
         DisableTombstone: mc.config.getBoolean(disableTombstoneKey),

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -123,7 +123,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
             // not have access to the blob's handle since it loaded after the blob was tombstoned.
             const response = await container2.request({ url: blobHandle.absolutePath });
             assert.strictEqual(response?.status, 404, `Expecting a 404 response`);
-            assert.equal(response.value, `Blob removed by gc: ${blobHandle.absolutePath}`, `Unexpected response value`);
+            assert.equal(response.value, `Blob removed by gc: ${blobHandle.absolutePath.substring(8)}`, `Unexpected response value`);
             assert(container2.closed !== true, "Container should not have closed");
 
             // But the summarizing container should succeed (logging and error)

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -78,6 +78,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
                 this.skip();
             }
 
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
             settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
             settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
         });
@@ -119,12 +120,13 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
             assert(absoluteUrl !== undefined, "Should be able to retrieve the absolute url");
 
             // Retrieving the blob should fail. Note that the blob is requested via its url since this container does
-            // not have access to the blob's handle.
+            // not have access to the blob's handle since it loaded after the blob was tombstoned.
             const response = await container2.request({ url: blobHandle.absolutePath });
             assert.strictEqual(response?.status, 404, `Expecting a 404 response`);
             assert(response.value.startsWith("Blob removed by gc:"), `Unexpected response value`);
             assert(container2.closed !== true, "Container should not have closed");
 
+            // But the summarizing container should succeed (logging and error)
             const { container: summarizingContainer } = await createSummarizerWithContainer(
                 provider,
                 absoluteUrl,
@@ -186,6 +188,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
             assert(response2.value.startsWith("Blob removed by gc:"), `Unexpected response value for blob handle 2`);
         });
 
+        //* Update this
         itExpects("Can un-tombstone attachment blob by storing a handle",
         [
             {
@@ -253,6 +256,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
         ],
         async () => {
             // Turn ThrowOnTombstoneUsage setting off.
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
             settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
 
             const { dataStore: mainDataStore, summarizer } = await createDataStoreAndSummarizer();
@@ -371,6 +375,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
                 this.skip();
             }
 
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
             settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
             settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
         });
@@ -644,6 +649,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
                 this.skip();
             }
 
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
             settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
             settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
         });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -79,7 +79,6 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
             }
 
             settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
-            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
             settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
         });
 
@@ -256,7 +255,6 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
         async () => {
             // Turn ThrowOnTombstoneUsage setting off.
             settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
-            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
 
             const { dataStore: mainDataStore, summarizer } = await createDataStoreAndSummarizer();
 
@@ -375,7 +373,6 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
             }
 
             settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
-            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
             settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
         });
 
@@ -649,7 +646,6 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
             }
 
             settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
-            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
             settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
         });
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -188,7 +188,6 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
             assert(response2.value.startsWith("Blob removed by gc:"), `Unexpected response value for blob handle 2`);
         });
 
-        //* Update this
         itExpects("Can un-tombstone attachment blob by storing a handle",
         [
             {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -123,7 +123,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
             // not have access to the blob's handle since it loaded after the blob was tombstoned.
             const response = await container2.request({ url: blobHandle.absolutePath });
             assert.strictEqual(response?.status, 404, `Expecting a 404 response`);
-            assert(response.value.startsWith("Blob removed by gc:"), `Unexpected response value`);
+            assert.equal(response.value, `Blob removed by gc: ${blobHandle.absolutePath}`, `Unexpected response value`);
             assert(container2.closed !== true, "Container should not have closed");
 
             // But the summarizing container should succeed (logging and error)

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -549,7 +549,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             assert(response.value === `Datastore removed by gc: ${unreferencedId}`);
         });
 
-        //* Update this
         // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
         itExpects("Can un-tombstone datastores by storing a handle",
         [

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -58,8 +58,9 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
         if (provider.driver.type !== "local") {
             this.skip();
         }
+        settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
         settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
-        settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
+    settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
     });
 
     async function loadContainer(summaryVersion: string) {
@@ -440,7 +441,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             await assert.rejects(async () => requestFluidObject<ITestDataObject>(container, unreferencedId),
                 (error) => {
                     const correctErrorType = error.code === 404;
-                    const correctErrorMessage = error.message.startsWith(`Datastore removed by gc`) === true;
+                    const correctErrorMessage = error.message === `Datastore removed by gc: ${unreferencedId}`;
                     return correctErrorType && correctErrorMessage;
                 },
                 `Should not be able to retrieve a tombstoned datastore in non-summarizer clients`,
@@ -480,7 +481,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             await assert.rejects(async () => requestFluidObject<ITestDataObject>(container, unreferencedId),
                 (error) => {
                     const correctErrorType = error.code === 404;
-                    const correctErrorMessage = error.message.startsWith(`Datastore removed by gc`) === true;
+                    const correctErrorMessage = error.message === `Datastore removed by gc: ${unreferencedId}`;
                     return correctErrorType && correctErrorMessage;
                 },
                 `Should not be able to retrieve a tombstoned datastore.`,
@@ -548,6 +549,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             assert(response.value === `Datastore removed by gc: ${unreferencedId}`);
         });
 
+        //* Update this
         // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
         itExpects("Can un-tombstone datastores by storing a handle",
         [
@@ -639,6 +641,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             },
         ],
         async () => {
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
             settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
             const {
                 unreferencedId,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -584,7 +584,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             await assert.rejects(async () => requestFluidObject<ITestDataObject>(tombstoneContainer, unreferencedId),
                 (error) => {
                     const correctErrorType = error.code === 404;
-                    const correctErrorMessage = error.message.startsWith(`Datastore removed by gc`) === true;
+                    const correctErrorMessage = error.message === `Datastore removed by gc: ${unreferencedId}`;
                     return correctErrorType && correctErrorMessage;
                 },
                 `Should not be able to retrieve a tombstoned datastore.`,
@@ -966,10 +966,11 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             const container2 = await loadContainer(summary2.summaryVersion);
 
             // Requesting the tombstoned data store should result in an error.
-            await assert.rejects(async () => requestFluidObject<ITestDataObject>(container2, newDataStore._context.id),
+            const unreferencedId = newDataStore._context.id;
+            await assert.rejects(async () => requestFluidObject<ITestDataObject>(container2, unreferencedId),
                 (error) => {
                     const correctErrorType = error.code === 404;
-                    const correctErrorMessage = error.message.startsWith(`Datastore removed by gc`) === true;
+                    const correctErrorMessage = error.message === `Datastore removed by gc: ${unreferencedId}`;
                     return correctErrorType && correctErrorMessage;
                 },
                 `Should not be able to retrieve a tombstoned datastore.`,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -58,9 +58,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
         if (provider.driver.type !== "local") {
             this.skip();
         }
-        settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
-        settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
-    settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
+        settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
     });
 
     async function loadContainer(summaryVersion: string) {
@@ -70,32 +68,31 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
         );
     }
 
-    describe("Using tombstone data stores is not allowed", () => {
-        let documentAbsoluteUrl: string | undefined;
+    let documentAbsoluteUrl: string | undefined;
 
-        const makeContainer = async () => {
-            const container = await provider.makeTestContainer(testContainerConfig);
-            documentAbsoluteUrl = await container.getAbsoluteUrl("");
-            return container;
-        };
+    const makeContainer = async () => {
+        const container = await provider.makeTestContainer(testContainerConfig);
+        documentAbsoluteUrl = await container.getAbsoluteUrl("");
+        return container;
+    };
 
-        const loadSummarizerAndContainer = async (summaryVersion?: string) => {
-            return createSummarizerWithContainer(
-                provider,
-                documentAbsoluteUrl,
-                summaryVersion,
-                gcOptions,
-                mockConfigProvider(settings),
-            );
-        };
-        const summarize = async (summarizer: ISummarizer) => {
-            await provider.ensureSynchronized();
-            return summarizeNow(summarizer);
-        };
+    const loadSummarizerAndContainer = async (summaryVersion?: string) => {
+        return createSummarizerWithContainer(
+            provider,
+            documentAbsoluteUrl,
+            summaryVersion,
+            gcOptions,
+            mockConfigProvider(settings),
+        );
+    };
+    const summarize = async (summarizer: ISummarizer) => {
+        await provider.ensureSynchronized();
+        return summarizeNow(summarizer);
+    };
 
-        // This function creates an unreferenced datastore and returns the datastore's id and the summary version that
-        // datastore was unreferenced in.
-        const summarizationWithUnreferencedDataStoreAfterTime =
+    // This function creates an unreferenced datastore and returns the datastore's id and the summary version that
+    // datastore was unreferenced in.
+    const summarizationWithUnreferencedDataStoreAfterTime =
         async (approximateUnreferenceTimestampMs: number) => {
             const container = await makeContainer();
             const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
@@ -145,36 +142,43 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             };
         };
 
-        let opCount = 0;
-        // Sends a unique op that's guaranteed to change the DDS for this specific container.
-        // This can also be used to transition a client to write mode.
-        const sendOpToUpdateSummaryTimestampToNow = async (container: IContainer) => {
-            const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
-            defaultDataObject._root.set("send a", `op ${opCount++}`);
-        };
+    let opCount = 0;
+    // Sends a unique op that's guaranteed to change the DDS for this specific container.
+    // This can also be used to transition a client to write mode.
+    const sendOpToUpdateSummaryTimestampToNow = async (container: IContainer) => {
+        const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
+        defaultDataObject._root.set("send a", `op ${opCount++}`);
+    };
 
-        const getTombstonedDataObjectFromSummary = async (summaryVersion: string, id: string) => {
-            // Load a container with the data store tombstoned
-            const container = await loadContainer(summaryVersion);
+    const getTombstonedDataObjectFromSummary = async (summaryVersion: string, id: string) => {
+        // Load a container with the data store tombstoned
+        const container = await loadContainer(summaryVersion);
 
-            // Transition container to write mode
-            const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
-            defaultDataObject._root.set("send a", "op");
+        // Transition container to write mode
+        const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
+        defaultDataObject._root.set("send a", "op");
 
-            // Get dataObject
-            const containerRuntime = defaultDataObject._context.containerRuntime as any;
-            const dataStoreContext = containerRuntime.dataStores.contexts.get(id);
-            const dataStoreRuntime: IFluidDataStoreChannel = await dataStoreContext.realize();
-            return await dataStoreRuntime.entryPoint?.get() as ITestDataObject;
-        };
+        // Get dataObject
+        const containerRuntime = defaultDataObject._context.containerRuntime as any;
+        const dataStoreContext = containerRuntime.dataStores.contexts.get(id);
+        const dataStoreRuntime: IFluidDataStoreChannel = await dataStoreContext.realize();
+        return await dataStoreRuntime.entryPoint?.get() as ITestDataObject;
+    };
 
-        const setupContainerCloseErrorValidation = (container: IContainer, expectedCall: string) => {
-            container.on("closed", (error) => {
-                assert(error !== undefined, `Expecting an error!`);
-                assert(error.errorType === "dataCorruptionError");
-                assert(error.message === `Context is tombstoned! Call site [${expectedCall}]`);
-            });
-        };
+    const setupContainerCloseErrorValidation = (container: IContainer, expectedCall: string) => {
+        container.on("closed", (error) => {
+            assert(error !== undefined, `Expecting an error!`);
+            assert(error.errorType === "dataCorruptionError");
+            assert(error.message === `Context is tombstoned! Call site [${expectedCall}]`);
+        });
+    };
+
+    describe("Using tombstone data stores not allowed (per config)", () => {
+        beforeEach(() => {
+            // Allow Loading but not Usage
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
+        });
 
         // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
         itExpects("Send ops fails for tombstoned datastores in summarizing container loaded after sweep timeout",
@@ -412,6 +416,15 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             assert(receivingContainer.closed === true, `Container receiving messages to a tombstoned datastore should close.`);
         });
 
+    });
+
+    describe("Loading tombstone data stores not allowed (per config)", () => {
+        beforeEach(() => {
+            // Allow Usage but not Loading
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
+        });
+
         // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
         itExpects("Requesting tombstoned datastores fails in summarizing container loaded after sweep timeout",
         [
@@ -619,56 +632,56 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             assert(sendingContainer.closed !== true,
                 `Revived datastore should not close a container when sending signals and ops.`);
         });
+    });
 
-        itExpects("does not throw tombstone errors when ThrowOnTombstoneUsage setting is not enabled",
-        [
-            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested" },
-            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
-            {
-                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-                callSite: "submitMessage",
-            },
-            {
-                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-                callSite: "process",
-                clientType: "noninteractive/summarizer",
-            },
-            {
-                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-                callSite: "process",
-                clientType: "interactive",
-            },
-        ],
-        async () => {
-            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
-            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
-            const {
-                unreferencedId,
-                summarizingContainer,
-                summarizer,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+    itExpects("Loading/Using tombstone allowed when configured",
+    [
+        { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested" },
+        { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
+        {
+            eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+            callSite: "submitMessage",
+        },
+        {
+            eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+            callSite: "process",
+            clientType: "noninteractive/summarizer",
+        },
+        {
+            eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+            callSite: "process",
+            clientType: "interactive",
+        },
+    ],
+    async () => {
+        settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
+        settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
+        const {
+            unreferencedId,
+            summarizingContainer,
+            summarizer,
+        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 
-            // The datastore should be tombstoned now
-            const { summaryVersion } = await summarize(summarizer);
-            const container = await loadContainer(summaryVersion);
-            // Requesting the tombstoned data store should succeed since ThrowOnTombstoneUsage is not enabled.
-            // Logs a tombstone and sweep ready error
-            let dataObject: ITestDataObject;
-            await assert.doesNotReject(
-                async () => { dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId); },
-                `Should be able to request a tombstoned datastore.`,
-            );
-            // Modifying the tombstoned datastore should not fail since ThrowOnTombstoneUsage is not enabled.
-            // Logs a submitMessage error
-            assert.doesNotThrow(() => dataObject._root.set("send", "op"),
-                `Should be able to send ops for a tombstoned datastore.`,
-            );
+        // The datastore should be tombstoned now
+        const { summaryVersion } = await summarize(summarizer);
+        const container = await loadContainer(summaryVersion);
+        // Requesting the tombstoned data store should succeed since ThrowOnTombstoneLoad is not enabled.
+        // Logs a tombstone and sweep ready error
+        let dataObject: ITestDataObject;
+        await assert.doesNotReject(
+            async () => { dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId); },
+            `Should be able to request a tombstoned datastore.`,
+        );
+        // Modifying the tombstoned datastore should not fail since ThrowOnTombstoneUsage is not enabled.
+        // Logs a submitMessage error
+        assert.doesNotThrow(() => dataObject._root.set("send", "op"),
+            `Should be able to send ops for a tombstoned datastore.`,
+        );
 
-            // Wait for the above op to be process. That will result in another error logged during process.
-            // Both the summarizing container and the submitting container log a process error
-            await provider.ensureSynchronized();
-        });
+        // Wait for the above op to be process. That will result in another error logged during process.
+        // Both the summarizing container and the submitting container log a process error
+        await provider.ensureSynchronized();
     });
 
     describe("Tombstone information in summary", () => {
@@ -696,6 +709,12 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
                 assert(!actualTombstones.includes(url), `${url} should not be in tombstone blob`);
             }
         }
+
+        beforeEach(() => {
+            // This is not the typical configuration we expect (usage may be allowed), but keeping it more strict for the tests
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
+        });
 
         it("adds tombstone data stores information to tombstone blob in summary", async () => {
             const mainContainer = await provider.makeTestContainer(testContainerConfig);


### PR DESCRIPTION
## Description

We are working on a mechanism to allow consumers to retrieve and revive a Tombstoned object (see #13606). In these cases, the object will still appear tombstoned so we need to allow tombstoned objects to be used (ops sent/received).

This PR separates two flags where there was previously one.  Now it's `Fluid.GarbageCollection.ThrowOnTombstoneUsage` and `Fluid.GarbageCollection.ThrowOnTombstoneLoad`

## Reviewer Guidance

I also made some changes to `sendGCTombstoneEvent` in here.
