### PR TITLE
Remove TODOs from PactMap

### DIFF
--- a/packages/dds/pact-map/src/pactMap.ts
+++ b/packages/dds/pact-map/src/pactMap.ts
@@ -53,7 +53,6 @@ interface IPendingPact<T> {
     /**
      * The list of clientIds that we expect "accept" ops from.  Clients are also removed from this list if they
      * disconnect without accepting.  When this list empties, the pending value transitions to accepted.
-     * TODO: Consider using a Set locally, and serializing to array just for the snapshot
      */
     expectedSignoffs: string[];
 }
@@ -226,7 +225,6 @@ export class PactMap<T = unknown> extends SharedObject<IPactMapEvents> implement
         }
 
         // If not attached, we basically pretend we got an ack immediately.
-        // TODO: Should we just directly store the value rather than the full simulation?
         if (!this.isAttached()) {
             // Queueing as a microtask to permit callers to complete their callstacks before the result of the set
             // takes effect.  This more closely resembles the pattern in the attached state, where the ack will not

--- a/packages/dds/pact-map/src/test/pactMap.spec.ts
+++ b/packages/dds/pact-map/src/test/pactMap.spec.ts
@@ -324,8 +324,6 @@ describe("PactMap", () => {
             pactMap2.connect(services2);
         });
 
-        // TODO: Consider if there's any value in distinctly testing these scenarios for acceptance via
-        // accept ops vs. via the last expected signoff disconnecting.
         it("Doesn't resubmit accept ops that were sent before offline", async () => {
             const targetKey = "key";
             pactMap1.set(targetKey, "expected");
@@ -390,8 +388,6 @@ describe("PactMap", () => {
         it("Sequenced proposals that were accepted during offline have correct state after reconnect", async () => {
             const targetKey = "key";
             pactMap1.set(targetKey, "expected");
-            // TODO: In this flow, client 1 processes the set message ack before it disconnects but not the accepts
-            // Consider whether it's interesting for it to disconnect before processing any ops.
             containerRuntimeFactory.processOneMessage(); // pactMap1 "set"
             containerRuntime1.connected = false;
             containerRuntimeFactory.processAllMessages(); // Process the accept from client 2
@@ -404,8 +400,6 @@ describe("PactMap", () => {
         it("Sequenced proposals that remained pending during offline have correct state after reconnect", async () => {
             const targetKey = "key";
             pactMap1.set(targetKey, "expected");
-            // TODO: In this flow, client 1 processes the set message ack before it disconnects but not the accepts
-            // Consider whether it's interesting for it to disconnect before processing any ops.
             containerRuntimeFactory.processOneMessage(); // pactMap1 "set"
             containerRuntime1.connected = false;
             containerRuntime1.connected = true;


### PR DESCRIPTION
Went through these and decided they weren't necessary:

- I decided using a Set wouldn't really provide any benefit (e.g. deduping should already be happening in the QuorumClients), and would just be annoying to serialize to/from an array
- Although directly storing the value would maybe be a little more straightforward to follow in isolation, I think it would increase the risk of detached behavior diverging from attached behavior and so probably not worth it.
- I don't think the scenarios I called out in the tests are actually that interesting -- the variations aren't really material to the purposes of the test and/or are sufficiently covered by other tests.

[AB#3199](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3199)