### PR TITLE
r11s: utilize Throttling weight for submitOp and submitSignal

### DIFF
--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -165,13 +165,14 @@ function checkThrottleAndUsage(
     tenantId: string,
     logger?: core.ILogger,
     usageStorageId?: string,
-    usageData?: core.IUsageData): core.ThrottlingError | undefined {
+    usageData?: core.IUsageData,
+    incrementWeight: number = 1): core.ThrottlingError | undefined {
     if (!throttler) {
         return;
     }
 
     try {
-        throttler.incrementCount(throttleId, 1, usageStorageId, usageData);
+        throttler.incrementCount(throttleId, incrementWeight, usageStorageId, usageData);
     } catch (error) {
         if (error instanceof core.ThrottlingError) {
             return error;
@@ -514,11 +515,22 @@ export function configureWebSocketServices(
 
                     socket.emit("nack", "", [nackMessage]);
                 } else {
+                    let messageCount = 0;
+                    for (const messageBatch of messageBatches) {
+                        // Count all messages in each batch for accurate throttling calculation.
+                        // Note: This is happening before message size checking. It might be more helpful
+                        // to the user to deny with a 413 for op size before a 429 for throttling, because the
+                        // 413 will be retried, but initial batch will not be processed, effectively doubling
+                        // the throttled increment count for those messages.
+                        messageCount += (Array.isArray(messageBatch) ? messageBatch.length : 1);
+                    }
                     const throttleError = checkThrottleAndUsage(
                         submitOpThrottler,
                         getSubmitOpThrottleId(clientId, connection.tenantId),
                         connection.tenantId,
-                        logger);
+                        logger,
+                        undefined, undefined,
+                        messageCount /* incrementWeight */);
                     if (throttleError) {
                         const nackMessage = createNackMessage(
                             throttleError.code,
@@ -551,7 +563,7 @@ export function configureWebSocketServices(
                         const messages = Array.isArray(messageBatch) ? messageBatch : [messageBatch];
                         try {
                             const sanitized = messages
-                                .filter((message) => {
+                                .map((message) => {
                                     if (verifyMaxMessageSize === true) {
                                         // Local tests show `JSON.stringify` to be fast
                                         // - <1ms for JSONs <100kb
@@ -568,9 +580,6 @@ export function configureWebSocketServices(
                                         }
                                     }
 
-                                    return true;
-                                })
-                                .map((message) => {
                                     const sanitizedMessage: IDocumentMessage = sanitizeMessage(message);
                                     const sanitizedMessageWithTrace = addAlfredTrace(sanitizedMessage,
                                         numberOfMessagesPerTrace, connection.clientId,
@@ -599,6 +608,11 @@ export function configureWebSocketServices(
                     const nackMessage = createNackMessage(400, NackErrorType.BadRequestError, "Nonexistent client");
                     socket.emit("nack", "", [nackMessage]);
                 } else {
+                    let messageCount = 0;
+                    for (const contentBatch of contentBatches) {
+                        // Count all messages in each batch for accurate throttling calculation.
+                        messageCount += (Array.isArray(contentBatch) ? contentBatch.length : 1);
+                    }
                     const signalUsageData: core.IUsageData = {
                         value: 0,
                         tenantId: room.tenantId,
@@ -611,7 +625,8 @@ export function configureWebSocketServices(
                         room.tenantId,
                         logger,
                         isSignalUsageCountingEnabled ? core.signalUsageStorageId : undefined,
-                        isSignalUsageCountingEnabled ? signalUsageData : undefined);
+                        isSignalUsageCountingEnabled ? signalUsageData : undefined,
+                        messageCount /* incrementWeight */);
                     if (throttleError) {
                         const nackMessage = createNackMessage(
                             throttleError.code,
@@ -621,8 +636,8 @@ export function configureWebSocketServices(
                         socket.emit("nack", "", [nackMessage]);
                         return;
                     }
-                    contentBatches.forEach((contentBatche) => {
-                        const contents = Array.isArray(contentBatche) ? contentBatche : [contentBatche];
+                    contentBatches.forEach((contentBatch) => {
+                        const contents = Array.isArray(contentBatch) ? contentBatch : [contentBatch];
 
                         for (const content of contents) {
                             const signalMessage: ISignalMessage = {

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -518,10 +518,9 @@ export function configureWebSocketServices(
                     let messageCount = 0;
                     for (const messageBatch of messageBatches) {
                         // Count all messages in each batch for accurate throttling calculation.
-                        // Note: This is happening before message size checking. It might be more helpful
-                        // to the user to deny with a 413 for op size before a 429 for throttling, because the
-                        // 413 will be retried, but initial batch will not be processed, effectively doubling
-                        // the throttled increment count for those messages.
+                        // Note: This is happening before message size checking. We won't process
+                        // messages that are too large, so it is inaccurate to increment throttle
+                        // counts for unprocessed messages.
                         messageCount += (Array.isArray(messageBatch) ? messageBatch.length : 1);
                     }
                     const throttleError = checkThrottleAndUsage(


### PR DESCRIPTION
## Description

This is a bug fix for op and signal throttling in R11s. The current implementation does not take op or signal batching into account, so if a client sends a batch of 10k ops within a `submitOp` event, the throttling logic will treat it as 1 op. Same for `submitSignal`.

To address this bug, this PR uses the already-implemented throttle increment weight functionality to increment each submitOp event with weight equal to total number of messages.

## Reviewer Guidance

### Bad User Experience & Throttling Correctness

I left a note in the comments under `submitOp` about throttling before checking op sizes. I think this is worth fixing, but might be out of scope.

### Loop Efficiency

I recognize that looping through the batches to count and then looping again to order is inefficient, but the alternative would be incrementing throttle for every message during the order loop, and I don't know if the client would handle a half-processed batch well if we throttle mid-processing. Otherwise, we could pre-process the messages, keeping track of message count there during sanitization, then looping again to order them, but that's the same efficiency as looping to count, however, it could solve the NACK inefficiency problem described above.

I also realized my previous op size check fix (#11117) was now inefficiently looping twice when it only needed to loop once, so I fixed that here. The filter method their used to be used for other filtering, but that other filtering was removed in a `Main -> Next` commit (5564403dce7c620bef8cf94b1552cd9f1600eb6e).
