### PR TITLE
build(build-tools): Add missing peer dependencies

### DIFF
--- a/build-tools/.npmrc
+++ b/build-tools/.npmrc
@@ -1,3 +1,5 @@
 # Temporary, because otherwise pnpm fails due to peer dependencies not being satisfied
 # with our current dependency graph.
-strict-peer-dependencies=false
+strict-peer-dependencies=true
+
+resolve-peers-from-workspace-root=false

--- a/build-tools/.npmrc
+++ b/build-tools/.npmrc
@@ -1,3 +1,1 @@
-# Temporary, because otherwise pnpm fails due to peer dependencies not being satisfied
-# with our current dependency graph.
 strict-peer-dependencies=true

--- a/build-tools/.npmrc
+++ b/build-tools/.npmrc
@@ -1,5 +1,3 @@
 # Temporary, because otherwise pnpm fails due to peer dependencies not being satisfied
 # with our current dependency graph.
 strict-peer-dependencies=true
-
-resolve-peers-from-workspace-root=false

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -99,12 +99,5 @@
     "run-script-os": "^1.1.6",
     "typescript": "~4.5.5"
   },
-  "packageManager": "pnpm@7.14.2",
-  "pnpm": {
-      "peerDependencyRules": {
-        "allowedVersions": {
-          "eslint": "8.5.0"
-        }
-      }
-    }
+  "packageManager": "pnpm@7.14.2"
 }

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -99,5 +99,12 @@
     "run-script-os": "^1.1.6",
     "typescript": "~4.5.5"
   },
-  "packageManager": "pnpm@7.14.2"
+  "packageManager": "pnpm@7.14.2",
+  "pnpm": {
+      "peerDependencyRules": {
+        "allowedVersions": {
+          "eslint": "8.6.0"
+        }
+      }
+    }
 }

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -99,5 +99,12 @@
     "run-script-os": "^1.1.6",
     "typescript": "~4.5.5"
   },
-  "packageManager": "pnpm@7.14.2"
+  "packageManager": "pnpm@7.14.2",
+  "pnpm": {
+      "peerDependencyRules": {
+        "allowedVersions": {
+          "eslint": "8.5.0"
+        }
+      }
+    }
 }

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -80,7 +80,7 @@
     "@oclif/plugin-not-found": "^2.3.1",
     "@oclif/plugin-plugins": "^2.0.1",
     "@oclif/test": "^2",
