### PR TITLE
feat: Show diff UI when external server data changes

### DIFF
--- a/examples/hosts/app-integration/external-data/src/index.html
+++ b/examples/hosts/app-integration/external-data/src/index.html
@@ -9,8 +9,8 @@
         <title>Test application</title>
     </head>
     <body style="margin: 0">
-        <div id="app"></div>
-        <hr />
         <div id="debug"></div>
+        <hr />
+        <div id="app"></div>
     </body>
 </html>

--- a/examples/hosts/app-integration/external-data/src/model-interface/index.ts
+++ b/examples/hosts/app-integration/external-data/src/model-interface/index.ts
@@ -88,6 +88,10 @@ export interface ITask extends IEventProvider<ITaskEvents> {
      * Save the proposed changes to SavedData.
      */
     readonly acceptChange:() => Promise<void>;
+    /**
+     * Ignore the proposed changes to SavedData.
+     */
+    readonly ignoreChange:() => Promise<void>;
 
     readonly DEFAULT_PRIORITY: number;
     readonly DEFAULT_NAME: string;

--- a/examples/hosts/app-integration/external-data/src/model-interface/index.ts
+++ b/examples/hosts/app-integration/external-data/src/model-interface/index.ts
@@ -55,10 +55,6 @@ export interface ITaskEvents extends IEvent {
     (event: "incomingPriorityChanged", listener: () => void);
 }
 
-export const NONE_INCOMING_PRIORITY: number = Number.POSITIVE_INFINITY;
-export const NONE_INCOMING_NAME: string = "BLANK_NAME";
-export const NONE_INCOMING_TYPE: string = "none";
-
 /**
  * A single task, with functionality to inspect and modify its data.  Changes to this object will update the state
  * of the Fluid object, but will not automatically update the external data source.
@@ -79,15 +75,15 @@ export interface ITask extends IEventProvider<ITaskEvents> {
     /**
      * The task name coming in from the external server.
      */
-    incomingName: string;
+    readonly incomingName: string | undefined;
     /**
      * The task priority coming in from the external server.
      */
-    incomingPriority: number;
+    readonly incomingPriority: number | undefined;
     /**
      * The type of change to the task coming in from the external server.
      */
-    incomingType: string;
+    readonly incomingType: string | undefined;
     /**
      * Trigger event to render change to UI.
      */

--- a/examples/hosts/app-integration/external-data/src/model-interface/index.ts
+++ b/examples/hosts/app-integration/external-data/src/model-interface/index.ts
@@ -55,6 +55,10 @@ export interface ITaskEvents extends IEvent {
     (event: "externalPriorityChanged", listener: () => void);
 }
 
+export const DEFAULT_DIFF_PRIORITY: number = Number.POSITIVE_INFINITY;
+export const DEFAULT_DIFF_NAME: string = "BLANK_NAME";
+export const DEFAULT_DIFF_TYPE: string = "none";
+
 /**
  * A single task, with functionality to inspect and modify its data.  Changes to this object will update the state
  * of the Fluid object, but will not automatically update the external data source.
@@ -87,23 +91,19 @@ export interface ITask extends IEventProvider<ITaskEvents> {
     /**
      * Trigger event to render change to UI.
      */
-    readonly externalNameChanged:(name: string) => Promise<void>;
+    readonly externalNameChanged:(name: string) => void;
     /**
      * Trigger event to render change to UI.
      */
-    readonly externalPriorityChanged:(priority: number) => Promise<void>;
+    readonly externalPriorityChanged:(priority: number) => void;
     /**
      * Save the proposed changes to SavedData.
      */
-    readonly acceptChange:() => Promise<void>;
+    readonly acceptChange:() => void;
     /**
      * Ignore the proposed changes to SavedData.
      */
-    readonly ignoreChange:() => Promise<void>;
-
-    readonly DEFAULT_PRIORITY: number;
-    readonly DEFAULT_NAME: string;
-    readonly DEFAULT_DIFF_TYPE: string;
+    readonly ignoreChange:() => void;
 }
 
 /**

--- a/examples/hosts/app-integration/external-data/src/model-interface/index.ts
+++ b/examples/hosts/app-integration/external-data/src/model-interface/index.ts
@@ -96,10 +96,6 @@ export interface ITask extends IEventProvider<ITaskEvents> {
      * Save the proposed changes to SavedData.
      */
     readonly acceptChange:() => void;
-    /**
-     * Ignore the proposed changes to SavedData.
-     */
-    readonly ignoreChange:() => void;
 }
 
 /**

--- a/examples/hosts/app-integration/external-data/src/model-interface/index.ts
+++ b/examples/hosts/app-integration/external-data/src/model-interface/index.ts
@@ -41,23 +41,23 @@ export interface ITaskEvents extends IEvent {
      */
     (event: "nameChanged", listener: () => void);
     /**
-     * Emitted when the priority has changed.
+     * Emitted when the priority has changed to either the incoming value or to the NONE default value.
      */
     (event: "priorityChanged", listener: () => void);
     /**
-     * Emitted when the externalName has changed.
+     * Emitted when the incomingName has to either the incoming value or to the NONE default value.
      */
