### PR TITLE
Patch SharedTree ID Normalizer

### DIFF
--- a/experimental/dds/tree/src/id-compressor/IdCompressor.ts
+++ b/experimental/dds/tree/src/id-compressor/IdCompressor.ts
@@ -586,13 +586,13 @@ export class IdCompressor {
 				const lastKnownFinal =
 					this.sessionIdNormalizer.getLastFinalId() ??
 					fail('Cluster exists but normalizer does not have an entry for it.');
-				const lastFinalInCluster = (currentBaseFinalId +
+				const lastAlignedFinalInCluster = (currentBaseFinalId +
 					Math.min(currentCluster.count + finalizeCount, currentCluster.capacity) -
 					1) as FinalCompressedId;
-				if (lastFinalInCluster > lastKnownFinal) {
+				if (lastAlignedFinalInCluster > lastKnownFinal) {
 					this.sessionIdNormalizer.addFinalIds(
 						(lastKnownFinal + 1) as FinalCompressedId,
-						lastFinalInCluster,
+						lastAlignedFinalInCluster,
 						currentCluster
 					);
 				}
@@ -636,23 +636,13 @@ export class IdCompressor {
 							session.lastFinalizedLocalId !== undefined,
 							'Cluster already exists for session but there is no finalized local ID'
 						);
-						const newLastFinalizedLocal = session.lastFinalizedLocalId - finalizeCount;
-						const lastLocal = -this.localIdCount;
-						// Calculate the last final in the cluster that aligns with an existing local. If there are more unfinalized locals
-						// than fit in the expanded cluster, this will be the last final in the cluster
-						const newLastFinal = (newLastFinalizedFinal +
-							Math.min(newLastFinalizedLocal - lastLocal, this.newClusterCapacity)) as FinalCompressedId;
-						assert(
-							newLastFinal >= newLastFinalizedFinal,
-							'The number of unfinalized locals should only be positive'
-						);
 						const finalPivot = (newLastFinalizedFinal - overflow + 1) as FinalCompressedId;
 						// Inform the normalizer of all IDs that we now know will end up being finalized into this cluster, including the ones
 						// that were given out as locals (non-eager) because they exceeded the bounds of the current cluster before it was expanded.
 						// It is safe to associate the unfinalized locals with their future final IDs even before the ranges for those locals are
 						// actually finalized, because total order broadcast guarantees that any usage of those final IDs will be observed after
 						// the finalization of the ranges.
-						this.sessionIdNormalizer.addFinalIds(finalPivot, newLastFinal, currentCluster);
+						this.sessionIdNormalizer.registerFinalIdBlock(finalPivot, expansionAmount, currentCluster);
 						this.logger?.sendTelemetryEvent({
 							eventName: 'SharedTreeIdCompressor:ClusterExpansion',
 							sessionId: this.localSessionId,
@@ -724,8 +714,7 @@ export class IdCompressor {
 					clusterCapacity: newCapacity,
 					clusterCount: remainingCount,
 				});
-				const lastFinalizedFinal = (newBaseFinalId + newCluster.count - 1) as FinalCompressedId;
-				this.sessionIdNormalizer.addFinalIds(newBaseFinalId, lastFinalizedFinal, newCluster);
+				this.sessionIdNormalizer.registerFinalIdBlock(newBaseFinalId, newCluster.capacity, newCluster);
 			}
 
 			this.checkClusterForCollision(newCluster);
@@ -1009,10 +998,12 @@ export class IdCompressor {
 		let eagerFinalId: (FinalCompressedId & SessionSpaceCompressedId) | undefined;
 		let cluster: IdCluster | undefined;
 		if (currentClusterDetails !== undefined) {
-			const { clusterBase } = currentClusterDetails;
 			cluster = currentClusterDetails.cluster;
 			const lastFinalKnown = sessionIdNormalizer.getLastFinalId();
-			if (lastFinalKnown !== undefined && lastFinalKnown - clusterBase + 1 < cluster.capacity) {
+			if (
+				lastFinalKnown !== undefined &&
+				lastFinalKnown - currentClusterDetails.clusterBase + 1 < cluster.capacity
+			) {
 				eagerFinalId = (lastFinalKnown + 1) as FinalCompressedId & SessionSpaceCompressedId;
 			}
 		}
@@ -1189,15 +1180,14 @@ export class IdCompressor {
 				const inversionKey = IdCompressor.createInversionKey(override);
 				const compressionMapping =
 					this.clustersAndOverridesInversion.get(inversionKey) ?? fail('Bimap is malformed.');
-				if (
-					!IdCompressor.isClusterInfo(compressionMapping) &&
+				return !IdCompressor.isClusterInfo(compressionMapping) &&
 					!IdCompressor.isUnfinalizedOverride(compressionMapping) &&
 					compressionMapping.associatedLocalId === id
-				) {
-					return compressionMapping.originalOverridingFinal;
-				}
+					? compressionMapping.originalOverridingFinal
+					: (id as OpSpaceCompressedId);
 			}
-			return id as OpSpaceCompressedId;
+			const possibleFinal = this.sessionIdNormalizer.getFinalId(id);
+			return possibleFinal?.[0] ?? (id as OpSpaceCompressedId);
 		}
 		const [correspondingFinal, cluster] =
 			this.sessionIdNormalizer.getFinalId(id) ??

--- a/experimental/dds/tree/src/id-compressor/SessionIdNormalizer.ts
+++ b/experimental/dds/tree/src/id-compressor/SessionIdNormalizer.ts
@@ -226,16 +226,17 @@ export class SessionIdNormalizer<TRangeObject> {
 	}
 
 	/**
-	 * Registers a final ID with this normalizer.
-	 * If there are any local IDs at the tip of session-space that do not have a corresponding final, it will be registered (aligned) with
-	 * the first of those. Otherwise, will be registered as the next ID in session space in creation order. An example:
+	 * Registers one or more final IDs with this normalizer.
+	 * If there are any local IDs at the tip of session-space that do not have a corresponding final, they will be registered (aligned)
+	 * starting with the first of those. Otherwise, will be registered as the next ID in session space in creation order.
 	 *
+	 * An example:
 	 * Locals: [-1, -2,  X,  -4]
 	 * Finals: [ 0,  1,  2,   X]
 	 * Calling `addFinalIds` with first === last === 5 results in the following:
 	 * Locals: [-1, -2,  X,  -4]
 	 * Finals: [ 0,  1,  2,   5]
-	 * Calling `addFinalIds` with first === last === 6 results in the following:
+	 * Subsequently calling `addFinalIds` with first === last === 6 results in the following:
 	 * Locals: [-1, -2,  X,  -4,  X]
 	 * Finals: [ 0,  1,  2,   5,  6]
 	 *
@@ -257,18 +258,8 @@ export class SessionIdNormalizer<TRangeObject> {
 			finalRangesObj[1] = [firstFinal, lastFinal, rangeObject];
 			nextLocal = Math.min(this.nextLocalId, firstLocal - (lastFinal - firstFinal) - 1) as LocalCompressedId;
 		} else {
-			const isSingle = isSingleRange(finalRanges);
-			let lastFinalRange: FinalRange<TRangeObject>;
-			let firstAlignedLocal: LocalCompressedId;
-			if (isSingle) {
-				firstAlignedLocal = firstLocal;
-				lastFinalRange = finalRanges;
-			} else {
-				[firstAlignedLocal, lastFinalRange] = finalRanges.last() ?? fail('Map should be non-empty.');
-			}
-
-			const [firstAlignedFinal, lastAlignedFinal] = lastFinalRange;
-			const lastAlignedLocal = firstAlignedLocal - (lastAlignedFinal - firstAlignedFinal);
+			const [firstAlignedLocal, lastAlignedLocal, lastAlignedFinal, lastFinalRange] =
+				this.getAlignmentOfLastRange(firstLocal, finalRanges);
 			nextLocal = Math.min(
 				this.nextLocalId,
 				lastAlignedLocal - (lastFinal - firstFinal) - 2
@@ -278,7 +269,7 @@ export class SessionIdNormalizer<TRangeObject> {
 			} else {
 				const alignedLocal = (lastAlignedLocal - 1) as LocalCompressedId;
 				let rangeMap: FinalRangesMap<TRangeObject>;
-				if (isSingle) {
+				if (isSingleRange(finalRanges)) {
 					// Convert the single range to a range collection
 					rangeMap = SessionIdNormalizer.makeFinalRangesMap();
 					rangeMap.append(firstAlignedLocal, lastFinalRange);
@@ -295,6 +286,70 @@ export class SessionIdNormalizer<TRangeObject> {
 		}
 
 		this.nextLocalId = nextLocal;
+	}
+
+	/**
+	 * Alerts the normalizer to the existence of a block of final IDs that are *allocated* (but may not be entirely used).
+	 *
+	 * The normalizer may have unaligned (unfinalized) local IDs; any such outstanding locals will be eagerly aligned with
+	 * as many finals from the registered block as possible.
+	 *
+	 * It is important to register blocks via this method as soon as they are created for future eager final generations to be utilized, as such
+	 * generation is dependant on the normalizer being up-to-date with which local IDs have been aligned with finals. If, for instance,
+	 * a block of finals is not immediately registered with the normalizer and there are outstanding locals that would have aligned with them,
+	 * those locals will not be finalized until their creation range is finalized, which could be later if the block was created by an earlier
+	 * creation range's finalization but is large enough to span them both. In this scenario, no eager finals can be generated until the second
+	 * creation range is finalized.
+	 *
+	 * A usage example:
+	 * Locals: [-1, -2,  X,  -4, -5, -6]
+	 * Finals: [ 0,  1,  2,   X,  X,  X]
+	 * Calling `registerFinalIdBlock` with firstFinalInBlock === 5 and count === 10 results in the following:
+	 * Locals: [-1, -2,  X,  -4, -5, -6]
+	 * Finals: [ 0,  1,  2,   5,  6,  7]
+	 * Instead calling `registerFinalIdBlock` with firstFinalInBlock === 5 and count === 2 results in the following:
+	 * Locals: [-1, -2,  X,  -4, -5, -6]
+	 * Finals: [ 0,  1,  2,   5,  6,  X]
+	 *
+	 */
+	public registerFinalIdBlock(firstFinalInBlock: FinalCompressedId, count: number, rangeObject: TRangeObject): void {
+		assert(count >= 1, 'Malformed normalization block.');
+		const [firstLocal, [lastLocal, finalRanges]] =
+			this.idRanges.last() ?? fail('Final ID block should not be registered before any locals.');
+		let unalignedLocalCount: number;
+		if (finalRanges === undefined) {
+			unalignedLocalCount = firstLocal - lastLocal + 1;
+		} else {
+			const [_, lastAlignedLocal] = this.getAlignmentOfLastRange(firstLocal, finalRanges);
+			unalignedLocalCount = lastAlignedLocal - lastLocal;
+		}
+		assert(unalignedLocalCount > 0, 'Final ID block should not be registered without an existing local range.');
+		const lastFinal = (firstFinalInBlock + Math.min(unalignedLocalCount, count) - 1) as FinalCompressedId;
+		this.addFinalIds(firstFinalInBlock, lastFinal, rangeObject);
+	}
+
+	private getAlignmentOfLastRange(
+		firstLocal: LocalCompressedId,
+		finalRanges: FinalRanges<TRangeObject>
+	): [
+		firstAlignedLocal: LocalCompressedId,
+		lastAlignedLocal: LocalCompressedId,
+		lastAlignedFinal: FinalCompressedId,
+		lastFinalRange: FinalRange<TRangeObject>
+	] {
+		const isSingle = isSingleRange(finalRanges);
+		let lastFinalRange: FinalRange<TRangeObject>;
+		let firstAlignedLocal: LocalCompressedId;
+		if (isSingle) {
+			firstAlignedLocal = firstLocal;
+			lastFinalRange = finalRanges;
+		} else {
+			[firstAlignedLocal, lastFinalRange] = finalRanges.last() ?? fail('Map should be non-empty.');
+		}
+
+		const [firstAlignedFinal, lastAlignedFinal] = lastFinalRange;
+		const lastAlignedLocal = firstAlignedLocal - (lastAlignedFinal - firstAlignedFinal);
+		return [firstAlignedLocal, lastAlignedLocal as LocalCompressedId, lastAlignedFinal, lastFinalRange];
 	}
 
 	/**

--- a/experimental/dds/tree/src/test/IdCompressor.tests.ts
+++ b/experimental/dds/tree/src/test/IdCompressor.tests.ts
@@ -20,6 +20,7 @@ import {
 	SessionSpaceCompressedId,
 	OpSpaceCompressedId,
 	SessionId,
+	StableId,
 } from '../Identifiers';
 import { assert, assertNotUndefined, fail } from '../Common';
 import {
@@ -443,6 +444,23 @@ describe('IdCompressor', () => {
 			expect(() => compressor.finalizeCreationRange(secondRange)).to.throw('Ranges finalized out of order.');
 		});
 
+		it('can finalize ranges into clusters of varying sizes', () => {
+			for (let i = 1; i < 5; i++) {
+				for (let j = 0; j <= i; j++) {
+					const compressor = createCompressor(Client.Client1, i);
+					const ids = new Set<SessionSpaceCompressedId>();
+					for (let k = 0; k <= j; k++) {
+						ids.add(compressor.generateCompressedId());
+					}
+					compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+					const opIds = new Set<OpSpaceCompressedId>();
+					ids.forEach((id) => opIds.add(compressor.normalizeToOpSpace(id)));
+					expect(ids.size).to.equal(opIds.size);
+					opIds.forEach((id) => expect(isFinalId(id)).to.be.true);
+				}
+			}
+		});
+
 		it('prevents finalizing unacceptably enormous amounts of ID allocation', () => {
 			const compressor1 = createCompressor(Client.Client1);
 			const integerLargerThanHalfMax = Math.round((Number.MAX_SAFE_INTEGER / 3) * 2);
@@ -696,6 +714,461 @@ describe('IdCompressor', () => {
 				compressor2.localSessionId
 			);
 			expect(normalizedToClient1SessionSpace).to.equal(id);
+		});
+	});
+
+	describe('Telemetry', () => {
+		it('emits first cluster and new cluster telemetry events', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			mockLogger.assertMatch([
+				{
+					eventName: 'SharedTreeIdCompressor:FirstCluster',
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+				{
+					eventName: 'SharedTreeIdCompressor:NewCluster',
+					sessionId: '88888888-8888-4888-b088-888888888888',
+					clusterCapacity: 5,
+					clusterCount: 1,
+				},
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					sessionId: '88888888-8888-4888-b088-888888888888',
+					eagerFinalIdCount: 0,
+					overridesCount: 0,
+					localIdCount: 1,
+				},
+			]);
+		});
+
+		it('emits new cluster event on second cluster', () => {
+			// Fill the first cluster
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			for (let i = 0; i < 5; i++) {
+				compressor.generateCompressedId();
+			}
+			const range = compressor.takeNextCreationRange();
+			compressor.finalizeCreationRange(range);
+
+			// Create another cluster with a different client so that expansion doesn't happen
+			const mockLogger2 = new MockLogger();
+			const compressor2 = createCompressor(Client.Client2, 5, undefined, mockLogger2);
+			compressor2.finalizeCreationRange(range);
+			compressor2.generateCompressedId();
+			const range2 = compressor2.takeNextCreationRange();
+			compressor2.finalizeCreationRange(range2);
+			compressor.finalizeCreationRange(range2);
+			// Make sure we emitted the FirstCluster event
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:FirstCluster',
+				},
+			]);
+			mockLogger.clear();
+
+			// Trigger a new cluster creation and make sure FirstCluster isn't emitted
+			compressor.generateCompressedId();
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:NewCluster',
+				},
+			]);
+			mockLogger.assertMatchNone([
+				{
+					eventName: 'SharedTreeIdCompressor:FirstCluster',
+				},
+			]);
+		});
+
+		it('correctly logs telemetry events for eager final id allocations', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 0,
+					localIdCount: 1,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+			mockLogger.clear();
+			const finalId1 = compressor.generateCompressedId();
+			const finalId2 = compressor.generateCompressedId();
+			expect(isFinalId(finalId1)).to.be.true;
+			expect(isFinalId(finalId2)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 2,
+					localIdCount: 0,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+		});
+
+		it('correctly logs telemetry events for expansion case', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 0,
+					localIdCount: 1,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+			mockLogger.clear();
+
+			for (let i = 0; i < 4; i++) {
+				const id = compressor.generateCompressedId();
+				expect(isFinalId(id)).to.be.true;
+			}
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 4,
+					localIdCount: 0,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+			mockLogger.clear();
+
+			const expansionId1 = compressor.generateCompressedId();
+			const expansionId2 = compressor.generateCompressedId();
+			expect(isLocalId(expansionId1)).to.be.true;
+			expect(isLocalId(expansionId2)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatch([
+				{
+					eventName: 'SharedTreeIdCompressor:ClusterExpansion',
+					sessionId: '88888888-8888-4888-b088-888888888888',
+					previousCapacity: 5,
+					newCapacity: 12,
+					overflow: 2,
+				},
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 2,
+					localIdCount: 0,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+		});
+
+		it('emits correct telemetry status with overrides', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 0,
+					localIdCount: 1,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+			mockLogger.clear();
+
+			const finalId2 = compressor.generateCompressedId();
+			const overrideId3 = compressor.generateCompressedId('override');
+			expect(isFinalId(finalId2)).to.be.true;
+			expect(isLocalId(overrideId3)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 1,
+					localIdCount: 1,
+					overridesCount: 1,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+		});
+
+		it('emits telemetry when serialized', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			compressor.serialize(false);
+
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:SerializedIdCompressorSize',
+					size: 137,
+					clusterCount: 1,
+					sessionCount: 1,
+				},
+			]);
+		});
+	});
+
+	describe('Eager final ID allocation', () => {
+		it('eagerly allocates final IDs when cluster creation has been finalized', () => {
+			const compressor = createCompressor(Client.Client1, 5);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+			const localId2 = compressor.generateCompressedId();
+			expect(isLocalId(localId2)).to.be.true;
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			const finalId3 = compressor.generateCompressedId();
+			expect(isFinalId(finalId3)).to.be.true;
+			const finalId4 = compressor.generateCompressedId();
+			expect(isFinalId(finalId4)).to.be.true;
+			const finalId5 = compressor.generateCompressedId();
+			expect(isFinalId(finalId5)).to.be.true;
+			const localId6 = compressor.generateCompressedId();
+			expect(isLocalId(localId6)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+			const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
+			const opSpaceId3 = compressor.normalizeToOpSpace(finalId3);
+			const opSpaceId4 = compressor.normalizeToOpSpace(finalId4);
+			const opSpaceId5 = compressor.normalizeToOpSpace(finalId5);
+			const opSpaceId6 = compressor.normalizeToOpSpace(localId6);
+
+			expectAssert(isFinalId(opSpaceId1));
+			expectAssert(isFinalId(opSpaceId2));
+			expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId3);
+			expectAssert(isFinalId(opSpaceId4) && opSpaceId4 === finalId4);
+			expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId5);
+			expectAssert(isFinalId(opSpaceId6));
+
+			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
+			expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId3);
+			expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(finalId4);
+			expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId5);
+			expect(compressor.normalizeToSessionSpace(opSpaceId6)).to.equal(localId6);
+		});
+
+		it('does not eagerly allocate final IDs for IDs with overrides', () => {
+			const compressor = createCompressor(Client.Client1, 5);
+			const localId1 = compressor.generateCompressedId();
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const override1 = compressor.generateCompressedId('override1');
+			expect(isLocalId(override1)).to.be.true;
+			const finalId1 = compressor.generateCompressedId();
+			expect(isFinalId(finalId1)).to.be.true;
+
+			generateCompressedIds(compressor, 5);
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const override2 = compressor.generateCompressedId('override2');
+			expect(isLocalId(override2)).to.be.true;
+			const finalId2 = compressor.generateCompressedId();
+			expect(isFinalId(finalId2)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+			const opSpaceId2 = compressor.normalizeToOpSpace(override1);
+			const opSpaceId3 = compressor.normalizeToOpSpace(finalId1);
+			const opSpaceId4 = compressor.normalizeToOpSpace(override2);
+			const opSpaceId5 = compressor.normalizeToOpSpace(finalId2);
+
+			expectAssert(isFinalId(opSpaceId1));
+			expectAssert(isFinalId(opSpaceId2));
+			expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId1);
+			expectAssert(isFinalId(opSpaceId4));
+			expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId2);
+
+			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(override1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(override2);
+			expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId2);
+		});
+
+		it('correctly normalizes eagerly allocated final IDs', () => {
+			const compressor = createCompressor(Client.Client1, 5);
+			const localId1 = compressor.generateCompressedId();
+			const range1 = compressor.takeNextCreationRange();
+			const localId2 = compressor.generateCompressedId();
+			const range2 = compressor.takeNextCreationRange();
+			expect(isLocalId(localId1)).to.be.true;
+			expect(isLocalId(localId2)).to.be.true;
+
+			compressor.finalizeCreationRange(range1);
+			compressor.finalizeCreationRange(range2);
+
+			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+			const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
+
+			expectAssert(isFinalId(opSpaceId1));
+			expectAssert(isFinalId(opSpaceId2));
+
+			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
+		});
+
+		it('generates correct eager finals when there are outstanding locals after cluster expansion', () => {
+			const compressor = createCompressor(Client.Client1, 2);
+
+			// Before cluster expansion
+			expect(isLocalId(compressor.generateCompressedId())).to.be.true;
+			const rangeA = compressor.takeNextCreationRange();
+			compressor.finalizeCreationRange(rangeA);
+			expect(isFinalId(compressor.generateCompressedId())).to.be.true;
+
+			// After cluster expansion
+			expect(isLocalId(compressor.generateCompressedId())).to.be.true;
+			const rangeB = compressor.takeNextCreationRange();
+			const localId = compressor.generateCompressedId();
+			expect(isLocalId(localId)).to.be.true;
+
+			// Take a range that won't be finalized in this test; the finalizing of range B should associate this range with finals
+			const rangeC = compressor.takeNextCreationRange();
+
+			compressor.finalizeCreationRange(rangeB);
+			const eagerId = compressor.generateCompressedId();
+			expect(isFinalId(eagerId)).to.be.true;
+
+			expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
+			expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
+
+			compressor.finalizeCreationRange(rangeC);
+
+			expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
+			expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
+		});
+
+		it('generates unique eager finals when multiple outstanding creation ranges during finalizing', () => {
+			const compressor = createCompressor(Client.Client1, 10 /* must be 10 for the test to make sense */);
+
+			// Make a first outstanding range
+			const id1_1 = compressor.generateCompressedId();
+			const id1_2 = compressor.generateCompressedId();
+			expect(isLocalId(id1_1)).to.be.true;
+			expect(isLocalId(id1_2)).to.be.true;
+			const range1 = compressor.takeNextCreationRange();
+
+			// Make a second outstanding range
+			const id2_1 = compressor.generateCompressedId();
+			const id2_2 = compressor.generateCompressedId();
+			expect(isLocalId(id2_1)).to.be.true;
+			expect(isLocalId(id2_2)).to.be.true;
+			const range2 = compressor.takeNextCreationRange();
+
+			// Finalize just the first one, which should create finals that align with both outstanding ranges
+			compressor.finalizeCreationRange(range1);
+
+			// Make a third range. This one should be composed of eager finals that align after the two ranges above.
+			const id3_1 = compressor.generateCompressedId();
+			const id3_2 = compressor.generateCompressedId();
+			expect(isFinalId(id3_1)).to.be.true;
+			expect(isFinalId(id3_2)).to.be.true;
+			const range3 = compressor.takeNextCreationRange();
+
+			// Finalize both initial ranges.
+			compressor.finalizeCreationRange(range2);
+			compressor.finalizeCreationRange(range3);
+
+			// Make some more eager finals that should be aligned correctly.
+			const id4_1 = compressor.generateCompressedId();
+			const id4_2 = compressor.generateCompressedId();
+			expect(isFinalId(id4_1)).to.be.true;
+			expect(isFinalId(id4_2)).to.be.true;
+
+			// Assert everything is unique and consistent.
+			const ids = new Set<SessionSpaceCompressedId>();
+			const uuids = new Set<StableId | string>();
+			[id1_1, id1_2, id2_1, id2_2, id3_1, id3_2, id4_1, id4_2].forEach((id) => {
+				ids.add(id);
+				uuids.add(compressor.decompress(id));
+			});
+			expect(ids.size).to.equal(8);
+			expect(uuids.size).to.equal(8);
+		});
+
+		it('generates unique eager finals when there are still outstanding locals after a cluster is expanded', () => {
+			// const compressor = createCompressor(Client.Client1, 4 /* must be 4 for the test to make sense */);
+
+			const compressor = new IdCompressor(sessionIds.get(Client.Client1), 0);
+			compressor.clusterCapacity = 4;
+
+			// Make locals to fill half the future cluster
+			const id1_1 = compressor.generateCompressedId();
+			const id1_2 = compressor.generateCompressedId();
+			expect(isLocalId(id1_1)).to.be.true;
+			expect(isLocalId(id1_2)).to.be.true;
+			const range1 = compressor.takeNextCreationRange();
+
+			// Make locals to overflow the future cluster
+			const id2_1 = compressor.generateCompressedId();
+			const id2_2 = compressor.generateCompressedId();
+			const id2_3 = compressor.generateCompressedId();
+			expect(isLocalId(id2_1)).to.be.true;
+			expect(isLocalId(id2_2)).to.be.true;
+			expect(isLocalId(id2_3)).to.be.true;
+			const range2 = compressor.takeNextCreationRange();
+
+			// Finalize the first range. This should align the first four locals (i.e. all of range1, and 2/3 of range2)
+			compressor.finalizeCreationRange(range1);
+
+			// Make a single range that should still be overflowing the initial cluster (i.e. be local)
+			const id3_1 = compressor.generateCompressedId();
+			expect(isLocalId(id3_1)).to.be.true;
+			const range3 = compressor.takeNextCreationRange();
+
+			// First finalize should expand the cluster and align all outstanding ranges.
+			compressor.finalizeCreationRange(range2);
+
+			// All generated IDs should have aligned finals (even though range3 has not been finalized)
+			const allIds = [id1_1, id1_2, id2_1, id2_2, id2_3, id3_1];
+			allIds.forEach((id) => expect(isFinalId(compressor.normalizeToOpSpace(id))).to.be.true);
+
+			compressor.finalizeCreationRange(range3);
+
+			// Make one eager final
+			const id4_1 = compressor.generateCompressedId();
+			allIds.push(id4_1);
+			expect(isFinalId(id4_1)).to.be.true;
+
+			// Assert everything is unique and consistent.
+			const ids = new Set<SessionSpaceCompressedId>();
+			const uuids = new Set<StableId | string>();
+			allIds.forEach((id) => {
+				ids.add(id);
+				uuids.add(compressor.decompress(id));
+			});
+			expect(ids.size).to.equal(7);
+			expect(uuids.size).to.equal(7);
 		});
 	});
 
