### PR TITLE
FRS Perf Test Pipeline should download artefacts built with the same branch

### DIFF
--- a/tools/pipelines/fluid-afr-perf-test.yml
+++ b/tools/pipelines/fluid-afr-perf-test.yml
@@ -21,8 +21,10 @@ resources:
   pipelines:
     - pipeline: client
       source: Build - client packages
+      branch: ${{ Build.SourceBranchName }}
     - pipeline: azure
       source: Build - azure
+      branch: ${{ Build.SourceBranchName }}
 
 variables:
   - group: fluid-afr-perf-test-keys


### PR DESCRIPTION
## Description

The "Fluid AFR Perf and Reliability Tests" (`fluid-afr-perf-test`) pipeline should utilize artefacts built with the same branch that the pipeline is triggered on. This PR fixes that.