### PR TITLE
[GC-stress] Update totalSendCount to fix tests timing out

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -33,7 +33,7 @@
             "opRatePerMin": 800,
             "progressIntervalMs": 5000,
             "numClients": 10,
-            "totalSendCount": 48000,
+            "totalSendCount": 36000,
             "optionOverrides":{
                 "tinylicious":{
                     "comment": "SessionExpiry: 15 mins. Inactive Timeout: 16 mins. Sweep Timeout: 17 mins.",


### PR DESCRIPTION
The tests are timing out again. The issue is that when this happens, there are no logs to give an idea of what might be happening. Decreasing the totalSendCount to see if the test passes and we get logs. That might give idea into what might be causing the timeout. Last time, it was because of server throttling.