### PR TITLE
ci(build-tools): Check for conventional commit format in CI

### DIFF
--- a/.github/workflows/commit-validation.yml
+++ b/.github/workflows/commit-validation.yml
@@ -1,3 +1,8 @@
+# We've adopted conventional commits in the build-tools release group. The CI jobs in this file require the PR title and
+# body to match our standards and that PR template placeholder content has been removed from the PR body.
+#
+# More information can be found in the wiki: https://github.com/microsoft/FluidFramework/wiki/Commit-message-style
+
 name: "Commit message validation"
 on:
   pull_request:

--- a/.github/workflows/commit-validation.yml
+++ b/.github/workflows/commit-validation.yml
@@ -1,24 +1,20 @@
 name: "Commit message validation"
-
 on:
   pull_request:
     branches: [main, commitlint]
     paths: [
       # Commit validation in PRs applies to build-tools only as of now.
-      'build-tools/**',
-      '.github/workflows/commit-validation.yml'
-    ]
+      'build-tools/**', '.github/workflows/commit-validation.yml']
     types: [opened, synchronize, edited, ready_for_review]
-
 jobs:
   conventional-pr-title:
     name: PR title matches conventional commit format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # ratchet:pnpm/action-setup@v2.2.4
         with:
           version: 7
       - name: Install dependencies
@@ -27,19 +23,17 @@ jobs:
           # Only install the root dependencies since we don't need the whole workspace
           pnpm config set recursive-install false
           pnpm install --ignore-scripts
-
       # Lints the PR title according to the settings file in the repo
-      - uses: JulienKode/pull-request-name-linter-action@v0.5.0
+      - uses: JulienKode/pull-request-name-linter-action@8c05fb989d9f156ce61e33754f9802c9d3cffa58 # ratchet:JulienKode/pull-request-name-linter-action@v0.5.0
         name: Lint PR title
         with:
           configuration-path: build-tools/commitlint.config.cjs
-
   placeholder-content:
     name: PR template placeholder content
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: sitezen/pr-comment-checker@v1.0.1
+      # - uses: actions/checkout@v3
+      - uses: sitezen/pr-comment-checker@f1e956fac00c6d1163d15841886ae80b7ae58ecb # ratchet:sitezen/pr-comment-checker@v1.0.1
         with:
           pr_description_should_not_contain: |
             Feel free to remove or alter parts of this template that do not offer value for your specific change
@@ -47,4 +41,3 @@ jobs:
             Your PR description contains placeholder content from the PR template. Remove or replace the placeholder
             content. More information at:
             https://github.com/microsoft/FluidFramework/wiki/Commit-message-style#pr-template-content
-

--- a/.github/workflows/commit-validation.yml
+++ b/.github/workflows/commit-validation.yml
@@ -32,7 +32,6 @@ jobs:
     name: PR template placeholder content
     runs-on: ubuntu-latest
     steps:
-      # - uses: actions/checkout@v3
       - uses: sitezen/pr-comment-checker@f1e956fac00c6d1163d15841886ae80b7ae58ecb # ratchet:sitezen/pr-comment-checker@v1.0.1
         with:
           pr_description_should_not_contain: |

--- a/.github/workflows/commit-validation.yml
+++ b/.github/workflows/commit-validation.yml
@@ -1,0 +1,50 @@
+name: "Commit message validation"
+
+on:
+  pull_request:
+    branches: [main, commitlint]
+    paths: [
+      # Commit validation in PRs applies to build-tools only as of now.
+      'build-tools/**',
+      '.github/workflows/commit-validation.yml'
+    ]
+    types: [opened, synchronize, edited, ready_for_review]
+
+jobs:
+  conventional-pr-title:
+    name: PR title matches conventional commit format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 7
+      - name: Install dependencies
+        working-directory: build-tools
+        run: |
+          # Only install the root dependencies since we don't need the whole workspace
+          pnpm config set recursive-install false
+          pnpm install --ignore-scripts
+
+      # Lints the PR title according to the settings file in the repo
+      - uses: JulienKode/pull-request-name-linter-action@v0.5.0
+        name: Lint PR title
+        with:
+          configuration-path: build-tools/commitlint.config.cjs
+
+  placeholder-content:
+    name: PR template placeholder content
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: sitezen/pr-comment-checker@v1.0.1
+        with:
+          pr_description_should_not_contain: |
+            Feel free to remove or alter parts of this template that do not offer value for your specific change
+          wrong_pr_description_message: |
+            Your PR description contains placeholder content from the PR template. Remove or replace the placeholder
+            content. More information at:
+            https://github.com/microsoft/FluidFramework/wiki/Commit-message-style#pr-template-content
+

--- a/build-tools/commitlint.config.cjs
+++ b/build-tools/commitlint.config.cjs
@@ -6,7 +6,7 @@
 module.exports = {
     extends: ['@commitlint/config-conventional'],
     rules: {
-        'body-case': [1, 'sentence-case', 'always'],
-        'subject-case': [1, 'sentence-case', 'always'],
-    }
+        'body-case': [2, 'always', 'sentence-case'],
+        'subject-case': [2, 'always', 'sentence-case'],
+    },
 };

--- a/build-tools/commitlint.config.cjs
+++ b/build-tools/commitlint.config.cjs
@@ -4,5 +4,9 @@
  */
 
 module.exports = {
-    extends: ['@commitlint/config-conventional']
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+        'body-case': [1, 'sentence-case', 'always'],
+        'subject-case': [1, 'sentence-case', 'always'],
+    }
 };

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -33,7 +33,7 @@
     "format": "lerna run format --parallel --no-sort --stream",
     "preinstall": "npx only-allow pnpm",
     "postinstall": "npm run build:compile",
-    "install:root": "pnpm install --ignore-scripts",
+    "install:commitlint": "npm install --global @commitlint/config-conventional",
     "lint": "lerna run lint --no-sort --stream",
     "lint:fix": "lerna run lint:fix --no-sort --stream",
     "policy-check": "node packages/build-cli/bin/dev check policy --exclusions packages/build-tools/data/exclusions.json",


### PR DESCRIPTION
We've adopted conventional commits in the build-tools release group. This PR adds some CI jobs that will require the PR title and body to match our standards. It will also require PR template placeholder content to be removed from the PR body.

More in the wiki: <https://github.com/microsoft/FluidFramework/wiki/Commit-message-style>