-    "@octokit/core": "4.0.5",
+    "@octokit/core": "^4.0.5",
     "@rushstack/node-core-library": "^3.51.1",
     "chalk": "^2.4.2",
     "date-fns": "^2.29.1",

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -54,8 +54,8 @@
   "dependencies": {
     "@fluid-tools/version-tools": "^0.8.0",
     "@fluidframework/bundle-size-tools": "^0.8.0",
-    "@rushstack/node-core-library": "^3.51.1",
     "@octokit/core": "^4.0.5",
+    "@rushstack/node-core-library": "^3.51.1",
     "async": "^3.2.2",
     "chalk": "^2.4.2",
     "commander": "^6.2.1",

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -55,7 +55,7 @@
     "@fluid-tools/version-tools": "^0.8.0",
     "@fluidframework/bundle-size-tools": "^0.8.0",
     "@rushstack/node-core-library": "^3.51.1",
-    "@octokit/core": ">=3",
+    "@octokit/core": "^4.0.5",
     "async": "^3.2.2",
     "chalk": "^2.4.2",
     "commander": "^6.2.1",

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -55,6 +55,7 @@
     "@fluid-tools/version-tools": "^0.8.0",
     "@fluidframework/bundle-size-tools": "^0.8.0",
     "@rushstack/node-core-library": "^3.51.1",
+    "@octokit/core": ">=3",
     "async": "^3.2.2",
     "chalk": "^2.4.2",
     "commander": "^6.2.1",

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -63,7 +63,7 @@ importers:
       '@oclif/plugin-not-found': ^2.3.1
       '@oclif/plugin-plugins': ^2.0.1
       '@oclif/test': ^2
-      '@octokit/core': 4.0.5
+      '@octokit/core': ^4.0.5
       '@rushstack/node-core-library': ^3.51.1
       '@trivago/prettier-plugin-sort-imports': ^3.3.0
       '@types/chai': ^4
@@ -185,7 +185,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/bundle-size-tools': ^0.8.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@octokit/core': '>=3'
+      '@octokit/core': ^4.0.5
       '@rushstack/node-core-library': ^3.51.1
       '@trivago/prettier-plugin-sort-imports': ^3.3.0
       '@types/async': ^3.2.6
@@ -484,7 +484,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/core': '>=7.11.0'
-      eslint: ^7.5.0 || ^8.0.0 || 8.5.0
+      eslint: ^7.5.0 || ^8.0.0 || 8.6.0
     dependencies:
       '@babel/core': 7.19.3
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
@@ -2610,7 +2610,7 @@ packages:
   /@rushstack/eslint-plugin-security/0.2.6_kufnqfq7tb5rpdawkdb6g5smma:
     resolution: {integrity: sha512-gicwYhbc3Q5U43U2qmhePLedfF6+mSEjcQ/D+Bq4zQLP7zo9MGTKAeYPnLTq0M7hqoCEeQUFQZvNav+kjue6Nw==}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.5.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.3
       '@typescript-eslint/experimental-utils': 5.6.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -2623,7 +2623,7 @@ packages:
   /@rushstack/eslint-plugin/0.8.6_kufnqfq7tb5rpdawkdb6g5smma:
     resolution: {integrity: sha512-R0gbPI3nz1vRUZddOiwpGtBSQ6FXrnsUpKvKoVkADWhkYmtdi6cU/gpQ6amOa5LhLPhSdQNtkhCB+yhUINKgEg==}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.5.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.3
       '@typescript-eslint/experimental-utils': 5.6.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -2929,7 +2929,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^4.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0 || 8.5.0
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0 || 8.6.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -2955,7 +2955,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.5.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -2982,7 +2982,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.5.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -3044,7 +3044,7 @@ packages:
     resolution: {integrity: sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.5.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
     dependencies:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.9.1
@@ -3062,7 +3062,7 @@ packages:
     resolution: {integrity: sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.5.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
     dependencies:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.9.1
@@ -3080,7 +3080,7 @@ packages:
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0 || 8.5.0
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0 || 8.6.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -3100,7 +3100,7 @@ packages:
     resolution: {integrity: sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.5.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.6.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -5365,7 +5365,7 @@ packages:
     resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
     hasBin: true
     peerDependencies:
-      eslint: '>=7.0.0 || 8.5.0'
+      eslint: '>=7.0.0 || 8.6.0'
     dependencies:
       eslint: 8.6.0
     dev: true
@@ -5374,7 +5374,7 @@ packages:
     resolution: {integrity: sha512-b8UjW+nQyOkhiANVpIptqlKPyE7XRyQ40uQ1NoBhzVfu95gxfZGrpliq8ZHBpaOF2wCLZaexTSjg7Rvm99vj4A==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: '>=7.20.0 || 8.5.0'
+      eslint: '>=7.20.0 || 8.6.0'
     dependencies:
       eslint: 8.6.0
       eslint-config-xo: 0.35.0_eslint@8.6.0
@@ -5384,7 +5384,7 @@ packages:
     resolution: {integrity: sha512-emUZVHjmzl3I1aO2M/2gEpqa/GHXTl7LF/vQeAX4W+mQIU+2kyqY97FkMnSc2J8Osoq+vCSXCY/HjFUmFIF/Ag==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: '>=7.32.0 || 8.5.0'
+      eslint: '>=7.32.0 || 8.6.0'
     dependencies:
       eslint: 8.6.0
       eslint-config-xo: 0.38.0_eslint@8.6.0
@@ -5394,7 +5394,7 @@ packages:
     resolution: {integrity: sha512-+WyZTLWUJlvExFrBU/Ldw8AB/S0d3x+26JQdBWbcqig2ZaWh0zinYcHok+ET4IoPaEcRRf3FE9kjItNVjBwnAg==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: '>=7.20.0 || 8.5.0'
+      eslint: '>=7.20.0 || 8.6.0'
     dependencies:
       confusing-browser-globals: 1.0.10
       eslint: 8.6.0
@@ -5404,7 +5404,7 @@ packages:
     resolution: {integrity: sha512-G2jL+VyfkcZW8GoTmqLsExvrWssBedSoaQQ11vyhflDeT3csMdBVp0On+AVijrRuvgmkWeDwwUL5Rj0qDRHK6g==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: '>=7.20.0 || 8.5.0'
+      eslint: '>=7.20.0 || 8.6.0'
     dependencies:
       confusing-browser-globals: 1.0.10
       eslint: 8.6.0
@@ -5493,7 +5493,7 @@ packages:
     resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
-      eslint: '>=4.19.1 || 8.5.0'
+      eslint: '>=4.19.1 || 8.6.0'
     dependencies:
       eslint: 8.6.0
       eslint-utils: 2.1.0
@@ -5504,7 +5504,7 @@ packages:
     resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
     engines: {node: '>=6.5.0'}
     peerDependencies:
-      eslint: '>=4.19.1 || 8.5.0'
+      eslint: '>=4.19.1 || 8.6.0'
     dependencies:
       escape-string-regexp: 1.0.5
       eslint: 8.6.0
@@ -5516,7 +5516,7 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || 8.5.0
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || 8.6.0
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
@@ -5546,7 +5546,7 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || 8.5.0
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || 8.6.0
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
@@ -5576,7 +5576,7 @@ packages:
     resolution: {integrity: sha512-R6dZ4t83qPdMhIOGr7g2QII2pwCjYyKP+z0tPOfO1bbAbQyKC20Y2Rd6z1te86Lq3T7uM8bNo+VD9YFpE8HU/g==}
     engines: {node: ^14 || ^16 || ^17 || ^18}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0 || 8.5.0
+      eslint: ^7.0.0 || ^8.0.0 || 8.6.0
     dependencies:
       '@es-joy/jsdoccomment': 0.31.0
       comment-parser: 1.3.1
@@ -5594,7 +5594,7 @@ packages:
     resolution: {integrity: sha512-d7knAcQj1jPCzZf3caeBIn3BnW6ikcvfz0kSqQpwPYcVGLoJV5sz0l0OJB2LR8I7dvTDbqq1oV6ylhSgzA10zg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      eslint: '>=7.0.0 || 8.5.0'
+      eslint: '>=7.0.0 || 8.6.0'
     dependencies:
       eslint: 8.6.0
       eslint-utils: 3.0.0_eslint@8.6.0
@@ -5605,7 +5605,7 @@ packages:
     resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
-      eslint: '>=5.16.0 || 8.5.0'
+      eslint: '>=5.16.0 || 8.6.0'
     dependencies:
       eslint: 8.6.0
       eslint-plugin-es: 3.0.1_eslint@8.6.0
@@ -5620,7 +5620,7 @@ packages:
     resolution: {integrity: sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0 || 8.5.0
+      eslint: ^7.0.0 || ^8.0.0 || 8.6.0
     dependencies:
       eslint: 8.6.0
     dev: true
@@ -5629,7 +5629,7 @@ packages:
     resolution: {integrity: sha512-IOlFIRHzWfEQQKcAD4iyYDndHwTQiCMcJVJjxempf203jnNLUnW34AXLrV33+nEXoifJE2ZEGmcjKPL8957eSw==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || 8.5.0
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || 8.6.0
     dependencies:
       array-includes: 3.1.5
       array.prototype.flatmap: 1.3.0
@@ -5659,7 +5659,7 @@ packages:
     resolution: {integrity: sha512-xxN2vSctGWnDW6aLElm/LKIwcrmk6mdiEcW55Uv5krcrVcIFSWMmEgc/hwpemYfZacKZ5npFERGNz4aThsp1AA==}
     engines: {node: '>=12'}
     peerDependencies:
-      eslint: '>=7.32.0 || 8.5.0'
+      eslint: '>=7.32.0 || 8.6.0'
     dependencies:
       '@babel/helper-validator-identifier': 7.19.1
       ci-info: 3.4.0
@@ -5682,7 +5682,7 @@ packages:
     resolution: {integrity: sha512-5GRXISfBk8jMmYk1eeNDw8zSRnWTxBjWkzx2Prre6E2/yLu2twozZ3EomLWCBu9nWms/ZE361BItyMQwfnG1qA==}
     engines: {node: '>=12'}
     peerDependencies:
-      eslint: '>=7.32.0 || 8.5.0'
+      eslint: '>=7.32.0 || 8.6.0'
     dependencies:
       '@babel/helper-validator-identifier': 7.19.1
       ci-info: 3.4.0
@@ -5706,7 +5706,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^5.0.0
-      eslint: ^8.0.0 || 8.5.0
+      eslint: ^8.0.0 || 8.6.0
     peerDependenciesMeta:
       '@typescript-eslint/eslint-plugin':
         optional: true
@@ -5720,7 +5720,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^5.0.0
-      eslint: ^8.0.0 || 8.5.0
+      eslint: ^8.0.0 || 8.6.0
     peerDependenciesMeta:
       '@typescript-eslint/eslint-plugin':
         optional: true
@@ -5752,7 +5752,7 @@ packages:
   /eslint-template-visitor/2.3.2_eslint@8.6.0:
     resolution: {integrity: sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==}
     peerDependencies:
-      eslint: '>=7.0.0 || 8.5.0'
+      eslint: '>=7.0.0 || 8.6.0'
     dependencies:
       '@babel/core': 7.19.3
       '@babel/eslint-parser': 7.19.1_yivkgiz57qvlxgogwvu6ajj3xq
@@ -5775,7 +5775,7 @@ packages:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
-      eslint: '>=5 || 8.5.0'
+      eslint: '>=5 || 8.6.0'
     dependencies:
       eslint: 8.24.0
       eslint-visitor-keys: 2.1.0
@@ -5784,7 +5784,7 @@ packages:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
-      eslint: '>=5 || 8.5.0'
+      eslint: '>=5 || 8.6.0'
     dependencies:
       eslint: 8.6.0
       eslint-visitor-keys: 2.1.0

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -185,6 +185,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/bundle-size-tools': ^0.8.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
+      '@octokit/core': '>=3'
       '@rushstack/node-core-library': ^3.51.1
       '@trivago/prettier-plugin-sort-imports': ^3.3.0
       '@types/async': ^3.2.6
@@ -236,11 +237,12 @@ importers:
     dependencies:
       '@fluid-tools/version-tools': link:../version-tools
       '@fluidframework/bundle-size-tools': link:../bundle-size-tools
+      '@octokit/core': 4.0.5
       '@rushstack/node-core-library': 3.53.0
       async: 3.2.4
       chalk: 2.4.2
       commander: 6.2.1
-      danger: 10.9.0
+      danger: 10.9.0_@octokit+core@4.0.5
       date-fns: 2.29.3
       debug: 4.3.4
       fs-extra: 9.1.0
@@ -482,7 +484,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/core': '>=7.11.0'
-      eslint: ^7.5.0 || ^8.0.0
+      eslint: ^7.5.0 || ^8.0.0 || 8.5.0
     dependencies:
       '@babel/core': 7.19.3
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
@@ -2426,12 +2428,6 @@ packages:
       '@octokit/types': 7.5.1
     dev: true
 
-  /@octokit/plugin-request-log/1.0.4:
-    resolution: {integrity: sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==}
-    peerDependencies:
-      '@octokit/core': '>=3'
-    dev: false
-
   /@octokit/plugin-request-log/1.0.4_@octokit+core@3.6.0:
     resolution: {integrity: sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==}
     peerDependencies:
@@ -2445,7 +2441,6 @@ packages:
       '@octokit/core': '>=3'
     dependencies:
       '@octokit/core': 4.0.5
-    dev: true
 
   /@octokit/plugin-rest-endpoint-methods/2.4.0:
     resolution: {integrity: sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==}
@@ -2522,12 +2517,12 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@octokit/rest/16.43.2:
+  /@octokit/rest/16.43.2_@octokit+core@4.0.5:
     resolution: {integrity: sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==}
     dependencies:
       '@octokit/auth-token': 2.5.0
       '@octokit/plugin-paginate-rest': 1.1.2
-      '@octokit/plugin-request-log': 1.0.4
+      '@octokit/plugin-request-log': 1.0.4_@octokit+core@4.0.5
       '@octokit/plugin-rest-endpoint-methods': 2.4.0
       '@octokit/request': 5.6.3
       '@octokit/request-error': 1.2.1
@@ -2615,7 +2610,7 @@ packages:
   /@rushstack/eslint-plugin-security/0.2.6_kufnqfq7tb5rpdawkdb6g5smma:
     resolution: {integrity: sha512-gicwYhbc3Q5U43U2qmhePLedfF6+mSEjcQ/D+Bq4zQLP7zo9MGTKAeYPnLTq0M7hqoCEeQUFQZvNav+kjue6Nw==}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.5.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.3
       '@typescript-eslint/experimental-utils': 5.6.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -2628,7 +2623,7 @@ packages:
   /@rushstack/eslint-plugin/0.8.6_kufnqfq7tb5rpdawkdb6g5smma:
     resolution: {integrity: sha512-R0gbPI3nz1vRUZddOiwpGtBSQ6FXrnsUpKvKoVkADWhkYmtdi6cU/gpQ6amOa5LhLPhSdQNtkhCB+yhUINKgEg==}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.5.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.3
       '@typescript-eslint/experimental-utils': 5.6.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -2934,7 +2929,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^4.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0 || 8.5.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -2960,7 +2955,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.5.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -2987,7 +2982,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.5.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -3049,7 +3044,7 @@ packages:
     resolution: {integrity: sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.5.0
     dependencies:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.9.1
@@ -3067,7 +3062,7 @@ packages:
     resolution: {integrity: sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.5.0
     dependencies:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.9.1
@@ -3085,7 +3080,7 @@ packages:
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0 || 8.5.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -3105,7 +3100,7 @@ packages:
     resolution: {integrity: sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || 8.5.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -4840,12 +4835,12 @@ packages:
       type: 1.2.0
     dev: false
 
-  /danger/10.9.0:
+  /danger/10.9.0_@octokit+core@4.0.5:
     resolution: {integrity: sha512-eEWQAaIPfWSfzlQiFx+w9fWuP3jwq8VAV9W22EZRxfmCBnkdDa5aN0Akr7lzfCKudzy+4uEmIGUtxnYeFgTthQ==}
     hasBin: true
     dependencies:
       '@babel/polyfill': 7.12.1
-      '@octokit/rest': 16.43.2
+      '@octokit/rest': 16.43.2_@octokit+core@4.0.5
       async-retry: 1.2.3
       chalk: 2.4.2
       commander: 2.20.3
@@ -5370,7 +5365,7 @@ packages:
     resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
     hasBin: true
     peerDependencies:
-      eslint: '>=7.0.0'
+      eslint: '>=7.0.0 || 8.5.0'
     dependencies:
       eslint: 8.6.0
     dev: true
@@ -5379,7 +5374,7 @@ packages:
     resolution: {integrity: sha512-b8UjW+nQyOkhiANVpIptqlKPyE7XRyQ40uQ1NoBhzVfu95gxfZGrpliq8ZHBpaOF2wCLZaexTSjg7Rvm99vj4A==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: '>=7.20.0'
+      eslint: '>=7.20.0 || 8.5.0'
     dependencies:
       eslint: 8.6.0
       eslint-config-xo: 0.35.0_eslint@8.6.0
@@ -5389,7 +5384,7 @@ packages:
     resolution: {integrity: sha512-emUZVHjmzl3I1aO2M/2gEpqa/GHXTl7LF/vQeAX4W+mQIU+2kyqY97FkMnSc2J8Osoq+vCSXCY/HjFUmFIF/Ag==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: '>=7.32.0'
+      eslint: '>=7.32.0 || 8.5.0'
     dependencies:
       eslint: 8.6.0
       eslint-config-xo: 0.38.0_eslint@8.6.0
@@ -5399,7 +5394,7 @@ packages:
     resolution: {integrity: sha512-+WyZTLWUJlvExFrBU/Ldw8AB/S0d3x+26JQdBWbcqig2ZaWh0zinYcHok+ET4IoPaEcRRf3FE9kjItNVjBwnAg==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: '>=7.20.0'
+      eslint: '>=7.20.0 || 8.5.0'
     dependencies:
       confusing-browser-globals: 1.0.10
       eslint: 8.6.0
@@ -5409,7 +5404,7 @@ packages:
     resolution: {integrity: sha512-G2jL+VyfkcZW8GoTmqLsExvrWssBedSoaQQ11vyhflDeT3csMdBVp0On+AVijrRuvgmkWeDwwUL5Rj0qDRHK6g==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: '>=7.20.0'
+      eslint: '>=7.20.0 || 8.5.0'
     dependencies:
       confusing-browser-globals: 1.0.10
       eslint: 8.6.0
@@ -5498,7 +5493,7 @@ packages:
     resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
-      eslint: '>=4.19.1'
+      eslint: '>=4.19.1 || 8.5.0'
     dependencies:
       eslint: 8.6.0
       eslint-utils: 2.1.0
@@ -5509,7 +5504,7 @@ packages:
     resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
     engines: {node: '>=6.5.0'}
     peerDependencies:
-      eslint: '>=4.19.1'
+      eslint: '>=4.19.1 || 8.5.0'
     dependencies:
       escape-string-regexp: 1.0.5
       eslint: 8.6.0
@@ -5521,7 +5516,7 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || 8.5.0
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
@@ -5551,7 +5546,7 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || 8.5.0
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
@@ -5581,7 +5576,7 @@ packages:
     resolution: {integrity: sha512-R6dZ4t83qPdMhIOGr7g2QII2pwCjYyKP+z0tPOfO1bbAbQyKC20Y2Rd6z1te86Lq3T7uM8bNo+VD9YFpE8HU/g==}
     engines: {node: ^14 || ^16 || ^17 || ^18}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
+      eslint: ^7.0.0 || ^8.0.0 || 8.5.0
     dependencies:
       '@es-joy/jsdoccomment': 0.31.0
       comment-parser: 1.3.1
@@ -5599,7 +5594,7 @@ packages:
     resolution: {integrity: sha512-d7knAcQj1jPCzZf3caeBIn3BnW6ikcvfz0kSqQpwPYcVGLoJV5sz0l0OJB2LR8I7dvTDbqq1oV6ylhSgzA10zg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      eslint: '>=7.0.0'
+      eslint: '>=7.0.0 || 8.5.0'
     dependencies:
       eslint: 8.6.0
       eslint-utils: 3.0.0_eslint@8.6.0
@@ -5610,7 +5605,7 @@ packages:
     resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
-      eslint: '>=5.16.0'
+      eslint: '>=5.16.0 || 8.5.0'
     dependencies:
       eslint: 8.6.0
       eslint-plugin-es: 3.0.1_eslint@8.6.0
@@ -5625,7 +5620,7 @@ packages:
     resolution: {integrity: sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
+      eslint: ^7.0.0 || ^8.0.0 || 8.5.0
     dependencies:
       eslint: 8.6.0
     dev: true
@@ -5634,7 +5629,7 @@ packages:
     resolution: {integrity: sha512-IOlFIRHzWfEQQKcAD4iyYDndHwTQiCMcJVJjxempf203jnNLUnW34AXLrV33+nEXoifJE2ZEGmcjKPL8957eSw==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || 8.5.0
     dependencies:
       array-includes: 3.1.5
       array.prototype.flatmap: 1.3.0
@@ -5664,7 +5659,7 @@ packages:
     resolution: {integrity: sha512-xxN2vSctGWnDW6aLElm/LKIwcrmk6mdiEcW55Uv5krcrVcIFSWMmEgc/hwpemYfZacKZ5npFERGNz4aThsp1AA==}
     engines: {node: '>=12'}
     peerDependencies:
-      eslint: '>=7.32.0'
+      eslint: '>=7.32.0 || 8.5.0'
     dependencies:
       '@babel/helper-validator-identifier': 7.19.1
       ci-info: 3.4.0
@@ -5687,7 +5682,7 @@ packages:
     resolution: {integrity: sha512-5GRXISfBk8jMmYk1eeNDw8zSRnWTxBjWkzx2Prre6E2/yLu2twozZ3EomLWCBu9nWms/ZE361BItyMQwfnG1qA==}
     engines: {node: '>=12'}
     peerDependencies:
-      eslint: '>=7.32.0'
+      eslint: '>=7.32.0 || 8.5.0'
     dependencies:
       '@babel/helper-validator-identifier': 7.19.1
       ci-info: 3.4.0
@@ -5711,7 +5706,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^5.0.0
-      eslint: ^8.0.0
+      eslint: ^8.0.0 || 8.5.0
     peerDependenciesMeta:
       '@typescript-eslint/eslint-plugin':
         optional: true
@@ -5725,7 +5720,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^5.0.0
-      eslint: ^8.0.0
+      eslint: ^8.0.0 || 8.5.0
     peerDependenciesMeta:
       '@typescript-eslint/eslint-plugin':
         optional: true
@@ -5757,7 +5752,7 @@ packages:
   /eslint-template-visitor/2.3.2_eslint@8.6.0:
     resolution: {integrity: sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==}
     peerDependencies:
-      eslint: '>=7.0.0'
+      eslint: '>=7.0.0 || 8.5.0'
     dependencies:
       '@babel/core': 7.19.3
       '@babel/eslint-parser': 7.19.1_yivkgiz57qvlxgogwvu6ajj3xq
@@ -5780,7 +5775,7 @@ packages:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
-      eslint: '>=5'
+      eslint: '>=5 || 8.5.0'
     dependencies:
       eslint: 8.24.0
       eslint-visitor-keys: 2.1.0
@@ -5789,7 +5784,7 @@ packages:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
-      eslint: '>=5'
+      eslint: '>=5 || 8.5.0'
     dependencies:
       eslint: 8.6.0
       eslint-visitor-keys: 2.1.0


### PR DESCRIPTION
Add missing "@octokit/core" peerDependency and updates the pnpm overrides to permit eslint 8.6 even though eslint-config-oclif-typescript isn't officially compatible.