### PR TITLE
build(check:policy): Remove unused stringify import

### DIFF
--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -9,7 +9,6 @@ import merge from "lodash.merge";
 import { NpmPackageJsonLint } from "npm-package-json-lint";
 import { EOL as newline } from "os";
 import path from "path";
-import { stringify } from "querystring";
 import * as readline from "readline";
 import replace from "replace-in-file";
 import sortPackageJson from "sort-package-json";


### PR DESCRIPTION
The import was likely added by VSCode at some point and was missed during review.