### PR TITLE
Fix external controller test

### DIFF
--- a/azure/lerna-package-lock.json
+++ b/azure/lerna-package-lock.json
@@ -406,35 +406,6 @@
         "strip-json-comments": "^3.1.1"
       }
     },
-    "@fluid-experimental/get-container": {
-      "version": "1.4.0-121020",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/get-container/-/get-container-1.4.0-121020.tgz",
-      "integrity": "sha512-+Kdhj2ZN+bJDo+3LrmzM2BT1oHv5XyDg3BqbZY0ZrDiSY8sIfrGnhrcSNh1CmcU0PogYD55bMOKMpA7UWlwbaQ==",
-      "requires": {
-        "@fluidframework/container-definitions": "1.4.0-121020",
-        "@fluidframework/container-loader": "1.4.0-121020",
-        "@fluidframework/core-interfaces": "1.4.0-121020",
-        "@fluidframework/driver-definitions": "1.4.0-121020",
-        "@fluidframework/driver-utils": "1.4.0-121020",
-        "@fluidframework/local-driver": "1.4.0-121020",
-        "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/routerlicious-driver": "1.4.0-121020",
-        "@fluidframework/server-local-server": "^0.1036.5000",
-        "@fluidframework/test-runtime-utils": "1.4.0-121020",
-        "@fluidframework/tinylicious-driver": "1.4.0-121020",
-        "jsonwebtoken": "^8.4.0"
-      },
-      "dependencies": {
-        "@fluidframework/protocol-definitions": {
-          "version": "0.1028.2000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000.tgz",
-          "integrity": "sha512-ZUPCmPFcK7UAK4RkfVWfzQPAWFvYNm6ywP51V42YC38gCGye+Epvyr3beA+FSaHPIZGxm5+Uw52+ykTvmDb2UA==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1"
-          }
-        }
-      }
-    },
     "@fluid-tools/version-tools": {
       "version": "0.4.4000",
       "resolved": "https://registry.npmjs.org/@fluid-tools/version-tools/-/version-tools-0.4.4000.tgz",
@@ -513,25 +484,25 @@
       },
       "dependencies": {
         "@fluidframework/aqueduct": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.3.3.tgz",
-          "integrity": "sha512-SKSK7W3A0rhT6Y0R3yy6jZkXlwXB4GE5cyESl+awKOzcscDX8FTYNu5mhrE6XN9zGrLiZfjzGt/mmRyj8WHH5A==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.3.4.tgz",
+          "integrity": "sha512-yyUkwz9GMy+jatbZC0Rnyla+UGYScd0JMDeiguCQP4J+jzKZWv2xqu66DWVSrXM/CiwyCFBa48ksR7d8+gCf2A==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/container-definitions": "^1.3.3",
-            "@fluidframework/container-loader": "^1.3.3",
-            "@fluidframework/container-runtime": "^1.3.3",
-            "@fluidframework/container-runtime-definitions": "^1.3.3",
-            "@fluidframework/core-interfaces": "^1.3.3",
-            "@fluidframework/datastore": "^1.3.3",
-            "@fluidframework/datastore-definitions": "^1.3.3",
-            "@fluidframework/map": "^1.3.3",
-            "@fluidframework/request-handler": "^1.3.3",
-            "@fluidframework/runtime-definitions": "^1.3.3",
-            "@fluidframework/runtime-utils": "^1.3.3",
-            "@fluidframework/synthesize": "^1.3.3",
-            "@fluidframework/view-interfaces": "^1.3.3",
+            "@fluidframework/container-definitions": "^1.3.4",
+            "@fluidframework/container-loader": "^1.3.4",
+            "@fluidframework/container-runtime": "^1.3.4",
+            "@fluidframework/container-runtime-definitions": "^1.3.4",
+            "@fluidframework/core-interfaces": "^1.3.4",
+            "@fluidframework/datastore": "^1.3.4",
+            "@fluidframework/datastore-definitions": "^1.3.4",
+            "@fluidframework/map": "^1.3.4",
+            "@fluidframework/request-handler": "^1.3.4",
+            "@fluidframework/runtime-definitions": "^1.3.4",
+            "@fluidframework/runtime-utils": "^1.3.4",
+            "@fluidframework/synthesize": "^1.3.4",
+            "@fluidframework/view-interfaces": "^1.3.4",
             "uuid": "^8.3.1"
           }
         },
@@ -550,32 +521,32 @@
           }
         },
         "@fluidframework/container-definitions": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.3.3.tgz",
