### PR TITLE
refactor(tree): simplify delta visitor code

### DIFF
--- a/packages/dds/tree/src/core/tree/visitDelta.ts
+++ b/packages/dds/tree/src/core/tree/visitDelta.ts
@@ -66,10 +66,9 @@ import * as Delta from "./delta";
  * @param visitor - The object to notify of the changes encountered.
  */
 export function visitDelta(delta: Delta.Root, visitor: DeltaVisitor): void {
-    const props = { visitor, hasMoves: false };
-    const containsMoves = visitFieldMarks(delta, props, firstPass);
+    const containsMoves = visitFieldMarks(delta, visitor, firstPass);
     if (containsMoves) {
-        visitFieldMarks(delta, props, secondPass);
+        visitFieldMarks(delta, visitor, secondPass);
     }
 }
 
@@ -89,36 +88,32 @@ export interface DeltaVisitor {
     exitField(key: FieldKey): void;
 }
 
-interface PassProps {
-    /**
-     * Can be omitted if equal to zero.
-     */
-    startIndex?: number;
-    visitor: DeltaVisitor;
-}
-
-type Pass = (delta: Delta.MarkList, props: PassProps) => boolean;
+type Pass = (delta: Delta.MarkList, visitor: DeltaVisitor) => boolean;
 
 interface ModifyLike {
     setValue?: Value;
     fields?: Delta.FieldMarks;
 }
 
