### PR TITLE
[Port v2int 2.3] Provide capability to dispose Container (#13617)

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -15,6 +15,20 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 - Avoid using code formatting in the title (it's fine to use in the body).
 - To explain the benefit of your change, use the [What's New](https://fluidframework.com/docs/updates/v1.0.0/) section on FluidFramework.com.
 
+# 2.0.0-internal.2.3.0
+
+## 2.0.0-internal.2.3.0 Upcoming changes
+- [Upcoming changes to container closure](#Upcoming-changes-to-container-closure)
+
+### Upcoming changes to container closure
+
+In the next major release, calling `IContainer.close(...)` will no longer dispose the container runtime, document service, or document storage service.
+
+If the container is not expected to be used after the `close(...)` call, replace it instead with a `IContainer.dispose(...)` call. This change will no longer switch the container to "readonly" mode and relevant code should instead listen to the Container's "disposed" event.
+Otherwise, to retain all current behavior, add a call to `IContainer.dispose(...)` after every `close(...)` call (passing the same error object if present).
+
+Please see the [Closure](packages/loader/container-loader/README.md#Closure) section of Loader README.md for more details.
+
 # 2.0.0-internal.2.2.0
 
 ## 2.0.0-internal.2.2.0 Upcoming changes

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -133,6 +133,7 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
     readonly connectionState: ConnectionState;
     deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     disconnect(): void;
+    dispose?(error?: ICriticalContainerError): void;
     // @alpha
     forceReadonly?(readonly: boolean): any;
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
@@ -164,6 +165,8 @@ export interface IContainerContext extends IDisposable {
     readonly connected: boolean;
     // (undocumented)
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
+    // (undocumented)
+    readonly disposeFn?: (error?: ICriticalContainerError) => void;
     // @deprecated (undocumented)
     readonly existing: boolean | undefined;
     getAbsoluteUrl?(relativeUrl: string): Promise<string | undefined>;
@@ -209,6 +212,7 @@ export interface IContainerEvents extends IEvent {
     (event: "disconnected", listener: () => void): any;
     (event: "attached", listener: () => void): any;
     (event: "closed", listener: (error?: ICriticalContainerError) => void): any;
+    (event: "disposed", listener: (error?: ICriticalContainerError) => void): any;
     (event: "warning", listener: (error: ContainerWarning) => void): any;
     (event: "op", listener: (message: ISequencedDocumentMessage) => void): any;
     (event: "dirty", listener: (dirty: boolean) => void): any;

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -83,6 +83,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     get deltaManager(): IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     // (undocumented)
     disconnect(): void;
+    // (undocumented)
+    dispose?(error?: ICriticalContainerError): void;
     forceReadonly(readonly: boolean): void;
     // (undocumented)
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -121,6 +121,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // (undocumented)
     get disposed(): boolean;
     // (undocumented)
+    get disposeFn(): (error?: ICriticalContainerError) => void;
+    // (undocumented)
     readonly enqueueSummarize: ISummarizer["enqueueSummarize"];
     // (undocumented)
     get flushMode(): FlushMode;
@@ -512,6 +514,8 @@ export interface ISummarizerInternalsProvider {
 export interface ISummarizerRuntime extends IConnectableRuntime {
     // (undocumented)
     closeFn(): void;
+    // (undocumented)
+    disposeFn?(): void;
     // (undocumented)
     readonly logger: ITelemetryLogger;
     // @deprecated (undocumented)

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -185,6 +185,17 @@ export interface IContainerEvents extends IEvent {
     (event: "closed", listener: (error?: ICriticalContainerError) => void);
 
     /**
+     * Emitted when the {@link IContainer} is disposed, which permanently disables it.
+     *
+     * @remarks Listener parameters:
+     *
+     * - `error`: If the container was disposed due to error, this will contain details about the error that caused it.
+     *
+     * @see {@link IContainer.dispose}
+     */
+    (event: "disposed", listener: (error?: ICriticalContainerError) => void);
+
+    /**
      * Emitted when the container encounters a state which may lead to errors, which may be actionable by the consumer.
      *
      * @remarks
@@ -328,6 +339,15 @@ export interface IContainer extends IEventProvider<IContainerEvents>, IFluidRout
      * Whether or not there are any local changes that have not been saved.
      */
     readonly isDirty: boolean;
+
+    /**
+     * Disposes the container. If not already closed, this acts as a closure and then disposes runtime resources.
+     * The container is not expected to be used anymore once it is disposed.
+     *
+     * @param error - If the container is being disposed due to error, this provides details about the error that
+     * resulted in disposing it.
+     */
+    dispose?(error?: ICriticalContainerError): void;
 
     /**
      * Closes the container.

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -136,6 +136,7 @@ export interface IContainerContext extends IDisposable {
     readonly submitBatchFn: (batch: IBatchMessage[]) => number;
     readonly submitSummaryFn: (summaryOp: ISummaryContent) => number;
     readonly submitSignalFn: (contents: any) => void;
+    readonly disposeFn?: (error?: ICriticalContainerError) => void;
     readonly closeFn: (error?: ICriticalContainerError) => void;
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     readonly quorum: IQuorumClients;

--- a/packages/loader/container-loader/README.md
+++ b/packages/loader/container-loader/README.md
@@ -68,7 +68,13 @@ Usually container is returned when state of container (and data stores) is rehyd
 
 ### Closure
 
-Container can be closed directly by host by calling `Container.close()`. Once closed, container terminates connection to ordering service, and any local changes (former or future) do not propagate to storage.
+Container can be closed directly by host by calling `Container.close()` and/or `Container.dispose()`. If the container is expected to be used upon closure, use the `close()` API. Otherwise, use the `dispose()` API. The differences between these methods are detailed in the sections below.
+
+#### `Container.close()`
+
+Once closed, container terminates connection to ordering service, and any local changes (former or future) do not propagate to storage. This method is to be used when the container **IS** still expected to be used and the container needs to be switched to a "safe" state for viewing. For example, allowing a user to copy the content out of a container.
+
+The "closed" state effectively means the container is disconnected forever and cannot be reconnected.
 
 Container can also be closed by runtime itself as result of some critical error. Critical errors can be internal (like violation in op ordering invariants), or external (file was deleted). Please see [Error Handling](#Error-handling) for more details
 
@@ -80,6 +86,19 @@ When container is closed, the following is true (in no particular order):
 4. "disconnected" event fires, if connection was active at the moment of container closure.
 
 `"closed"` event is available on Container for hosts. `"disposed"` event is delivered to container runtime when container is closed. But container runtime can be also disposed when new code proposal is made and new version of the code (and container runtime) is loaded in accordance with it.
+
+#### `Container.dispose()`
+
+Once disposed, container terminates connection to ordering service, and any local changes (former or future) do not propagate to storage. This method is to be used when the container is **NOT** expected to be used anymore.
+
+When container is disposed, the following is true (in no particular order):
+
+1. Container.closed property is set to true
+2. "disposed" event fires on container
+3. "disconnected" event fires, if connection was active at the moment of container disposal.
+4. "dispose" event fires on container runtime
+
+`"disposed"` event is available on Container for hosts. `"dispose"` event is delivered to container runtime when container is disposed, but container runtime can be also disposed when new code proposal is made and new version of the code (and container runtime) is loaded in accordance with it.
 
 ## Audience
 

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -189,7 +189,7 @@ export class ConnectionManager implements IConnectionManager {
 
     private _connectionProps: ITelemetryProperties = {};
 
-    private closed = false;
+    private _disposed = false;
 
     private readonly _outbound: DeltaQueue<IDocumentMessage[]>;
 
@@ -327,11 +327,11 @@ export class ConnectionManager implements IConnectionManager {
         });
     }
 
-    public dispose(error?: ICriticalContainerError) {
-        if (this.closed) {
+    public dispose(error?: ICriticalContainerError, switchToReadonly: boolean = true) {
+        if (this._disposed) {
             return;
         }
-        this.closed = true;
+        this._disposed = true;
 
         this.pendingConnection = undefined;
 
@@ -347,10 +347,12 @@ export class ConnectionManager implements IConnectionManager {
         // This raises "disconnect" event if we have active connection.
         this.disconnectFromDeltaStream(disconnectReason);
 
-        // Notify everyone we are in read-only state.
-        // Useful for data stores in case we hit some critical error,
-        // to switch to a mode where user edits are not accepted
-        this.set_readonlyPermissions(true);
+        if (switchToReadonly) {
+            // Notify everyone we are in read-only state.
+            // Useful for data stores in case we hit some critical error,
+            // to switch to a mode where user edits are not accepted
+            this.set_readonlyPermissions(true);
+        }
     }
 
     /**
@@ -438,7 +440,7 @@ export class ConnectionManager implements IConnectionManager {
     }
 
     private async connectCore(connectionMode?: ConnectionMode): Promise<void> {
-        assert(!this.closed, 0x26a /* "not closed" */);
+        assert(!this._disposed, 0x26a /* "not closed" */);
 
         if (this.connection !== undefined) {
             return;  // Connection attempt already completed successfully
@@ -485,7 +487,7 @@ export class ConnectionManager implements IConnectionManager {
 
         // This loop will keep trying to connect until successful, with a delay between each iteration.
         while (connection === undefined) {
-            if (this.closed) {
+            if (this._disposed) {
                 throw new Error("Attempting to connect a closed DeltaManager");
             }
             if (abortSignal.aborted === true) {
@@ -676,7 +678,7 @@ export class ConnectionManager implements IConnectionManager {
 
         this.set_readonlyPermissions(readonly);
 
-        if (this.closed) {
+        if (this._disposed) {
             // Raise proper events, Log telemetry event and close connection.
             this.disconnectFromDeltaStream("ConnectionManager already closed");
             return;
@@ -826,7 +828,7 @@ export class ConnectionManager implements IConnectionManager {
         }
 
         // If closed then we can't reconnect
-        if (this.closed || this.reconnectMode !== ReconnectMode.Enabled) {
+        if (this._disposed || this.reconnectMode !== ReconnectMode.Enabled) {
             return;
         }
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -387,7 +387,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
     private readonly mc: MonitoringContext;
 
-    private _lifecycleState: "loading" | "loaded" | "closing" | "closed" = "loading";
+    private _lifecycleState: "loading" | "loaded" | "closing" | "closed" | "disposed" = "loading";
 
     private setLoaded() {
         // It's conceivable the container could be closed when this is called
@@ -400,7 +400,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
     }
 
     public get closed(): boolean {
-        return (this._lifecycleState === "closing" || this._lifecycleState === "closed");
+        return (this._lifecycleState === "closing" || this._lifecycleState === "closed" || this._lifecycleState === "disposed");
     }
 
     private _attachState = AttachState.Detached;
@@ -753,16 +753,25 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         return this.protocolHandler.quorum;
     }
 
+    public dispose?(error?: ICriticalContainerError) {
+        this._deltaManager.close(error, true /* doDispose */);
+        this.verifyClosed();
+    }
+
     public close(error?: ICriticalContainerError) {
         // 1. Ensure that close sequence is exactly the same no matter if it's initiated by host or by DeltaManager
         // 2. We need to ensure that we deliver disconnect event to runtime properly. See connectionStateChanged
         //    handler. We only deliver events if container fully loaded. Transitioning from "loading" ->
         //    "closing" will lose that info (can also solve by tracking extra state).
         this._deltaManager.close(error);
+        this.verifyClosed();
+    }
+
+    private verifyClosed(): void {
         assert(this.connectionState === ConnectionState.Disconnected,
             0x0cf /* "disconnect event was not raised!" */);
 
-        assert(this._lifecycleState === "closed", 0x314 /* Container properly closed */);
+        assert(this._lifecycleState === "closed" || this._lifecycleState === "disposed", 0x314 /* Container properly closed */);
     }
 
     private closeCore(error?: ICriticalContainerError) {
@@ -801,12 +810,46 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
             this.emit("closed", error);
 
-            this.removeAllListeners();
             if (this.visibilityEventHandler !== undefined) {
                 document.removeEventListener("visibilitychange", this.visibilityEventHandler);
             }
         } finally {
             this._lifecycleState = "closed";
+        }
+    }
+
+    private _disposed = false;
+    private disposeCore(error?: ICriticalContainerError) {
+        assert(!this._disposed, "Container already disposed");
+        this._disposed = true;
+
+        try {
+            // Ensure that we raise all key events even if one of these throws
+            try {
+                this._protocolHandler?.close();
+
+                this.connectionStateHandler.dispose();
+
+                this._context?.dispose(error !== undefined ? new Error(error.message) : undefined);
+
+                this.storageService.dispose();
+
+                // Notify storage about critical errors. They may be due to disconnect between client & server knowledge
+                // about file, like file being overwritten in storage, but client having stale local cache.
+                // Driver need to ensure all caches are cleared on critical errors
+                this.service?.dispose(error);
+            } catch (exception) {
+                this.mc.logger.sendErrorEvent({ eventName: "ContainerDisposeException" }, exception);
+            }
+
+            this.emit("disposed", error);
+
+            this.removeAllListeners();
+            if (this.visibilityEventHandler !== undefined) {
+                document.removeEventListener("visibilitychange", this.visibilityEventHandler);
+            }
+        } finally {
+            this._lifecycleState = "disposed";
         }
     }
 
@@ -830,6 +873,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         this.mc.logger.sendTelemetryEvent({ eventName: "CloseAndGetPendingLocalState" });
 
+        // Only close here as method name suggests
         this.close();
 
         return JSON.stringify(pendingState);
@@ -960,6 +1004,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     newError.addTelemetryProperties({ resolvedUrl: resolvedUrl.url });
                 }
                 this.close(newError);
+                this.dispose?.(newError);
                 throw newError;
             }
         },
@@ -1096,7 +1141,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         }
 
         // pre-0.58 error message: existingContextDoesNotSatisfyIncomingProposal
-        this.close(new GenericError("Existing context does not satisfy incoming proposal"));
+        const error = new GenericError("Existing context does not satisfy incoming proposal");
+        this.close(error);
+        this.dispose?.(error);
     }
 
     private async getVersion(version: string | null): Promise<IVersion | undefined> {
@@ -1161,7 +1208,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             await this.storageService.connectToService(this.service);
         } else {
             // if we have pendingLocalState we can load without storage; don't wait for connection
-            this.storageService.connectToService(this.service).catch((error) => this.close(error));
+            this.storageService.connectToService(this.service).catch((error) => {
+                this.close(error);
+                this.dispose?.(error);
+            });
         }
 
         this._attachState = AttachState.Attached;
@@ -1432,7 +1482,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                         });
                     }
                     this.processCodeProposal().catch((error) => {
-                        this.close(normalizeError(error));
+                        const normalizedError = normalizeError(error);
+                        this.close(normalizedError);
+                        this.dispose?.(normalizedError);
                         throw error;
                     });
                 }
@@ -1539,7 +1591,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         deltaManager.on("disconnect", (reason: string) => {
             this.collabWindowTracker?.stopSequenceNumberUpdate();
-            this.connectionStateHandler.receivedDisconnectEvent(reason);
+            if (!this.closed) {
+                this.connectionStateHandler.receivedDisconnectEvent(reason);
+            }
         });
 
         deltaManager.on("throttled", (warning: IThrottlingWarning) => {
@@ -1559,6 +1613,10 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
 
         deltaManager.on("closed", (error?: ICriticalContainerError) => {
             this.closeCore(error);
+        });
+
+        deltaManager.on("disposed", (error?: ICriticalContainerError) => {
+            this.disposeCore(error);
         });
 
         return deltaManager;
@@ -1676,11 +1734,14 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                     metadata);
             case MessageType.Summarize:
                 return this.submitSummaryMessage(contents as unknown as ISummaryContent);
-            default:
-                this.close(new GenericError("invalidContainerSubmitOpType",
+            default: {
+                const newError = new GenericError("invalidContainerSubmitOpType",
                     undefined /* error */,
-                    { messageType: type }));
+                    { messageType: type });
+                this.close(newError);
+                this.dispose?.(newError);
                 return -1;
+            }
         }
     }
 
@@ -1838,6 +1899,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
             (summaryOp: ISummaryContent) => this.submitSummaryMessage(summaryOp),
             (batch: IBatchMessage[]) => this.submitBatch(batch),
             (message) => this.submitSignal(message),
+            (error?: ICriticalContainerError) => this.dispose?.(error),
             (error?: ICriticalContainerError) => this.close(error),
             Container.version,
             (dirty: boolean) => this.updateDirtyContainerState(dirty),

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -64,6 +64,7 @@ export class ContainerContext implements IContainerContext {
         submitSummaryFn: (summaryOp: ISummaryContent) => number,
         submitBatchFn: (batch: IBatchMessage[]) => number,
         submitSignalFn: (contents: any) => void,
+        disposeFn: (error?: ICriticalContainerError) => void,
         closeFn: (error?: ICriticalContainerError) => void,
         version: string,
         updateDirtyContainerState: (dirty: boolean) => void,
@@ -83,6 +84,7 @@ export class ContainerContext implements IContainerContext {
             submitSummaryFn,
             submitBatchFn,
             submitSignalFn,
+            disposeFn,
             closeFn,
             version,
             updateDirtyContainerState,
@@ -181,12 +183,12 @@ export class ContainerContext implements IContainerContext {
         /** @returns clientSequenceNumber of last message in a batch */
         public readonly submitBatchFn: (batch: IBatchMessage[]) => number,
         public readonly submitSignalFn: (contents: any) => void,
+        public readonly disposeFn: (error?: ICriticalContainerError) => void,
         public readonly closeFn: (error?: ICriticalContainerError) => void,
         public readonly version: string,
         public readonly updateDirtyContainerState: (dirty: boolean) => void,
         public readonly existing: boolean,
         public readonly pendingLocalState?: unknown,
-
     ) {
         this._connected = this.container.connected;
         this._quorum = quorum;

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -100,7 +100,7 @@ export interface IConnectionManager {
     /**
      * Disposed connection manager
      */
-    dispose(error?: ICriticalContainerError): void;
+    dispose(error?: ICriticalContainerError, switchToReadonly?: boolean): void;
 
     get connectionMode(): ConnectionMode;
 }

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -67,7 +67,7 @@ export interface IConnectionArgs {
  */
 export interface IDeltaManagerInternalEvents extends IDeltaManagerEvents {
     (event: "throttled", listener: (error: IThrottlingWarning) => void);
-    (event: "closed", listener: (error?: ICriticalContainerError) => void);
+    (event: "closed" | "disposed", listener: (error?: ICriticalContainerError) => void);
 }
 
 /**
@@ -102,7 +102,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 
     public get active(): boolean { return this._active(); }
 
-    public get disposed() { return this.closed; }
+    public get disposed() { return this._closed; }
 
     public get IDeltaSender() { return this; }
 
@@ -143,7 +143,8 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
     private readonly _inbound: DeltaQueue<ISequencedDocumentMessage>;
     private readonly _inboundSignal: DeltaQueue<ISignalMessage>;
 
-    private closed = false;
+    private _closed = false;
+    private _disposed = false;
 
     private handler: IDeltaHandlerStrategy | undefined;
     private deltaStorage: IDocumentDeltaStorageService | undefined;
@@ -439,7 +440,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
         // we know snapshot sequence number that is set in attachOpHandler. So all such calls should be noop.
         assert(this.fetchReason === undefined, 0x268 /* "There can't be pending fetch that early in boot sequence!" */);
 
-        if (this.closed) {
+        if (this._closed) {
             return;
         }
 
@@ -584,14 +585,23 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 
     /**
      * Closes the connection and clears inbound & outbound queues.
+     *
+     * @param doDispose - should the DeltaManager treat this close call as a dispose?
+     * Differences between close and dispose:
+     * - dispose will emit "disposed" event while close emits "closed"
+     * - dispose will remove all listeners
+     * - dispose can be called after closure, but not vis versa
      */
-    public close(error?: ICriticalContainerError): void {
-        if (this.closed) {
+     public close(error?: ICriticalContainerError, doDispose?: boolean): void {
+        if (this._closed) {
+            if (doDispose === true) {
+                this.disposeInternal(error);
+            }
             return;
         }
-        this.closed = true;
+        this._closed = true;
 
-        this.connectionManager.dispose(error);
+        this.connectionManager.dispose(error, doDispose !== true);
 
         this.closeAbortController.abort();
 
@@ -606,11 +616,23 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
         // Drop pending messages - this will ensure catchUp() does not go into infinite loop
         this.pending = [];
 
+        if (doDispose === true) {
+            this.disposeInternal(error);
+        } else {
+            this.emit("closed", error);
+        }
+    }
+
+    private disposeInternal(error?: ICriticalContainerError): void {
+        if (this._disposed) {
+            return;
+        }
+        this._disposed = true;
+
         // This needs to be the last thing we do (before removing listeners), as it causes
         // Container to dispose context and break ability of data stores / runtime to "hear"
         // from delta manager, including notification (above) about readonly state.
-        this.emit("closed", error);
-
+        this.emit("disposed", error);
         this.removeAllListeners();
     }
 
@@ -898,7 +920,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
             return;
         }
 
-        if (this.closed) {
+        if (this._closed) {
             this.logger.sendTelemetryEvent({ eventName: "fetchMissingDeltasClosedConnection", reason });
             return;
         }
@@ -950,7 +972,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
      * Sorts pending ops and attempts to apply them
      */
     private processPendingOps(reason?: string): void {
-        if (this.closed) {
+        if (this._closed) {
             return;
         }
 

--- a/packages/loader/container-loader/src/test/containerContext.spec.ts
+++ b/packages/loader/container-loader/src/test/containerContext.spec.ts
@@ -75,6 +75,7 @@ describe("ContainerContext Tests", () => {
             Sinon.fake(),
             Sinon.fake(),
             Sinon.fake(),
+            Sinon.fake(),
             Container.version,
             Sinon.fake(),
             existing,

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -160,7 +160,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
         // This will result in "summarizerClientDisconnected" stop reason recorded in telemetry,
         // unless stop() was called earlier
         this.dispose();
-        this.runtime.closeFn();
+        (this.runtime.disposeFn ?? this.runtime.closeFn)()
     }
 
     private async runCore(onBehalfOf: string): Promise<SummarizerStopReason> {

--- a/packages/runtime/container-runtime/src/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summarizerTypes.ts
@@ -94,6 +94,7 @@ export interface ISummarizerRuntime extends IConnectableRuntime {
     readonly logger: ITelemetryLogger;
     /** clientId of parent (non-summarizing) container that owns summarizer container */
     readonly summarizerClientId: string | undefined;
+    disposeFn?(): void;
     closeFn(): void;
     /** @deprecated 1.0, please remove all implementations and usage */
     on(event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): this;

--- a/packages/test/test-end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/consensusOrderedCollectionEndToEndTests.spec.ts
@@ -63,7 +63,10 @@ function generate(
             const container2 = await provider.loadTestContainer(testContainerConfig);
             dataStore2 = await requestFluidObject<ITestFluidObject>(container2, "default");
             sharedMap2 = await dataStore2.getSharedObject<SharedMap>(mapId);
-            closeContainer2 = () => container2.close();
+            closeContainer2 = () => {
+                container2.close();
+                container2.dispose?.();
+            }
 
             // Load the Container that was created by the first client.
             const container3 = await provider.loadTestContainer(testContainerConfig);

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -44,6 +44,7 @@ import {
     itExpects,
 } from "@fluidframework/test-version-utils";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 const id = "fluid-test://localhost/containerTest";
 const testRequest: IRequest = { url: id };
@@ -518,6 +519,73 @@ describeNoCompat("Container", (getTestObjectProvider) => {
             container.connectionState, ConnectionState.Connected,
             "container is not connected after rapid disconnect() + connect()",
         );
+    });
+
+    it("Disposing container does not send deltaManager readonly event", async () => {
+        const container = await createConnectedContainer();
+
+        let run = 0;
+        container.deltaManager.on("readonly", () => run++);
+
+        container.dispose?.();
+        assert.strictEqual(run, 0, "DeltaManager should not send readonly event on container dispose");
+    });
+
+    it("Closing container sends deltaManager readonly event", async () => {
+        const container = await createConnectedContainer();
+
+        let run = 0;
+        container.deltaManager.on("readonly", () => run++);
+
+        container.close();
+        assert.strictEqual(run, 1, "DeltaManager should send readonly event on container close");
+    });
+
+    it("Disposing container should send dispose events", async () => {
+        const container = await createConnectedContainer();
+        const dataObject = await requestFluidObject<ITestDataObject>(container, "default");
+
+        let containerDisposed = 0;
+        let containerClosed = 0;
+        let deltaManagerDisposed = 0;
+        let deltaManagerClosed = 0;
+        let runtimeDispose = 0;
+        container.on("disposed", () => containerDisposed++);
+        container.on("closed", () => containerClosed++);
+        (container.deltaManager as any).on("disposed", () => deltaManagerDisposed++);
+        (container.deltaManager as any).on("closed", () => deltaManagerClosed++);
+        (dataObject._context.containerRuntime as ContainerRuntime).on("dispose", () => runtimeDispose++);
+
+        container.dispose?.();
+        assert.strictEqual(containerDisposed, 1, "Container should send disposed event on container dispose");
+        assert.strictEqual(containerClosed, 0, "Container should not send closed event on container dispose");
+        assert.strictEqual(deltaManagerDisposed, 1, "DeltaManager should send disposed event on container dispose");
+        assert.strictEqual(deltaManagerClosed, 0, "DeltaManager should not send closed event on container dispose");
+        assert.strictEqual(runtimeDispose, 1, "ContainerRuntime should send dispose event on container dispose");
+    });
+
+    it("Closing then disposing container should send close and dispose events", async () => {
+        const container = await createConnectedContainer();
+        const dataObject = await requestFluidObject<ITestDataObject>(container, "default");
+
+        let containerDisposed = 0;
+        let containerClosed = 0;
+        let deltaManagerDisposed = 0;
+        let deltaManagerClosed = 0;
+        let runtimeDispose = 0;
+        container.on("disposed", () => containerDisposed++);
+        container.on("closed", () => containerClosed++);
+        (container.deltaManager as any).on("disposed", () => deltaManagerDisposed++);
+        (container.deltaManager as any).on("closed", () => deltaManagerClosed++);
+        (dataObject._context.containerRuntime as ContainerRuntime).on("dispose", () => runtimeDispose++);
+
+        container.close();
+        container.dispose?.();
+        assert.strictEqual(containerDisposed, 1, "Container should send disposed event");
+        assert.strictEqual(containerClosed, 1, "Container should send closed event");
+        assert.strictEqual(deltaManagerDisposed, 1, "DeltaManager should send disposed event");
+        assert.strictEqual(deltaManagerClosed, 1, "DeltaManager should send closed event");
+        assert.strictEqual(runtimeDispose, 1, "ContainerRuntime should send dispose event");
     });
 });
 


### PR DESCRIPTION
# [AB#1343](https://dev.azure.com/fluidframework/internal/_workitems/edit/1343)

See https://github.com/microsoft/FluidFramework/pull/13617

[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

New `Container.dispose()` method that host can call when it knows nobody is going to use container anymore.
This flow will be identical to today's `Contanainer.close()` but will not raise `"readonly"` events (container will still raise `"closed"` events). Components can leverage `"dispose"` events on runtime / data stores to learn about this transition.

## Upcoming Breaking Changes

Future change in next major release will mean calling `IContainer.close(...)` is no longer expected to dispose the container runtime, document service, or document storage service.

If the container is not expected to be used after the `close(...)` call, replace it instead with a `IContainer.dispose(...)` call. This change will no longer switch the container to "readonly" mode and relevant code should instead listen to the Container's "disposed" event.
Otherwise, to retain all current behavior, add a call to `IContainer.dispose(...)` after every `close(...)` call (passing the same error object if present).