### PR TITLE
fix(generate:typetests): Generate using prepped data when branch has no config

### DIFF
--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -10,6 +10,7 @@ import * as path from "path";
 import sortPackageJson from "sort-package-json";
 
 import { options } from "../fluidBuild/options";
+import type { PreviousVersionStyle } from "../typeValidator/packageJson";
 import { IFluidBuildConfig } from "./fluidRepo";
 import { defaultLogger } from "./logging";
 import { MonoRepo, MonoRepoKind, PackageManager } from "./monoRepo";
@@ -92,6 +93,12 @@ export interface PackageJson {
          * If true, disables type test preparation and generation for the package.
          */
         disabled?: boolean;
+
+        /**
+         * The previous version style that was used when the prepare phase was run. This value is cached so that
+         * generation can work even on branches without the correct config.
+         */
+        previousVersionStyle?: PreviousVersionStyle;
 
         /**
          * The version range used as the "previous" version to compare against when generating type tests. This may be

--- a/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
@@ -388,7 +388,7 @@ export async function getAndUpdatePackageDetails(
         style ??
         // If the branch config has a configured version style, use it
         previousVersionStyle ??
-        // Otherwise use the branch config
+        // Otherwise calculate the version style based on the branch config
         (releaseType === "major"
             ? "^previousMajor"
             : releaseType === "minor"

--- a/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
@@ -353,6 +353,7 @@ export async function getAndUpdatePackageDetails(
     }
 
     const version = packageDetails.json.version;
+    const cachedPreviousVersionStyle = packageDetails.json.typeValidation?.previousVersionStyle;
     const fluidConfig = pkg.monoRepo?.fluidBuildConfig ?? pkg.fluidBuildConfig;
     const branch = branchName ?? context.originalBranchName;
     let releaseType: VersionBumpType | undefined;
@@ -385,20 +386,23 @@ export async function getAndUpdatePackageDetails(
     previousVersionStyle =
         // If the style was explicitly passed in, use it
         style ??
-        // if the branch config was a version style, use it
+        // If the branch config has a configured version style, use it
         previousVersionStyle ??
+        // Otherwise use the branch config
         (releaseType === "major"
             ? "^previousMajor"
             : releaseType === "minor"
             ? "~previousMinor"
             : releaseType === "patch"
             ? "previousPatch"
-            : undefined);
+            : undefined) ??
+        // Finally if the branch is unknown, use the cached version style from the package.json
+        cachedPreviousVersionStyle;
 
     if (previousVersionStyle === undefined) {
         // Skip if there's no previous version style defined for the package.
         return {
-            skipReason: `Skipping package: no previousVersionStyle is defined for the branch`,
+            skipReason: `Skipping package: no previousVersionStyle is defined`,
         };
     }
 
@@ -456,6 +460,7 @@ export async function getAndUpdatePackageDetails(
 
         packageDetails.json.typeValidation = {
             version,
+            previousVersionStyle,
             baselineRange: baseline,
             baselineVersion: baseline === prevVersion ? undefined : prevVersion,
             broken: resetBroken === true ? {} : packageDetails.json.typeValidation?.broken ?? {},

--- a/package.json
+++ b/package.json
@@ -193,8 +193,7 @@
       "main": "minor",
       "lts": "minor",
       "release/**": "patch",
-      "next": "major",
-      "*": "minor"
+      "next": "major"
     }
   }
 }


### PR DESCRIPTION
The typetests run in two phases, preparation and generation. During the generation phase, the current code fails when someone is running on an "unknown" branch. The tool just skips the package completely, leading to outdated type tests.

This change caches the previous version style in the package's typetest configuration at preparation time. Then when it is run in generation mode, it falls back to the cached value if the branch is unknown.

This preserves the ability to override the settings at the command line and in a branch config, while ensuring that type tests get updated as people make changes without them having to pass special arguments.

A more complete fix would refactor the code so that prep and generation are separated completely so that generation needn't know the previous version style at all. However, that change is bigger and I don't want to regress anything.