### PR TITLE
Add a trivial attributor e2e test

### DIFF
--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -153,6 +153,7 @@ export interface IProvideTestFluidObject {
 
 // @public (undocumented)
 export interface ITestContainerConfig {
+    enableAttribution?: boolean;
     fluidDataObjectType?: DataObjectFactoryType;
     loaderProps?: Partial<ILoaderProps>;
     registry?: ChannelFactoryRegistry;

--- a/packages/framework/attributor/src/attributor.ts
+++ b/packages/framework/attributor/src/attributor.ts
@@ -128,9 +128,11 @@ export class OpStreamAttributor extends Attributor implements IAttributor {
 		super(initialEntries);
 		deltaManager.on("op", (message: ISequencedDocumentMessage) => {
 			const client = audience.getMember(message.clientId);
-			// TODO: This case may be legitimate, and if so we need to figure out how to handle it.
-			assert(client !== undefined, 0x4af /* Received message from user not in the audience */);
-			this.keyToInfo.set(message.sequenceNumber, { user: client.user, timestamp: message.timestamp });
+			if (message.type === "op") {
+				// TODO: This case may be legitimate, and if so we need to figure out how to handle it.
+				assert(client !== undefined, 0x4af /* Received message from user not in the audience */);
+				this.keyToInfo.set(message.sequenceNumber, { user: client.user, timestamp: message.timestamp });
+			}
 		});
 	}
 }

--- a/packages/framework/attributor/src/test/mixinAttributor.spec.ts
+++ b/packages/framework/attributor/src/test/mixinAttributor.spec.ts
@@ -91,6 +91,7 @@ describe("mixinAttributor", () => {
         const runtimeAttribution = maybeProvidesAttributor.IRuntimeAttributor;
 
         const op: Partial<ISequencedDocumentMessage> = {
+            type: "op",
             sequenceNumber: 7,
             clientId,
             timestamp: 1006
@@ -116,6 +117,7 @@ describe("mixinAttributor", () => {
         );
 
         const op: Partial<ISequencedDocumentMessage> = {
+            type: "op",
             sequenceNumber: 7,
             clientId,
             timestamp: 1006

--- a/packages/framework/attributor/src/test/opStreamAttributor.spec.ts
+++ b/packages/framework/attributor/src/test/opStreamAttributor.spec.ts
@@ -17,6 +17,7 @@ class OpFactory {
     public makeOp({ timestamp, clientId }: { timestamp: number; clientId: string; }): ISequencedDocumentMessage {
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         return {
+            type: "op",
             timestamp,
             clientId,
             sequenceNumber: this.seq++,

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -72,6 +72,7 @@
     "@fluid-tools/benchmark": "^0.45.0",
     "@fluidframework/agent-scheduler": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluidframework/aqueduct": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+    "@fluidframework/attributor": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluidframework/cell": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^1.0.0",

--- a/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
@@ -1,0 +1,94 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+    AttributionInfo,
+    createRuntimeAttributor,
+    enableOnNewFileKey,
+    IRuntimeAttributor,
+} from "@fluidframework/attributor";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { SharedString } from "@fluidframework/sequence";
+import {
+    ITestObjectProvider,
+    ITestContainerConfig,
+    DataObjectFactoryType,
+    ChannelFactoryRegistry,
+    ITestFluidObject,
+} from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluidframework/test-version-utils";
+import { IContainer } from "@fluidframework/container-definitions";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
+
+const stringId = "sharedStringKey";
+const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
+const testContainerConfig: ITestContainerConfig = {
+    fluidDataObjectType: DataObjectFactoryType.Test,
+    registry,
+};
+
+function assertAttributionMatches(sharedString: SharedString, position: number, attributor: IRuntimeAttributor, expected: Partial<AttributionInfo>): void {
+    const { segment, offset } = sharedString.getContainingSegment(position);
+    assert(segment !== undefined && offset !== undefined, `Position ${position} had no associated segment.`);
+    assert(segment.attribution !== undefined, `Position ${position}'s segment had no attribution information.`);
+    const key = segment.attribution.getAtOffset(offset);
+    const { timestamp, user } = attributor.get(key) ?? {};
+    if (expected.timestamp !== undefined) {
+        assert.equal(timestamp, expected.timestamp);
+    }
+    if (expected.user !== undefined) {
+        assert.deepEqual(user, expected.user);
+    }
+}
+
+// TODO: Expand the e2e tests in this suite to cover interesting combinations of configuration and versioning that aren't covered by mixinAttributor
+// unit tests.
+describeNoCompat("Attributor", (getTestObjectProvider) => {
+    let provider: ITestObjectProvider;
+    beforeEach(() => {
+        provider = getTestObjectProvider();
+    });
+
+    const configProvider = ((settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+        getRawConfig: (name: string): ConfigTypes => settings[name],
+    }));
+
+    it("Can attribute content from multiple collaborators", async () => {
+        const sharedStringFromContainer = async (container: IContainer) => {
+            const dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
+            return dataObject.getSharedObject<SharedString>(stringId);
+        }
+
+        const getTestConfig = (runtimeAttributor?: IRuntimeAttributor): ITestContainerConfig => ({
+            ...testContainerConfig,
+            enableAttribution: runtimeAttributor !== undefined,
+            loaderProps: { 
+                scope: { IRuntimeAttributor: runtimeAttributor },
+                configProvider: configProvider({
+                    [enableOnNewFileKey]: true,
+                })
+            }
+        });
+        
+        const attributor = createRuntimeAttributor();
+        const container1 = await provider.makeTestContainer(getTestConfig(attributor));
+        const sharedString1 = await sharedStringFromContainer(container1);
+
+        const container2 = await provider.loadTestContainer(testContainerConfig);
+        const sharedString2 = await sharedStringFromContainer(container2);
+
+        const text = "client 1";
+        sharedString1.insertText(0, text);
+        await provider.ensureSynchronized();
+        sharedString2.insertText(0, "client 2, ");
+        await provider.ensureSynchronized();
+        assert.equal(sharedString1.getText(), "client 2, client 1");
+
+        assert(container1.clientId !== undefined && container2.clientId !== undefined, "Both containers should have client ids.");
+        assertAttributionMatches(sharedString1, 3, attributor, { user: container1.audience.getMember(container2.clientId)?.user});
+        assertAttributionMatches(sharedString1, 13, attributor, { user: container1.audience.getMember(container1.clientId)?.user});
+    });
+});

--- a/packages/test/test-utils/src/testContainerRuntimeFactory.ts
+++ b/packages/test/test-utils/src/testContainerRuntimeFactory.ts
@@ -67,7 +67,7 @@ export const createTestContainerRuntimeFactory = (containerRuntimeCtor: typeof C
                     ...this.requestHandlers,
                 ),
                 this.runtimeOptions,
-                undefined, // containerScope
+                context.scope,
                 existing,
             );
 

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -88,6 +88,9 @@ export interface ITestContainerConfig {
     /** Container runtime options for the container instance */
     runtimeOptions?: IContainerRuntimeOptions;
 
+    /** Whether this runtime should be instantiated using a mixed-in attributor class */
+    enableAttribution?: boolean;
+
     /** Loader options for the loader used to create containers */
     loaderProps?: Partial<ILoaderProps>;
 }

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@fluid-experimental/sequence-deprecated": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluidframework/aqueduct": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+    "@fluidframework/attributor": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluidframework/cell": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
     "@fluidframework/common-definitions": "^0.20.1",
     "@fluidframework/common-utils": "^1.0.0",

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -20,6 +20,7 @@ import {
 } from "@fluidframework/test-utils";
 import { TestDriverTypes } from "@fluidframework/test-driver-definitions";
 import { FluidTestDriverConfig, createFluidTestDriver } from "@fluidframework/test-drivers";
+import { mixinAttributor } from "@fluidframework/attributor";
 import { pkgVersion } from "./packageVersion";
 import { getLoaderApi, getContainerRuntimeApi, getDataRuntimeApi, getDriverApi } from "./testApi";
 
@@ -116,7 +117,9 @@ export async function getVersionedTestObjectProvider(
     const getDataStoreFactoryFn = createGetDataStoreFactoryFunction(dataRuntimeApi);
     const containerFactoryFn = (containerOptions?: ITestContainerConfig) => {
         const dataStoreFactory = getDataStoreFactoryFn(containerOptions);
-        const factoryCtor = createTestContainerRuntimeFactory(containerRuntimeApi.ContainerRuntime);
+        const runtimeCtor = containerOptions?.enableAttribution === true ?
+            mixinAttributor(containerRuntimeApi.ContainerRuntime) : containerRuntimeApi.ContainerRuntime;
+        const factoryCtor = createTestContainerRuntimeFactory(runtimeCtor);
         return new factoryCtor(TestDataObjectType, dataStoreFactory, containerOptions?.runtimeOptions,
             [innerRequestHandler]);
     };


### PR DESCRIPTION
## Description

This adds a trivial e2e test for the attribution stack, leveraging the SharedString DDS bookkeeping.

Plans are to expand on this suite to include more reasonable valid configurations (so that we have good test coverage for integration when customers go to adopt this API). I'm checking this in early as it also includes all necessary test infrastructure tweaks to support the container runtime mixin pattern in test infra, as well as a bug fix for OpStreamAttributor.