-          "integrity": "sha512-jcpQbw5PDGrnEDVOPUaLNakKtEg9dRQn70pvsZnzZkheS51ycWjFL3o0CPj0xBYgOrvxedFtg53iRpNzQ4a/ag==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.3.4.tgz",
+          "integrity": "sha512-ZMPy6ihPAwwgDacr11BGDVDVriVT2Ws75OhXiTHo1RxWdimRDS9K6q9IsgzBjBOTgJo5VZDn0SwJyq2I7Ak+tA==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/core-interfaces": "^1.3.3",
-            "@fluidframework/driver-definitions": "^1.3.3",
+            "@fluidframework/core-interfaces": "^1.3.4",
+            "@fluidframework/driver-definitions": "^1.3.4",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
             "events": "^3.1.0"
           }
         },
         "@fluidframework/container-loader": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.3.3.tgz",
-          "integrity": "sha512-siduiqx2sxOAYHjkuwRpg0FXXOVDxH/EYkbU5rC5HQ5+8mlMJvH8JcEeJSkDFGkZFSEU+VDKArb3pPtzMt03Xg==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.3.4.tgz",
+          "integrity": "sha512-Q/GZzBO88ikfV4T8CH003ySKPS1CWtQNzXTVL2pMxK5sT/5nsur5pS3lN+kIXiTezLtplDroa3At7boHdm3Y+w==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/container-definitions": "^1.3.3",
-            "@fluidframework/container-utils": "^1.3.3",
-            "@fluidframework/core-interfaces": "^1.3.3",
-            "@fluidframework/driver-definitions": "^1.3.3",
-            "@fluidframework/driver-utils": "^1.3.3",
+            "@fluidframework/container-definitions": "^1.3.4",
+            "@fluidframework/container-utils": "^1.3.4",
+            "@fluidframework/core-interfaces": "^1.3.4",
+            "@fluidframework/driver-definitions": "^1.3.4",
+            "@fluidframework/driver-utils": "^1.3.4",
             "@fluidframework/protocol-base": "^0.1036.5001",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/telemetry-utils": "^1.3.3",
+            "@fluidframework/telemetry-utils": "^1.3.4",
             "abort-controller": "^3.0.0",
             "double-ended-queue": "^2.1.0-0",
             "events": "^3.1.0",
@@ -585,165 +556,165 @@
           }
         },
         "@fluidframework/container-runtime": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.3.3.tgz",
-          "integrity": "sha512-GfB0PQqh0oHPe7K+XJ3Hhi/0tzpKePdrFjJ92g0pgMF4bMauDPvrQIHdtWqRlmkoQkZylri3gzv+TmtmY0bUWA==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.3.4.tgz",
+          "integrity": "sha512-wMIgNWK7C/HLVwd4f0XueYAIAomZOqq87P460/GJEY/w4cEZUaKWWUgKkp8StzxzWtm6lOV5rn/ih2ik6y/3ig==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/container-definitions": "^1.3.3",
-            "@fluidframework/container-runtime-definitions": "^1.3.3",
-            "@fluidframework/container-utils": "^1.3.3",
-            "@fluidframework/core-interfaces": "^1.3.3",
-            "@fluidframework/datastore": "^1.3.3",
-            "@fluidframework/driver-definitions": "^1.3.3",
-            "@fluidframework/driver-utils": "^1.3.3",
-            "@fluidframework/garbage-collector": "^1.3.3",
+            "@fluidframework/container-definitions": "^1.3.4",
+            "@fluidframework/container-runtime-definitions": "^1.3.4",
+            "@fluidframework/container-utils": "^1.3.4",
+            "@fluidframework/core-interfaces": "^1.3.4",
+            "@fluidframework/datastore": "^1.3.4",
+            "@fluidframework/driver-definitions": "^1.3.4",
+            "@fluidframework/driver-utils": "^1.3.4",
+            "@fluidframework/garbage-collector": "^1.3.4",
             "@fluidframework/protocol-base": "^0.1036.5001",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.3.3",
-            "@fluidframework/runtime-utils": "^1.3.3",
-            "@fluidframework/telemetry-utils": "^1.3.3",
+            "@fluidframework/runtime-definitions": "^1.3.4",
+            "@fluidframework/runtime-utils": "^1.3.4",
+            "@fluidframework/telemetry-utils": "^1.3.4",
             "double-ended-queue": "^2.1.0-0",
             "events": "^3.1.0",
             "uuid": "^8.3.1"
           }
         },
         "@fluidframework/container-runtime-definitions": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.3.3.tgz",
-          "integrity": "sha512-spzIwQyJLZS+udVWNQoaGerYlDezzCT505prSKQ3mSH2HM0VQPrcQdVp8Z+wTbrwyBizZJhoqp4mF2RwDlwo3g==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.3.4.tgz",
+          "integrity": "sha512-R6c8cggI0At/j9pUZQmNnmCx60qWd5Mbpa5XIeOO3OfUT0ze+eZ1KxQ94su+A2LEmZq9+d1B06T/O1ePRMrRHg==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/container-definitions": "^1.3.3",
-            "@fluidframework/core-interfaces": "^1.3.3",
-            "@fluidframework/driver-definitions": "^1.3.3",
+            "@fluidframework/container-definitions": "^1.3.4",
+            "@fluidframework/core-interfaces": "^1.3.4",
+            "@fluidframework/driver-definitions": "^1.3.4",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.3.3",
+            "@fluidframework/runtime-definitions": "^1.3.4",
             "@types/node": "^14.18.0"
           }
         },
         "@fluidframework/container-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.3.3.tgz",