@@ -1110,7 +1583,7 @@ describe('IdCompressor', () => {
 		});
 
 		itNetwork('produces consistent IDs with large fuzz input', (network) => {
-			const generator = take(1000, makeOpGenerator({ includeOverrides: true }));
+			const generator = take(2000, makeOpGenerator({ includeOverrides: true }));
 			performFuzzActions(generator, network, 1984, undefined, true, (network) => network.assertNetworkState());
 			network.deliverOperations(DestinationClient.All);
 		});
@@ -1154,358 +1627,6 @@ describe('IdCompressor', () => {
 			expect(() => network.getCompressor(Client.Client2).decompress(emptyId)).to.throw(
 				'Compressed ID was not generated by this compressor'
 			);
-		});
-
-		describe('Telemetry', () => {
-			it('emits first cluster and new cluster telemetry events', () => {
-				const mockLogger = new MockLogger();
-				const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-				const localId1 = compressor.generateCompressedId();
-				expect(isLocalId(localId1)).to.be.true;
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				mockLogger.assertMatch([
-					{
-						eventName: 'SharedTreeIdCompressor:FirstCluster',
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-					{
-						eventName: 'SharedTreeIdCompressor:NewCluster',
-						sessionId: '88888888-8888-4888-b088-888888888888',
-						clusterCapacity: 5,
-						clusterCount: 1,
-					},
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						sessionId: '88888888-8888-4888-b088-888888888888',
-						eagerFinalIdCount: 0,
-						overridesCount: 0,
-						localIdCount: 1,
-					},
-				]);
-			});
-
-			it('emits new cluster event on second cluster', () => {
-				// Fill the first cluster
-				const mockLogger = new MockLogger();
-				const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-				for (let i = 0; i < 5; i++) {
-					compressor.generateCompressedId();
-				}
-				const range = compressor.takeNextCreationRange();
-				compressor.finalizeCreationRange(range);
-
-				// Create another cluster with a different client so that expansion doesn't happen
-				const mockLogger2 = new MockLogger();
-				const compressor2 = createCompressor(Client.Client2, 5, undefined, mockLogger2);
-				compressor2.finalizeCreationRange(range);
-				compressor2.generateCompressedId();
-				const range2 = compressor2.takeNextCreationRange();
-				compressor2.finalizeCreationRange(range2);
-				compressor.finalizeCreationRange(range2);
-				// Make sure we emitted the FirstCluster event
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:FirstCluster',
-					},
-				]);
-				mockLogger.clear();
-
-				// Trigger a new cluster creation and make sure FirstCluster isn't emitted
-				compressor.generateCompressedId();
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:NewCluster',
-					},
-				]);
-				mockLogger.assertMatchNone([
-					{
-						eventName: 'SharedTreeIdCompressor:FirstCluster',
-					},
-				]);
-			});
-
-			it('correctly logs telemetry events for eager final id allocations', () => {
-				const mockLogger = new MockLogger();
-				const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-				const localId1 = compressor.generateCompressedId();
-				expect(isLocalId(localId1)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						eagerFinalIdCount: 0,
-						localIdCount: 1,
-						overridesCount: 0,
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-				]);
-				mockLogger.clear();
-				const finalId1 = compressor.generateCompressedId();
-				const finalId2 = compressor.generateCompressedId();
-				expect(isFinalId(finalId1)).to.be.true;
-				expect(isFinalId(finalId2)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						eagerFinalIdCount: 2,
-						localIdCount: 0,
-						overridesCount: 0,
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-				]);
-			});
-
-			it('correctly logs telemetry events for expansion case', () => {
-				const mockLogger = new MockLogger();
-				const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-				const localId1 = compressor.generateCompressedId();
-				expect(isLocalId(localId1)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						eagerFinalIdCount: 0,
-						localIdCount: 1,
-						overridesCount: 0,
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-				]);
-				mockLogger.clear();
-
-				for (let i = 0; i < 4; i++) {
-					const id = compressor.generateCompressedId();
-					expect(isFinalId(id)).to.be.true;
-				}
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						eagerFinalIdCount: 4,
-						localIdCount: 0,
-						overridesCount: 0,
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-				]);
-				mockLogger.clear();
-
-				const expansionId1 = compressor.generateCompressedId();
-				const expansionId2 = compressor.generateCompressedId();
-				expect(isLocalId(expansionId1)).to.be.true;
-				expect(isLocalId(expansionId2)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatch([
-					{
-						eventName: 'SharedTreeIdCompressor:ClusterExpansion',
-						sessionId: '88888888-8888-4888-b088-888888888888',
-						previousCapacity: 5,
-						newCapacity: 12,
-						overflow: 2,
-					},
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						eagerFinalIdCount: 2,
-						localIdCount: 0,
-						overridesCount: 0,
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-				]);
-			});
-
-			it('emits correct telemetry status with overrides', () => {
-				const mockLogger = new MockLogger();
-				const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-				const localId1 = compressor.generateCompressedId();
-				expect(isLocalId(localId1)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						eagerFinalIdCount: 0,
-						localIdCount: 1,
-						overridesCount: 0,
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-				]);
-				mockLogger.clear();
-
-				const finalId2 = compressor.generateCompressedId();
-				const overrideId3 = compressor.generateCompressedId('override');
-				expect(isFinalId(finalId2)).to.be.true;
-				expect(isLocalId(overrideId3)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-						eagerFinalIdCount: 1,
-						localIdCount: 1,
-						overridesCount: 1,
-						sessionId: '88888888-8888-4888-b088-888888888888',
-					},
-				]);
-			});
-
-			it('emits telemetry when serialized', () => {
-				const mockLogger = new MockLogger();
-				const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-				const localId1 = compressor.generateCompressedId();
-				expect(isLocalId(localId1)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				compressor.serialize(false);
-
-				mockLogger.assertMatchAny([
-					{
-						eventName: 'SharedTreeIdCompressor:SerializedIdCompressorSize',
-						size: 137,
-						clusterCount: 1,
-						sessionCount: 1,
-					},
-				]);
-			});
-		});
-
-		describe('Eager final ID allocation', () => {
-			it('eagerly allocates final IDs when cluster creation has been finalized', () => {
-				const compressor = createCompressor(Client.Client1, 5);
-				const localId1 = compressor.generateCompressedId();
-				expect(isLocalId(localId1)).to.be.true;
-				const localId2 = compressor.generateCompressedId();
-				expect(isLocalId(localId2)).to.be.true;
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				const finalId3 = compressor.generateCompressedId();
-				expect(isFinalId(finalId3)).to.be.true;
-				const finalId4 = compressor.generateCompressedId();
-				expect(isFinalId(finalId4)).to.be.true;
-				const finalId5 = compressor.generateCompressedId();
-				expect(isFinalId(finalId5)).to.be.true;
-				const localId6 = compressor.generateCompressedId();
-				expect(isLocalId(localId6)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-				const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
-				const opSpaceId3 = compressor.normalizeToOpSpace(finalId3);
-				const opSpaceId4 = compressor.normalizeToOpSpace(finalId4);
-				const opSpaceId5 = compressor.normalizeToOpSpace(finalId5);
-				const opSpaceId6 = compressor.normalizeToOpSpace(localId6);
-
-				expectAssert(isFinalId(opSpaceId1));
-				expectAssert(isFinalId(opSpaceId2));
-				expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId3);
-				expectAssert(isFinalId(opSpaceId4) && opSpaceId4 === finalId4);
-				expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId5);
-				expectAssert(isFinalId(opSpaceId6));
-
-				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
-				expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId3);
-				expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(finalId4);
-				expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId5);
-				expect(compressor.normalizeToSessionSpace(opSpaceId6)).to.equal(localId6);
-			});
-
-			it('does not eagerly allocate final IDs for IDs with overrides', () => {
-				const compressor = createCompressor(Client.Client1, 5);
-				const localId1 = compressor.generateCompressedId();
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const override1 = compressor.generateCompressedId('override1');
-				expect(isLocalId(override1)).to.be.true;
-				const finalId1 = compressor.generateCompressedId();
-				expect(isFinalId(finalId1)).to.be.true;
-
-				generateCompressedIds(compressor, 5);
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const override2 = compressor.generateCompressedId('override2');
-				expect(isLocalId(override2)).to.be.true;
-				const finalId2 = compressor.generateCompressedId();
-				expect(isFinalId(finalId2)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-				const opSpaceId2 = compressor.normalizeToOpSpace(override1);
-				const opSpaceId3 = compressor.normalizeToOpSpace(finalId1);
-				const opSpaceId4 = compressor.normalizeToOpSpace(override2);
-				const opSpaceId5 = compressor.normalizeToOpSpace(finalId2);
-
-				expectAssert(isFinalId(opSpaceId1));
-				expectAssert(isFinalId(opSpaceId2));
-				expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId1);
-				expectAssert(isFinalId(opSpaceId4));
-				expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId2);
-
-				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(override1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(override2);
-				expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId2);
-			});
-
-			it('correctly normalizes eagerly allocated final IDs', () => {
-				const compressor = createCompressor(Client.Client1, 5);
-				const localId1 = compressor.generateCompressedId();
-				const range1 = compressor.takeNextCreationRange();
-				const localId2 = compressor.generateCompressedId();
-				const range2 = compressor.takeNextCreationRange();
-				expect(isLocalId(localId1)).to.be.true;
-				expect(isLocalId(localId2)).to.be.true;
-
-				compressor.finalizeCreationRange(range1);
-				compressor.finalizeCreationRange(range2);
-
-				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-				const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
-
-				expectAssert(isFinalId(opSpaceId1));
-				expectAssert(isFinalId(opSpaceId2));
-
-				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
-			});
-
-			it('generates correct eager finals when there are outstanding locals after cluster expansion', () => {
-				const compressor = createCompressor(Client.Client1, 2);
-
-				// Before cluster expansion
-				expect(isLocalId(compressor.generateCompressedId())).to.be.true;
-				const rangeA = compressor.takeNextCreationRange();
-				compressor.finalizeCreationRange(rangeA);
-				expect(isFinalId(compressor.generateCompressedId())).to.be.true;
-
-				// After cluster expansion
-				expect(isLocalId(compressor.generateCompressedId())).to.be.true;
-				const rangeB = compressor.takeNextCreationRange();
-				const localId = compressor.generateCompressedId();
-				expect(isLocalId(localId)).to.be.true;
-
-				// Take a range that won't be finalized in this test; the finalizing of range B should associate this range with finals
-				const rangeC = compressor.takeNextCreationRange();
-
-				compressor.finalizeCreationRange(rangeB);
-				const eagerId = compressor.generateCompressedId();
-				expect(isFinalId(eagerId)).to.be.true;
-
-				expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
-				expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
-
-				compressor.finalizeCreationRange(rangeC);
-
-				expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
-				expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
-			});
 		});
 
 		describe('Finalizing', () => {
@@ -1673,7 +1794,7 @@ describe('IdCompressor', () => {
 			});
 
 			itNetwork('can serialize after a large fuzz input', 3, (network) => {
-				const generator = take(1000, makeOpGenerator({ includeOverrides: true }));
+				const generator = take(2000, makeOpGenerator({ includeOverrides: true }));
 				performFuzzActions(generator, network, Math.PI, undefined, true, (network) => {
 					// Periodically check that everyone in the network has the same serialized state
 					network.deliverOperations(DestinationClient.All);

--- a/experimental/dds/tree/src/test/utilities/IdCompressorTestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/IdCompressorTestUtilities.ts
@@ -184,6 +184,13 @@ export class IdCompressorTestNetwork {
 	}
 
 	/**
+	 * Returns the number of undelivered operations for the given client that are in flight in the network.
+	 */
+	public getPendingOperations(destination: Client): number {
+		return this.serverOperations.length - this.clientProgress.get(destination);
+	}
+
+	/**
 	 * Returns an immutable handle to a compressor in the network.
 	 */
 	public getCompressor(client: Client): ReadonlyIdCompressor {
@@ -324,9 +331,29 @@ export class IdCompressorTestNetwork {
 	/**
 	 * Delivers all undelivered ID ranges and cluster capacity changes from the server to the target clients.
 	 */
-	public deliverOperations(clientTakingDelivery: DestinationClient) {
+	public deliverOperations(clientTakingDelivery: Client, opsToDeliver?: number);
+
+	/**
+	 * Delivers all undelivered ID ranges and cluster capacity changes from the server to the target clients.
+	 */
+	public deliverOperations(clientTakingDelivery: DestinationClient);
+
+	/**
+	 * Delivers all undelivered ID ranges and cluster capacity changes from the server to the target clients.
+	 */
+	public deliverOperations(clientTakingDelivery: DestinationClient, opsToDeliver?: number) {
+		let opIndexBound: number;
+		if (clientTakingDelivery === DestinationClient.All) {
+			assert(opsToDeliver === undefined);
+			opIndexBound = this.serverOperations.length;
+		} else {
+			opIndexBound =
+				opsToDeliver !== undefined
+					? this.clientProgress.get(clientTakingDelivery) + opsToDeliver
+					: this.serverOperations.length;
+		}
 		for (const [clientTo, compressorTo] of this.getTargetCompressors(clientTakingDelivery)) {
-			for (let i = this.clientProgress.get(clientTo); i < this.serverOperations.length; i++) {
+			for (let i = this.clientProgress.get(clientTo); i < opIndexBound; i++) {
 				const operation = this.serverOperations[i];
 				if (typeof operation === 'number') {
 					compressorTo.clusterCapacity = operation;
@@ -356,7 +383,7 @@ export class IdCompressorTestNetwork {
 				}
 			}
 
-			this.clientProgress.set(clientTo, this.serverOperations.length);
+			this.clientProgress.set(clientTo, opIndexBound);
 		}
 	}
 
@@ -376,6 +403,16 @@ export class IdCompressorTestNetwork {
 		const sequencedLogs = Object.values(Client).map(
 			(client) => [this.compressors.get(client), this.getSequencedIdLog(client)] as const
 		);
+
+		// First, ensure all clients each generated a unique ID for each of their own calls to generate.
+		for (const [compressor, ids] of sequencedLogs) {
+			const uuids = new Set<StableId | string>();
+			for (const idData of ids) {
+				const uuid = compressor.decompress(idData.id);
+				expect(!uuids.has(uuid), 'Duplicate UUID generated.');
+				uuids.add(uuid);
+			}
+		}
 
 		const maxLogLength = sequencedLogs.map(([_, data]) => data.length).reduce((p, n) => Math.max(p, n));
 
@@ -566,7 +603,7 @@ export function expectSerializes(
 
 		for (const cluster of serialized.clusters) {
 			const [sessionIndex] = cluster;
-			expect(sessionIndex < serialized.sessions.length);
+			expect(sessionIndex < serialized.sessions.length).to.be.true;
 			chainCount[sessionIndex]++;
 		}
 
@@ -574,9 +611,9 @@ export function expectSerializes(
 			const [sessionIndex, capacity, maybeSize] = cluster;
 			const chainIndex = chainProcessed[sessionIndex];
 			if (chainIndex < chainCount[sessionIndex] - 1) {
-				expect(maybeSize === undefined);
+				expect(typeof maybeSize !== 'number').to.be.true;
 			} else {
-				expect(maybeSize === undefined || typeof maybeSize !== 'number' || maybeSize < capacity);
+				expect(maybeSize === undefined || typeof maybeSize !== 'number' || maybeSize < capacity).to.be.true;
 			}
 			chainProcessed[sessionIndex]++;
 		}
@@ -616,9 +653,14 @@ interface AllocateIds {
 	overrides: { [index: number]: string };
 }
 
-interface DeliverOperations {
-	type: 'deliverOperations';
-	client: DestinationClient;
+interface DeliverAllOperations {
+	type: 'deliverAllOperations';
+}
+
+interface DeliverSomeOperations {
+	type: 'deliverSomeOperations';
+	client: Client;
+	count: number;
 }
 
 interface ChangeCapacity {
@@ -643,7 +685,14 @@ interface Validate {
 	type: 'validate';
 }
 
-type Operation = AllocateIds | DeliverOperations | ChangeCapacity | GenerateUnifyingIds | Reconnect | Validate;
+type Operation =
+	| AllocateIds
+	| DeliverSomeOperations
+	| DeliverAllOperations
+	| ChangeCapacity
+	| GenerateUnifyingIds
+	| Reconnect
+	| Validate;
 
 interface FuzzTestState extends BaseFuzzTestState {
 	network: IdCompressorTestNetwork;
@@ -697,10 +746,30 @@ export function makeOpGenerator(options: OperationGenerationConfig): Generator<O
 		};
 	}
 
-	function deliverOperationsGenerator({ random, selectableClients }: FuzzTestState): DeliverOperations {
+	function deliverAllOperationsGenerator(): DeliverAllOperations {
 		return {
-			type: 'deliverOperations',
-			client: random.pick([...selectableClients, MetaClient.All]),
+			type: 'deliverAllOperations',
+		};
+	}
+
+	function deliverSomeOperationsGenerator({
+		random,
+		selectableClients,
+		network,
+	}: FuzzTestState): DeliverSomeOperations {
+		const pendingClients = selectableClients.filter((c) => network.getPendingOperations(c) > 0);
+		if (pendingClients.length === 0) {
+			return {
+				type: 'deliverSomeOperations',
+				client: random.pick(selectableClients),
+				count: 0,
+			};
+		}
+		const client = random.pick(pendingClients);
+		return {
+			type: 'deliverSomeOperations',
+			client,
+			count: random.integer(1, network.getPendingOperations(client)),
 		};
 	}
 
@@ -717,9 +786,10 @@ export function makeOpGenerator(options: OperationGenerationConfig): Generator<O
 	return interleave(
 		createWeightedGenerator<Operation, FuzzTestState>([
 			[changeCapacityGenerator, 1],
-			[allocateIdsGenerator, 8],
-			[deliverOperationsGenerator, 4],
-			[generateUnifyingIdsGenerator, 1],
+			[allocateIdsGenerator, 16],
+			[deliverAllOperationsGenerator, 2],
+			[deliverSomeOperationsGenerator, 6],
+			[generateUnifyingIdsGenerator, 2],
 			[reconnectGenerator, 1],
 		]),
 		take(1, repeat<Operation, FuzzTestState>({ type: 'validate' })),
@@ -767,8 +837,12 @@ export function performFuzzActions(
 				network.enqueueCapacityChange(op.newSize);
 				return { ...state, clusterSize: op.newSize };
 			},
-			deliverOperations: (state, op) => {
-				network.deliverOperations(op.client);
+			deliverSomeOperations: (state, op) => {
+				network.deliverOperations(op.client, op.count);
+				return state;
+			},
+			deliverAllOperations: (state) => {
+				network.deliverOperations(DestinationClient.All);
 				return state;
 			},
 			generateUnifyingIds: (state, { clientA, clientB, uuid }) => {

--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2392,11 +2392,11 @@
       }
     },
     "@fluid-experimental/property-changeset": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-changeset/-/property-changeset-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-PEI+qNJEDOijy8gKO8cTOY6WO79cAgK5mlD+g9eMslRiYnb8XUtC5o5HlaE2/bxs2482T2TbSuxvAg2udnIhTw==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-changeset/-/property-changeset-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-nScLGykY9wAViszy42G7i9dx+Woq4Vq9zfvFON3t6QfnQNZFPvHnshTfMrfCB73FQo5dM3jd2z9yb7snzdxFMA==",
       "requires": {
-        "@fluid-experimental/property-common": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-common": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "ajv": "7.1.1",
         "ajv-keywords": "4.0.0",
         "async": "^3.2.2",
@@ -2422,9 +2422,9 @@
       }
     },
     "@fluid-experimental/property-common": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-common/-/property-common-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-hIJNenPxo58wCN2esX5PkAn4gwwiCiCeBWZQSJJwogbBk4U9/t9UalXO0QvHA9GKimFtD+yx0CYd7jOJ78tGFw==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-common/-/property-common-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-Dh/8AETqJI25f285DBl7OgoEKUzWOpXNxk6coJnVtM7Z8UVMr67V/FGETFZpMkKkFh3m/k9giVMJ3Sgd6fGMPQ==",
       "requires": {
         "ajv": "7.1.1",
         "async": "^3.2.2",
@@ -2454,20 +2454,20 @@
       }
     },
     "@fluid-experimental/property-dds": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-dds/-/property-dds-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-Kk6Xn3wG2GnStKetUiY2apbD7qu8C4fYKLoZc7IuYDEm4LB2oDI4iOpkCmIEE6W38iMw+/HMYiscLLLTiBlUEg==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-dds/-/property-dds-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-YkEmLQbNu+ysVWgW2JcGnY2voxM5lKMW7XV8MHdlgzudrcGcfl2wNRB4I0u3seb/9tF6qVA2btAwdda47wnMjg==",
       "requires": {
-        "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluid-experimental/property-properties": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-properties": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "axios": "^0.26.0",
         "fastest-json-copy": "^1.0.1",
         "lodash": "^4.17.21",
@@ -2521,12 +2521,12 @@
       }
     },
     "@fluid-experimental/property-properties": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-properties/-/property-properties-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-2qNQZiIHCxMMirQA5bpGBe1JNHDCM7MhW+kW0TvZyjdsGFYayTXDOIdv8syPV0mlj9cjDGOrpZJM80Sd7BtVzw==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-properties/-/property-properties-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-0HqGYyx36jUKZkQUJ+TVQ+4jDuUNh+Qi6mdMXDmPc7goyhTV8YfbCX9/pOi4xaJtQG7AzL+xpFLSeinsbeg1sw==",
       "requires": {
-        "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluid-experimental/property-common": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-common": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "ajv": "7.1.1",
         "async": "^3.2.2",
         "fastest-json-copy": "^1.0.1",
@@ -2565,16 +2565,16 @@
       }
     },
     "@fluid-experimental/sequence-deprecated": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-fniPcWnMyshl+iIo1BuBlNdVPe9+FpmCh3/K5TXe2dx8Ht2DsZ51ycT/qes49eA8VL9/1cZtZ9fqtdsMzdY25w==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-ldSdeuTnyvptwOV+saugFGEpvSMTgnT+GN4nfM/xMgUBGybygwdI4TghEgIP+jhgvnSDofnfPS2Dpq+rydSydg==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/sequence": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/sequence": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluid-experimental/sequence-deprecated-previous": {
@@ -2836,25 +2836,25 @@
       }
     },
     "@fluidframework/aqueduct": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-iI43c+FrJVd3sqPdN7sadcQ+gb13F83K0GxV/wIL0HwsErHqfQaIb2ZmY+nCY5IehuWu35do8RI9YG2v/nYzlA==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-9zJC60vFWQPmreMHANYu+IZRmeRDnIh1To+h4vPykZat24pvr1AFNCW5FI76r2KXbEg4pa+1LiDYD9iT2ODTAw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/map": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/synthesize": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/map": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/request-handler": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/synthesize": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -2997,17 +2997,17 @@
       }
     },
     "@fluidframework/cell": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-ZmoXkZBxtLyYBNnEXeycPjr/ZvpmvDpQa9JwHbJ0LwE7B6Dbu5dI7kzpP0ScgD2No4GnNPpnj4Ng/+3I3vQi9w==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-+pOaJbnkS7pLiPOCKjACtWfVKRjDCHFiomMFBucy84Y9Hdp88FkIyLFFNB4UnpPTjQOGyK/ShV9Xm+OjyAztSQ==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/cell-previous": {
@@ -3051,14 +3051,15 @@
       }
     },
     "@fluidframework/container-definitions": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-rNHJh5366x0DCIbxohCtIaLEeluII5lTLDr+kdbHv98slHaNh9vmeQ1rhOVTmDWNNXcKmy0/sZ/NE0AN+mO4oQ==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-VqwMsYW4k2SBzgnUD/DiWLsJK94+aNpnzpsifZB3gEnFQoZf/4ikjVJAvNWyehDBV0FuyKeuz/wJ4ChahI3R5Q==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/protocol-definitions": "^1.1.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/protocol-definitions": "^1.1.0",
+        "events": "^3.1.0"
       }
     },
     "@fluidframework/container-definitions-previous": {
@@ -3073,22 +3074,23 @@
       }
     },
     "@fluidframework/container-loader": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-Woyt7ztxjHsnk1v8FkrK0zuXxj1CC+XZv1ocN77sIR6m43WPfOCjDE53TT/uylr5ppCFa7lLALm+FH9AD9z3Og==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-v36ciS1V+VlNXU78p30oW9Mu2TvniWbEgQPmdQDr2Ea14JWi7YwVQLNlolTt6aggIK6h9A4G5vZcSKWm1UZyGw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "abort-controller": "^3.0.0",
         "double-ended-queue": "^2.1.0-0",
+        "events": "^3.1.0",
         "lodash": "^4.17.21",
         "url": "^0.11.0",
         "uuid": "^8.3.1"
@@ -3117,42 +3119,42 @@
       }
     },
     "@fluidframework/container-runtime": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-qyYbAKF6bDK7MpLp198rxsTJlzY7qihY73jtBO+K6th8/mFSwUWzovzkV3cLtsrhwYjbMSa2KfIc/H5kEVwZJg==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-xVsI7pT9QEBf6avfEuL/0iESiD1Zch5+dt7muun1d509R9w+MNrG01RqLxHnlY0bolsdkSSpLR2VKAqRwbbgsw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "double-ended-queue": "^2.1.0-0",
+        "events": "^3.1.0",
         "lz4js": "^0.2.0",
         "uuid": "^8.3.1"
       }
     },
     "@fluidframework/container-runtime-definitions": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-tLf6BuIWkf5PudxPEMwq5rsFhGQhAurQoxHCrTAwOQsQVG0MXCLU6iTz64XuNhtazozAZmdOVvI1UVRUfhggUQ==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-MaPs3Gc6wuSTjnOBvuK07Pbpf3XE3dckNSXMzpeHOwbhudp3+zPNTlgE9SE3b9CnGFOMNIqFj4ZBdxCtA9UyvQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@types/node": "^14.18.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/container-runtime-definitions-previous": {
