### PR TITLE
Fix prompt release deps minor bugs

### DIFF
--- a/build-tools/packages/build-cli/src/commands/release/report.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report.ts
@@ -678,5 +678,5 @@ async function writeReport(
     log?.info(`${kind} report written to ${reportPath}`);
     const reportOutput = toReportKind(report, kind);
 
-    return writeJson(reportPath, sortJson(reportOutput), { spaces: 2 });
+    return writeJson(reportPath, reportOutput, { spaces: 2 });
 }

--- a/build-tools/packages/build-cli/src/handlers/promptFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/promptFunctions.ts
@@ -6,7 +6,7 @@ import { strict as assert } from "assert";
 import chalk from "chalk";
 import { Machine } from "jssm";
 
-import type { InstructionalPrompt } from "../instructionalPromptWriter";
+import { ADOPipelineLinks, InstructionalPrompt } from "../instructionalPromptWriter";
 import { difference, generateReleaseBranchName, getPreReleaseDependencies } from "../lib";
 import { CommandLogger } from "../logging";
 import { MachineState } from "../machines";
@@ -262,6 +262,16 @@ export const promptToRelease: StateHandlerFunction = async (
     assert(context !== undefined, "Context is undefined.");
 
     const flag = isReleaseGroup(releaseGroup) ? "-g" : "-p";
+
+    const link =
+        releaseGroup === "client"
+            ? ADOPipelineLinks.CLIENT
+            : releaseGroup === "server"
+            ? ADOPipelineLinks.SERVER
+            : releaseGroup === "azure"
+            ? ADOPipelineLinks.AZURE
+            : ADOPipelineLinks.BUILDTOOLS;
+
     const prompt: InstructionalPrompt = {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         title: `READY TO RELEASE version ${chalk.bold(releaseVersion!)}!`,
@@ -273,7 +283,7 @@ export const promptToRelease: StateHandlerFunction = async (
                 )} build for the following release group in ADO for branch ${chalk.blue(
                     chalk.bold(context.originalBranchName),
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                )}:\n\n    ${chalk.green(chalk.bold(releaseGroup!))}`,
+                )}:\n\n    ${chalk.green(chalk.bold(releaseGroup!))}: ${link}`,
             },
             {
                 title: "NEXT",
@@ -335,6 +345,7 @@ export const promptToReleaseDeps: StateHandlerFunction = async (
             prompt.sections.push({
                 title: "FIRST",
                 message: `Release these packages first:\n\n${chalk.blue(packageSection)}`,
+                cmd: `flub bump deps ${packageSection} --updateType latest`,
             });
         }
 
@@ -347,6 +358,7 @@ export const promptToReleaseDeps: StateHandlerFunction = async (
             prompt.sections.push({
                 title: "NEXT",
                 message: `Release these release groups:\n\n${chalk.blue(packageSection)}`,
+                cmd: `flub bump deps ${packageSection} --updateType latest`,
             });
         }
     }

--- a/build-tools/packages/build-cli/src/instructionalPromptWriter.ts
+++ b/build-tools/packages/build-cli/src/instructionalPromptWriter.ts
@@ -45,6 +45,17 @@ interface Section {
 }
 
 /**
+ * Links to ADO pipeline for all release group
+ */
+
+export enum ADOPipelineLinks {
+    CLIENT = "https://dev.azure.com/fluidframework/internal/_build?definitionId=12",
+    SERVER = "https://dev.azure.com/fluidframework/internal/_build?definitionId=30",
+    BUILDTOOLS = "https://dev.azure.com/fluidframework/internal/_build?definitionId=14",
+    AZURE = "https://dev.azure.com/fluidframework/internal/_build?definitionId=85",
+}
+
+/**
  * An abstract base class for classes that write {@link InstructionalPrompt}s to the terminal.
  */
 export abstract class InstructionalPromptWriter {


### PR DESCRIPTION
This PR fixes the following minor bugs:

1. Prompt to release should include commands to release independent packages/release groups: [AB#1963](https://dev.azure.com/fluidframework/internal/_sprints/taskboard/Team%20Sasha/internal/CY23Q1/Team%20Sasha%20-%202023.01-A?workitem=1963)

2. Prompt to release should include links to the release group pipelines: [AB#2176](https://dev.azure.com/fluidframework/internal/_sprints/taskboard/Team%20Sasha/internal/CY23Q1/Team%20Sasha%20-%202023.01-A?workitem=2176)

3. Release dates should be displayed in the `full` release report: [AB#2198](https://dev.azure.com/fluidframework/internal/_sprints/taskboard/Team%20Sasha/internal/CY23Q1/Team%20Sasha%20-%202023.01-A?workitem=2198)

![image](https://user-images.githubusercontent.com/48232592/213785881-c1c31dc4-6090-4b55-83b2-68b9bd72cd15.png)