-          "integrity": "sha512-O2oelQRImbpQvfr3lWemmLaE91pFWPGKOHSFB8Dwsz740yQvu8uB6tc4jTv/PDTjNq9o/D5SbhVhlehu5Upbog==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.3.4.tgz",
+          "integrity": "sha512-HXad0XLffY7hJPrkdA1koO0OyIQROx/7mUJ992gj3qUIJEmHCH5csLJPfdH3RQmMjfXSdhlYYzshYK4PLlv2+A==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/container-definitions": "^1.3.3",
+            "@fluidframework/container-definitions": "^1.3.4",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/telemetry-utils": "^1.3.3"
+            "@fluidframework/telemetry-utils": "^1.3.4"
           }
         },
         "@fluidframework/core-interfaces": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.3.3.tgz",
-          "integrity": "sha512-YLwQwRrBiwB3GTNdx+0JxTI/2u41iaPoZ5iAZD+55i/tm1S1wR9rY0FQf88lw5m4GTiC00iZgJCizbw/ot1J1Q=="
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.3.4.tgz",
+          "integrity": "sha512-z5pD/97mQDfNJh7h4f8ZpCZqKLwDJ+D686Rf0Iif8Lp0r69KRSQAKgowmoHzo7tB6V5XV7wO6603pvbdPqUuCA=="
         },
         "@fluidframework/datastore": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.3.3.tgz",
-          "integrity": "sha512-xg7HC/M/ZZo+1UH+2nO9wGh3oEn7T0IoWO39IAM968tVqNiQsZHA14Nygd3eih2JkwblKdGMLwK/bvDbo+Isyg==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.3.4.tgz",
+          "integrity": "sha512-XU6jvoPfGHdLRAYFPa3MVxRHMxFEhw5D+Hsn9PMgO0FLQhslpQy1m3328W5KNxeAHiIpA16OX/ts1S86AW29ww==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/container-definitions": "^1.3.3",
-            "@fluidframework/container-utils": "^1.3.3",
-            "@fluidframework/core-interfaces": "^1.3.3",
-            "@fluidframework/datastore-definitions": "^1.3.3",
-            "@fluidframework/driver-definitions": "^1.3.3",
-            "@fluidframework/driver-utils": "^1.3.3",
-            "@fluidframework/garbage-collector": "^1.3.3",
+            "@fluidframework/container-definitions": "^1.3.4",
+            "@fluidframework/container-utils": "^1.3.4",
+            "@fluidframework/core-interfaces": "^1.3.4",
+            "@fluidframework/datastore-definitions": "^1.3.4",
+            "@fluidframework/driver-definitions": "^1.3.4",
+            "@fluidframework/driver-utils": "^1.3.4",
+            "@fluidframework/garbage-collector": "^1.3.4",
             "@fluidframework/protocol-base": "^0.1036.5001",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.3.3",
-            "@fluidframework/runtime-utils": "^1.3.3",
-            "@fluidframework/telemetry-utils": "^1.3.3",
+            "@fluidframework/runtime-definitions": "^1.3.4",
+            "@fluidframework/runtime-utils": "^1.3.4",
+            "@fluidframework/telemetry-utils": "^1.3.4",
             "lodash": "^4.17.21",
             "uuid": "^8.3.1"
           }
         },
         "@fluidframework/datastore-definitions": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.3.3.tgz",
-          "integrity": "sha512-hhEQ6nEdUWw7XoYmFXZcHQKkzi0vBUyxF7Nb+USI/dwZb3Y68WIV0ABpnAPNWPqEgoV46gsQmNmDq4WY6QUajQ==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.3.4.tgz",
+          "integrity": "sha512-s/1HuDAYtBxZcTpqvq4Vqn3j4UE4S+XecUKJ0LRP151byT1gO3nXJUFa5KGQJPG18AZcuRHeii6heA6ZwXZBCA==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/container-definitions": "^1.3.3",
-            "@fluidframework/core-interfaces": "^1.3.3",
+            "@fluidframework/container-definitions": "^1.3.4",
+            "@fluidframework/core-interfaces": "^1.3.4",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.3.3",
+            "@fluidframework/runtime-definitions": "^1.3.4",
             "@types/node": "^14.18.0"
           }
         },
         "@fluidframework/driver-base": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.3.3.tgz",
