### PR TITLE
[GC-stress] Re-enabled ODSP tests and skipped attachment blobs test for ODSP

### DIFF
--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -39,6 +39,7 @@
     "start:frs": "node ./dist/nodeStressTest.js --driver routerlicious --driverEndpoint frs --profile ci_frs",
     "start:mini": "node ./dist/nodeStressTest.js  --profile mini",
     "start:odsp": "node ./dist/nodeStressTest.js --driver odsp",
+    "start:odsp:gc": "node ./dist/nodeStressTest.js --driver odsp --profile gc",
     "start:odsp:gc:ci": "node ./dist/nodeStressTest.js --driver odsp --profile gc_ci",
     "start:odspdf": "node ./dist/nodeStressTest.js --driver odsp --driverEndpoint odsp-df",
     "start:reauth": "node ./dist/nodeStressTest.js --profile mini --browserAuth",

--- a/packages/test/test-service-load/src/gcDataStores.ts
+++ b/packages/test/test-service-load/src/gcDataStores.ts
@@ -332,13 +332,16 @@ export class DataObjectNonCollab extends BaseDataObject implements IGCActivityOb
                     activityFailed = true;
                 });
 
-                this.performBlobActivity(config).then((done: boolean) => {
-                    if (!done) {
+                // Skip performing blob activity for ODSP. It creates too many network requests resulting in throttling.
+                if (config.testConfig.driverType !== "odsp") {
+                    this.performBlobActivity(config).then((done: boolean) => {
+                        if (!done) {
+                            activityFailed = true;
+                        }
+                    }).catch((error) => {
                         activityFailed = true;
-                    }
-                }).catch((error) => {
-                    activityFailed = true;
-                });
+                    });
+                }
             }
 
             this.counter.increment(1);
@@ -504,12 +507,12 @@ export class DataObjectNonCollab extends BaseDataObject implements IGCActivityOb
                     break;
                 }
                 case GCActivityType.Revive: {
-                    const nextunreferencedAttachmentBlobs = this.unreferencedAttachmentBlobs.shift();
-                    if (nextunreferencedAttachmentBlobs !== undefined) {
-                        console.log(`########## Reviving blob [${nextunreferencedAttachmentBlobs.id}]`);
-                        this.blobMap.set(nextunreferencedAttachmentBlobs.id, nextunreferencedAttachmentBlobs.object.handle);
-                        this.referencedAttachmentBlobs.push(nextunreferencedAttachmentBlobs);
-                        return nextunreferencedAttachmentBlobs.object.run(this.childRunConfig, nextunreferencedAttachmentBlobs.id);
+                    const nextUnreferencedAttachmentBlobs = this.unreferencedAttachmentBlobs.shift();
+                    if (nextUnreferencedAttachmentBlobs !== undefined) {
+                        console.log(`########## Reviving blob [${nextUnreferencedAttachmentBlobs.id}]`);
+                        this.blobMap.set(nextUnreferencedAttachmentBlobs.id, nextUnreferencedAttachmentBlobs.object.handle);
+                        this.referencedAttachmentBlobs.push(nextUnreferencedAttachmentBlobs);
+                        return nextUnreferencedAttachmentBlobs.object.run(this.childRunConfig, nextUnreferencedAttachmentBlobs.id);
                     }
                     break;
                 }

--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -8,7 +8,7 @@ import fs from "fs";
 import ps from "ps-node";
 import commander from "commander";
 import xml from "xml";
-import { TestDriverTypes, DriverEndpoint } from "@fluidframework/test-driver-definitions";
+import { TestDriverTypes, DriverEndpoint, ITestDriver } from "@fluidframework/test-driver-definitions";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ILoadTestConfig } from "./testConfigFile";
 import { createTestDriver, getProfile, initialize, loggerP, safeExit, writeToFile } from "./utils";