@@ -3195,15 +3197,15 @@
       }
     },
     "@fluidframework/container-utils": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-r12L0SFVhcQ7cUHMetKSHtHbPIAJrcgAUc1N+0vgb3OZ6PRmuFkAT9HRhpT7SorIXohHuqQ5BgsP+8KX4U35Jw==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-mn+E3GMSDD3JhYQVAn6gnmoNLDDhrq7XfqSIrEeydyzocc5wnBzSxwkF8zk6PwvvRHzojRstgWMuLtXwNU3eyQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/container-utils-previous": {
@@ -3219,9 +3221,9 @@
       }
     },
     "@fluidframework/core-interfaces": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-lctB4yMaykYK40W8oUkfC4OHLEiwPgFzATYnS8vfDMmz+EHL0RvzI5+LQO9T2WiXAaKvAlxHgYA1OvzCkOmXtw=="
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-q3Vzti54PaPP4BzYIQ/FjNM+8kqHG1ewa23qBUMIZ6qU5eL7Nz5wLrIEScSd208nvaPI/paSeIKpgncriAYFrg=="
     },
     "@fluidframework/core-interfaces-previous": {
       "version": "npm:@fluidframework/core-interfaces@2.0.0-internal.2.2.0",
@@ -3229,17 +3231,17 @@
       "integrity": "sha512-B7JNJWkR/0y6CJn90Kk8vTMmZDRKR81OEd82a3CUuYbfAJBsVcMeTPFdh9obrLiH7FS9/f1MxQHFXy7zLOAOWw=="
     },
     "@fluidframework/counter": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-O+ivnEnYrv38eIwoXYgAo3U4yoQuHUIAYi7JmJ6ZJ6O3h8DVu7iJIve+jxd8B++ntfS0VkQebQI7AgYgc7ucjQ==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-M8BDIoRYuLs8ZXIYVYhhuM26xic/l3wkYS9OQbgf+iuRLWfvbbhZRWR5q/2bW1n11tByvzcH6ZztzRsRuJOlAw==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/counter-previous": {
