### PR TITLE
Fix missing datastore info in resolved url in location redirection handling

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -18,7 +18,11 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 # 2.0.0-internal.2.4.0
 
 ## 2.0.0-internal.2.4.0 Upcoming changes
+- [Support for passing empty string in `IUrlResolver.getAbsoluteUrl` relativeUrl argument in OdspDriverUrlResolverForShareLink and OdspDriverUrlResolver](#Support-for-passing-empty-string-in-IUrlResolver.getAbsoluteUrl-relativeUrl-argument-in-OdspDriverUrlResolverForShareLink-and-OdspDriverUrlResolver)
 - [Deprecate `ensureContainerConnected()` in `@fluidframework/test-utils`](#deprecate-ensurecontainerconnected-in-fluidframeworktest-utils)
+
+### Support for passing empty string in `IUrlResolver.getAbsoluteUrl` relativeUrl argument in OdspDriverUrlResolverForShareLink and OdspDriverUrlResolver
+Now if an empty string is passed, then the relativeUrl or data store path will be derived from the resolved url if possible.
 
 ### Deprecate `ensureContainerConnected()` in `@fluidframework/test-utils`
 

--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -83,6 +83,8 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
         containerPackageName?: string;
     };
     // (undocumented)
+    dataStorePath?: string;
+    // (undocumented)
     endpoints: {
         snapshotStorageUrl: string;
         attachmentPOSTStorageUrl: string;

--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -139,7 +139,6 @@ export class OdspDocumentServiceFactoryWithCodeSplit extends OdspDocumentService
 // @public
 export class OdspDriverUrlResolver implements IUrlResolver {
     constructor();
-    // (undocumented)
     getAbsoluteUrl(resolvedUrl: IResolvedUrl, relativeUrl: string, packageInfoSource?: IContainerPackageInfo): Promise<string>;
     // (undocumented)
     resolve(request: IRequest): Promise<IOdspResolvedUrl>;

--- a/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
+++ b/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
@@ -133,6 +133,8 @@ export interface IOdspResolvedUrl extends IFluidResolvedUrl, IOdspUrlParts {
 
     fileVersion: string | undefined;
 
+    dataStorePath?: string;
+
     /**
      * Sharing link data created for the ODSP item.
      * Contains information about either sharing link created while creating a new file or

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -159,6 +159,14 @@ export class OdspDriverUrlResolver implements IUrlResolver {
         };
     }
 
+    /**
+     * Requests a driver + data store storage URL.
+     * @param resolvedUrl - The driver resolved URL.
+     * @param relativeUrl - The relative data store path URL.
+     * For requesting a driver URL, this value should always be '/'. If an empty string is passed, then dataStorePath
+     * will be extracted from the resolved url if present.
+     * @param packageInfoSource - optional, represents container package information to be included in url.
+     */
     public async getAbsoluteUrl(
         resolvedUrl: IResolvedUrl,
         relativeUrl: string,

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -148,6 +148,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
             siteUrl,
             driveId,
             itemId,
+            dataStorePath: path,
             fileName: "",
             summarizer,
             codeHint: {
@@ -163,11 +164,17 @@ export class OdspDriverUrlResolver implements IUrlResolver {
         relativeUrl: string,
         packageInfoSource?: IContainerPackageInfo,
     ): Promise<string> {
+        const odspResolvedUrl = getOdspResolvedUrl(resolvedUrl);
+
         let dataStorePath = relativeUrl;
+        if (relativeUrl === "" && odspResolvedUrl.dataStorePath !== undefined) {
+            // If the user has passed an empty dataStorePath, then extract it from the resolved url.
+            dataStorePath = odspResolvedUrl.dataStorePath;
+        }
         if (dataStorePath.startsWith("/")) {
             dataStorePath = dataStorePath.substr(1);
-        }
-        const odspResolvedUrl = getOdspResolvedUrl(resolvedUrl);
+        } 
+
         // back-compat: GitHub #9653
         const isFluidPackage = (pkg: any) =>
             typeof pkg === "object"

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -187,7 +187,8 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
      * and it will throw in case share link fetcher props were not specified when instance was created.
      * @param resolvedUrl - The driver resolved URL
      * @param dataStorePath - The relative data store path URL.
-     * For requesting a driver URL, this value should always be '/'
+     * For requesting a driver URL, this value should always be '/'. If an empty string is passed, then dataStorePath
+     * will be extracted from the resolved url if present.
      * @param packageInfoSource - optional, represents container package information to be included in url.
      */
     public async getAbsoluteUrl(

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -200,6 +200,12 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
         const shareLink = await this.getShareLinkPromise(odspResolvedUrl);
         const shareLinkUrl = new URL(shareLink);
 
+        let actualDataStorePath = dataStorePath;
+        // If the user has passed an empty dataStorePath, then extract it from the resolved url.
+        if (dataStorePath === "" && odspResolvedUrl.dataStorePath !== undefined) {
+            actualDataStorePath = odspResolvedUrl.dataStorePath;
+        }
+
         // back-compat: GitHub #9653
         const isFluidPackage = (pkg: any) =>
             typeof pkg === "object"
@@ -216,13 +222,13 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
         }
         containerPackageName = containerPackageName ?? odspResolvedUrl.codeHint?.containerPackageName;
 
-        const context = await this.getContext?.(odspResolvedUrl, dataStorePath);
+        const context = await this.getContext?.(odspResolvedUrl, actualDataStorePath);
 
         storeLocatorInOdspUrl(shareLinkUrl, {
             siteUrl: odspResolvedUrl.siteUrl,
             driveId: odspResolvedUrl.driveId,
             itemId: odspResolvedUrl.itemId,
-            dataStorePath,
+            dataStorePath: actualDataStorePath,
             appName: this.appName,
             containerPackageName,
             fileVersion: odspResolvedUrl.fileVersion,

--- a/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
@@ -10,6 +10,7 @@ import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
 import { OdspDriverUrlResolver } from "../odspDriverUrlResolver";
 import { getHashedDocumentId } from "../odspPublicUtils";
 import { createOdspCreateContainerRequest } from "../createOdspCreateContainerRequest";
+import { createOdspUrl } from "../createOdspUrl";
 
 describe("Odsp Driver Resolver", () => {
     const siteUrl = "https://localhost";
@@ -115,6 +116,21 @@ describe("Odsp Driver Resolver", () => {
         assert.strictEqual(searchParams.get("path"), "datastore", "Path should match");
         assert.strictEqual(searchParams.get("containerPackageName"), packageName, "ContainerPackageName should match");
         assert.strictEqual(url, `${siteUrl}`, "Url should match");
+    });
+
+    it("should resolve and then getAbsoluteUrl should pick dataStorePath from resolvedUrl", async () => {
+        const resolvedUrl1 = await resolver.resolve({ url: createOdspUrl({
+            driveId, itemId: "itemId", siteUrl, dataStorePath: "datastore",
+            fileVersion: "0.1", appName: "app", containerPackageName: packageName,
+        })});
+        const response = await resolver.getAbsoluteUrl(resolvedUrl1, "");
+
+        const resolvedUrl2 = await resolver.resolve({ url: response });
+        assert.strictEqual(resolvedUrl2.driveId, driveId, "Drive id should be equal");
+        assert.strictEqual(resolvedUrl2.dataStorePath, "datastore", "DataStorePath should be equal");
+        assert.strictEqual(resolvedUrl2.codeHint?.containerPackageName, packageName, "DataStorePath should be equal");
+        assert.strictEqual(resolvedUrl2.siteUrl, siteUrl, "SiteUrl should be equal");
+        assert.strictEqual(resolvedUrl2.itemId, "itemId", "Item id should be absent");
     });
 
     it("Should resolve url given container package info", async () => {

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -97,6 +97,29 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
             assert(actualNavParam !== undefined, "Nav param should be defined!!");
             assert.strictEqual(expectedNavParam, actualNavParam, "Nav param should match");
         });
+
+        it(`getAbsoluteUrl - Should resolve and then getAbsoluteUrl should pick dataStorePath from resolvedUrl, hasVersion: ${urlWithNav.hasVersion}, hasContext: ${urlWithNav.hasContext}`, async () => {
+            const resolvedUrl1 = await mockGetFileLink(Promise.resolve(sharelink), async () => {
+                return urlResolverWithShareLinkFetcher.resolve({ url: urlWithNav.url });
+            });
+            const absoluteUrl = await urlResolverWithShareLinkFetcher.getAbsoluteUrl(resolvedUrl1, "");
+            const actualNavParam = new URLSearchParams(absoluteUrl).get("nav");
+            const expectedNavParam = new URLSearchParams(sharelink).get("nav");
+            assert(actualNavParam !== undefined, "Nav param should be defined!!");
+            assert.strictEqual(expectedNavParam, actualNavParam, "Nav param should match");
+
+            // Then resolve again.
+            const resolvedUrl2 = await mockGetFileLink(Promise.resolve(sharelink), async () => {
+                return urlResolverWithShareLinkFetcher.resolve({ url: absoluteUrl });
+            });
+            assert.strictEqual(resolvedUrl2.dataStorePath, dataStorePath, "dataStorePath should be preserved");
+            assert.strictEqual(resolvedUrl2.driveId, driveId, "Drive id should be equal");
+            assert.strictEqual(resolvedUrl2.siteUrl, siteUrl, "SiteUrl should be equal");
+            assert.strictEqual(resolvedUrl2.itemId, itemId, "Item id should be equal");
+            assert.strictEqual(resolvedUrl2.fileVersion, urlWithNav.hasVersion ? fileVersion : undefined);
+            assert.strictEqual(resolvedUrl2.hashedDocumentId, await getHashedDocumentId(driveId, itemId), "Doc id should be equal");
+            assert(resolvedUrl2.endpoints.snapshotStorageUrl !== undefined, "Snapshot url should not be empty");
+        });
     }
 
     it("resolve - Should generate sharelink and set it in shareLinkMap if using resolver with TokenFetcher", async () => {

--- a/packages/loader/location-redirection-utils/src/resolveWithLocationRedirection.ts
+++ b/packages/loader/location-redirection-utils/src/resolveWithLocationRedirection.ts
@@ -40,10 +40,12 @@ export async function resolveWithLocationRedirectionHandling<T>(
             }
             logger?.sendTelemetryEvent({ eventName: "LocationRedirectionError" });
             const resolvedUrl = error.redirectUrl;
-            // Generate the new request with new location details from the resolved url.
+            // Generate the new request with new location details from the resolved url. For datastore/relative path,
+            // we don't need to pass "/" as host could have asked for a specific data store. So driver need to
+            // extract it from the resolved url.
             const absoluteUrl = await urlResolver.getAbsoluteUrl(
                 resolvedUrl,
-                "/",
+                "",
                 undefined,
             );
             req = { url: absoluteUrl, headers: req.headers };


### PR DESCRIPTION
## Description

resolveWithLocationRedirectionHandling removes dataStorePath from the original request on redirection.