### PR TITLE
r11s: Add telemetry around throttling internal cache

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -84,7 +84,7 @@ data:
                     "minThrottleIntervalInMs": {{ .Values.alfred.throttling.socketConnections.minThrottleIntervalInMs }},
                     "maxInMemoryCacheSize": {{ .Values.alfred.throttling.socketConnections.maxInMemoryCacheSize }},
                     "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.socketConnections.maxInMemoryCacheAgeInMs }},
-                    "enableEnhancedTelemetry": {{ .Values.alfred.throttling.restCalls.enableEnhancedTelemetry }}
+                    "enableEnhancedTelemetry": {{ .Values.alfred.throttling.socketConnections.enableEnhancedTelemetry }}
                 },
                 "submitOps": {
                     "maxPerMs": {{ .Values.alfred.throttling.submitOps.maxPerMs }},
@@ -93,7 +93,7 @@ data:
                     "minThrottleIntervalInMs": {{ .Values.alfred.throttling.submitOps.minThrottleIntervalInMs }},
                     "maxInMemoryCacheSize": {{ .Values.alfred.throttling.submitOps.maxInMemoryCacheSize }},
                     "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.submitOps.maxInMemoryCacheAgeInMs }},
-                    "enableEnhancedTelemetry": {{ .Values.alfred.throttling.restCalls.enableEnhancedTelemetry }}
+                    "enableEnhancedTelemetry": {{ .Values.alfred.throttling.submitOps.enableEnhancedTelemetry }}
                 },
                 "submitSignal": {
                     "maxPerMs": {{ .Values.alfred.throttling.submitSignal.maxPerMs }},
@@ -102,7 +102,7 @@ data:
                     "minThrottleIntervalInMs": {{ .Values.alfred.throttling.submitSignal.minThrottleIntervalInMs }},
                     "maxInMemoryCacheSize": {{ .Values.alfred.throttling.submitSignal.maxInMemoryCacheSize }},
                     "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.submitSignal.maxInMemoryCacheAgeInMs }},
-                    "enableEnhancedTelemetry": {{ .Values.alfred.throttling.restCalls.enableEnhancedTelemetry }}
+                    "enableEnhancedTelemetry": {{ .Values.alfred.throttling.submitSignal.enableEnhancedTelemetry }}
                 }
             },
             "topic": "{{ .Values.kafka.topics.rawdeltas }}",

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -74,7 +74,8 @@ data:
                     "minCooldownIntervalInMs": {{ .Values.alfred.throttling.restCalls.minCooldownIntervalInMs }},
                     "minThrottleIntervalInMs": {{ .Values.alfred.throttling.restCalls.minThrottleIntervalInMs }},
                     "maxInMemoryCacheSize": {{ .Values.alfred.throttling.restCalls.maxInMemoryCacheSize }},
-                    "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.restCalls.maxInMemoryCacheAgeInMs }}
+                    "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.restCalls.maxInMemoryCacheAgeInMs }},
+                    "enableEnhancedTelemetry": {{ .Values.alfred.throttling.restCalls.enableEnhancedTelemetry }}
                 },
                 "socketConnections": {
                     "maxPerMs": {{ .Values.alfred.throttling.socketConnections.maxPerMs }},
@@ -82,7 +83,8 @@ data:
                     "minCooldownIntervalInMs": {{ .Values.alfred.throttling.socketConnections.minCooldownIntervalInMs }},
                     "minThrottleIntervalInMs": {{ .Values.alfred.throttling.socketConnections.minThrottleIntervalInMs }},
                     "maxInMemoryCacheSize": {{ .Values.alfred.throttling.socketConnections.maxInMemoryCacheSize }},
-                    "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.socketConnections.maxInMemoryCacheAgeInMs }}
+                    "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.socketConnections.maxInMemoryCacheAgeInMs }},
+                    "enableEnhancedTelemetry": {{ .Values.alfred.throttling.restCalls.enableEnhancedTelemetry }}
                 },
                 "submitOps": {
                     "maxPerMs": {{ .Values.alfred.throttling.submitOps.maxPerMs }},
@@ -90,7 +92,8 @@ data:
                     "minCooldownIntervalInMs": {{ .Values.alfred.throttling.submitOps.minCooldownIntervalInMs }},
                     "minThrottleIntervalInMs": {{ .Values.alfred.throttling.submitOps.minThrottleIntervalInMs }},
                     "maxInMemoryCacheSize": {{ .Values.alfred.throttling.submitOps.maxInMemoryCacheSize }},
-                    "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.submitOps.maxInMemoryCacheAgeInMs }}
+                    "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.submitOps.maxInMemoryCacheAgeInMs }},
+                    "enableEnhancedTelemetry": {{ .Values.alfred.throttling.restCalls.enableEnhancedTelemetry }}
                 },
                 "submitSignal": {
                     "maxPerMs": {{ .Values.alfred.throttling.submitSignal.maxPerMs }},
@@ -98,7 +101,8 @@ data:
                     "minCooldownIntervalInMs": {{ .Values.alfred.throttling.submitSignal.minCooldownIntervalInMs }},
                     "minThrottleIntervalInMs": {{ .Values.alfred.throttling.submitSignal.minThrottleIntervalInMs }},
                     "maxInMemoryCacheSize": {{ .Values.alfred.throttling.submitSignal.maxInMemoryCacheSize }},
-                    "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.submitSignal.maxInMemoryCacheAgeInMs }}
+                    "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.submitSignal.maxInMemoryCacheAgeInMs }},
+                    "enableEnhancedTelemetry": {{ .Values.alfred.throttling.restCalls.enableEnhancedTelemetry }}
                 }
             },
             "topic": "{{ .Values.kafka.topics.rawdeltas }}",

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -26,6 +26,7 @@ alfred:
         minThrottleIntervalInMs: 1000000
         maxInMemoryCacheSize: 1000
         maxInMemoryCacheAgeInMs: 60000