-    (event: "externalNameChanged", listener: () => void);
+    (event: "incomingNameChanged", listener: () => void);
 
     /**
-     * Emitted when extneralPriority has changed.
+     * Emitted when incomingPriority has changed to either the incoming value or to the NONE default value.
      */
-    (event: "externalPriorityChanged", listener: () => void);
+    (event: "incomingPriorityChanged", listener: () => void);
 }
 
-export const DEFAULT_DIFF_PRIORITY: number = Number.POSITIVE_INFINITY;
-export const DEFAULT_DIFF_NAME: string = "BLANK_NAME";
-export const DEFAULT_DIFF_TYPE: string = "none";
+export const NONE_INCOMING_PRIORITY: number = Number.POSITIVE_INFINITY;
+export const NONE_INCOMING_NAME: string = "BLANK_NAME";
+export const NONE_INCOMING_TYPE: string = "none";
 
 /**
  * A single task, with functionality to inspect and modify its data.  Changes to this object will update the state
@@ -79,23 +79,23 @@ export interface ITask extends IEventProvider<ITaskEvents> {
     /**
      * The task name coming in from the external server.
      */
-    diffName: string;
+    incomingName: string;
     /**
      * The task priority coming in from the external server.
      */
-    diffPriority: number;
+    incomingPriority: number;
     /**
      * The type of change to the task coming in from the external server.
      */
-    diffType: string;
+    incomingType: string;
     /**
      * Trigger event to render change to UI.
      */
-    readonly externalNameChanged:(name: string) => void;
+    readonly incomingNameChanged:(name: string) => void;
     /**
      * Trigger event to render change to UI.
      */
-    readonly externalPriorityChanged:(priority: number) => void;
+    readonly incomingPriorityChanged:(priority: number) => void;
     /**
      * Save the proposed changes to SavedData.
      */

--- a/examples/hosts/app-integration/external-data/src/model-interface/index.ts
+++ b/examples/hosts/app-integration/external-data/src/model-interface/index.ts
@@ -30,13 +30,6 @@ export interface IAppModel extends IEventProvider<IAppModelEvents> {
      * A task tracker list.
      */
     readonly taskList: ITaskList;
-
-    /**
-    * Send custom signals to the server which will cause the server to respond
-    * with the (currently experimental) RuntimeMessage Signal to communicate
-    * an external data change and and possibly the changed data as well
-    */
-    readonly debugSendCustomSignal: () => void;
 }
 
 /**
@@ -46,7 +39,12 @@ export interface ITaskEvents extends IEvent {
     /**
      * Emitted when the name or priority have changed respectively.
      */
-    (event: "nameChanged" | "priorityChanged", listener: () => void);
+    (event:
+        "nameChanged" |
+        "priorityChanged" |
+        "externalNameChanged" |
+        "externalPriorityChanged",
+        listener: ( changedData: string) => void);
 }
 
 /**
@@ -66,6 +64,34 @@ export interface ITask extends IEventProvider<ITaskEvents> {
      * The task priority.  Modifications are persisted in Fluid and shared amongst collaborators.
      */
     priority: number;
+    /**
+     * The task name coming in from the external server.
+     */
+    diffName: string;
+    /**
+     * The task priority coming in from the external server.
+     */
+    diffPriority: number;
+    /**
+     * The type of change to the task coming in from the external server.
+     */
+    diffType: string;
+    /**
+     * Trigger event to render change to UI.
+     */
+    readonly externalNameChanged:(name: string) => Promise<void>;
+    /**
+     * Trigger event to render change to UI.
+     */
+    readonly externalPriorityChanged:(priority: number) => Promise<void>;
+    /**
+     * Save the proposed changes to SavedData.
+     */
+    readonly acceptChange:() => Promise<void>;
+
+    readonly DEFAULT_PRIORITY: number;
+    readonly DEFAULT_NAME: string;
+    readonly DEFAULT_DIFF_TYPE: string;
 }
 
 /**

--- a/examples/hosts/app-integration/external-data/src/model-interface/index.ts
+++ b/examples/hosts/app-integration/external-data/src/model-interface/index.ts
@@ -95,7 +95,7 @@ export interface ITask extends IEventProvider<ITaskEvents> {
     /**
      * Save the proposed changes to SavedData.
      */
