### PR TITLE
get client/server time lapse for upload blobs before sending op

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2392,11 +2392,11 @@
       }
     },
     "@fluid-experimental/property-changeset": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-changeset/-/property-changeset-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-nScLGykY9wAViszy42G7i9dx+Woq4Vq9zfvFON3t6QfnQNZFPvHnshTfMrfCB73FQo5dM3jd2z9yb7snzdxFMA==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-changeset/-/property-changeset-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-r4Uw7k2pdV7QrqwSdGkui4pTKt+MDgIAVsEciYijgA9YQao2RK7omAkJ/u+jST00MyGpr7DmtBGl4Z3CHz5MMg==",
       "requires": {
-        "@fluid-experimental/property-common": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-common": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "ajv": "7.1.1",
         "ajv-keywords": "4.0.0",
         "async": "^3.2.2",
@@ -2422,9 +2422,9 @@
       }
     },
     "@fluid-experimental/property-common": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-common/-/property-common-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-Dh/8AETqJI25f285DBl7OgoEKUzWOpXNxk6coJnVtM7Z8UVMr67V/FGETFZpMkKkFh3m/k9giVMJ3Sgd6fGMPQ==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-common/-/property-common-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-cz44x3SVlEDwyVlavNP1LtqHUO8spdBwKSNOnq+YMBhl3jqDRN/1jyycoTPmz9MoZ7EfO++dIFiJ9QiaIXzEug==",
       "requires": {
         "ajv": "7.1.1",
         "async": "^3.2.2",
@@ -2454,20 +2454,20 @@
       }
     },
     "@fluid-experimental/property-dds": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-dds/-/property-dds-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-YkEmLQbNu+ysVWgW2JcGnY2voxM5lKMW7XV8MHdlgzudrcGcfl2wNRB4I0u3seb/9tF6qVA2btAwdda47wnMjg==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-dds/-/property-dds-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-tqwZC/1n5h7LVHiLrvPyQ/NUFIARoX2KwgQ6zfGTC5MgP77LR88t0JJsqVrM9S1HGS9CUmCBVGcz2P/hjVJuXw==",
       "requires": {
-        "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluid-experimental/property-properties": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-properties": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "axios": "^0.26.0",
         "fastest-json-copy": "^1.0.1",
         "lodash": "^4.17.21",
@@ -2521,12 +2521,12 @@
       }
     },
     "@fluid-experimental/property-properties": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-properties/-/property-properties-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-0HqGYyx36jUKZkQUJ+TVQ+4jDuUNh+Qi6mdMXDmPc7goyhTV8YfbCX9/pOi4xaJtQG7AzL+xpFLSeinsbeg1sw==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/property-properties/-/property-properties-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-twFZt7MhyMsQ/bIsI8mijY58rJXlvNoQ29FVEJAvJ3GaDfLu2ysaIWQw7h7BvBtNMZYVh3uGGBY5Cr99rdfCuQ==",
       "requires": {
-        "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluid-experimental/property-common": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-changeset": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/property-common": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "ajv": "7.1.1",
         "async": "^3.2.2",
         "fastest-json-copy": "^1.0.1",
@@ -2565,16 +2565,16 @@
       }
     },
     "@fluid-experimental/sequence-deprecated": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-ldSdeuTnyvptwOV+saugFGEpvSMTgnT+GN4nfM/xMgUBGybygwdI4TghEgIP+jhgvnSDofnfPS2Dpq+rydSydg==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-/KqUfLyGkxGhXhAKCiXkOQlRgHS+MEUWy+Nvq4ivwwK3dTRb5PcS/LI0EwvoJ8Sld5kiaBT1DE5Wm2zka1IRRw==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/sequence": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/sequence": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluid-experimental/sequence-deprecated-previous": {
@@ -2836,25 +2836,25 @@
       }
     },
     "@fluidframework/aqueduct": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-9zJC60vFWQPmreMHANYu+IZRmeRDnIh1To+h4vPykZat24pvr1AFNCW5FI76r2KXbEg4pa+1LiDYD9iT2ODTAw==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-nXfYGOtbuQZtkwivp1iu4BGeuOVP14kEwbbwZ0dHZQ52aLSVqTt4FlEWtEY0yoC928DEaEVkTdrlarHB6ggJ8Q==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/map": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/synthesize": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/map": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/request-handler": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/synthesize": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -2997,17 +2997,17 @@
       }
     },
     "@fluidframework/cell": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-+pOaJbnkS7pLiPOCKjACtWfVKRjDCHFiomMFBucy84Y9Hdp88FkIyLFFNB4UnpPTjQOGyK/ShV9Xm+OjyAztSQ==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-kSh+YuwaliQDoMF/xeDapGo9d6sCaF1p65Jg5uGVpxpoeKoNiBk3IRQkja9WfmiVGE7V8MXF1t2J9Ijmo7gF8Q==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/cell-previous": {
