### PR TITLE
Log telemetry event on container dispose

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -846,8 +846,9 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 // This gives us a chance to know what errors happened on open vs. on fully loaded container.
                 this.mc.logger.sendTelemetryEvent(
                     {
-                        eventName: "ContainerDispose",
+                        eventName: "ContainerClose",
                         category: error === undefined ? "generic" : "error",
+                        disposed: true, // This property distinguishes the log from standard ContainerClose
                     },
                     error,
                 );

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -846,9 +846,8 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 // This gives us a chance to know what errors happened on open vs. on fully loaded container.
                 this.mc.logger.sendTelemetryEvent(
                     {
-                        eventName: "ContainerClose",
+                        eventName: "ContainerDispose",
                         category: error === undefined ? "generic" : "error",
-                        disposed: true, // This property distinguishes the log from standard ContainerClose
                     },
                     error,
                 );

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -842,6 +842,16 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
         try {
             // Ensure that we raise all key events even if one of these throws
             try {
+                // Raise event first, to ensure we capture _lifecycleState before transition.
+                // This gives us a chance to know what errors happened on open vs. on fully loaded container.
+                this.mc.logger.sendTelemetryEvent(
+                    {
+                        eventName: "ContainerDispose",
+                        category: "generic",
+                    },
+                    error,
+                );
+
                 // ! Progressing from "closed" to "disposing" is not allowed
                 if (this._lifecycleState !== "closed") {
                     this._lifecycleState = "disposing";

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -847,7 +847,7 @@ export class Container extends EventEmitterWithErrorHandling<IContainerEvents> i
                 this.mc.logger.sendTelemetryEvent(
                     {
                         eventName: "ContainerDispose",
-                        category: "generic",
+                        category: error === undefined ? "generic" : "error",
                     },
                     error,
                 );

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -630,7 +630,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
             this.disposeInternal(error);
         } else {
             this.emit("closed", error);
-            this.disposeInternal(error); // ! TODO: remove this call in 2.0.0-internal.3.0.0 (when closed no longer disposes)
+            this.disposeInternal(error); // ! TODO: remove this call when Container close no longer disposes
         }
     }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -762,7 +762,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                 if (loadSequenceNumberVerification === "log") {
                     logger.sendErrorEvent({ eventName: "SequenceNumberMismatch" }, error);
                 } else {
-                    // Call both close and dispose as close implementation will no longer dispose runtime in future (2.0.0-internal.3.0.0)
+                    // Call both close and dispose as closeFn implementation will no longer dispose runtime in future
                     context.closeFn(error);
                     context.disposeFn?.(error);
                 }

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -160,7 +160,7 @@ export class Summarizer extends EventEmitter implements ISummarizer {
         // This will result in "summarizerClientDisconnected" stop reason recorded in telemetry,
         // unless stop() was called earlier
         this.dispose();
-        (this.runtime.disposeFn ?? this.runtime.closeFn)()
+        (this.runtime.disposeFn ?? this.runtime.closeFn)();
     }
 
     private async runCore(onBehalfOf: string): Promise<SummarizerStopReason> {

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -50,7 +50,7 @@ const usageErrorMessage = "Empty file summary creation isn't supported in this d
 
 const containerCloseAndDisposeUsageErrors = [
     { eventName: "fluid:telemetry:Container:ContainerClose", error: usageErrorMessage },
-    { eventName: "fluid:telemetry:Container:ContainerClose", error: usageErrorMessage, disposed: true },
+    { eventName: "fluid:telemetry:Container:ContainerDispose", error: usageErrorMessage },
 ];
 const ContainerCloseUsageError: ExpectedEvents = {
     local: containerCloseAndDisposeUsageErrors,

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -48,10 +48,14 @@ const testContainerConfig: ITestContainerConfig = {
 
 const usageErrorMessage = "Empty file summary creation isn't supported in this driver.";
 
+const containerCloseAndDisposeUsageErrors = [
+    { eventName: "fluid:telemetry:Container:ContainerClose", error: usageErrorMessage },
+    { eventName: "fluid:telemetry:Container:ContainerDispose", error: usageErrorMessage },
+];
 const ContainerCloseUsageError: ExpectedEvents = {
-    local: [{ eventName: "fluid:telemetry:Container:ContainerClose", error: usageErrorMessage }],
-    routerlicious: [{ eventName: "fluid:telemetry:Container:ContainerClose", error: usageErrorMessage }],
-    tinylicious: [{ eventName: "fluid:telemetry:Container:ContainerClose", error: usageErrorMessage }],
+    local: containerCloseAndDisposeUsageErrors,
+    routerlicious: containerCloseAndDisposeUsageErrors,
+    tinylicious: containerCloseAndDisposeUsageErrors,
 };
 
 describeFullCompat("blobs", (getTestObjectProvider) => {

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -50,7 +50,7 @@ const usageErrorMessage = "Empty file summary creation isn't supported in this d
 
 const containerCloseAndDisposeUsageErrors = [
     { eventName: "fluid:telemetry:Container:ContainerClose", error: usageErrorMessage },
-    { eventName: "fluid:telemetry:Container:ContainerDispose", error: usageErrorMessage },
+    { eventName: "fluid:telemetry:Container:ContainerClose", error: usageErrorMessage, disposed: true },
 ];
 const ContainerCloseUsageError: ExpectedEvents = {
     local: containerCloseAndDisposeUsageErrors,

--- a/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
@@ -128,9 +128,9 @@ describeNoCompat("CodeProposal.EndToEnd", (getTestObjectProvider) => {
     itExpects("Code Proposal",
     [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "Existing context does not satisfy incoming proposal" },
-        { eventName: "fluid:telemetry:Container:ContainerClose", error: "Existing context does not satisfy incoming proposal", disposed: true },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "Existing context does not satisfy incoming proposal" },
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "Existing context does not satisfy incoming proposal" },
-        { eventName: "fluid:telemetry:Container:ContainerClose", error: "Existing context does not satisfy incoming proposal", disposed: true },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "Existing context does not satisfy incoming proposal" },
     ],
     async () => {
         const proposal: IFluidCodeDetails = { package: packageV2 };

--- a/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
@@ -128,9 +128,9 @@ describeNoCompat("CodeProposal.EndToEnd", (getTestObjectProvider) => {
     itExpects("Code Proposal",
     [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "Existing context does not satisfy incoming proposal" },
-        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "Existing context does not satisfy incoming proposal" },
+        { eventName: "fluid:telemetry:Container:ContainerClose", error: "Existing context does not satisfy incoming proposal", disposed: true },
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "Existing context does not satisfy incoming proposal" },
-        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "Existing context does not satisfy incoming proposal" },
+        { eventName: "fluid:telemetry:Container:ContainerClose", error: "Existing context does not satisfy incoming proposal", disposed: true },
     ],
     async () => {
         const proposal: IFluidCodeDetails = { package: packageV2 };

--- a/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/codePropsal.spec.ts
@@ -128,7 +128,9 @@ describeNoCompat("CodeProposal.EndToEnd", (getTestObjectProvider) => {
     itExpects("Code Proposal",
     [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "Existing context does not satisfy incoming proposal" },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "Existing context does not satisfy incoming proposal" },
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "Existing context does not satisfy incoming proposal" },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "Existing context does not satisfy incoming proposal" },
     ],
     async () => {
         const proposal: IFluidCodeDetails = { package: packageV2 };

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -139,6 +139,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
         "Load container unsuccessfully",
         [
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "expectedFailure" },
+            { eventName: "fluid:telemetry:Container:ContainerDispose", error: "expectedFailure" },
             { eventName: "TestException", error: "expectedFailure", errorType: ContainerErrorType.genericError },
         ],
         async () => {
@@ -159,6 +160,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
     [
         { eventName: "fluid:telemetry:DeltaManager:GetDeltas_Exception", error: "expectedFailure" },
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "expectedFailure" },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "expectedFailure" },
         { eventName: "TestException", error: "expectedFailure", errorType: ContainerErrorType.genericError },
     ],
     async () => {

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -139,7 +139,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
         "Load container unsuccessfully",
         [
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "expectedFailure" },
-            { eventName: "fluid:telemetry:Container:ContainerClose", error: "expectedFailure", disposed: true },
+            { eventName: "fluid:telemetry:Container:ContainerDispose", error: "expectedFailure" },
             { eventName: "TestException", error: "expectedFailure", errorType: ContainerErrorType.genericError },
         ],
         async () => {
@@ -160,7 +160,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
     [
         { eventName: "fluid:telemetry:DeltaManager:GetDeltas_Exception", error: "expectedFailure" },
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "expectedFailure" },
-        { eventName: "fluid:telemetry:Container:ContainerClose", error: "expectedFailure", disposed: true },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "expectedFailure" },
         { eventName: "TestException", error: "expectedFailure", errorType: ContainerErrorType.genericError },
     ],
     async () => {

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -139,7 +139,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
         "Load container unsuccessfully",
         [
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "expectedFailure" },
-            { eventName: "fluid:telemetry:Container:ContainerDispose", error: "expectedFailure" },
+            { eventName: "fluid:telemetry:Container:ContainerClose", error: "expectedFailure", disposed: true },
             { eventName: "TestException", error: "expectedFailure", errorType: ContainerErrorType.genericError },
         ],
         async () => {
@@ -160,7 +160,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
     [
         { eventName: "fluid:telemetry:DeltaManager:GetDeltas_Exception", error: "expectedFailure" },
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "expectedFailure" },
-        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "expectedFailure" },
+        { eventName: "fluid:telemetry:Container:ContainerClose", error: "expectedFailure", disposed: true },
         { eventName: "TestException", error: "expectedFailure", errorType: ContainerErrorType.genericError },
     ],
     async () => {

--- a/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -187,9 +187,10 @@ describeNoCompat("SharedCounter orderSequentially", (getTestObjectProvider) => {
             errorType: ContainerErrorType.dataProcessingError,
         },
         {
-            eventName: "fluid:telemetry:Container:ContainerDispose",
+            eventName: "fluid:telemetry:Container:ContainerClose",
             error: "RollbackError: rollback not supported",
             errorType: ContainerErrorType.dataProcessingError,
+            disposed: true,
         },
     ],
     async () => {

--- a/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -187,10 +187,9 @@ describeNoCompat("SharedCounter orderSequentially", (getTestObjectProvider) => {
             errorType: ContainerErrorType.dataProcessingError,
         },
         {
-            eventName: "fluid:telemetry:Container:ContainerClose",
+            eventName: "fluid:telemetry:Container:ContainerDispose",
             error: "RollbackError: rollback not supported",
             errorType: ContainerErrorType.dataProcessingError,
-            disposed: true,
         },
     ],
     async () => {

--- a/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -186,6 +186,11 @@ describeNoCompat("SharedCounter orderSequentially", (getTestObjectProvider) => {
             error: "RollbackError: rollback not supported",
             errorType: ContainerErrorType.dataProcessingError,
         },
+        {
+            eventName: "fluid:telemetry:Container:ContainerDispose",
+            error: "RollbackError: rollback not supported",
+            errorType: ContainerErrorType.dataProcessingError,
+        },
     ],
     async () => {
         let error: Error | undefined;

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -655,6 +655,7 @@ describeNoCompat("Detached Container", (getTestObjectProvider) => {
 
     itExpects("Container should be closed on failed attach with non retryable error", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "Test Error" },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "Test Error" },
     ], async () => {
         const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
 

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -655,7 +655,7 @@ describeNoCompat("Detached Container", (getTestObjectProvider) => {
 
     itExpects("Container should be closed on failed attach with non retryable error", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "Test Error" },
-        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "Test Error" },
+        { eventName: "fluid:telemetry:Container:ContainerClose", error: "Test Error", disposed: true },
     ], async () => {
         const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
 

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -655,7 +655,7 @@ describeNoCompat("Detached Container", (getTestObjectProvider) => {
 
     itExpects("Container should be closed on failed attach with non retryable error", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "Test Error" },
-        { eventName: "fluid:telemetry:Container:ContainerClose", error: "Test Error", disposed: true },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "Test Error" },
     ], async () => {
         const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
 

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -81,11 +81,10 @@ describeNoCompat("Errors Types", (getTestObjectProvider) => {
                 fatalConnectError: true,
             },
             {
-                eventName: "fluid:telemetry:Container:ContainerClose",
+                eventName: "fluid:telemetry:Container:ContainerDispose",
                 errorType: ContainerErrorType.genericError,
                 error: "Injected error",
                 fatalConnectError: true,
-                disposed: true,
             },
         ],
         async () => {

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -80,6 +80,12 @@ describeNoCompat("Errors Types", (getTestObjectProvider) => {
                 error: "Injected error",
                 fatalConnectError: true,
             },
+            {
+                eventName: "fluid:telemetry:Container:ContainerDispose",
+                errorType: ContainerErrorType.genericError,
+                error: "Injected error",
+                fatalConnectError: true,
+            },
         ],
         async () => {
             try {

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -81,10 +81,11 @@ describeNoCompat("Errors Types", (getTestObjectProvider) => {
                 fatalConnectError: true,
             },
             {
-                eventName: "fluid:telemetry:Container:ContainerDispose",
+                eventName: "fluid:telemetry:Container:ContainerClose",
                 errorType: ContainerErrorType.genericError,
                 error: "Injected error",
                 fatalConnectError: true,
+                disposed: true,
             },
         ],
         async () => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -261,9 +261,10 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
                 errorType: "dataCorruptionError",
             },
             {
-                eventName: "fluid:telemetry:Container:ContainerDispose",
+                eventName: "fluid:telemetry:Container:ContainerClose",
                 error: "Context is tombstoned! Call site [process]",
                 errorType: "dataCorruptionError",
+                disposed: true,
             },
         ],
         async () => {
@@ -315,9 +316,10 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
                 errorType: "dataCorruptionError",
             },
             {
-                eventName: "fluid:telemetry:Container:ContainerDispose",
+                eventName: "fluid:telemetry:Container:ContainerClose",
                 error: "Context is tombstoned! Call site [process]",
                 errorType: "dataCorruptionError",
+                disposed: true,
             },
         ],
         async () => {
@@ -399,9 +401,10 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
                 errorType: "dataCorruptionError",
             },
             {
-                eventName: "fluid:telemetry:Container:ContainerDispose",
+                eventName: "fluid:telemetry:Container:ContainerClose",
                 error: "Context is tombstoned! Call site [processSignal]",
                 errorType: "dataCorruptionError",
+                disposed: true,
             },
         ],
         async () => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -260,6 +260,11 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
                 error: "Context is tombstoned! Call site [process]",
                 errorType: "dataCorruptionError",
             },
+            {
+                eventName: "fluid:telemetry:Container:ContainerDispose",
+                error: "Context is tombstoned! Call site [process]",
+                errorType: "dataCorruptionError",
+            },
         ],
         async () => {
             const {
@@ -306,6 +311,11 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             },
             {
                 eventName: "fluid:telemetry:Container:ContainerClose",
+                error: "Context is tombstoned! Call site [process]",
+                errorType: "dataCorruptionError",
+            },
+            {
+                eventName: "fluid:telemetry:Container:ContainerDispose",
                 error: "Context is tombstoned! Call site [process]",
                 errorType: "dataCorruptionError",
             },
@@ -385,6 +395,11 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             },
             {
                 eventName: "fluid:telemetry:Container:ContainerClose",
+                error: "Context is tombstoned! Call site [processSignal]",
+                errorType: "dataCorruptionError",
+            },
+            {
+                eventName: "fluid:telemetry:Container:ContainerDispose",
                 error: "Context is tombstoned! Call site [processSignal]",
                 errorType: "dataCorruptionError",
             },

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -261,10 +261,9 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
                 errorType: "dataCorruptionError",
             },
             {
-                eventName: "fluid:telemetry:Container:ContainerClose",
+                eventName: "fluid:telemetry:Container:ContainerDispose",
                 error: "Context is tombstoned! Call site [process]",
                 errorType: "dataCorruptionError",
-                disposed: true,
             },
         ],
         async () => {
@@ -316,10 +315,9 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
                 errorType: "dataCorruptionError",
             },
             {
-                eventName: "fluid:telemetry:Container:ContainerClose",
+                eventName: "fluid:telemetry:Container:ContainerDispose",
                 error: "Context is tombstoned! Call site [process]",
                 errorType: "dataCorruptionError",
-                disposed: true,
             },
         ],
         async () => {
@@ -401,10 +399,9 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
                 errorType: "dataCorruptionError",
             },
             {
-                eventName: "fluid:telemetry:Container:ContainerClose",
+                eventName: "fluid:telemetry:Container:ContainerDispose",
                 error: "Context is tombstoned! Call site [processSignal]",
                 errorType: "dataCorruptionError",
-                disposed: true,
             },
         ],
         async () => {

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -98,6 +98,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
     itExpects("A large op will close the container", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
     ], async () => {
         const maxMessageSizeInBytes = 1024 * 1024; // 1Mb
         await setupContainers(testContainerConfig);
@@ -189,6 +190,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
     itExpects("Large ops fail when compression is disabled and the content is over max op size", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
     ], async function() {
         const maxMessageSizeInBytes = 5 * 1024 * 1024; // 5MB
         await setupContainers(testContainerConfig); // Compression is disabled by default
@@ -201,6 +203,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
     itExpects("Large ops fail when compression is disabled by feature gate and the content is over max op size", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
     ], async function() {
         const maxMessageSizeInBytes = 5 * 1024 * 1024; // 5MB
         await setupContainers({
@@ -220,6 +223,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
     itExpects("Large ops fail when compression enabled and compressed content is over max op size", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
     ], async function() {
         const maxMessageSizeInBytes = 5 * 1024 * 1024; // 5MB
         await setupContainers({
@@ -273,6 +277,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
         itExpects("Large ops fail when compression chunking is disabled by feature gate", [
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
+            { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
         ], async function() {
             const maxMessageSizeInBytes = 5 * 1024 * 1024; // 5MB
             await setupContainers(

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -98,7 +98,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
     itExpects("A large op will close the container", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
-        { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge", disposed: true },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
     ], async () => {
         const maxMessageSizeInBytes = 1024 * 1024; // 1Mb
         await setupContainers(testContainerConfig);
@@ -190,7 +190,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
     itExpects("Large ops fail when compression is disabled and the content is over max op size", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
-        { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge", disposed: true },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
     ], async function() {
         const maxMessageSizeInBytes = 5 * 1024 * 1024; // 5MB
         await setupContainers(testContainerConfig); // Compression is disabled by default
@@ -203,7 +203,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
     itExpects("Large ops fail when compression is disabled by feature gate and the content is over max op size", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
-        { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge", disposed: true },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
     ], async function() {
         const maxMessageSizeInBytes = 5 * 1024 * 1024; // 5MB
         await setupContainers({
@@ -223,7 +223,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
     itExpects("Large ops fail when compression enabled and compressed content is over max op size", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
-        { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge", disposed: true },
+        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
     ], async function() {
         const maxMessageSizeInBytes = 5 * 1024 * 1024; // 5MB
         await setupContainers({
@@ -277,7 +277,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
         itExpects("Large ops fail when compression chunking is disabled by feature gate", [
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
-            { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge", disposed: true },
+            { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
         ], async function() {
             const maxMessageSizeInBytes = 5 * 1024 * 1024; // 5MB
             await setupContainers(

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -98,7 +98,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
     itExpects("A large op will close the container", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
-        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
+        { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge", disposed: true },
     ], async () => {
         const maxMessageSizeInBytes = 1024 * 1024; // 1Mb
         await setupContainers(testContainerConfig);
@@ -190,7 +190,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
     itExpects("Large ops fail when compression is disabled and the content is over max op size", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
-        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
+        { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge", disposed: true },
     ], async function() {
         const maxMessageSizeInBytes = 5 * 1024 * 1024; // 5MB
         await setupContainers(testContainerConfig); // Compression is disabled by default
@@ -203,7 +203,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
     itExpects("Large ops fail when compression is disabled by feature gate and the content is over max op size", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
-        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
+        { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge", disposed: true },
     ], async function() {
         const maxMessageSizeInBytes = 5 * 1024 * 1024; // 5MB
         await setupContainers({
@@ -223,7 +223,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
     itExpects("Large ops fail when compression enabled and compressed content is over max op size", [
         { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
-        { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
+        { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge", disposed: true },
     ], async function() {
         const maxMessageSizeInBytes = 5 * 1024 * 1024; // 5MB
         await setupContainers({
@@ -277,7 +277,7 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 
         itExpects("Large ops fail when compression chunking is disabled by feature gate", [
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" },
-            { eventName: "fluid:telemetry:Container:ContainerDispose", error: "BatchTooLarge" },
+            { eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge", disposed: true },
         ], async function() {
             const maxMessageSizeInBytes = 5 * 1024 * 1024; // 5MB
             await setupContainers(

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -293,9 +293,9 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
 
         const events = [
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "malformedDataStoreAliasMessage" },
-            { eventName: "fluid:telemetry:Container:ContainerClose", error: "malformedDataStoreAliasMessage", disposed: true },
+            { eventName: "fluid:telemetry:Container:ContainerDispose", error: "malformedDataStoreAliasMessage" },
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "malformedDataStoreAliasMessage" },
-            { eventName: "fluid:telemetry:Container:ContainerClose", error: "malformedDataStoreAliasMessage", disposed: true },
+            { eventName: "fluid:telemetry:Container:ContainerDispose", error: "malformedDataStoreAliasMessage" },
         ];
         itExpects("Receiving a bad alias message breaks the container", events, async function() {
             const dataCorruption = allDataCorruption([container1, container2]);

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -293,9 +293,9 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
 
         const events = [
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "malformedDataStoreAliasMessage" },
-            { eventName: "fluid:telemetry:Container:ContainerDispose", error: "malformedDataStoreAliasMessage" },
+            { eventName: "fluid:telemetry:Container:ContainerClose", error: "malformedDataStoreAliasMessage", disposed: true },
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "malformedDataStoreAliasMessage" },
-            { eventName: "fluid:telemetry:Container:ContainerDispose", error: "malformedDataStoreAliasMessage" },
+            { eventName: "fluid:telemetry:Container:ContainerClose", error: "malformedDataStoreAliasMessage", disposed: true },
         ];
         itExpects("Receiving a bad alias message breaks the container", events, async function() {
             const dataCorruption = allDataCorruption([container1, container2]);

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -293,7 +293,9 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
 
         const events = [
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "malformedDataStoreAliasMessage" },
+            { eventName: "fluid:telemetry:Container:ContainerDispose", error: "malformedDataStoreAliasMessage" },
             { eventName: "fluid:telemetry:Container:ContainerClose", error: "malformedDataStoreAliasMessage" },
+            { eventName: "fluid:telemetry:Container:ContainerDispose", error: "malformedDataStoreAliasMessage" },
         ];
         itExpects("Receiving a bad alias message breaks the container", events, async function() {
             const dataCorruption = allDataCorruption([container1, container2]);


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

Disposing Container should log a telemetry event like closing a Container does. These events are critical for investigations.
See https://github.com/microsoft/FluidFramework/pull/13617