### PR TITLE
build(azure): Don't run format as a part of the build step

### DIFF
--- a/azure/package.json
+++ b/azure/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "author": "Microsoft and contributors",
   "scripts": {
-    "build": "npm run policy-check && npm run layer-check && npm run build:genver && npm run format && npm run build:compile && npm run lint && npm run build:docs",
+    "build": "npm run policy-check && npm run layer-check && npm run build:genver && npm run build:compile && npm run lint && npm run build:docs",
     "build:ci": "npm run build:genver && lerna run build:compile --stream",
     "build:compile": "lerna run build:compile --stream",
     "build:docs": "npm run build:docs:api-extractor && npm run build:docs:copy-metadata",


### PR DESCRIPTION
Build from the release group root was incorrectly running prettier (i.e. "format") as a step during its "build" script. This was generating unrelated formatting changes while running the build, which is undesirable.