-    readonly acceptChange:() => void;
+    readonly overwriteWithIncomingData:() => void;
 }
 
 /**

--- a/examples/hosts/app-integration/external-data/src/model-interface/index.ts
+++ b/examples/hosts/app-integration/external-data/src/model-interface/index.ts
@@ -37,14 +37,22 @@ export interface IAppModel extends IEventProvider<IAppModelEvents> {
  */
 export interface ITaskEvents extends IEvent {
     /**
-     * Emitted when the name or priority have changed respectively.
+     * Emitted when the name has changed.
      */
-    (event:
-        "nameChanged" |
-        "priorityChanged" |
-        "externalNameChanged" |
-        "externalPriorityChanged",
-        listener: ( changedData: string) => void);
+    (event: "nameChanged", listener: () => void);
+    /**
+     * Emitted when the priority has changed.
+     */
+    (event: "priorityChanged", listener: () => void);
+    /**
+     * Emitted when the externalName has changed.
+     */
+    (event: "externalNameChanged", listener: () => void);
+
+    /**
+     * Emitted when extneralPriority has changed.
+     */
+    (event: "externalPriorityChanged", listener: () => void);
 }
 
 /**

--- a/examples/hosts/app-integration/external-data/src/model/appModel.ts
+++ b/examples/hosts/app-integration/external-data/src/model/appModel.ts
@@ -5,7 +5,6 @@
 
 import { TypedEventEmitter } from "@fluidframework/common-utils";
 import { IContainer } from "@fluidframework/container-definitions";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 
 import type { IAppModel, IAppModelEvents, ITaskList } from "../model-interface";
 
@@ -16,15 +15,8 @@ import type { IAppModel, IAppModelEvents, ITaskList } from "../model-interface";
 export class AppModel extends TypedEventEmitter<IAppModelEvents> implements IAppModel {
     public constructor(
         public readonly taskList: ITaskList,
-        container: IContainer,
-        private readonly runtime: IContainerRuntime ) {
+        container: IContainer) {
         super();
     }
 
-    /**
-     * {@inheritDoc IAppModel.debugSendCustomSignal}
-     */
-    public readonly debugSendCustomSignal = (): void => {
-        this.runtime.submitSignal("debugSignal", {message: "externalDataChanged"});
-    }
 }

--- a/examples/hosts/app-integration/external-data/src/model/appModel.ts
+++ b/examples/hosts/app-integration/external-data/src/model/appModel.ts
@@ -18,5 +18,4 @@ export class AppModel extends TypedEventEmitter<IAppModelEvents> implements IApp
         container: IContainer) {
         super();
     }
-
 }

