### PR TITLE
docs: Update compressor readme link

### DIFF
--- a/packages/dds/tree/src/id-compressor/README.md
+++ b/packages/dds/tree/src/id-compressor/README.md
@@ -1,3 +1,3 @@
 # ID Compressor
 
-An [IdCompressor](./IdCompressor.ts) generates unique identifiers that may be efficiently compressed/decompressed and synchronized with other IdCompressors.
+An [IdCompressor](./idCompressor.ts) generates unique identifiers that may be efficiently compressed/decompressed and synchronized with other IdCompressors.


### PR DESCRIPTION
Fixes a dead link in the idCompressor readme.