### PR TITLE
server: optimize initial summary write

### DIFF
--- a/server/charts/historian/templates/gitrest-configmap.yaml
+++ b/server/charts/historian/templates/gitrest-configmap.yaml
@@ -34,7 +34,11 @@ data:
             "persistLatestFullSummary": {{ .Values.gitrest.git.persistLatestFullSummary }},
             "repoPerDocEnabled": {{ .Values.gitrest.git.repoPerDocEnabled }},
             "enableRepositoryManagerMetrics": {{ .Values.gitrest.git.enableRepositoryManagerMetrics }},
+            {{- if eq (toString .Values.gitrest.git.enableLowIoWrite) "initial" }}
+            "enableLowIoWrite": "{{ .Values.gitrest.git.enableLowIoWrite }}",
+            {{- else }}
             "enableLowIoWrite": {{ .Values.gitrest.git.enableLowIoWrite }},
+            {{- end }}
             "enableOptimizedInitialSummary": {{ .Values.gitrest.git.enableOptimizedInitialSummary }},
             "enableSlimGitInit": {{ .Values.gitrest.git.enableSlimGitInit }}
         }

--- a/server/charts/historian/templates/gitrest-configmap.yaml
+++ b/server/charts/historian/templates/gitrest-configmap.yaml
@@ -32,8 +32,10 @@ data:
                 "name": "{{ .Values.gitrest.git.lib.name }}"
             },
             "persistLatestFullSummary": {{ .Values.gitrest.git.persistLatestFullSummary }},
-            "enableLowIoWrite": {{ .Values.gitrest.git.enableLowIoWrite }},
             "repoPerDocEnabled": {{ .Values.gitrest.git.repoPerDocEnabled }},
-            "enableRepositoryManagerMetrics": {{ .Values.gitrest.git.enableRepositoryManagerMetrics }}
+            "enableRepositoryManagerMetrics": {{ .Values.gitrest.git.enableRepositoryManagerMetrics }},
+            "enableLowIoWrite": {{ .Values.gitrest.git.enableLowIoWrite }},
+            "enableOptimizedInitialSummary": {{ .Values.gitrest.git.enableOptimizedInitialSummary }},
+            "enableSlimGitInit": {{ .Values.gitrest.git.enableSlimGitInit }}
         }
     }

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -43,9 +43,11 @@ gitrest:
     lib:
       name: nodegit
     persistLatestFullSummary: false
-    enableLowIoWrite: false
     repoPerDocEnabled: false
     enableRepositoryManagerMetrics: false
+    enableLowIoWrite: false
+    enableOptimizedInitialSummary: false
+    enableSlimGitInit: false
 
 gitssh:
   name: gitssh

--- a/server/gitrest/lerna-package-lock.json
+++ b/server/gitrest/lerna-package-lock.json
@@ -538,7 +538,7 @@
 				"@fluidframework/server-services-core": "0.1038.3000-117199",
 				"@fluidframework/server-services-telemetry": "0.1038.3000-117199",
 				"debug": "^4.1.1",
-				"express": "^4.16.3",
+				"express": "^4.17.3",
 				"ioredis": "^4.24.2",
 				"json-stringify-safe": "^5.0.1",
 				"jsonwebtoken": "^9.0.0",
@@ -8775,7 +8775,7 @@
 		"clean-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
-			"integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
+			"integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
@@ -9899,7 +9899,7 @@
 				"yallist": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
 					"dev": true
 				}
 			}
