### PR TITLE
ci: Remove deprecated set-output command

### DIFF
--- a/.github/workflows/linkcheck-reporter.yml
+++ b/.github/workflows/linkcheck-reporter.yml
@@ -19,7 +19,7 @@ jobs:
           path: ./results
       - name: Load PR number
         id: load_pr
-        run: echo "::set-output name=pr::$(cat pr)"
+        run: echo "pr=$(cat pr)" >> $GITHUB_OUTPUT
         working-directory: ./results
       - name: Post report in comment
         uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443 # pin@v2


### PR DESCRIPTION
The command has been deprecated and replaced. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for more information.
