### PR TITLE
Publish PactMap as an experimental package

### DIFF
--- a/packages/dds/pact-map/package.json
+++ b/packages/dds/pact-map/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@fluid-experimental/pact-map",
   "version": "2.0.0-internal.2.4.0",
-  "private": true,
   "description": "Distributed data structure for key-value pairs using pact consensus",
   "homepage": "https://fluidframework.com",
   "repository": {


### PR DESCRIPTION
All remaining known work is documentation and example building, and I've had more opportunity to flex it via the migration work over time - seems ready for experimental usage at least.

[AB#1598](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1598)