-function visitFieldMarks(fields: Delta.FieldMarks, props: PassProps, func: Pass): boolean {
+function visitFieldMarks(fields: Delta.FieldMarks, visitor: DeltaVisitor, func: Pass): boolean {
     let containsMoves = false;
     for (const [key, field] of fields) {
-        props.visitor.enterField(key);
-        const result = func(field, { ...props, startIndex: 0 });
+        visitor.enterField(key);
+        const result = func(field, visitor);
         containsMoves ||= result;
-        props.visitor.exitField(key);
+        visitor.exitField(key);
     }
     return containsMoves;
 }
 
-function visitModify(modify: ModifyLike, props: PassProps, func: Pass): boolean {
+function visitModify(
+    index: number,
+    modify: ModifyLike,
+    visitor: DeltaVisitor,
+    func: Pass,
+): boolean {
     let containsMoves = false;
-    const { startIndex, visitor } = props;
-    visitor.enterNode(startIndex ?? 0);
+    visitor.enterNode(index);
     // Note that the `in` operator return true for properties that are present on the object even if they
     // are set to `undefined. This is leveraged here to represent the fact that the value should be set to
     // `undefined` as opposed to leaving the value untouched.
@@ -126,17 +121,16 @@ function visitModify(modify: ModifyLike, props: PassProps, func: Pass): boolean 
         visitor.onSetValue(modify.setValue);
     }
     if (modify.fields !== undefined) {
-        const result = visitFieldMarks(modify.fields, props, func);
+        const result = visitFieldMarks(modify.fields, visitor, func);
         containsMoves ||= result;
     }
-    visitor.exitNode(startIndex ?? 0);
+    visitor.exitNode(index);
     return containsMoves;
 }
 
-function firstPass(delta: Delta.MarkList, props: PassProps): boolean {
-    const { startIndex, visitor } = props;
+function firstPass(delta: Delta.MarkList, visitor: DeltaVisitor): boolean {
     let containsMoves = false;
-    let index = startIndex ?? 0;
+    let index = 0;
     for (const mark of delta) {
         if (typeof mark === "number") {
             // Untouched nodes
@@ -147,14 +141,14 @@ function firstPass(delta: Delta.MarkList, props: PassProps): boolean {
             const type = mark.type;
             switch (type) {
                 case Delta.MarkType.ModifyAndDelete:
-                    result = visitModify(mark, { ...props, startIndex: index }, firstPass);
+                    result = visitModify(index, mark, visitor, firstPass);
                     visitor.onDelete(index, 1);
                     break;
                 case Delta.MarkType.Delete:
                     visitor.onDelete(index, mark.count);
                     break;
                 case Delta.MarkType.ModifyAndMoveOut: {
-                    result = visitModify(mark, { ...props, startIndex: index }, firstPass);
+                    result = visitModify(index, mark, visitor, firstPass);
                     visitor.onMoveOut(index, 1, mark.moveId);
                     break;
                 }
@@ -162,7 +156,7 @@ function firstPass(delta: Delta.MarkList, props: PassProps): boolean {
                     visitor.onMoveOut(index, mark.count, mark.moveId);
                     break;
                 case Delta.MarkType.Modify:
-                    result = visitModify(mark, { ...props, startIndex: index }, firstPass);
+                    result = visitModify(index, mark, visitor, firstPass);
                     index += 1;
                     break;
                 case Delta.MarkType.Insert:
@@ -171,7 +165,7 @@ function firstPass(delta: Delta.MarkList, props: PassProps): boolean {
                     break;
                 case Delta.MarkType.InsertAndModify:
                     visitor.onInsert(index, [mark.content]);
-                    result = visitModify(mark, { ...props, startIndex: index }, firstPass);
+                    result = visitModify(index, mark, visitor, firstPass);
                     index += 1;
                     break;
                 case Delta.MarkType.MoveIn:
@@ -188,9 +182,8 @@ function firstPass(delta: Delta.MarkList, props: PassProps): boolean {
     return containsMoves;
 }
 
-function secondPass(delta: Delta.MarkList, props: PassProps): boolean {
-    const { startIndex, visitor } = props;
-    let index = startIndex ?? 0;
+function secondPass(delta: Delta.MarkList, visitor: DeltaVisitor): boolean {
+    let index = 0;
     for (const mark of delta) {
         if (typeof mark === "number") {
             // Untouched nodes
@@ -206,7 +199,7 @@ function secondPass(delta: Delta.MarkList, props: PassProps): boolean {
                     // Handled in the first pass
                     break;
                 case Delta.MarkType.Modify:
-                    visitModify(mark, { ...props, startIndex: index }, secondPass);
+                    visitModify(index, mark, visitor, secondPass);
                     index += 1;
                     break;
                 case Delta.MarkType.Insert:
@@ -224,7 +217,7 @@ function secondPass(delta: Delta.MarkList, props: PassProps): boolean {
                 }
                 case Delta.MarkType.MoveInAndModify:
                     visitor.onMoveIn(index, 1, mark.moveId);
-                    visitModify(mark, { ...props, startIndex: index }, secondPass);
+                    visitModify(index, mark, visitor, secondPass);
                     index += 1;
                     break;
                 default:

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -333,17 +333,17 @@ describe("EditManager", () => {
         for (const scenario of buildScenario([], meta)) {
             // Uncomment the code below to log the titles of generated scenarios.
             // This is helpful for creating a unit test out of a generated scenario that fails.
-            const title = scenario
-                .map((s) => {
-                    if (s.type === "Pull") {
-                        return `Pull(${s.seq}) from:${s.from} ref:${s.ref}`;
-                    } else if (s.type === "Ack") {
-                        return `Ack(${s.seq})`;
-                    }
-                    return `Push(${s.seq})`;
-                })
-                .join("|");
-            console.debug(title);
+            // const title = scenario
+            //     .map((s) => {
+            //         if (s.type === "Pull") {
+            //             return `Pull(${s.seq}) from:${s.from} ref:${s.ref}`;
+            //         } else if (s.type === "Ack") {
+            //             return `Ack(${s.seq})`;
+            //         }
+            //         return `Push(${s.seq})`;
+            //     })
+            //     .join("|");
+            // console.debug(title);
             runUnitTestScenario(undefined, scenario);
         }
     });


### PR DESCRIPTION
Removes cruft from the implementation details of the delta visitor.
Also removes debug logging from EditManager tests (they were left on by mistake and are making the tests slower).