### PR TITLE
fix: Handle creation range interleaving (#13640)

### DIFF
--- a/experimental/dds/tree/src/id-compressor/IdCompressor.ts
+++ b/experimental/dds/tree/src/id-compressor/IdCompressor.ts
@@ -586,13 +586,13 @@ export class IdCompressor {
 				const lastKnownFinal =
 					this.sessionIdNormalizer.getLastFinalId() ??
 					fail('Cluster exists but normalizer does not have an entry for it.');
-				const lastFinalInCluster = (currentBaseFinalId +
+				const lastAlignedFinalInCluster = (currentBaseFinalId +
 					Math.min(currentCluster.count + finalizeCount, currentCluster.capacity) -
 					1) as FinalCompressedId;
-				if (lastFinalInCluster > lastKnownFinal) {
+				if (lastAlignedFinalInCluster > lastKnownFinal) {
 					this.sessionIdNormalizer.addFinalIds(
 						(lastKnownFinal + 1) as FinalCompressedId,
-						lastFinalInCluster,
+						lastAlignedFinalInCluster,
 						currentCluster
 					);
 				}
@@ -636,23 +636,13 @@ export class IdCompressor {
 							session.lastFinalizedLocalId !== undefined,
 							'Cluster already exists for session but there is no finalized local ID'
 						);
-						const newLastFinalizedLocal = session.lastFinalizedLocalId - finalizeCount;
-						const lastLocal = -this.localIdCount;
-						// Calculate the last final in the cluster that aligns with an existing local. If there are more unfinalized locals
-						// than fit in the expanded cluster, this will be the last final in the cluster
-						const newLastFinal = (newLastFinalizedFinal +
-							Math.min(newLastFinalizedLocal - lastLocal, this.newClusterCapacity)) as FinalCompressedId;
-						assert(
-							newLastFinal >= newLastFinalizedFinal,
-							'The number of unfinalized locals should only be positive'
-						);
 						const finalPivot = (newLastFinalizedFinal - overflow + 1) as FinalCompressedId;
 						// Inform the normalizer of all IDs that we now know will end up being finalized into this cluster, including the ones
 						// that were given out as locals (non-eager) because they exceeded the bounds of the current cluster before it was expanded.
 						// It is safe to associate the unfinalized locals with their future final IDs even before the ranges for those locals are
 						// actually finalized, because total order broadcast guarantees that any usage of those final IDs will be observed after
 						// the finalization of the ranges.
-						this.sessionIdNormalizer.addFinalIds(finalPivot, newLastFinal, currentCluster);
+						this.sessionIdNormalizer.registerFinalIdBlock(finalPivot, expansionAmount, currentCluster);
 						this.logger?.sendTelemetryEvent({
 							eventName: 'SharedTreeIdCompressor:ClusterExpansion',
 							sessionId: this.localSessionId,
@@ -724,8 +714,7 @@ export class IdCompressor {
 					clusterCapacity: newCapacity,
 					clusterCount: remainingCount,
 				});
-				const lastFinalizedFinal = (newBaseFinalId + newCluster.count - 1) as FinalCompressedId;
-				this.sessionIdNormalizer.addFinalIds(newBaseFinalId, lastFinalizedFinal, newCluster);
+				this.sessionIdNormalizer.registerFinalIdBlock(newBaseFinalId, newCluster.capacity, newCluster);
 			}
 
 			this.checkClusterForCollision(newCluster);
@@ -1009,10 +998,12 @@ export class IdCompressor {
 		let eagerFinalId: (FinalCompressedId & SessionSpaceCompressedId) | undefined;
 		let cluster: IdCluster | undefined;
 		if (currentClusterDetails !== undefined) {
-			const { clusterBase } = currentClusterDetails;
 			cluster = currentClusterDetails.cluster;
 			const lastFinalKnown = sessionIdNormalizer.getLastFinalId();
-			if (lastFinalKnown !== undefined && lastFinalKnown - clusterBase + 1 < cluster.capacity) {
+			if (
+				lastFinalKnown !== undefined &&
+				lastFinalKnown - currentClusterDetails.clusterBase + 1 < cluster.capacity
+			) {
 				eagerFinalId = (lastFinalKnown + 1) as FinalCompressedId & SessionSpaceCompressedId;
 			}
 		}
@@ -1189,15 +1180,14 @@ export class IdCompressor {
 				const inversionKey = IdCompressor.createInversionKey(override);
 				const compressionMapping =
 					this.clustersAndOverridesInversion.get(inversionKey) ?? fail('Bimap is malformed.');
-				if (
-					!IdCompressor.isClusterInfo(compressionMapping) &&
+				return !IdCompressor.isClusterInfo(compressionMapping) &&
 					!IdCompressor.isUnfinalizedOverride(compressionMapping) &&
 					compressionMapping.associatedLocalId === id
-				) {
-					return compressionMapping.originalOverridingFinal;
-				}
+					? compressionMapping.originalOverridingFinal
+					: (id as OpSpaceCompressedId);
 			}
-			return id as OpSpaceCompressedId;
+			const possibleFinal = this.sessionIdNormalizer.getFinalId(id);
+			return possibleFinal?.[0] ?? (id as OpSpaceCompressedId);
 		}
 		const [correspondingFinal, cluster] =
 			this.sessionIdNormalizer.getFinalId(id) ??

--- a/experimental/dds/tree/src/id-compressor/SessionIdNormalizer.ts
+++ b/experimental/dds/tree/src/id-compressor/SessionIdNormalizer.ts
@@ -226,16 +226,17 @@ export class SessionIdNormalizer<TRangeObject> {
 	}
 
 	/**
-	 * Registers a final ID with this normalizer.
-	 * If there are any local IDs at the tip of session-space that do not have a corresponding final, it will be registered (aligned) with
-	 * the first of those. Otherwise, will be registered as the next ID in session space in creation order. An example:
+	 * Registers one or more final IDs with this normalizer.
+	 * If there are any local IDs at the tip of session-space that do not have a corresponding final, they will be registered (aligned)
+	 * starting with the first of those. Otherwise, will be registered as the next ID in session space in creation order.
 	 *
+	 * An example:
 	 * Locals: [-1, -2,  X,  -4]
 	 * Finals: [ 0,  1,  2,   X]
 	 * Calling `addFinalIds` with first === last === 5 results in the following:
 	 * Locals: [-1, -2,  X,  -4]
 	 * Finals: [ 0,  1,  2,   5]
-	 * Calling `addFinalIds` with first === last === 6 results in the following:
+	 * Subsequently calling `addFinalIds` with first === last === 6 results in the following:
 	 * Locals: [-1, -2,  X,  -4,  X]
 	 * Finals: [ 0,  1,  2,   5,  6]
 	 *
@@ -257,18 +258,8 @@ export class SessionIdNormalizer<TRangeObject> {
 			finalRangesObj[1] = [firstFinal, lastFinal, rangeObject];
 			nextLocal = Math.min(this.nextLocalId, firstLocal - (lastFinal - firstFinal) - 1) as LocalCompressedId;
 		} else {
-			const isSingle = isSingleRange(finalRanges);
-			let lastFinalRange: FinalRange<TRangeObject>;
-			let firstAlignedLocal: LocalCompressedId;
-			if (isSingle) {
-				firstAlignedLocal = firstLocal;
-				lastFinalRange = finalRanges;
-			} else {
-				[firstAlignedLocal, lastFinalRange] = finalRanges.last() ?? fail('Map should be non-empty.');
-			}
-
-			const [firstAlignedFinal, lastAlignedFinal] = lastFinalRange;
-			const lastAlignedLocal = firstAlignedLocal - (lastAlignedFinal - firstAlignedFinal);
+			const [firstAlignedLocal, lastAlignedLocal, lastAlignedFinal, lastFinalRange] =
+				this.getAlignmentOfLastRange(firstLocal, finalRanges);
 			nextLocal = Math.min(
 				this.nextLocalId,
 				lastAlignedLocal - (lastFinal - firstFinal) - 2
@@ -278,7 +269,7 @@ export class SessionIdNormalizer<TRangeObject> {
 			} else {
 				const alignedLocal = (lastAlignedLocal - 1) as LocalCompressedId;
 				let rangeMap: FinalRangesMap<TRangeObject>;
-				if (isSingle) {
+				if (isSingleRange(finalRanges)) {
 					// Convert the single range to a range collection
 					rangeMap = SessionIdNormalizer.makeFinalRangesMap();
 					rangeMap.append(firstAlignedLocal, lastFinalRange);
@@ -295,6 +286,70 @@ export class SessionIdNormalizer<TRangeObject> {
 		}
 
 		this.nextLocalId = nextLocal;
+	}
+
+	/**
+	 * Alerts the normalizer to the existence of a block of final IDs that are *allocated* (but may not be entirely used).
+	 *
+	 * The normalizer may have unaligned (unfinalized) local IDs; any such outstanding locals will be eagerly aligned with
+	 * as many finals from the registered block as possible.
+	 *
+	 * It is important to register blocks via this method as soon as they are created for future eager final generations to be utilized, as such
+	 * generation is dependant on the normalizer being up-to-date with which local IDs have been aligned with finals. If, for instance,
+	 * a block of finals is not immediately registered with the normalizer and there are outstanding locals that would have aligned with them,
+	 * those locals will not be finalized until their creation range is finalized, which could be later if the block was created by an earlier
+	 * creation range's finalization but is large enough to span them both. In this scenario, no eager finals can be generated until the second
+	 * creation range is finalized.
+	 *
+	 * A usage example:
+	 * Locals: [-1, -2,  X,  -4, -5, -6]
+	 * Finals: [ 0,  1,  2,   X,  X,  X]
+	 * Calling `registerFinalIdBlock` with firstFinalInBlock === 5 and count === 10 results in the following:
+	 * Locals: [-1, -2,  X,  -4, -5, -6]
+	 * Finals: [ 0,  1,  2,   5,  6,  7]
+	 * Instead calling `registerFinalIdBlock` with firstFinalInBlock === 5 and count === 2 results in the following:
+	 * Locals: [-1, -2,  X,  -4, -5, -6]
+	 * Finals: [ 0,  1,  2,   5,  6,  X]
+	 *
+	 */
+	public registerFinalIdBlock(firstFinalInBlock: FinalCompressedId, count: number, rangeObject: TRangeObject): void {
+		assert(count >= 1, 'Malformed normalization block.');
+		const [firstLocal, [lastLocal, finalRanges]] =
+			this.idRanges.last() ?? fail('Final ID block should not be registered before any locals.');
+		let unalignedLocalCount: number;
+		if (finalRanges === undefined) {
+			unalignedLocalCount = firstLocal - lastLocal + 1;
+		} else {
+			const [_, lastAlignedLocal] = this.getAlignmentOfLastRange(firstLocal, finalRanges);
+			unalignedLocalCount = lastAlignedLocal - lastLocal;
+		}
+		assert(unalignedLocalCount > 0, 'Final ID block should not be registered without an existing local range.');
+		const lastFinal = (firstFinalInBlock + Math.min(unalignedLocalCount, count) - 1) as FinalCompressedId;
+		this.addFinalIds(firstFinalInBlock, lastFinal, rangeObject);
+	}
+
+	private getAlignmentOfLastRange(
+		firstLocal: LocalCompressedId,
+		finalRanges: FinalRanges<TRangeObject>
+	): [
+		firstAlignedLocal: LocalCompressedId,
+		lastAlignedLocal: LocalCompressedId,
+		lastAlignedFinal: FinalCompressedId,
+		lastFinalRange: FinalRange<TRangeObject>
+	] {
+		const isSingle = isSingleRange(finalRanges);
+		let lastFinalRange: FinalRange<TRangeObject>;
+		let firstAlignedLocal: LocalCompressedId;
+		if (isSingle) {
+			firstAlignedLocal = firstLocal;
+			lastFinalRange = finalRanges;
+		} else {
+			[firstAlignedLocal, lastFinalRange] = finalRanges.last() ?? fail('Map should be non-empty.');
+		}
+
+		const [firstAlignedFinal, lastAlignedFinal] = lastFinalRange;
+		const lastAlignedLocal = firstAlignedLocal - (lastAlignedFinal - firstAlignedFinal);
+		return [firstAlignedLocal, lastAlignedLocal as LocalCompressedId, lastAlignedFinal, lastFinalRange];
 	}
 
 	/**

--- a/experimental/dds/tree/src/test/IdCompressor.tests.ts
+++ b/experimental/dds/tree/src/test/IdCompressor.tests.ts
@@ -20,6 +20,7 @@ import {
 	SessionSpaceCompressedId,
 	OpSpaceCompressedId,
 	SessionId,
+	StableId,
 } from '../Identifiers';
 import { assert, assertNotUndefined, fail } from '../Common';
 import {
@@ -443,6 +444,23 @@ describe('IdCompressor', () => {
 			expect(() => compressor.finalizeCreationRange(secondRange)).to.throw('Ranges finalized out of order.');
 		});
 
+		it('can finalize ranges into clusters of varying sizes', () => {
+			for (let i = 1; i < 5; i++) {
+				for (let j = 0; j <= i; j++) {
+					const compressor = createCompressor(Client.Client1, i);
+					const ids = new Set<SessionSpaceCompressedId>();
+					for (let k = 0; k <= j; k++) {
+						ids.add(compressor.generateCompressedId());
+					}
+					compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+					const opIds = new Set<OpSpaceCompressedId>();
+					ids.forEach((id) => opIds.add(compressor.normalizeToOpSpace(id)));
+					expect(ids.size).to.equal(opIds.size);
+					opIds.forEach((id) => expect(isFinalId(id)).to.be.true);
+				}
+			}
+		});
+
 		it('prevents finalizing unacceptably enormous amounts of ID allocation', () => {
 			const compressor1 = createCompressor(Client.Client1);
 			const integerLargerThanHalfMax = Math.round((Number.MAX_SAFE_INTEGER / 3) * 2);
@@ -696,6 +714,461 @@ describe('IdCompressor', () => {
 				compressor2.localSessionId
 			);
 			expect(normalizedToClient1SessionSpace).to.equal(id);
+		});
+	});
+
+	describe('Telemetry', () => {
+		it('emits first cluster and new cluster telemetry events', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			mockLogger.assertMatch([
+				{
+					eventName: 'SharedTreeIdCompressor:FirstCluster',
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+				{
+					eventName: 'SharedTreeIdCompressor:NewCluster',
+					sessionId: '88888888-8888-4888-b088-888888888888',
+					clusterCapacity: 5,
+					clusterCount: 1,
+				},
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					sessionId: '88888888-8888-4888-b088-888888888888',
+					eagerFinalIdCount: 0,
+					overridesCount: 0,
+					localIdCount: 1,
+				},
+			]);
+		});
+
+		it('emits new cluster event on second cluster', () => {
+			// Fill the first cluster
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			for (let i = 0; i < 5; i++) {
+				compressor.generateCompressedId();
+			}
+			const range = compressor.takeNextCreationRange();
+			compressor.finalizeCreationRange(range);
+
+			// Create another cluster with a different client so that expansion doesn't happen
+			const mockLogger2 = new MockLogger();
+			const compressor2 = createCompressor(Client.Client2, 5, undefined, mockLogger2);
+			compressor2.finalizeCreationRange(range);
+			compressor2.generateCompressedId();
+			const range2 = compressor2.takeNextCreationRange();
+			compressor2.finalizeCreationRange(range2);
+			compressor.finalizeCreationRange(range2);
+			// Make sure we emitted the FirstCluster event
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:FirstCluster',
+				},
+			]);
+			mockLogger.clear();
+
+			// Trigger a new cluster creation and make sure FirstCluster isn't emitted
+			compressor.generateCompressedId();
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:NewCluster',
+				},
+			]);
+			mockLogger.assertMatchNone([
+				{
+					eventName: 'SharedTreeIdCompressor:FirstCluster',
+				},
+			]);
+		});
+
+		it('correctly logs telemetry events for eager final id allocations', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 0,
+					localIdCount: 1,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+			mockLogger.clear();
+			const finalId1 = compressor.generateCompressedId();
+			const finalId2 = compressor.generateCompressedId();
+			expect(isFinalId(finalId1)).to.be.true;
+			expect(isFinalId(finalId2)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 2,
+					localIdCount: 0,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+		});
+
+		it('correctly logs telemetry events for expansion case', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 0,
+					localIdCount: 1,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+			mockLogger.clear();
+
+			for (let i = 0; i < 4; i++) {
+				const id = compressor.generateCompressedId();
+				expect(isFinalId(id)).to.be.true;
+			}
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 4,
+					localIdCount: 0,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+			mockLogger.clear();
+
+			const expansionId1 = compressor.generateCompressedId();
+			const expansionId2 = compressor.generateCompressedId();
+			expect(isLocalId(expansionId1)).to.be.true;
+			expect(isLocalId(expansionId2)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatch([
+				{
+					eventName: 'SharedTreeIdCompressor:ClusterExpansion',
+					sessionId: '88888888-8888-4888-b088-888888888888',
+					previousCapacity: 5,
+					newCapacity: 12,
+					overflow: 2,
+				},
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 2,
+					localIdCount: 0,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+		});
+
+		it('emits correct telemetry status with overrides', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 0,
+					localIdCount: 1,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+			mockLogger.clear();
+
+			const finalId2 = compressor.generateCompressedId();
+			const overrideId3 = compressor.generateCompressedId('override');
+			expect(isFinalId(finalId2)).to.be.true;
+			expect(isLocalId(overrideId3)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 1,
+					localIdCount: 1,
+					overridesCount: 1,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+		});
+
+		it('emits telemetry when serialized', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			compressor.serialize(false);
+
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:SerializedIdCompressorSize',
+					size: 137,
+					clusterCount: 1,
+					sessionCount: 1,
+				},
+			]);
+		});
+	});
+
+	describe('Eager final ID allocation', () => {
+		it('eagerly allocates final IDs when cluster creation has been finalized', () => {
+			const compressor = createCompressor(Client.Client1, 5);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+			const localId2 = compressor.generateCompressedId();
+			expect(isLocalId(localId2)).to.be.true;
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			const finalId3 = compressor.generateCompressedId();
+			expect(isFinalId(finalId3)).to.be.true;
+			const finalId4 = compressor.generateCompressedId();
+			expect(isFinalId(finalId4)).to.be.true;
+			const finalId5 = compressor.generateCompressedId();
+			expect(isFinalId(finalId5)).to.be.true;
+			const localId6 = compressor.generateCompressedId();
+			expect(isLocalId(localId6)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+			const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
+			const opSpaceId3 = compressor.normalizeToOpSpace(finalId3);
+			const opSpaceId4 = compressor.normalizeToOpSpace(finalId4);
+			const opSpaceId5 = compressor.normalizeToOpSpace(finalId5);
+			const opSpaceId6 = compressor.normalizeToOpSpace(localId6);
+
+			expectAssert(isFinalId(opSpaceId1));
+			expectAssert(isFinalId(opSpaceId2));
+			expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId3);
+			expectAssert(isFinalId(opSpaceId4) && opSpaceId4 === finalId4);
+			expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId5);
+			expectAssert(isFinalId(opSpaceId6));
+
+			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
+			expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId3);
+			expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(finalId4);
+			expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId5);
+			expect(compressor.normalizeToSessionSpace(opSpaceId6)).to.equal(localId6);
+		});
+
+		it('does not eagerly allocate final IDs for IDs with overrides', () => {
+			const compressor = createCompressor(Client.Client1, 5);
+			const localId1 = compressor.generateCompressedId();
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const override1 = compressor.generateCompressedId('override1');
+			expect(isLocalId(override1)).to.be.true;
+			const finalId1 = compressor.generateCompressedId();
+			expect(isFinalId(finalId1)).to.be.true;
+
+			generateCompressedIds(compressor, 5);
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const override2 = compressor.generateCompressedId('override2');
+			expect(isLocalId(override2)).to.be.true;
+			const finalId2 = compressor.generateCompressedId();
+			expect(isFinalId(finalId2)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+			const opSpaceId2 = compressor.normalizeToOpSpace(override1);
+			const opSpaceId3 = compressor.normalizeToOpSpace(finalId1);
+			const opSpaceId4 = compressor.normalizeToOpSpace(override2);
+			const opSpaceId5 = compressor.normalizeToOpSpace(finalId2);
+
+			expectAssert(isFinalId(opSpaceId1));
+			expectAssert(isFinalId(opSpaceId2));
+			expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId1);
+			expectAssert(isFinalId(opSpaceId4));
+			expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId2);
+
+			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(override1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(override2);
+			expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId2);
+		});
+
+		it('correctly normalizes eagerly allocated final IDs', () => {
+			const compressor = createCompressor(Client.Client1, 5);
+			const localId1 = compressor.generateCompressedId();
+			const range1 = compressor.takeNextCreationRange();
+			const localId2 = compressor.generateCompressedId();
+			const range2 = compressor.takeNextCreationRange();
+			expect(isLocalId(localId1)).to.be.true;
+			expect(isLocalId(localId2)).to.be.true;
+
+			compressor.finalizeCreationRange(range1);
+			compressor.finalizeCreationRange(range2);
+
+			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+			const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
+
+			expectAssert(isFinalId(opSpaceId1));
+			expectAssert(isFinalId(opSpaceId2));
+
+			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
+		});
+
+		it('generates correct eager finals when there are outstanding locals after cluster expansion', () => {
+			const compressor = createCompressor(Client.Client1, 2);
+
+			// Before cluster expansion
+			expect(isLocalId(compressor.generateCompressedId())).to.be.true;
+			const rangeA = compressor.takeNextCreationRange();
+			compressor.finalizeCreationRange(rangeA);
+			expect(isFinalId(compressor.generateCompressedId())).to.be.true;
+
+			// After cluster expansion
+			expect(isLocalId(compressor.generateCompressedId())).to.be.true;
+			const rangeB = compressor.takeNextCreationRange();
+			const localId = compressor.generateCompressedId();
+			expect(isLocalId(localId)).to.be.true;
+
+			// Take a range that won't be finalized in this test; the finalizing of range B should associate this range with finals
+			const rangeC = compressor.takeNextCreationRange();
+
+			compressor.finalizeCreationRange(rangeB);
+			const eagerId = compressor.generateCompressedId();
+			expect(isFinalId(eagerId)).to.be.true;
+
+			expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
+			expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
+
+			compressor.finalizeCreationRange(rangeC);
+
+			expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
+			expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
+		});
+
+		it('generates unique eager finals when multiple outstanding creation ranges during finalizing', () => {
+			const compressor = createCompressor(Client.Client1, 10 /* must be 10 for the test to make sense */);
+
+			// Make a first outstanding range
+			const id1_1 = compressor.generateCompressedId();
+			const id1_2 = compressor.generateCompressedId();
+			expect(isLocalId(id1_1)).to.be.true;
+			expect(isLocalId(id1_2)).to.be.true;
+			const range1 = compressor.takeNextCreationRange();
+
+			// Make a second outstanding range
+			const id2_1 = compressor.generateCompressedId();
+			const id2_2 = compressor.generateCompressedId();
+			expect(isLocalId(id2_1)).to.be.true;
+			expect(isLocalId(id2_2)).to.be.true;
+			const range2 = compressor.takeNextCreationRange();
+
+			// Finalize just the first one, which should create finals that align with both outstanding ranges
+			compressor.finalizeCreationRange(range1);
+
+			// Make a third range. This one should be composed of eager finals that align after the two ranges above.
+			const id3_1 = compressor.generateCompressedId();
+			const id3_2 = compressor.generateCompressedId();
+			expect(isFinalId(id3_1)).to.be.true;
+			expect(isFinalId(id3_2)).to.be.true;
+			const range3 = compressor.takeNextCreationRange();
+
+			// Finalize both initial ranges.
+			compressor.finalizeCreationRange(range2);
+			compressor.finalizeCreationRange(range3);
+
+			// Make some more eager finals that should be aligned correctly.
+			const id4_1 = compressor.generateCompressedId();
+			const id4_2 = compressor.generateCompressedId();
+			expect(isFinalId(id4_1)).to.be.true;
+			expect(isFinalId(id4_2)).to.be.true;
+
+			// Assert everything is unique and consistent.
+			const ids = new Set<SessionSpaceCompressedId>();
+			const uuids = new Set<StableId | string>();
+			[id1_1, id1_2, id2_1, id2_2, id3_1, id3_2, id4_1, id4_2].forEach((id) => {
+				ids.add(id);
+				uuids.add(compressor.decompress(id));
+			});
+			expect(ids.size).to.equal(8);
+			expect(uuids.size).to.equal(8);
+		});
+
+		it('generates unique eager finals when there are still outstanding locals after a cluster is expanded', () => {
+			// const compressor = createCompressor(Client.Client1, 4 /* must be 4 for the test to make sense */);
+
+			const compressor = new IdCompressor(sessionIds.get(Client.Client1), 0);
+			compressor.clusterCapacity = 4;
+
+			// Make locals to fill half the future cluster
+			const id1_1 = compressor.generateCompressedId();
+			const id1_2 = compressor.generateCompressedId();
+			expect(isLocalId(id1_1)).to.be.true;
+			expect(isLocalId(id1_2)).to.be.true;
+			const range1 = compressor.takeNextCreationRange();
+
+			// Make locals to overflow the future cluster
+			const id2_1 = compressor.generateCompressedId();
+			const id2_2 = compressor.generateCompressedId();
+			const id2_3 = compressor.generateCompressedId();
+			expect(isLocalId(id2_1)).to.be.true;
+			expect(isLocalId(id2_2)).to.be.true;
+			expect(isLocalId(id2_3)).to.be.true;
+			const range2 = compressor.takeNextCreationRange();
+
+			// Finalize the first range. This should align the first four locals (i.e. all of range1, and 2/3 of range2)
+			compressor.finalizeCreationRange(range1);
+
+			// Make a single range that should still be overflowing the initial cluster (i.e. be local)
+			const id3_1 = compressor.generateCompressedId();
+			expect(isLocalId(id3_1)).to.be.true;
+			const range3 = compressor.takeNextCreationRange();
+
+			// First finalize should expand the cluster and align all outstanding ranges.
+			compressor.finalizeCreationRange(range2);
+
+			// All generated IDs should have aligned finals (even though range3 has not been finalized)
+			const allIds = [id1_1, id1_2, id2_1, id2_2, id2_3, id3_1];
+			allIds.forEach((id) => expect(isFinalId(compressor.normalizeToOpSpace(id))).to.be.true);
+
+			compressor.finalizeCreationRange(range3);
+
+			// Make one eager final
+			const id4_1 = compressor.generateCompressedId();
+			allIds.push(id4_1);
+			expect(isFinalId(id4_1)).to.be.true;
+
+			// Assert everything is unique and consistent.
+			const ids = new Set<SessionSpaceCompressedId>();
+			const uuids = new Set<StableId | string>();
+			allIds.forEach((id) => {
+				ids.add(id);
+				uuids.add(compressor.decompress(id));
+			});
+			expect(ids.size).to.equal(7);
+			expect(uuids.size).to.equal(7);
 		});
 	});
 
