### PR TITLE
Add doOverRanges to reduce test farm boilerplate

### DIFF
--- a/packages/dds/merge-tree/src/test/client.localReferenceFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.localReferenceFarm.spec.ts
@@ -14,10 +14,10 @@ import {
     runMergeTreeOperationRunner,
     generateClientNames,
     IConfigRange,
+    doOverRanges,
 } from "./mergeTreeOperationRunner";
 import { TestClient } from "./testClient";
 import { TestClientLogger } from "./testClientLogger";
-import { doOverRange } from ".";
 
  const defaultOptions: Record<"initLen" | "modLen", IConfigRange> & IMergeTreeOperationRunnerConfig = {
     initLen: { min: 2, max: 4 },
@@ -32,81 +32,79 @@ describe("MergeTree.Client", () => {
     // Generate a list of single character client names, support up to 69 clients
     const clientNames = generateClientNames();
 
-    doOverRange(defaultOptions.initLen, defaultOptions.growthFunc, (initLen) => {
-        doOverRange(defaultOptions.modLen, defaultOptions.growthFunc, (modLen) => {
-            it(`LocalReferenceFarm_${initLen}_${modLen}`, async () => {
-                const mt = random.engines.mt19937();
-                mt.seedWithArray([0xDEADBEEF, 0xFEEDBED, initLen, modLen]);
+    doOverRanges(defaultOptions, ({ initLen, modLen }) => {
+        it(`LocalReferenceFarm_${initLen}_${modLen}`, async () => {
+            const mt = random.engines.mt19937();
+            mt.seedWithArray([0xDEADBEEF, 0xFEEDBED, initLen, modLen]);
 
-                const clients: TestClient[] = new Array(3).fill(0).map(() => new TestClient());
-                clients.forEach(
-                    (c, i) => c.startOrUpdateCollaboration(clientNames[i]));
+            const clients: TestClient[] = new Array(3).fill(0).map(() => new TestClient());
+            clients.forEach(
+                (c, i) => c.startOrUpdateCollaboration(clientNames[i]));
 
-                let seq = 0;
+            let seq = 0;
+            // init with random values
+            seq = runMergeTreeOperationRunner(
+                mt,
+                seq,
+                clients,
+                initLen,
+                defaultOptions,
+            );
+            // add local references
+            const refs: ReferencePosition[][] = [];
+
+            const validateRefs = (reason: string, workload: () => void) => {
+                const preWorkload = TestClientLogger.toString(clients);
+                workload();
+                for (let c = 1; c < clients.length; c++) {
+                    for (let r = 0; r < refs[c].length; r++) {
+                        const pos0 = clients[0].localReferencePositionToPosition(refs[0][r]);
+                        const posC = clients[c].localReferencePositionToPosition(refs[c][r]);
+                        if (pos0 !== posC) {
+                            assert.equal(
+                                pos0, posC,
+                                `${reason}:\n${preWorkload}\n${TestClientLogger.toString(clients)}`);
+                        }
+                    }
+                }
+                // console.log(`${reason}:\n${preWorkload}\n${TestClientLogger.toString(clients)}`)
+            };
+
+            validateRefs("Initialize", () => {
+                clients.forEach((c, i) => {
+                    refs.push([]);
+                    for (let t = 0; t < c.getLength(); t++) {
+                        const seg = c.getContainingSegment(t);
+                        const lref = c.createLocalReferencePosition(
+                            seg.segment!, seg.offset, ReferenceType.SlideOnRemove, { t });
+                        refs[i].push(lref);
+                    }
+                });
+            });
+
+            validateRefs("After Init Zamboni", () => {
+                // trigger zamboni multiple times as it is incremental
+                for (let i = clients[0].getCollabWindow().minSeq; i <= seq; i++) {
+                    clients.forEach((c) => c.updateMinSeq(i));
+                }
+            });
+
+            validateRefs("After More Ops", () => {
                 // init with random values
                 seq = runMergeTreeOperationRunner(
                     mt,
                     seq,
                     clients,
-                    initLen,
+                    modLen,
                     defaultOptions,
                 );
-                // add local references
-                const refs: ReferencePosition[][] = [];
+            });
 
-                const validateRefs = (reason: string, workload: () => void) => {
-                    const preWorkload = TestClientLogger.toString(clients);
-                    workload();
-                    for (let c = 1; c < clients.length; c++) {
-                        for (let r = 0; r < refs[c].length; r++) {
-                            const pos0 = clients[0].localReferencePositionToPosition(refs[0][r]);
-                            const posC = clients[c].localReferencePositionToPosition(refs[c][r]);
-                            if (pos0 !== posC) {
-                                assert.equal(
-                                    pos0, posC,
-                                    `${reason}:\n${preWorkload}\n${TestClientLogger.toString(clients)}`);
-                            }
-                        }
-                    }
-                    // console.log(`${reason}:\n${preWorkload}\n${TestClientLogger.toString(clients)}`)
-                };
-
-                validateRefs("Initialize", () => {
-                    clients.forEach((c, i) => {
-                        refs.push([]);
-                        for (let t = 0; t < c.getLength(); t++) {
-                            const seg = c.getContainingSegment(t);
-                            const lref = c.createLocalReferencePosition(
-                                seg.segment!, seg.offset, ReferenceType.SlideOnRemove, { t });
-                            refs[i].push(lref);
-                        }
-                    });
-                });
-
-                validateRefs("After Init Zamboni", () => {
-                    // trigger zamboni multiple times as it is incremental
-                    for (let i = clients[0].getCollabWindow().minSeq; i <= seq; i++) {
-                        clients.forEach((c) => c.updateMinSeq(i));
-                    }
-                });
-
-                validateRefs("After More Ops", () => {
-                    // init with random values
-                    seq = runMergeTreeOperationRunner(
-                        mt,
-                        seq,
-                        clients,
-                        modLen,
-                        defaultOptions,
-                    );
-                });
-
-                validateRefs("After Final Zamboni", () => {
-                    // trigger zamboni multiple times as it is incremental
-                    for (let i = clients[0].getCollabWindow().minSeq; i <= seq; i++) {
-                        clients.forEach((c) => c.updateMinSeq(i));
-                    }
-                });
+            validateRefs("After Final Zamboni", () => {
+                // trigger zamboni multiple times as it is incremental
+                for (let i = clients[0].getCollabWindow().minSeq; i <= seq; i++) {
+                    clients.forEach((c) => c.updateMinSeq(i));
+                }
             });
         });
     });

--- a/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
@@ -9,7 +9,7 @@ import random from "random-js";
 import {
     annotateRange,
     applyMessages,
-    doOverRange,
+    doOverRanges,
     generateOperationMessagesForClients,
     insertAtRefPos,
     removeRange,
@@ -33,52 +33,50 @@ const defaultOptions = {
 };
 
 describe("MergeTree.Client", () => {
-    doOverRange(defaultOptions.minLength, defaultOptions.growthFunc, (minLength) => {
-        doOverRange(defaultOptions.opsPerRollbackRange, defaultOptions.growthFunc, (opsPerRollback) => {
-            it(`RollbackFarm_${minLength} OpsPerRollback: ${opsPerRollback}`, async () => {
-                const mt = random.engines.mt19937();
-                mt.seedWithArray([0xDEADBEEF, 0xFEEDBED, minLength, opsPerRollback]);
+    doOverRanges(defaultOptions, ({ minLength, opsPerRollbackRange: opsPerRollback }) => {
+        it(`RollbackFarm_${minLength} OpsPerRollback: ${opsPerRollback}`, async () => {
+            const mt = random.engines.mt19937();
+            mt.seedWithArray([0xDEADBEEF, 0xFEEDBED, minLength, opsPerRollback]);
 
-                // A: readonly, B: rollback, C: rollback + edit, D: edit
-                const clients = createClientsAtInitialState({ initialState: "" }, "A", "B", "C", "D");
-                let seq = 0;
+            // A: readonly, B: rollback, C: rollback + edit, D: edit
+            const clients = createClientsAtInitialState({ initialState: "" }, "A", "B", "C", "D");
+            let seq = 0;
 
-                for (let round = 0; round < defaultOptions.rounds; round++) {
-                    clients.all.forEach((c) => c.updateMinSeq(seq));
+            for (let round = 0; round < defaultOptions.rounds; round++) {
+                clients.all.forEach((c) => c.updateMinSeq(seq));
 
-                    const logger = new TestClientLogger(clients.all, `Round ${round}`);
+                const logger = new TestClientLogger(clients.all, `Round ${round}`);
 
-                    // initialize and ack 10 random actions on either C or D
-                    const initialMsgs = generateOperationMessagesForClients(
-                        mt,
-                        seq,
-                        [clients.A, clients.C, clients.D],
-                        logger,
-                        defaultOptions.opsPerRound,
-                        minLength,
-                        defaultOptions.operations);
-                    seq = applyMessages(seq, initialMsgs, clients.all, logger);
+                // initialize and ack 10 random actions on either C or D
+                const initialMsgs = generateOperationMessagesForClients(
+                    mt,
+                    seq,
+                    [clients.A, clients.C, clients.D],
+                    logger,
+                    defaultOptions.opsPerRound,
+                    minLength,
+                    defaultOptions.operations);
+                seq = applyMessages(seq, initialMsgs, clients.all, logger);
 
-                    logger.validate();
+                logger.validate();
 
-                    // generate messages to rollback on B or C, then rollback
-                    const rollbackMsgs = generateOperationMessagesForClients(
-                        mt,
-                        seq,
-                        [clients.A, clients.B, clients.C],
-                        logger,
-                        opsPerRollback,
-                        minLength,
-                        defaultOptions.operations);
-                    while (rollbackMsgs.length > 0) {
-                        const msg = rollbackMsgs.pop();
-                        clients[msg![0].clientId].rollback?.({ type: msg![0].contents.type }, msg![1]);
-                    }
-
-                    logger.validate();
+                // generate messages to rollback on B or C, then rollback
+                const rollbackMsgs = generateOperationMessagesForClients(
+                    mt,
+                    seq,
+                    [clients.A, clients.B, clients.C],
+                    logger,
+                    opsPerRollback,
+                    minLength,
+                    defaultOptions.operations);
+                while (rollbackMsgs.length > 0) {
+                    const msg = rollbackMsgs.pop();
+                    clients[msg![0].clientId].rollback?.({ type: msg![0].contents.type }, msg![1]);
                 }
-            })
-            .timeout(30 * 10000);
-        });
+
+                logger.validate();
+            }
+        })
+        .timeout(30 * 10000);
     });
 });

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -59,6 +59,7 @@ export const insertAtRefPos: TestOperation =
 export interface IConfigRange {
     min: number;
     max: number;
+    growthFunc?: (input: number) => number;
 }
 
 export function doOverRange(
@@ -77,6 +78,67 @@ export function doOverRange(
         lastCurrent = current;
         doAction(current);
     }
+}
+
+export function resolveRange(range: IConfigRange, defaultGrowthFunc: (input: number) => number): number[] {
+    const results: number[] = [];
+    doOverRange(range, range.growthFunc ?? defaultGrowthFunc, (num) => { results.push(num); })
+    return results;
+}
+
+export function resolveRanges<T extends object>(ranges: T, defaultGrowthFunc: (input: number) => number): ResolvedRanges<T> {
+    return Object.entries(ranges)
+        .filter(([_, value]) => isConfigRange(value))
+        .map(([key, value]) => [key, resolveRange(value, defaultGrowthFunc)] as const)
+        .reduce((prev, [key, resolvedRange]) => { prev[key] = resolvedRange; return prev; }, {}) as ResolvedRanges<T>;
+}
+
+function isConfigRange(t: any): t is IConfigRange { 
+    return typeof t === 'object' && typeof t.min === 'number' && typeof t.max === 'number';
+}
+
+type ReplaceRangeWith<T, TReplace> = T extends { min: number; max: number } ? TReplace : never;
+
+type RangePropertyNames<T> = { [K in keyof T]-?: T[K] extends IConfigRange ? K : never }[keyof T]
+
+type PickFromRanges<T> = {
+    [K in RangePropertyNames<T>]: ReplaceRangeWith<T[K], number>
+}
+
+type ResolvedRanges<T> = {
+    [K in RangePropertyNames<T>]: ReplaceRangeWith<T[K], number[]>
+}
+
+interface ProvidesGrowthFunc {
+    growthFunc: (input: number) => number;
+}
+
+export function doOverRanges<T extends ProvidesGrowthFunc>(
+    ranges: T,
+    doAction: (selection: PickFromRanges<T>, description: string) => void
+) {
+    const rangeEntries: [string, IConfigRange][] = Object.entries(ranges)
+        .filter(([_, value]) => isConfigRange(value));
+
+    const doOverRangesHelper = (selections: [string, number][]) => {
+        if (selections.length === rangeEntries.length) {
+            const selectionsObj = {};
+            for (const [key, value] of selections) {
+                selections[key] = value;
+            }
+            const description = selections.map(([key, value]) => `${key}:${value}`).join('_');
+            doAction(selectionsObj as PickFromRanges<T>, description);
+        } else {
+            const [key, value] = rangeEntries[selections.length];
+            doOverRange(value, value.growthFunc ?? ranges.growthFunc, (selection) => {
+                selections.push([key, selection]);
+                doOverRangesHelper(selections)
+                selections.pop();
+            });
+        }
+    }
+
+    doOverRangesHelper([]);
 }
 
 export interface IMergeTreeOperationRunnerConfig {

--- a/packages/dds/merge-tree/src/test/revertibleFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/revertibleFarm.spec.ts
@@ -15,10 +15,10 @@ import {
 import { walkAllChildSegments } from "../mergeTreeNodeWalk";
 import {
     removeRange,
-    doOverRange,
     generateOperationMessagesForClients,
     applyMessages,
     annotateRange,
+    doOverRanges,
 } from "./mergeTreeOperationRunner";
 import { createRevertDriver } from "./testClient";
 import { createClientsAtInitialState, TestClientLogger } from "./testClientLogger";
@@ -39,161 +39,157 @@ import { createClientsAtInitialState, TestClientLogger } from "./testClientLogge
 };
 
 describe("MergeTree.Client", () => {
-    doOverRange(defaultOptions.minLength, defaultOptions.minLength.growthFunc, (minLen) => {
-        doOverRange(defaultOptions.concurrentOpsWithRevert, defaultOptions.growthFunc, (opsWithRevert) => {
-            doOverRange(defaultOptions.revertOps, defaultOptions.growthFunc, (revertOps) => {
-                for (const ackBeforeRevert of defaultOptions.ackBeforeRevert) {
-                    it(`InitialOps: ${defaultOptions.initialOps} MinLen: ${minLen}  ConcurrentOpsWithRevert: ${opsWithRevert} RevertOps: ${revertOps} AckBeforeRevert: ${ackBeforeRevert}`, async () => {
-                        const mt = random.engines.mt19937();
-                        mt.seedWithArray([
-                            0xDEADBEEF,
-                            0xFEEDBED,
+    doOverRanges(defaultOptions, ({ minLength: minLen, revertOps: opsWithRevert, revertOps }) => {
+        for (const ackBeforeRevert of defaultOptions.ackBeforeRevert) {
+            it(`InitialOps: ${defaultOptions.initialOps} MinLen: ${minLen}  ConcurrentOpsWithRevert: ${opsWithRevert} RevertOps: ${revertOps} AckBeforeRevert: ${ackBeforeRevert}`, async () => {
+                const mt = random.engines.mt19937();
+                mt.seedWithArray([
+                    0xDEADBEEF,
+                    0xFEEDBED,
+                    minLen,
+                    revertOps,
+                    [...ackBeforeRevert].reduce<number>((pv, cv) => pv + cv.charCodeAt(0), 0),
+                    opsWithRevert,
+                ]);
+
+                const clients = createClientsAtInitialState(
+                    {
+                        initialState: "",
+                        options: { mergeTreeUseNewLengthCalculations: true },
+                    },
+                    "A", "B", "C");
+                let seq = 0;
+                for (let rnd = 0; rnd < defaultOptions.rounds; rnd++) {
+                    clients.all.forEach((c) => c.updateMinSeq(seq));
+
+                    const logger = new TestClientLogger(clients.all, `Round ${rnd}`);
+                    {
+                        // init with random values
+                        const initialMsgs = generateOperationMessagesForClients(
+                            mt,
+                            seq,
+                            clients.all,
+                            logger,
+                            defaultOptions.initialOps,
                             minLen,
+                            defaultOptions.operations);
+
+                        seq = applyMessages(seq, initialMsgs, clients.all, logger);
+                    }
+
+                    // cache the base text to ensure we get back to it after revert
+                    const undoBaseText = logger.validate({ clear: true, errorPrefix: "After Initial Ops" });
+
+                    const clientB_Revertibles: MergeTreeDeltaRevertible[] = [];
+                    const clientBDriver = createRevertDriver(clients.B);
+                    const oldCallback = clients.B.mergeTreeDeltaCallback;
+
+                    const msgs: [ISequencedDocumentMessage, SegmentGroup | SegmentGroup[]][] = [];
+                    {
+                        clientBDriver.submitOpCallback = (op) => msgs.push(
+                            [
+                                clients.B.makeOpMessage(op, undefined, undefined, undefined, seq),
+                                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                                clients.B.peekPendingSegmentGroups()!,
+                            ]);
+                        clients.B.mergeTreeDeltaCallback = (op, delta) => {
+                            oldCallback?.(op, delta);
+                            if (op.sequencedMessage === undefined) {
+                                appendToMergeTreeDeltaRevertibles(
+                                    clientBDriver, delta, clientB_Revertibles);
+                            }
+                        };
+                        msgs.push(...generateOperationMessagesForClients(
+                            mt,
+                            seq,
+                            [clients.A, clients.B],
+                            logger,
                             revertOps,
-                            [...ackBeforeRevert].reduce<number>((pv, cv) => pv + cv.charCodeAt(0), 0),
+                            minLen,
+                            defaultOptions.operations));
+                    }
+
+                    if (opsWithRevert > 0) {
+                        // add modifications from another client
+                        msgs.push(...generateOperationMessagesForClients(
+                            mt,
+                            seq,
+                            [clients.A, clients.C],
+                            logger,
                             opsWithRevert,
-                        ]);
+                            minLen,
+                            defaultOptions.operations));
+                    }
 
-                        const clients = createClientsAtInitialState(
-                            {
-                                initialState: "",
-                                options: { mergeTreeUseNewLengthCalculations: true },
-                            },
-                            "A", "B", "C");
-                        let seq = 0;
-                        for (let rnd = 0; rnd < defaultOptions.rounds; rnd++) {
-                            clients.all.forEach((c) => c.updateMinSeq(seq));
-
-                            const logger = new TestClientLogger(clients.all, `Round ${rnd}`);
-                            {
-                                // init with random values
-                                const initialMsgs = generateOperationMessagesForClients(
-                                    mt,
-                                    seq,
-                                    clients.all,
-                                    logger,
-                                    defaultOptions.initialOps,
-                                    minLen,
-                                    defaultOptions.operations);
-
-                                seq = applyMessages(seq, initialMsgs, clients.all, logger);
-                            }
-
-                            // cache the base text to ensure we get back to it after revert
-                            const undoBaseText = logger.validate({ clear: true, errorPrefix: "After Initial Ops" });
-
-                            const clientB_Revertibles: MergeTreeDeltaRevertible[] = [];
-                            const clientBDriver = createRevertDriver(clients.B);
-                            const oldCallback = clients.B.mergeTreeDeltaCallback;
-
-                            const msgs: [ISequencedDocumentMessage, SegmentGroup | SegmentGroup[]][] = [];
-                            {
-                                clientBDriver.submitOpCallback = (op) => msgs.push(
-                                    [
-                                        clients.B.makeOpMessage(op, undefined, undefined, undefined, seq),
-                                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                                        clients.B.peekPendingSegmentGroups()!,
-                                    ]);
-                                clients.B.mergeTreeDeltaCallback = (op, delta) => {
-                                    oldCallback?.(op, delta);
-                                    if (op.sequencedMessage === undefined) {
-                                        appendToMergeTreeDeltaRevertibles(
-                                            clientBDriver, delta, clientB_Revertibles);
-                                    }
-                                };
-                                msgs.push(...generateOperationMessagesForClients(
-                                    mt,
-                                    seq,
-                                    [clients.A, clients.B],
-                                    logger,
-                                    revertOps,
-                                    minLen,
-                                    defaultOptions.operations));
-                            }
-
-                            if (opsWithRevert > 0) {
-                                // add modifications from another client
-                                msgs.push(...generateOperationMessagesForClients(
-                                    mt,
-                                    seq,
-                                    [clients.A, clients.C],
-                                    logger,
-                                    opsWithRevert,
-                                    minLen,
-                                    defaultOptions.operations));
-                            }
-
-                            let redoBaseText: string | undefined;
-                            if (ackBeforeRevert !== "None") {
-                                const ackAll = ackBeforeRevert === "All";
-                                seq = applyMessages(
-                                    seq,
-                                    msgs.splice(
-                                        0,
-                                        ackAll
-                                            ? msgs.length
-                                            : random.integer(0, Math.floor(msgs.length / 2))(mt)),
-                                    clients.all,
-                                    logger);
-                                if (ackAll) {
-                                    redoBaseText = logger.validate({ errorPrefix: "Before Revert Ack" });
-                                }
-                            }
-
-                            try {
-                                revertMergeTreeDeltaRevertibles(clientBDriver, clientB_Revertibles.splice(0));
-                                seq = applyMessages(seq, msgs.splice(0), clients.all, logger);
-                            } catch (e) {
-                                throw logger.addLogsToError(e);
-                            }
-                            logger.validate({
-                                clear: true,
-                                baseText: opsWithRevert === 0 ? undoBaseText : undefined,
-                                errorPrefix: "After Revert (undo)",
-                            });
-
-                            try {
-                                // reset the callback before the final revert
-                                // to avoid accruing any new detached references
-                                clients.B.mergeTreeDeltaCallback = oldCallback;
-                                revertMergeTreeDeltaRevertibles(clientBDriver, clientB_Revertibles.splice(0));
-                                seq = applyMessages(seq, msgs.splice(0), clients.all, logger);
-
-                                walkAllChildSegments(
-                                    clients.B.mergeTree.root,
-                                    (seg: ISegment) => {
-                                        if (seg?.trackingCollection.empty === false) {
-                                            assert.notDeepStrictEqual(
-                                                seg?.trackingCollection.empty,
-                                                false,
-                                                "there should be no left over tracking group");
-                                        }
-                                        if (seg?.localRefs?.empty === false) {
-                                            assert.notDeepStrictEqual(
-                                                seg?.localRefs?.empty,
-                                                false,
-                                                "there should be no left over local references");
-                                        }
-                                    },
-                                );
-                                const detachedReferences = clientBDriver.__mergeTreeRevertible?.detachedReferences;
-                                if (detachedReferences?.localRefs?.empty === false) {
-                                    assert.notDeepStrictEqual(
-                                        detachedReferences?.localRefs?.empty,
-                                        false,
-                                        "there should be no left over local references in detached references");
-                                }
-                            } catch (e) {
-                                throw logger.addLogsToError(e);
-                            }
-                            logger.validate({
-                                errorPrefix: "After Re-Revert (redo)",
-                                baseText: redoBaseText,
-                            });
+                    let redoBaseText: string | undefined;
+                    if (ackBeforeRevert !== "None") {
+                        const ackAll = ackBeforeRevert === "All";
+                        seq = applyMessages(
+                            seq,
+                            msgs.splice(
+                                0,
+                                ackAll
+                                    ? msgs.length
+                                    : random.integer(0, Math.floor(msgs.length / 2))(mt)),
+                            clients.all,
+                            logger);
+                        if (ackAll) {
+                            redoBaseText = logger.validate({ errorPrefix: "Before Revert Ack" });
                         }
+                    }
+
+                    try {
+                        revertMergeTreeDeltaRevertibles(clientBDriver, clientB_Revertibles.splice(0));
+                        seq = applyMessages(seq, msgs.splice(0), clients.all, logger);
+                    } catch (e) {
+                        throw logger.addLogsToError(e);
+                    }
+                    logger.validate({
+                        clear: true,
+                        baseText: opsWithRevert === 0 ? undoBaseText : undefined,
+                        errorPrefix: "After Revert (undo)",
+                    });
+
+                    try {
+                        // reset the callback before the final revert
+                        // to avoid accruing any new detached references
+                        clients.B.mergeTreeDeltaCallback = oldCallback;
+                        revertMergeTreeDeltaRevertibles(clientBDriver, clientB_Revertibles.splice(0));
+                        seq = applyMessages(seq, msgs.splice(0), clients.all, logger);
+
+                        walkAllChildSegments(
+                            clients.B.mergeTree.root,
+                            (seg: ISegment) => {
+                                if (seg?.trackingCollection.empty === false) {
+                                    assert.notDeepStrictEqual(
+                                        seg?.trackingCollection.empty,
+                                        false,
+                                        "there should be no left over tracking group");
+                                }
+                                if (seg?.localRefs?.empty === false) {
+                                    assert.notDeepStrictEqual(
+                                        seg?.localRefs?.empty,
+                                        false,
+                                        "there should be no left over local references");
+                                }
+                            },
+                        );
+                        const detachedReferences = clientBDriver.__mergeTreeRevertible?.detachedReferences;
+                        if (detachedReferences?.localRefs?.empty === false) {
+                            assert.notDeepStrictEqual(
+                                detachedReferences?.localRefs?.empty,
+                                false,
+                                "there should be no left over local references in detached references");
+                        }
+                    } catch (e) {
+                        throw logger.addLogsToError(e);
+                    }
+                    logger.validate({
+                        errorPrefix: "After Re-Revert (redo)",
+                        baseText: redoBaseText,
                     });
                 }
             });
-        });
+        }
     });
 });


### PR DESCRIPTION
## Description

Adds a convenience helper to reduce the boilerplate of writing multiple `doOverRange` "loops" in merge-tree fuzz test farms. I also added a `resolveRanges` method which composes nicely with our existing `generatePairwiseOptions` helper.

You could write this more eloquently with a `product` implementation (probably `lodash.product`). I'm indifferent on adding that dependency and leveraging it instead of handcrafting it.