--- a/examples/hosts/app-integration/external-data/src/model/containerCode.ts
+++ b/examples/hosts/app-integration/external-data/src/model/containerCode.ts
@@ -20,7 +20,7 @@ const taskListId = "task-list";
 * fetching the new data. This is an enum as there may be more signals that need to be created.
 */
 const SignalType = {
-    ExternalDataChanged: "externalDataChange"
+    ExternalDataChanged: "ExternalDataChanged"
 };
 
 /**
@@ -62,11 +62,12 @@ export class TaskListContainerRuntimeFactory extends ModelContainerRuntimeFactor
         );
         // Register listener only once the model is fully loaded and ready
         runtime.on("signal", (message) => {
-            if (message.type === SignalType.ExternalDataChanged) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if ('content' in message && 'type' in message.content && message.content.type === SignalType.ExternalDataChanged) {
                 // eslint-disable-next-line @typescript-eslint/no-floating-promises
                 taskList.importExternalData();
             }
         });
-        return new AppModel(taskList, container, runtime);
+        return new AppModel(taskList, container);
     }
 }

--- a/examples/hosts/app-integration/external-data/src/model/containerCode.ts
+++ b/examples/hosts/app-integration/external-data/src/model/containerCode.ts
@@ -64,7 +64,7 @@ export class TaskListContainerRuntimeFactory extends ModelContainerRuntimeFactor
         runtime.on("signal", (message) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (message?.content?.type === SignalType.ExternalDataChanged) {        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                taskList.importExternalData();
+                taskList.importExternalData().catch(console.error);
             }
         });
         return new AppModel(taskList, container);

--- a/examples/hosts/app-integration/external-data/src/model/containerCode.ts
+++ b/examples/hosts/app-integration/external-data/src/model/containerCode.ts
@@ -63,8 +63,7 @@ export class TaskListContainerRuntimeFactory extends ModelContainerRuntimeFactor
         // Register listener only once the model is fully loaded and ready
         runtime.on("signal", (message) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        if ('content' in message && 'type' in message.content && message.content.type === SignalType.ExternalDataChanged) {
-                // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        if (message?.content?.type === SignalType.ExternalDataChanged) {        // eslint-disable-next-line @typescript-eslint/no-floating-promises
                 taskList.importExternalData();
             }
         });

--- a/examples/hosts/app-integration/external-data/src/model/taskList.ts
+++ b/examples/hosts/app-integration/external-data/src/model/taskList.ts
@@ -315,7 +315,7 @@ export class TaskList extends DataObject implements ITaskList {
                 priority: task.priority,
             };
         }
-        console.log(formattedTasks);
+
         try {
             await fetch(
                 `http://localhost:${customerServicePort}/set-tasks`,

--- a/examples/hosts/app-integration/external-data/src/model/taskList.ts
+++ b/examples/hosts/app-integration/external-data/src/model/taskList.ts
@@ -381,7 +381,7 @@ export class TaskList extends DataObject implements ITaskList {
             } else {
                 // Since all data modifications happen within the SharedString or SharedCell (task IDs are immutable),
                 // the root directory should never see anything except adds and deletes.
-                // console.error("Unexpected modification to task list");
+                console.error("Unexpected modification to task list");
             }
         });
 

--- a/examples/hosts/app-integration/external-data/src/model/taskList.ts
+++ b/examples/hosts/app-integration/external-data/src/model/taskList.ts
@@ -90,11 +90,6 @@ class Task extends TypedEventEmitter<ITaskEvents> implements ITask {
             this.incomingName = undefined;
         }
     }
-    public ignoreChange = (): void => {
-        this.incomingType = undefined;
-        this.incomingName = undefined;
-        this.incomingPriority = undefined;
-    }
 }
 
 /**

--- a/examples/hosts/app-integration/external-data/src/model/taskList.ts
+++ b/examples/hosts/app-integration/external-data/src/model/taskList.ts
@@ -83,6 +83,14 @@ class Task extends TypedEventEmitter<ITaskEvents> implements ITask {
         this.diffType = "none";
         this.emit('externalNameChanged');
     }
+    public ignoreChange = async (): Promise<void> => {
+        this.diffPriority = this.DEFAULT_PRIORITY;
+        this.diffType = "none";
+        this.emit('externalPriorityChanged');
+        this.diffName = '';
+        this.diffType = "none";
+        this.emit('externalNameChanged');
+    }
 }
 
 /**

--- a/examples/hosts/app-integration/external-data/src/model/taskList.ts
+++ b/examples/hosts/app-integration/external-data/src/model/taskList.ts
@@ -78,7 +78,7 @@ class Task extends TypedEventEmitter<ITaskEvents> implements ITask {
         this.incomingType = "change";
         this.incomingPriority = savedPriority;
     }
-    public acceptChange = (): void => {
+    public overwriteWithIncomingData = (): void => {
         this.incomingType = undefined;
         if (this.incomingPriority !== undefined) {
             this._priority.set(this.incomingPriority);

--- a/examples/hosts/app-integration/external-data/src/start.ts
+++ b/examples/hosts/app-integration/external-data/src/start.ts
@@ -20,7 +20,7 @@ const updateTabForId = (id: string): void => {
     document.title = id;
 };
 
-const render = (model: IAppModel): void => {
+const render = (model: IAppModel, showExternalServerView: boolean): void => {
     const appDiv = document.querySelector("#app") as HTMLDivElement;
     ReactDOM.unmountComponentAtNode(appDiv);
     ReactDOM.render(
@@ -30,12 +30,14 @@ const render = (model: IAppModel): void => {
 
     // The DebugView is just for demo purposes, to offer manual controls and inspectability for things that normally
     // would be some external system or arbitrarily occurring.
-    const debugDiv = document.querySelector("#debug") as HTMLDivElement;
-    ReactDOM.unmountComponentAtNode(debugDiv);
-    ReactDOM.render(
-        React.createElement(DebugView, { model }),
-        debugDiv,
-    );
+    if (showExternalServerView) {
+        const debugDiv = document.querySelector("#debug") as HTMLDivElement;
+        ReactDOM.unmountComponentAtNode(debugDiv);
+        ReactDOM.render(
+            React.createElement(DebugView),
+            debugDiv,
+        );
+    }
 };
 
 async function start(): Promise<void> {
@@ -45,6 +47,7 @@ async function start(): Promise<void> {
 
     let id: string;
     let model: IAppModel;
+    let showExternalServerView = true;
 
     if (location.hash.length === 0) {
         // Normally our code loader is expected to match up with the version passed here.
@@ -57,9 +60,10 @@ async function start(): Promise<void> {
     } else {
         id = location.hash.slice(1);
         model = await tinyliciousModelLoader.loadExisting(id);
+        showExternalServerView = false;
     }
 
-    render(model);
+    render(model, showExternalServerView);
     updateTabForId(id);
 }
 

--- a/examples/hosts/app-integration/external-data/src/view/debugView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/debugView.tsx
@@ -9,13 +9,6 @@ import type { TaskData } from "../model-interface";
 import { customerServicePort } from "../mock-service-interface";
 
 /**
- * {@link DebugView} input props.
- */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface IDebugViewProps {
-}
-
-/**
  * "Debug" view of external data source.
  *
  * @remarks
@@ -25,7 +18,7 @@ export interface IDebugViewProps {
  *
  * For the purposes of this test app, it is useful to be able to see both data sources side-by-side.
  */