@@ -110,7 +110,7 @@ async function orchestratorProcess(
     const seedArg = `0x${seed.toString(16)}`;
     const logger = await loggerP;
 
-    const testDriver = await createTestDriver(
+    const testDriver: ITestDriver = await createTestDriver(
         driver,
         endpoint,
         seed,
@@ -123,7 +123,7 @@ async function orchestratorProcess(
         // If no testId is provided, (or) if testId is provided but createTestId is not false, then
         // create a file;
         // In case testId is provided, name of the file to be created is taken as the testId provided
-        : initialize(testDriver, seed, profile, args.verbose === true, args.testId));
+        : initialize(testDriver, endpoint, seed, profile, args.verbose === true, args.testId));
 
     const estRunningTimeMin = Math.floor(profile.totalSendCount / profile.opRatePerMin);
     console.log(`Connecting to ${args.testId !== undefined ? "existing" : "new"}`);

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -144,15 +144,15 @@ async function runnerProcess(
     let testFailed: boolean = false;
 
     try {
+        // Added temporarily to disable attachment blob testing for ODSP.
+        runConfig.testConfig.driverType = driver;
         const optionsOverride = `${driver}${endpoint !== undefined ? `-${endpoint}` : ""}`;
         const loaderOptions = generateLoaderOptions(
-            seed, runConfig.testConfig?.optionOverrides?.[optionsOverride]?.loader);
-
+            seed, runConfig.testConfig?.optionOverrides?.[optionsOverride]?.loader)[0];
         const containerOptions = generateRuntimeOptions(
-            seed, runConfig.testConfig?.optionOverrides?.[optionsOverride]?.container);
-
+            seed, runConfig.testConfig?.optionOverrides?.[optionsOverride]?.container)[0];
         const configurations = generateConfigurations(
-            seed, runConfig.testConfig?.optionOverrides?.[optionsOverride]?.configurations);
+            seed, runConfig.testConfig?.optionOverrides?.[optionsOverride]?.configurations)[0];
         const testDriver: ITestDriver = await createTestDriver(driver, endpoint, seed, runConfig.runId);
         const baseLogger = await loggerP;
         const logger = ChildLogger.create(baseLogger, undefined,
@@ -203,12 +203,12 @@ async function runnerProcess(
                 const loader = new Loader({
                     urlResolver: testDriver.createUrlResolver(),
                     documentServiceFactory,
-                    codeLoader: createCodeLoader(containerOptions[runConfig.runId % containerOptions.length]),
+                    codeLoader: createCodeLoader(containerOptions),
                     logger,
-                    options: loaderOptions[runConfig.runId % containerOptions.length],
+                    options: loaderOptions,
                     configProvider: {
                         getRawConfig(name) {
-                            return configurations[runConfig.runId % configurations.length][name];
+                            return configurations[name];
                         },
                     },
                 });

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -68,6 +68,10 @@ export interface ILoadTestConfig {
      * Specify Ops payload size for the test run.
      */
     opSizeinBytes?: number;
+    /**
+     * The driver type for a given run. This is added temporarily to skip testing attachment blobs for ODSP.
+     */
+    driverType?: TestDriverTypes;
 }
 
 export interface OptionOverride{

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -141,8 +141,14 @@ class MockDetachedBlobStorage implements IDetachedBlobStorage {
     }
 }
 
-export async function initialize(testDriver: ITestDriver, endpoint: DriverEndpoint | undefined, seed: number, testConfig: ILoadTestConfig,
-    verbose: boolean, testIdn?: string) {
+export async function initialize(
+    testDriver: ITestDriver,
+    endpoint: DriverEndpoint | undefined,
+    seed: number,
+    testConfig: ILoadTestConfig,
+    verbose: boolean,
+    testIdn?: string,
+) {
     const randEng = random.engines.mt19937();
     randEng.seed(seed);
     const optionsOverride = `${testDriver.type}${endpoint !== undefined ? `-${endpoint}` : ""}`;

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -141,21 +141,17 @@ class MockDetachedBlobStorage implements IDetachedBlobStorage {
     }
 }
 
-export async function initialize(testDriver: ITestDriver, seed: number, testConfig: ILoadTestConfig,
+export async function initialize(testDriver: ITestDriver, endpoint: DriverEndpoint | undefined, seed: number, testConfig: ILoadTestConfig,
     verbose: boolean, testIdn?: string) {
     const randEng = random.engines.mt19937();
     randEng.seed(seed);
-    const optionsOverride =
-        `${testDriver.type}${testDriver.endpointName !== undefined ? `-${testDriver.endpointName}` : ""}`;
-    const loaderOptions = random.pick(
-        randEng,
-        generateLoaderOptions(seed, testConfig.optionOverrides?.[optionsOverride]?.loader));
-    const containerOptions = random.pick(
-        randEng,
-        generateRuntimeOptions(seed, testConfig.optionOverrides?.[optionsOverride]?.container));
-    const configurations = random.pick(
-        randEng,
-        generateConfigurations(seed, testConfig?.optionOverrides?.[optionsOverride]?.configurations));
+    const optionsOverride = `${testDriver.type}${endpoint !== undefined ? `-${endpoint}` : ""}`;
+    const loaderOptions = generateLoaderOptions(
+        seed, testConfig.optionOverrides?.[optionsOverride]?.loader)[0];
+    const containerOptions = generateRuntimeOptions(
+        seed, testConfig.optionOverrides?.[optionsOverride]?.container)[0];
+    const configurations = generateConfigurations(
+        seed, testConfig?.optionOverrides?.[optionsOverride]?.configurations)[0];
 
     const logger = ChildLogger.create(await loggerP, undefined,
     {

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -110,10 +110,6 @@
     "version": "2.0.0-internal.2.2.0",
     "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
     "baselineVersion": "2.0.0-internal.2.1.0",
-    "broken": {
-      "InterfaceDeclaration_ITestContainerConfig": {
-        "backCompat": false
-      }
-    }
+    "broken": {}
   }
 }

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -419,7 +419,6 @@ declare function get_current_InterfaceDeclaration_ITestContainerConfig():
 declare function use_old_InterfaceDeclaration_ITestContainerConfig(
     use: TypeOnly<old.ITestContainerConfig>);
 use_old_InterfaceDeclaration_ITestContainerConfig(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITestContainerConfig());
 
 /*

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -34,25 +34,25 @@ variables:
 
 lockBehavior: sequential
 stages:
-  # stress tests odsp
-  # - stage:
-  #   displayName:  Stress tests - Odsp
-  #   dependsOn: []
-  #   # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
-  #   variables:
-  #   - group: stress-odsp-lock
-  #   jobs:
-  #   - template: templates/include-test-real-service.yml
-  #     parameters:
-  #       poolBuild: Large
-  #       testPackage: "@fluid-internal/test-service-load"
-  #       testWorkspace: ${{ variables.testWorkspace }}
-  #       timeoutInMinutes: 150
-  #       testCommand: start:odsp:gc:ci
-  #       env:
-  #         login__microsoft__clientId: $(login-microsoft-clientId)
-  #         login__microsoft__secret: $(login-microsoft-secret)
-  #         login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
+  stress tests odsp
+  - stage:
+    displayName:  Stress tests - Odsp
+    dependsOn: []
+    # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
+    variables:
+    - group: stress-odsp-lock
+    jobs:
+    - template: templates/include-test-real-service.yml
+      parameters:
+        poolBuild: Large
+        testPackage: "@fluid-internal/test-service-load"
+        testWorkspace: ${{ variables.testWorkspace }}
+        timeoutInMinutes: 150
+        testCommand: start:odsp:gc:ci
+        env:
+          login__microsoft__clientId: $(login-microsoft-clientId)
+          login__microsoft__secret: $(login-microsoft-secret)
+          login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
           #FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
 
   # stress tests tinylicious


### PR DESCRIPTION
Re-enabled running test against ODSP which was disabled due to too many attachment blob uploads / downloads resulting in throttling. Also, fixed a couple other issues:
- The configurations in the test config were randomly applied to containers. However, for sweep to work correctly, these configs have to apply to all containers. For example, if some container does not have session expiry, it can use deleted content.
- The configurations in the test config was never picked up for the first container.