### PR TITLE
Don't use deprecated OdspDocumentServiceFactory in fluid repo

### DIFF
--- a/examples/utils/bundle-size-tests/src/odspDriver.ts
+++ b/examples/utils/bundle-size-tests/src/odspDriver.ts
@@ -2,9 +2,9 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { OdspDocumentServiceFactoryWithCodeSplit } from "@fluidframework/odsp-driver";
+import { OdspDocumentServiceFactory } from "@fluidframework/odsp-driver";
 
 export function apisToBundle() {
      // Pass through dummy parameters, this file is only used for bundle analysis
-    new OdspDocumentServiceFactoryWithCodeSplit(undefined as any, undefined as any);
+    new OdspDocumentServiceFactory(undefined as any, undefined as any);
 }

--- a/packages/tools/webpack-fluid-loader/src/getDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/getDocumentServiceFactory.ts
@@ -6,7 +6,7 @@
 import { assert } from "@fluidframework/common-utils";
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
 import { LocalDocumentServiceFactory, LocalSessionStorageDbFactory } from "@fluidframework/local-driver";
-import { OdspDocumentServiceFactoryWithCodeSplit } from "@fluidframework/odsp-driver";
+import { OdspDocumentServiceFactory } from "@fluidframework/odsp-driver";
 import { HostStoragePolicy, IPersistedCache } from "@fluidframework/odsp-driver-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
@@ -62,7 +62,7 @@ export function getDocumentServiceFactory(
         case "spo":
         case "spo-df":
             // TODO: web socket token
-            return new OdspDocumentServiceFactoryWithCodeSplit(
+            return new OdspDocumentServiceFactory(
                 async () => options.odspAccessToken ?? null,
                 async () => options.pushAccessToken ?? null,
                 odspPersistantCache,


### PR DESCRIPTION
## Description

Don't use deprecated OdspDocumentServiceFactory in fluid repo