### PR TITLE
[GC-stress] Increase totalSendCount which was decreased earlier

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -33,7 +33,7 @@
             "opRatePerMin": 800,
             "progressIntervalMs": 5000,
             "numClients": 10,
-            "totalSendCount": 24000,
+            "totalSendCount": 48000,
             "optionOverrides":{
                 "tinylicious":{
                     "comment": "SessionExpiry: 15 mins. Inactive Timeout: 16 mins. Sweep Timeout: 17 mins.",


### PR DESCRIPTION
https://github.com/microsoft/FluidFramework/pull/13306 reduced the totalSendCount to half because the tests were timing out. That was due to a different issue which is fixed, so chanding totalSendCount back to what it was before.