@@ -1110,7 +1583,7 @@ describe('IdCompressor', () => {
 		});
 
 		itNetwork('produces consistent IDs with large fuzz input', (network) => {
-			const generator = take(1000, makeOpGenerator({ includeOverrides: true }));
+			const generator = take(2000, makeOpGenerator({ includeOverrides: true }));
 			performFuzzActions(generator, network, 1984, undefined, true, (network) => network.assertNetworkState());
 			network.deliverOperations(DestinationClient.All);
 		});
@@ -1154,358 +1627,6 @@ describe('IdCompressor', () => {
 			expect(() => network.getCompressor(Client.Client2).decompress(emptyId)).to.throw(
 				'Compressed ID was not generated by this compressor'
 			);
-		});
-
-		describe('Telemetry', () => {
-			it('emits first cluster and new cluster telemetry events', () => {
-				const mockLogger = new MockLogger();
-				const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-				const localId1 = compressor.generateCompressedId();
-				expect(isLocalId(localId1)).to.be.true;
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				mockLogger.assertMatch([
-					{
-						eventName: 'SharedTreeIdCompressor:FirstCluster',
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-					{
-						eventName: 'SharedTreeIdCompressor:NewCluster',
-						sessionId: '88888888-8888-4888-b088-888888888888',
-						clusterCapacity: 5,
-						clusterCount: 1,
-					},
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						sessionId: '88888888-8888-4888-b088-888888888888',
-						eagerFinalIdCount: 0,
-						overridesCount: 0,
-						localIdCount: 1,
-					},
-				]);
-			});
-
-			it('emits new cluster event on second cluster', () => {
-				// Fill the first cluster
-				const mockLogger = new MockLogger();
-				const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-				for (let i = 0; i < 5; i++) {
-					compressor.generateCompressedId();
-				}
-				const range = compressor.takeNextCreationRange();
-				compressor.finalizeCreationRange(range);
-
-				// Create another cluster with a different client so that expansion doesn't happen
-				const mockLogger2 = new MockLogger();
-				const compressor2 = createCompressor(Client.Client2, 5, undefined, mockLogger2);
-				compressor2.finalizeCreationRange(range);
-				compressor2.generateCompressedId();
-				const range2 = compressor2.takeNextCreationRange();
-				compressor2.finalizeCreationRange(range2);
-				compressor.finalizeCreationRange(range2);
-				// Make sure we emitted the FirstCluster event
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:FirstCluster',
-					},
-				]);
-				mockLogger.clear();
-
-				// Trigger a new cluster creation and make sure FirstCluster isn't emitted
-				compressor.generateCompressedId();
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:NewCluster',
-					},
-				]);
-				mockLogger.assertMatchNone([
-					{
-						eventName: 'SharedTreeIdCompressor:FirstCluster',
-					},
-				]);
-			});
-
-			it('correctly logs telemetry events for eager final id allocations', () => {
-				const mockLogger = new MockLogger();
-				const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-				const localId1 = compressor.generateCompressedId();
-				expect(isLocalId(localId1)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						eagerFinalIdCount: 0,
-						localIdCount: 1,
-						overridesCount: 0,
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-				]);
-				mockLogger.clear();
-				const finalId1 = compressor.generateCompressedId();
-				const finalId2 = compressor.generateCompressedId();
-				expect(isFinalId(finalId1)).to.be.true;
-				expect(isFinalId(finalId2)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						eagerFinalIdCount: 2,
-						localIdCount: 0,
-						overridesCount: 0,
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-				]);
-			});
-
-			it('correctly logs telemetry events for expansion case', () => {
-				const mockLogger = new MockLogger();
-				const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-				const localId1 = compressor.generateCompressedId();
-				expect(isLocalId(localId1)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						eagerFinalIdCount: 0,
-						localIdCount: 1,
-						overridesCount: 0,
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-				]);
-				mockLogger.clear();
-
-				for (let i = 0; i < 4; i++) {
-					const id = compressor.generateCompressedId();
-					expect(isFinalId(id)).to.be.true;
-				}
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						eagerFinalIdCount: 4,
-						localIdCount: 0,
-						overridesCount: 0,
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-				]);
-				mockLogger.clear();
-
-				const expansionId1 = compressor.generateCompressedId();
-				const expansionId2 = compressor.generateCompressedId();
-				expect(isLocalId(expansionId1)).to.be.true;
-				expect(isLocalId(expansionId2)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatch([
-					{
-						eventName: 'SharedTreeIdCompressor:ClusterExpansion',
-						sessionId: '88888888-8888-4888-b088-888888888888',
-						previousCapacity: 5,
-						newCapacity: 12,
-						overflow: 2,
-					},
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						eagerFinalIdCount: 2,
-						localIdCount: 0,
-						overridesCount: 0,
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-				]);
-			});
-
-			it('emits correct telemetry status with overrides', () => {
-				const mockLogger = new MockLogger();
-				const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-				const localId1 = compressor.generateCompressedId();
-				expect(isLocalId(localId1)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						eagerFinalIdCount: 0,
-						localIdCount: 1,
-						overridesCount: 0,
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-				]);
-				mockLogger.clear();
-
-				const finalId2 = compressor.generateCompressedId();
-				const overrideId3 = compressor.generateCompressedId('override');
-				expect(isFinalId(finalId2)).to.be.true;
-				expect(isLocalId(overrideId3)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						eagerFinalIdCount: 1,
-						localIdCount: 1,
-						overridesCount: 1,
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-				]);
-			});
-
-			it('emits telemetry when serialized', () => {
-				const mockLogger = new MockLogger();
-				const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-				const localId1 = compressor.generateCompressedId();
-				expect(isLocalId(localId1)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				compressor.serialize(false);
-
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:SerializedIdCompressorSize',
-						size: 137,
-						clusterCount: 1,
-						sessionCount: 1,
-					},
-				]);
-			});
-		});
-
-		describe('Eager final ID allocation', () => {
-			it('eagerly allocates final IDs when cluster creation has been finalized', () => {
-				const compressor = createCompressor(Client.Client1, 5);
-				const localId1 = compressor.generateCompressedId();
-				expect(isLocalId(localId1)).to.be.true;
-				const localId2 = compressor.generateCompressedId();
-				expect(isLocalId(localId2)).to.be.true;
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				const finalId3 = compressor.generateCompressedId();
-				expect(isFinalId(finalId3)).to.be.true;
-				const finalId4 = compressor.generateCompressedId();
-				expect(isFinalId(finalId4)).to.be.true;
-				const finalId5 = compressor.generateCompressedId();
-				expect(isFinalId(finalId5)).to.be.true;
-				const localId6 = compressor.generateCompressedId();
-				expect(isLocalId(localId6)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-				const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
-				const opSpaceId3 = compressor.normalizeToOpSpace(finalId3);
-				const opSpaceId4 = compressor.normalizeToOpSpace(finalId4);
-				const opSpaceId5 = compressor.normalizeToOpSpace(finalId5);
-				const opSpaceId6 = compressor.normalizeToOpSpace(localId6);
-
-				expectAssert(isFinalId(opSpaceId1));
-				expectAssert(isFinalId(opSpaceId2));
-				expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId3);
-				expectAssert(isFinalId(opSpaceId4) && opSpaceId4 === finalId4);
-				expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId5);
-				expectAssert(isFinalId(opSpaceId6));
-
-				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
-				expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId3);
-				expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(finalId4);
-				expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId5);
-				expect(compressor.normalizeToSessionSpace(opSpaceId6)).to.equal(localId6);
-			});
-
-			it('does not eagerly allocate final IDs for IDs with overrides', () => {
-				const compressor = createCompressor(Client.Client1, 5);
-				const localId1 = compressor.generateCompressedId();
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const override1 = compressor.generateCompressedId('override1');
-				expect(isLocalId(override1)).to.be.true;
-				const finalId1 = compressor.generateCompressedId();
-				expect(isFinalId(finalId1)).to.be.true;
-
-				generateCompressedIds(compressor, 5);
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const override2 = compressor.generateCompressedId('override2');
-				expect(isLocalId(override2)).to.be.true;
-				const finalId2 = compressor.generateCompressedId();
-				expect(isFinalId(finalId2)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-				const opSpaceId2 = compressor.normalizeToOpSpace(override1);
-				const opSpaceId3 = compressor.normalizeToOpSpace(finalId1);
-				const opSpaceId4 = compressor.normalizeToOpSpace(override2);
-				const opSpaceId5 = compressor.normalizeToOpSpace(finalId2);
-
-				expectAssert(isFinalId(opSpaceId1));
-				expectAssert(isFinalId(opSpaceId2));
-				expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId1);
-				expectAssert(isFinalId(opSpaceId4));
-				expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId2);
-
-				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(override1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(override2);
-				expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId2);
-			});
-
-			it('correctly normalizes eagerly allocated final IDs', () => {
-				const compressor = createCompressor(Client.Client1, 5);
-				const localId1 = compressor.generateCompressedId();
-				const range1 = compressor.takeNextCreationRange();
-				const localId2 = compressor.generateCompressedId();
-				const range2 = compressor.takeNextCreationRange();
-				expect(isLocalId(localId1)).to.be.true;
-				expect(isLocalId(localId2)).to.be.true;
-
-				compressor.finalizeCreationRange(range1);
-				compressor.finalizeCreationRange(range2);
-
-				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-				const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
-
-				expectAssert(isFinalId(opSpaceId1));
-				expectAssert(isFinalId(opSpaceId2));
-
-				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
-			});
-
-			it('generates correct eager finals when there are outstanding locals after cluster expansion', () => {
-				const compressor = createCompressor(Client.Client1, 2);
-
-				// Before cluster expansion
-				expect(isLocalId(compressor.generateCompressedId())).to.be.true;
-				const rangeA = compressor.takeNextCreationRange();
-				compressor.finalizeCreationRange(rangeA);
-				expect(isFinalId(compressor.generateCompressedId())).to.be.true;
-
-				// After cluster expansion
-				expect(isLocalId(compressor.generateCompressedId())).to.be.true;
-				const rangeB = compressor.takeNextCreationRange();
-				const localId = compressor.generateCompressedId();
-				expect(isLocalId(localId)).to.be.true;
-
-				// Take a range that won't be finalized in this test; the finalizing of range B should associate this range with finals
-				const rangeC = compressor.takeNextCreationRange();
-
-				compressor.finalizeCreationRange(rangeB);
-				const eagerId = compressor.generateCompressedId();
-				expect(isFinalId(eagerId)).to.be.true;
-
-				expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
-				expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
-
-				compressor.finalizeCreationRange(rangeC);
-
-				expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
-				expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
-			});
 		});
 
 		describe('Finalizing', () => {
@@ -1673,7 +1794,7 @@ describe('IdCompressor', () => {
 			});
 
 			itNetwork('can serialize after a large fuzz input', 3, (network) => {
-				const generator = take(1000, makeOpGenerator({ includeOverrides: true }));
+				const generator = take(2000, makeOpGenerator({ includeOverrides: true }));
 				performFuzzActions(generator, network, Math.PI, undefined, true, (network) => {
 					// Periodically check that everyone in the network has the same serialized state
 					network.deliverOperations(DestinationClient.All);

--- a/experimental/dds/tree/src/test/utilities/IdCompressorTestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/IdCompressorTestUtilities.ts
@@ -184,6 +184,13 @@ export class IdCompressorTestNetwork {
 	}
 
 	/**
+	 * Returns the number of undelivered operations for the given client that are in flight in the network.
+	 */
+	public getPendingOperations(destination: Client): number {
+		return this.serverOperations.length - this.clientProgress.get(destination);
+	}
+
+	/**
 	 * Returns an immutable handle to a compressor in the network.
 	 */
 	public getCompressor(client: Client): ReadonlyIdCompressor {
@@ -324,9 +331,29 @@ export class IdCompressorTestNetwork {
 	/**
 	 * Delivers all undelivered ID ranges and cluster capacity changes from the server to the target clients.
 	 */
-	public deliverOperations(clientTakingDelivery: DestinationClient) {
+	public deliverOperations(clientTakingDelivery: Client, opsToDeliver?: number);
+
+	/**
+	 * Delivers all undelivered ID ranges and cluster capacity changes from the server to the target clients.
+	 */
+	public deliverOperations(clientTakingDelivery: DestinationClient);
+
+	/**
+	 * Delivers all undelivered ID ranges and cluster capacity changes from the server to the target clients.
+	 */
+	public deliverOperations(clientTakingDelivery: DestinationClient, opsToDeliver?: number) {
+		let opIndexBound: number;
+		if (clientTakingDelivery === DestinationClient.All) {
+			assert(opsToDeliver === undefined);
+			opIndexBound = this.serverOperations.length;
+		} else {
+			opIndexBound =
+				opsToDeliver !== undefined
+					? this.clientProgress.get(clientTakingDelivery) + opsToDeliver
+					: this.serverOperations.length;
+		}
 		for (const [clientTo, compressorTo] of this.getTargetCompressors(clientTakingDelivery)) {
-			for (let i = this.clientProgress.get(clientTo); i < this.serverOperations.length; i++) {
+			for (let i = this.clientProgress.get(clientTo); i < opIndexBound; i++) {
 				const operation = this.serverOperations[i];
 				if (typeof operation === 'number') {
 					compressorTo.clusterCapacity = operation;
@@ -356,7 +383,7 @@ export class IdCompressorTestNetwork {
 				}
 			}
 
-			this.clientProgress.set(clientTo, this.serverOperations.length);
+			this.clientProgress.set(clientTo, opIndexBound);
 		}
 	}
 
@@ -376,6 +403,16 @@ export class IdCompressorTestNetwork {
 		const sequencedLogs = Object.values(Client).map(
 			(client) => [this.compressors.get(client), this.getSequencedIdLog(client)] as const
 		);
+
+		// First, ensure all clients each generated a unique ID for each of their own calls to generate.
+		for (const [compressor, ids] of sequencedLogs) {
+			const uuids = new Set<StableId | string>();
+			for (const idData of ids) {
+				const uuid = compressor.decompress(idData.id);
+				expect(!uuids.has(uuid), 'Duplicate UUID generated.');
+				uuids.add(uuid);
+			}
+		}
 
 		const maxLogLength = sequencedLogs.map(([_, data]) => data.length).reduce((p, n) => Math.max(p, n));
 
@@ -566,7 +603,7 @@ export function expectSerializes(
 
 		for (const cluster of serialized.clusters) {
 			const [sessionIndex] = cluster;
-			expect(sessionIndex < serialized.sessions.length);
+			expect(sessionIndex < serialized.sessions.length).to.be.true;
 			chainCount[sessionIndex]++;
 		}
 
@@ -574,9 +611,9 @@ export function expectSerializes(
 			const [sessionIndex, capacity, maybeSize] = cluster;
 			const chainIndex = chainProcessed[sessionIndex];
 			if (chainIndex < chainCount[sessionIndex] - 1) {
-				expect(maybeSize === undefined);
+				expect(typeof maybeSize !== 'number').to.be.true;
 			} else {
-				expect(maybeSize === undefined || typeof maybeSize !== 'number' || maybeSize < capacity);
+				expect(maybeSize === undefined || typeof maybeSize !== 'number' || maybeSize < capacity).to.be.true;
 			}
 			chainProcessed[sessionIndex]++;
 		}
@@ -616,9 +653,14 @@ interface AllocateIds {
 	overrides: { [index: number]: string };
 }
 
-interface DeliverOperations {
-	type: 'deliverOperations';
-	client: DestinationClient;
+interface DeliverAllOperations {
+	type: 'deliverAllOperations';
+}
+
+interface DeliverSomeOperations {
+	type: 'deliverSomeOperations';
+	client: Client;
+	count: number;
 }
 
 interface ChangeCapacity {
@@ -643,7 +685,14 @@ interface Validate {
 	type: 'validate';
 }
 
-type Operation = AllocateIds | DeliverOperations | ChangeCapacity | GenerateUnifyingIds | Reconnect | Validate;
+type Operation =
+	| AllocateIds
+	| DeliverSomeOperations
+	| DeliverAllOperations
+	| ChangeCapacity
+	| GenerateUnifyingIds
+	| Reconnect
+	| Validate;
 
 interface FuzzTestState extends BaseFuzzTestState {
 	network: IdCompressorTestNetwork;
@@ -697,10 +746,30 @@ export function makeOpGenerator(options: OperationGenerationConfig): Generator<O
 		};
 	}
 
-	function deliverOperationsGenerator({ random, selectableClients }: FuzzTestState): DeliverOperations {
+	function deliverAllOperationsGenerator(): DeliverAllOperations {
 		return {
-			type: 'deliverOperations',
-			client: random.pick([...selectableClients, MetaClient.All]),
+			type: 'deliverAllOperations',
+		};
+	}
+
+	function deliverSomeOperationsGenerator({
+		random,
+		selectableClients,
+		network,
+	}: FuzzTestState): DeliverSomeOperations {
+		const pendingClients = selectableClients.filter((c) => network.getPendingOperations(c) > 0);
+		if (pendingClients.length === 0) {
+			return {
+				type: 'deliverSomeOperations',
+				client: random.pick(selectableClients),
+				count: 0,
+			};
+		}
+		const client = random.pick(pendingClients);
+		return {
+			type: 'deliverSomeOperations',
+			client,
+			count: random.integer(1, network.getPendingOperations(client)),
 		};
 	}
 
@@ -717,9 +786,10 @@ export function makeOpGenerator(options: OperationGenerationConfig): Generator<O
 	return interleave(
 		createWeightedGenerator<Operation, FuzzTestState>([
 			[changeCapacityGenerator, 1],
-			[allocateIdsGenerator, 8],
-			[deliverOperationsGenerator, 4],
-			[generateUnifyingIdsGenerator, 1],
+			[allocateIdsGenerator, 16],
+			[deliverAllOperationsGenerator, 2],
+			[deliverSomeOperationsGenerator, 6],
+			[generateUnifyingIdsGenerator, 2],
 			[reconnectGenerator, 1],
 		]),
 		take(1, repeat<Operation, FuzzTestState>({ type: 'validate' })),
@@ -767,8 +837,12 @@ export function performFuzzActions(
 				network.enqueueCapacityChange(op.newSize);
 				return { ...state, clusterSize: op.newSize };
 			},
-			deliverOperations: (state, op) => {
-				network.deliverOperations(op.client);
+			deliverSomeOperations: (state, op) => {
+				network.deliverOperations(op.client, op.count);
+				return state;
+			},
+			deliverAllOperations: (state) => {
+				network.deliverOperations(DestinationClient.All);
 				return state;
 			},
 			generateUnifyingIds: (state, { clientA, clientB, uuid }) => {


### PR DESCRIPTION
This PR fixes an issue in the compressor in which the normalizer was unaware of the creation of unallocated final IDs (via cluster creation/expansion) and thus incorrectly allocated duplicate eager final IDs. This scenario occurs when range finalizing is slow (e.g. high latency network) and results in duplicate IDs being handed to the user of SharedTree.
