### PR TITLE
Action for marking and deleting stale branches

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -1,16 +1,18 @@
-name: Mark and Remove Stale Branches
+name: Stale Branches
 on: workflow_dispatch
 
+permissions:
+  issues: write
+  contents: write
+
 jobs:
-  remove-stale-branches:
-    name: Remove Stale Branches
+  stale_branches:
     runs-on: ubuntu-latest
     steps:
-      - uses: fpicalausa/remove-stale-branches@859dde72c29b4f69af188b7adaeabf21497534d9
-        with:
-          dry-run: true
-          exempt-authors-regex: "^dependabot"
-          exempt-branches-regex: ^(main|next|release.*)$
-          days-before-branch-stale: 90
-          days-before-branch-delete: 7
-          stale-branch-message: "@{author} Your branch [{branchName}]({branchUrl}) hasn't been updated in the last {daysBeforeBranchStale} days and is marked as stale. It will be removed in {daysBeforeBranchDelete} days.\r\nIf you want to keep this branch around, delete this commit or add new commits to this branch."
+    - name: Stale Branches
+      uses: crs-k/stale-branches@2864505cecb7aeea50767b9d2631ed550eb069b6
+      with:
+        days-before-delete: 365
+        days-before-stale: 120
+        tag-committer: true
+        max-issues: 20

--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -13,4 +13,4 @@ jobs:
           exempt-branches-regex: ^(main|next|release.*)$
           days-before-branch-stale: 90
           days-before-branch-delete: 7
-          stale-branch-message: "@{author} Your branch [{branchName}]({branchUrl}) hasn't been updated in the last {daysBeforeBranchStale} days and is marked as stale. It will be removed in {daysBeforeBranchDelete} days.\r\nIf you want to keep this branch around, delete this comment or add new commits to this branch."
+          stale-branch-message: "@{author} Your branch [{branchName}]({branchUrl}) hasn't been updated in the last {daysBeforeBranchStale} days and is marked as stale. It will be removed in {daysBeforeBranchDelete} days.\r\nIf you want to keep this branch around, delete this commit or add new commits to this branch."

--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -1,18 +1,20 @@
-name: Stale Branches
-on: workflow_dispatch
+# This is a GitHub action that will automatically delete any branches
+# that aren't protected and haven't been committed to in over 6 months.
 
-permissions:
-  issues: write
-  contents: write
+name: Delete Stale Branches
+on: workflow_dispatch
 
 jobs:
   stale_branches:
+    name: Cleanup old branches
     runs-on: ubuntu-latest
     steps:
-    - name: Stale Branches
-      uses: crs-k/stale-branches@2864505cecb7aeea50767b9d2631ed550eb069b6
-      with:
-        days-before-delete: 365
-        days-before-stale: 120
-        tag-committer: true
-        max-issues: 20
+      - name: Checkout repository
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
+      - name: Run delete-old-branches-action
+        uses: beatlabs/delete-old-branches-action@db61ade054731e37b5740e23336445fbc75ccd7b # v0.0.9
+        with:
+          repo_token: ${{ github.token }}
+          date: '6 months ago'
+          dry_run: true
+          exclude_open_pr_branches: true

--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -1,0 +1,16 @@
+name: Mark and Remove Stale Branches
+on: workflow_dispatch
+
+jobs:
+  remove-stale-branches:
+    name: Remove Stale Branches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fpicalausa/remove-stale-branches@859dde72c29b4f69af188b7adaeabf21497534d9
+        with:
+          dry-run: true
+          exempt-authors-regex: "^dependabot"
+          exempt-branches-regex: ^(main|next|release.*)$
+          days-before-branch-stale: 90
+          days-before-branch-delete: 7
+          stale-branch-message: "@{author} Your branch [{branchName}]({branchUrl}) hasn't been updated in the last {daysBeforeBranchStale} days and is marked as stale. It will be removed in {daysBeforeBranchDelete} days.\r\nIf you want to keep this branch around, delete this comment or add new commits to this branch."


### PR DESCRIPTION
## Description

This adds a GitHub action for marking stale branches and deleting them after notifying the owner of the branch. It will open a maximum of 20 issues and will mark a branch as stale after 120 days of no use. It won't automatically delete any protected branches and waits 365 days of no commits so that gives the owners of the branch ample time to decide if they need it. 