### PR TITLE
Perf: disable 'unicore/no-for-loop'

### DIFF
--- a/common/build/eslint-config-fluid/eslint7.js
+++ b/common/build/eslint-config-fluid/eslint7.js
@@ -168,6 +168,9 @@ module.exports = {
                 },
             },
         ],
+        // Rationale: Destructuring of `Array.entries()` in order to get the index variable results in a
+        //            significant performance regression [node 14 x64].
+        "unicorn/no-for-loop": "off",
         "unicorn/no-new-buffer": "error",
         "unicorn/no-unsafe-regex": "error",
 

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -1298,7 +1298,7 @@
             "error"
         ],
         "unicorn/no-for-loop": [
-            "error"
+            "off"
         ],
         "unicorn/no-hex-escape": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -1185,6 +1185,9 @@
                 }
             }
         ],
+        "unicorn/no-for-loop": [
+            "off"
+        ],
         "unicorn/no-nested-ternary": [
             "off"
         ],

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -1298,7 +1298,7 @@
             "error"
         ],
         "unicorn/no-for-loop": [
-            "error"
+            "off"
         ],
         "unicorn/no-hex-escape": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -1343,7 +1343,7 @@
             "error"
         ],
         "unicorn/no-for-loop": [
-            "error"
+            "off"
         ],
         "unicorn/no-hex-escape": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -1298,7 +1298,7 @@
             "error"
         ],
         "unicorn/no-for-loop": [
-            "error"
+            "off"
         ],
         "unicorn/no-hex-escape": [
             "error"

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -38,6 +38,11 @@ module.exports = {
             },
         ],
         "unicorn/empty-brace-spaces": "off",
+
+        // Rationale: Destructuring of `Array.entries()` in order to get the index variable results in a
+        //            significant performance regression [node 14 x64].
+        "unicorn/no-for-loop": "off",
+
         "unicorn/prevent-abbreviations": "off",
 
         /**


### PR DESCRIPTION
In general, we prefer for-of loops for iterating over all items in a collection when the element index is not used.

This rule goes a step further, rewriting for-of loops that use the index variable by destructuring Array.entries(). 

Unfortunately, this yields a measurable performance regression [node 14 x64].  I recommend we disable this rule until JS engines optimize this iteration pattern.