### PR TITLE
Add collaborativeTextArea to sharedString

### DIFF
--- a/packages/tools/client-debugger/client-debugger-view/src/components/data-object-views/SharedStringView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/data-object-views/SharedStringView.tsx
@@ -25,6 +25,7 @@ export function SharedStringView(props: SharedStringViewProps): React.ReactEleme
     const { sharedString } = props;
 
     const [text, setText] = React.useState<string>(sharedString.getText());
+    console.log(text);
 
     React.useEffect(() => {
         function updateText(): void {
@@ -39,13 +40,10 @@ export function SharedStringView(props: SharedStringViewProps): React.ReactEleme
         };
     }, []);
 
+
     return (
         <Stack>
-            <StackItem>
-                <b>SharedString</b>
-            </StackItem>
-            <StackItem>{text}</StackItem>
-            <StackItem> <CollaborativeTextArea sharedStringHelper={new SharedStringHelper(sharedString)}/> </StackItem>
+            <StackItem> <CollaborativeTextArea style={{ height: 30, width: 200 }} sharedStringHelper={new SharedStringHelper(sharedString)}/> </StackItem>
         </Stack>
     );
 }

--- a/packages/tools/client-debugger/client-debugger-view/src/components/data-object-views/SharedStringView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/data-object-views/SharedStringView.tsx
@@ -42,11 +42,10 @@ export function SharedStringView(props: SharedStringViewProps): React.ReactEleme
     return (
         <Stack>
             <StackItem>
-                {" "}
                 <CollaborativeTextArea
                     style={{ height: 30, width: 200 }}
                     sharedStringHelper={new SharedStringHelper(sharedString)}
-                />{" "}
+                />
             </StackItem>
         </Stack>
     );

--- a/packages/tools/client-debugger/client-debugger-view/src/components/data-object-views/SharedStringView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/data-object-views/SharedStringView.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Stack, StackItem } from "@fluentui/react";
 import React from "react";
 
 import { SharedString } from "@fluidframework/sequence";
@@ -24,29 +23,10 @@ export interface SharedStringViewProps {
 export function SharedStringView(props: SharedStringViewProps): React.ReactElement {
     const { sharedString } = props;
 
-    const [_text, setText] = React.useState<string>(sharedString.getText());
-
-    React.useEffect(() => {
-        function updateText(): void {
-            const newText = sharedString.getText();
-            setText(newText);
-        }
-
-        sharedString.on("sequenceDelta", updateText);
-
-        return (): void => {
-            sharedString.off("sequenceDelta", updateText);
-        };
-    }, []);
-
     return (
-        <Stack>
-            <StackItem>
-                <CollaborativeTextArea
-                    style={{ height: 30, width: 200 }}
-                    sharedStringHelper={new SharedStringHelper(sharedString)}
-                />
-            </StackItem>
-        </Stack>
+        <CollaborativeTextArea
+            style={{ height: 30, width: 200 }}
+            sharedStringHelper={new SharedStringHelper(sharedString)}
+        />
     );
 }

--- a/packages/tools/client-debugger/client-debugger-view/src/components/data-object-views/SharedStringView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/data-object-views/SharedStringView.tsx
@@ -6,6 +6,7 @@ import { Stack, StackItem } from "@fluentui/react";
 import React from "react";
 
 import { SharedString } from "@fluidframework/sequence";
+import { CollaborativeTextArea, SharedStringHelper } from "@fluid-experimental/react-inputs";
 
 /**
  * {@link SharedStringView} input props.
@@ -44,6 +45,7 @@ export function SharedStringView(props: SharedStringViewProps): React.ReactEleme
                 <b>SharedString</b>
             </StackItem>
             <StackItem>{text}</StackItem>
+            <StackItem> <CollaborativeTextArea sharedStringHelper={new SharedStringHelper(sharedString)}/> </StackItem>
         </Stack>
     );
 }

--- a/packages/tools/client-debugger/client-debugger-view/src/components/data-object-views/SharedStringView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/data-object-views/SharedStringView.tsx
@@ -24,8 +24,7 @@ export interface SharedStringViewProps {
 export function SharedStringView(props: SharedStringViewProps): React.ReactElement {
     const { sharedString } = props;
 
-    const [text, setText] = React.useState<string>(sharedString.getText());
-    console.log(text);
+    const [_text, setText] = React.useState<string>(sharedString.getText());
 
     React.useEffect(() => {
         function updateText(): void {
@@ -40,10 +39,15 @@ export function SharedStringView(props: SharedStringViewProps): React.ReactEleme
         };
     }, []);
 
-
     return (
         <Stack>
-            <StackItem> <CollaborativeTextArea style={{ height: 30, width: 200 }} sharedStringHelper={new SharedStringHelper(sharedString)}/> </StackItem>
+            <StackItem>
+                {" "}
+                <CollaborativeTextArea
+                    style={{ height: 30, width: 200 }}
+                    sharedStringHelper={new SharedStringHelper(sharedString)}
+                />{" "}
+            </StackItem>
         </Stack>
     );
 }


### PR DESCRIPTION
#### Description
https://dev.azure.com/fluidframework/internal/_workitems/edit/3051/

Add `CollaborativeTextArea` to client-debugger to add text-editing experience in visualizer.

<img width="911" alt="image" src="https://user-images.githubusercontent.com/111468570/213383912-61e374d3-711d-43ea-bda5-1154da4e7eff.png">