@@ -3275,40 +3277,39 @@
       }
     },
     "@fluidframework/datastore": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-3AECXMJu4v0Zhh8759Ve5ohne2bXjQOvMFUUHksIXihabViUwz5/4ZkgaPZF1YBXeAzFVSYdSsdD6cdpbeynnQ==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-+QQL72EYcBanTqE5VYvBN6SsrJWGU3xbXFp0t9JThpy7A9tDIJZMcleFCgurAPntp3Y7mP3pRPcrfCiCM5TpYA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "lodash": "^4.17.21",
         "uuid": "^8.3.1"
       }
     },
     "@fluidframework/datastore-definitions": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-InmktQyhLODak0j3bAFOUEDtO0KRVUecOTjwk44qYIWXEGP2Q7qo6Zl+Lrey6G08FCMHzaajVjyvRksJypMW1g==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-nS6kkoj0BgnyHDk/GJFmiqSPjctkeCTw1A4wzdV3W48fFFLXDdW8wMyMxgvUootqn72TSeTiOyErttCOc92dEQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@types/node": "^14.18.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/datastore-definitions-previous": {
@@ -3374,16 +3375,16 @@
       }
     },
     "@fluidframework/driver-base": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-5O2Euvxhsl/oeQjIZ3aCVRCiDfJ8yBqeNMTFhh21xJMYfJILJg4MB2B4HCasCOLpr5ODiNCCYNtIMV2e3EmbxA==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-+OmqtmVBAdt8anHt5kXwDNc8qVj54f2VG9Yot/ABWGH2aZXnuFNN9CIptfCN1t6+lIBdGzoCED/pCLTlw4jDvA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/driver-base-previous": {