-          "integrity": "sha512-UBgNxnPoDSd5q+Z389FT6otWf0+hZi+N6r3KNRZBDdjcE2b1dKHgUJhxczZgkc2HFvydrgRFWsV8354xSWZu2g==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.3.4.tgz",
+          "integrity": "sha512-j+MrSKs1nnCEzwykJSQWz9ewAF09vY2febipDChH1D/LxVuPwjcF4rfYVU4tOfW+JIk5umy89Ms2Zb5jN8rb7w==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/driver-definitions": "^1.3.3",
-            "@fluidframework/driver-utils": "^1.3.3",
+            "@fluidframework/driver-definitions": "^1.3.4",
+            "@fluidframework/driver-utils": "^1.3.4",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/telemetry-utils": "^1.3.3"
+            "@fluidframework/telemetry-utils": "^1.3.4"
           }
         },
         "@fluidframework/driver-definitions": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.3.3.tgz",
-          "integrity": "sha512-TaZnj8Qt6HdmBTu7kRcXzfL72SrZpq0N99vULisvHwsx3asIeUsuAP1SAkmTo8sMo4qa5yPwiOrd8i4tFkLi7A==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.3.4.tgz",
+          "integrity": "sha512-cDQqq2Gk1Z6QU+nmGZW6EmkC/qrbRlLRBtD9ozxjhn6TuM/hdfuMnTiuy1zo5PWLKXQn0cDHeNr9fRuz36UpxQ==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/core-interfaces": "^1.3.3",
+            "@fluidframework/core-interfaces": "^1.3.4",
             "@fluidframework/protocol-definitions": "^0.1028.2000"
           }
         },
         "@fluidframework/driver-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.3.3.tgz",
-          "integrity": "sha512-7IdLdEDY8yj2k9aULkWOPKzOPabU99mDqapiBZWfKH7EL+P/sW9krvLAzug6ioKe5ZXtw1wXFFCeVjE/QaFkxw==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.3.4.tgz",
+          "integrity": "sha512-02+kHFCadTgCuNuxpJ74sbeOpAwhk0dReZmpE5FeenNLCPUWrp7KqEi+hN1EjBYnhp2jz+xDxyQymLbmufSSZQ==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/core-interfaces": "^1.3.3",
-            "@fluidframework/driver-definitions": "^1.3.3",
+            "@fluidframework/core-interfaces": "^1.3.4",
+            "@fluidframework/driver-definitions": "^1.3.4",
             "@fluidframework/gitresources": "^0.1036.5001",
             "@fluidframework/protocol-base": "^0.1036.5001",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/telemetry-utils": "^1.3.3",
+            "@fluidframework/telemetry-utils": "^1.3.4",
             "axios": "^0.26.0",
             "uuid": "^8.3.1"
           }
         },
         "@fluidframework/fluid-static": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.3.3.tgz",
-          "integrity": "sha512-EXb0fu0NOlgTWeflv+bOpZXF7QHmUa5I7iSaQDH+l2PCX5E3u7OmxanWIoeHgFkbo+u/mhwnNPHVFQBr35bvYQ==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.3.4.tgz",
+          "integrity": "sha512-pBxJmOWx51nOK0d9O9q/oXLK/vvXTdXNgAVQVlbIv45HFJxYIiBaj6dAp7AnJrWINKADLLzOmdZJQs8bhTlTBw==",
           "requires": {
-            "@fluidframework/aqueduct": "^1.3.3",
+            "@fluidframework/aqueduct": "^1.3.4",
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/container-definitions": "^1.3.3",
-            "@fluidframework/container-loader": "^1.3.3",
-            "@fluidframework/container-runtime-definitions": "^1.3.3",
-            "@fluidframework/core-interfaces": "^1.3.3",
-            "@fluidframework/datastore-definitions": "^1.3.3",
+            "@fluidframework/container-definitions": "^1.3.4",
+            "@fluidframework/container-loader": "^1.3.4",
+            "@fluidframework/container-runtime-definitions": "^1.3.4",
+            "@fluidframework/core-interfaces": "^1.3.4",
+            "@fluidframework/datastore-definitions": "^1.3.4",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/request-handler": "^1.3.3",
-            "@fluidframework/runtime-definitions": "^1.3.3",
-            "@fluidframework/runtime-utils": "^1.3.3"
+            "@fluidframework/request-handler": "^1.3.4",
+            "@fluidframework/runtime-definitions": "^1.3.4",
+            "@fluidframework/runtime-utils": "^1.3.4"
           }
         },
         "@fluidframework/garbage-collector": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.3.3.tgz",