@@ -3051,13 +3051,13 @@
       }
     },
     "@fluidframework/container-definitions": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-VqwMsYW4k2SBzgnUD/DiWLsJK94+aNpnzpsifZB3gEnFQoZf/4ikjVJAvNWyehDBV0FuyKeuz/wJ4ChahI3R5Q==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-lFKKsX13T3iMlSNGYDWEYed/86vXJp+rtDh9D11VElAunx+AMy0Y5JSCqRewHfsJwemQAzPwjgTYBlmwnYyPog==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "events": "^3.1.0"
       }
@@ -3074,20 +3074,20 @@
       }
     },
     "@fluidframework/container-loader": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-v36ciS1V+VlNXU78p30oW9Mu2TvniWbEgQPmdQDr2Ea14JWi7YwVQLNlolTt6aggIK6h9A4G5vZcSKWm1UZyGw==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-bmpLNHepyohZ0cFOuaLUr98SbnUUVaTjvK0CTEQP9CHx4gLQ40PrkzwIZlhkPK3VDamQg197EyHfjO0wTf1Nxw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "abort-controller": "^3.0.0",
         "double-ended-queue": "^2.1.0-0",
         "events": "^3.1.0",
@@ -3119,25 +3119,25 @@
       }
     },
     "@fluidframework/container-runtime": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-xVsI7pT9QEBf6avfEuL/0iESiD1Zch5+dt7muun1d509R9w+MNrG01RqLxHnlY0bolsdkSSpLR2VKAqRwbbgsw==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-VHyq08ekdXNEHJ/T4EOquSABdY1z24dlYKCgvuleHVEABrB2HHTT4GFc/+K/V+F4+ekEe9s1NHL35Z4dJzHFcQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "double-ended-queue": "^2.1.0-0",
         "events": "^3.1.0",
         "lz4js": "^0.2.0",
@@ -3145,16 +3145,16 @@
       }
     },
     "@fluidframework/container-runtime-definitions": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-MaPs3Gc6wuSTjnOBvuK07Pbpf3XE3dckNSXMzpeHOwbhudp3+zPNTlgE9SE3b9CnGFOMNIqFj4ZBdxCtA9UyvQ==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-8QbcBZELW40YEIK1uLUhwNKT7PshQX7nVlkFuMrFLSqf1LeWWzZru05Jp8WzC+SvmEX6cZfggf0Bm8ujmhvK3Q==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/container-runtime-definitions-previous": {
@@ -3197,15 +3197,15 @@
       }
     },
     "@fluidframework/container-utils": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-mn+E3GMSDD3JhYQVAn6gnmoNLDDhrq7XfqSIrEeydyzocc5wnBzSxwkF8zk6PwvvRHzojRstgWMuLtXwNU3eyQ==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-6SITu0bPIL/iQTpwlD8lxkAWL6g0jT0jQG2qdOi6qsPET5oiKoBsAeSrKRvjXbmPkkCZNqc6/xFiTxCl0k+X4A==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/container-utils-previous": {
@@ -3221,9 +3221,9 @@
       }
     },
     "@fluidframework/core-interfaces": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-q3Vzti54PaPP4BzYIQ/FjNM+8kqHG1ewa23qBUMIZ6qU5eL7Nz5wLrIEScSd208nvaPI/paSeIKpgncriAYFrg=="
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-4K6Xj/fyXWehQ4d4J4NnQXOfxHPWD0WR/XWOtovuXdhmKNGYKxI6mU2k0RWZ7v699Ixaik0s8ymbJNWy/SisMw=="
     },
     "@fluidframework/core-interfaces-previous": {
       "version": "npm:@fluidframework/core-interfaces@2.0.0-internal.2.2.0",
@@ -3231,17 +3231,17 @@
       "integrity": "sha512-B7JNJWkR/0y6CJn90Kk8vTMmZDRKR81OEd82a3CUuYbfAJBsVcMeTPFdh9obrLiH7FS9/f1MxQHFXy7zLOAOWw=="
     },
     "@fluidframework/counter": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-M8BDIoRYuLs8ZXIYVYhhuM26xic/l3wkYS9OQbgf+iuRLWfvbbhZRWR5q/2bW1n11tByvzcH6ZztzRsRuJOlAw==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-jqkqjGexabsqtkKBAlnfPBUSAIT5kYgbL2Gsxz8bOOddMH9AJhH1VSbHf3y/bNDOFez6oqBvduBRCaE0PiImcw==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/counter-previous": {
