### PR TITLE
fix: Handle creation range interleaving (integration)

### DIFF
--- a/packages/dds/tree/src/id-compressor/sessionIdNormalizer.ts
+++ b/packages/dds/tree/src/id-compressor/sessionIdNormalizer.ts
@@ -231,16 +231,17 @@ export class SessionIdNormalizer<TRangeObject> {
     }
 
     /**
-     * Registers a final ID with this normalizer.
-     * If there are any local IDs at the tip of session-space that do not have a corresponding final, it will be registered (aligned) with
-     * the first of those. Otherwise, will be registered as the next ID in session space in creation order. An example:
+     * Registers one or more final IDs with this normalizer.
+     * If there are any local IDs at the tip of session-space that do not have a corresponding final, they will be registered (aligned)
+     * starting with the first of those. Otherwise, will be registered as the next ID in session space in creation order.
      *
+     * An example:
      * Locals: [-1, -2,  X,  -4]
      * Finals: [ 0,  1,  2,   X]
      * Calling `addFinalIds` with first === last === 5 results in the following:
      * Locals: [-1, -2,  X,  -4]
      * Finals: [ 0,  1,  2,   5]
-     * Calling `addFinalIds` with first === last === 6 results in the following:
+     * Subsequently calling `addFinalIds` with first === last === 6 results in the following:
      * Locals: [-1, -2,  X,  -4,  X]
      * Finals: [ 0,  1,  2,   5,  6]
      *
@@ -269,19 +270,8 @@ export class SessionIdNormalizer<TRangeObject> {
                 firstLocal - (lastFinal - firstFinal) - 1,
             ) as LocalCompressedId;
         } else {
-            const isSingle = isSingleRange(finalRanges);
-            let lastFinalRange: FinalRange<TRangeObject>;
-            let firstAlignedLocal: LocalCompressedId;
-            if (isSingle) {
-                firstAlignedLocal = firstLocal;
-                lastFinalRange = finalRanges;
-            } else {
-                [firstAlignedLocal, lastFinalRange] =
-                    finalRanges.last() ?? fail("Map should be non-empty.");
-            }
-
-            const [firstAlignedFinal, lastAlignedFinal] = lastFinalRange;
-            const lastAlignedLocal = firstAlignedLocal - (lastAlignedFinal - firstAlignedFinal);
+            const [firstAlignedLocal, lastAlignedLocal, lastAlignedFinal, lastFinalRange] =
+                this.getAlignmentOfLastRange(firstLocal, finalRanges);
             nextLocal = Math.min(
                 this.nextLocalId,
                 lastAlignedLocal - (lastFinal - firstFinal) - 2,
@@ -291,7 +281,7 @@ export class SessionIdNormalizer<TRangeObject> {
             } else {
                 const alignedLocal = (lastAlignedLocal - 1) as LocalCompressedId;
                 let rangeMap: FinalRangesMap<TRangeObject>;
-                if (isSingle) {
+                if (isSingleRange(finalRanges)) {
                     // Convert the single range to a range collection
                     rangeMap = SessionIdNormalizer.makeFinalRangesMap();
                     rangeMap.append(firstAlignedLocal, lastFinalRange);
@@ -311,6 +301,86 @@ export class SessionIdNormalizer<TRangeObject> {
         }
 
         this.nextLocalId = nextLocal;
+    }
+
+    /**
+     * Alerts the normalizer to the existence of a block of final IDs that are *allocated* (but may not be entirely used).
+     *
+     * The normalizer may have unaligned (unfinalized) local IDs; any such outstanding locals will be eagerly aligned with
+     * as many finals from the registered block as possible.
+     *
+     * It is important to register blocks via this method as soon as they are created for future eager final generations to be utilized, as such
+     * generation is dependant on the normalizer being up-to-date with which local IDs have been aligned with finals. If, for instance,
+     * a block of finals is not immediately registered with the normalizer and there are outstanding locals that would have aligned with them,
+     * those locals will not be finalized until their creation range is finalized, which could be later if the block was created by an earlier
+     * creation range's finalization but is large enough to span them both. In this scenario, no eager finals can be generated until the second
+     * creation range is finalized.
+     *
+     * A usage example:
+     * Locals: [-1, -2,  X,  -4, -5, -6]
+     * Finals: [ 0,  1,  2,   X,  X,  X]
+     * Calling `registerFinalIdBlock` with firstFinalInBlock === 5 and count === 10 results in the following:
+     * Locals: [-1, -2,  X,  -4, -5, -6]
+     * Finals: [ 0,  1,  2,   5,  6,  7]
+     * Instead calling `registerFinalIdBlock` with firstFinalInBlock === 5 and count === 2 results in the following:
+     * Locals: [-1, -2,  X,  -4, -5, -6]
+     * Finals: [ 0,  1,  2,   5,  6,  X]
+     *
+     */
+    public registerFinalIdBlock(
+        firstFinalInBlock: FinalCompressedId,
+        count: number,
+        rangeObject: TRangeObject,
+    ): void {
+        assert(count >= 1, "Malformed normalization block.");
+        const [firstLocal, [lastLocal, finalRanges]] =
+            this.idRanges.last() ??
+            fail("Final ID block should not be registered before any locals.");
+        let unalignedLocalCount: number;
+        if (finalRanges === undefined) {
+            unalignedLocalCount = firstLocal - lastLocal + 1;
+        } else {
+            const [_, lastAlignedLocal] = this.getAlignmentOfLastRange(firstLocal, finalRanges);
+            unalignedLocalCount = lastAlignedLocal - lastLocal;
+        }
+        assert(
+            unalignedLocalCount > 0,
+            "Final ID block should not be registered without an existing local range.",
+        );
+        const lastFinal = (firstFinalInBlock +
+            Math.min(unalignedLocalCount, count) -
+            1) as FinalCompressedId;
+        this.addFinalIds(firstFinalInBlock, lastFinal, rangeObject);
+    }
+
+    private getAlignmentOfLastRange(
+        firstLocal: LocalCompressedId,
+        finalRanges: FinalRanges<TRangeObject>,
+    ): [
+        firstAlignedLocal: LocalCompressedId,
+        lastAlignedLocal: LocalCompressedId,
+        lastAlignedFinal: FinalCompressedId,
+        lastFinalRange: FinalRange<TRangeObject>,
+    ] {
+        const isSingle = isSingleRange(finalRanges);
+        let lastFinalRange: FinalRange<TRangeObject>;
+        let firstAlignedLocal: LocalCompressedId;
+        if (isSingle) {
+            firstAlignedLocal = firstLocal;
+            lastFinalRange = finalRanges;
+        } else {
+            [firstAlignedLocal, lastFinalRange] =
+                finalRanges.last() ?? fail("Map should be non-empty.");
+        }
+
+        const [firstAlignedFinal, lastAlignedFinal] = lastFinalRange;
+        const lastAlignedLocal = firstAlignedLocal - (lastAlignedFinal - firstAlignedFinal);
+        return [
+            firstAlignedLocal,
+            lastAlignedLocal as LocalCompressedId,
+            lastAlignedFinal,
+            lastFinalRange,
+        ];
     }
 
     /**

--- a/packages/dds/tree/src/test/id-compressor/idCompressorTestUtilities.ts
+++ b/packages/dds/tree/src/test/id-compressor/idCompressorTestUtilities.ts
@@ -426,9 +426,11 @@ export class IdCompressorTestNetwork {
         for (const [compressor, ids] of sequencedLogs) {
             const allUuids = new Set<StableId | string>();
             for (const idData of ids) {
-                const uuid = compressor.decompress(idData.id);
-                assert.strictEqual(!allUuids.has(uuid), true, "Duplicate UUID generated.");
-                allUuids.add(uuid);
+                if (idData.expectedOverride === undefined) {
+                    const uuid = compressor.decompress(idData.id);
+                    assert.strictEqual(!allUuids.has(uuid), true, "Duplicate UUID generated.");
+                    allUuids.add(uuid);
+                }
             }
         }
 

--- a/packages/dds/tree/src/test/id-compressor/idCompressorTestUtilities.ts
+++ b/packages/dds/tree/src/test/id-compressor/idCompressorTestUtilities.ts
@@ -190,6 +190,13 @@ export class IdCompressorTestNetwork {
     }
 
     /**
+     * Returns the number of undelivered operations for the given client that are in flight in the network.
+     */
+    public getPendingOperations(destination: Client): number {
+        return this.serverOperations.length - this.clientProgress.get(destination);
+    }
+
+    /**
      * Returns an immutable handle to a compressor in the network.
      */
     public getCompressor(client: Client): ReadonlyIdCompressor {
@@ -336,9 +343,29 @@ export class IdCompressorTestNetwork {
     /**
      * Delivers all undelivered ID ranges and cluster capacity changes from the server to the target clients.
      */
-    public deliverOperations(clientTakingDelivery: DestinationClient) {
+    public deliverOperations(clientTakingDelivery: Client, opsToDeliver?: number): void;
+
+    /**
+     * Delivers all undelivered ID ranges and cluster capacity changes from the server to the target clients.
+     */
+    public deliverOperations(clientTakingDelivery: DestinationClient): void;
+
+    /**
+     * Delivers all undelivered ID ranges and cluster capacity changes from the server to the target clients.
+     */
+    public deliverOperations(clientTakingDelivery: DestinationClient, opsToDeliver?: number): void {
+        let opIndexBound: number;
+        if (clientTakingDelivery === DestinationClient.All) {
+            assert(opsToDeliver === undefined);
+            opIndexBound = this.serverOperations.length;
+        } else {
+            opIndexBound =
+                opsToDeliver !== undefined
+                    ? this.clientProgress.get(clientTakingDelivery) + opsToDeliver
+                    : this.serverOperations.length;
+        }
         for (const [clientTo, compressorTo] of this.getTargetCompressors(clientTakingDelivery)) {
-            for (let i = this.clientProgress.get(clientTo); i < this.serverOperations.length; i++) {
+            for (let i = this.clientProgress.get(clientTo); i < opIndexBound; i++) {
                 const operation = this.serverOperations[i];
                 if (typeof operation === "number") {
                     compressorTo.clusterCapacity = operation;
@@ -374,7 +401,7 @@ export class IdCompressorTestNetwork {
                 }
             }
 
-            this.clientProgress.set(clientTo, this.serverOperations.length);
+            this.clientProgress.set(clientTo, opIndexBound);
         }
     }
 
@@ -394,6 +421,16 @@ export class IdCompressorTestNetwork {
         const sequencedLogs = Object.values(Client).map(
             (client) => [this.compressors.get(client), this.getSequencedIdLog(client)] as const,
         );
+
+        // First, ensure all clients each generated a unique ID for each of their own calls to generate.
+        for (const [compressor, ids] of sequencedLogs) {
+            const allUuids = new Set<StableId | string>();
+            for (const idData of ids) {
+                const uuid = compressor.decompress(idData.id);
+                assert.strictEqual(!allUuids.has(uuid), true, "Duplicate UUID generated.");
+                allUuids.add(uuid);
+            }
+        }
 
         const maxLogLength = sequencedLogs
             .map(([_, data]) => data.length)
@@ -649,9 +686,14 @@ interface AllocateIds {
     overrides: { [index: number]: string };
 }
 
-interface DeliverOperations {
-    type: "deliverOperations";
-    client: DestinationClient;
+interface DeliverAllOperations {
+    type: "deliverAllOperations";
+}
+
+interface DeliverSomeOperations {
+    type: "deliverSomeOperations";
+    client: Client;
+    count: number;
 }
 
 interface ChangeCapacity {
@@ -678,7 +720,8 @@ interface Validate {
 
 type Operation =
     | AllocateIds
-    | DeliverOperations
+    | DeliverSomeOperations
+    | DeliverAllOperations
     | ChangeCapacity
     | GenerateUnifyingIds
     | Reconnect
@@ -748,13 +791,30 @@ export function makeOpGenerator(
         };
     }
 
-    function deliverOperationsGenerator({
+    function deliverAllOperationsGenerator(): DeliverAllOperations {
+        return {
+            type: "deliverAllOperations",
+        };
+    }
+
+    function deliverSomeOperationsGenerator({
         random,
         selectableClients,
-    }: FuzzTestState): DeliverOperations {
+        network,
+    }: FuzzTestState): DeliverSomeOperations {
+        const pendingClients = selectableClients.filter((c) => network.getPendingOperations(c) > 0);
+        if (pendingClients.length === 0) {
+            return {
+                type: "deliverSomeOperations",
+                client: random.pick(selectableClients),
+                count: 0,
+            };
+        }
+        const client = random.pick(pendingClients);
         return {
-            type: "deliverOperations",
-            client: random.pick([...selectableClients, MetaClient.All]),
+            type: "deliverSomeOperations",
+            client,
+            count: random.integer(1, network.getPendingOperations(client)),
         };
     }
 
@@ -774,9 +834,10 @@ export function makeOpGenerator(
     return interleave(
         createWeightedGenerator<Operation, FuzzTestState>([
             [changeCapacityGenerator, 1],
-            [allocateIdsGenerator, 8],
-            [deliverOperationsGenerator, 4],
-            [generateUnifyingIdsGenerator, 1],
+            [allocateIdsGenerator, 16],
+            [deliverAllOperationsGenerator, 2],
+            [deliverSomeOperationsGenerator, 6],
+            [generateUnifyingIdsGenerator, 2],
             [reconnectGenerator, 1],
         ]),
         take(1, repeat<Operation, FuzzTestState>({ type: "validate" })),
@@ -826,8 +887,12 @@ export function performFuzzActions(
                 network.enqueueCapacityChange(op.newSize);
                 return { ...state, clusterSize: op.newSize };
             },
-            deliverOperations: (state, op) => {
-                network.deliverOperations(op.client);
+            deliverSomeOperations: (state, op) => {
+                network.deliverOperations(op.client, op.count);
+                return state;
+            },
+            deliverAllOperations: (state) => {
+                network.deliverOperations(DestinationClient.All);
                 return state;
             },
             generateUnifyingIds: (state, { clientA, clientB, uuid }) => {

--- a/packages/dds/tree/src/test/id-compressor/sessionIdNormalizer.spec.ts
+++ b/packages/dds/tree/src/test/id-compressor/sessionIdNormalizer.spec.ts
@@ -81,7 +81,7 @@ describe("SessionIdNormalizer", () => {
             (e) => validateAssertionError(e, "Malformed normalization block."),
         );
         assert.throws(
-            () => () => {
+            () => {
                 normalizer.registerFinalIdBlock(final(1), -1, dummy);
             },
             (e) => validateAssertionError(e, "Malformed normalization block."),

--- a/packages/dds/tree/src/test/id-compressor/sessionIdNormalizer.spec.ts
+++ b/packages/dds/tree/src/test/id-compressor/sessionIdNormalizer.spec.ts
@@ -31,7 +31,7 @@ describe("SessionIdNormalizer", () => {
     it("fails when adding finals with no corresponding locals", () => {
         const normalizer = makeTestNormalizer();
         assert.throws(
-            () => normalizer.addFinalIds(final(0), final(1), undefined),
+            () => normalizer.addFinalIds(final(0), final(1), dummy),
             (e) => validateAssertionError(e, "Final IDs must be added to an existing local range."),
         );
     });
@@ -40,8 +40,51 @@ describe("SessionIdNormalizer", () => {
         const normalizer = makeTestNormalizer();
         normalizer.addLocalId();
         assert.throws(
-            () => normalizer.addFinalIds(final(1), final(0), undefined),
+            () => normalizer.addFinalIds(final(1), final(0), dummy),
             (e) => validateAssertionError(e, "Malformed normalization range."),
+        );
+    });
+
+    it("fails when registering final blocks with no corresponding locals", () => {
+        const normalizer = makeTestNormalizer();
+        assert.throws(
+            () => {
+                normalizer.registerFinalIdBlock(final(0), 5, dummy);
+            },
+            (e) =>
+                validateAssertionError(
+                    e,
+                    "Final ID block should not be registered before any locals.",
+                ),
+        );
+        normalizer.addLocalId();
+        addFinalIds(normalizer, final(0), final(0));
+        assert.throws(
+            () => {
+                normalizer.registerFinalIdBlock(final(1), 5, dummy);
+            },
+            (e) =>
+                validateAssertionError(
+                    e,
+                    "Final ID block should not be registered without an existing local range.",
+                ),
+        );
+    });
+
+    it("fails when registering final blocks with an invalid count", () => {
+        const normalizer = makeTestNormalizer();
+        normalizer.addLocalId();
+        assert.throws(
+            () => {
+                normalizer.registerFinalIdBlock(final(1), 0, dummy);
+            },
+            (e) => validateAssertionError(e, "Malformed normalization block."),
+        );
+        assert.throws(
+            () => () => {
+                normalizer.registerFinalIdBlock(final(1), -1, dummy);
+            },
+            (e) => validateAssertionError(e, "Malformed normalization block."),
         );
     });
 
@@ -58,12 +101,67 @@ describe("SessionIdNormalizer", () => {
         const normalizer = makeTestNormalizer();
         normalizer.addLocalId(); // -1
         normalizer.addLocalId(); // -2
-        normalizer.addFinalIds(final(0), final(2), undefined);
+        addFinalIds(normalizer, final(0), final(2));
         normalizer.addLocalId(); // -4
-        normalizer.addFinalIds(final(5), final(5), undefined);
+        addFinalIds(normalizer, final(5), final(5));
         assert.throws(
-            () => normalizer.addFinalIds(final(9), final(9), undefined),
+            () => addFinalIds(normalizer, final(9), final(9)),
             (e) => validateAssertionError(e, "Gaps in final space must align to a local."),
+        );
+    });
+
+    it("aligns outstanding locals when a block of finals is registered", () => {
+        /**
+         * Locals: [-1, -2,  -3,  -4]
+         * Finals: [ 0,  X,   X,   X]
+         * Calling `registerFinalIdBlock` with first === 3, count === 10 results in the following:
+         * Locals: [-1, -2,  -3,  -4]
+         * Finals: [ 0,  3,   4,   5]
+         *
+         */
+        const normalizer = makeTestNormalizer();
+        const local1 = normalizer.addLocalId(); // -1
+        const local2 = normalizer.addLocalId(); // -2
+        const local3 = normalizer.addLocalId(); // -3
+        const local4 = normalizer.addLocalId(); // -4
+        normalizer.addFinalIds(final(0), final(0), dummy);
+
+        normalizer.registerFinalIdBlock(final(3), 10, dummy);
+        const locals = [local1, local2, local3, local4];
+        for (let i = 1; i < locals.length; i++) {
+            const expectedFinal = final(i + 2);
+            const finalObj = normalizer.getFinalId(locals[i]);
+            if (finalObj === undefined) {
+                assert.fail();
+            } else {
+                assert.equal(finalObj[0], expectedFinal);
+            }
+        }
+
+        const local5 = normalizer.addLocalId();
+        assert.equal(local5, -5);
+        assert.equal(normalizer.getFinalId(local5), undefined);
+    });
+
+    it("fails to align a block of finals when there are no outstanding local IDs", () => {
+        /**
+         * Locals: [-1,  X]
+         * Finals: [ 0,  1]
+         * Calling `registerFinalIdBlock` with first === 5, count === 10 should fail.
+         */
+        const normalizer = makeTestNormalizer();
+        normalizer.addLocalId(); // -1
+        normalizer.addFinalIds(final(0), final(1), dummy);
+
+        assert.throws(
+            () => {
+                normalizer.registerFinalIdBlock(final(5), 10, dummy);
+            },
+            (e) =>
+                validateAssertionError(
+                    e,
+                    "Final ID block should not be registered without an existing local range.",
+                ),
         );
     });
 
@@ -79,7 +177,7 @@ describe("SessionIdNormalizer", () => {
             () => normalizer.getFinalId(secondLocal),
             (e) => validateAssertionError(e, "Local ID was never recorded with this normalizer."),
         );
-        normalizer.addFinalIds(final(0), final(5), undefined);
+        addFinalIds(normalizer, final(0), final(5));
         assert.throws(
             () => normalizer.getFinalId(secondLocal),
             (e) => validateAssertionError(e, "Local ID was never recorded with this normalizer."),
@@ -99,14 +197,14 @@ describe("SessionIdNormalizer", () => {
 
     itWithNormalizer("can normalize IDs with trailing finals", (normalizer) => {
         normalizer.addLocalId();
-        normalizer.addFinalIds(final(0), final(1), undefined);
-        normalizer.addFinalIds(final(2), final(3), undefined);
-        normalizer.addFinalIds(final(4), final(10), undefined);
+        addFinalIds(normalizer, final(0), final(1));
+        addFinalIds(normalizer, final(2), final(3));
+        addFinalIds(normalizer, final(4), final(10));
     });
 
     itWithNormalizer("can normalize IDs with trailing locals", (normalizer) => {
         normalizer.addLocalId();
-        normalizer.addFinalIds(final(0), final(1), undefined);
+        addFinalIds(normalizer, final(0), final(1));
         normalizer.addLocalId();
         normalizer.addLocalId();
     });
@@ -115,8 +213,8 @@ describe("SessionIdNormalizer", () => {
         normalizer.addLocalId();
         normalizer.addLocalId();
         normalizer.addLocalId();
-        normalizer.addFinalIds(final(0), final(1), undefined);
-        normalizer.addFinalIds(final(10), final(11), undefined);
+        addFinalIds(normalizer, final(0), final(1));
+        addFinalIds(normalizer, final(10), final(11));
     });
 
     itWithNormalizer(
@@ -125,14 +223,14 @@ describe("SessionIdNormalizer", () => {
             normalizer.addLocalId(); // -1
             normalizer.addLocalId(); // -2
             normalizer.addLocalId(); // -3
-            normalizer.addFinalIds(final(0), final(3), dummy);
+            addFinalIds(normalizer, final(0), final(3));
             normalizer.addLocalId(); // -5
             normalizer.addLocalId(); // -6
-            normalizer.addFinalIds(final(4), final(5), dummy);
+            addFinalIds(normalizer, final(4), final(5));
             normalizer.addLocalId(); // -7
-            normalizer.addFinalIds(final(8), final(9), dummy);
+            addFinalIds(normalizer, final(8), final(9));
             normalizer.addLocalId(); // -9
-            normalizer.addFinalIds(final(14), final(15), dummy);
+            addFinalIds(normalizer, final(14), final(15));
             normalizer.addLocalId(); // -11
             normalizer.addLocalId(); // -12
         },
@@ -144,11 +242,11 @@ describe("SessionIdNormalizer", () => {
         normalizer.addLocalId(); // -3
         normalizer.addLocalId(); // -4
         assert.equal(normalizer.getLastFinalId(), undefined);
-        normalizer.addFinalIds(final(0), final(1), undefined);
+        addFinalIds(normalizer, final(0), final(1));
         assert.equal(normalizer.getLastFinalId(), 1);
-        normalizer.addFinalIds(final(2), final(2), undefined);
+        addFinalIds(normalizer, final(2), final(2));
         assert.equal(normalizer.getLastFinalId(), 2);
-        normalizer.addFinalIds(final(10), final(15), undefined);
+        addFinalIds(normalizer, final(10), final(15));
         assert.equal(normalizer.getLastFinalId(), 15);
     });
 
@@ -275,6 +373,14 @@ function itWithNormalizer(
     });
 }
 
+function addFinalIds(
+    normalizer: SessionIdNormalizer<DummyRange>,
+    firstFinal: FinalCompressedId,
+    lastFinal: FinalCompressedId,
+): void {
+    normalizer.addFinalIds(firstFinal, lastFinal, dummy);
+}
+
 function makeNormalizerProxy(
     normalizer: SessionIdNormalizer<DummyRange>,
     locals: (LocalCompressedId | undefined)[],
@@ -286,40 +392,61 @@ function makeNormalizerProxy(
             property: P,
         ): SessionIdNormalizer<DummyRange>[P] {
             if (typeof target[property] === "function") {
-                if (property === "addLocalId") {
-                    return new Proxy(target[property], {
-                        apply: (func, thisArg, argumentsList) => {
-                            const local = Reflect.apply(
-                                func,
-                                thisArg,
-                                argumentsList,
-                            ) as LocalCompressedId;
-                            if (locals.length > 0) {
-                                for (
-                                    let i =
-                                        (locals[locals.length - 1] ??
-                                            fail("Inconsistent locals map")) - 1;
-                                    i > local;
-                                    i--
-                                ) {
-                                    locals.push(undefined);
+                switch (property) {
+                    case "addLocalId": {
+                        return new Proxy(target[property], {
+                            apply: (func, thisArg, argumentsList) => {
+                                const local = Reflect.apply(
+                                    func,
+                                    thisArg,
+                                    argumentsList,
+                                ) as LocalCompressedId;
+                                if (locals.length > 0) {
+                                    for (
+                                        let i =
+                                            (locals[locals.length - 1] ??
+                                                fail("Inconsistent locals map")) - 1;
+                                        i > local;
+                                        i--
+                                    ) {
+                                        locals.push(undefined);
+                                    }
                                 }
-                            }
-                            locals.push(local);
-                            return local;
-                        },
-                    });
-                } else if (property === "addFinalIds") {
-                    return new Proxy(target[property], {
-                        apply: (func, thisArg, argumentsList) => {
-                            const firstFinal: FinalCompressedId = argumentsList[0];
-                            const lastFinal: FinalCompressedId = argumentsList[1];
-                            for (let i = firstFinal; i <= lastFinal; i++) {
-                                finals.push(i);
-                            }
-                            Reflect.apply(func, thisArg, argumentsList);
-                        },
-                    });
+                                locals.push(local);
+                                return local;
+                            },
+                        });
+                    }
+                    case "addFinalIds": {
+                        return new Proxy(target[property], {
+                            apply: (func, thisArg, argumentsList) => {
+                                const firstFinal: FinalCompressedId = argumentsList[0];
+                                const lastFinal: FinalCompressedId = argumentsList[1];
+                                for (let i = firstFinal; i <= lastFinal; i++) {
+                                    finals.push(i);
+                                }
+                                Reflect.apply(func, thisArg, argumentsList);
+                            },
+                        });
+                    }
+                    case "registerFinalIdBlock": {
+                        return new Proxy(target[property], {
+                            apply: (func, thisArg, argumentsList) => {
+                                const firstFinal: FinalCompressedId = argumentsList[0];
+                                const count: FinalCompressedId = argumentsList[1];
+                                const usedFinals = Math.max(
+                                    0,
+                                    Math.min(locals.length - finals.length, count),
+                                );
+                                for (let i = firstFinal; i < usedFinals; i++) {
+                                    finals.push(i);
+                                }
+                                Reflect.apply(func, thisArg, argumentsList);
+                            },
+                        });
+                    }
+                    default:
+                    // No default
                 }
             }
             return Reflect.get(target, property) as SessionIdNormalizer<DummyRange>[P];
@@ -430,7 +557,7 @@ function fuzzNormalizer(
                 return state;
             },
             addFinalIds: (state, { first, last }) => {
-                state.normalizer.addFinalIds(first, last, undefined);
+                state.normalizer.addFinalIds(first, last, dummy);
                 return state;
             },
         },


### PR DESCRIPTION
This is mostly a lifted version of #13640 that is ported to the IdCompressor in fluid-internal/tree.

This PR fixes an issue in the compressor in which the normalizer was unaware of the creation of unallocated final IDs (via cluster creation/expansion) and thus incorrectly allocated duplicate eager final IDs. This scenario occurs when range finalizing is slow (e.g. high latency network) and results in duplicate IDs being handed to the user of SharedTree.