+        enableEnhancedTelemetry: false
     socketConnections:
         maxPerMs: 1000000
         maxBurst: 1000000
@@ -33,6 +34,7 @@ alfred:
         minThrottleIntervalInMs: 1000000
         maxInMemoryCacheSize: 1000
         maxInMemoryCacheAgeInMs: 60000
+        enableEnhancedTelemetry: false
     submitOps:
         maxPerMs: 1000000
         maxBurst: 1000000
@@ -40,6 +42,7 @@ alfred:
         minThrottleIntervalInMs: 1000000
         maxInMemoryCacheSize: 1000
         maxInMemoryCacheAgeInMs: 60000
+        enableEnhancedTelemetry: false
     submitSignal:
         maxPerMs: 1000000
         maxBurst: 1000000
@@ -47,6 +50,7 @@ alfred:
         minThrottleIntervalInMs: 1000000
         maxInMemoryCacheSize: 1000
         maxInMemoryCacheAgeInMs: 60000
+        enableEnhancedTelemetry: false
   socketIoAdapter:
     enableCustomSocketIoAdapter: true
     shouldDisableDefaultNamespace: false

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -240,6 +240,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
             minThrottleIntervalInMs: number;
             maxInMemoryCacheSize: number;
             maxInMemoryCacheAgeInMs: number;
+            enableEnhancedTelemetry?: boolean;
         }
         const configureThrottler = (throttleConfig: Partial<IThrottleConfig>): core.IThrottler => {
             const throttlerHelper = new services.ThrottlerHelper(
@@ -254,6 +255,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
                 winston,
                 throttleConfig.maxInMemoryCacheSize,
                 throttleConfig.maxInMemoryCacheAgeInMs,
+                throttleConfig.enableEnhancedTelemetry,
             );
         };
 

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -64,7 +64,8 @@
                 "minCooldownIntervalInMs": 1000000,
                 "minThrottleIntervalInMs": 1000000,
                 "maxInMemoryCacheSize": 1000,
-                "maxInMemoryCacheAgeInMs": 60000
+                "maxInMemoryCacheAgeInMs": 60000,
+                "enableEnhancedTelemetry": false
             },
             "socketConnections": {
                 "maxPerMs": 1000000,
@@ -72,7 +73,8 @@
                 "minCooldownIntervalInMs": 1000000,
                 "minThrottleIntervalInMs": 1000000,
                 "maxInMemoryCacheSize": 1000,
-                "maxInMemoryCacheAgeInMs": 60000
+                "maxInMemoryCacheAgeInMs": 60000,
+                "enableEnhancedTelemetry": false
             },
             "submitOps": {
                 "maxPerMs": 1000000,
@@ -80,7 +82,8 @@
                 "minCooldownIntervalInMs": 1000000,
                 "minThrottleIntervalInMs": 1000000,
                 "maxInMemoryCacheSize": 1000,
-                "maxInMemoryCacheAgeInMs": 60000
+                "maxInMemoryCacheAgeInMs": 60000,
+                "enableEnhancedTelemetry": false
             },
             "submitSignal": {
                 "maxPerMs": 1000000,
@@ -88,7 +91,8 @@
                 "minCooldownIntervalInMs": 1000000,
                 "minThrottleIntervalInMs": 1000000,
                 "maxInMemoryCacheSize": 1000,
-                "maxInMemoryCacheAgeInMs": 60000
+                "maxInMemoryCacheAgeInMs": 60000,
+                "enableEnhancedTelemetry": false
             }
         },
         "topic": "rawdeltas",

--- a/server/routerlicious/packages/services/src/throttler.ts
+++ b/server/routerlicious/packages/services/src/throttler.ts
@@ -49,7 +49,7 @@ export class Throttler implements IThrottler {
                         ...telemetryProperties.baseLumberjackProperties,
                         ageInMs: now - value,
                     };
-                    this.logger.warn(`Purged lastThrottleUpdateAt for ${key} before maxAge reached`, { messageMetaData: telemetryProperties.baseMessageMetaData });
+                    this.logger?.warn(`Purged lastThrottleUpdateAt for ${key} before maxAge reached`, { messageMetaData: telemetryProperties.baseMessageMetaData });
                     Lumberjack.warning(`Purged lastThrottleUpdateAt for ${key} before maxAge reached`, lumberjackProperties);
                 }
             },
@@ -128,7 +128,7 @@ export class Throttler implements IThrottler {
 
         const now = Date.now();
         if (this.lastThrottleUpdateAtMap.get(id) === undefined) {
-            this.logger.info(`Starting to track throttling status for ${id}`, { messageMetaData: telemetryProperties.baseMessageMetaData });
+            this.logger?.info(`Starting to track throttling status for ${id}`, { messageMetaData: telemetryProperties.baseMessageMetaData });
             Lumberjack.info(`Starting to track throttling status for ${id}`, telemetryProperties.baseLumberjackProperties);
             this.lastThrottleUpdateAtMap.set(id, now);
         }


### PR DESCRIPTION
## Description

R11s throttling utilizes an in-memory LRU cache to keep track of local throttle status in-between computations and syncs with the external Redis cache. This cache is necessarily limited for memory consumption purposes, but if the cache is _too_ limited, it can cause problems as throttling information for different clients can be lost.

AFR has configurations that we think works, but we don't have the telemetry to back that up. This PR
1. adds telemetry around cache purge for items that have not expired by age, which is an indication of the cache overflowing.
2. adds telemetry for when a throttler instance begins tracking a specific key, which will help us confirm that the throttle interval is being respected consistently.
3. adds an error log where a promise was being marked as `void` (ignored) previously.
