### PR TITLE
Move Test Only Metric from MergeTree Client to TestClient

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -99,14 +99,6 @@ export interface BlockUpdateActions {
 export class Client extends TypedEventEmitter<IClientEvents> {
     constructor(specToSegment: (spec: IJSONSegment) => ISegment, logger: ITelemetryLogger, options?: PropertySet);
     // (undocumented)
-    accumOps: number;
-    // (undocumented)
-    accumTime: number;
-    // (undocumented)
-    accumWindow: number;
-    // (undocumented)
-    accumWindowTime: number;
-    // (undocumented)
     addLongClientId(longClientId: string): void;
     annotateMarker(marker: Marker, props: PropertySet, combiningOp?: ICombiningOp): IMergeTreeAnnotateMsg | undefined;
     annotateMarkerNotifyConsensus(marker: Marker, props: PropertySet, consensusCallback: (m: Marker) => void): IMergeTreeAnnotateMsg | undefined;
@@ -176,21 +168,13 @@ export class Client extends TypedEventEmitter<IClientEvents> {
     load(runtime: IFluidDataStoreRuntime, storage: IChannelStorageService, serializer: IFluidSerializer): Promise<{
         catchupOpsP: Promise<ISequencedDocumentMessage[]>;
     }>;
-    // (undocumented)
-    localOps: number;
     localReferencePositionToPosition(lref: ReferencePosition): number;
-    // (undocumented)
-    localTime: number;
     // (undocumented)
     localTransaction(groupOp: IMergeTreeGroupMsg): void;
     // (undocumented)
     readonly logger: ITelemetryLogger;
     // (undocumented)
     longClientId: string | undefined;
-    // (undocumented)
-    maxWindowTime: number;
-    // (undocumented)
-    measureOps: boolean;
     peekPendingSegmentGroups(count?: number): SegmentGroup | SegmentGroup[] | undefined;
     posFromRelativePos(relativePos: IRelativePosition): number;
     regeneratePendingOp(resetOp: IMergeTreeOp, segmentGroup: SegmentGroup | SegmentGroup[]): IMergeTreeOp;
@@ -911,30 +895,6 @@ export interface MergeTreeRevertibleDriver {
     localReferencePositionToPosition(lref: LocalReferencePosition): number;
     // (undocumented)
     removeRange(start: number, end: number): any;
-}
-
-// @public (undocumented)
-export interface MergeTreeStats {
-    // (undocumented)
-    histo: number[];
-    // (undocumented)
-    leafCount: number;
-    // (undocumented)
-    liveCount: number;
-    // (undocumented)
-    maxHeight: number;
-    // (undocumented)
-    maxOrdTime?: number;
-    // (undocumented)
-    nodeCount: number;
-    // (undocumented)
-    ordTime?: number;
-    // (undocumented)
-    packTime?: number;
-    // (undocumented)
-    removedLeafCount: number;
-    // (undocumented)
-    windowTime?: number;
 }
 
 // @public (undocumented)

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -109,14 +109,16 @@
     "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
     "baselineVersion": "2.0.0-internal.2.1.1",
     "broken": {
-      "ClassDeclaration_Client": {"forwardCompat": false, "backCompat": false},
-      "InterfaceDeclaration_SegmentGroup": {"forwardCompat": false},
       "ClassDeclaration_Client": {
         "forwardCompat": false,
         "backCompat": false
       },
       "InterfaceDeclaration_SegmentGroup": {
         "forwardCompat": false
+      },
+      "InterfaceDeclaration_MergeTreeStats": {
+        "forwardCompat": false,
+        "backCompat": false
       }
     }
   }

--- a/packages/dds/merge-tree/src/index.ts
+++ b/packages/dds/merge-tree/src/index.ts
@@ -81,7 +81,6 @@ export {
 	MaxNodesInBlock,
 	MergeBlock,
 	MergeNode,
-	MergeTreeStats,
 	MinListener,
 	NodeAction,
 	ordinalToArray,

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -461,7 +461,6 @@ export interface IRootMergeBlock extends IMergeBlock {
 }
 
 /**
- * @deprecated For internal use only. public export will be removed.
  * @internal
  */
 export class MergeTree {

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -327,19 +327,6 @@ export interface SearchResult {
     pos: number;
 }
 
-export interface MergeTreeStats {
-    maxHeight: number;
-    nodeCount: number;
-    leafCount: number;
-    removedLeafCount: number;
-    liveCount: number;
-    histo: number[];
-    windowTime?: number;
-    packTime?: number;
-    ordTime?: number;
-    maxOrdTime?: number;
-}
-
 export interface SegmentGroup {
     segments: ISegment[];
     previousProps?: PropertySet[];

--- a/packages/dds/merge-tree/src/test/beastTest.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.ts
@@ -631,7 +631,6 @@ export function TestPack(verbose = true) {
             return;
         }
         const aveTime = (client.accumTime / client.accumOps).toFixed(1);
-        const aveLocalTime = (client.localTime / client.localOps).toFixed(1);
         const stats = getStats(client.mergeTree);
         const windowTime = stats.windowTime!;
         const packTime = stats.packTime;
@@ -648,9 +647,6 @@ export function TestPack(verbose = true) {
         }
         if (checkIncr) {
             aveIncrGetTextTime = (incrGetTextTime / incrGetTextCalls).toFixed(1);
-        }
-        if (client.localOps > 0) {
-            log(`local time ${client.localTime} us ops: ${client.localOps} ave time ${aveLocalTime}`);
         }
         log(`get text time: ${aveGetTextTime} incr: ${aveIncrGetTextTime} catch up ${aveCatchUpTime}`);
         log(`accum time ${client.accumTime} us ops: ${client.accumOps} ave time ${aveTime} - wtime ${adjTime} pack ${avePackTime} ave window ${aveWindow}`);
@@ -926,7 +922,7 @@ export function TestPack(verbose = true) {
                 reportTiming(clients[2]);
                 let totalTime = server.accumTime + server.accumWindowTime;
                 for (const client of clients) {
-                    totalTime += (client.accumTime + client.localTime + client.accumWindowTime);
+                    totalTime += (client.accumTime + client.accumWindowTime);
                 }
                 if (verbose) {
                     log(`total time ${(totalTime / 1000000.0).toFixed(1)} check time ${(checkTime / 1000000.0).toFixed(1)}`);

--- a/packages/dds/merge-tree/src/test/index.ts
+++ b/packages/dds/merge-tree/src/test/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export { createRevertDriver, getStats, specToSegment, TestClient, TestClientRevertibleDriver } from "./testClient";
+export { createRevertDriver, getStats, MergeTreeStats, specToSegment, TestClient, TestClientRevertibleDriver } from "./testClient";
 export { checkTextMatchRelative, TestServer } from "./testServer";
 export {
 	countOperations,
@@ -122,7 +122,6 @@ export {
 	MergeTreeMaintenanceCallback,
 	MergeTreeMaintenanceType,
 	MergeTreeRevertibleDriver,
-	MergeTreeStats,
 	MinListener,
 	minReferencePosition,
 	NodeAction,

--- a/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
+++ b/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
@@ -2135,6 +2135,7 @@ use_old_InterfaceDeclaration_MergeTreeRevertibleDriver(
 declare function get_old_InterfaceDeclaration_MergeTreeStats():
     TypeOnly<old.MergeTreeStats>;
 declare function use_current_InterfaceDeclaration_MergeTreeStats(
+    // @ts-expect-error removed
     use: TypeOnly<current.MergeTreeStats>);
 use_current_InterfaceDeclaration_MergeTreeStats(
     get_old_InterfaceDeclaration_MergeTreeStats());
@@ -2145,6 +2146,7 @@ use_current_InterfaceDeclaration_MergeTreeStats(
 * "InterfaceDeclaration_MergeTreeStats": {"backCompat": false}
 */
 declare function get_current_InterfaceDeclaration_MergeTreeStats():
+    // @ts-expect-error removed
     TypeOnly<current.MergeTreeStats>;
 declare function use_old_InterfaceDeclaration_MergeTreeStats(
     use: TypeOnly<old.MergeTreeStats>);

--- a/packages/dds/sequence/src/test/testFarm.ts
+++ b/packages/dds/sequence/src/test/testFarm.ts
@@ -160,7 +160,6 @@ export function TestPack(verbose = true) {
             return;
         }
         const aveTime = (client.accumTime / client.accumOps).toFixed(1);
-        const aveLocalTime = (client.localTime / client.localOps).toFixed(1);
         const stats = MergeTree.getStats(client.mergeTree);
         const packTime = stats.packTime;
         const ordTime = stats.ordTime;
@@ -168,9 +167,7 @@ export function TestPack(verbose = true) {
         const avePackTime = ((packTime ?? 0) / (client.accumOps)).toFixed(1);
         const aveExtraWindowTime = (client.accumWindowTime / client.accumOps).toFixed(1);
         const aveWindow = (client.accumWindow / client.accumOps).toFixed(1);
-        if (client.localOps > 0) {
-            console.log(`local time ${client.localTime} us ops: ${client.localOps} ave time ${aveLocalTime}`);
-        }
+
         console.log(`ord time average: ${aveOrdTime}us max ${stats.maxOrdTime}us`);
         console.log(`${client.longClientId} accum time ${client.accumTime} us ops: ${client.accumOps} ave time ${aveTime} - pack ${avePackTime} ave window ${aveWindow}`);
         console.log(`${client.longClientId} accum window time ${client.accumWindowTime} us ave window time not in ops ${aveExtraWindowTime}; max ${client.maxWindowTime}`);
@@ -672,7 +669,7 @@ export function TestPack(verbose = true) {
                 reportTiming(clients[2]);
                 let totalTime = testServer.accumTime + testServer.accumWindowTime;
                 for (const client of clients) {
-                    totalTime += (client.accumTime + client.localTime + client.accumWindowTime);
+                    totalTime += (client.accumTime + client.accumWindowTime);
                 }
                 if (verbose) {
                     console.log(`total time ${(totalTime / 1000000.0).toFixed(1)} check time ${(checkTime / 1000000.0).toFixed(1)}`);


### PR DESCRIPTION
These properties are not usable outside of test code, as we do not directly expose the merge tree client in anywhere, which makes them safe to clean up, and move directly to the test client.

[AB#2580](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2580)