@@ -3277,39 +3277,39 @@
       }
     },
     "@fluidframework/datastore": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-+QQL72EYcBanTqE5VYvBN6SsrJWGU3xbXFp0t9JThpy7A9tDIJZMcleFCgurAPntp3Y7mP3pRPcrfCiCM5TpYA==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-u0KM69F5UkGFn2K/VMMkVgnVrBW6WFCB6ubIN/iK9OuJ9PjmSEfBgfo9Id3Sf6vob84jD0m77Rd/mpnpggjJ3g==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "lodash": "^4.17.21",
         "uuid": "^8.3.1"
       }
     },
     "@fluidframework/datastore-definitions": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-nS6kkoj0BgnyHDk/GJFmiqSPjctkeCTw1A4wzdV3W48fFFLXDdW8wMyMxgvUootqn72TSeTiOyErttCOc92dEQ==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-gCNlkK8XyqjZGjXtzstNl8XoxPx9w8YqUzq43HTKOA03Sqif7moroWdy10ijQ73R0GPM04LbzkjLxLahxm0h8w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/datastore-definitions-previous": {
@@ -3375,16 +3375,16 @@
       }
     },
     "@fluidframework/driver-base": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-+OmqtmVBAdt8anHt5kXwDNc8qVj54f2VG9Yot/ABWGH2aZXnuFNN9CIptfCN1t6+lIBdGzoCED/pCLTlw4jDvA==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-ZQVvDy4vk9nL0zS0i5uyWTVH5jOFaGsy/eOoMJzwv0R6XWlgA6unR5OM5xCZ/RujECgWooPcBBR4zMXuIegmJg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/driver-base-previous": {
@@ -3401,12 +3401,12 @@
       }
     },
     "@fluidframework/driver-definitions": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-jv+ryQ4roA/iCty9eXB1yKyknaMyFP56hAMS1NMB2P7xRIcLBkaEfDqGu7+8dcDTy2sDEyHdPQ4gSV0MvQVX0A==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-IL5USerfqSHdj7jcyHXHGrTpMBqGW2cuQhl3DEq3I1eLG++p7WPz4Upmkfo/Ql6pGV17DMxzbTwQ0NpyzLhOvQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0"
       }
     },
@@ -3421,18 +3421,18 @@
       }
     },
     "@fluidframework/driver-utils": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-4/5FsPn7BbUal5wl8lwczDBskF5savEu5mh+r0T8QdQc3rkIlhur0x8v7vu/9zqDlJOeD3Vxy/cmGhSh1WPRoQ==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-4kEy2XiAt8pGrJ366q128dZ8je9rCkfO8qEkYrktwqtH8qDqU4gVEK0Em8t0mwO4pu6zhUXN3T4X2/UQ2d8P2A==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/gitresources": "^0.1038.2000",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "axios": "^0.26.0",
         "url": "^0.11.0",
         "uuid": "^8.3.1"
@@ -3521,22 +3521,22 @@
       }
     },
     "@fluidframework/fluid-static": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-oWPuROROD90assA2ieABSQUsbPR6T7OtdAmcwb+FfMO49uG5t39VdHZyp9BtuR8K3atwpqEAlm6m0Y9PTVAuwQ==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-FjUmuN/Hn12Gfy44E8Oi0tSGvn1UtfhpCw3YqAVGGgP6S5iiAF+5C5efSICTD0BnuXxG58mrKl+nH95xsbCq7A==",
       "requires": {
-        "@fluidframework/aqueduct": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/aqueduct": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/request-handler": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/fluid-static-previous": {
@@ -3559,14 +3559,14 @@
       }
     },
     "@fluidframework/garbage-collector": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-zJVELgDSlmTK3fRh3F8gMX/JmojIczAFlW1D20JCVJAvt9UaLSHyikeF0uN+4lHMqPFouWkwn3LjCScc5By+Jg==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-iGleJ2EEMCNdhGKxb4VtJXuF2SQPCHHDdeTca8bb14DfW73roWBBCYRVdVPFolA92zP07Cz3xna9uHRE13RKxg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/garbage-collector-previous": {