-export const DebugView: React.FC<IDebugViewProps> = () => {
+export const DebugView: React.FC = () => {
     return (
         <div>
             <h2 style={{ textDecoration: "underline" }}>External Data Server App</h2>
@@ -38,10 +31,7 @@ export const DebugView: React.FC<IDebugViewProps> = () => {
 };
 
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface IExternalDataViewProps {}
-
-const ExternalDataView: React.FC<IExternalDataViewProps> = (props: IExternalDataViewProps) => {
+const ExternalDataView: React.FC = () => {
     const [externalData, setExternalData] = useState({});
     useEffect(() => {
         // HACK: Once we have external changes triggering the appropriate Fluid signal, we can simply listen
@@ -72,7 +62,6 @@ const ExternalDataView: React.FC<IExternalDataViewProps> = (props: IExternalData
         }
 
         // Run once immediately to run without waiting.
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         pollForServiceUpdates().catch(console.error);
 
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -130,10 +119,6 @@ const SyncStatusView: React.FC<ISyncStatusViewProps> = (props: ISyncStatusViewPr
     );
 };
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface IControlsViewProps {
-}
-
 /**
  * Invoke service function to reset the external data source to its original contents.
  */
@@ -155,7 +140,7 @@ function debugResetExternalData(): void {
 // TODO: Implement simulation of an external data change.  Maybe include UI for the debug user to edit the data
 // themselves (as if they were editing it outside of Fluid).
 // TODO: Consider how we might simulate errors/failures here to play with retry and recovery.
-const ControlsView: React.FC<IControlsViewProps> = (props: IControlsViewProps) => {
+const ControlsView: React.FC = () => {
     return (
         <div>
             <h3>Debug controls</h3>
@@ -209,7 +194,7 @@ class ExternalDataTask {
 /**
  * A tabular, editable view of the task list.  Includes a save button to sync the changes back to the data source.
  */
-export const TaskListView: React.FC<IDebugViewProps> = () => {
+export const TaskListView: React.FC = () => {
     const [externalData, setExternalData] = useState({});
     useEffect(() => {
         // HACK: Once we have external changes triggering the appropriate Fluid signal, we can simply listen
@@ -240,8 +225,7 @@ export const TaskListView: React.FC<IDebugViewProps> = () => {
         }
 
         // Run once immediately to run without waiting.
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        pollForServiceUpdates();
+        pollForServiceUpdates().catch(console.error);
 
         return (): void => {}
     }, [externalData, setExternalData]);

--- a/examples/hosts/app-integration/external-data/src/view/debugView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/debugView.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect, useState } from "react";
 import isEqual from 'lodash.isequal'
 import type { TaskData } from "../model-interface";
-import { customerServicePort  } from "../mock-service-interface";
+import { customerServicePort } from "../mock-service-interface";
 
 /**
  * {@link DebugView} input props.
@@ -73,7 +73,7 @@ const ExternalDataView: React.FC<IExternalDataViewProps> = (props: IExternalData
 
         // Run once immediately to run without waiting.
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        pollForServiceUpdates();
+        pollForServiceUpdates().catch(console.error);
 
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         const timer = setInterval(pollForServiceUpdates, 3000); // Poll every 3 seconds
@@ -168,7 +168,7 @@ const ControlsView: React.FC<IControlsViewProps> = (props: IControlsViewProps) =
 
 
 interface ITaskRowProps {
-    task: ExternalDataTask
+    task: ExternalDataTask;
 }
 
 /**
@@ -177,21 +177,21 @@ interface ITaskRowProps {
 const TaskRow: React.FC<ITaskRowProps> = (props: ITaskRowProps) => {
     const { task } = props;
 
-    const IdChangeHandler = (e: React.SyntheticEvent<HTMLInputElement>): void => {
+    const idChangeHandler = (e: React.SyntheticEvent<HTMLInputElement>): void => {
         task.id = e.currentTarget.value;
     };
-    const NameChangeHandler = (e: React.SyntheticEvent<HTMLInputElement>): void => {
+    const nameChangeHandler = (e: React.SyntheticEvent<HTMLInputElement>): void => {
         task.name = e.currentTarget.value;
     };
-    const PriorityChangeHandler = (e: React.SyntheticEvent<HTMLInputElement>): void => {
+    const priorityChangeHandler = (e: React.SyntheticEvent<HTMLInputElement>): void => {
         task.priority =  Number.parseInt(e.currentTarget.value, 10);
     };
 
     return (
         <tr>
-            <td><input defaultValue={ task.id }  style={{ width: "30px" }} onChange={ IdChangeHandler }></input></td>
-            <td><input defaultValue={ task.name } style={{ width: "200px" }} onChange={ NameChangeHandler }></input></td>
-            <td><input defaultValue={ task.priority } type="number" style={{ width: "50px" }} onChange={ PriorityChangeHandler }></input></td>
+            <td><input defaultValue={ task.id }  style={{ width: "30px" }} onChange={ idChangeHandler }></input></td>
+            <td><input defaultValue={ task.name } style={{ width: "200px" }} onChange={ nameChangeHandler }></input></td>
+            <td><input defaultValue={ task.priority } type="number" style={{ width: "50px" }} onChange={ priorityChangeHandler }></input></td>
         </tr>
     );
 };
@@ -253,10 +253,6 @@ export const TaskListView: React.FC<IDebugViewProps> = () => {
         <TaskRow key={task.id} task={ task } />
     ));
     const saveChanges = async (): Promise<void> => {
-        // const taskStrings = tasks.map((task) => {
-        //     return `${task.id}:${task.name}:${task.priority}`;
-        // });
-        // const stringDataToWrite = `${taskStrings.join("\n")}`;
         const formattedTasks = {}
         for (const task of tasks) {
             formattedTasks[task.id] = {

--- a/examples/hosts/app-integration/external-data/src/view/debugView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/debugView.tsx
@@ -70,8 +70,9 @@ const ExternalDataView: React.FC = () => {
         // Run once immediately to run without waiting.
         pollForServiceUpdates(externalData, setExternalData).catch(console.error);
 
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        const timer = setInterval(pollForServiceUpdates, 3000); // Poll every 3 seconds
+        const timer = setInterval(
+            ()=>{pollForServiceUpdates(externalData, setExternalData).catch(console.error)},
+            3000); // Poll every 3 seconds
         return (): void => {
             clearInterval(timer);
         }

--- a/examples/hosts/app-integration/external-data/src/view/debugView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/debugView.tsx
@@ -109,12 +109,12 @@ interface ISyncStatusViewProps { }
 const SyncStatusView: React.FC<ISyncStatusViewProps> = (props: ISyncStatusViewProps) => {
     return (
         <div>
-            {/* <h3>Sync status</h3>
+            <h3>Sync status</h3>
             <div style={{ margin: "10px 0" }}>
                 Fluid has [no] unsync'd changes (not implemented)<br />
                 External data source has [no] unsync'd changes (not implemented)<br />
                 Current sync activity: [idle | fetching | writing | resolving conflicts?] (not implemented)<br />
-            </div> */}
+            </div>
         </div>
     );
 };

--- a/examples/hosts/app-integration/external-data/src/view/debugView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/debugView.tsx
@@ -188,16 +188,15 @@ const TaskRow: React.FC<ITaskRowProps> = (props: ITaskRowProps) => {
     );
 };
 
-class ExternalDataTask {
-    public id: string;
-    public name: string;
-    public priority: number;
-    public constructor(id: string, name: string, priority: number) {
-        this.id = id;
-        this.name = name;
-        this.priority = priority;
-    }
-}
+/**
+* Model for external task data
+*/
+export interface ExternalDataTask {
+    id: string;
+    name: string;
+    priority: number;
+};
+
 /**
  * A tabular, editable view of the task list.  Includes a save button to sync the changes back to the data source.
  */
@@ -210,10 +209,10 @@ export const TaskListView: React.FC = () => {
         return (): void => {}
     }, [externalData, setExternalData]);
     const parsedExternalData = Object.entries(externalData as TaskData);
-    const tasks: ExternalDataTask[] =  parsedExternalData.map(([key, {name, priority}]) => (
-        new ExternalDataTask(key, name, priority)
+    const tasks =  parsedExternalData.map(([id, {name, priority}]) => (
+        {id, name, priority}
     ));
-    const taskRows = tasks.map((task: ExternalDataTask) => (
+    const taskRows = tasks.map((task) => (
         <TaskRow key={task.id} task={ task } />
     ));
     const saveChanges = async (): Promise<void> => {

--- a/examples/hosts/app-integration/external-data/src/view/index.ts
+++ b/examples/hosts/app-integration/external-data/src/view/index.ts
@@ -4,5 +4,5 @@
  */
 
 export { IAppViewProps, AppView } from "./appView";
-export { IDebugViewProps, DebugView } from "./debugView";
+export { DebugView } from "./debugView";
 export { ITaskListViewProps, TaskListView } from "./taskListView";

--- a/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
@@ -105,6 +105,10 @@ const TaskRow: React.FC<ITaskRowProps> = (props: ITaskRowProps) => {
                 <button
                     onClick={ task.acceptChange } style={{ visibility: showAcceptButton }}>Accept change</button>
             </td>
+            <td>
+                <button
+                    onClick={ task.ignoreChange } style={{ visibility: showAcceptButton }}>Ignore change</button>
+            </td>
         </tr>
     );
 };

--- a/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
@@ -9,6 +9,8 @@ import React, { useEffect, useRef, useState } from "react";
 
 import type { ITask, ITaskList } from "../model-interface";
 
+import { DEFAULT_DIFF_PRIORITY, DEFAULT_DIFF_NAME } from "../model-interface";
+
 interface ITaskRowProps {
     readonly task: ITask;
     readonly deleteTask: () => void;
@@ -54,8 +56,8 @@ const TaskRow: React.FC<ITaskRowProps> = (props: ITaskRowProps) => {
     };
 
     const diffVisible = savedDiffType === "none";
-    const showPriority = !diffVisible && savedPriority !== task.DEFAULT_PRIORITY ? "visible" : "hidden";
-    const showName = !diffVisible && savedName !== task.DEFAULT_NAME ? "visible" : "hidden";
+    const showPriority = !diffVisible && savedPriority !== DEFAULT_DIFF_PRIORITY ? "visible" : "hidden";
+    const showName = !diffVisible && savedName !== DEFAULT_DIFF_NAME ? "visible" : "hidden";
     const showAcceptButton = diffVisible ? "hidden" : "visible";
 
     let diffColor: string = "white";

--- a/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
@@ -103,7 +103,7 @@ const TaskRow: React.FC<ITaskRowProps> = (props: ITaskRowProps) => {
             <td style={{ visibility: showPriority, backgroundColor: diffColor }}>{ incomingPriority }</td>
             <td>
                 <button
-                    onClick={ task.acceptChange } style={{ visibility: showAcceptButton }}>Accept change</button>
+                    onClick={ task.overwriteWithIncomingData } style={{ visibility: showAcceptButton }}>Accept change</button>
             </td>
         </tr>
     );

--- a/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
@@ -9,8 +9,6 @@ import React, { useEffect, useRef, useState } from "react";
 
 import type { ITask, ITaskList } from "../model-interface";
 
-import { NONE_INCOMING_NAME, NONE_INCOMING_PRIORITY, NONE_INCOMING_TYPE } from "../model-interface";
-
 interface ITaskRowProps {
     readonly task: ITask;
     readonly deleteTask: () => void;
@@ -22,9 +20,9 @@ interface ITaskRowProps {
 const TaskRow: React.FC<ITaskRowProps> = (props: ITaskRowProps) => {
     const { task, deleteTask } = props;
     const priorityRef = useRef<HTMLInputElement>(null);
-    const [incomingName, setIncomingName] =  useState<string>(task.incomingName);
-    const [incomingPriority, setIncomingPriority] = useState<number>(task.incomingPriority);
-    const [incomingType, setIncomingType] = useState<string>(task.incomingType);
+    const [incomingName, setIncomingName] =  useState<string | undefined>(task.incomingName);
+    const [incomingPriority, setIncomingPriority] = useState<number | undefined>(task.incomingPriority);
+    const [incomingType, setIncomingType] = useState<string | undefined>(task.incomingType);
     useEffect(() => {
         const updateFromRemotePriority = (): void => {
             if (priorityRef.current !== null) {
@@ -55,9 +53,9 @@ const TaskRow: React.FC<ITaskRowProps> = (props: ITaskRowProps) => {
         task.priority = newValue;
     };
 
-    const diffVisible = incomingType === NONE_INCOMING_TYPE;
-    const showPriority = !diffVisible && incomingPriority !== NONE_INCOMING_PRIORITY ? "visible" : "hidden";
-    const showName = !diffVisible && incomingName !== NONE_INCOMING_NAME ? "visible" : "hidden";
+    const diffVisible = incomingType === undefined;
+    const showPriority = !diffVisible && incomingPriority !== undefined ? "visible" : "hidden";
+    const showName = !diffVisible && incomingName !== undefined ? "visible" : "hidden";
     const showAcceptButton = diffVisible ? "hidden" : "visible";
 
     let diffColor: string = "white";

--- a/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
@@ -45,8 +45,8 @@ const TaskRow: React.FC<ITaskRowProps> = (props: ITaskRowProps) => {
         updateFromRemotePriority();
         return (): void => {
             task.off("priorityChanged", updateFromRemotePriority);
-            task.on("externalPriorityChanged", showSavedPriority);
-            task.on("externalNameChanged", showSavedName);
+            task.off("externalPriorityChanged", showSavedPriority);
+            task.off("externalNameChanged", showSavedName);
         };
     }, [task]);
 

--- a/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
@@ -105,10 +105,6 @@ const TaskRow: React.FC<ITaskRowProps> = (props: ITaskRowProps) => {
                 <button
                     onClick={ task.acceptChange } style={{ visibility: showAcceptButton }}>Accept change</button>
             </td>
-            <td>
-                <button
-                    onClick={ task.ignoreChange } style={{ visibility: showAcceptButton }}>Ignore change</button>
-            </td>
         </tr>
     );
 };

--- a/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
@@ -36,8 +36,6 @@ const TaskRow: React.FC<ITaskRowProps> = (props: ITaskRowProps) => {
         const showSavedName = (): void => {
             setSavedName(task.diffName);
             setSavedDiffType(task.diffType);
-            console.log(savedName);
-            console.log(savedDiffType);
         }
         task.on("priorityChanged", updateFromRemotePriority);
         task.on("externalPriorityChanged", showSavedPriority);
@@ -48,7 +46,7 @@ const TaskRow: React.FC<ITaskRowProps> = (props: ITaskRowProps) => {
             task.off("externalPriorityChanged", showSavedPriority);
             task.off("externalNameChanged", showSavedName);
         };
-    }, [task]);
+    }, [task, savedName, savedPriority, savedDiffType]);
 
     const inputHandler = (e: React.FormEvent): void => {
         const newValue = Number.parseInt((e.target as HTMLInputElement).value, 10);

--- a/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/taskListView.tsx
@@ -9,7 +9,7 @@ import React, { useEffect, useRef, useState } from "react";
 
 import type { ITask, ITaskList } from "../model-interface";
 
-import { DEFAULT_DIFF_PRIORITY, DEFAULT_DIFF_NAME } from "../model-interface";
+import { NONE_INCOMING_NAME, NONE_INCOMING_PRIORITY, NONE_INCOMING_TYPE } from "../model-interface";
 
 interface ITaskRowProps {
     readonly task: ITask;
@@ -22,46 +22,46 @@ interface ITaskRowProps {
 const TaskRow: React.FC<ITaskRowProps> = (props: ITaskRowProps) => {
     const { task, deleteTask } = props;
     const priorityRef = useRef<HTMLInputElement>(null);
-    const [savedName, setSavedName] =  useState<string>(task.diffName);
-    const [savedPriority, setSavedPriority] = useState<number>(task.diffPriority);
-    const [savedDiffType, setSavedDiffType] = useState<string>(task.diffType);
+    const [incomingName, setIncomingName] =  useState<string>(task.incomingName);
+    const [incomingPriority, setIncomingPriority] = useState<number>(task.incomingPriority);
+    const [incomingType, setIncomingType] = useState<string>(task.incomingType);
     useEffect(() => {
         const updateFromRemotePriority = (): void => {
             if (priorityRef.current !== null) {
                 priorityRef.current.value = task.priority.toString();
             }
         };
-        const showSavedPriority = (): void => {
-            setSavedPriority(task.diffPriority);
-            setSavedDiffType(task.diffType);
+        const showIncomingPriority = (): void => {
+            setIncomingPriority(task.incomingPriority);
+            setIncomingType(task.incomingType);
         }
         const showSavedName = (): void => {
-            setSavedName(task.diffName);
-            setSavedDiffType(task.diffType);
+            setIncomingName(task.incomingName);
+            setIncomingType(task.incomingType);
         }
         task.on("priorityChanged", updateFromRemotePriority);
-        task.on("externalPriorityChanged", showSavedPriority);
-        task.on("externalNameChanged", showSavedName);
+        task.on("incomingPriorityChanged", showIncomingPriority);
+        task.on("incomingNameChanged", showSavedName);
         updateFromRemotePriority();
         return (): void => {
             task.off("priorityChanged", updateFromRemotePriority);
-            task.off("externalPriorityChanged", showSavedPriority);
-            task.off("externalNameChanged", showSavedName);
+            task.off("incomingPriorityChanged", showIncomingPriority);
+            task.off("incomingNameChanged", showSavedName);
         };
-    }, [task, savedName, savedPriority, savedDiffType]);
+    }, [task, incomingName, incomingPriority, incomingType]);
 
     const inputHandler = (e: React.FormEvent): void => {
         const newValue = Number.parseInt((e.target as HTMLInputElement).value, 10);
         task.priority = newValue;
     };
 
-    const diffVisible = savedDiffType === "none";
-    const showPriority = !diffVisible && savedPriority !== DEFAULT_DIFF_PRIORITY ? "visible" : "hidden";
-    const showName = !diffVisible && savedName !== DEFAULT_DIFF_NAME ? "visible" : "hidden";
+    const diffVisible = incomingType === NONE_INCOMING_TYPE;
+    const showPriority = !diffVisible && incomingPriority !== NONE_INCOMING_PRIORITY ? "visible" : "hidden";
+    const showName = !diffVisible && incomingName !== NONE_INCOMING_NAME ? "visible" : "hidden";
     const showAcceptButton = diffVisible ? "hidden" : "visible";
 
     let diffColor: string = "white";
-    switch(savedDiffType) {
+    switch(incomingType) {
         case "add": {
            diffColor = "green";
            break;
@@ -101,8 +101,8 @@ const TaskRow: React.FC<ITaskRowProps> = (props: ITaskRowProps) => {
                     ❌
                 </button>
             </td>
-            <td style={{ visibility: showName, backgroundColor: diffColor }}>{ savedName }</td>
-            <td style={{ visibility: showPriority, backgroundColor: diffColor }}>{ savedPriority }</td>
+            <td style={{ visibility: showName, backgroundColor: diffColor }}>{ incomingName }</td>
+            <td style={{ visibility: showPriority, backgroundColor: diffColor }}>{ incomingPriority }</td>
             <td>
                 <button
                     onClick={ task.acceptChange } style={{ visibility: showAcceptButton }}>Accept change</button>

--- a/experimental/framework/react-inputs/src/CollaborativeInput.tsx
+++ b/experimental/framework/react-inputs/src/CollaborativeInput.tsx
@@ -57,9 +57,9 @@ export class CollaborativeInput
     public componentDidMount() {
         // Sets an event listener so we can update our state as the value changes
         this.props.sharedString.on("sequenceDelta", (ev: SequenceDeltaEvent) => {
-            if (!ev.isLocal) {
+            // if (!ev.isLocal) {
                 this.updateInputFromSharedString();
-            }
+            // }
         });
         this.updateInputFromSharedString();
     }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1845,8 +1845,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     }
 
     public processSignal(message: ISignalMessage, local: boolean) {
-        console.log(`I am in container runtime`);
-        console.log(message);
         const envelope = message.content as ISignalEnvelope; // can either reshape to look like isignalenvelope or if else logic to bypass this
         // add one more envelope instead of striping it down
         const transformed: IInboundSignalMessage = {
@@ -1876,7 +1874,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
 
         if (envelope.address === undefined) { // this is what we want
-            console.log("I am a containerRuntime sending a transformed message");
+            console.log(`CONTAINER-RUNTIME:containerRuntime.ts:processSignal--sending transformed signal`);
+            console.log(message);
             // No address indicates a container signal message.
             this.emit("signal", transformed, local);
             return;


### PR DESCRIPTION

**Note: This PR is targeting a shared dev branch, not main. These changes are strictly a hack for prototyping, and will not be merged into main 🙂**

This PR does a number of things:
1. It creates a different form to simulate the external data server
2. It triggers and completes the full loop of using a signal to deliver the information that the external data has changed
3. It introduces elementary conflict resolution UI to demonstrate the behaviour on the client app when the external server changes it's data.

Here is what that full loop looks like currently:

![full_flow_with_ignore_changes](https://user-images.githubusercontent.com/6777404/214147235-96a96661-c3d6-4f49-97ed-37ad75ee6adb.gif)


