### PR TITLE
build(core-utils): Disable type tests

### DIFF
--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -85,5 +85,8 @@
 		"rimraf": "^2.6.2",
 		"source-map-support": "^0.5.16",
 		"typescript": "~4.5.5"
-	}
+	},
+  "typeValidation": {
+    "disabled": true
+  }
 }


### PR DESCRIPTION
The core-utils package is new and has not yet been published, so typetests don't make sense.