-          "integrity": "sha512-zg0/Jjmmwdct3qsWBo0U9uPVCZhJEoXm73dTTyt3whEFciDSLVbSvIHSO6Oo7YGGwkFcN1lOgFtOqBlFfttzXg==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.3.4.tgz",
+          "integrity": "sha512-+10EDLPxH81CoEg2fN5auczoRHreyxSJzDJ7T1Bq7Tac6VkgkHFJv4LWeJzyo15a8qfZ93FtPbZZOVPbNXWrPA==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/runtime-definitions": "^1.3.3"
+            "@fluidframework/runtime-definitions": "^1.3.4"
           }
         },
         "@fluidframework/gitresources": {
@@ -752,20 +723,20 @@
           "integrity": "sha512-Beg1A/eR7wCPYYb5u5iqqc092NkWnSvl4XCn2ImA4FDKtnYggD2/KYd9Hp0feM6Z99aU4FYSBidL2NewWlvF7A=="
         },
         "@fluidframework/map": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.3.3.tgz",
-          "integrity": "sha512-Gn+PjkjOCEmXb04z0UZrT0wvSWV3dgqZGLChCe9Jfa23BGQKoEunCZ4ghPfsVQsAcGve1kUp4x0hwqtlecQT5g==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.3.4.tgz",
+          "integrity": "sha512-NsepeSgVZXXj8iDu3DgCdF4/Dmr/l/DY4hoZRfKzOrXKVoUYJgCUKr/6BxERiTD97Mh2bU7SGowSEfc6S2hEXg==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/container-utils": "^1.3.3",
-            "@fluidframework/core-interfaces": "^1.3.3",
-            "@fluidframework/datastore-definitions": "^1.3.3",
-            "@fluidframework/driver-utils": "^1.3.3",
+            "@fluidframework/container-utils": "^1.3.4",
+            "@fluidframework/core-interfaces": "^1.3.4",
+            "@fluidframework/datastore-definitions": "^1.3.4",
+            "@fluidframework/driver-utils": "^1.3.4",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.3.3",
-            "@fluidframework/runtime-utils": "^1.3.3",
-            "@fluidframework/shared-object-base": "^1.3.3",
+            "@fluidframework/runtime-definitions": "^1.3.4",
+            "@fluidframework/runtime-utils": "^1.3.4",
+            "@fluidframework/shared-object-base": "^1.3.4",
             "path-browserify": "^1.0.1"
           }
         },
@@ -789,32 +760,32 @@
           }
         },
         "@fluidframework/request-handler": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.3.3.tgz",
-          "integrity": "sha512-fVVgwBFHHFHo0szSyDKvlzPDkXcTlHnm/PaS578U3ApjWAJAO6Avo4OrNnKGlSO1CYd5iFMoqw2V1HcW841Dng==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.3.4.tgz",
+          "integrity": "sha512-zeLKUywJwdWajuTf0Saeqm/kZH3apVo6mXzYMw8DiEzSgt0LV0FAJWphhb6Juib/fXunfjuBr2BkiKa7q9+zzQ==",
           "requires": {
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/container-runtime-definitions": "^1.3.3",
-            "@fluidframework/core-interfaces": "^1.3.3",
-            "@fluidframework/runtime-definitions": "^1.3.3",
-            "@fluidframework/runtime-utils": "^1.3.3"
+            "@fluidframework/container-runtime-definitions": "^1.3.4",
+            "@fluidframework/core-interfaces": "^1.3.4",
+            "@fluidframework/runtime-definitions": "^1.3.4",
+            "@fluidframework/runtime-utils": "^1.3.4"
           }
         },
         "@fluidframework/routerlicious-driver": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.3.3.tgz",
-          "integrity": "sha512-/FvzNC0o6uhJegdC9WJbyNXfAG/mcahGo9i4sTsm5COg1IBI70FZ76JHMQyoHsm/tYuER9reiDTXNKCZK+iKpQ==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.3.4.tgz",
+          "integrity": "sha512-Ho/Y5GLjeahcBjW4Owxb+kYqu9OvUAZ4IIAQVeRvhn/HMyRRmjRI2PUoA99E1TXSh6Lj/DZKErvUYaRiYDkQQw==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/driver-base": "^1.3.3",
-            "@fluidframework/driver-definitions": "^1.3.3",
-            "@fluidframework/driver-utils": "^1.3.3",
+            "@fluidframework/driver-base": "^1.3.4",
+            "@fluidframework/driver-definitions": "^1.3.4",
+            "@fluidframework/driver-utils": "^1.3.4",
             "@fluidframework/gitresources": "^0.1036.5001",
             "@fluidframework/protocol-base": "^0.1036.5001",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
             "@fluidframework/server-services-client": "^0.1036.5001",
-            "@fluidframework/telemetry-utils": "^1.3.3",
+            "@fluidframework/telemetry-utils": "^1.3.4",
             "cross-fetch": "^3.1.5",
             "json-stringify-safe": "5.0.1",
             "querystring": "^0.2.0",
@@ -846,66 +817,66 @@
           }
         },
         "@fluidframework/runtime-definitions": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.3.3.tgz",