@@ -3400,12 +3401,12 @@
       }
     },
     "@fluidframework/driver-definitions": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-uLfyuq78VPWmMDZpFyFq6Uwjer0G9N8CkVWiUAnfy4Txl2ZSyDyps23LY1K4//reVzOVX/FHI1QlCUSUicDtZA==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-jv+ryQ4roA/iCty9eXB1yKyknaMyFP56hAMS1NMB2P7xRIcLBkaEfDqGu7+8dcDTy2sDEyHdPQ4gSV0MvQVX0A==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0"
       }
     },
@@ -3420,18 +3421,18 @@
       }
     },
     "@fluidframework/driver-utils": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-ZC7lpf7O2tICxGvZpcvgoDGqSGC2nEE+aX0UuKzHNmPXzLbC2oB4xDijGwE9vFN91YyihaDRTFF2TcXIkvoGAw==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-4/5FsPn7BbUal5wl8lwczDBskF5savEu5mh+r0T8QdQc3rkIlhur0x8v7vu/9zqDlJOeD3Vxy/cmGhSh1WPRoQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/gitresources": "^0.1038.2000",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "axios": "^0.26.0",
         "url": "^0.11.0",
         "uuid": "^8.3.1"
@@ -3520,22 +3521,22 @@
       }
     },
     "@fluidframework/fluid-static": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-rFOx5Lda/Izsi2U/NFX7vefIEfwPmG44Ca8KUFGmXSfhcctxQPuRXJCirGKUYAU59KAJsyKvMXXb0a49Yh9leA==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-oWPuROROD90assA2ieABSQUsbPR6T7OtdAmcwb+FfMO49uG5t39VdHZyp9BtuR8K3atwpqEAlm6m0Y9PTVAuwQ==",
       "requires": {
-        "@fluidframework/aqueduct": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/aqueduct": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/request-handler": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/fluid-static-previous": {
@@ -3558,13 +3559,14 @@
       }
     },
     "@fluidframework/garbage-collector": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-LC/S0E/pgtPur+aKFOUHBzYOCvSaCH0rHxqJ4a6L3nF0cBjWKl3gS7uGVl9tDLuupCQei1nBcRb4kyVetomQLg==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-zJVELgDSlmTK3fRh3F8gMX/JmojIczAFlW1D20JCVJAvt9UaLSHyikeF0uN+4lHMqPFouWkwn3LjCScc5By+Jg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/protocol-definitions": "^1.1.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/garbage-collector-previous": {
