### PR TITLE
Fixed the first container created in service load tests not picking up optionOverrides for ODSP

### DIFF
--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -127,7 +127,7 @@ async function orchestratorProcess(
 		: // If no testId is provided, (or) if testId is provided but createTestId is not false, then
 		  // create a file;
 		  // In case testId is provided, name of the file to be created is taken as the testId provided
-		  initialize(testDriver, seed, profile, args.verbose === true, args.testId));
+		  initialize(testDriver, seed, endpoint, profile, args.verbose === true, args.testId));
 
 	const estRunningTimeMin = Math.floor(
 		(2 * profile.totalSendCount) / (profile.opRatePerMin * profile.numClients),

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -140,15 +140,14 @@ class MockDetachedBlobStorage implements IDetachedBlobStorage {
 export async function initialize(
 	testDriver: ITestDriver,
 	seed: number,
+    endpoint: DriverEndpoint | undefined,
 	testConfig: ILoadTestConfig,
 	verbose: boolean,
 	testIdn?: string,
 ) {
 	const randEng = random.engines.mt19937();
 	randEng.seed(seed);
-	const optionsOverride = `${testDriver.type}${
-		testDriver.endpointName !== undefined ? `-${testDriver.endpointName}` : ""
-	}`;
+    const optionsOverride = `${testDriver.type}${endpoint !== undefined ? `-${endpoint}` : ""}`;
 	const loaderOptions = random.pick(
 		randEng,
 		generateLoaderOptions(seed, testConfig.optionOverrides?.[optionsOverride]?.loader),

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -140,14 +140,14 @@ class MockDetachedBlobStorage implements IDetachedBlobStorage {
 export async function initialize(
 	testDriver: ITestDriver,
 	seed: number,
-    endpoint: DriverEndpoint | undefined,
+	endpoint: DriverEndpoint | undefined,
 	testConfig: ILoadTestConfig,
 	verbose: boolean,
 	testIdn?: string,
 ) {
 	const randEng = random.engines.mt19937();
 	randEng.seed(seed);
-    const optionsOverride = `${testDriver.type}${endpoint !== undefined ? `-${endpoint}` : ""}`;
+	const optionsOverride = `${testDriver.type}${endpoint !== undefined ? `-${endpoint}` : ""}`;
 	const loaderOptions = random.pick(
 		randEng,
 		generateLoaderOptions(seed, testConfig.optionOverrides?.[optionsOverride]?.loader),

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -141,9 +141,15 @@ export async function initialize(
 	testDriver: ITestDriver,
 	seed: number,
     endpoint: DriverEndpoint | undefined,
+<<<<<<< HEAD
 	testConfig: ILoadTestConfig,
 	verbose: boolean,
 	testIdn?: string,
+=======
+    testConfig: ILoadTestConfig,
+    verbose: boolean,
+    testIdn?: string,
+>>>>>>> nit
 ) {
 	const randEng = random.engines.mt19937();
 	randEng.seed(seed);

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -141,15 +141,9 @@ export async function initialize(
 	testDriver: ITestDriver,
 	seed: number,
     endpoint: DriverEndpoint | undefined,
-<<<<<<< HEAD
 	testConfig: ILoadTestConfig,
 	verbose: boolean,
 	testIdn?: string,
-=======
-    testConfig: ILoadTestConfig,
-    verbose: boolean,
-    testIdn?: string,
->>>>>>> nit
 ) {
 	const randEng = random.engines.mt19937();
 	randEng.seed(seed);


### PR DESCRIPTION
In service load tests, the first client created was not picking up optionsOverrides from the testConfig.json file for ODSP because it was generating the optionsOverride value as "odsp-odsp" instead of "odsp". It however, worked fine for the subsequent clients created in runner.ts.
The first client used testDriver.endPointName which for ODSP is "odsp". The subsequent clients use "endPoint" directly passed to them which is "".