-          "integrity": "sha512-FyOVdiR+y3IIU75OI/P++bhx2LmW4f/Hy8xwjPTiZC9KoOLwUSl0CUdx8+ewVQMjJ+hM5ueHbl4wrRgGxD1vgw==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.3.4.tgz",
+          "integrity": "sha512-6UWb3yJFZ46sWrLZTRLmVyAa1N56x7x7d/GFiqm28tq1TVCi7PyXlIoOfOqNTriJY8ZZdfoC2HHUmux6tVNaGQ==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/container-definitions": "^1.3.3",
-            "@fluidframework/core-interfaces": "^1.3.3",
-            "@fluidframework/driver-definitions": "^1.3.3",
+            "@fluidframework/container-definitions": "^1.3.4",
+            "@fluidframework/core-interfaces": "^1.3.4",
+            "@fluidframework/driver-definitions": "^1.3.4",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
             "@types/node": "^14.18.0"
           }
         },
         "@fluidframework/runtime-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.3.3.tgz",
-          "integrity": "sha512-9Umqs9tMPgaJ5Th+LZSCQbCjY2JOIjvBca7t6/WPac5pMlZw1BYIFEmggDyhlaUI4IhSjmYClcBylB2r9udCPg==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.3.4.tgz",
+          "integrity": "sha512-FZtpPUBaqE9LyYCSjJYHzOoqWfAk5F59rrGAjXzfY5UplhIZQuQNTBpyGsTk+48r2JypqBNYChnhkajQGHb3Ng==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/container-definitions": "^1.3.3",
-            "@fluidframework/container-runtime-definitions": "^1.3.3",
-            "@fluidframework/core-interfaces": "^1.3.3",
-            "@fluidframework/datastore-definitions": "^1.3.3",
-            "@fluidframework/garbage-collector": "^1.3.3",
+            "@fluidframework/container-definitions": "^1.3.4",
+            "@fluidframework/container-runtime-definitions": "^1.3.4",
+            "@fluidframework/core-interfaces": "^1.3.4",
+            "@fluidframework/datastore-definitions": "^1.3.4",
+            "@fluidframework/garbage-collector": "^1.3.4",
             "@fluidframework/protocol-base": "^0.1036.5001",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.3.3",
-            "@fluidframework/telemetry-utils": "^1.3.3"
+            "@fluidframework/runtime-definitions": "^1.3.4",
+            "@fluidframework/telemetry-utils": "^1.3.4"
           }
         },
         "@fluidframework/shared-object-base": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.3.3.tgz",
-          "integrity": "sha512-gJs4pbwWglybPrPLibtUqkGpAn+/tAe+G15W2cvwmu9YGOTN1djK5UqD7jBjgU6HyJ3LOJ7fIT17K6MjOGsWGw==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.3.4.tgz",
+          "integrity": "sha512-N9rhkCK/6/hIwIHhP6/C5+Z0AQLqAc3asFXjk7bAAFpthOS4UdInCxDQfIUxmNjBxH/0YVBvTArB3WBqggEjSg==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
-            "@fluidframework/container-definitions": "^1.3.3",
-            "@fluidframework/container-runtime": "^1.3.3",
-            "@fluidframework/container-utils": "^1.3.3",
-            "@fluidframework/core-interfaces": "^1.3.3",
-            "@fluidframework/datastore": "^1.3.3",
-            "@fluidframework/datastore-definitions": "^1.3.3",
+            "@fluidframework/container-definitions": "^1.3.4",
+            "@fluidframework/container-runtime": "^1.3.4",
+            "@fluidframework/container-utils": "^1.3.4",
+            "@fluidframework/core-interfaces": "^1.3.4",
+            "@fluidframework/datastore": "^1.3.4",
+            "@fluidframework/datastore-definitions": "^1.3.4",
             "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.3.3",
-            "@fluidframework/runtime-utils": "^1.3.3",
-            "@fluidframework/telemetry-utils": "^1.3.3",
+            "@fluidframework/runtime-definitions": "^1.3.4",
+            "@fluidframework/runtime-utils": "^1.3.4",
+            "@fluidframework/telemetry-utils": "^1.3.4",
             "uuid": "^8.3.1"
           }
         },
         "@fluidframework/synthesize": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.3.3.tgz",
-          "integrity": "sha512-Ou5ckfHANwtQ1HINNUJ59elTTGkxXCXhiX5BtaeXPSqr0rNCgUL0bx9Eud5sUnn2HbzUkxG60T5bRxlRLoxqbA=="
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.3.4.tgz",
+          "integrity": "sha512-f5WMiwN0kJZpMmPv9JEkYJL2FLIhjk3yTeeDqEXLpVIcBrEdIB10Vv6l5OvDsHFqRBHv/Z2/V+Vaq48kz5YB3A=="
         },
         "@fluidframework/telemetry-utils": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.3.3.tgz",