@@ -3600,17 +3600,17 @@
       }
     },
     "@fluidframework/ink": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-a415hyaNAGuHTb9N0Gv9323sK05bde0d7tMm3e9HK/hIRzAEOd8zbIawj/pzTicF0nER95pmFQuPwQSBuv79EQ==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-CJ1/jPxiL1quHQwwC1Sq+rdwe+JRi/NGwN3wh3vUqft4FnWpDFpZAWK2drnarm11wMLUiiH3+4SZcyrMUGytoQ==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -3630,24 +3630,24 @@
       }
     },
     "@fluidframework/local-driver": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-X7jQXV77zcWVEL9zFR44oR0f0X1GwdOrXmy5vze4Gu3lQ8GRdUIFtWJeS3PdZFNUlXrmHqe9K51bVmDYm9NZRA==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-lKGSvjdLU4b8Qd2F3VvMSPDTp++4Gtz9cdIGf+9Ce/vQwL99kiSsTnD7/JpxBXlm8Ru99Rs7ospfiL/qf4FDVQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/server-local-server": "^0.1038.2000",
         "@fluidframework/server-services-client": "^0.1038.2000",
         "@fluidframework/server-services-core": "^0.1038.2000",
         "@fluidframework/server-test-utils": "^0.1038.2000",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "events": "^3.1.0",
         "jsrsasign": "^10.5.25",
         "url": "^0.11.0",
@@ -3690,20 +3690,20 @@
       }
     },
     "@fluidframework/map": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-7tWssmf4e3PY54yM+4jIvhxU+4DP/0+brR9ZwvDyIvu1q+eL0L3i93zR+kMk+gesDKAVw45Cpd4v+ksOos2nwg==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-uMhVghPduSxJM6HsZLSr18oRgemdY0a3VqvGOdjNGPaDuGBbvmY2KacJyUVgcVes70ZEeOGHjfF+pNPkfUWomA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "path-browserify": "^1.0.1"
       }
     },
@@ -3726,21 +3726,21 @@
       }
     },
     "@fluidframework/matrix": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-W57mgxTwi10NEtxOijXYhtR0cgw8RWqjSuQdxtoNaJLP7ynenbtnjPHynvlWzdxuYua/9DULME8pM8J4Dc0cGw==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-LB1WCF08FMPW5NBz5WqkJvRJtbcX/bgzmXbiBiHfoCQxU/ZQjl7USIoaeKqgBKZV7BNaTpPjVKWZKMF7aiI+VA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@tiny-calc/nano": "0.0.0-alpha.5",
         "events": "^3.1.0",
         "tslib": "^1.10.0"
@@ -3767,21 +3767,21 @@
       }
     },
     "@fluidframework/merge-tree": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-eY53aSR7YoKn44AUYpqzSNTX3G/C1LAeR+SNBuxcILqpAw2NtHYs7HcF93oN7bOpIA6HhDXJYvTP/alNNWyfwg==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-BVtuaQKlY8YpHyUCCuGGqsrEn45nM0fen9RIp1Pc35arQYcBCyA71Fc8dudnMfmMz4imsByZlwTLxk1kCuA/Dg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/merge-tree-previous": {
@@ -3813,16 +3813,16 @@
       }
     },
     "@fluidframework/odsp-doclib-utils": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-Y++o1mZPlqHk2dMkh9hAIX9uV7l19ZZJhuzJGsfbJakkizGU6w4ENtlXfJ1yFC2Y90mzdcSchvmuMG0IzCL9sA==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-Ol7e+jCnCBgNLyU2W83dxDCbrBReAiRwIOaYMB6hYjmFgT7SHMFD/p89IZDLZRMKMAX4vIWMCJPkt5jWS9tXVA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "node-fetch": "^2.6.1"
       }
     },
@@ -3841,22 +3841,22 @@
       }
     },
     "@fluidframework/odsp-driver": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-VJ8gtbk20XGH1bVXs5Z+EvIys0zEr+wkWUK7rujM0hiR/eJc0TM6e8g+mshFNpiKDYFuGzcYccUKtnPACpwvOQ==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-K+nd6rn+nzZmuH+3bjEWCkUZDX54MDAzRVN0ouAUjhQx2PJcXBjGRebbefg5J9hsJ4m0iMa7CBOPlJGsx6fQEg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/gitresources": "^0.1038.2000",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.1",
         "socket.io-client": "^4.4.1",
