### PR TITLE
feat(release): Include links to ADO pipelines in release tools

### DIFF
--- a/build-tools/packages/build-cli/src/handlers/promptFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/promptFunctions.ts
@@ -6,7 +6,7 @@ import { strict as assert } from "assert";
 import chalk from "chalk";
 import { Machine } from "jssm";
 
-import { ADOPipelineLinks, InstructionalPrompt } from "../instructionalPromptWriter";
+import { InstructionalPrompt, mapADOLinks } from "../instructionalPromptWriter";
 import { difference, generateReleaseBranchName, getPreReleaseDependencies } from "../lib";
 import { CommandLogger } from "../logging";
 import { MachineState } from "../machines";
@@ -263,15 +263,6 @@ export const promptToRelease: StateHandlerFunction = async (
 
     const flag = isReleaseGroup(releaseGroup) ? "-g" : "-p";
 
-    const link =
-        releaseGroup === "client"
-            ? ADOPipelineLinks.CLIENT
-            : releaseGroup === "server"
-            ? ADOPipelineLinks.SERVER
-            : releaseGroup === "azure"
-            ? ADOPipelineLinks.AZURE
-            : ADOPipelineLinks.BUILDTOOLS;
-
     const prompt: InstructionalPrompt = {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         title: `READY TO RELEASE version ${chalk.bold(releaseVersion!)}!`,
@@ -283,7 +274,7 @@ export const promptToRelease: StateHandlerFunction = async (
                 )} build for the following release group in ADO for branch ${chalk.blue(
                     chalk.bold(context.originalBranchName),
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                )}:\n\n    ${chalk.green(chalk.bold(releaseGroup!))}`,
+                )}:\n\n    ${chalk.green(chalk.bold(releaseGroup!))}: ${mapADOLinks(releaseGroup)}`,
             },
             {
                 title: "NEXT",

--- a/build-tools/packages/build-cli/src/handlers/promptFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/promptFunctions.ts
@@ -6,7 +6,7 @@ import { strict as assert } from "assert";
 import chalk from "chalk";
 import { Machine } from "jssm";
 
-import { InstructionalPrompt, mapADOLinks } from "../instructionalPromptWriter";
+import { type InstructionalPrompt, mapADOLinks } from "../instructionalPromptWriter";
 import { difference, generateReleaseBranchName, getPreReleaseDependencies } from "../lib";
 import { CommandLogger } from "../logging";
 import { MachineState } from "../machines";

--- a/build-tools/packages/build-cli/src/handlers/promptFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/promptFunctions.ts
@@ -6,7 +6,7 @@ import { strict as assert } from "assert";
 import chalk from "chalk";
 import { Machine } from "jssm";
 
-import type { InstructionalPrompt } from "../instructionalPromptWriter";
+import { ADOPipelineLinks, InstructionalPrompt } from "../instructionalPromptWriter";
 import { difference, generateReleaseBranchName, getPreReleaseDependencies } from "../lib";
 import { CommandLogger } from "../logging";
 import { MachineState } from "../machines";
@@ -262,6 +262,16 @@ export const promptToRelease: StateHandlerFunction = async (
     assert(context !== undefined, "Context is undefined.");
 
     const flag = isReleaseGroup(releaseGroup) ? "-g" : "-p";
+
+    const link =
+        releaseGroup === "client"
+            ? ADOPipelineLinks.CLIENT
+            : releaseGroup === "server"
+            ? ADOPipelineLinks.SERVER
+            : releaseGroup === "azure"
+            ? ADOPipelineLinks.AZURE
+            : ADOPipelineLinks.BUILDTOOLS;
+
     const prompt: InstructionalPrompt = {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         title: `READY TO RELEASE version ${chalk.bold(releaseVersion!)}!`,

--- a/build-tools/packages/build-cli/src/instructionalPromptWriter.ts
+++ b/build-tools/packages/build-cli/src/instructionalPromptWriter.ts
@@ -45,6 +45,17 @@ interface Section {
 }
 
 /**
+ * Links to ADO pipeline for all release group
+ */
+
+export enum ADOPipelineLinks {
+    CLIENT = "https://dev.azure.com/fluidframework/internal/_build?definitionId=12",
+    SERVER = "https://dev.azure.com/fluidframework/internal/_build?definitionId=30",
+    BUILDTOOLS = "https://dev.azure.com/fluidframework/internal/_build?definitionId=14",
+    AZURE = "https://dev.azure.com/fluidframework/internal/_build?definitionId=85",
+}
+
+/**
  * An abstract base class for classes that write {@link InstructionalPrompt}s to the terminal.
  */
 export abstract class InstructionalPromptWriter {

--- a/build-tools/packages/build-cli/src/instructionalPromptWriter.ts
+++ b/build-tools/packages/build-cli/src/instructionalPromptWriter.ts
@@ -53,6 +53,48 @@ export enum ADOPipelineLinks {
     SERVER = "https://dev.azure.com/fluidframework/internal/_build?definitionId=30",
     BUILDTOOLS = "https://dev.azure.com/fluidframework/internal/_build?definitionId=14",
     AZURE = "https://dev.azure.com/fluidframework/internal/_build?definitionId=85",
+    APIMARKDOWNDOCUMENTER = "https://dev.azure.com/fluidframework/internal/_build?definitionId=97",
+    BENCHMARK = "https://dev.azure.com/fluidframework/internal/_build?definitionId=96",
+    TESTTOOLS = "https://dev.azure.com/fluidframework/internal/_build?definitionId=13",
+    TINYLICIOUS = "https://dev.azure.com/fluidframework/internal/_build?definitionId=22",
+    BUILDCOMMON = "https://dev.azure.com/fluidframework/internal/_build?definitionId=3",
+    ESLINTCONFLIGFLUID = "https://dev.azure.com/fluidframework/internal/_build?definitionId=7",
+    COMMONDEFINITIONS = "https://dev.azure.com/fluidframework/internal/_build?definitionId=8",
+    COMMONUTILS = "https://dev.azure.com/fluidframework/internal/_build?definitionId=10",
+    PROTOCOLDEFINITIONS = "https://dev.azure.com/fluidframework/internal/_build?definitionId=67",
+}
+
+/**
+ *
+ * Returns ADO pipeline link for the releaseGroup
+ */
+export const mapADOLinks = (releaseGroup: string | undefined): string => {
+    const adoLink = releaseGroup === "client"
+            ? ADOPipelineLinks.CLIENT
+            : releaseGroup === "server"
+            ? ADOPipelineLinks.SERVER
+            : releaseGroup === "azure"
+            ? ADOPipelineLinks.AZURE
+            : releaseGroup === "build-tools"
+            ? ADOPipelineLinks.BUILDTOOLS
+            : releaseGroup === "@fluid-tools/api-markdown-documenter"
+            ? ADOPipelineLinks.APIMARKDOWNDOCUMENTER
+            : releaseGroup ===  "@fluid-tools/benchmark"
+            ? ADOPipelineLinks.BENCHMARK
+            : releaseGroup === "@fluidframework/test-tools"
+            ? ADOPipelineLinks.TESTTOOLS
+            : releaseGroup === "tinylicious"
+            ? ADOPipelineLinks.TINYLICIOUS
+            : releaseGroup === "@fluidframework/build-common"
+            ? ADOPipelineLinks.BUILDCOMMON
+            : releaseGroup === "@fluidframework/eslint-config-fluid"
+            ? ADOPipelineLinks.ESLINTCONFLIGFLUID
+            : releaseGroup === "@fluidframework/common-definitions"
+            ? ADOPipelineLinks.COMMONDEFINITIONS
+            : releaseGroup === "@fluidframework/common-utils"
+            ? ADOPipelineLinks.COMMONUTILS
+            : ADOPipelineLinks.PROTOCOLDEFINITIONS;
+    return adoLink;
 }
 
 /**

--- a/build-tools/packages/build-cli/src/instructionalPromptWriter.ts
+++ b/build-tools/packages/build-cli/src/instructionalPromptWriter.ts
@@ -2,11 +2,13 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+import { MonoRepoKind } from "@fluidframework/build-tools";
 import { StringBuilder } from "@rushstack/node-core-library";
 import chalk from "chalk";
 
 import { indentString } from "./lib";
 import { CommandLogger } from "./logging";
+import { ReleaseGroup, ReleasePackage } from "./releaseGroups";
 
 /**
  * An instructional prompt to display to a user in a terminal. A prompt can have any number of sections, and each
@@ -45,56 +47,31 @@ interface Section {
 }
 
 /**
- * Links to ADO pipeline for all release group
+ * Map release groups to ADO pipeline
  */
+export const ADOPipelineLinks = new Map<ReleasePackage | ReleaseGroup, string>([
+    [MonoRepoKind.Client, "https://dev.azure.com/fluidframework/internal/_build?definitionId=12"],
+    [MonoRepoKind.Server, "https://dev.azure.com/fluidframework/internal/_build?definitionId=30"],
+    [MonoRepoKind.Azure, "https://dev.azure.com/fluidframework/internal/_build?definitionId=85"],
+    [MonoRepoKind.BuildTools, "https://dev.azure.com/fluidframework/internal/_build?definitionId=14"],
+    ["@fluid-tools/api-markdown-documenter", "https://dev.azure.com/fluidframework/internal/_build?definitionId=97"],
+    ["@fluid-tools/benchmark", "https://dev.azure.com/fluidframework/internal/_build?definitionId=96"],
+    ["@fluidframework/test-tools", "https://dev.azure.com/fluidframework/internal/_build?definitionId=13"],
+    ["tinylicious", "https://dev.azure.com/fluidframework/internal/_build?definitionId=22"],
+    ["@fluidframework/build-common", "https://dev.azure.com/fluidframework/internal/_build?definitionId=3"],
+    ["@fluidframework/eslint-config-fluid", "https://dev.azure.com/fluidframework/internal/_build?definitionId=7"],
+    ["@fluidframework/common-definitions", "https://dev.azure.com/fluidframework/internal/_build?definitionId=8"],
+    ["@fluidframework/common-utils", "https://dev.azure.com/fluidframework/internal/_build?definitionId=10"],
+    ["@fluidframework/protocol-definitions", "https://dev.azure.com/fluidframework/internal/_build?definitionId=67"]
+  ]);
 
-export enum ADOPipelineLinks {
-    CLIENT = "https://dev.azure.com/fluidframework/internal/_build?definitionId=12",
-    SERVER = "https://dev.azure.com/fluidframework/internal/_build?definitionId=30",
-    BUILDTOOLS = "https://dev.azure.com/fluidframework/internal/_build?definitionId=14",
-    AZURE = "https://dev.azure.com/fluidframework/internal/_build?definitionId=85",
-    APIMARKDOWNDOCUMENTER = "https://dev.azure.com/fluidframework/internal/_build?definitionId=97",
-    BENCHMARK = "https://dev.azure.com/fluidframework/internal/_build?definitionId=96",
-    TESTTOOLS = "https://dev.azure.com/fluidframework/internal/_build?definitionId=13",
-    TINYLICIOUS = "https://dev.azure.com/fluidframework/internal/_build?definitionId=22",
-    BUILDCOMMON = "https://dev.azure.com/fluidframework/internal/_build?definitionId=3",
-    ESLINTCONFLIGFLUID = "https://dev.azure.com/fluidframework/internal/_build?definitionId=7",
-    COMMONDEFINITIONS = "https://dev.azure.com/fluidframework/internal/_build?definitionId=8",
-    COMMONUTILS = "https://dev.azure.com/fluidframework/internal/_build?definitionId=10",
-    PROTOCOLDEFINITIONS = "https://dev.azure.com/fluidframework/internal/_build?definitionId=67",
-}
 
 /**
  *
  * Returns ADO pipeline link for the releaseGroup
  */
-export const mapADOLinks = (releaseGroup: string | undefined): string => {
-    const adoLink = releaseGroup === "client"
-            ? ADOPipelineLinks.CLIENT
-            : releaseGroup === "server"
-            ? ADOPipelineLinks.SERVER
-            : releaseGroup === "azure"
-            ? ADOPipelineLinks.AZURE
-            : releaseGroup === "build-tools"
-            ? ADOPipelineLinks.BUILDTOOLS
-            : releaseGroup === "@fluid-tools/api-markdown-documenter"
-            ? ADOPipelineLinks.APIMARKDOWNDOCUMENTER
-            : releaseGroup ===  "@fluid-tools/benchmark"
-            ? ADOPipelineLinks.BENCHMARK
-            : releaseGroup === "@fluidframework/test-tools"
-            ? ADOPipelineLinks.TESTTOOLS
-            : releaseGroup === "tinylicious"
-            ? ADOPipelineLinks.TINYLICIOUS
-            : releaseGroup === "@fluidframework/build-common"
-            ? ADOPipelineLinks.BUILDCOMMON
-            : releaseGroup === "@fluidframework/eslint-config-fluid"
-            ? ADOPipelineLinks.ESLINTCONFLIGFLUID
-            : releaseGroup === "@fluidframework/common-definitions"
-            ? ADOPipelineLinks.COMMONDEFINITIONS
-            : releaseGroup === "@fluidframework/common-utils"
-            ? ADOPipelineLinks.COMMONUTILS
-            : ADOPipelineLinks.PROTOCOLDEFINITIONS;
-    return adoLink;
+export const mapADOLinks = (releaseGroup: ReleaseGroup | ReleasePackage | undefined): string | undefined => {
+    return releaseGroup === undefined ? "" : ADOPipelineLinks.get(releaseGroup);
 }
 
 /**

--- a/build-tools/packages/build-cli/src/instructionalPromptWriter.ts
+++ b/build-tools/packages/build-cli/src/instructionalPromptWriter.ts
@@ -2,9 +2,10 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { MonoRepoKind } from "@fluidframework/build-tools";
 import { StringBuilder } from "@rushstack/node-core-library";
 import chalk from "chalk";
+
+import { MonoRepoKind } from "@fluidframework/build-tools";
 
 import { indentString } from "./lib";
 import { CommandLogger } from "./logging";
@@ -49,30 +50,58 @@ interface Section {
 /**
  * Map release groups to ADO pipeline
  */
-export const ADOPipelineLinks = new Map<ReleasePackage | ReleaseGroup, string>([
+export const ADOPipelineLinks = new Map<ReleasePackage | ReleaseGroup | undefined, string>([
     [MonoRepoKind.Client, "https://dev.azure.com/fluidframework/internal/_build?definitionId=12"],
     [MonoRepoKind.Server, "https://dev.azure.com/fluidframework/internal/_build?definitionId=30"],
     [MonoRepoKind.Azure, "https://dev.azure.com/fluidframework/internal/_build?definitionId=85"],
-    [MonoRepoKind.BuildTools, "https://dev.azure.com/fluidframework/internal/_build?definitionId=14"],
-    ["@fluid-tools/api-markdown-documenter", "https://dev.azure.com/fluidframework/internal/_build?definitionId=97"],
-    ["@fluid-tools/benchmark", "https://dev.azure.com/fluidframework/internal/_build?definitionId=96"],
-    ["@fluidframework/test-tools", "https://dev.azure.com/fluidframework/internal/_build?definitionId=13"],
+    [
+        MonoRepoKind.BuildTools,
+        "https://dev.azure.com/fluidframework/internal/_build?definitionId=14",
+    ],
+    [
+        "@fluid-tools/api-markdown-documenter",
+        "https://dev.azure.com/fluidframework/internal/_build?definitionId=97",
+    ],
+    [
+        "@fluid-tools/benchmark",
+        "https://dev.azure.com/fluidframework/internal/_build?definitionId=96",
+    ],
+    [
+        "@fluidframework/test-tools",
+        "https://dev.azure.com/fluidframework/internal/_build?definitionId=13",
+    ],
     ["tinylicious", "https://dev.azure.com/fluidframework/internal/_build?definitionId=22"],
-    ["@fluidframework/build-common", "https://dev.azure.com/fluidframework/internal/_build?definitionId=3"],
-    ["@fluidframework/eslint-config-fluid", "https://dev.azure.com/fluidframework/internal/_build?definitionId=7"],
-    ["@fluidframework/common-definitions", "https://dev.azure.com/fluidframework/internal/_build?definitionId=8"],
-    ["@fluidframework/common-utils", "https://dev.azure.com/fluidframework/internal/_build?definitionId=10"],
-    ["@fluidframework/protocol-definitions", "https://dev.azure.com/fluidframework/internal/_build?definitionId=67"]
-  ]);
-
+    [
+        "@fluidframework/build-common",
+        "https://dev.azure.com/fluidframework/internal/_build?definitionId=3",
+    ],
+    [
+        "@fluidframework/eslint-config-fluid",
+        "https://dev.azure.com/fluidframework/internal/_build?definitionId=7",
+    ],
+    [
+        "@fluidframework/common-definitions",
+        "https://dev.azure.com/fluidframework/internal/_build?definitionId=8",
+    ],
+    [
+        "@fluidframework/common-utils",
+        "https://dev.azure.com/fluidframework/internal/_build?definitionId=10",
+    ],
+    [
+        "@fluidframework/protocol-definitions",
+        "https://dev.azure.com/fluidframework/internal/_build?definitionId=67",
+    ],
+]);
 
 /**
  *
  * Returns ADO pipeline link for the releaseGroup
  */
-export const mapADOLinks = (releaseGroup: ReleaseGroup | ReleasePackage | undefined): string | undefined => {
-    return releaseGroup === undefined ? "" : ADOPipelineLinks.get(releaseGroup);
-}
+export const mapADOLinks = (
+    releaseGroup: ReleaseGroup | ReleasePackage | undefined,
+): string | undefined => {
+    return ADOPipelineLinks.get(releaseGroup);
+};
 
 /**
  * An abstract base class for classes that write {@link InstructionalPrompt}s to the terminal.


### PR DESCRIPTION
Prompt to release should include links to the release group pipelines: [AB#2176](https://dev.azure.com/fluidframework/internal/_sprints/taskboard/Team%20Sasha/internal/CY23Q1/Team%20Sasha%20-%202023.01-A?workitem=2176)