### PR TITLE
Fix build of request-handler tests

### DIFF
--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -80,6 +80,7 @@
     "@rushstack/eslint-config": "^2.5.1",
     "@types/diff": "^3.5.1",
     "@types/mocha": "^9.1.1",
+    "@types/node": "^14.18.36",
     "@types/random-js": "^1.0.31",
     "concurrently": "^6.2.0",
     "copyfiles": "^2.4.1",

--- a/packages/framework/request-handler/src/test/tsconfig.json
+++ b/packages/framework/request-handler/src/test/tsconfig.json
@@ -4,6 +4,7 @@
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [
+            "node",
             "mocha"
         ],
         "declaration": false,


### PR DESCRIPTION
## Description

This adds `@node/types` to `packages/framework/request-handler/src/test/tsconfig.json` to fix the build error in `packages/framework/request-handler/src/test/requestHandlers.spec.ts`

Without this, `import { strict as assert } from "assert";` gets typed as `any` which makes `assert.equal` unable to narrow types resulting in a type error.

```
@fluidframework/request-handler: error during command 'tsc --project ./src/test/tsconfig.json'
@fluidframework/request-handler: src/test/requestHandlers.spec.ts:95:26 - error TS2532: Object is possibly 'undefined'.
@fluidframework/request-handler: 
@fluidframework/request-handler: 95             assert.equal(response.value.route, "/route");
@fluidframework/request-handler:                             ~~~~~~~~
@fluidframework/request-handler: 
@fluidframework/request-handler: 
@fluidframework/request-handler: Found 1 error.
INFO: [  5/63] x @fluidframework/request-handler: tsc --project ./src/test/tsconfig.json - 0.502s
```

Its currently unclear how the code dot into this broken state, but this fixes it.