-          "integrity": "sha512-8CMRmJbP4XD6kMuIZEFo5dy1BASMiddZtANd3wXhK+uyxiU7fGPN9rmJv9HyHymgnGintX/LPxqjcbElbwUwQQ==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.3.4.tgz",
+          "integrity": "sha512-D4AlkZONjpzlgOqI/D2KCiQ9nreanW83O5rAwPdMEPoaPPQh4/CNyT03SACys/jHqzH3Qbh1FHJYMt1Cd86K6Q==",
           "requires": {
             "@fluidframework/common-definitions": "^0.20.1",
             "@fluidframework/common-utils": "^0.32.2",
@@ -915,11 +886,11 @@
           }
         },
         "@fluidframework/view-interfaces": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.3.3.tgz",
-          "integrity": "sha512-IgcADtNoBzJwv+AYmHR2BKcxpW2tlfVfAVsABtz0ybrYI8hSH8ygi6ZdsqkT8PCAymI4d7h+lFu1YdidqVEHHQ==",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.3.4.tgz",
+          "integrity": "sha512-BCXtZ33JCvwxm+iyxZc2L/JjBoOkKBI3U5hcHDtKh0fk1RCgjbLHpgsMSyf7FNCA33TRcvoJ83fRcfm2Apvxhg==",
           "requires": {
-            "@fluidframework/core-interfaces": "^1.3.3"
+            "@fluidframework/core-interfaces": "^1.3.4"
           }
         },
         "axios": {
@@ -3026,31 +2997,6 @@
             "sha.js": "^2.4.11"
           }
         },