@@ -3598,17 +3600,17 @@
       }
     },
     "@fluidframework/ink": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-/wcLSjnyyEzbnlVnNNC3Hc82zzDH2JOfsbRrbXZ3W6P7nD92vheLq2tw1kp4aUzPPcHXWpniB+/XSGQzK+zXWw==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-a415hyaNAGuHTb9N0Gv9323sK05bde0d7tMm3e9HK/hIRzAEOd8zbIawj/pzTicF0nER95pmFQuPwQSBuv79EQ==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -3628,24 +3630,25 @@
       }
     },
     "@fluidframework/local-driver": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-yfIZAZ6s1gnUwYQkgtd2S6fjHgcsxwyozCHB70Ona8/inVF+iuDaTQAnzYp7ZJJpanqXD8UhaXf49AJDsQan/w==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-X7jQXV77zcWVEL9zFR44oR0f0X1GwdOrXmy5vze4Gu3lQ8GRdUIFtWJeS3PdZFNUlXrmHqe9K51bVmDYm9NZRA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/server-local-server": "^0.1038.2000",
         "@fluidframework/server-services-client": "^0.1038.2000",
         "@fluidframework/server-services-core": "^0.1038.2000",
         "@fluidframework/server-test-utils": "^0.1038.2000",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "events": "^3.1.0",
         "jsrsasign": "^10.5.25",
         "url": "^0.11.0",
         "uuid": "^8.3.1"