@@ -3864,11 +3864,11 @@
       }
     },
     "@fluidframework/odsp-driver-definitions": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-HqAbuRtXrkU04rlFHkkvzHeuW279ZJPsV0f7A+bcNGcwgiPTGH9sqNCu324X/IvZTZPiKdyjI4jEgZPvQOp2Sw==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-kluOovU1P+Q4psm7JSctimw+9C+qDORJqagowDVZJUHaozrStoN/pxbdOBBDtI+EU7WYyjQXT7Yc3Y+mZGmeEg==",
       "requires": {
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/odsp-driver-definitions-previous": {
@@ -3903,14 +3903,14 @@
       }
     },
     "@fluidframework/odsp-urlresolver": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-dRZliF/smZOP8wvjXCMuOEuFZ4wHh9/b384g+4bpIAja5AtHXPQ/srDP1pM06dj5VBRzE/EebAywZnShp7Ednw==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-NOdskc29Shzt5jTF7CkOAgfJx2/uPt2x+xP+CxQEsiVkvPjHQPN5ibKxKs64sA/rfOXUrAO7aIqGWIZYUo6kCA==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/odsp-urlresolver-previous": {
@@ -3925,17 +3925,17 @@
       }
     },
     "@fluidframework/ordered-collection": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-RQutZsy8UJpvLw9S0SIRBny7HeKldNFSVsQMa1pDaDggLmu0FdxuueAyneIepxwYeUYKcmnkcHrB9ZL6aIZfWw==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-xYxYKh3w6pTn/ONagN6CluSnMfFEE5Ooe6EJGgF9/jauHRQX8pDf+5PX5H20r/CIsw2L4JYlxj4LXiK2aq4/cw==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -3974,17 +3974,17 @@
       }
     },
     "@fluidframework/register-collection": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-1lIua78N1NwYPHyxUrVwOBReQ8MxlFfFyglmgamqaxs6023cMd+kmYTlu6xcEuPFjs1b3fBNGQt9xlmkPkiJFA==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-n2vy7AOTu6mMBvzlGtGdlIZzdBtLz8X8nUMhXT/thluufYTD+Gd2yf7Kby3MtVH7u82ayIIB4utFXqzdZd6TiA==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/register-collection-previous": {
@@ -4002,16 +4002,16 @@
       }
     },
     "@fluidframework/replay-driver": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-J2vyi0Is+s3wykQash8+veRjaQ389Weffab4U23KgqsJQG2t2pMXcFKSG+IQsm+SP0XnIhW3SX0O4czOe8vfRw==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-GhCgqBz4IB7Wjq5CSzZmmxMQsWdIK34K0+H9Md2K5UW+DorHHKI2UlNH6OCYVsP/Bi2eIYbhzuq8jLHHgfAFSg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/replay-driver-previous": {
@@ -4028,15 +4028,15 @@
       }
     },
     "@fluidframework/request-handler": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-A8MyrpcpprqXfjhmlYetRWFzGmqQUkJwYubHbPilKPRsETSBSIqXjyhTkvHg71S6KLCts9yJmvUeJoK15v9OIQ==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-dJs+3J18wkwWy2ryBKo53NXNnk04lWpwzrgIVu3oCMhrc6cuwbjIINzKqq1g0j0F6/cCfSUEGOhKt4iKfdcEYw==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/request-handler-previous": {
@@ -4052,20 +4052,20 @@
       }
     },
     "@fluidframework/routerlicious-driver": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-1qiVpHOaj3avpe/8/Stp9Gma4cxnm/eGoXCuQzxyAldXEdzKCwVnUuHGVdXno3kyM56mX+g6kt1ioRPEBnOHTA==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-Gip35bZscNg/vj98mZZiz4hrRjKW0enXPFUj7wmCZ4v1gzcOe+XWtYlv2zFAyXYc5dtkP2qHTeuSxucGDxZdOg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/gitresources": "^0.1038.2000",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "@fluidframework/server-services-client": "^0.1038.2000",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "cross-fetch": "^3.1.5",
         "json-stringify-safe": "5.0.1",
         "querystring": "^0.2.0",
@@ -4111,15 +4111,15 @@
       }
     },
     "@fluidframework/runtime-definitions": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-9Ho3150Dsxc4NBSJZU6IsLZxhxIo0VL9WMUm/1WkV+qh39HwGPUK9RATsIFGO+pdNve7aNPsk2G1Xphrmm+9/A==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-Lcg5D/rAdDwEUuQXWFhXYTRUp2cGWkiYjEUalQFU7J35A9rl/j2OaAw8Oq3ruY3J+GOGWWtlReSkTF2f+GtLPw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0"
       }
     },
