### PR TITLE
GC: Added handling of attachment blobs that are deleted by sweep phase

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1196,6 +1196,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             },
             (blobPath: string) => this.garbageCollector.nodeUpdated(blobPath, "Loaded"),
             (fromPath: string, toPath: string) => this.garbageCollector.addedOutboundReference(fromPath, toPath),
+            (blobPath: string) => this.garbageCollector.isNodeDeleted(blobPath),
             this,
             pendingRuntimeState?.pendingAttachmentBlobs,
         );

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -87,7 +87,7 @@ import {
     getFluidDataStoreAttributes,
 } from "./summaryFormat";
 import { throwOnTombstoneUsageKey } from "./garbageCollectionConstants";
-import { sendGCTombstoneEvent } from "./garbageCollectionTombstoneUtils";
+import { sendGCUnexpectedUsageEvent } from "./garbageCollectionHelpers";
 import { summarizerClientType } from "./summarizerClientElection";
 
 function createAttributes(
@@ -777,7 +777,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
             const messageString = `Context is tombstoned! Call site [${callSite}]`;
             const error = new DataCorruptionError(messageString, safeTelemetryProps);
 
-            sendGCTombstoneEvent(
+            sendGCUnexpectedUsageEvent(
                 this.mc,
                 {
                     eventName: "GC_Tombstone_DataStore_Changed",

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -56,7 +56,7 @@ import { IDataStoreAliasMessage, isDataStoreAliasMessage } from "./dataStore";
 import { GCNodeType } from "./garbageCollection";
 import { throwOnTombstoneLoadKey } from "./garbageCollectionConstants";
 import { summarizerClientType } from "./summarizerClientElection";
-import { sendGCTombstoneEvent } from "./garbageCollectionTombstoneUtils";
+import { sendGCUnexpectedUsageEvent } from "./garbageCollectionHelpers";
 
 type PendingAliasResolve = (success: boolean) => void;
 
@@ -450,7 +450,7 @@ export class DataStores implements IDisposable {
                 request,
                 { [TombstoneResponseHeaderKey]: true },
             ), request);
-            sendGCTombstoneEvent(
+            sendGCUnexpectedUsageEvent(
                 this.mc,
                 {
                     eventName: "GC_Tombstone_DataStore_Requested",

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -65,7 +65,7 @@ import {
     stableGCVersion,
     trackGCStateKey
 } from "./garbageCollectionConstants";
-import { sendGCTombstoneEvent } from "./garbageCollectionTombstoneUtils";
+import { sendGCUnexpectedUsageEvent } from "./garbageCollectionHelpers";
 import { SweepReadyUsageDetectionHandler } from "./gcSweepReadyUsageDetection";
 import {
     getGCVersion,
@@ -1304,7 +1304,7 @@ export class GarbageCollector implements IGarbageCollector {
                 eventName = "GC_Tombstone_Blob_Revived";
             }
 
-            sendGCTombstoneEvent(
+            sendGCUnexpectedUsageEvent(
                 this.mc,
                 {
                     eventName,

--- a/packages/runtime/container-runtime/src/garbageCollectionHelpers.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionHelpers.ts
@@ -6,12 +6,13 @@
 import { ITelemetryGenericEvent } from "@fluidframework/common-definitions";
 import { packagePathToTelemetryProperty } from "@fluidframework/runtime-utils";
 import { MonitoringContext } from "@fluidframework/telemetry-utils";
-import { disableTombstoneKey, throwOnTombstoneLoadKey, throwOnTombstoneUsageKey } from "./garbageCollectionConstants";
+import { disableTombstoneKey, runSweepKey, throwOnTombstoneLoadKey, throwOnTombstoneUsageKey } from "./garbageCollectionConstants";
 
 /**
- * Consolidates info / logic for logging when we encounter a Tombstone
+ * Consolidates info / logic for logging when we encounter unexpected usage of GC'd objects. For example, when a
+ * tombstoned or deleted object is loaded.
  */
-export function sendGCTombstoneEvent(
+export function sendGCUnexpectedUsageEvent(
     mc: MonitoringContext,
     event: ITelemetryGenericEvent & { category: "error" | "generic", isSummarizerClient: boolean },
     packagePath: readonly string[] | undefined,
@@ -23,6 +24,9 @@ export function sendGCTombstoneEvent(
         ThrowOnTombstoneUsage: mc.config.getBoolean(throwOnTombstoneUsageKey),
         ThrowOnTombstoneLoad: mc.config.getBoolean(throwOnTombstoneLoadKey),
     });
+    event.sweepFlags = JSON.stringify({
+        EnableSweepFlag: mc.config.getBoolean(runSweepKey),
+    })
 
     mc.logger.sendTelemetryEvent(event, error);
 }

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -54,6 +54,7 @@ class MockRuntime extends TypedEventEmitter<IContainerRuntimeEvents> implements 
             (localId: string, blobId?: string) => this.sendBlobAttachOp(localId, blobId),
             () => undefined,
             () => undefined,
+            (blobPath: string) => this.isBlobDeleted(blobPath),
             this,
         );
     }
@@ -100,6 +101,12 @@ class MockRuntime extends TypedEventEmitter<IContainerRuntimeEvents> implements 
         return P;
     }
 
+    public async getBlob(blobHandle: IFluidHandle<ArrayBufferLike>) {
+        const pathParts = blobHandle.absolutePath.split("/");
+        const blobId = pathParts[2];
+        return this.blobManager.getBlob(blobId);
+    }
+
     public blobManager: BlobManager;
     public connected = false;
     public attachState: AttachState;
@@ -111,6 +118,7 @@ class MockRuntime extends TypedEventEmitter<IContainerRuntimeEvents> implements 
     private processBlobsP = new Deferred<void>();
     private blobPs: Promise<any>[] = [];
     private handlePs: Promise<any>[] = [];
+    private readonly deletedBlobs: string[] = [];
 
     public processOps() {
         assert(this.connected || this.ops.length === 0);
@@ -187,6 +195,14 @@ class MockRuntime extends TypedEventEmitter<IContainerRuntimeEvents> implements 
         const op = { metadata: { localId: uuid(), blobId: response.id } };
         this.blobManager.processBlobAttachOp(op as ISequencedDocumentMessage, false);
         return op;
+    }
+
+    public deleteBlob(blobHandle: IFluidHandle<ArrayBufferLike>) {
+        this.deletedBlobs.push(blobHandle.absolutePath);
+    }
+
+    public isBlobDeleted(blobPath: string): boolean {
+        return this.deletedBlobs.includes(blobPath);
     }
 }
 
@@ -533,5 +549,48 @@ describe("BlobManager", () => {
         const summaryData = await runtime.attach();
         assert.strictEqual(summaryData?.ids.length, 3);
         assert.strictEqual(summaryData?.redirectTable.size, 3);
+    });
+
+    it("fetching deleted blob fails", async () => {
+        await runtime.attach();
+        await runtime.connect();
+        const blob1Contents = IsoBuffer.from("blob1", "utf8");
+        const blob2Contents = IsoBuffer.from("blob2", "utf8");
+        const handle1P = runtime.createBlob(blob1Contents);
+        const handle2P = runtime.createBlob(blob2Contents);
+        await runtime.processAll();
+
+        const blob1Handle = await handle1P;
+        const blob2Handle = await handle2P;
+
+        // Validate that the blobs can be retrieved.
+        assert.strictEqual(await runtime.getBlob(blob1Handle), blob1Contents);
+        assert.strictEqual(await runtime.getBlob(blob2Handle), blob2Contents);
+
+        // Delete blob1. Retrieving it should result in an error.
+        runtime.deleteBlob(blob1Handle);
+        await assert.rejects(
+            async () => runtime.getBlob(blob1Handle),
+            (error) => {
+                const blob1Id = blob1Handle.absolutePath.split("/")[2];
+                const correctErrorType = error.code === 404;
+                const correctErrorMessage = error.message === `Blob was deleted: ${blob1Id}`;
+                return correctErrorType && correctErrorMessage;
+            },
+            "Deleted blob2 fetch should have failed"
+        );
+
+        // Delete blob2. Retrieving it should result in an error.
+        runtime.deleteBlob(blob2Handle);
+        await assert.rejects(
+            async () => runtime.getBlob(blob2Handle),
+            (error) => {
+                const blob2Id = blob2Handle.absolutePath.split("/")[2];
+                const correctErrorType = error.code === 404;
+                const correctErrorMessage = error.message === `Blob was deleted: ${blob2Id}`;
+                return correctErrorType && correctErrorMessage;
+            },
+            "Deleted blob2 fetch should have failed"
+        );
     });
 });


### PR DESCRIPTION
If a blob that has been deleted by the GC sweep phase is requested, fail the request with a 404 and a message that says "Blob was deleted". An error is also logged so that we can track such instances in telemetry.

[AB#2389](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2389)