### PR TITLE
GC RFC: Add gcContainerGeneration and tests illustrating its usage

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -355,6 +355,7 @@ export interface IGCRuntimeOptions {
     [key: string]: any;
     disableGC?: boolean;
     gcAllowed?: boolean;
+    readonly gcContainerGeneration?: number;
     runFullGC?: boolean;
     sessionExpiryTimeoutMs?: number;
     sweepAllowed?: boolean;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -350,6 +350,15 @@ export interface IGCRuntimeOptions {
     sweepAllowed?: boolean;
 
     /**
+     * The "GC Container Generation" is provided by the container author to denote GC-impacting changes to the container's structure.
+     * The value provided at creation time is persisted, and compared with the value provided at each load.
+     *
+     * If the persisted value doesn't match the value provided on load, GC Sweep will be disabled to protect against dataloss in case
+     * containers with an older Generation were found to have GC-impacting bugs.
+     */
+    readonly gcContainerGeneration?: number;
+
+    /**
      * Flag that if true, will disable garbage collection for the session.
      * Can be used to disable running GC on containers where it is allowed via the gcAllowed option.
      */

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -93,11 +93,19 @@ export type GCVersion = number;
 export interface IGCMetadata {
     /**
      * The version of the GC code that was run to generate the GC data that is written in the summary.
+     * If the persisted value doesn't match the current value in the code, saved GC data will be discarded and regenerated from scratch.
      * Also, used to determine whether GC is enabled for this container or not:
      * - A value of 0 or undefined means GC is disabled.
      * - A value greater than 0 means GC is enabled.
      */
     readonly gcFeature?: GCVersion;
+    /**
+     * The "GC Container Generation" is provided by the container author to denote GC-impacting changes to the container's structure.
+     * The value provided at creation time is persisted, and compared with the value provided at each load.
+     * If the persisted value doesn't match the value provided on load, GC Sweep will be disabled to protect against dataloss in case
+     * containers with an older Generation were found to have GC-impacting bugs.
+     */
+    readonly gcContainerGeneration?: number;
     /**
      * Tells whether the GC sweep phase is enabled for this container.
      * - True means sweep phase is enabled.

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -210,6 +210,15 @@ describe("Garbage Collection Tests", () => {
                 assert(gc.gcEnabled, "gcEnabled incorrect");
                 assert.equal(gc.latestSummaryGCVersion, 1, "latestSummaryGCVersion incorrect");
             });
+            it("gcContainerGeneration mismatch, sweepEnabled true", () => {
+                gc = createGcWithPrivateMembers({ gcContainerGeneration: 0, sweepEnabled: true }, { gcContainerGeneration: 1 });
+                assert(gc.gcEnabled, "gcEnabled incorrect");
+                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+            });
+            it("gcContainerGeneration matches", () => {
+                gc = createGcWithPrivateMembers({ gcContainerGeneration: 2, sweepEnabled: true }, { gcContainerGeneration: 2 });
+                assert(gc.sweepEnabled, "sweepEnabled incorrect");
+            });
             it("sweepEnabled false", () => {
                 gc = createGcWithPrivateMembers({ sweepEnabled: false });
                 assert(!gc.sweepEnabled, "sweepEnabled incorrect");
@@ -227,10 +236,11 @@ describe("Garbage Collection Tests", () => {
                 const inputMetadata: IGCMetadata = {
                     sweepEnabled: true,
                     gcFeature: 1,
+                    gcContainerGeneration: 2,
                     sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
                     sweepTimeoutMs: 123,
                 };
-                gc = createGcWithPrivateMembers(inputMetadata);
+                gc = createGcWithPrivateMembers(inputMetadata, { gcContainerGeneration: 2 });
                 const outputMetadata = gc.getMetadata();
                 const expectedOutputMetadata: IGCMetadata = { ...inputMetadata, gcFeature: stableGCVersion };
                 assert.deepEqual(outputMetadata, expectedOutputMetadata, "getMetadata returned different metadata than loaded from");
@@ -240,10 +250,11 @@ describe("Garbage Collection Tests", () => {
                 const inputMetadata: IGCMetadata = {
                     sweepEnabled: true,
                     gcFeature: 1,
+                    gcContainerGeneration: 2,
                     sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
                     sweepTimeoutMs: 123,
                 };
-                gc = createGcWithPrivateMembers(inputMetadata);
+                gc = createGcWithPrivateMembers(inputMetadata, { gcContainerGeneration: 2 });
                 const outputMetadata = gc.getMetadata();
                 const expectedOutputMetadata: IGCMetadata = { ...inputMetadata, gcFeature: currentGCVersion };
                 assert.deepEqual(outputMetadata, expectedOutputMetadata, "getMetadata returned different metadata than loaded from");
@@ -326,10 +337,11 @@ describe("Garbage Collection Tests", () => {
                 const expectedMetadata: IGCMetadata = {
                     sweepEnabled: true,
                     gcFeature: 1,
+                    gcContainerGeneration: 2,
                     sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
                     sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
                 };
-                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: true });
+                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: true, gcContainerGeneration: 2 });
                 const outputMetadata = gc.getMetadata();
                 assert.deepEqual(outputMetadata, expectedMetadata, "getMetadata returned different metadata than expected");
             });
@@ -339,10 +351,11 @@ describe("Garbage Collection Tests", () => {
                 const expectedMetadata: IGCMetadata = {
                     sweepEnabled: true,
                     gcFeature: currentGCVersion,
+                    gcContainerGeneration: 2,
                     sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
                     sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
                 };
-                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: true });
+                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: true, gcContainerGeneration: 2 });
                 const outputMetadata = gc.getMetadata();
                 assert.deepEqual(outputMetadata, expectedMetadata, "getMetadata returned different metadata than expected");
             });


### PR DESCRIPTION
## Description

We've discussed the virtue of having a "min bar" where documents created before that point are exempt from Tombstone Failures and Sweep.  This is one idea for how to implement that.

The "GC Container Generation" is provided by the container author to denote GC-impacting changes to the container's structure. The value provided at creation time is persisted, and then compared with the value provided at each load. If the persisted value doesn't match the value provided on load, GC Sweep will be disabled to protect against data loss in case containers with an older Generation were found to have GC-impacting bugs.

## Reviewer Guidance

This PR is just adding failing tests that illustrate how gcContainerGeneration could be used to "move on" when bugs are found in container/component implementations.

To implement this, I think we'd either need to repurpose `sweepEnabled` to also apply to whether Tombstone requests fail, or we'd need an additional property on GC that is plumbed out to the ContainerRuntime and used in the `throwOnTombstoneLoad` calculations throughout.