### PR TITLE
Fixes local build failure

### DIFF
--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -40,8 +40,8 @@
 		"test:mocha": "mocha",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "tsc",
-		"typetests:gen": "#flub generate typetests --generate --dir .",
-		"typetests:prepare": "#flub generate typetests --prepare --dir . --pin"
+		"typetests:gen": "flub generate typetests --generate --dir .",
+		"typetests:prepare": "flub generate typetests --prepare --dir . --pin"
 	},
 	"nyc": {
 		"all": true,


### PR DESCRIPTION
`npm run build:fast` started failing

`#flub generate` -> `flub generate`

Looking at #13628 an extra `#` was added to the typetests command