@@ -4138,21 +4138,21 @@
       }
     },
     "@fluidframework/runtime-utils": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-6NzRIuDOhqMwQCp11uy3k22y60jcvez6SoMXD9spQ7+bdGpvAQjS/co0pH301aIA7tlpmhpYCMyobxFgCc/C3w==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-oP2/DMtN/6UIAaSZVToppdRBh0CNcPI8eLKkYfUaPYEvJaWsxxkqyFnnpUrZU3eUByVWu1eoV51ZrCd6/0aFIw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/runtime-utils-previous": {
@@ -4174,22 +4174,22 @@
       }
     },
     "@fluidframework/sequence": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-ndoynB1AofaWGluFqsUxKbWgyyL9GdXrMIISBiyEfwhYd1zQ7rQGMnQz7g7vUwSaptypOFkIYiwDaliJvrFCAg==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-JfGMndl/1lAnpfw/5Wo/J4gC6H0Iho6pOTQg9wE3Cq4Zx5QY62Bg+P2Rt0pSHXmBL0Jx5orrFppN9d6pU67GLg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -4508,22 +4508,22 @@
       }
     },
     "@fluidframework/shared-object-base": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-B+7Y95KO6u5bMnbjHpvdENdrAAxyoqwgdG9XOsPrn/qqINkQaAC4ZVXNRmGYecHgkrl0SDrPgrIC4B0OGZUA0g==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-vfwzDCXa4IQPVD834pFLvrk48bHt07E7vzW7IQzD/9Usy/DkUr5RYxlKhz2VBnTEdJR1eTNhMSTJOIbyGDLaYA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "uuid": "^8.3.1"
       }
     },
@@ -4562,9 +4562,9 @@
       }
     },
     "@fluidframework/synthesize": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-nJCoLpLNlW5DY7++QGeN8F9QYRvQgTV+7LFyRjvRVu6H6ZoFQY3e4q+MKTCh7s5aS1RLke8K5xA2aQzxD4htTg=="
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-In7t7m5GEFj6oPbRx5wMX3RC1Rk+T96VScMx/Pnnm6bIHCdaqLCFiXUnmdmFuw4s9PF2kt+OuXlBvmT2WhOsvw=="
     },
     "@fluidframework/synthesize-previous": {
       "version": "npm:@fluidframework/synthesize@2.0.0-internal.2.2.0",
@@ -4589,9 +4589,9 @@
       }
     },
     "@fluidframework/telemetry-utils": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-Yfkk7R+mOVGry86ekoGxz6pfx2bkdhoL62ITck/fAl0x+LvN2KPbAJcF6EpewBdKj2IuVVspN/UWkaav20HQ8Q==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-rrLEYaTlegfUKgcuullBWsTg26EvG4rc3NMxUTyllG54lWlCZqTA5U7e5fVsItHzD6n7Ki2FoHqCXpzrM3IRCA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
@@ -4623,13 +4623,13 @@
       }
     },
     "@fluidframework/test-driver-definitions": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-AOGIlRFpNXhEcfW60eh9Z5tow9awlKw7W+rXfqsT8SCJn4aypEI80Ult/nXoCA5Bz42Yn/X1BSRMTH1WFdghiw==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-dRd9IVePqWAOYbcd2mNaRQdp938pdWo8dkoOU+JU1+h6/4+HVrVgQplW3cULo0j7ll1cXBsuws6pn97T88pPrQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "uuid": "^8.3.1"
       }
@@ -4647,27 +4647,27 @@
       }
     },
     "@fluidframework/test-drivers": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-lyVbtkzHuXQl6dbe9954XQTgzsXi0wwGzxVTpWenNc9wqK8q6Bk6iYYr1RA5swprkd/WDUcrKDbOqxbePgc3sw==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-rtm8nzcH/jaVIFQNkqWa9fDx3QQZe0a0QzmHduoayqPCnq0nftP66/9Vw5aL8BYL38cjyAYmWgQROqAVhjbdJg==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/local-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/local-driver": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/server-local-server": "^0.1038.2000",
-        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/tool-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/tool-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "axios": "^0.26.0",
         "semver": "^7.3.4",
         "uuid": "^8.3.1"