@@ -3687,20 +3690,20 @@
       }
     },
     "@fluidframework/map": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-XPC+P1skPGnAiTlcm7pYT9JXI1c1fngzaQjGoPR6Xnwjq46OO7fMTBGG9q7a07+nTLkxvNMpsnSyzz2EhYb7XA==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-7tWssmf4e3PY54yM+4jIvhxU+4DP/0+brR9ZwvDyIvu1q+eL0L3i93zR+kMk+gesDKAVw45Cpd4v+ksOos2nwg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "path-browserify": "^1.0.1"
       }
     },
@@ -3723,22 +3726,23 @@
       }
     },
     "@fluidframework/matrix": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-4GZIsk5JEyyqcrG3iASlB3PJTF2hZma6LZc8NfPvOnavbZmk4GFBjXUa4unBr7gp0HUVYoI0V/GeKO/fmSf5tQ==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-W57mgxTwi10NEtxOijXYhtR0cgw8RWqjSuQdxtoNaJLP7ynenbtnjPHynvlWzdxuYua/9DULME8pM8J4Dc0cGw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@tiny-calc/nano": "0.0.0-alpha.5",
+        "events": "^3.1.0",
         "tslib": "^1.10.0"
       }
     },
@@ -3763,21 +3767,21 @@
       }
     },
     "@fluidframework/merge-tree": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-jSh/9UKr7I6oQUi1dUrJtCpUzrJEcsYUPFs2G7xRNVyBgSCORqh483gG1up50Ro1X6vEXe0e3682nYUIC6DpFw==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-eY53aSR7YoKn44AUYpqzSNTX3G/C1LAeR+SNBuxcILqpAw2NtHYs7HcF93oN7bOpIA6HhDXJYvTP/alNNWyfwg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/merge-tree-previous": {
@@ -3809,16 +3813,16 @@
       }
     },
     "@fluidframework/odsp-doclib-utils": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-S289cQ/9BqVbRECGhzhIs4x/MkpRgyghBsuMnxlLbZEdz7qP0id7Vy1a92dIBP5ZsObXtSb4Ypl+rQU3/BmP/Q==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-Y++o1mZPlqHk2dMkh9hAIX9uV7l19ZZJhuzJGsfbJakkizGU6w4ENtlXfJ1yFC2Y90mzdcSchvmuMG0IzCL9sA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "node-fetch": "^2.6.1"
       }
     },
@@ -3837,22 +3841,22 @@
       }
     },
     "@fluidframework/odsp-driver": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-MQRUR6zvI/u2pv9oeR9k8Y9olh0nhAs2mjGM+0Tf/blduRyiK2H1+F5J45ph/wxykHw1oquZyF5DQraAdPlImQ==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-VJ8gtbk20XGH1bVXs5Z+EvIys0zEr+wkWUK7rujM0hiR/eJc0TM6e8g+mshFNpiKDYFuGzcYccUKtnPACpwvOQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/gitresources": "^0.1038.2000",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.1",
         "socket.io-client": "^4.4.1",
@@ -3860,11 +3864,11 @@
       }
     },
     "@fluidframework/odsp-driver-definitions": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-nBLW0hBtPOCe8juIPFcAUVswbnWZT/wFBesaeOiUUjt9slPMy5SY66RGo2tYFWcIMOVW2Cs8bljDQi/KRsbnNQ==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-HqAbuRtXrkU04rlFHkkvzHeuW279ZJPsV0f7A+bcNGcwgiPTGH9sqNCu324X/IvZTZPiKdyjI4jEgZPvQOp2Sw==",
       "requires": {
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/odsp-driver-definitions-previous": {
@@ -3899,14 +3903,14 @@
       }
     },
     "@fluidframework/odsp-urlresolver": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-8LQlDA++uuUoOvayAj+7zs8790/B45D1DRhydpVnit68Ch7bK2hbDQMUL4w08OrxGHLSNd6W8Ryni+nA3Kd47A==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-dRZliF/smZOP8wvjXCMuOEuFZ4wHh9/b384g+4bpIAja5AtHXPQ/srDP1pM06dj5VBRzE/EebAywZnShp7Ednw==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/odsp-urlresolver-previous": {
@@ -3921,17 +3925,17 @@
       }
     },
     "@fluidframework/ordered-collection": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-jYoLfT1HguxUOs4JLGc+fXOGihB6D4ClTTMUZtyjBHyw7rLTOXxa0Vc1n3QoMXk3eSCb1lpcWB9R1k1qJU7Yww==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-RQutZsy8UJpvLw9S0SIRBny7HeKldNFSVsQMa1pDaDggLmu0FdxuueAyneIepxwYeUYKcmnkcHrB9ZL6aIZfWw==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -3970,17 +3974,17 @@
       }
     },
     "@fluidframework/register-collection": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-tI9VtpHpqWO1Dh5f6+Hs4Nl0Vr22EypMGncoRmv0PsfTdy8YBrdlhxESl3vmAWX2tQlaboVE8Qi5OGO0HpspDw==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-1lIua78N1NwYPHyxUrVwOBReQ8MxlFfFyglmgamqaxs6023cMd+kmYTlu6xcEuPFjs1b3fBNGQt9xlmkPkiJFA==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/register-collection-previous": {
@@ -3998,16 +4002,16 @@
       }
     },
     "@fluidframework/replay-driver": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-rofaaxxoTdmLf1/kxVP91e+R+ZDnN1rIXIY0DO/SKpZa0E4kmT61y1eiC4IlEyEJk3tpuAf1b0Jzg6hf34mi6w==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-J2vyi0Is+s3wykQash8+veRjaQ389Weffab4U23KgqsJQG2t2pMXcFKSG+IQsm+SP0XnIhW3SX0O4czOe8vfRw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/replay-driver-previous": {
@@ -4024,15 +4028,15 @@
       }
     },
     "@fluidframework/request-handler": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-pY2zZ0fWa6phEgraRGQggzxgLZ46D0WpKA9gdV++hKOnib3PyrRoRGZ9F2TxSzUWQkuOE5l3y/y7Rz7DBstIKg==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-A8MyrpcpprqXfjhmlYetRWFzGmqQUkJwYubHbPilKPRsETSBSIqXjyhTkvHg71S6KLCts9yJmvUeJoK15v9OIQ==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/request-handler-previous": {
@@ -4048,20 +4052,20 @@
       }
     },
     "@fluidframework/routerlicious-driver": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-zHHsqY5pHydkFaVlOCEi1hQ/07Le78FcIzEBActrr+/CgWluxrQmeiFLEub/ZCcT+RkuRAnGxTxLoMdT4vOjgg==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-1qiVpHOaj3avpe/8/Stp9Gma4cxnm/eGoXCuQzxyAldXEdzKCwVnUuHGVdXno3kyM56mX+g6kt1ioRPEBnOHTA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/gitresources": "^0.1038.2000",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "@fluidframework/server-services-client": "^0.1038.2000",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "cross-fetch": "^3.1.5",
         "json-stringify-safe": "5.0.1",
         "querystring": "^0.2.0",
@@ -4107,17 +4111,16 @@
       }
     },
     "@fluidframework/runtime-definitions": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-If4I4HWOdiV0iOr/DSwUk1kEdnjoz02JJUMEu2iXotvGQYuGofkpZBfNr6+Xw4k2pVUbIWqpZIsm9kIJhVPVWQ==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-9Ho3150Dsxc4NBSJZU6IsLZxhxIo0VL9WMUm/1WkV+qh39HwGPUK9RATsIFGO+pdNve7aNPsk2G1Xphrmm+9/A==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/protocol-definitions": "^1.1.0",
-        "@types/node": "^14.18.0"
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/protocol-definitions": "^1.1.0"
       }
     },
     "@fluidframework/runtime-definitions-previous": {
@@ -4135,21 +4138,21 @@
       }
     },
     "@fluidframework/runtime-utils": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-iKS5kAGvwCVM4+4IeANIC8dEhPSzcd3z6OnWeQxnoXG3+vNtaEj9TjyipIZIC3aNqJdWO2+pRaoBJP9NHmECMg==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-6NzRIuDOhqMwQCp11uy3k22y60jcvez6SoMXD9spQ7+bdGpvAQjS/co0pH301aIA7tlpmhpYCMyobxFgCc/C3w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/runtime-utils-previous": {
