### PR TITLE
Tree: Add node count to Delta.MoveIn

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -930,6 +930,8 @@ type MoveId_2 = ChangesetLocalId;
 
 // @public
 interface MoveIn {
+    // (undocumented)
+    readonly count: number;
     readonly moveId: MoveId;
     // (undocumented)
     readonly type: typeof MarkType.MoveIn;

--- a/packages/dds/tree/src/core/tree/delta.ts
+++ b/packages/dds/tree/src/core/tree/delta.ts
@@ -223,6 +223,7 @@ export interface ModifyAndMoveOut<TTree = ProtoNode> {
  */
 export interface MoveIn {
     readonly type: typeof MarkType.MoveIn;
+    readonly count: number;
     /**
      * The delta should carry exactly one `MoveOut` mark with the same move ID.
      */

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
@@ -68,6 +68,7 @@ function convertMarkList(marks: T.MarkList): Delta.MarkList {
                 case "MoveIn": {
                     const moveMark: Delta.MoveIn = {
                         type: Delta.MarkType.MoveIn,
+                        count: mark.count,
                         moveId: brandOpaque<Delta.MoveId>(mark.id),
                     };
                     out.pushContent(moveMark);

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceEditBuilder.ts
@@ -80,8 +80,8 @@ export class SequenceEditBuilder extends ProgressiveEditBuilderBase<SequenceChan
                         const id2 = this.opId++;
                         marks.push(
                             { type: "MoveOut", id, count: gap },
-                            { type: "MoveIn", id, count: count - gap },
-                            { type: "MoveIn", id: id2, count: gap },
+                            { type: "MoveIn", id, count: gap },
+                            { type: "MoveIn", id: id2, count: count - gap },
                             { type: "MoveOut", id: id2, count: count - gap },
                         );
                     } else {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -45,6 +45,7 @@ export function sequenceFieldToDelta<TNodeChange>(
                 case "ReturnTo": {
                     const moveMark: Delta.MoveIn = {
                         type: Delta.MarkType.MoveIn,
+                        count: mark.count,
                         moveId: brandOpaque<Delta.MoveId>(mark.id),
                     };
                     out.pushContent(moveMark);

--- a/packages/dds/tree/src/test/feature-libraries/deltaUtils.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/deltaUtils.spec.ts
@@ -87,6 +87,7 @@ describe("DeltaUtils", () => {
                         {
                             type: Delta.MarkType.MoveIn,
                             moveId,
+                            count: 1,
                         },
                         {
                             type: Delta.MarkType.MoveOut,
@@ -155,6 +156,7 @@ describe("DeltaUtils", () => {
                         {
                             type: Delta.MarkType.MoveIn,
                             moveId,
+                            count: 1,
                         },
                         {
                             type: Delta.MarkType.MoveOut,

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
@@ -194,6 +194,7 @@ describe("SequenceField - toDelta", () => {
         const moveIn: Delta.MoveIn = {
             type: Delta.MarkType.MoveIn,
             moveId: deltaMoveId,
+            count: 10,
         };
         const expected: Delta.MarkList = [42, moveOut, 8, moveIn];
         const actual = toDelta(changeset);
@@ -283,7 +284,7 @@ describe("SequenceField - toDelta", () => {
             },
         ];
         const nestedMoveDelta = new Map([
-            [fooField, [{ type: Delta.MarkType.MoveIn, moveId: deltaMoveId }]],
+            [fooField, [{ type: Delta.MarkType.MoveIn, moveId: deltaMoveId, count: 42 }]],
         ]);
         const mark: Delta.InsertAndModify = {
             type: Delta.MarkType.InsertAndModify,

--- a/packages/dds/tree/src/test/forestTestSuite.ts
+++ b/packages/dds/tree/src/test/forestTestSuite.ts
@@ -550,6 +550,7 @@ export function testForest(config: ForestTestConfiguration): void {
                 };
                 const moveIn: Delta.MoveIn = {
                     type: Delta.MarkType.MoveIn,
+                    count: 1,
                     moveId,
                 };
                 const modify: Delta.Modify = {
@@ -627,7 +628,7 @@ export function testForest(config: ForestTestConfiguration): void {
                     ]),
                 };
                 const delta: Delta.Root = new Map([
-                    [rootFieldKeySymbol, [mark, { type: Delta.MarkType.MoveIn, moveId }]],
+                    [rootFieldKeySymbol, [mark, { type: Delta.MarkType.MoveIn, count: 1, moveId }]],
                 ]);
                 forest.applyDelta(delta);
 
@@ -656,7 +657,7 @@ export function testForest(config: ForestTestConfiguration): void {
                                 },
                             ],
                         ],
-                        [yField, [{ type: Delta.MarkType.MoveIn, moveId }]],
+                        [yField, [{ type: Delta.MarkType.MoveIn, count: 1, moveId }]],
                     ]),
                 };
                 const delta: Delta.Root = new Map([[rootFieldKeySymbol, [mark]]]);

--- a/packages/dds/tree/src/test/sequence-change-family/sequenceEditBuilder.spec.ts
+++ b/packages/dds/tree/src/test/sequence-change-family/sequenceEditBuilder.spec.ts
@@ -292,6 +292,7 @@ describe("SequenceEditBuilder", () => {
                                     {
                                         type: Delta.MarkType.MoveIn,
                                         moveId,
+                                        count: 10,
                                     },
                                 ],
                             ],
@@ -320,6 +321,7 @@ describe("SequenceEditBuilder", () => {
                                     {
                                         type: Delta.MarkType.MoveIn,
                                         moveId,
+                                        count: 10,
                                     },
                                     15,
                                     {
@@ -359,10 +361,12 @@ describe("SequenceEditBuilder", () => {
                                     {
                                         type: Delta.MarkType.MoveIn,
                                         moveId,
+                                        count: 15,
                                     },
                                     {
                                         type: Delta.MarkType.MoveIn,
                                         moveId: moveId2,
+                                        count: 5,
                                     },
                                     {
                                         type: Delta.MarkType.MoveOut,
@@ -407,6 +411,7 @@ describe("SequenceEditBuilder", () => {
                                     {
                                         type: Delta.MarkType.MoveIn,
                                         moveId,
+                                        count: 10,
                                     },
                                 ],
                             ],
@@ -459,6 +464,7 @@ describe("SequenceEditBuilder", () => {
                                                     {
                                                         type: Delta.MarkType.MoveIn,
                                                         moveId,
+                                                        count: 3,
                                                     },
                                                 ],
                                             ],
@@ -498,6 +504,7 @@ describe("SequenceEditBuilder", () => {
                                                     {
                                                         type: Delta.MarkType.MoveIn,
                                                         moveId,
+                                                        count: 3,
                                                     },
                                                 ],
                                             ],
@@ -576,6 +583,7 @@ describe("SequenceEditBuilder", () => {
                                                     {
                                                         type: Delta.MarkType.MoveIn,
                                                         moveId,
+                                                        count: 3,
                                                     },
                                                 ],
                                             ],
@@ -656,6 +664,7 @@ describe("SequenceEditBuilder", () => {
                                                                     {
                                                                         type: Delta.MarkType.MoveIn,
                                                                         moveId,
+                                                                        count: 3,
                                                                     },
                                                                 ],
                                                             ],
@@ -706,6 +715,7 @@ describe("SequenceEditBuilder", () => {
                     {
                         type: Delta.MarkType.MoveIn,
                         moveId,
+                        count: 10,
                     },
                 ],
             ],
@@ -730,6 +740,7 @@ describe("SequenceEditBuilder", () => {
                                     {
                                         type: Delta.MarkType.MoveIn,
                                         moveId,
+                                        count: 10,
                                     },
                                 ],
                             ],

--- a/packages/dds/tree/src/test/sequence-change-family/toDelta.spec.ts
+++ b/packages/dds/tree/src/test/sequence-change-family/toDelta.spec.ts
@@ -212,6 +212,7 @@ describe("toDelta", () => {
         const moveIn: Delta.MoveIn = {
             type: Delta.MarkType.MoveIn,
             moveId,
+            count: 10,
         };
         const expected: Delta.MarkList = [
             {
@@ -255,6 +256,7 @@ describe("toDelta", () => {
         const moveIn: Delta.MoveIn = {
             type: Delta.MarkType.MoveIn,
             moveId,
+            count: 10,
         };
         const expected: Delta.MarkList = [
             {
@@ -305,6 +307,7 @@ describe("toDelta", () => {
         const moveIn: Delta.MoveIn = {
             type: Delta.MarkType.MoveIn,
             moveId,
+            count: 10,
         };
         const expected: Delta.Root = new Map([
             [

--- a/packages/dds/tree/src/test/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/tree/anchorSet.spec.ts
@@ -97,6 +97,7 @@ describe("AnchorSet", () => {
 
         const moveIn: Delta.MoveIn = {
             type: Delta.MarkType.MoveIn,
+            count: 1,
             moveId: brand(1),
         };
 

--- a/packages/dds/tree/src/test/tree/visit.spec.ts
+++ b/packages/dds/tree/src/test/tree/visit.spec.ts
@@ -60,6 +60,7 @@ function testTreeVisit(marks: Delta.MarkList, expected: Readonly<VisitScript>): 
 
 const rootKey: FieldKey = brand("root");
 const fooKey: FieldKey = brand("foo");
+const barKey: FieldKey = brand("bar");
 const nodeX = { type: jsonString.name, value: "X" };
 const content = [singleTextCursor(nodeX)];
 
@@ -195,7 +196,7 @@ describe("visit", () => {
         testTreeVisit(delta, expected);
     });
 
-    it("move children", () => {
+    it("move children to the right", () => {
         const moveId: Delta.MoveId = brand(1);
         const moveOut: Delta.MoveOut = {
             type: Delta.MarkType.MoveOut,
@@ -205,6 +206,7 @@ describe("visit", () => {
 
         const moveIn: Delta.MoveIn = {
             type: Delta.MarkType.MoveIn,
+            count: 2,
             moveId,
         };
 
@@ -233,6 +235,105 @@ describe("visit", () => {
             ["enterField", fooKey],
             ["onMoveIn", 5, 2, moveId],
             ["exitField", fooKey],
+            ["exitNode", 0],
+            ["exitField", rootKey],
+        ];
+
+        testVisit(delta, expected);
+    });
+
+    it("move children to the left", () => {
+        const moveId: Delta.MoveId = brand(1);
+        const moveOut: Delta.MoveOut = {
+            type: Delta.MarkType.MoveOut,
+            count: 2,
+            moveId,
+        };
+
+        const moveIn: Delta.MoveIn = {
+            type: Delta.MarkType.MoveIn,
+            count: 2,
+            moveId,
+        };
+
+        const delta: Delta.Root = new Map([
+            [
+                rootKey,
+                [
+                    {
+                        type: Delta.MarkType.Modify,
+                        fields: new Map([[fooKey, [2, moveIn, 3, moveOut]]]),
+                    },
+                ],
+            ],
+        ]);
+
+        const expected: VisitScript = [
+            ["enterField", rootKey],
+            ["enterNode", 0],
+            ["enterField", fooKey],
+            ["onMoveOut", 5, 2, moveId],
+            ["exitField", fooKey],
+            ["exitNode", 0],
+            ["exitField", rootKey],
+            ["enterField", rootKey],
+            ["enterNode", 0],
+            ["enterField", fooKey],
+            ["onMoveIn", 2, 2, moveId],
+            ["exitField", fooKey],
+            ["exitNode", 0],
+            ["exitField", rootKey],
+        ];
+
+        testVisit(delta, expected);
+    });
+
+    it("move cousins", () => {
+        const moveId: Delta.MoveId = brand(1);
+        const moveOut: Delta.MoveOut = {
+            type: Delta.MarkType.MoveOut,
+            count: 2,
+            moveId,
+        };
+
+        const moveIn: Delta.MoveIn = {
+            type: Delta.MarkType.MoveIn,
+            count: 2,
+            moveId,
+        };
+
+        const delta: Delta.Root = new Map([
+            [
+                rootKey,
+                [
+                    {
+                        type: Delta.MarkType.Modify,
+                        fields: new Map([
+                            [fooKey, [moveIn]],
+                            [barKey, [moveOut]],
+                        ]),
+                    },
+                ],
+            ],
+        ]);
+
+        const expected: VisitScript = [
+            ["enterField", rootKey],
+            ["enterNode", 0],
+            ["enterField", fooKey],
+            ["exitField", fooKey],
+            ["enterField", barKey],
+            ["onMoveOut", 0, 2, moveId],
+            ["exitField", barKey],
+            ["exitNode", 0],
+            ["exitField", rootKey],
+            ["enterField", rootKey],
+            ["enterNode", 0],
+            ["enterField", fooKey],
+            ["onMoveIn", 0, 2, moveId],
+            ["exitField", fooKey],
+            ["enterField", barKey],
+            ["exitField", barKey],
             ["exitNode", 0],
             ["exitField", rootKey],
         ];


### PR DESCRIPTION
Adds the count of nodes being moved on Delta.MoveIn marks.

While this ends up making the Delta larger (by a constant factor), it simplifies the processing of deltas.
This is especially easier for code that wants to focus on a single part of a Delta, and therefore doesn't want to be forced to crawl the whole Delta in order to determine the size of any given MoveIn it encounters.