### PR TITLE
Add new settings to r11s values.yaml

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -137,6 +137,11 @@ redisForThrottling:
   port: 6379
   tls: false
 
+redisForTenantCache:
+  url: redis_url
+  port: 6379
+  tls: false
+
 kafka:
   topics:
     rawdeltas: rawdeltas


### PR DESCRIPTION
## Description

A [recent PR](https://github.com/microsoft/FluidFramework/pull/13465/files#diff-5f423c257b4d7c5dca757fa6caf38473d6bb4607331043d55d5a8fc31577d9be) introduced new redis-related settings to the r11s chart. This one updates the `values.yaml` file with defaults for those settings so our internal deployment of the chart doesn't fail with this error:

`Error: UPGRADE FAILED: template: routerlicious/templates/scriptorium-deployment.yaml:21:28: executing "routerlicious/templates/scriptorium-deployment.yaml" at <include (print $.Template.BasePath "/fluid-configmap.yaml") .>: error calling include: template: routerlicious/templates/fluid-configmap.yaml:220:31: executing "routerlicious/templates/fluid-configmap.yaml" at <.Values.redisForTenantCache.url>: nil pointer evaluating interface {}.url`