@@ -4171,21 +4174,22 @@
       }
     },
     "@fluidframework/sequence": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-MuRGzr4ebZmSa5rP6LJ8jU3exEk43N+5TBTEuam8QSaFPw7eZ7S1+DBU2V+7SZZFoM4m1cdmj14OEHGMbTeQxg==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-ndoynB1AofaWGluFqsUxKbWgyyL9GdXrMIISBiyEfwhYd1zQ7rQGMnQz7g7vUwSaptypOFkIYiwDaliJvrFCAg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -4504,22 +4508,22 @@
       }
     },
     "@fluidframework/shared-object-base": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-qAc7yLJSMtPV86YYioRyVjJpi0TlHzd45wVm9fsU8eEuvzMH7l3sNo3Dl6iIzMGNhwv/IWaoIa4ZJ56rmGydOw==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-B+7Y95KO6u5bMnbjHpvdENdrAAxyoqwgdG9XOsPrn/qqINkQaAC4ZVXNRmGYecHgkrl0SDrPgrIC4B0OGZUA0g==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -4558,9 +4562,9 @@
       }
     },
     "@fluidframework/synthesize": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-R8k/rkkhqg5c7LMAt7ewS6wAecGQoAkdzkgXLV5QLGKeJptPNq88m9KhzIGFwMs3HpIhG0671PfhBlg39Hw9SQ=="
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-nJCoLpLNlW5DY7++QGeN8F9QYRvQgTV+7LFyRjvRVu6H6ZoFQY3e4q+MKTCh7s5aS1RLke8K5xA2aQzxD4htTg=="
     },
     "@fluidframework/synthesize-previous": {
       "version": "npm:@fluidframework/synthesize@2.0.0-internal.2.2.0",
@@ -4585,9 +4589,9 @@
       }
     },
     "@fluidframework/telemetry-utils": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-eEvSxKX4BlU3pxRMwhLHwxDR4t4waw7ddHJgF12ra3BLQn9L3meiKO/gxC9p4CAzlLbw6yLJXGqnw4NUpp0cfg==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-Yfkk7R+mOVGry86ekoGxz6pfx2bkdhoL62ITck/fAl0x+LvN2KPbAJcF6EpewBdKj2IuVVspN/UWkaav20HQ8Q==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
@@ -4619,13 +4623,13 @@
       }
     },
     "@fluidframework/test-driver-definitions": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-1Q5IFUy2eZlFU9NHDwoGhXiLU3jVjbSHPz9YDA4+TeJSlrIp9HSalTIaUsKGVu1cFXtSDrj0I7K16Idz61JEmw==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-AOGIlRFpNXhEcfW60eh9Z5tow9awlKw7W+rXfqsT8SCJn4aypEI80Ult/nXoCA5Bz42Yn/X1BSRMTH1WFdghiw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "uuid": "^8.3.1"
       }
@@ -4643,27 +4647,27 @@
       }
     },
     "@fluidframework/test-drivers": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-a41i8MsuXT0JoeMDz8lFYWhzjk+aP+oNbito1djMkh2WLGwWvhJtGZfT3gxsMQbYk7fzUYmouLBNYZ5De9MySg==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-lyVbtkzHuXQl6dbe9954XQTgzsXi0wwGzxVTpWenNc9wqK8q6Bk6iYYr1RA5swprkd/WDUcrKDbOqxbePgc3sw==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/local-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/local-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/server-local-server": "^0.1038.2000",
-        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/tool-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/tool-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "axios": "^0.26.0",
         "semver": "^7.3.4",
         "uuid": "^8.3.1"
@@ -4709,9 +4713,9 @@
       }
     },
     "@fluidframework/test-pairwise-generator": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-ekwbM+l6e5fXKQM/CtwqQfkQ/QIN7RDAblUeYcvjCkrjgaz7GmBbxYEM23Q4Q9n7W941AioydKZuUtJmPff4/w==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-6iEcLTLcuJyaqX3vwPBUcvl0zcMIXQA0c15y4BGV25YHyGMMLqxF6pdCYF0nnE97qQ3vUDUU1ubD5+T/75k5Aw==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
         "random-js": "^1.0.8"
@@ -4727,23 +4731,24 @@
       }
     },
     "@fluidframework/test-runtime-utils": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-WGSpjgoGOWdEOLyf7KZUgWuOVfxsIgU4b4jbJiW+vTqXtzOcZebzmgGeavruel2k1VuZH2nP1l+y6M1TA2i02A==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-6UjTORkfd5RKpYYpj62M3EJ5Tn4Gq5E4QLG3YtC5+K3Lo84R8wTQ+GeaHRCvhFrGe4b0l7qPyRabfsIZ+VwL6g==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "axios": "^0.26.0",
+        "events": "^3.1.0",
         "jsrsasign": "^10.5.25",
         "uuid": "^8.3.1"
       }
@@ -4777,32 +4782,32 @@
       "dev": true
     },
     "@fluidframework/test-utils": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-/B5Frfd86Lz7/uop7oAowowKI9rDW9U6fvFoR5/FDXEQrXOff8ocOw3n6ZogoehqEvloMEraD66vFwQny3N1kA==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-jLOknNQg1iGgwYN98qKdsDDAlF1fc9tJ9E7qRG6306i0HPQjqO8JjzmMUEVLgcp4O6oxI5gAyIgcEkpxq5nONQ==",
       "requires": {
-        "@fluidframework/aqueduct": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/aqueduct": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/local-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/map": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/local-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/map": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/request-handler": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "best-random": "^1.0.0",
         "debug": "^4.1.1",
         "uuid": "^8.3.1"
@@ -4895,15 +4900,15 @@
       }
     },
     "@fluidframework/tinylicious-driver": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-Cqe/sgoJtRoi5uYuCk+Z01kh2dLhCmfDv3Jx3WWl5StTd9u/6J6WxODjr3sGR/ftHiBzNOmk0xm5QNSPwIfcMw==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-OQtFzZIOxwQVlxalQl6GbVR7R9LbpT2EEdwsYOaIhpk1kmGFR6/JsQ2vgh2P7tO3P/5QzDZSf592F0o/wIcoZA==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/server-services-client": "^0.1038.2000",
         "jsrsasign": "^10.5.25",
         "uuid": "^8.3.1"
@@ -4925,12 +4930,12 @@
       }
     },
     "@fluidframework/tool-utils": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-BOXjO/kS7s7aLHz3zhMMkFNqKlgV0Skm3U6VcurILVKCOLF5y+muNyhtYkeUNq0wrEEyQu5Y3U8aOuFmgbLypw==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-2sguFkVhEOrX/a3+ePKePUoyt8WmEaVBZ1fBxzy63l7ZMPZrfSPCchMbgDKRJNxPCfRTEI/G2TEZg5QJsrKmeg==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "async-mutex": "^0.3.1",
@@ -4966,12 +4971,12 @@
       }
     },
     "@fluidframework/view-adapters": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-BNgtHYUiHu/+usW2uz9wKfQQGnImL3M6mt409Bhke8p7Lrmwjwde3DKSmYCkXrHP0DFQoSeG+K2WJey49g6j3g==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-z3l4wnut3X/87ljIFR8aI1VxVwmSh6HYxppwDECHV9sBTKmvqHUeHiZ9F6tkg5QBUoPko2TlQag6G2A5E0HwmQ==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "react": "^17.0.1",
         "react-dom": "^17.0.1"
       }
@@ -4988,11 +4993,11 @@
       }
     },
     "@fluidframework/view-interfaces": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-EPsNvDvtEa4x1QHAsfIx9sqSMb5EcaAeV8NMq28seuvb93f9Yzdior8dd2/knmgrgxMIq15LQWUBz2EF3ULTeg==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-Owdq4DBru4vSH1BZkFoTmchXAI0evrqEtRmF+j5JtOsgi9xfmoEkU7RLLK/K6w4uJmc/jIBF1kRhQNqiqNZxWQ==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/view-interfaces-previous": {
@@ -5004,12 +5009,12 @@
       }
     },
     "@fluidframework/web-code-loader": {
-      "version": "2.0.0-internal.2.2.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.2.1.tgz",
-      "integrity": "sha512-gHUb94qdfFZmK26/a/FDf16B0WRJr0KFadE9iOytBF4ncWxRufTYWeeJGuZ0Bt3WK/dx2vmwvwcx5ah3jawi+g==",
+      "version": "2.0.0-internal.2.3.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.3.0.tgz",
+      "integrity": "sha512-kOtwpD9zclH/3e4zEVa5OBOtV8NMsBqlN7Tt77whBLPkZPDLGdABMyXPTfS+VnLFLg+Y1Y3dSFwEd4EhxeypPQ==",
       "requires": {
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
         "isomorphic-fetch": "^3.0.0"
       }
     },

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -80,6 +80,7 @@
     "@rushstack/eslint-config": "^2.5.1",
     "@types/diff": "^3.5.1",
     "@types/mocha": "^9.1.1",
+    "@types/node": "^14.18.36",
     "@types/random-js": "^1.0.31",
     "concurrently": "^6.2.0",
     "copyfiles": "^2.4.1",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -80,7 +80,7 @@
     "@rushstack/eslint-config": "^2.5.1",
     "@types/diff": "^3.5.1",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^14.18.36",
+    "@types/node": "^14.18.0",
     "@types/random-js": "^1.0.31",
     "concurrently": "^6.2.0",
     "copyfiles": "^2.4.1",

--- a/packages/framework/request-handler/src/test/tsconfig.json
+++ b/packages/framework/request-handler/src/test/tsconfig.json
@@ -4,6 +4,7 @@
         "rootDir": "./",
         "outDir": "../../dist/test",
         "types": [
+            "node",
             "mocha"
         ],
         "declaration": false,


### PR DESCRIPTION
This patch incorporates the changes from
https://github.com/microsoft/FluidFramework/pull/13640
and
https://github.com/microsoft/FluidFramework/pull/13671
as well as bumping some outdated versions in `lerna-package-lock.json`

Reviewers - could you please double check that the changes in `lerna-package-lock.json` make sense? They were the result of me running `npm i`, and while I didn't intend to check them in as part of this patch initially, it seems to me that having the existing references to 2.2.1 instead of 2.3 is a mistake.