### PR TITLE
ci: Validate CODEOWNERS on all PR changes

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -36,11 +36,6 @@ jobs:
   validate-codeowners:
     name: Validate CODEOWNERS
     runs-on: ubuntu-latest
-    # Run only on events that could change the code
-    if: |
-      github.event.action == 'opened' ||
-      github.event.action == 'synchronize' ||
-      github.event.action == 'reopened'
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
         with:


### PR DESCRIPTION
In the current config, the CODEOWNERS job is skipped when PR content is updated without doing a subsequent push to the PR branch. After this change, the CODEOWNERS job will run on all PR edits.