### PR TITLE
enable checkpoint heuristics and add checkpointing logs in deli

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -1713,6 +1713,13 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
                     checkpointParams.clear = true;
                 }
                 void this.checkpointContext.checkpoint(checkpointParams);
+                const checkpointReason = CheckpointReason[checkpointParams.reason];
+                const checkpointResult = `Writing checkpoint. Reason: ${checkpointReason}`;
+                const lumberjackProperties = {
+                    ...getLumberBaseProperties(this.documentId, this.tenantId),
+                    checkpointReason,
+                };
+                Lumberjack.info(checkpointResult, lumberjackProperties);
             },
             (error) => {
                 const errorMsg = `Could not send message to scriptorium`;

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -132,7 +132,7 @@
         "checkpointBatchSize": 10,
         "checkpointTimeIntervalMsec": 1000,
         "checkpointHeuristics": {
-            "enable": false,
+            "enable": true,
             "idleTime": 10000,
             "maxTime": 60000,
             "maxMessages": 500
@@ -141,7 +141,7 @@
     "scribe": {
         "kafkaClientId": "scribe",
         "checkpointHeuristics": {
-            "enable": false,
+            "enable": true,
             "idleTime": 10000,
             "maxTime": 60000,
             "maxMessages": 500


### PR DESCRIPTION
## Description

> Enables checkpoint heuristics in scribe and deli for local development. 
> Adds a log when deli creates a checkpoint. (Similar to what is already implemented in scribe.)