@@ -4713,9 +4713,9 @@
       }
     },
     "@fluidframework/test-pairwise-generator": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-6iEcLTLcuJyaqX3vwPBUcvl0zcMIXQA0c15y4BGV25YHyGMMLqxF6pdCYF0nnE97qQ3vUDUU1ubD5+T/75k5Aw==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-8B5vecNWM3FzUFWZotlrUUh0PxZ1w1aDII8Gl/dRV7c556CA0mu1BHrWm/LU/L34TBHEFRk2c3ph11ycN52jcQ==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
         "random-js": "^1.0.8"
@@ -4731,22 +4731,22 @@
       }
     },
     "@fluidframework/test-runtime-utils": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-6UjTORkfd5RKpYYpj62M3EJ5Tn4Gq5E4QLG3YtC5+K3Lo84R8wTQ+GeaHRCvhFrGe4b0l7qPyRabfsIZ+VwL6g==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-PrUqeeJKfb3ANTAYJ7nxh6wFnVIQ5jSNMy0lDMr8RXCCSkgi+3TktvxyeMCvtfCPBjecBYjjWoVycrCeSCKJxQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "axios": "^0.26.0",
         "events": "^3.1.0",
         "jsrsasign": "^10.5.25",
@@ -4782,32 +4782,32 @@
       "dev": true
     },
     "@fluidframework/test-utils": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-jLOknNQg1iGgwYN98qKdsDDAlF1fc9tJ9E7qRG6306i0HPQjqO8JjzmMUEVLgcp4O6oxI5gAyIgcEkpxq5nONQ==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-Cfobbb++JVJui3TA3aswI559lHqxYFP3MLgxv8dTRG4n3asR7EFqvvbdyS2xiNLkZfjiev4C2gDfp92Hts+5IQ==",
       "requires": {
-        "@fluidframework/aqueduct": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/aqueduct": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/local-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/map": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/local-driver": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/map": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/request-handler": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "best-random": "^1.0.0",
         "debug": "^4.1.1",
         "uuid": "^8.3.1"
@@ -4900,15 +4900,15 @@
       }
     },
     "@fluidframework/tinylicious-driver": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-OQtFzZIOxwQVlxalQl6GbVR7R9LbpT2EEdwsYOaIhpk1kmGFR6/JsQ2vgh2P7tO3P/5QzDZSf592F0o/wIcoZA==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-owiBerX+rUvBteAt4Kh9/2KZqT4KbSUzIgapFgqSeiDT711SM4toMrwnOa9XHqNzEVUOglH9Otv8FqF7UPAVCQ==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/server-services-client": "^0.1038.2000",
         "jsrsasign": "^10.5.25",
         "uuid": "^8.3.1"
@@ -4930,12 +4930,12 @@
       }
     },
     "@fluidframework/tool-utils": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-2sguFkVhEOrX/a3+ePKePUoyt8WmEaVBZ1fBxzy63l7ZMPZrfSPCchMbgDKRJNxPCfRTEI/G2TEZg5QJsrKmeg==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-9csOXRT/s7I1BXDQdFR0JFKO2xHKtgF1X3ymRQpmb28+IyaiEeYvdplXlk454CgNBa48jtcJEHvV40yJ/rc69Q==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "async-mutex": "^0.3.1",
@@ -4971,12 +4971,12 @@
       }
     },
     "@fluidframework/view-adapters": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-z3l4wnut3X/87ljIFR8aI1VxVwmSh6HYxppwDECHV9sBTKmvqHUeHiZ9F6tkg5QBUoPko2TlQag6G2A5E0HwmQ==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-Z1CRUxB7ZZx6vWtX9UW4BQqo+kcQ9WqYLtct9kXwNCQhKeTY2tx54qwGHZE/41Tq0t2CO1FMsOnJmGr1CtejGA==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "react": "^17.0.1",
         "react-dom": "^17.0.1"
       }
@@ -4993,11 +4993,11 @@
       }
     },
     "@fluidframework/view-interfaces": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-Owdq4DBru4vSH1BZkFoTmchXAI0evrqEtRmF+j5JtOsgi9xfmoEkU7RLLK/K6w4uJmc/jIBF1kRhQNqiqNZxWQ==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-WoBtHbW5XjyRzEJ5GltKSU2uJ5BDQhmoKlAwLCxZdw7jvtjucjpQkO6Dv0vPBq8bw1Ew1kvr58hVsHVkj7pKvQ==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0"
       }
     },
     "@fluidframework/view-interfaces-previous": {
@@ -5009,12 +5009,12 @@
       }
     },
     "@fluidframework/web-code-loader": {
-      "version": "2.0.0-internal.2.3.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.3.0.tgz",
-      "integrity": "sha512-kOtwpD9zclH/3e4zEVa5OBOtV8NMsBqlN7Tt77whBLPkZPDLGdABMyXPTfS+VnLFLg+Y1Y3dSFwEd4EhxeypPQ==",
+      "version": "2.0.0-internal.2.3.1",
+      "resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.3.1.tgz",
+      "integrity": "sha512-ovBLjQI6HrOlRy448hUnFLApWPdZ4bbn7Zkw/hUQ3MwYCMrrQ8NJSjR23kgdovkKEAa6s4AUan133uP+rUU/VA==",
       "requires": {
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.3.1 <2.0.0-internal.3.0.0",
         "isomorphic-fetch": "^3.0.0"
       }
     },
