### PR TITLE
[GC-stress] Removed artifactBuildId from test-real-service-stress.yaml

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -69,7 +69,6 @@ stages:
         poolBuild: Large
         testPackage: "@fluid-internal/test-service-load"
         testWorkspace: ${{ variables.testWorkspace }}
-        artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 150
         testCommand: start:t9s:gc:ci
         env:


### PR DESCRIPTION
Removed artifactBuildId that was added by https://github.com/microsoft/FluidFramework/pull/13736.