### PR TITLE
feat(Tree): make detach index optional

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -1353,9 +1353,9 @@ const sequenceFieldEditor: {
     buildChildChange: <TNodeChange = NodeChangeset>(index: number, change: TNodeChange) => Changeset<TNodeChange>;
     insert: (index: number, cursors: ITreeCursor | ITreeCursor[]) => Changeset<never>;
     delete: (index: number, count: number) => Changeset<never>;
-    revive: (index: number, count: number, detachedBy: RevisionTag, detachIndex: number, isIntention?: true | undefined) => Changeset<never>;
+    revive: (index: number, count: number, detachedBy: RevisionTag, detachIndex?: number | undefined, isIntention?: true | undefined) => Changeset<never>;
     move(sourceIndex: number, count: number, destIndex: number): Changeset<never>;
-    return(sourceIndex: number, count: number, destIndex: number, detachedBy: RevisionTag, detachIndex: number): Changeset<never>;
+    return(sourceIndex: number, count: number, destIndex: number, detachedBy: RevisionTag, detachIndex?: number | undefined): Changeset<never>;
 };
 
 // @public (undocumented)

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -55,14 +55,16 @@ export const sequenceFieldEditor = {
         index: number,
         count: number,
         detachedBy: RevisionTag,
-        detachIndex: number,
+        detachIndex?: number,
         isIntention?: true,
     ): Changeset<never> => {
         const mark: Reattach<never> = {
             type: "Revive",
             count,
             detachedBy,
-            detachIndex,
+            // Revives are typically created to undo a delete from the prior revision.
+            // When that's the case, we know the content used to be at the index at which it is being revived.
+            detachIndex: detachIndex ?? index,
         };
         if (isIntention) {
             mark.isIntention = true;
@@ -107,7 +109,7 @@ export const sequenceFieldEditor = {
         count: number,
         destIndex: number,
         detachedBy: RevisionTag,
-        detachIndex: number,
+        detachIndex?: number,
     ): Changeset<never> {
         if (count === 0) {
             return [];
@@ -126,7 +128,9 @@ export const sequenceFieldEditor = {
             id,
             count,
             detachedBy,
-            detachIndex,
+            // Returns are typically created to undo a move from the prior revision.
+            // When that's the case, we know the content used to be at the index to which it is being returned.
+            detachIndex: detachIndex ?? destIndex,
         };
 
         const factory = new MarkListFactory<never>();

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.spec.ts
@@ -113,7 +113,7 @@ describe("SequenceField - Invert", () => {
     it("revert-only blocked revive => no-op", () => {
         const input = composeAnonChanges([
             Change.modify(0, childChange1),
-            Change.revive(1, 2, tag, 0, tag2, undefined, tag3),
+            Change.revive(1, 2, tag, 1, tag2, undefined, tag3),
             Change.modify(1, childChange2),
         ]);
         const expected = composeAnonChanges([
@@ -149,7 +149,17 @@ describe("SequenceField - Invert", () => {
         const input = composeAnonChanges([Change.modify(0, childChange1), Change.move(0, 2, 3)]);
         const expected = composeAnonChanges([
             Change.modify(3, inverseChildChange1),
-            Change.return(3, 2, 0, tag, 0),
+            Change.return(3, 2, 0, tag),
+        ]);
+        const actual = invert(input);
+        assert.deepEqual(actual, expected);
+    });
+
+    it("move backward => return", () => {
+        const input = composeAnonChanges([Change.modify(3, childChange1), Change.move(2, 2, 0)]);
+        const expected = composeAnonChanges([
+            Change.modify(1, inverseChildChange1),
+            Change.return(0, 2, 2, tag),
         ]);
         const actual = invert(input);
         assert.deepEqual(actual, expected);
@@ -158,11 +168,11 @@ describe("SequenceField - Invert", () => {
     it("return => return", () => {
         const input = composeAnonChanges([
             Change.modify(0, childChange1),
-            Change.return(0, 2, 3, brand(41), 0),
+            Change.return(0, 2, 3, brand(41)),
         ]);
         const expected = composeAnonChanges([
             Change.modify(3, inverseChildChange1),
-            Change.return(3, 2, 0, tag, 0),
+            Change.return(3, 2, 0, tag),
         ]);
         const actual = invert(input);
         assert.deepEqual(actual, expected);

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/rebase.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/rebase.spec.ts
@@ -535,18 +535,10 @@ describe("SequenceField - Rebase", () => {
     });
 
     it("return ↷ related revive ", () => {
-        const revive = Change.revive(2, 1, tag1, 0);
-        const ret = Change.return(0, 1, 1, tag1, 0);
+        const revive = Change.revive(0, 1, tag1, 0);
+        const ret = Change.return(10, 1, 0, tag1);
         const actual = rebase(ret, revive, tag2);
         const expected: SF.Changeset<never> = [
-            {
-                type: "ReturnFrom",
-                count: 1,
-                id: brand(0),
-                detachedBy: tag1,
-                isDstConflicted: true,
-            },
-            1,
             {
                 type: "ReturnTo",
                 count: 1,
@@ -554,6 +546,14 @@ describe("SequenceField - Rebase", () => {
                 detachedBy: tag1,
                 detachIndex: 0,
                 conflictsWith: tag2,
+            },
+            10,
+            {
+                type: "ReturnFrom",
+                count: 1,
+                id: brand(0),
+                detachedBy: tag1,
+                isDstConflicted: true,
             },
         ];
         normalizeMoveIds(actual);
@@ -575,11 +575,11 @@ describe("SequenceField - Rebase", () => {
                 count: 1,
                 id: brand(0),
                 detachedBy: tag1,
-                detachIndex: 0,
+                detachIndex: 1,
                 conflictsWith: tag2,
             },
         ];
-        const ret2 = Change.return(0, 1, 10, tag3, 0);
+        const ret2 = Change.return(0, 1, 10, tag3);
         const actual = rebase(ret2, ret1, brand(1));
         normalizeMoveIds(actual);
         assert.deepEqual(actual, ret2);

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
@@ -37,8 +37,8 @@ const testChanges: [string, (index: number) => SF.Changeset<TestChange>][] = [
     ["ConflictedRevive", (i) => Change.revive(2, 2, tag2, i, tag3)],
     ["MoveOut", (i) => Change.move(i, 2, 1)],
     ["MoveIn", (i) => Change.move(1, 2, i)],
-    ["ReturnFrom", (i) => Change.return(i, 2, 1, tag4, 0)],
-    ["ReturnTo", (i) => Change.return(1, 2, i, tag4, 0)],
+    ["ReturnFrom", (i) => Change.return(i, 2, 1, tag4)],
+    ["ReturnTo", (i) => Change.return(1, 2, i, tag4)],
 ];
 deepFreeze(testChanges);
 
@@ -297,7 +297,7 @@ describe("SequenceField - Sandwich Rebasing", () => {
     it.skip("[Move ABC, Return ABC] ↷ Delete B", () => {
         const delB = tagChange(Change.delete(1, 1), brand(1));
         const movABC = tagChange(Change.move(0, 3, 1), brand(2));
-        const retABC = tagChange(Change.return(1, 3, 0, brand(2), 0), brand(3));
+        const retABC = tagChange(Change.return(1, 3, 0, brand(2)), brand(3));
         const movABC2 = rebaseTagged(movABC, delB);
         const invMovABC = SF.invert(movABC, TestChange.invert);
         const retABC2 = rebaseTagged(retABC, tagInverse(invMovABC, movABC2.revision));

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -38,7 +38,7 @@ export const cases: {
     delete: createDeleteChangeset(1, 3),
     revive: createReviveChangeset(2, 2, tag, 0),
     move: createMoveChangeset(1, 2, 2),
-    return: createReturnChangeset(1, 3, 0, tag, 0),
+    return: createReturnChangeset(1, 3, 0, tag),
 };
 
 function createInsertChangeset(
@@ -61,7 +61,7 @@ function createReviveChangeset(
     startIndex: number,
     count: number,
     detachedBy: RevisionTag,
-    detachIndex: number,
+    detachIndex?: number,
     conflictsWith?: RevisionTag,
     linage?: SF.LineageEvent[],
     lastDetachedBy?: RevisionTag,
@@ -84,7 +84,7 @@ function createIntentionalReviveChangeset(
     startIndex: number,
     count: number,
     detachedBy: RevisionTag,
-    detachIndex: number,
+    detachIndex?: number,
     conflictsWith?: RevisionTag,
     linage?: SF.LineageEvent[],
 ): SF.Changeset<never> {
@@ -118,7 +118,7 @@ function createReturnChangeset(
     count: number,
     destIndex: number,
     detachedBy: RevisionTag,
-    detachIndex: number,
+    detachIndex?: number,
 ): SF.Changeset<never> {
     return SF.sequenceFieldEditor.return(sourceIndex, count, destIndex, detachedBy, detachIndex);
 }


### PR DESCRIPTION
In non-test scenarios, as well as most test scenarios, the detach index is the same as the location of the reattach.