@@ -10979,7 +10979,7 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
 		"fastq": {
@@ -11339,7 +11339,7 @@
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
 			"dev": true
 		},
 		"functions-have-names": {
@@ -12715,7 +12715,7 @@
 		"jju": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-			"integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
 			"dev": true
 		},
 		"js-sdsl": {
@@ -12787,7 +12787,7 @@
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
 		"json-stringify-nice": {
@@ -14223,7 +14223,7 @@
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
 		"nconf": {
@@ -15277,7 +15277,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
 		},
 		"object-inspect": {
 			"version": "1.12.2",
@@ -16207,7 +16207,7 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
 			"dev": true
 		},
 		"psl": {
@@ -16975,7 +16975,7 @@
 		"sigmund": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+			"integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
 			"dev": true
 		},
 		"signal-exit": {
@@ -17151,7 +17151,7 @@
 		"spawn-command": {
 			"version": "0.0.2-1",
 			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+			"integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
 			"dev": true
 		},
 		"spawn-wrap": {
@@ -17562,7 +17562,7 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
 		"through": {

--- a/server/gitrest/package-lock.json
+++ b/server/gitrest/package-lock.json
@@ -4080,7 +4080,7 @@
 		"clean-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
-			"integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
+			"integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
@@ -4998,7 +4998,7 @@
 				"yallist": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
 					"dev": true
 				}
 			}
@@ -5922,7 +5922,7 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
 		"fastq": {
@@ -6247,7 +6247,7 @@
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
 			"dev": true
 		},
 		"functions-have-names": {
@@ -7457,7 +7457,7 @@
 		"jju": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-			"integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
 			"dev": true
 		},
 		"js-sdsl": {
@@ -7515,7 +7515,7 @@
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
 		"json-stringify-nice": {
@@ -8518,7 +8518,7 @@
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
 		"negotiator": {
@@ -9400,7 +9400,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"dev": true
 		},
 		"object-inspect": {
@@ -10046,7 +10046,7 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
 			"dev": true
 		},
 		"punycode": {
@@ -10617,7 +10617,7 @@
 		"sigmund": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+			"integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
 			"dev": true
 		},
 		"signal-exit": {
@@ -10725,7 +10725,7 @@
 		"spawn-command": {
 			"version": "0.0.2-1",
 			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+			"integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
 			"dev": true
 		},
 		"spawn-wrap": {
@@ -11091,7 +11091,7 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
 		"through": {

--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -116,7 +116,8 @@ async function createSummary(
     repoManagerParams: IRepoManagerParams,
     externalWriterConfig?: IExternalWriterConfig,
     persistLatestFullSummary = false,
-    enableLowIoWrite: "initial" | boolean = false
+    enableLowIoWrite: "initial" | boolean = false,
+    optimizeForInitialSummary: boolean = false,
 ): Promise<IWriteSummaryResponse | IWholeFlatSummary> {
     const lumberjackProperties = {
         ...getLumberjackBasePropertiesFromRepoManagerParams(repoManagerParams),
@@ -128,7 +129,10 @@ async function createSummary(
         repoManager,
         lumberjackProperties,
         externalWriterConfig?.enabled ?? false,
-        { enableLowIoWrite },
+        {
+            enableLowIoWrite,
+            optimizeForInitialSummary,
+        },
     );
 
     Lumberjack.info("Creating summary", lumberjackProperties);
@@ -269,6 +273,9 @@ export function create(
      */
     router.post("/repos/:owner/:repo/git/summaries", async (request, response) => {
         const repoManagerParams = getRepoManagerParamsFromRequest(request);
+        const isInitialSummary: boolean | undefined = typeof request.params.initial === "string"
+            ? request.params.initial === "true"
+            : undefined;
         if (!repoManagerParams.storageRoutingId?.tenantId ||
             !repoManagerParams.storageRoutingId?.documentId) {
             handleResponse(
@@ -277,20 +284,28 @@ export function create(
             return;
         }
         const wholeSummaryPayload: IWholeSummaryPayload = request.body;
-        const resultP = getRepoManagerFromWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled)
-            .then(async (repoManager): Promise<IWriteSummaryResponse | IWholeFlatSummary> => {
-                const fsManager = fileSystemManagerFactory.create(repoManagerParams.fileSystemManagerParams);
+        const resultP = (async () => {
+            // There are possible optimizations we can make throughout the summary write process
+            // if we are using repoPerDoc model and it is the first summary for that document.
+            const optimizeForInitialSummary = isInitialSummary && repoPerDocEnabled;
+            // If creating a repo per document, we do not need to check for an existing repo on initial summary write.
+            const repoManager = await getRepoManagerFromWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled, optimizeForInitialSummary);
+            const fsManager = fileSystemManagerFactory.create(repoManagerParams.fileSystemManagerParams);
+            // A new document cannot already be soft-deleted.
+            if (!optimizeForInitialSummary) {
                 await checkSoftDeleted(fsManager, repoManager.path, repoManagerParams, repoPerDocEnabled);
-                return createSummary(
-                    repoManager,
-                    fsManager,
-                    wholeSummaryPayload,
-                    repoManagerParams,
-                    getExternalWriterParams(request.query?.config as string | undefined),
-                    persistLatestFullSummary,
-                    enableLowIoWrite,
-                );
-            }).catch((error) => logAndThrowApiError(error, request, repoManagerParams));
+            }
+            return createSummary(
+                repoManager,
+                fsManager,
+                wholeSummaryPayload,
+                repoManagerParams,
+                getExternalWriterParams(request.query?.config as string | undefined),
+                persistLatestFullSummary,
+                enableLowIoWrite,
+                optimizeForInitialSummary,
+            );
+        })().catch((error) => logAndThrowApiError(error, request, repoManagerParams));
         handleResponse(resultP, response, undefined, undefined, 201);
     });
 

--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -115,6 +115,7 @@ async function createSummary(
     payload: IWholeSummaryPayload,
     repoManagerParams: IRepoManagerParams,
     externalWriterConfig?: IExternalWriterConfig,
+    isInitialSummary?: boolean,
     persistLatestFullSummary = false,
     enableLowIoWrite: "initial" | boolean = false,
     optimizeForInitialSummary: boolean = false,
@@ -137,7 +138,7 @@ async function createSummary(
 
     Lumberjack.info("Creating summary", lumberjackProperties);
 
-    const { isNew, writeSummaryResponse } = await wholeSummaryManager.writeSummary(payload);
+    const { isNew, writeSummaryResponse } = await wholeSummaryManager.writeSummary(payload, isInitialSummary);
 
     // Waiting to pre-compute and persist latest summary would slow down document creation,
     // so skip this step if it is a new document.
@@ -305,6 +306,7 @@ export function create(
                 wholeSummaryPayload,
                 repoManagerParams,
                 getExternalWriterParams(request.query?.config as string | undefined),
+                isInitialSummary,
                 persistLatestFullSummary,
                 enableLowIoWrite,
                 optimizeForInitialSummary,

--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -239,6 +239,7 @@ export function create(
     const router: Router = Router();
     const persistLatestFullSummary: boolean = store.get("git:persistLatestFullSummary") ?? false;
     const enableLowIoWrite: "initial" | boolean = store.get("git:enableLowIoWrite") ?? false;
+    const enableOptimizedInitialSummary: boolean = store.get("git:enableOptimizedInitialSummary") ?? false;
     const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
 
     /**
@@ -292,7 +293,7 @@ export function create(
         const resultP = (async () => {
             // There are possible optimizations we can make throughout the summary write process
             // if we are using repoPerDoc model and it is the first summary for that document.
-            const optimizeForInitialSummary = isInitialSummary && repoPerDocEnabled;
+            const optimizeForInitialSummary = enableOptimizedInitialSummary && isInitialSummary && repoPerDocEnabled;
             // If creating a repo per document, we do not need to check for an existing repo on initial summary write.
             const repoManager = await getRepoManagerFromWriteAPI(repoManagerFactory, repoManagerParams, repoPerDocEnabled, optimizeForInitialSummary);
             const fsManager = fileSystemManagerFactory.create(repoManagerParams.fileSystemManagerParams);

--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -273,9 +273,13 @@ export function create(
      */
     router.post("/repos/:owner/:repo/git/summaries", async (request, response) => {
         const repoManagerParams = getRepoManagerParamsFromRequest(request);
-        const isInitialSummary: boolean | undefined = typeof request.params.initial === "string"
-            ? request.params.initial === "true"
-            : undefined;
+        // request.query type is { [string]: string } but it's actually { [string]: any }
+        // Account for possibilities of undefined, boolean, or string types. A number will be false.
+        const isInitialSummary: boolean | undefined = typeof request.query.initial === "undefined"
+            ? undefined
+            : typeof request.query.initial === "boolean"
+                ? request.query.initial
+                : request.query.initial === "true";
         if (!repoManagerParams.storageRoutingId?.tenantId ||
             !repoManagerParams.storageRoutingId?.documentId) {
             handleResponse(

--- a/server/gitrest/packages/gitrest-base/src/runnerFactory.ts
+++ b/server/gitrest/packages/gitrest-base/src/runnerFactory.ts
@@ -27,7 +27,9 @@ export class GitrestResources implements core.IResources {
         public readonly port: string | number,
         public readonly fileSystemManagerFactory: IFileSystemManagerFactory,
         public readonly repositoryManagerFactory: IRepositoryManagerFactory,
-        public readonly asyncLocalStorage?: AsyncLocalStorage<string>) {
+        public readonly asyncLocalStorage?: AsyncLocalStorage<string>,
+        public readonly enableOptimizedInitialSummary?: boolean,
+    ) {
         this.webServerFactory = new services.BasicWebServerFactory();
     }
 
@@ -45,6 +47,7 @@ export class GitrestResourcesFactory implements core.IResourcesFactory<GitrestRe
         const gitLibrary: string | undefined = config.get("git:lib:name");
         const repoPerDocEnabled: boolean = config.get("git:repoPerDocEnabled") ?? false;
         const enableRepositoryManagerMetrics: boolean = config.get("git:enableRepositoryManagerMetrics") ?? false;
+        const enableSlimGitInit: boolean = config.get("git:enableSlimGitInit") ?? false;
         const getRepositoryManagerFactory = () => {
             if (!gitLibrary || gitLibrary === "nodegit") {
                 return new NodegitRepositoryManagerFactory(
@@ -61,6 +64,7 @@ export class GitrestResourcesFactory implements core.IResourcesFactory<GitrestRe
                     externalStorageManager,
                     repoPerDocEnabled,
                     enableRepositoryManagerMetrics,
+                    enableSlimGitInit,
                 );
             }
             throw new Error("Invalid git library name.");
@@ -85,6 +89,7 @@ export class GitrestRunnerFactory implements core.IRunnerFactory<GitrestResource
             resources.port,
             resources.fileSystemManagerFactory,
             resources.repositoryManagerFactory,
-            resources.asyncLocalStorage);
+            resources.asyncLocalStorage,
+        );
     }
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
@@ -33,7 +33,7 @@ export interface IRepositoryManager {
     createCommit(commit: git.ICreateCommitParams): Promise<git.ICommit>;
     getRefs(): Promise<git.IRef[]>;
     getRef(ref: string, externalWriterConfig?: IExternalWriterConfig): Promise<git.IRef>;
-    createRef(createRefParams: git.ICreateRefParams, externalWriterConfig?: IExternalWriterConfig): Promise<git.IRef>;
+    createRef(createRefParams: git.ICreateRefParams & { force?: boolean }, externalWriterConfig?: IExternalWriterConfig): Promise<git.IRef>;
     patchRef(refId: string, patchRefParams: git.IPatchRefParams, externalWriterConfig?: IExternalWriterConfig): Promise<git.IRef>;
     deleteRef(refId: string): Promise<void>;
     getTag(tagId: string): Promise<git.ITag>;

--- a/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
@@ -83,6 +83,7 @@ export interface IRepoManagerParams {
     repoName: string;
     storageRoutingId?: IStorageRoutingId;
     fileSystemManagerParams?: IFileSystemManagerParams;
+    optimizeForInitialSummary?: boolean;
 }
 
 export interface IRepositoryManagerFactory {

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -221,7 +221,12 @@ export function logAndThrowApiError(error: any, request: Request, params: IRepoM
 export async function getRepoManagerFromWriteAPI(
     repoManagerFactory: IRepositoryManagerFactory,
     repoManagerParams: IRepoManagerParams,
-    repoPerDocEnabled: boolean) {
+    repoPerDocEnabled: boolean,
+    optimizeForInitialSummary?: boolean,
+) {
+    if (optimizeForInitialSummary) {
+        return repoManagerFactory.create({ ...repoManagerParams, optimizeForInitialSummary });
+    }
     try {
         return await repoManagerFactory.open(repoManagerParams);
     } catch (error: any) {

--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -299,7 +299,7 @@ export class IsomorphicGitRepositoryManager extends RepositoryManagerBase {
     }
 
     protected async createRefCore(
-        createRefParams: resources.ICreateRefParams,
+        createRefParams: resources.ICreateRefParams & { force?: boolean },
         externalWriterConfig?: IExternalWriterConfig,
     ): Promise<resources.IRef> {
         await isomorphicGit.writeRef({
@@ -307,6 +307,7 @@ export class IsomorphicGitRepositoryManager extends RepositoryManagerBase {
             gitdir: this.directory,
             ref: createRefParams.ref,
             value: createRefParams.sha,
+            force: createRefParams.force,
         });
         return conversions.refToIRef(createRefParams.sha, createRefParams.ref);
     }
@@ -374,12 +375,11 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
             enableRepositoryManagerMetrics);
     }
 
-    protected async initGitRepo(fs: IFileSystemManager, gitdir: string, defaultBranch?: string): Promise<void> {
+    protected async initGitRepo(fs: IFileSystemManager, gitdir: string): Promise<void> {
         return isomorphicGit.init({
             fs,
             gitdir,
             bare: true,
-            defaultBranch,
         });
     }
 

--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -374,11 +374,12 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
             enableRepositoryManagerMetrics);
     }
 
-    protected async initGitRepo(fs: IFileSystemManager, gitdir: string): Promise<void> {
+    protected async initGitRepo(fs: IFileSystemManager, gitdir: string, defaultBranch?: string): Promise<void> {
         return isomorphicGit.init({
             fs,
             gitdir,
             bare: true,
+            defaultBranch,
         });
     }
 
@@ -395,12 +396,12 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
         externalStorageManager: IExternalStorageManager,
         lumberjackBaseProperties: Record<string, any>,
         enableRepositoryManagerMetrics: boolean): IRepositoryManager {
-            return new IsomorphicGitRepositoryManager(
-                fileSystemManager,
-                repoOwner,
-                repoName,
-                gitdir,
-                lumberjackBaseProperties,
-                enableRepositoryManagerMetrics);
+        return new IsomorphicGitRepositoryManager(
+            fileSystemManager,
+            repoOwner,
+            repoName,
+            gitdir,
+            lumberjackBaseProperties,
+            enableRepositoryManagerMetrics);
     }
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -366,6 +366,7 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
         externalStorageManager: IExternalStorageManager,
         repoPerDocEnabled: boolean,
         enableRepositoryManagerMetrics: boolean = false,
+        private readonly enableSlimGitInit: boolean = false,
     ) {
         super(
             storageDirectoryConfig,
@@ -376,12 +377,13 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
     }
 
     protected async initGitRepo(fs: IFileSystemManager, gitdir: string): Promise<void> {
-        // return isomorphicGit.init({
-        //     fs,
-        //     gitdir,
-        //     bare: true,
-        // });
-        return this.slimInit(fs, gitdir);
+        return this.enableSlimGitInit
+            ? this.slimInit(fs, gitdir)
+            : isomorphicGit.init({
+                fs,
+                gitdir,
+                bare: true,
+            });
     }
 
     protected async openGitRepo(gitdir: string): Promise<void> {

--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -376,11 +376,12 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
     }
 
     protected async initGitRepo(fs: IFileSystemManager, gitdir: string): Promise<void> {
-        return isomorphicGit.init({
-            fs,
-            gitdir,
-            bare: true,
-        });
+        // return isomorphicGit.init({
+        //     fs,
+        //     gitdir,
+        //     bare: true,
+        // });
+        return this.slimInit(fs, gitdir);
     }
 
     protected async openGitRepo(gitdir: string): Promise<void> {
@@ -403,5 +404,23 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
             gitdir,
             lumberjackBaseProperties,
             enableRepositoryManagerMetrics);
+    }
+
+    /**
+     * A trimmed down version of iso-git's init function
+     * https://github.com/isomorphic-git/isomorphic-git/blob/c09dfa20ffe0ab9e6602e0fa172d72ba8994e443/src/commands/init.js#L15
+     * 
+     * Removes checking existence, writing a config file, writing a hooks and info folders, and /HEAD file.
+     * 
+     * This brings file reads from 1 to 0, and writes from 10 to 3.
+     */
+    private async slimInit(fs: IFileSystemManager, gitdir: string): Promise<void> {
+        const folders = [
+            'objects',
+            'refs/heads',
+        ].map(dir => `${gitdir}/${dir}`);
+        for (const folder of folders) {
+            await fs.promises.mkdir(folder, { recursive: true });
+        }
     }
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
@@ -261,14 +261,14 @@ export class NodegitRepositoryManager extends RepositoryManagerBase {
     }
 
     protected async createRefCore(
-        createRefParams: resources.ICreateRefParams,
+        createRefParams: resources.ICreateRefParams & { force?: boolean },
         externalWriterConfig?: IExternalWriterConfig,
     ): Promise<resources.IRef> {
         const ref = await nodegit.Reference.create(
             this.repo,
             createRefParams.ref,
             nodegit.Oid.fromString(createRefParams.sha),
-            0,
+            createRefParams.force ? 1 : 0,
             "");
 
         if (externalWriterConfig?.enabled) {
@@ -386,13 +386,13 @@ export class NodegitRepositoryManagerFactory extends RepositoryManagerFactoryBas
         externalStorageManager: IExternalStorageManager,
         lumberjackBaseProperties: Record<string, any>,
         enableRepositoryManagerMetrics: boolean): IRepositoryManager {
-            return new NodegitRepositoryManager(
-                repoOwner,
-                repoName,
-                repo,
-                gitdir,
-                externalStorageManager,
-                lumberjackBaseProperties,
-                enableRepositoryManagerMetrics);
+        return new NodegitRepositoryManager(
+            repoOwner,
+            repoName,
+            repo,
+            gitdir,
+            externalStorageManager,
+            lumberjackBaseProperties,
+            enableRepositoryManagerMetrics);
     }
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerBase.ts
@@ -141,7 +141,7 @@ export abstract class RepositoryManagerBase implements IRepositoryManager {
     }
 
     public async createRef(
-        createRefParams: git.ICreateRefParams,
+        createRefParams: git.ICreateRefParams & { force?: boolean },
         externalWriterConfig?: IExternalWriterConfig,
     ): Promise<git.IRef> {
         return this.enableRepositoryManagerMetrics ?

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
@@ -36,7 +36,7 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
         repoOperationType: RepoOperationType) => Promise<IRepositoryManager>;
     // Cache repositories to allow for reuse
     protected readonly repositoryCache = new Map<string, TRepo>();
-    protected abstract initGitRepo(fs: IFileSystemManager, gitdir: string, defaultBranch?: string): Promise<TRepo>;
+    protected abstract initGitRepo(fs: IFileSystemManager, gitdir: string): Promise<TRepo>;
     protected abstract openGitRepo(gitdir: string): Promise<TRepo>;
     protected abstract createRepoManager(
         fileSystemManager: IFileSystemManager,
@@ -67,10 +67,8 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
             gitdir: string,
             lumberjackBaseProperties: Record<string, any>,
         ) => {
-            // Setting default branch to documentId allows us to skip unnecessary creation of a "master" branch during initial summary write.
-            const defaultBranch = params.optimizeForInitialSummary ? params.storageRoutingId.documentId : undefined;
             // Create and then cache the repository
-            const repository = await this.initGitRepo(fileSystemManager, gitdir, defaultBranch);
+            const repository = await this.initGitRepo(fileSystemManager, gitdir);
             this.repositoryCache.set(repoPath, repository);
             Lumberjack.info(
                 "Created a new repo",

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
@@ -36,7 +36,7 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
         repoOperationType: RepoOperationType) => Promise<IRepositoryManager>;
     // Cache repositories to allow for reuse
     protected readonly repositoryCache = new Map<string, TRepo>();
-    protected abstract initGitRepo(fs: IFileSystemManager, gitdir: string): Promise<TRepo>;
+    protected abstract initGitRepo(fs: IFileSystemManager, gitdir: string, defaultBranch?: string): Promise<TRepo>;
     protected abstract openGitRepo(gitdir: string): Promise<TRepo>;
     protected abstract createRepoManager(
         fileSystemManager: IFileSystemManager,
@@ -67,8 +67,10 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
             gitdir: string,
             lumberjackBaseProperties: Record<string, any>,
         ) => {
+            // Setting default branch to documentId allows us to skip unnecessary creation of a "master" branch during initial summary write.
+            const defaultBranch = params.optimizeForInitialSummary ? params.storageRoutingId.documentId : undefined;
             // Create and then cache the repository
-            const repository = await this.initGitRepo(fileSystemManager, gitdir);
+            const repository = await this.initGitRepo(fileSystemManager, gitdir, defaultBranch);
             this.repositoryCache.set(repoPath, repository);
             Lumberjack.info(
                 "Created a new repo",
@@ -187,28 +189,37 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
         const fileSystemManager = this.fileSystemManagerFactory.create(params.fileSystemManagerParams);
         // We define the function below to be able to call it either on its own or within the mutex.
         const action = async () => {
-            // We only lock on the mutex for "create repo" operations, since we want repo creation to happen
-            // atomically. That means that "open repo" operations can happen in parallel, without the need
-            // for acquiring the lock/mutex. However, imagine the following scenario: one "create repo" operation
-            // acquired the lock for repo A, and then a concurrent "open repo" request comes for repo A. The
-            // "open repo" request will not try to acquire the mutex. However, it still needs to wait just in
-            // case there is an ongoing "create repo" operation, in order for the "open repo" to succeed.
-            // The conditional below makes sure we only proceed with the "open repo" operation if there
-            // is no ongoing "create repo".
-            if (repoOperationType === "open" && this.mutexes.get(repoName)?.isLocked()) {
-                await this.mutexes.get(repoName).waitForUnlock();
-            }
-            if (!this.repositoryCache.has(repoPath)) {
-                const repoExists = await helpers.exists(fileSystemManager, directoryPath);
-                if (!repoExists || !repoExists.isDirectory()) {
-                    await onRepoNotExists(
-                        fileSystemManager,
-                        repoPath,
-                        directoryPath,
-                        lumberjackBaseProperties);
-                } else {
-                    const repo = await this.openGitRepo(directoryPath);
-                    this.repositoryCache.set(repoPath, repo);
+            if (params.optimizeForInitialSummary && repoOperationType === "create") {
+                // Skip checking if repo exists when optimizing for an initial summary.
+                await onRepoNotExists(
+                    fileSystemManager,
+                    repoPath,
+                    directoryPath,
+                    lumberjackBaseProperties);
+            } else {
+                // We only lock on the mutex for "create repo" operations, since we want repo creation to happen
+                // atomically. That means that "open repo" operations can happen in parallel, without the need
+                // for acquiring the lock/mutex. However, imagine the following scenario: one "create repo" operation
+                // acquired the lock for repo A, and then a concurrent "open repo" request comes for repo A. The
+                // "open repo" request will not try to acquire the mutex. However, it still needs to wait just in
+                // case there is an ongoing "create repo" operation, in order for the "open repo" to succeed.
+                // The conditional below makes sure we only proceed with the "open repo" operation if there
+                // is no ongoing "create repo".
+                if (repoOperationType === "open" && this.mutexes.get(repoName)?.isLocked()) {
+                    await this.mutexes.get(repoName).waitForUnlock();
+                }
+                if (!this.repositoryCache.has(repoPath)) {
+                    const repoExists = await helpers.exists(fileSystemManager, directoryPath);
+                    if (!repoExists || !repoExists.isDirectory()) {
+                        await onRepoNotExists(
+                            fileSystemManager,
+                            repoPath,
+                            directoryPath,
+                            lumberjackBaseProperties);
+                    } else {
+                        const repo = await this.openGitRepo(directoryPath);
+                        this.repositoryCache.set(repoPath, repo);
+                    }
                 }
             }
 

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -20,8 +20,10 @@
             "name": "nodegit"
         },
         "persistLatestFullSummary": false,
-        "enableLowIoWrite": false,
         "repoPerDocEnabled": false,
-        "enableRepositoryManagerMetrics": false
+        "enableRepositoryManagerMetrics": false,
+        "enableLowIoWrite": false,
+        "enableOptimizedInitialSummary": false,
+        "enableSlimGitInit": false
     }
 }

--- a/server/historian/lerna-package-lock.json
+++ b/server/historian/lerna-package-lock.json
@@ -283,7 +283,7 @@
 		"@dsherret/to-absolute-glob": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+			"integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
 			"dev": true,
 			"requires": {
 				"is-absolute": "^1.0.0",
@@ -5477,7 +5477,7 @@
 		"ansi-colors": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g=",
+			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
 			"dev": true
 		},
 		"ansi-escapes": {
@@ -6145,7 +6145,7 @@
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
 		},
 		"buffer-fill": {
 			"version": "1.0.0",
@@ -8018,7 +8018,7 @@
 				"yallist": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
 					"dev": true
 				}
 			}
@@ -8908,7 +8908,7 @@
 		"eslint-scope": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
 			"requires": {
 				"esrecurse": "^4.3.0",
@@ -8975,7 +8975,7 @@
 		"esrecurse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-			"integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.2.0"
@@ -8992,7 +8992,7 @@
 		"estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true
 		},
 		"esutils": {
@@ -9290,7 +9290,7 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
 		"fastest-levenshtein": {
@@ -9913,7 +9913,7 @@
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
 			"dev": true
 		},
 		"functions-have-names": {
@@ -11614,7 +11614,7 @@
 		"jju": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-			"integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
 			"dev": true
 		},
 		"js-sdsl": {
@@ -11684,7 +11684,7 @@
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
 		},
 		"json-stringify-safe": {
@@ -12148,7 +12148,7 @@
 		"lodash.isboolean": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
 			"dev": true
 		},
 		"lodash.isequal": {
@@ -12160,7 +12160,7 @@
 		"lodash.isinteger": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
 			"dev": true
 		},
 		"lodash.ismatch": {
@@ -12172,7 +12172,7 @@
 		"lodash.isnumber": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
 			"dev": true
 		},
 		"lodash.isobject": {
@@ -12184,13 +12184,13 @@
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
 			"dev": true
 		},
 		"lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
 			"dev": true
 		},
 		"lodash.keys": {
@@ -12220,7 +12220,7 @@
 		"lodash.once": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
 			"dev": true
 		},
 		"lodash.set": {
@@ -13250,7 +13250,7 @@
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
 		"natural-orderby": {
@@ -15131,7 +15131,7 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
 			"dev": true
 		},
 		"psl": {
@@ -15990,7 +15990,7 @@
 		"sigmund": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+			"integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
 			"dev": true
 		},
 		"signal-exit": {
@@ -16279,7 +16279,7 @@
 		"spawn-command": {
 			"version": "0.0.2-1",
 			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+			"integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
 			"dev": true
 		},
 		"spawn-wrap": {
@@ -16955,7 +16955,7 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
 		"through": {
@@ -17031,7 +17031,7 @@
 		"tree-kill": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-			"integrity": "sha1-TKCakJLIi3OnzcXooBtQeweQoMw=",
+			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
 			"dev": true
 		},
 		"trim-newlines": {

--- a/server/historian/package-lock.json
+++ b/server/historian/package-lock.json
@@ -243,7 +243,7 @@
     "@dsherret/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha512-InCaQ/KEOcFtAFztn47wadritBLP2nT6m/ucbBnIgI5YwxuMzKKCHtqazR2+D1yR6y1ZTnPea9aLFEUrTttUSQ==",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
@@ -4855,7 +4855,7 @@
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g=",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
     },
     "ansi-escapes": {
@@ -5367,7 +5367,7 @@
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
       "dev": true
     },
     "buffer-from": {
@@ -6936,7 +6936,7 @@
         "yallist": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
           "dev": true
         }
       }
@@ -7760,7 +7760,7 @@
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
@@ -7827,7 +7827,7 @@
     "esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
         "estraverse": "^5.2.0"
@@ -7844,7 +7844,7 @@
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
@@ -8051,7 +8051,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "fastest-levenshtein": {
@@ -8598,7 +8598,7 @@
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
     },
     "functions-have-names": {
@@ -10246,7 +10246,7 @@
     "jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-      "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true
     },
     "js-sdsl": {
@@ -10316,7 +10316,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "json-stringify-safe": {
@@ -10697,7 +10697,7 @@
     "lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
       "dev": true
     },
     "lodash.isequal": {
@@ -10709,7 +10709,7 @@
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
       "dev": true
     },
     "lodash.ismatch": {
@@ -10721,7 +10721,7 @@
     "lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
       "dev": true
     },
     "lodash.isobject": {
@@ -10733,13 +10733,13 @@
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
     "lodash.keys": {
@@ -10769,7 +10769,7 @@
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "dev": true
     },
     "lodash.set": {
@@ -11698,7 +11698,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "natural-orderby": {
@@ -13375,7 +13375,7 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
       "dev": true
     },
     "psl": {
@@ -14031,7 +14031,7 @@
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
       "dev": true
     },
     "signal-exit": {
@@ -14189,7 +14189,7 @@
     "spawn-command": {
       "version": "0.0.2-1",
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
       "dev": true
     },
     "spawn-wrap": {
@@ -14794,7 +14794,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "through": {
@@ -14856,7 +14856,7 @@
     "tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha1-TKCakJLIi3OnzcXooBtQeweQoMw=",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
     "trim-newlines": {

--- a/server/historian/packages/historian-base/src/routes/summaries.ts
+++ b/server/historian/packages/historian-base/src/routes/summaries.ts
@@ -45,7 +45,9 @@ export function create(
     async function createSummary(
         tenantId: string,
         authorization: string,
-        params: IWholeSummaryPayload): Promise<IWriteSummaryResponse> {
+        params: IWholeSummaryPayload,
+        initial: boolean,
+    ): Promise<IWriteSummaryResponse> {
         const service = await utils.createGitService(
             config,
             tenantId,
@@ -53,7 +55,7 @@ export function create(
             tenantService,
             cache,
             asyncLocalStorage);
-        return service.createSummary(params);
+        return service.createSummary(params, initial);
     }
 
     async function deleteSummary(
@@ -92,7 +94,15 @@ export function create(
     router.post("/repos/:ignored?/:tenantId/git/summaries",
         throttle(throttler, winston, commonThrottleOptions),
         (request, response, next) => {
-            const summaryP = createSummary(request.params.tenantId, request.get("Authorization"), request.body);
+            const initial = typeof request.params.initial === "string"
+                ? request.params.initial === "true"
+                : undefined;
+            const summaryP = createSummary(
+                request.params.tenantId,
+                request.get("Authorization"),
+                request.body,
+                initial,
+            );
 
             utils.handleResponse(
                 summaryP,

--- a/server/historian/packages/historian-base/src/routes/summaries.ts
+++ b/server/historian/packages/historian-base/src/routes/summaries.ts
@@ -7,7 +7,6 @@ import { AsyncLocalStorage } from "async_hooks";
 import { IWholeFlatSummary, IWholeSummaryPayload, IWriteSummaryResponse } from "@fluidframework/server-services-client";
 import { IThrottler } from "@fluidframework/server-services-core";
 import { IThrottleMiddlewareOptions, throttle, getParam } from "@fluidframework/server-services-utils";
-import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
@@ -102,7 +101,7 @@ export function create(
                 : typeof request.query.initial === "boolean"
                     ? request.query.initial
                     : request.query.initial === "true";
-            Lumberjack.info("Writing summary", { initial, param: request.params.initial, params: request.params });
+
             const summaryP = createSummary(
                 request.params.tenantId,
                 request.get("Authorization"),

--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -211,7 +211,7 @@ export class RestGitService {
         const summaryResponse = await this.post<IWholeFlatSummary | IWriteSummaryResponse>(
             `/repos/${this.getRepoPath()}/git/summaries`,
             summaryParams,
-            { initial });
+            initial !== undefined ? { initial } : undefined);
         if (summaryParams.type === "container" && (summaryResponse as IWholeFlatSummary).trees !== undefined) {
             // Cache the written summary for future retrieval. If this fails, next summary retrieval
             // will receive an older version, but that is OK. Client will catch up with ops.

--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -207,10 +207,11 @@ export class RestGitService {
         return this.post(`/repos/${this.getRepoPath()}/git/refs`, params);
     }
 
-    public async createSummary(summaryParams: IWholeSummaryPayload): Promise<IWriteSummaryResponse> {
+    public async createSummary(summaryParams: IWholeSummaryPayload, initial?: boolean): Promise<IWriteSummaryResponse> {
         const summaryResponse = await this.post<IWholeFlatSummary | IWriteSummaryResponse>(
             `/repos/${this.getRepoPath()}/git/summaries`,
-            summaryParams);
+            summaryParams,
+            { initial });
         if (summaryParams.type === "container" && (summaryResponse as IWholeFlatSummary).trees !== undefined) {
             // Cache the written summary for future retrieval. If this fails, next summary retrieval
             // will receive an older version, but that is OK. Client will catch up with ops.
@@ -415,8 +416,8 @@ export class RestGitService {
             .catch(getRequestErrorTranslator(url, "GET", this.lumberProperties));
     }
 
-    private async post<T>(url: string, requestBody: any): Promise<T> {
-        return this.restWrapper.post<T>(url, requestBody, undefined, {
+    private async post<T>(url: string, requestBody: any, query?: Record<string, unknown>): Promise<T> {
+        return this.restWrapper.post<T>(url, requestBody, query, {
             "Content-Type": "application/json",
         }).catch(getRequestErrorTranslator(url, "POST", this.lumberProperties));
     }

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -550,7 +550,7 @@ export abstract class RestWrapper {
 export class SummaryTreeUploadManager implements ISummaryUploadManager {
     constructor(manager: IGitManager, blobsShaCache: Map<string, string>, getPreviousFullSnapshot: (parentHandle: string) => Promise<ISnapshotTreeEx | null | undefined>);
     // (undocumented)
-    writeSummaryTree(summaryTree: ISummaryTree_2, parentHandle: string): Promise<string>;
+    writeSummaryTree(summaryTree: ISummaryTree_2, parentHandle: string, summaryType: IWholeSummaryPayloadType, sequenceNumber?: number, initial?: boolean): Promise<string>;
 }
 
 // @public

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -100,7 +100,7 @@ export class GitManager implements IGitManager {
     // (undocumented)
     createRef(branch: string, sha: string): Promise<resources.IRef>;
     // (undocumented)
-    createSummary(summary: IWholeSummaryPayload): Promise<IWriteSummaryResponse>;
+    createSummary(summary: IWholeSummaryPayload, initial?: boolean): Promise<IWriteSummaryResponse>;
     // (undocumented)
     createTree(files: api.ITree): Promise<resources.ITree>;
     // (undocumented)
@@ -137,7 +137,7 @@ export class Historian implements IHistorian {
     // (undocumented)
     createRef(params: resources.ICreateRefParams): Promise<resources.IRef>;
     // (undocumented)
-    createSummary(summary: IWholeSummaryPayload): Promise<IWriteSummaryResponse>;
+    createSummary(summary: IWholeSummaryPayload, initial?: boolean): Promise<IWriteSummaryResponse>;
     // (undocumented)
     createTag(tag: resources.ICreateTagParams): Promise<resources.ITag>;
     // (undocumented)
@@ -235,7 +235,7 @@ export interface IGitManager {
     // (undocumented)
     createRef(branch: string, sha: string): Promise<resources.IRef>;
     // (undocumented)
-    createSummary(summary: IWholeSummaryPayload): Promise<IWriteSummaryResponse>;
+    createSummary(summary: IWholeSummaryPayload, initial?: boolean): Promise<IWriteSummaryResponse>;
     // (undocumented)
     createTree(files: api.ITree): Promise<resources.ITree>;
     // (undocumented)
@@ -275,7 +275,7 @@ export interface IGitService {
     // (undocumented)
     createRef(params: resources.ICreateRefParams): Promise<resources.IRef>;
     // (undocumented)
-    createSummary(summary: IWholeSummaryPayload): Promise<IWriteSummaryResponse>;
+    createSummary(summary: IWholeSummaryPayload, initial?: boolean): Promise<IWriteSummaryResponse>;
     // (undocumented)
     createTag(tag: resources.ICreateTagParams): Promise<resources.ITag>;
     // (undocumented)
@@ -550,7 +550,7 @@ export abstract class RestWrapper {
 export class SummaryTreeUploadManager implements ISummaryUploadManager {
     constructor(manager: IGitManager, blobsShaCache: Map<string, string>, getPreviousFullSnapshot: (parentHandle: string) => Promise<ISnapshotTreeEx | null | undefined>);
     // (undocumented)
-    writeSummaryTree(summaryTree: ISummaryTree_2, parentHandle: string, summaryType: IWholeSummaryPayloadType, sequenceNumber?: number): Promise<string>;
+    writeSummaryTree(summaryTree: ISummaryTree_2, parentHandle: string): Promise<string>;
 }
 
 // @public
@@ -572,7 +572,7 @@ export type WholeSummaryTreeValue = IWholeSummaryTree | IWholeSummaryBlob;
 export class WholeSummaryUploadManager implements ISummaryUploadManager {
     constructor(manager: IGitManager);
     // (undocumented)
-    writeSummaryTree(summaryTree: ISummaryTree, parentHandle: string | undefined, summaryType: IWholeSummaryPayloadType, sequenceNumber?: number): Promise<string>;
+    writeSummaryTree(summaryTree: ISummaryTree, parentHandle: string | undefined, summaryType: IWholeSummaryPayloadType, sequenceNumber?: number, initial?: boolean): Promise<string>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/server/routerlicious/lerna-package-lock.json
+++ b/server/routerlicious/lerna-package-lock.json
@@ -6982,7 +6982,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"color-string": {
 			"version": "1.9.1",
@@ -8398,7 +8398,7 @@
 		"defaults": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-			"integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 			"dev": true,
 			"requires": {
 				"clone": "^1.0.2"
@@ -8783,7 +8783,7 @@
 		"es6-object-assign": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-			"integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
+			"integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
 			"dev": true
 		},
 		"es6-promise": {
@@ -8814,7 +8814,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"eslint": {
 			"version": "8.27.0",
@@ -10691,7 +10691,7 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-property-descriptors": {
 			"version": "1.0.0",
@@ -11472,7 +11472,7 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-string": {
 			"version": "1.0.7",
@@ -15087,7 +15087,7 @@
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-			"integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
@@ -15689,7 +15689,7 @@
 		"parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
 			"dev": true,
 			"requires": {
 				"error-ex": "^1.3.1",
@@ -16539,7 +16539,7 @@
 		"retry": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
 			"dev": true
 		},
 		"reusify": {
@@ -18035,7 +18035,7 @@
 		"timsort": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-			"integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
+			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
 			"dev": true
 		},
 		"tmp": {

--- a/server/routerlicious/package-lock.json
+++ b/server/routerlicious/package-lock.json
@@ -4945,7 +4945,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
@@ -6053,7 +6053,7 @@
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
@@ -6318,7 +6318,7 @@
     "es6-object-assign": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
       "dev": true
     },
     "es6-promise": {
@@ -6345,7 +6345,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "esprima": {
@@ -7339,7 +7339,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-property-descriptors": {
@@ -8058,7 +8058,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-string": {
@@ -11073,7 +11073,7 @@
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
@@ -11593,7 +11593,7 @@
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
       "dev": true,
       "requires": {
         "error-ex": "^1.3.1",
@@ -12219,7 +12219,7 @@
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true
     },
     "reusify": {
@@ -13074,7 +13074,7 @@
     "timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
+      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
     "tmp": {

--- a/server/routerlicious/packages/services-client/src/gitManager.ts
+++ b/server/routerlicious/packages/services-client/src/gitManager.ts
@@ -141,7 +141,7 @@ export class GitManager implements IGitManager {
     }
 
     public async createSummary(summary: IWholeSummaryPayload, initial: boolean = false): Promise<IWriteSummaryResponse> {
-        return this.historian.createSummary(summary);
+        return this.historian.createSummary(summary, initial);
     }
 
     public async deleteSummary(softDelete: boolean): Promise<void> {

--- a/server/routerlicious/packages/services-client/src/gitManager.ts
+++ b/server/routerlicious/packages/services-client/src/gitManager.ts
@@ -140,7 +140,7 @@ export class GitManager implements IGitManager {
         return this.historian.createCommit(commit);
     }
 
-    public async createSummary(summary: IWholeSummaryPayload): Promise<IWriteSummaryResponse> {
+    public async createSummary(summary: IWholeSummaryPayload, initial: boolean = false): Promise<IWriteSummaryResponse> {
         return this.historian.createSummary(summary);
     }
 

--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -129,8 +129,12 @@ export class Historian implements IHistorian {
             `/git/trees/${encodeURIComponent(sha)}`,
             this.getQueryString({ recursive: recursive ? 1 : 0 }));
     }
-    public async createSummary(summary: IWholeSummaryPayload, initial: boolean = false): Promise<IWriteSummaryResponse> {
-        return this.restWrapper.post<IWriteSummaryResponse>(`/git/summaries`, summary, this.getQueryString({ initial }));
+    public async createSummary(summary: IWholeSummaryPayload, initial?: boolean): Promise<IWriteSummaryResponse> {
+        return this.restWrapper.post<IWriteSummaryResponse>(
+            `/git/summaries`,
+            summary,
+            this.getQueryString(initial === undefined ? undefined : { initial }),
+        );
     }
     public async deleteSummary(softDelete: boolean): Promise<void> {
         const headers = { "Soft-Delete": softDelete };

--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -79,8 +79,8 @@ export class Historian implements IHistorian {
     public async getCommits(sha: string, count: number): Promise<git.ICommitDetails[]> {
         return this.restWrapper.get<git.ICommitDetails[]>(
             `/commits`, this.getQueryString({ count, sha }))
-                .catch((error) => (error === 400 || error === 404) ?
-                    [] as git.ICommitDetails[] : Promise.reject<git.ICommitDetails[]>(error));
+            .catch((error) => (error === 400 || error === 404) ?
+                [] as git.ICommitDetails[] : Promise.reject<git.ICommitDetails[]>(error));
     }
 
     public async getCommit(sha: string): Promise<git.ICommit> {
@@ -129,8 +129,8 @@ export class Historian implements IHistorian {
             `/git/trees/${encodeURIComponent(sha)}`,
             this.getQueryString({ recursive: recursive ? 1 : 0 }));
     }
-    public async createSummary(summary: IWholeSummaryPayload): Promise<IWriteSummaryResponse> {
-        return this.restWrapper.post<IWriteSummaryResponse>(`/git/summaries`, summary, this.getQueryString());
+    public async createSummary(summary: IWholeSummaryPayload, initial: boolean = false): Promise<IWriteSummaryResponse> {
+        return this.restWrapper.post<IWriteSummaryResponse>(`/git/summaries`, summary, this.getQueryString({ initial }));
     }
     public async deleteSummary(softDelete: boolean): Promise<void> {
         const headers = { "Soft-Delete": softDelete };

--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -133,7 +133,7 @@ export class Historian implements IHistorian {
         return this.restWrapper.post<IWriteSummaryResponse>(
             `/git/summaries`,
             summary,
-            this.getQueryString(initial === undefined ? undefined : { initial }),
+            this.getQueryString(initial !== undefined ? { initial } : undefined),
         );
     }
     public async deleteSummary(softDelete: boolean): Promise<void> {

--- a/server/routerlicious/packages/services-client/src/storage.ts
+++ b/server/routerlicious/packages/services-client/src/storage.ts
@@ -73,7 +73,7 @@ export interface IGitService {
     getTag(tag: string): Promise<git.ITag>;
     createTree(tree: git.ICreateTreeParams): Promise<git.ITree>;
     getTree(sha: string, recursive: boolean): Promise<git.ITree>;
-    createSummary(summary: IWholeSummaryPayload): Promise<IWriteSummaryResponse>;
+    createSummary(summary: IWholeSummaryPayload, initial?: boolean): Promise<IWriteSummaryResponse>;
     deleteSummary(softDelete: boolean): Promise<void>;
     getSummary(sha: string): Promise<IWholeFlatSummary>;
 }
@@ -109,7 +109,7 @@ export interface IGitManager {
     createRef(branch: string, sha: string): Promise<git.IRef>;
     upsertRef(branch: string, commitSha: string): Promise<git.IRef>;
     write(branch: string, inputTree: api.ITree, parents: string[], message: string): Promise<git.ICommit>;
-    createSummary(summary: IWholeSummaryPayload): Promise<IWriteSummaryResponse>;
+    createSummary(summary: IWholeSummaryPayload, initial?: boolean): Promise<IWriteSummaryResponse>;
     deleteSummary(softDelete: boolean): Promise<void>;
     getSummary(sha: string): Promise<IWholeFlatSummary>;
 }

--- a/server/routerlicious/packages/services-client/src/summaryTreeUploadManager.ts
+++ b/server/routerlicious/packages/services-client/src/summaryTreeUploadManager.ts
@@ -13,6 +13,7 @@ import {
     SummaryType,
 } from "@fluidframework/protocol-definitions";
 import { ISummaryUploadManager, IGitManager } from "./storage";
+import { IWholeSummaryPayloadType } from "./storageContracts";
 
 /**
  * Recursively writes summary tree as individual summary blobs.
@@ -29,6 +30,9 @@ export class SummaryTreeUploadManager implements ISummaryUploadManager {
     public async writeSummaryTree(
         summaryTree: ISummaryTree,
         parentHandle: string,
+        summaryType: IWholeSummaryPayloadType,
+        sequenceNumber?: number,
+        initial?: boolean,
     ): Promise<string> {
         const previousFullSnapshot = await this.getPreviousFullSnapshot(parentHandle);
         return this.writeSummaryTreeCore(summaryTree, previousFullSnapshot ?? undefined);

--- a/server/routerlicious/packages/services-client/src/summaryTreeUploadManager.ts
+++ b/server/routerlicious/packages/services-client/src/summaryTreeUploadManager.ts
@@ -13,7 +13,6 @@ import {
     SummaryType,
 } from "@fluidframework/protocol-definitions";
 import { ISummaryUploadManager, IGitManager } from "./storage";
-import { IWholeSummaryPayloadType } from "./storageContracts";
 
 /**
  * Recursively writes summary tree as individual summary blobs.
@@ -30,8 +29,6 @@ export class SummaryTreeUploadManager implements ISummaryUploadManager {
     public async writeSummaryTree(
         summaryTree: ISummaryTree,
         parentHandle: string,
-        summaryType: IWholeSummaryPayloadType,
-        sequenceNumber?: number,
     ): Promise<string> {
         const previousFullSnapshot = await this.getPreviousFullSnapshot(parentHandle);
         return this.writeSummaryTreeCore(summaryTree, previousFullSnapshot ?? undefined);

--- a/server/routerlicious/packages/services-client/src/test/historian.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/historian.spec.ts
@@ -442,7 +442,7 @@ describe("Historian", () => {
     });
 
     describe("getTree", () => {
-        const url = getUrlWithToken(`/git/trees/${encodeURIComponent(sha)}`, initialCredentials, { recursive: 1});
+        const url = getUrlWithToken(`/git/trees/${encodeURIComponent(sha)}`, initialCredentials, { recursive: 1 });
         const response = mockTree;
         it("succeeds on 200", async () => {
             axiosMock.onGet(url).reply(mockReplyWithAuth(initialCredentials, response));
@@ -474,6 +474,18 @@ describe("Historian", () => {
         it("succeeds on 200", async () => {
             axiosMock.onPost(url, summaryPayload).reply(mockReplyWithAuth(initialCredentials, response));
             const received = await historian.createSummary(summaryPayload);
+            assert.deepStrictEqual(received, response);
+        });
+        it("succeeds with initial=true query param", async () => {
+            const initialUrl = getUrlWithToken(`/git/summaries`, initialCredentials, { initial: true });
+            axiosMock.onPost(initialUrl, summaryPayload).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.createSummary(summaryPayload, true);
+            assert.deepStrictEqual(received, response);
+        });
+        it("succeeds with initial=false query param", async () => {
+            const initialUrl = getUrlWithToken(`/git/summaries`, initialCredentials, { initial: false });
+            axiosMock.onPost(initialUrl, summaryPayload).reply(mockReplyWithAuth(initialCredentials, response));
+            const received = await historian.createSummary(summaryPayload, false);
             assert.deepStrictEqual(received, response);
         });
         it("retries once with new credentials on 401", async () => {

--- a/server/routerlicious/packages/services-client/src/wholeSummaryUploadManager.ts
+++ b/server/routerlicious/packages/services-client/src/wholeSummaryUploadManager.ts
@@ -14,7 +14,7 @@ import { convertSummaryTreeToWholeSummaryTree } from "./storageUtils";
 /**
  * Converts summary to snapshot tree and uploads with single snaphot tree payload.
  */
- export class WholeSummaryUploadManager implements ISummaryUploadManager {
+export class WholeSummaryUploadManager implements ISummaryUploadManager {
     constructor(
         private readonly manager: IGitManager,
     ) {
@@ -24,9 +24,10 @@ import { convertSummaryTreeToWholeSummaryTree } from "./storageUtils";
         summaryTree: ISummaryTree,
         parentHandle: string | undefined,
         summaryType: IWholeSummaryPayloadType,
-        sequenceNumber?: number,
+        sequenceNumber: number = 0,
+        initial: boolean = false,
     ): Promise<string> {
-        const id = await this.writeSummaryTreeCore(parentHandle, summaryTree, summaryType, sequenceNumber ?? 0);
+        const id = await this.writeSummaryTreeCore(parentHandle, summaryTree, summaryType, sequenceNumber, initial);
         if (!id) {
             throw new Error(`Failed to write summary tree`);
         }
@@ -38,6 +39,7 @@ import { convertSummaryTreeToWholeSummaryTree } from "./storageUtils";
         tree: ISummaryTree,
         type: IWholeSummaryPayloadType,
         sequenceNumber: number,
+        initial: boolean,
     ): Promise<string> {
         const snapshotTree = convertSummaryTreeToWholeSummaryTree(
             parentHandle,
@@ -52,6 +54,6 @@ import { convertSummaryTreeToWholeSummaryTree } from "./storageUtils";
             type,
         };
 
-        return this.manager.createSummary(snapshotPayload).then((response) => response.id);
+        return this.manager.createSummary(snapshotPayload, initial).then((response) => response.id);
     }
 }

--- a/server/routerlicious/packages/services-shared/src/storage.ts
+++ b/server/routerlicious/packages/services-shared/src/storage.ts
@@ -140,7 +140,13 @@ export class DocumentStorage implements IDocumentStorage {
         const initialSummaryUploadMetric =
             Lumberjack.newLumberMetric(LumberEventName.CreateDocInitialSummaryWrite, lumberjackProperties);
         try {
-            const handle = await uploadManager.writeSummaryTree(fullTree, "", "container", 0);
+            const handle = await uploadManager.writeSummaryTree(
+                fullTree, /* summaryTree */
+                "", /* parentHandle */
+                "container", /* summaryType */
+                0, /* sequenceNumber */
+                true, /* initial */
+            );
             let initialSummaryUploadSuccessMessage = `Tree reference: ${JSON.stringify(handle)}`;
 
             if (!this.enableWholeSummaryUpload) {
@@ -211,19 +217,19 @@ export class DocumentStorage implements IDocumentStorage {
         try {
             const collection = await this.databaseManager.getDocumentCollection();
             const result = await collection.findOrCreate(
-            {
-                documentId,
-                tenantId,
-            },
-            {
-                createTime: Date.now(),
-                deli: JSON.stringify(deli),
-                documentId,
-                session,
-                scribe: JSON.stringify(scribe),
-                tenantId,
-                version: "0.1",
-            });
+                {
+                    documentId,
+                    tenantId,
+                },
+                {
+                    createTime: Date.now(),
+                    deli: JSON.stringify(deli),
+                    documentId,
+                    session,
+                    scribe: JSON.stringify(scribe),
+                    tenantId,
+                    version: "0.1",
+                });
             updateDocumentCollectionMetric.success("Successfully updated document collection");
             return result;
         } catch (error: any) {


### PR DESCRIPTION
## Description

In AFR, we utilize Gitrest with a remote storage filesystem behind it. That means that every FS operation matters for performance, especially if the remote storage location is far away (e.g. WestUS AFR service to EastUS storage service).

The explicit read/writes in the Gitrest initial summary flow look like this (before and after this change):

### Current

Explicit Read/Writes (6 reads, 14+ writes):

1. OpenRepo
    1. Check if repo exists (1 read)
2. CreateRepo
    1. Check if repo exists (1 read)
    1. Init Repo (1 read, 10 writes)
3. CheckSoftDelete
    1. Check if repo contains .softDeleted file (1 read)
4. GetRef
    1. Check if refs/heads/documentId exists (1 read)
5. CreateBlob (1 write)
6. CreateTree (1 write)
7. CreateCommit (1 write)
8. CreateRef
    1. Checks if ref exists (1 read)
    2. Writes ref (1+ write)

### New

Explicit Read/Writes (0 reads, 7+ writes):

1. CreateRepo
    1. Init Repo (3 writes)
2. CreateBlob (1 write)
3. CreateTree (1 write)
4. CreateCommit (1 write)
5. CreateRef
    1. Writes ref (1+ write)

> **Disclaimer:** Explicit Read/Writes does not include internal implementation details for any given FS. For example, `mkdir` might do a read to check if a directory exists before writing it.

## Breaking Changes

None. There is 1 Public API change, but it is an additional optional param. All changes are backwards compatible.