-        "@fluidframework/protocol-definitions": {
-          "version": "0.1028.2000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000.tgz",
-          "integrity": "sha512-ZUPCmPFcK7UAK4RkfVWfzQPAWFvYNm6ywP51V42YC38gCGye+Epvyr3beA+FSaHPIZGxm5+Uw52+ykTvmDb2UA==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1"
-          }
-        }
-      }
-    },
-    "@fluidframework/tinylicious-driver": {
-      "version": "1.4.0-121020",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.4.0-121020.tgz",
-      "integrity": "sha512-NFlB9McJQ7VqhxNwJmbTV/tb4ok25CsoWLCxzYD5sv7liNJSpz56srB4abrJs7vyjIjw2izSl8H+jJQ2RxwDSQ==",
-      "requires": {
-        "@fluidframework/core-interfaces": "1.4.0-121020",
-        "@fluidframework/driver-definitions": "1.4.0-121020",
-        "@fluidframework/driver-utils": "1.4.0-121020",
-        "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/routerlicious-driver": "1.4.0-121020",
-        "@fluidframework/server-services-client": "^0.1036.5000",
-        "jsrsasign": "^10.5.25",
-        "uuid": "^8.3.1"
-      },
-      "dependencies": {
         "@fluidframework/protocol-definitions": {
           "version": "0.1028.2000",
           "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000.tgz",

--- a/azure/packages/external-controller/package.json
+++ b/azure/packages/external-controller/package.json
@@ -49,10 +49,13 @@
     "fluid-framework": "^1.4.0-121020"
   },
   "devDependencies": {
-    "@fluid-experimental/get-container": "^1.4.0-121020",
     "@fluidframework/build-common": "^1.1.0",
+    "@fluidframework/container-definitions": "^1.4.0-121020",
+    "@fluidframework/container-loader": "^1.4.0-121020",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/fluid-static": "^1.4.0-121020",
+    "@fluidframework/local-driver": "^1.4.0-121020",
+    "@fluidframework/server-local-server": "^0.1036.5000",
     "@fluidframework/test-client-utils": "1.4.0-121020",
     "@fluidframework/test-tools": "^0.2.3074",
     "@rushstack/eslint-config": "^2.5.1",

--- a/azure/packages/external-controller/tests/index.ts
+++ b/azure/packages/external-controller/tests/index.ts
@@ -6,9 +6,22 @@
 /* eslint-disable import/no-internal-modules */
 import { SharedMap } from "fluid-framework";
 
+import {
+    IContainer,
+    IFluidModuleWithDetails,
+    IRuntimeFactory,
+} from "@fluidframework/container-definitions";
+import { Loader } from "@fluidframework/container-loader";
 import { DOProviderContainerRuntimeFactory, FluidContainer } from "@fluidframework/fluid-static";
-
-import { getSessionStorageContainer } from "@fluid-experimental/get-container";
+import {
+    LocalDocumentServiceFactory,
+    LocalResolver,
+    LocalSessionStorageDbFactory,
+} from "@fluidframework/local-driver";
+import {
+    ILocalDeltaConnectionServer,
+    LocalDeltaConnectionServer,
+} from "@fluidframework/server-local-server";
 
 import { DiceRollerController } from "../src/controller";
 import { makeAppView } from "../src/view";
@@ -21,6 +34,65 @@ if (window.location.hash.length === 0) {
     window.location.hash = Date.now().toString();
 }
 const documentId = window.location.hash.substring(1);
+
+// The local server needs to be shared across the Loader instances for collaboration to happen
+const localServerMap = new Map<string, ILocalDeltaConnectionServer>();
+
+const urlResolver = new LocalResolver();
+
+/**
+ * Connect to the local SessionStorage Fluid service and retrieve a Container with the given ID running the given code.
+ * @param documentId - The document id to retrieve or create
+ * @param containerRuntimeFactory - The container factory to be loaded in the container
+ */
+export async function getSessionStorageContainer(
+    documentId: string,
+    containerRuntimeFactory: IRuntimeFactory,
+    createNew: boolean,
+): Promise<{ container: IContainer; attach: (() => Promise<void>) | undefined }> {
+    let localServer = localServerMap.get(documentId);
+    if (localServer === undefined) {
+        localServer = LocalDeltaConnectionServer.create(
+            new LocalSessionStorageDbFactory(documentId),
+        );
+        localServerMap.set(documentId, localServer);
+    }
+
+    const documentServiceFactory = new LocalDocumentServiceFactory(localServer);
+    const url = `${window.location.origin}/${documentId}`;
+
+    // To bypass proposal-based loading, we need a codeLoader that will return our already-in-memory container factory.
+    // The expected format of that response is an IFluidModule with a fluidExport.
+    const load = async (): Promise<IFluidModuleWithDetails> => {
+        return {
+            module: { fluidExport: containerRuntimeFactory },
+            details: { package: "no-dynamic-package", config: {} },
+        };
+    };
+
+    const codeLoader = { load };
+
+    const loader = new Loader({
+        urlResolver,
+        documentServiceFactory,
+        codeLoader,
+    });
+
+    let container: IContainer;
+    let attach: (() => Promise<void>) | undefined;
+
+    if (createNew) {
+        // We're not actually using the code proposal (our code loader always loads the same module regardless of the
+        // proposal), but the IContainer will only give us a NullRuntime if there's no proposal.  So we'll use a fake
+        // proposal.
+        container = await loader.createDetachedContainer({ package: "", config: {} });
+        attach = async () => container.attach({ url });
+    } else {
+        container = await loader.resolve({ url });
+    }
+
+    return { container, attach };
+}
 
 export const containerConfig = {
     name: "dice-roller-container",
@@ -51,7 +123,7 @@ export async function createContainerAndRenderInElement(
 ) {
     // The SessionStorage Container is an in-memory Fluid container that uses the local browser SessionStorage
     // to store ops.
-    const container = await getSessionStorageContainer(
+    const { container, attach } = await getSessionStorageContainer(
         documentId,
         new DOProviderContainerRuntimeFactory(containerConfig),
         createNewFlag,
@@ -61,6 +133,7 @@ export async function createContainerAndRenderInElement(
     const fluidContainer = (await container.request({ url: "/" })).value;
     if (createNewFlag) {
         await initializeNewContainer(fluidContainer);
+        await attach?.();
     }
 
     const sharedMap1 = fluidContainer.initialObjects.map1 as SharedMap;
@@ -69,10 +142,6 @@ export async function createContainerAndRenderInElement(
     const diceRollerController2 = new DiceRollerController(sharedMap2);
 
     element.append(makeAppView([diceRollerController, diceRollerController2]));
-
-    // Setting "fluidStarted" is just for our test automation
-    // eslint-disable-next-line @typescript-eslint/dot-notation
-    window["fluidStarted"] = true;
 }
 
 /**
@@ -90,6 +159,10 @@ async function setup() {
     }
     // The second time we don't need to createNew because we know a Container exists.
     await createContainerAndRenderInElement(rightElement, false);
+
+    // Setting "fluidStarted" is just for our test automation
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    window["fluidStarted"] = true;
 }
 
 setup().catch((e) => {


### PR DESCRIPTION
The test for external-controller is currently broken in main.

I'm not sure if anything changed recently to expose it, vs. maybe it's just been broken for a long time.

Since the external-controller approach sets up the initial data (the dice value) in the controller, it relies on this happening prior to container attach (or else other clients may see a not-fully-initialized model and their controller blows up).  In the normal demo (using tinylicious and AzureClient) this works fine, because we control when attach() gets called.  But in the test, we use getSessionStorageContainer which attaches the container before returning.

The problem is also exacerbated because the first container must do a read->write transition (which is async), so those first ops that would have done the initialization are guaranteed to be sent after the second client tries and fails to load.  Maybe this is what changed, if we always joined in write mode before I think it would not repro because we could cheat and synchronously write the ops to session storage?

In any case, the best fix is to delay the attach until initialization is actually complete, matching the non-test version of the demo.  I do this with a variation of getSessionStorageContainer that returns an attach callback.  Eliminating the get-container dependency is good anyway, since this package should be deprecated removed eventually.