### PR TITLE
log first error in runWithRetry

### DIFF
--- a/packages/drivers/odsp-driver/src/retryUtils.ts
+++ b/packages/drivers/odsp-driver/src/retryUtils.ts
@@ -44,15 +44,14 @@ export async function runWithRetry<T>(
             const coherencyError = error?.[Odsp409Error] === true;
             const serviceReadonlyError = error?.errorType === OdspErrorType.serviceReadOnly;
 
+            // logging the first failed retry
             if(attempts === 1){
-                logger.sendTelemetryEvent(
-                    {
+                logger.sendTelemetryEvent({
                         eventName: `${callName}_firstFailed`,
                         callName,
                         attempts,
                         duration: performance.now() - start, // record total wait time.
-                    },
-                    error);
+                    }, error);
             }
 
             // Retry for retriable 409 coherency errors or serviceReadOnly errors. These errors are always retriable

--- a/packages/drivers/odsp-driver/src/retryUtils.ts
+++ b/packages/drivers/odsp-driver/src/retryUtils.ts
@@ -44,8 +44,10 @@ export async function runWithRetry<T>(
             const coherencyError = error?.[Odsp409Error] === true;
             const serviceReadonlyError = error?.errorType === OdspErrorType.serviceReadOnly;
 
-            // logging the first failed retry
-            if(attempts === 1){
+            // logging the first failed retry instead of every attempt. We want to avoid filling telemetry
+            // when we have tight loop of retrying in offline mode, but we also want to know what caused
+            // the failure in the first place
+            if(attempts === 1) {
                 logger.sendTelemetryEvent({
                         eventName: `${callName}_firstFailed`,
                         callName,

--- a/packages/drivers/odsp-driver/src/retryUtils.ts
+++ b/packages/drivers/odsp-driver/src/retryUtils.ts
@@ -43,6 +43,18 @@ export async function runWithRetry<T>(
 
             const coherencyError = error?.[Odsp409Error] === true;
             const serviceReadonlyError = error?.errorType === OdspErrorType.serviceReadOnly;
+
+            if(attempts === 1){
+                logger.sendTelemetryEvent(
+                    {
+                        eventName: `${callName}_firstFailed`,
+                        callName,
+                        attempts,
+                        duration: performance.now() - start, // record total wait time.
+                    },
+                    error);
+            }
+
             // Retry for retriable 409 coherency errors or serviceReadOnly errors. These errors are always retriable
             // unless someone specifically set canRetry = false on the error like in fetchSnapshot() flow. So in
             // that case don't retry.

--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -84,6 +84,13 @@ export async function runWithRetry<T>(
                 );
             }
 
+            if(numRetries === 0) {
+                logger.sendTelemetryEvent({
+                    eventName: `${fetchCallName}_firstFailed`,
+                    duration: performance.now() - startTime,
+                    fetchCallName,
+                }, err);
+            }
             numRetries++;
             lastError = err;
             // If the error is throttling error, then wait for the specified time before retrying.

--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -84,6 +84,7 @@ export async function runWithRetry<T>(
                 );
             }
 
+            // logging the first failed retry
             if(numRetries === 0) {
                 logger.sendTelemetryEvent({
                     eventName: `${fetchCallName}_firstFailed`,
@@ -91,6 +92,7 @@ export async function runWithRetry<T>(
                     fetchCallName,
                 }, err);
             }
+
             numRetries++;
             lastError = err;
             // If the error is throttling error, then wait for the specified time before retrying.

--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -84,7 +84,9 @@ export async function runWithRetry<T>(
                 );
             }
 
-            // logging the first failed retry
+            // logging the first failed retry instead of every attempt. We want to avoid filling telemetry
+            // when we have tight loop of retrying in offline mode, but we also want to know what caused
+            // the failure in the first place
             if(numRetries === 0) {
                 logger.sendTelemetryEvent({
                     eventName: `${fetchCallName}_firstFailed`,


### PR DESCRIPTION
## Description

Log the first failed attempt in runWithRetry so when we have a ton of retries we can have more information on what caused it in the first place

