### PR TITLE
fix(check:policy): Ignore packages that don't have pre-requisite scripts

### DIFF
--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -614,16 +614,18 @@ export const handlers: Handler[] = [
                     "format",
                 );
 
-                if (!hasPrettierScript) {
-                    missingScripts.push(`prettier`);
-                }
+                if (hasPrettierScript || hasPrettierFixScript || hasFormatScript) {
+                    if (!hasPrettierScript) {
+                        missingScripts.push(`prettier`);
+                    }
 
-                if (!hasPrettierFixScript) {
-                    missingScripts.push(`prettier:fix`);
-                }
+                    if (!hasPrettierFixScript) {
+                        missingScripts.push(`prettier:fix`);
+                    }
 
-                if (!hasFormatScript) {
-                    missingScripts.push(`format`);
+                    if (!hasFormatScript) {
+                        missingScripts.push(`format`);
+                    }
                 }
             }
 

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -613,18 +613,21 @@ export const handlers: Handler[] = [
                     json.scripts,
                     "format",
                 );
+                const isLernaFormat = json["scripts"]["format"]?.includes("lerna");
 
-                if (hasPrettierScript || hasPrettierFixScript || hasFormatScript) {
-                    if (!hasPrettierScript) {
-                        missingScripts.push(`prettier`);
-                    }
+                if (!isLernaFormat) {
+                    if (hasPrettierScript || hasPrettierFixScript || hasFormatScript) {
+                        if (!hasPrettierScript) {
+                            missingScripts.push(`prettier`);
+                        }
 
-                    if (!hasPrettierFixScript) {
-                        missingScripts.push(`prettier:fix`);
-                    }
+                        if (!hasPrettierFixScript) {
+                            missingScripts.push(`prettier:fix`);
+                        }
 
-                    if (!hasFormatScript) {
-                        missingScripts.push(`format`);
+                        if (!hasFormatScript) {
+                            missingScripts.push(`format`);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR adds additional clause to check if `json["scripts"]["format"]` is `lerna format` or not. By making this change, `policyChecker` and `policyResolver` will pass the build. 