@@ -19756,9 +19756,9 @@
       "integrity": "sha512-iAjbBa3X4UQtYxcCsAr0YaZMRwyC79q4KHui0XtEN7GGLJA4fzD116KUYXXZKskaOYSchnaOFT/a8zSlEx3P9Q=="
     },
     "@types/easy-table": {
-        "version": "0.0.32",
-        "resolved": "https://registry.npmjs.org/@types/easy-table/-/easy-table-0.0.32.tgz",
-        "integrity": "sha512-zKh0f/ixYFnr3Ldf5ZJTi1ZpnRqAynTTtVyGvWDf/TT12asE8ac98t3/WGWfFdRPp/qsccxg82C/Kl3NPNhqEw=="
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/easy-table/-/easy-table-0.0.32.tgz",
+      "integrity": "sha512-zKh0f/ixYFnr3Ldf5ZJTi1ZpnRqAynTTtVyGvWDf/TT12asE8ac98t3/WGWfFdRPp/qsccxg82C/Kl3NPNhqEw=="
     },
     "@types/enzyme": {
       "version": "3.10.12",
@@ -41678,7 +41678,7 @@
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "requires": {
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
@@ -46432,7 +46432,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-bom-buf": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7779,7 +7779,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true
     },
     "asap": {
@@ -8848,7 +8848,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "concat-stream": {
@@ -9641,7 +9641,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true
     },
     "decamelize-keys": {
@@ -10790,7 +10790,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "fsevents": {
@@ -11630,7 +11630,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -11933,7 +11933,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
     "is-binary-path": {
@@ -11984,7 +11984,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -12205,7 +12205,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "isobject": {
@@ -12299,7 +12299,7 @@
     "jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-      "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true
     },
     "jmespath": {
@@ -12899,7 +12899,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.includes": {
@@ -12917,7 +12917,7 @@
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "dev": true
     },
     "lodash.isinteger": {
@@ -13885,7 +13885,7 @@
     "noms": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
-      "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
+      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -14826,7 +14826,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -14943,7 +14943,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "dev": true
     },
     "p-limit": {
@@ -15197,7 +15197,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-key": {
@@ -15922,7 +15922,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "require-from-string": {
@@ -15991,7 +15991,7 @@
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true
     },
     "reusify": {
@@ -16130,7 +16130,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "setimmediate": {
@@ -16424,7 +16424,7 @@
     "spawn-command": {
       "version": "0.0.2-1",
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
       "dev": true
     },
     "spawn-please": {
@@ -16551,7 +16551,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "ssri": {
@@ -16997,7 +16997,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true
     },
     "tree-kill": {
@@ -17320,7 +17320,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "uuid": {
@@ -17486,7 +17486,7 @@
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
       "requires": {
         "tr46": "~0.0.3",
@@ -17579,7 +17579,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "write-file-atomic": {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1198,6 +1198,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             (fromPath: string, toPath: string) => this.garbageCollector.addedOutboundReference(fromPath, toPath),
             this,
             pendingRuntimeState?.pendingAttachmentBlobs,
+            () => this.getCurrentReferenceTimestampMs(),
         );
 
         this.scheduleManager = new ScheduleManager(

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -55,6 +55,8 @@ class MockRuntime extends TypedEventEmitter<IContainerRuntimeEvents> implements 
             () => undefined,
             () => undefined,
             this,
+            undefined,
+            () => undefined,
         );
     }
 


### PR DESCRIPTION
https://dev.azure.com/fluidframework/internal/_workitems/edit/1318

I added a method to collect and send telemetry regarding times relevant to future TTL calculations. This will allow us to monitor how often we are sending an attachblob op before/after TTL expiration.

It is a cleaner version of previous PR https://github.com/microsoft/FluidFramework/pull/13659