### PR TITLE
docs: Update the Shared Tree roadmap

### DIFF
--- a/packages/dds/tree/docs/roadmap.md
+++ b/packages/dds/tree/docs/roadmap.md
@@ -4,7 +4,7 @@ The Fluid Framework is a client/server tech stack designed to intuitively synchr
 The framework consists of 3 key parts: the Fluid Service, Fluid Runtime, and Distributed Data Structures (DDSes).
 The **Fluid Service** is responsible for sequencing and broadcasting changes (ops) to each client and persisting state to storage.
 The **Fluid Runtime** is responsible for sending local ops to the Fluid Service and merging incoming ops.
-The **DDS** es are the data structures that the Fluid Service and Fluid Runtime keep synchronized.
+The **DDS**es are the data structures that the Fluid Service and Fluid Runtime keep synchronized.
 
 From the perspective of an application developer, using the Fluid Framework is largely an exercise in choosing the right DDSes and integrating them into the application.
 For example, one of the simplest DDSes is a Shared Map that can be used in much the same way a developer would use a standard JavaScript map.

--- a/packages/dds/tree/docs/roadmap.md
+++ b/packages/dds/tree/docs/roadmap.md
@@ -1,14 +1,24 @@
 # Introduction
 
-The Fluid Framework is a client/server tech stack designed to intuitively synchronize data between clients in real time. The framework consists of 3 key parts: the Fluid Service, Fluid Runtime, and Distributed Data Structures (DDSes). The **Fluid Service** is responsible for sequencing and broadcasting changes (ops) to each client and persisting state to storage. The **Fluid Runtime** is responsible for sending local ops to the Fluid Service and merging incoming ops. The **DDS** es are the data structures that the Fluid Service and Fluid Runtime keep synchronized.
+The Fluid Framework is a client/server tech stack designed to intuitively synchronize data between clients in real time.
+The framework consists of 3 key parts: the Fluid Service, Fluid Runtime, and Distributed Data Structures (DDSes).
+The **Fluid Service** is responsible for sequencing and broadcasting changes (ops) to each client and persisting state to storage.
+The **Fluid Runtime** is responsible for sending local ops to the Fluid Service and merging incoming ops.
+The **DDS** es are the data structures that the Fluid Service and Fluid Runtime keep synchronized.
 
-From the perspective of an application developer, using the Fluid Framework is largely an exercise in choosing the right DDSes and integrating them into the application. For example, one of the simplest DDSes is a Shared Map that can be used in much the same way a developer would use a standard JavaScript map. The key difference is that a Shared Map will reflect remote changes.
+From the perspective of an application developer, using the Fluid Framework is largely an exercise in choosing the right DDSes and integrating them into the application.
+For example, one of the simplest DDSes is a Shared Map that can be used in much the same way a developer would use a standard JavaScript map.
+The key difference is that a Shared Map will reflect remote changes.
 
-Fluid Framework has evolved significantly in response to developer feedback. One key piece of feedback has been the desire for a DDS that can effectively model complex, hierarchical data. Shared Tree is the response to that feedback.
+Fluid Framework has evolved significantly in response to developer feedback.
+One key piece of feedback has been the desire for a DDS that can effectively model complex, hierarchical data.
+Shared Tree is the response to that feedback.
 
 # What is Shared Tree
 
-Shared Tree is a DDS designed to keep hierarchical data synchronized between clients. Its development is being driven by significant feedback from developers looking for Fluid data structures that map more closely to their application data models. This document lays out the goals for Shared Tree development and the motivation behind those goals. Here is a list of the key scenarios described in this document:
+Shared Tree is a DDS designed to keep hierarchical data synchronized between clients.
+Its development is being driven by significant feedback from developers looking for Fluid data structures that map more closely to their application data models.
+This document lays out the goals for Shared Tree development and the motivation behind those goals. Here is a list of the key scenarios described in this document:
 
 - [Read and write data to the Shared Tree without an in-memory JavaScript representation](#tree-reading-and-writing-without-reification)
 - [Apply sets of related changes atomically with no interleaved changes (transactions)](#synchronous-non-overlapping-transactions)
@@ -28,13 +38,17 @@ Shared Tree is a DDS designed to keep hierarchical data synchronized between cli
 - [Provide access to the state of the data in the past](#history)
 - [Create, change, and merge branched data in a similar manner to source control](#branching-and-merging)
 - [Improve performance by building indexes](#indexes)
+- [Allow higher-level semantics in edits to the tree](#high-level-commands)
 - [Support for data sets larger than client memory/storage](#partial-checkout)
 
 Read the [Shared Tree github readme](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree) for a more technical overview.
 
 # Performance
 
-Fast performance lies at the heart of the Fluid Framework vision. It was designed from the ground up to minimize latency introduced by servers by shifting merge responsibilities to the client. That said, taking full advantage of this architecture is the top priority for Shared Tree. These are the near-term performance goals:
+Fast performance lies at the heart of the Fluid Framework vision.
+It was designed from the ground up to minimize latency introduced by servers by shifting merge responsibilities to the client.
+That said, taking full advantage of this architecture is the top priority for Shared Tree.
+These are the near-term performance goals:
 
 - Equivalent or better performance as compared with the experimental Shared Tree DDS
 - Include granular performance benchmarks for each Shared Tree component including reading and writing of the in-memory tree and merging changes
@@ -50,7 +64,9 @@ As the Shared Tree feature set grows, the performance goals will also evolve to 
 
 # Stability
 
-Shared Tree is a complex DDS aimed at supporting a broad range of data types and merge semantics. As such, it is critical that Shared Tree investments include significant focus on reliability. The following goals and investments will ensure Shared Tree is reliable and remains stable as it evolves:
+Shared Tree is a complex DDS aimed at supporting a broad range of data types and merge semantics.
+As such, it is critical that Shared Tree investments include significant focus on reliability.
+The following goals and investments will ensure Shared Tree is reliable and remains stable as it evolves:
 
 - Roughly 90% unit test coverage
 
@@ -62,13 +78,16 @@ Shared Tree is a complex DDS aimed at supporting a broad range of data types and
 
 # Roadmap
 
-The following is a prioritized list of investment areas for Shared Tree development. Each item includes an indication of whether it is complete, in active development, or pending.
+The following is a prioritized list of investment areas for Shared Tree development.
+Each item includes an indication of whether it is complete, in active development, or pending.
 
 ## Rebaser core architecture
 
 > Complete
 
-In Shared Tree, the core algorithms for processing edits to the tree have the dual responsibility of maintaining intention preservation while also supporting very large documents—potentially larger than client memory. The scaling requirement means that these algorithms should be able to operate without reifying (loading/reading) the tree data and should be a function only of the operations themselves. The intention preservation requirement dictates that all editing operations should have an intuitive effect on the tree even during concurrency.
+In Shared Tree, the core algorithms for processing edits to the tree have the dual responsibility of maintaining intention preservation while also supporting very large documents—potentially larger than client memory.
+The scaling requirement means that these algorithms should be able to operate without reifying (loading/reading) the tree data and should be a function only of the operations themselves.
+The intention preservation requirement dictates that all editing operations should have an intuitive effect on the tree even during concurrency.
 
 The mechanism in Shared Tree responsible for satisfying these criteria is called the Rebaser. Some of the resulting design documents can be found [here](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/docs). The operations available in the editing API (e.g., insert, delete) are rolled out incrementally in future milestones.
 
@@ -76,45 +95,65 @@ The mechanism in Shared Tree responsible for satisfying these criteria is called
 
 > Complete
 
-Supporting larger-than-memory data sets in the tree requires efficiently handling trees that contain large numbers of strong identifiers (UUIDs). To meet this requirement, Shared Tree leverages a novel distributed compression scheme that reduces the average storage cost of the identifiers to that of a small integer. This enables better scaling in scenarios where large numbers of these compressed IDs are needed (e.g., graph-like references). The documentation for this scheme can be found [here](https://github.com/microsoft/FluidFramework/blob/7301e1c742f0cdb0e02466918af1af06a969c3c3/packages/dds/tree/src/id-compressor/idCompressor.ts#L272).
+Supporting larger-than-memory data sets in the tree requires efficiently handling trees that contain large numbers of strong identifiers (UUIDs).
+To meet this requirement, Shared Tree leverages a novel distributed compression scheme that reduces the average storage cost of the identifiers to that of a small integer.
+This enables better scaling in scenarios where large numbers of these compressed IDs are needed (e.g., graph-like references).
+The documentation for this scheme can be found [here](https://github.com/microsoft/FluidFramework/blob/7301e1c742f0cdb0e02466918af1af06a969c3c3/packages/dds/tree/src/id-compressor/idCompressor.ts#L272).
 
 ## Data model specification
 
 > Complete
 
-Shared Tree has a number of requirements that have a direct impact on the tree data model. These include schema annotations on nodes, strong identifiers, references in the tree, and JSON interoperability. The team designed a low-level data model that accommodates them; it is JSON-like, but with a few key divergences. The specification can be found [here](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/docs/data-model).
+Shared Tree has a number of requirements that have a direct impact on the tree data model.
+These include schema annotations on nodes, strong identifiers, references in the tree, and JSON interoperability.
+The team designed a low-level data model that accommodates them; it is JSON-like, but with a few key divergences.
+The specification can be found [here](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/docs/data-model).
 
 ## Basic data synchronization
 
 > Complete
 
-For developers eager to start using the Shared Tree DDS, this milestone represents the point where they can do so for scenarios involving transient data. That is, at this stage developers can create a Shared Tree from other data and use it to sync that data between all clients. Insert, delete, and modify operations will be functional; however, the storage formats will not be final at this stage. There will be no data migration strategy for the data stored in the Shared Tree DDS at this stage. The move operation is also not yet available.
+For developers eager to start using the Shared Tree DDS, this milestone represents the point where they can do so for scenarios involving transient data.
+That is, at this stage developers can create a Shared Tree from other data and use it to sync that data between all clients.
+Insert, delete, and modify operations will be functional; however, the storage formats will not be final at this stage.
+There will be no data migration strategy for the data stored in the Shared Tree DDS at this stage.
+The move operation is also not yet available.
 
 ## Tree reading and writing without reification
 
 > Complete
 
-In most scenarios, the Shared Tree will include an in-memory JavaScript representation. This milestone makes it possible to read and write data to the Shared Tree without creating (reifing) that in-memory JavaScript representation. This is particularly useful in scenarios where the client maintains a copy of the data on the other side of an interop boundary (e.g., WASM, C++). It also allows clients/microservices to check permissions without loading the document and inspect changes without caring about the entire tree.
+In most scenarios, the Shared Tree will include an in-memory JavaScript representation.
+This milestone makes it possible to read and write data to the Shared Tree without creating (reifing) that in-memory JavaScript representation.
+This is particularly useful in scenarios where the client maintains a copy of the data on the other side of an interop boundary (e.g., WASM, C++).
+It also allows clients/microservices to check permissions without loading the document and inspect changes without caring about the entire tree.
 
-To accomplish this, the underlying Shared Tree layer is built on a [cursor API](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/core/tree/cursor.ts) that allows navigation of the tree by moving from node to node via explicit directional calls. This cursor API is intended to be an expert API as working with it is very cumbersome compared with the much more ergonomic APIs exposed in future milestones. Built on top of cursors is the [Forest API](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/src/feature-libraries/chunked-forest), a minimal interface that exposes the tree without reification.
+To accomplish this, the underlying Shared Tree layer is built on a [cursor API](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/core/tree/cursor.ts) that allows navigation of the tree by moving from node to node via explicit directional calls.
+This cursor API is intended to be an expert API as working with it is very cumbersome compared with the much more ergonomic APIs exposed in future milestones.
+Built on top of cursors is the [Forest API](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/src/feature-libraries/chunked-forest), a minimal interface that exposes the tree without reification.
 
 ## Synchronous non-overlapping transactions
 
 > Complete
 
-Developers often want to group changes to the Shared Tree into logical units. Reasons for doing so include:
+Developers often want to group changes to the Shared Tree into logical units.
+Reasons for doing so include:
 
 - Atomicity: a set of changes should be applied without any other changes (local or remote) being interleaved with them.
 - App semantics: a set of changes represents a logical edit in the application model that must be applied atomically, and tree-level operations (such as undo/redo or history) should never result in an intermediate state being exposed.
 - Dependencies between changes: changes within a grouping depend on some invariant (e.g., an insert should be applied only if none of the other changes in its group fail to apply due to concurrent edits).
 
-This milestone enables the creation of a single synchronous transaction per Shared Tree and guarantees atomicity (including for remote recipients of the edit). The other requirements will be satisfied by future milestones such as _Undo/redo_ and _Constraints_.
+This milestone enables the creation of a single synchronous transaction per Shared Tree and guarantees atomicity (including for remote recipients of the edit).
+The other requirements will be satisfied by future milestones such as _Undo/redo_ and _Constraints_.
 
 ## Tree reading and writing with JS object style API
 
 > Complete
 
-A key objective of Shared Tree is that it be intuitive and easy for developers to use. To enable this, Shared Tree will include a high-level API that presents the tree as if it were composed of JavaScript objects. This is ideally suited for developers who prioritize familiarity and speed of development over low-level performance. Note that this API is a wrapper that uses JavaScript proxies and does not impose any schema. Schema will be supported but not as part of this milestone.
+A key objective of Shared Tree is that it be intuitive and easy for developers to use.
+To enable this, Shared Tree will include a high-level API that presents the tree as if it were composed of JavaScript objects.
+This is ideally suited for developers who prioritize familiarity and speed of development over low-level performance.
+Note that this API is a wrapper that uses JavaScript proxies and does not impose any schema. Schema will be supported but not as part of this milestone.
 
 This API is called the Editable Tree API and is [here](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/src/feature-libraries/editable-tree).
 
@@ -122,23 +161,32 @@ This API is called the Editable Tree API and is [here](https://github.com/micros
 
 > In progress
 
-The ability to undo and redo changes is table stakes for a collaborative editing system. However, there are a variety of possible specifications with varying levels of complexity.
+The ability to undo and redo changes is table stakes for a collaborative editing system.
+However, there are a variety of possible specifications with varying levels of complexity.
 
-For this milestone, Shared Tree offers an [undo/redo mechanism](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/docs/wip/inverse-changes/README.md#undo-semantics) that generates the inverse of a given edit (most frequently the most recent local change group but not necessarily) and applies it to the document. This simple implementation is easy to reason about but can lead to cases where concurrent changes can render the inverse edit inconsistent with the user's intent (e.g., conflicted or unapplied). In a future milestone, [alternative designs](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/docs/undo) are explored that better handle these cases.
+For this milestone, Shared Tree offers an [undo/redo mechanism](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/docs/wip/inverse-changes/README.md#undo-semantics) that generates the inverse of a given edit (most frequently the most recent local change group but not necessarily) and applies it to the document.
+This simple implementation is easy to reason about but can lead to cases where concurrent changes can render the inverse edit inconsistent with the user's intent (e.g., conflicted or unapplied).
+In a future milestone, [alternative designs](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/docs/undo) are explored that better handle these cases.
 
 ## Move
 
 > In progress
 
-Conceptually, a move is simply a delete and an insert of the same data. However, without proper semantics (and thus rebasing), concurrent changes can result in missing or duplicated data. The move operation preserves the identity of the nodes being moved and ensures that the outcome matches the developer's expectations.
+Conceptually, a move is simply a delete and an insert of the same data.
+However, without proper semantics (and thus rebasing), concurrent changes can result in missing or duplicated data.
+The move operation preserves the identity of the nodes being moved and ensures that the outcome matches the developer's expectations.
 
-Shared Tree will support two types of move operation. One is a **set** move where the nodes in the range when it is defined are the only nodes that move. The other is a **slice** move where any nodes inserted in the range during the move are also moved.
+Shared Tree will support two types of move operation.
+One is a **set** move where the nodes in the range when it is defined are the only nodes that move.
+The other is a **slice** move where any nodes inserted in the range during the move are also moved.
 
 ## Strong node identifiers and lookup index
 
 > In progress
 
-This milestone allows all nodes to optionally include a unique identifier that allows that node to be referenced without specifying the path to that node within the tree. This is critical in cases where nodes need durable references pointing to them (both within the tree—graph-like references—and in external cases such as URLs), as changes to the tree can invalidate path-based references. These identifiers are stored as compressed integers for storage and performance reasons but can be translated into UUIDs when requested.
+This milestone allows all nodes to optionally include a unique identifier that allows that node to be referenced without specifying the path to that node within the tree.
+This is critical in cases where nodes need durable references pointing to them (both within the tree—graph-like references—and in external cases such as URLs), as changes to the tree can invalidate path-based references.
+These identifiers are stored as compressed integers for storage and performance reasons but can be translated into UUIDs when requested.
 
 The Shared Tree will maintain an index of all nodes with identifiers to provide fast look-ups.
 
@@ -146,47 +194,78 @@ The Shared Tree will maintain an index of all nodes with identifiers to provide 
 
 > In progress
 
-In applications with complex editing flows, particularly in asynchronous programming models, it can be unergonomic or insufficient to use synchronous and non-overlapping transactions. In such cases, it is desirable to allow multiple transactions to exist concurrently on the same local instance of the Shared Tree while still guaranteeing isolation from other changes, both local and remote, during their lifetime (i.e., snapshot isolation). They should also be able to operate asynchronously, allowing transactions to span multiple JS frames. This milestone will enable the construction of such transactions, each of which operates on an isolated view of the tree determined by start of the transaction.
+In applications with complex editing flows, particularly in asynchronous programming models, it can be unergonomic or insufficient to use synchronous and non-overlapping transactions.
+In such cases, it is desirable to allow multiple transactions to exist concurrently on the same local instance of the Shared Tree while still guaranteeing isolation from other changes, both local and remote, during their lifetime (i.e., snapshot isolation).
+They should also be able to operate asynchronously, allowing transactions to span multiple JS frames.
+This milestone will enable the construction of such transactions, each of which operates on an isolated view of the tree determined by start of the transaction.
 
-As an example, consider a flow in which a developer initiates a call to some external service. It may be desirable to immediately show some temporary value (e.g., a placeholder value) in the tree and add the results of the async external call to it when it completes. However, the edit to the tree should only finish and be sent to other clients if/when the service call finishes. Additionally, the developer may want to prevent incoming changes from taking effect until after this flow completes, as it may be confusing or even inconsistent during the intermediate state. Implementing this correctly requires both asynchrony and snapshot isolation in the transaction layer.
+As an example, consider a flow in which a developer initiates a call to some external service.
+It may be desirable to immediately show some temporary value (e.g., a placeholder value) in the tree and add the results of the async external call to it when it completes.
+However, the edit to the tree should only finish and be sent to other clients if/when the service call finishes.
+Additionally, the developer may want to prevent incoming changes from taking effect until after this flow completes, as it may be confusing or even inconsistent during the intermediate state.
+Implementing this correctly requires both asynchrony and snapshot isolation in the transaction layer.
 
 ## Parity with experimental Shared Tree
 
 > In progress
 
-This milestone marks the point at which the Shared Tree is at parity (a superset of the functionality and as good or better performance) with the legacy Shared Tree. At this stage, developers using the legacy tree DDS can (and should) switch to Shared Tree. To make this transition as painless as possible, the following will be true:
+This milestone marks the point at which the Shared Tree is at parity (a superset of the functionality and as good or better performance) with the legacy Shared Tree.
+At this stage, developers using the legacy tree DDS can (and should) switch to Shared Tree.
+To make this transition as painless as possible, the following will be true:
 
-- Developers will have access to a data migration system. This mechanism can be used to safely and losslessly migrate data from the legacy tree to the Shared Tree. The migration is performed client-side and can be run on demand (at load time, in response to a user action, etc.).
-- The persisted format is stable and backward compatibility is guaranteed. This means that all versions of data (ops and summaries) ever written by the new Shared Tree are supported for reading (loading) forever.
-- As the Shared Tree data format evolves, there will—for every new data version released—always exist a Shared Tree package that supports writing both the latest major version and the one just prior. This allows staged rollouts of the new version on the application side. For example, the release of version 2.0 will include the ability to write format 2.0 but will default to writing format 1.0; an adopting application with ship the 2.0 package in this state, wait until some satisfactorily high adoption rate is reached (e.g., 99.9% of clients are on the new version) and then enable the writing of version 2.0. This is safe to do, as all clients (even the ones who are still defaulting to writing version 1.0) can read the new version.
+- Developers will have access to a data migration system.
+This mechanism can be used to safely and losslessly migrate data from the legacy tree to the Shared Tree. The migration is performed client-side and can be run on demand (at load time, in response to a user action, etc.).
+- The persisted format is stable and backward compatibility is guaranteed.
+This means that all versions of data (ops and summaries) ever written by the new Shared Tree are supported for reading (loading) forever.
+- As the Shared Tree data format evolves, there will—for every new data version released—always exist a Shared Tree package that supports writing both the latest major version and the one just prior.
+This allows staged rollouts of the new version on the application side.
+For example, the release of version 2.0 will include the ability to write format 2.0 but will default to writing format 1.0; an adopting application with ship the 2.0 package in this state, wait until some satisfactorily high adoption rate is reached (e.g., 99.9% of clients are on the new version) and then enable the writing of version 2.0.
+This is safe to do, as all clients (even the ones who are still defaulting to writing version 1.0) can read the new version.
 
 ## Embedded collections (e.g., sets, maps)
 
 > In progress
 
-While the Shared Tree data model is very flexible, developers may find themselves requiring that a subset of their data model has a more specific or performant representation. One such example would be modeling an associative relationship using a key/value store. In these cases, however, it is still required that their data receive the same benefits (e.g., identity, schema, move semantics) as when it is stored as nodes in the rest of the tree. This milestone accommodates these needs by allowing embedded collections that are managed by the Shared Tree and its rebasing mechanisms. Initially, only sets and maps will be offered; however, the architecture allows easy extension in the future to include more domain-specific options.
+While the Shared Tree data model is very flexible, developers may find themselves requiring that a subset of their data model has a more specific or performant representation.
+One such example would be modeling an associative relationship using a key/value store.
+In these cases, however, it is still required that their data receive the same benefits (e.g., identity, schema, move semantics) as when it is stored as nodes in the rest of the tree.
+This milestone accommodates these needs by allowing embedded collections that are managed by the Shared Tree and its rebasing mechanisms.
+Initially, only sets and maps will be offered;
+however, the architecture allows easy extension in the future to include more domain-specific options.
 
 ## Constraints
 
 > In progress
 
-By default, edits (i.e., transactions) in Shared Tree will always succeed (never conflict) due to the high-quality automatic merge resolution. Transactions alwaysguarantee atomicity (no interleaved changes from other transactions), but some changes may not have an effect due to concurrent edits that are applied first (e.g., a transaction that changes two nodes may only apply a subset of the changes due to one of the nodes being concurrently deleted). While convenient and usually sufficient, this behavior may not appropriately uphold application invariants.
+By default, edits (i.e., transactions) in Shared Tree will always succeed (never conflict) due to the high-quality automatic merge resolution.
+Transactions always guarantee atomicity (no interleaved changes from other transactions), but some changes may not have an effect due to concurrent edits that are applied first
+(e.g., a transaction that changes two nodes may only apply a subset of the changes due to one of the nodes being concurrently deleted).
+While convenient and usually sufficient, this behavior may not appropriately uphold application invariants.
 
-This milestone enables a developer to declaratively specify what sorts of concurrent edits should cause a transaction to fail and be marked as conflicted. These declarations are known as _constraints_ and are evaluated as the edit (transaction) is applied_._ The constraints delivered in this milestone include specifying that a given node still exists and specifying that a given node or field has not been edited (recursively or non-recursively).
+This milestone enables a developer to declaratively specify what sorts of concurrent edits should cause a transaction to fail and be marked as conflicted.
+These declarations are known as _constraints_ and are evaluated as the edit (transaction) is applied.
+The constraints delivered in this milestone include specifying that a given node still exists and specifying that a given node or field has not been edited (recursively or non-recursively).
 
 ## Schema and schema enforcement
 
 > Pending
 
-Schema determines how the data in the Shared Tree is structured and modified based on user-defined rules. Nodes in the tree include a _type_ field; these types are associated with rules that govern the shape of the data (e.g., which types are allowed in which fields). This metadata is stored in the tree ([schema specification](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/src/core/schema-stored)) and the Shared Tree uses it to guarantee that data conforms to the schema even in the face of concurrent editing. This milestone exposes the ability to author a schema, create schematized data, and guarantees that edits will never violate that schema. It does not provide a type-safe way to view the data—that is enabled by the _Type-safe schema API_ milestone.
+Schema determines how the data in the Shared Tree is structured and modified based on user-defined rules. Nodes in the tree include a _type_ field;
+these types are associated with rules that govern the shape of the data (e.g., which types are allowed in which fields).
+This metadata is stored in the tree ([schema specification](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/src/core/schema-stored)) and the Shared Tree uses it to guarantee that data conforms to the schema even in the face of concurrent editing.
+This milestone exposes the ability to author a schema, create schematized data, and guarantees that edits will never violate that schema.
+It does not provide a type-safe way to view the data—that is enabled by the _Type-safe schema API_ milestone.
 
 ## Lossless JSON roundtripping
 
 > Pending
 
-Many customer scenarios include the need to migrate existing data into the Shared Tree and export that data. Due to its ubiquity, JSON data is the focus of this milestone. The Shared Tree provides two mechanisms to import and export JSON data losslessly:
+Many customer scenarios include the need to migrate existing data into the Shared Tree and export that data.
+Due to its ubiquity, JSON data is the focus of this milestone.
+The Shared Tree provides two mechanisms to import and export JSON data losslessly:
 
-- A [JSON domain](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/domains/json/jsonDomainSchema.ts) (schema) that defines the mapping between the Shared Tree data model and JSON. This includes a [low-level cursor](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/domains/json/jsonCursor.ts) to navigate the data as though it were native JSON.
+- A [JSON domain](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/domains/json/jsonDomainSchema.ts) (schema) that defines the mapping between the Shared Tree data model and JSON.
+This includes a [low-level cursor](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/domains/json/jsonCursor.ts) to navigate the data as though it were native JSON.
 - APIs to ingest JSON data into a subtree typed as JSON as well as export a JSON-typed tree to raw JSON.
 
 These APIs are as lossless as JavaScript's own JSON API, so the same [caveats](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) apply.
@@ -195,7 +274,11 @@ These APIs are as lossless as JavaScript's own JSON API, so the same [caveats](h
 
 > Pending
 
-Based on feedback from developers already building apps with Fluid, there is a clear need to include support for collaborative text within the Shared Tree. This will require support for larger sequences of nodes than is otherwise typical. This milestone will include investments to make large sequences performant and scalable while still handling efficient collaboration. Of course, large sequences will not be limited to text, as text nodes all have the same characteristics as any other node in the tree. For example, they can be moved, they have identity, changes can be easily reverted, etc.
+Based on feedback from developers already building apps with Fluid, there is a clear need to include support for collaborative text within the Shared Tree.
+This will require support for larger sequences of nodes than is otherwise typical.
+This milestone will include investments to make large sequences performant and scalable while still handling efficient collaboration.
+Of course, large sequences will not be limited to text, as text nodes all have the same characteristics as any other node in the tree.
+For example, they can be moved, they have identity, changes can be easily reverted, etc.
 
 ## Storage performance: incrementality and virtualization
 
@@ -203,71 +286,111 @@ Based on feedback from developers already building apps with Fluid, there is a c
 
 Applications built on Shared Tree should be able to handle large datasets without paying hidden performance costs in load time or summarization.
 
-Incrementality breaks the tree up into discrete chunks of nodes that are the unit of invalidation (re-upload) for changes to the tree. This allows DDS summarization performance to scale with the scope of the content that has changed rather than the amount of total content in the DDS. This drastically reduces latency and network bandwidth and is a precursor to supporting larger than memory datasets.
+Incrementality breaks the tree up into discrete chunks of nodes that are the unit of invalidation (re-upload) for changes to the tree.
+This allows DDS summarization performance to scale with the scope of the content that has changed rather than the amount of total content in the DDS.
+This drastically reduces latency and network bandwidth and is a precursor to supporting larger than memory datasets.
 
-Virtualization allows the client to download portions of the tree on demand rather than downloading the entire tree on boot. This will dramatically improve load performance and is another precursor to supporting larger than memory datasets.
+Virtualization allows the client to download portions of the tree on demand rather than downloading the entire tree on boot.
+This will dramatically improve load performance and is another precursor to supporting larger than memory datasets.
 
-This milestone enables both for the tree. A long-form design proposal for these features exists [here](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/docs/storage/treeStorage.md).
+This milestone enables both for the tree.
+A long-form design proposal for these features exists [here](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/docs/storage/treeStorage.md).
 
 ## Type-safe schema API
 
 > Pending
 
-While schema definition and enforcement provide important data consistency guarantees, it does not prevent developers from writing bugs related to mismatched data types. For example, an attempt to interpret a nodes data in a way that is incompatible with its type (e.g., assuming a node contains a string when the schema dictates that it is a number) will result in a runtime failure. Developers must have an ergonomic way to work with the tree that prevents these bugs at compile-time.
+While schema definition and enforcement provide important data consistency guarantees, it does not prevent developers from writing bugs related to mismatched data types.
+For example, an attempt to interpret a nodes data in a way that is incompatible with its type (e.g., assuming a node contains a string when the schema dictates that it is a number) will result in a runtime failure.
+Developers must have an ergonomic way to work with the tree that prevents these bugs at compile-time.
 
-In this milestone, Shared Tree provides automatically created TypeScript types that map to the names and concepts defined in the schema. Using these types allows users to read and write to the tree at a higher and more comfortable level of abstraction. For example, a _Point_ type would allow reading of the numeric _Point.x_ and _Point.y_ fields in a way that is agnostic to the underlying tree representation. This feature results in a much better integration with tooling, including autocomplete and intellisense.
+In this milestone, Shared Tree provides automatically created TypeScript types that map to the names and concepts defined in the schema.
+Using these types allows users to read and write to the tree at a higher and more comfortable level of abstraction.
+For example, a _Point_ type would allow reading of the numeric _Point.x_ and _Point.y_ fields in a way that is agnostic to the underlying tree representation.
+This feature results in a much better integration with tooling, including autocomplete and intellisense.
 
 ## Retroactive undo/redo
 
 > Pending
 
-This milestone enables a more complex and semantic form of undo/redo. Under this design, undo modifies the document in a way which both inverts the effect of a given change and adjusts the effect of that change on changes which came after it. For example, retroactively undoing a deletion would also apply edits to the deleted content which had previously failed due to their target being deleted. Retroactively undoing an edit might also cause the undoing of later transactions which would not have been valid if the original edit had not been made. One potential retroactive undo policy would be to set the document to the state it would have been in if the undone change had never been made.
+This milestone enables a more complex and semantic form of undo/redo.
+Under this design, undo modifies the document in a way which both inverts the effect of a given change and adjusts the effect of that change on changes which came after it.
+For example, retroactively undoing a deletion would also apply edits to the deleted content which had previously failed due to their target being deleted.
+Retroactively undoing an edit might also cause the undoing of later transactions which would not have been valid if the original edit had not been made.
+One potential retroactive undo policy would be to set the document to the state it would have been in if the undone change had never been made.
 
 ## History
 
 > Pending
 
-There are many scenarios where developers need the ability to present data as it appeared at some point in the past. This is particularly valuable in cases where that data is being changed by multiple users, often concurrently. Developers need to be able to answer the question: what happened here?
+There are many scenarios where developers need the ability to present data as it appeared at some point in the past.
+This is particularly valuable in cases where that data is being changed by multiple users, often concurrently.
+Developers need to be able to answer the question: what happened here?
 
-This milestone introduces the History feature which will provide a way for developers to view an immutable view of the tree as it appeared in the past. The feature will be scoped to the entire tree initially but will eventually be refined so that developers can show history for specific areas of the tree.
+This milestone introduces the History feature which will provide a way for developers to view an immutable view of the tree as it appeared in the past.
+The feature will be scoped to the entire tree initially but will eventually be refined so that developers can show history for specific areas of the tree.
 
 ## Branching and Merging
 
 > Pending
 
-In some cases, it is desirable that users be able to operate on data in isolation. Maybe they are going to be working offline or making changes to data where concurrent changes would be disruptive. Whatever the scenario, the requirement is for Shared Tree to support branching and merging parts of the tree in much the same way that source control such as Git. This milestone introduces the ability for developers to create branches from parts of the tree, rebase those branches, and merge the changes back to the main branch.
+In some cases, it is desirable that users be able to operate on data in isolation.
+Maybe they are going to be working offline or making changes to data where concurrent changes would be disruptive.
+Whatever the scenario, the requirement is for Shared Tree to support branching and merging parts of the tree in much the same way that source control such as Git.
+This milestone introduces the ability for developers to create branches from parts of the tree, rebase those branches, and merge the changes back to the main branch.
 
 ## Indexes
 
 > Pending
 
-Developers often need to make complex queries about the tree that may not align with the hierarchy/structure of their data model. Some examples of this type of query include:
+Developers often need to make complex queries about the tree that may not align with the hierarchy/structure of their data model.
+Some examples of this type of query include:
 
 - Searching for all entities within a 2D plane that intersect some bounding box
 - Searching for all graph-like references that point to nodes of a particular type
 - Finding all nodes holding an integer with an odd value
+- Finding the best cached image for a sub-plane (i.e. tiling)
 
-With small documents, it may be reasonable to compute an answer by navigating the tree directly (and perhaps exhaustively). As datasets scale, developers will likely need to accelerate these read operations in order to keep them performant. It is convenient to do this by storing an index that is specialized to answer these queries. In the 2D plane example above, this index could be implemented via a [spatial search tree](https://en.wikipedia.org/wiki/Spatial_database#Spatial_index) that stores the positions of nodes in the tree.
+With small documents, it may be reasonable to compute an answer by navigating the tree directly (and perhaps exhaustively).
+As datasets scale, developers will likely need to accelerate these read operations in order to keep them performant.
+It is convenient to do this by storing an index that is specialized to answer these queries.
+In the 2D plane example above, this index could be implemented via a [spatial search tree](https://en.wikipedia.org/wiki/Spatial_database#Spatial_index) that stores the positions of nodes in the tree.
 
-It is also desirable to store these indexes alongside the Shared Tree data itself, rather than keeping it in a secondary store or recomputing it on each document load—which itself may be infeasible with larger-than-memory documents. However, it would be burdensome to expect a developer to handle all the complexity of index maintenance, which includes serialization and integration with branching and async transactions.
+It is also desirable to store these indexes alongside the Shared Tree data itself, rather than keeping it in a secondary store or recomputing it on each document load—which itself may be infeasible with larger-than-memory documents.
+However, it would be burdensome to expect a developer to handle all the complexity of index maintenance, which includes serialization and integration with branching and async transactions.
 
 In this milestone, Shared Tree exposes an extension point that allows developers to create their own persisted indexes while providing built-in solutions for much of the complexity of the integration.
 
-## Partial Checkout
+## High-level commands
 
 > Pending
 
-Shared Tree document scaling must not be limited by client memory (or even client disk size). It must be feasible to load and collaborate on documents of any size and still enjoy the low-latency, intention-preserving editing experience provided by the tree. For exceptionally large documents it is likely that the number of concurrently editing clients vastly exceeds the number of clients editing the same region of the tree. This means that each client would receive, process, and ignore most edits—resulting in computational waste and bottlenecks.
+// TODO
 
-The _Storage performance: incrementality and virtualization_ milestone ensures that document load times and summarization performance (both bandwidth and CPU time) are not limiting factors in these cases. This milestone introduces a _partial checkout_: a partial view of the tree registered with the server during document load. The view (a subset of the tree) is dynamic and can be expanded by navigating the tree. The server provides op filtering to ensure that a client only receives the edits that apply to the region of the tree that they are viewing.
+## Partial checkout
+
+> Pending
+
+Shared Tree document scaling must not be limited by client memory (or even client disk size).
+It must be feasible to load and collaborate on documents of any size and still enjoy the low-latency, intention-preserving editing experience provided by the tree.
+For exceptionally large documents it is likely that the number of concurrently editing clients vastly exceeds the number of clients editing the same region of the tree.
+This means that each client would receive, process, and ignore most edits—resulting in computational waste and bottlenecks.
+
+The _Storage performance: incrementality and virtualization_ milestone ensures that document load times and summarization performance (both bandwidth and CPU time) are not limiting factors in these cases.
+This milestone introduces a _partial checkout_: a partial view of the tree registered with the server during document load.
+The view (a subset of the tree) is dynamic and can be expanded by navigating the tree.
+The server provides op filtering to ensure that a client only receives the edits that apply to the region of the tree that they are viewing.
 
 # Long-term outlook
 
-The items in this document represent the current thinking around what developers using Shared Tree will need in the coming months and years. This doesn't mean that the list is necessarily complete. There is always room for change in the plan driven by usage and feedback. Further, there is continuous discussion amongst Fluid Framework contributors focused on what other work needs to be done to flesh out the Shared Tree offering and the Fluid Framework more broadly.
+The items in this document represent the current thinking around what developers using Shared Tree will need in the coming months and years.
+This doesn't mean that the list is necessarily complete.
+There is always room for change in the plan driven by usage and feedback.
+Further, there is continuous discussion amongst Fluid Framework contributors focused on what other work needs to be done to flesh out the Shared Tree offering and the Fluid Framework more broadly.
 
 To offer some insight into these discussions, here are some of those topics:
 
-- Extensible field kinds would allow developers to extend Shared Tree types and merge semantics in very powerful ways
+- Extensible embedded data types would allow developers to extend Shared Tree types and merge semantics in very powerful ways
 - How could clients that do not run the Fluid Runtime consume and update Fluid data?
 - How might Fluid support service level features such as indexed queries and fine-grained, fully secure access control?
 

--- a/packages/dds/tree/docs/roadmap.md
+++ b/packages/dds/tree/docs/roadmap.md
@@ -1,174 +1,274 @@
-# SharedTree DDS Roadmap
+# Introduction
 
-This document tracks the delivery of a new Fluid DDS for efficiently modeling tree structured data, such as JSON and XML. See the [tree readme](../README.md) for a high-level description of the DDS and the goals of the project.
+The Fluid Framework is a client/server tech stack designed to intuitively synchronize data between clients in real time. The framework consists of 3 key parts: the Fluid Service, Fluid Runtime, and Distributed Data Structures (DDSes). The **Fluid Service** is responsible for sequencing and broadcasting changes (ops) to each client and persisting state to storage. The **Fluid Runtime** is responsible for sending local ops to the Fluid Service and merging incoming ops. The **DDS** es are the data structures that the Fluid Service and Fluid Runtime keep synchronized.
 
-## Milestones
+From the perspective of an application developer, using the Fluid Framework is largely an exercise in choosing the right DDSes and integrating them into the application. For example, one of the simplest DDSes is a Shared Map that can be used in much the same way a developer would use a standard JavaScript map. The key difference is that a Shared Map will reflect remote changes.
 
-### M0: Concurrent design work for M1 deliverables
+Fluid Framework has evolved significantly in response to developer feedback. One key piece of feedback has been the desire for a DDS that can effectively model complex, hierarchical data. Shared Tree is the response to that feedback.
 
-By convention, design deliverables are listed in the milestone preceding the dependent implementation work items. Therefore, we've informally introduced M0 to track M1's design dependencies, even though execution on M0 and M1 are happening concurrently.
+# What is Shared Tree
 
-#### Deliverables
+Shared Tree is a DDS designed to keep hierarchical data synchronized between clients. Its development is being driven by significant feedback from developers looking for Fluid data structures that map more closely to their application data models. This document lays out the goals for Shared Tree development and the motivation behind those goals. Here is a list of the key scenarios described in this document:
 
--   [Merge/rebase design](https://github.com/microsoft/FluidFramework/issues/9658)
--   [Data model design](../docs/data-model/README.md)
+- [Read and write data to the Shared Tree without an in-memory JavaScript representation](#tree-reading-and-writing-without-reification)
+- [Apply sets of related changes atomically with no interleaved changes (transactions)](#synchronous-non-overlapping-transactions)
+- [Use an API that represents tree data as JavaScript objects](#tree-reading-and-writing-with-js-object-style-api)
+- [Undo changes made locally without unduly impacting concurrent remote changes](#undoredo)
+- [Move data within the Shared Tree without risk of duplication or data invalidation](#move)
+- [Assign durable identifiers to nodes to enable URL-like links and graph-like references](#strong-node-identifiers-and-lookup-index)
+- [Manage multiple transactions asynchronously](#asynchronous-transactions-and-snapshot-isolation)
+- [Embed collections such as sets and maps within the tree](#embedded-collections-eg-sets-maps)
+- [Apply constraints to transactions so that if a condition isn't met, the transaction is rejected](#constraints)
+- [Define schema for the tree that is enforced when data is merged](#schema-and-schema-enforcement)
+- [Import and export JSON data into the tree losslessly](#lossless-json-roundtripping)
+- [Include text that supports real-time collaboration in the tree](#large-sequence--collaborative-text-support)
+- [Improve performance of large data sets through incremental commits and virtualization on load](#storage-performance-incrementality-and-virtualization)
+- [Use Schema defined TypeScript types](#type-safe-schema-api)
+- [Undo changes made locally in a way that preserves the intent of concurrent changes](#retroactive-undoredo)
+- [Provide access to the state of the data in the past](#history)
+- [Create, change, and merge branched data in a similar manner to source control](#branching-and-merging)
+- [Improve performance by building indexes](#indexes)
+- [Support for data sets larger than client memory/storage](#partial-checkout)
 
-### M1: Basic Data Synchronization
+Read the [Shared Tree github readme](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree) for a more technical overview.
 
-M1 enables early adopters to begin using SharedTree for transient data synchronization scenarios. The op and storage formats will not yet be finalized and no data migration path will be provided. However, the basic Insert/Delete/Modify operations will be sufficiently robust to preview with non-persistent Fluid sessions.
+# Performance
 
-At this stage, the designs for slices, move and durable Ids are understood, but may not yet be fully implemented. Undo/Redo may at this point not be integrated into the DDS.
+Fast performance lies at the heart of the Fluid Framework vision. It was designed from the ground up to minimize latency introduced by servers by shifting merge responsibilities to the client. That said, taking full advantage of this architecture is the top priority for Shared Tree. These are the near-term performance goals:
 
-#### Requirements:
+- Equivalent or better performance as compared with the experimental Shared Tree DDS
+- Include granular performance benchmarks for each Shared Tree component including reading and writing of the in-memory tree and merging changes
+- Build a benchmarking stress test app to set baselines and measure improvements
+- Architect the tree such that the lowest layers provide the best performance at the cost of ergonomics; build more friendly (but potentially slower) APIs on top, enabling applications to choose their preferred layer
 
--   Construct a changeset comprised of insert, delete, and modify operations
--   Commit a changeset to the local tree
--   Observe changes committed by local and remote clients
+As the Shared Tree feature set grows, the performance goals will also evolve to include the following:
 
-#### Deliverables
+- Tree reading will be a reasonable constant factor as compared with reading a JS object tree as the tree grows in size and complexity
+- Collections within the tree such as long sequences, maps, and sets will be optimized
+- Summarization performance will scale with the scale of the data being changed – currently summarization performance is determined by the size of the complete data set
+- Boot performance can be optimized by loading only the data required through virtualization
 
--   Changeset (operations)
-    -   Insert new subtrees
-    -   Modify node values
-    -   Delete set ranges
-    -   Builder (Accumulation)
-    -   Reader / Writer (Serialization)
--   Rebase
-    -   Insert / Delete / Modify
-    -   Squash (if sandwich, else MT)
--   In-memory representation
-    -   Apply changeset
-    -   Serialize to changeset
--   DDS
-    -   Collab window management
-    -   Rebase management
-    -   Change notification
-    -   Summarization (esp. attach workflow for perf)
--   Design
-    -   Move, Slice and Ids are understood
-    -   Forward compatible summarization & op formats
-    -   Understanding of where "lossy" squashes fit into roadmap
-    -   JSON API
+# Stability
 
-### M1.5: JSON Editing
+Shared Tree is a complex DDS aimed at supporting a broad range of data types and merge semantics. As such, it is critical that Shared Tree investments include significant focus on reliability. The following goals and investments will ensure Shared Tree is reliable and remains stable as it evolves:
 
-M1.5 enables users to collaboratively edit JSONish[^1] data using the SharedTree. M1.5 happens concurrently with the end of M1 and beginning of M2.
+- Roughly 90% unit test coverage
 
-JSONish editing is exposed through a specialized API layer that ensures that tree edits are constrained to the JSONish domain. The underlying types and constraints used to implement this are hard coded. Support for custom schemas is planned for a future milestone.
+- Fuzz testing of all major components
 
-[^1]: JSONish is a pragmatic interpretation of the JSON spec with respect to the JS type system. It includes objects, arrays, strings, float64, bool, and null.
+- Two or more test apps built on Shared Tree that are used to validate every significant update
+- Code for types and persisting state is isolated and policies are in place to ensure stable migrations between versions
+- Forwards and backwards compatibility tests
 
-#### Requirements
+# Roadmap
 
--   JSONish data losslessly round-trips to/from SharedTree
--   Edits are constrained to JSONish domain
+The following is a prioritized list of investment areas for Shared Tree development. Each item includes an indication of whether it is complete, in active development, or pending.
 
-#### Deliverables
+## Rebaser core architecture
 
--   Bijective mapping between SharedTree data model and JSONish
--   JSON types:
-    -   map: object
-    -   seq: array and string
-    -   scalar: number (as F64), bool, null
--   Schema enforcement
--   API
-    -   Reified nodes
-    -   property: get/set
-    -   array/string: insert/remove set/slice
+> Complete
 
-### M2: SharedTree MVP
+In Shared Tree, the core algorithms for processing edits to the tree have the dual responsibility of maintaining intention preservation while also supporting very large documents—potentially larger than client memory. The scaling requirement means that these algorithms should be able to operate without reifying (loading/reading) the tree data and should be a function only of the operations themselves. The intention preservation requirement dictates that all editing operations should have an intuitive effect on the tree even during concurrency.
 
-M2 enables general use of SharedTree in persistent Fluid sessions for moderately sized trees of maps and sequences. It also delivers performance and size improvements based on real-world data gathered from early adopters, especially focusing on those that impact the persisted ops and summary formats.
+The mechanism in Shared Tree responsible for satisfying these criteria is called the Rebaser. Some of the resulting design documents can be found [here](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/docs). The operations available in the editing API (e.g., insert, delete) are rolled out incrementally in future milestones.
 
-Public APIs are still subject to change, but the tree data model will have settled and code can be mechanically migrated to future versions.
+## UUID Compression Scheme
 
-Tree size continues to be limited by client memory and bandwidth. Move and durable Ids are robust, and the operation and summary formats are finalized at v1. The tree may not yet be suitable for editing of high-density data, such as strings and numeric arrays.
+> Complete
 
-#### Requirements
+Supporting larger-than-memory data sets in the tree requires efficiently handling trees that contain large numbers of strong identifiers (UUIDs). To meet this requirement, Shared Tree leverages a novel distributed compression scheme that reduces the average storage cost of the identifiers to that of a small integer. This enables better scaling in scenarios where large numbers of these compressed IDs are needed (e.g., graph-like references). The documentation for this scheme can be found [here](https://github.com/microsoft/FluidFramework/blob/7301e1c742f0cdb0e02466918af1af06a969c3c3/packages/dds/tree/src/id-compressor/idCompressor.ts#L272).
 
--   Application code can be mechanically migrated to future versions of SharedTree w/o data migration.
--   Atomically delete a slice range of nodes.
--   Atomically move a set/slice of nodes to a new location in the tree preserving their identity
--   Durable unique IDs per node, suitable for permalinks, etc.
--   Integrated Undo/Redo
+## Data model specification
 
-#### Deliverables
+> Complete
 
--   Changeset:
-    -   Move set
-    -   Move slice
-    -   Delete slice
-    -   Invert
-    -   Perf / size improvements
-        -   Squash (also req. to cancel changes if using sandwich rebase)
--   Rebase:
-    -   Move set
-    -   Move slice
-    -   Delete slice
--   In-memory representation:
-    -   Id <-> node map
--   DDS
-    -   Look up node by id
-    -   Id management
-    -   Undo management
-    -   A stable data model API
--   Runtime
-    -   Id compression
--   Design
-    -   Summary and constraints are understood
+Shared Tree has a number of requirements that have a direct impact on the tree data model. These include schema annotations on nodes, strong identifiers, references in the tree, and JSON interoperability. The team designed a low-level data model that accommodates them; it is JSON-like, but with a few key divergences. The specification can be found [here](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/docs/data-model).
 
-### M3: Schema and Constraints
+## Basic data synchronization
 
-M3 helps developers tame the complexity of their applications by introducing schemas and constraints that reduce the number of incoherent data states that can arise from concurrent edits.
+> Complete
 
-Schemas declaratively state what must be true before and after each operation. Constraints declaratively state what must remain true during the interval between when the client created the edit to when it is sequenced.
+For developers eager to start using the Shared Tree DDS, this milestone represents the point where they can do so for scenarios involving transient data. That is, at this stage developers can create a Shared Tree from other data and use it to sync that data between all clients. Insert, delete, and modify operations will be functional; however, the storage formats will not be final at this stage. There will be no data migration strategy for the data stored in the Shared Tree DDS at this stage. The move operation is also not yet available.
 
-In both cases, a conflict prevents the operation from being applied, resulting in remote clients discarding the edit and the local client reverting it and notifying the application.
+## Tree reading and writing without reification
 
-#### Requirements
+> Complete
 
--   Declarative schema language
--   Supported constraints:
-    -   Subtree unchanged
-    -   Input/output types
+In most scenarios, the Shared Tree will include an in-memory JavaScript representation. This milestone makes it possible to read and write data to the Shared Tree without creating (reifing) that in-memory JavaScript representation. This is particularly useful in scenarios where the client maintains a copy of the data on the other side of an interop boundary (e.g., WASM, C++). It also allows clients/microservices to check permissions without loading the document and inspect changes without caring about the entire tree.
 
-#### Deliverables
+To accomplish this, the underlying Shared Tree layer is built on a [cursor API](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/core/tree/cursor.ts) that allows navigation of the tree by moving from node to node via explicit directional calls. This cursor API is intended to be an expert API as working with it is very cumbersome compared with the much more ergonomic APIs exposed in future milestones. Built on top of cursors is the [Forest API](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/src/feature-libraries/chunked-forest), a minimal interface that exposes the tree without reification.
 
--   Changeset:
-    -   Encode constraints
-    -   Encode type info
-    -   Encode semantic info (hierarchical edits)
--   Constraints
-    -   'Subtree unchanged'
--   Schema
-    -   Parser
-    -   Repository
--   DDS
-    -   Conflict management
-        -   Detection
-        -   Revert
-        -   Handler
+## Synchronous non-overlapping transactions
 
-### M4+: API and Modeling
+> Complete
 
-M4 expands the audience for SharedTree by introducing higher level abstractions.
+Developers often want to group changes to the Shared Tree into logical units. Reasons for doing so include:
 
-### M5+: History and Branching
+- Atomicity: a set of changes should be applied without any other changes (local or remote) being interleaved with them.
+- App semantics: a set of changes represents a logical edit in the application model that must be applied atomically, and tree-level operations (such as undo/redo or history) should never result in an intermediate state being exposed.
+- Dependencies between changes: changes within a grouping depend on some invariant (e.g., an insert should be applied only if none of the other changes in its group fail to apply due to concurrent edits).
 
-M5 enables applications to create and merge branches from arbitrary points in history.
+This milestone enables the creation of a single synchronous transaction per Shared Tree and guarantees atomicity (including for remote recipients of the edit). The other requirements will be satisfied by future milestones such as _Undo/redo_ and _Constraints_.
 
-### M6+: Partial Checkout
+## Tree reading and writing with JS object style API
 
-M6 enables a SharedTree to scale beyond the memory and bandwith constraints of the client though partial views of the tree.
+> Complete
 
-### M7+: Non-fluid clients (e.g., GraphQL, Open API, etc.)
+A key objective of Shared Tree is that it be intuitive and easy for developers to use. To enable this, Shared Tree will include a high-level API that presents the tree as if it were composed of JavaScript objects. This is ideally suited for developers who prioritize familiarity and speed of development over low-level performance. Note that this API is a wrapper that uses JavaScript proxies and does not impose any schema. Schema will be supported but not as part of this milestone.
 
-M7 provides services APIs for isolated reads and writes of the chunked tree storage. This makes it convenient to implement providers for GraphQL, Open API, and other REST-like APIs for non-Fluid clients to access the underlying data.
+This API is called the Editable Tree API and is [here](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/src/feature-libraries/editable-tree).
 
-### M8+: Indexed queries
+## Undo/redo
 
-M8 adds service-side support for building and maintaining indices into the tree data.
+> In progress
 
-### M9+: Fine-grained access control
+The ability to undo and redo changes is table stakes for a collaborative editing system. However, there are a variety of possible specifications with varying levels of complexity.
 
-M9 provides mechanisms for restricting access to subsets of the tree data.
+For this milestone, Shared Tree offers an [undo/redo mechanism](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/docs/wip/inverse-changes/README.md#undo-semantics) that generates the inverse of a given edit (most frequently the most recent local change group but not necessarily) and applies it to the document. This simple implementation is easy to reason about but can lead to cases where concurrent changes can render the inverse edit inconsistent with the user's intent (e.g., conflicted or unapplied). In a future milestone, [alternative designs](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/docs/undo) are explored that better handle these cases.
+
+## Move
+
+> In progress
+
+Conceptually, a move is simply a delete and an insert of the same data. However, without proper semantics (and thus rebasing), concurrent changes can result in missing or duplicated data. The move operation preserves the identity of the nodes being moved and ensures that the outcome matches the developer's expectations.
+
+Shared Tree will support two types of move operation. One is a **set** move where the nodes in the range when it is defined are the only nodes that move. The other is a **slice** move where any nodes inserted in the range during the move are also moved.
+
+## Strong node identifiers and lookup index
+
+> In progress
+
+This milestone allows all nodes to optionally include a unique identifier that allows that node to be referenced without specifying the path to that node within the tree. This is critical in cases where nodes need durable references pointing to them (both within the tree—graph-like references—and in external cases such as URLs), as changes to the tree can invalidate path-based references. These identifiers are stored as compressed integers for storage and performance reasons but can be translated into UUIDs when requested.
+
+The Shared Tree will maintain an index of all nodes with identifiers to provide fast look-ups.
+
+## Asynchronous transactions and snapshot isolation
+
+> In progress
+
+In applications with complex editing flows, particularly in asynchronous programming models, it can be unergonomic or insufficient to use synchronous and non-overlapping transactions. In such cases, it is desirable to allow multiple transactions to exist concurrently on the same local instance of the Shared Tree while still guaranteeing isolation from other changes, both local and remote, during their lifetime (i.e., snapshot isolation). They should also be able to operate asynchronously, allowing transactions to span multiple JS frames. This milestone will enable the construction of such transactions, each of which operates on an isolated view of the tree determined by start of the transaction.
+
+As an example, consider a flow in which a developer initiates a call to some external service. It may be desirable to immediately show some temporary value (e.g., a placeholder value) in the tree and add the results of the async external call to it when it completes. However, the edit to the tree should only finish and be sent to other clients if/when the service call finishes. Additionally, the developer may want to prevent incoming changes from taking effect until after this flow completes, as it may be confusing or even inconsistent during the intermediate state. Implementing this correctly requires both asynchrony and snapshot isolation in the transaction layer.
+
+## Parity with experimental Shared Tree
+
+> In progress
+
+This milestone marks the point at which the Shared Tree is at parity (a superset of the functionality and as good or better performance) with the legacy Shared Tree. At this stage, developers using the legacy tree DDS can (and should) switch to Shared Tree. To make this transition as painless as possible, the following will be true:
+
+- Developers will have access to a data migration system. This mechanism can be used to safely and losslessly migrate data from the legacy tree to the Shared Tree. The migration is performed client-side and can be run on demand (at load time, in response to a user action, etc.).
+- The persisted format is stable and backward compatibility is guaranteed. This means that all versions of data (ops and summaries) ever written by the new Shared Tree are supported for reading (loading) forever.
+- As the Shared Tree data format evolves, there will—for every new data version released—always exist a Shared Tree package that supports writing both the latest major version and the one just prior. This allows staged rollouts of the new version on the application side. For example, the release of version 2.0 will include the ability to write format 2.0 but will default to writing format 1.0; an adopting application with ship the 2.0 package in this state, wait until some satisfactorily high adoption rate is reached (e.g., 99.9% of clients are on the new version) and then enable the writing of version 2.0. This is safe to do, as all clients (even the ones who are still defaulting to writing version 1.0) can read the new version.
+
+## Embedded collections (e.g., sets, maps)
+
+> In progress
+
+While the Shared Tree data model is very flexible, developers may find themselves requiring that a subset of their data model has a more specific or performant representation. One such example would be modeling an associative relationship using a key/value store. In these cases, however, it is still required that their data receive the same benefits (e.g., identity, schema, move semantics) as when it is stored as nodes in the rest of the tree. This milestone accommodates these needs by allowing embedded collections that are managed by the Shared Tree and its rebasing mechanisms. Initially, only sets and maps will be offered; however, the architecture allows easy extension in the future to include more domain-specific options.
+
+## Constraints
+
+> In progress
+
+By default, edits (i.e., transactions) in Shared Tree will always succeed (never conflict) due to the high-quality automatic merge resolution. Transactions alwaysguarantee atomicity (no interleaved changes from other transactions), but some changes may not have an effect due to concurrent edits that are applied first (e.g., a transaction that changes two nodes may only apply a subset of the changes due to one of the nodes being concurrently deleted). While convenient and usually sufficient, this behavior may not appropriately uphold application invariants.
+
+This milestone enables a developer to declaratively specify what sorts of concurrent edits should cause a transaction to fail and be marked as conflicted. These declarations are known as _constraints_ and are evaluated as the edit (transaction) is applied_._ The constraints delivered in this milestone include specifying that a given node still exists and specifying that a given node or field has not been edited (recursively or non-recursively).
+
+## Schema and schema enforcement
+
+> Pending
+
+Schema determines how the data in the Shared Tree is structured and modified based on user-defined rules. Nodes in the tree include a _type_ field; these types are associated with rules that govern the shape of the data (e.g., which types are allowed in which fields). This metadata is stored in the tree ([schema specification](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/src/core/schema-stored)) and the Shared Tree uses it to guarantee that data conforms to the schema even in the face of concurrent editing. This milestone exposes the ability to author a schema, create schematized data, and guarantees that edits will never violate that schema. It does not provide a type-safe way to view the data—that is enabled by the _Type-safe schema API_ milestone.
+
+## Lossless JSON roundtripping
+
+> Pending
+
+Many customer scenarios include the need to migrate existing data into the Shared Tree and export that data. Due to its ubiquity, JSON data is the focus of this milestone. The Shared Tree provides two mechanisms to import and export JSON data losslessly:
+
+- A [JSON domain](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/domains/json/jsonDomainSchema.ts) (schema) that defines the mapping between the Shared Tree data model and JSON. This includes a [low-level cursor](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/domains/json/jsonCursor.ts) to navigate the data as though it were native JSON.
+- APIs to ingest JSON data into a subtree typed as JSON as well as export a JSON-typed tree to raw JSON.
+
+These APIs are as lossless as JavaScript's own JSON API, so the same [caveats](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) apply.
+
+## Large sequence & collaborative text support
+
+> Pending
+
+Based on feedback from developers already building apps with Fluid, there is a clear need to include support for collaborative text within the Shared Tree. This will require support for larger sequences of nodes than is otherwise typical. This milestone will include investments to make large sequences performant and scalable while still handling efficient collaboration. Of course, large sequences will not be limited to text, as text nodes all have the same characteristics as any other node in the tree. For example, they can be moved, they have identity, changes can be easily reverted, etc.
+
+## Storage performance: incrementality and virtualization
+
+> Pending
+
+Applications built on Shared Tree should be able to handle large datasets without paying hidden performance costs in load time or summarization.
+
+Incrementality breaks the tree up into discrete chunks of nodes that are the unit of invalidation (re-upload) for changes to the tree. This allows DDS summarization performance to scale with the scope of the content that has changed rather than the amount of total content in the DDS. This drastically reduces latency and network bandwidth and is a precursor to supporting larger than memory datasets.
+
+Virtualization allows the client to download portions of the tree on demand rather than downloading the entire tree on boot. This will dramatically improve load performance and is another precursor to supporting larger than memory datasets.
+
+This milestone enables both for the tree. A long-form design proposal for these features exists [here](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/docs/storage/treeStorage.md).
+
+## Type-safe schema API
+
+> Pending
+
+While schema definition and enforcement provide important data consistency guarantees, it does not prevent developers from writing bugs related to mismatched data types. For example, an attempt to interpret a nodes data in a way that is incompatible with its type (e.g., assuming a node contains a string when the schema dictates that it is a number) will result in a runtime failure. Developers must have an ergonomic way to work with the tree that prevents these bugs at compile-time.
+
+In this milestone, Shared Tree provides automatically created TypeScript types that map to the names and concepts defined in the schema. Using these types allows users to read and write to the tree at a higher and more comfortable level of abstraction. For example, a _Point_ type would allow reading of the numeric _Point.x_ and _Point.y_ fields in a way that is agnostic to the underlying tree representation. This feature results in a much better integration with tooling, including autocomplete and intellisense.
+
+## Retroactive undo/redo
+
+> Pending
+
+This milestone enables a more complex and semantic form of undo/redo. Under this design, undo modifies the document in a way which both inverts the effect of a given change and adjusts the effect of that change on changes which came after it. For example, retroactively undoing a deletion would also apply edits to the deleted content which had previously failed due to their target being deleted. Retroactively undoing an edit might also cause the undoing of later transactions which would not have been valid if the original edit had not been made. One potential retroactive undo policy would be to set the document to the state it would have been in if the undone change had never been made.
+
+## History
+
+> Pending
+
+There are many scenarios where developers need the ability to present data as it appeared at some point in the past. This is particularly valuable in cases where that data is being changed by multiple users, often concurrently. Developers need to be able to answer the question: what happened here?
+
+This milestone introduces the History feature which will provide a way for developers to view an immutable view of the tree as it appeared in the past. The feature will be scoped to the entire tree initially but will eventually be refined so that developers can show history for specific areas of the tree.
+
+## Branching and Merging
+
+> Pending
+
+In some cases, it is desirable that users be able to operate on data in isolation. Maybe they are going to be working offline or making changes to data where concurrent changes would be disruptive. Whatever the scenario, the requirement is for Shared Tree to support branching and merging parts of the tree in much the same way that source control such as Git. This milestone introduces the ability for developers to create branches from parts of the tree, rebase those branches, and merge the changes back to the main branch.
+
+## Indexes
+
+> Pending
+
+Developers often need to make complex queries about the tree that may not align with the hierarchy/structure of their data model. Some examples of this type of query include:
+
+- Searching for all entities within a 2D plane that intersect some bounding box
+- Searching for all graph-like references that point to nodes of a particular type
+- Finding all nodes holding an integer with an odd value
+
+With small documents, it may be reasonable to compute an answer by navigating the tree directly (and perhaps exhaustively). As datasets scale, developers will likely need to accelerate these read operations in order to keep them performant. It is convenient to do this by storing an index that is specialized to answer these queries. In the 2D plane example above, this index could be implemented via a [spatial search tree](https://en.wikipedia.org/wiki/Spatial_database#Spatial_index) that stores the positions of nodes in the tree.
+
+It is also desirable to store these indexes alongside the Shared Tree data itself, rather than keeping it in a secondary store or recomputing it on each document load—which itself may be infeasible with larger-than-memory documents. However, it would be burdensome to expect a developer to handle all the complexity of index maintenance, which includes serialization and integration with branching and async transactions.
+
+In this milestone, Shared Tree exposes an extension point that allows developers to create their own persisted indexes while providing built-in solutions for much of the complexity of the integration.
+
+## Partial Checkout
+
+> Pending
+
+Shared Tree document scaling must not be limited by client memory (or even client disk size). It must be feasible to load and collaborate on documents of any size and still enjoy the low-latency, intention-preserving editing experience provided by the tree. For exceptionally large documents it is likely that the number of concurrently editing clients vastly exceeds the number of clients editing the same region of the tree. This means that each client would receive, process, and ignore most edits—resulting in computational waste and bottlenecks.
+
+The _Storage performance: incrementality and virtualization_ milestone ensures that document load times and summarization performance (both bandwidth and CPU time) are not limiting factors in these cases. This milestone introduces a _partial checkout_: a partial view of the tree registered with the server during document load. The view (a subset of the tree) is dynamic and can be expanded by navigating the tree. The server provides op filtering to ensure that a client only receives the edits that apply to the region of the tree that they are viewing.
+
+# Long-term outlook
+
+The items in this document represent the current thinking around what developers using Shared Tree will need in the coming months and years. This doesn't mean that the list is necessarily complete. There is always room for change in the plan driven by usage and feedback. Further, there is continuous discussion amongst Fluid Framework contributors focused on what other work needs to be done to flesh out the Shared Tree offering and the Fluid Framework more broadly.
+
+To offer some insight into these discussions, here are some of those topics:
+
+- Extensible field kinds would allow developers to extend Shared Tree types and merge semantics in very powerful ways
+- How could clients that do not run the Fluid Runtime consume and update Fluid data?
+- How might Fluid support service level features such as indexed queries and fine-grained, fully secure access control?
+
+This is not a complete catalog of future looking work, and everyone interested in Fluid should feel empowered to bring their own voice to the conversation.

--- a/packages/dds/tree/docs/roadmap.md
+++ b/packages/dds/tree/docs/roadmap.md
@@ -123,14 +123,13 @@ The move operation is also not yet available.
 
 > Complete
 
-In most scenarios, the Shared Tree will include an in-memory JavaScript representation.
+In most scenarios, the Shared Tree will construct an in-memory JavaScript representation of the tree.
 This milestone makes it possible to read and write data to the Shared Tree without creating (reifing) that in-memory JavaScript representation.
-This is particularly useful in scenarios where the client maintains a copy of the data on the other side of an interop boundary (e.g., WASM, C++).
+This is particularly useful in scenarios where the client has memory constraints or wants to maintains a copy of the data on the other side of an interop boundary (e.g., WASM, C++).
 It also allows clients/microservices to check permissions without loading the document and inspect changes without caring about the entire tree.
 
 To accomplish this, the underlying Shared Tree layer is built on a [cursor API](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/core/tree/cursor.ts) that allows navigation of the tree by moving from node to node via explicit directional calls.
-This cursor API is intended to be an expert API as working with it is very cumbersome compared with the much more ergonomic APIs exposed in future milestones.
-Built on top of cursors is the [Forest API](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/src/feature-libraries/chunked-forest), a minimal interface that exposes the tree without reification.
+This cursor API is intended to be an expert API as working with it is more cumbersome compared with the more ergonomic APIs exposed in future milestones.
 
 ## Synchronous non-overlapping transactions
 

--- a/packages/dds/tree/docs/roadmap.md
+++ b/packages/dds/tree/docs/roadmap.md
@@ -129,7 +129,10 @@ This is particularly useful in scenarios where the client has memory constraints
 It also allows clients/microservices to check permissions without loading the document and inspect changes without caring about the entire tree.
 
 To accomplish this, the underlying Shared Tree layer is built on a [cursor API](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/core/tree/cursor.ts) that allows navigation of the tree by moving from node to node via explicit directional calls.
+Layers built on cursors are also able to remain agnostic to the structure of the tree it is navigating, allowing for flexible/multiple implementations.
 This cursor API is intended to be an expert API as working with it is more cumbersome compared with the more ergonomic APIs exposed in future milestones.
+
+While this is an important architectural milestone to build in early, the benefits around reification will not be fully realized until the _Storage performance: incrementality and virtualization_ milestone, as downloading the entire tree on load is currently required.
 
 ## Synchronous non-overlapping transactions
 

--- a/packages/dds/tree/docs/roadmap.md
+++ b/packages/dds/tree/docs/roadmap.md
@@ -20,26 +20,26 @@ Shared Tree is a DDS designed to keep hierarchical data synchronized between cli
 Its development is being driven by significant feedback from developers looking for Fluid data structures that map more closely to their application data models.
 This document lays out the goals for Shared Tree development and the motivation behind those goals. Here is a list of the key scenarios described in this document:
 
-- [Read and write data to the Shared Tree without an in-memory JavaScript representation](#tree-reading-and-writing-without-reification)
-- [Apply sets of related changes atomically with no interleaved changes (transactions)](#synchronous-non-overlapping-transactions)
-- [Use an API that represents tree data as JavaScript objects](#tree-reading-and-writing-with-js-object-style-api)
-- [Undo changes made locally without unduly impacting concurrent remote changes](#undoredo)
-- [Move data within the Shared Tree without risk of duplication or data invalidation](#move)
-- [Assign durable identifiers to nodes to enable URL-like links and graph-like references](#strong-node-identifiers-and-lookup-index)
-- [Manage multiple transactions asynchronously](#asynchronous-transactions-and-snapshot-isolation)
-- [Embed collections such as sets and maps within the tree](#embedded-collections-eg-sets-maps)
-- [Apply constraints to transactions so that if a condition isn't met, the transaction is rejected](#constraints)
-- [Define schema for the tree that is enforced when data is merged](#schema-and-schema-enforcement)
-- [Import and export JSON data into the tree losslessly](#lossless-json-roundtripping)
-- [Include text that supports real-time collaboration in the tree](#large-sequence--collaborative-text-support)
-- [Improve performance of large data sets through incremental commits and virtualization on load](#storage-performance-incrementality-and-virtualization)
-- [Use Schema defined TypeScript types](#type-safe-schema-api)
-- [Undo changes made locally in a way that preserves the intent of concurrent changes](#retroactive-undoredo)
-- [Provide access to the state of the data in the past](#history)
-- [Create, change, and merge branched data in a similar manner to source control](#branching-and-merging)
-- [Improve performance by building indexes](#indexes)
-- [Allow higher-level semantics in edits to the tree](#high-level-commands)
-- [Support for data sets larger than client memory/storage](#partial-checkout)
+-   [Read and write data to the Shared Tree without an in-memory JavaScript representation](#tree-reading-and-writing-without-reification)
+-   [Apply sets of related changes atomically with no interleaved changes (transactions)](#synchronous-non-overlapping-transactions)
+-   [Use an API that represents tree data as JavaScript objects](#tree-reading-and-writing-with-js-object-style-api)
+-   [Undo changes made locally without unduly impacting concurrent remote changes](#undoredo)
+-   [Move data within the Shared Tree without risk of duplication or data invalidation](#move)
+-   [Assign durable identifiers to nodes to enable URL-like links and graph-like references](#strong-node-identifiers-and-lookup-index)
+-   [Manage multiple transactions asynchronously](#asynchronous-transactions-and-snapshot-isolation)
+-   [Embed collections such as sets and maps within the tree](#embedded-collections-eg-sets-maps)
+-   [Apply constraints to transactions so that if a condition isn't met, the transaction is rejected](#constraints)
+-   [Define schema for the tree that is enforced when data is merged](#schema-and-schema-enforcement)
+-   [Import and export JSON data into the tree losslessly](#lossless-json-roundtripping)
+-   [Include text that supports real-time collaboration in the tree](#large-sequence--collaborative-text-support)
+-   [Improve performance of large data sets through incremental commits and virtualization on load](#storage-performance-incrementality-and-virtualization)
+-   [Use Schema defined TypeScript types](#type-safe-schema-api)
+-   [Undo changes made locally in a way that preserves the intent of concurrent changes](#retroactive-undoredo)
+-   [Provide access to the state of the data in the past](#history)
+-   [Create, change, and merge branched data in a similar manner to source control](#branching-and-merging)
+-   [Improve performance by building indexes](#indexes)
+-   [Allow higher-level semantics in edits to the tree](#high-level-commands)
+-   [Support for data sets larger than client memory/storage](#partial-checkout)
 
 Read the [Shared Tree github readme](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree) for a more technical overview.
 
@@ -50,17 +50,17 @@ It was designed from the ground up to minimize latency introduced by servers by 
 That said, taking full advantage of this architecture is the top priority for Shared Tree.
 These are the near-term performance goals:
 
-- Equivalent or better performance as compared with the experimental Shared Tree DDS
-- Include granular performance benchmarks for each Shared Tree component including reading and writing of the in-memory tree and merging changes
-- Build a benchmarking stress test app to set baselines and measure improvements
-- Architect the tree such that the lowest layers provide the best performance at the cost of ergonomics; build more friendly (but potentially slower) APIs on top, enabling applications to choose their preferred layer
+-   Equivalent or better performance as compared with the experimental Shared Tree DDS
+-   Include granular performance benchmarks for each Shared Tree component including reading and writing of the in-memory tree and merging changes
+-   Build a benchmarking stress test app to set baselines and measure improvements
+-   Architect the tree such that the lowest layers provide the best performance at the cost of ergonomics; build more friendly (but potentially slower) APIs on top, enabling applications to choose their preferred layer
 
 As the Shared Tree feature set grows, the performance goals will also evolve to include the following:
 
-- Tree reading will be a reasonable constant factor as compared with reading a JS object tree as the tree grows in size and complexity
-- Collections within the tree such as long sequences, maps, and sets will be optimized
-- Summarization performance will scale with the scale of the data being changed – currently summarization performance is determined by the size of the complete data set
-- Boot performance can be optimized by loading only the data required through virtualization
+-   Tree reading will be a reasonable constant factor as compared with reading a JS object tree as the tree grows in size and complexity
+-   Collections within the tree such as long sequences, maps, and sets will be optimized
+-   Summarization performance will scale with the scale of the data being changed – currently summarization performance is determined by the size of the complete data set
+-   Boot performance can be optimized by loading only the data required through virtualization
 
 # Stability
 
@@ -68,13 +68,13 @@ Shared Tree is a complex DDS aimed at supporting a broad range of data types and
 As such, it is critical that Shared Tree investments include significant focus on reliability.
 The following goals and investments will ensure Shared Tree is reliable and remains stable as it evolves:
 
-- Roughly 90% unit test coverage
+-   Roughly 90% unit test coverage
 
-- Fuzz testing of all major components
+-   Fuzz testing of all major components
 
-- Two or more test apps built on Shared Tree that are used to validate every significant update
-- Code for types and persisting state is isolated and policies are in place to ensure stable migrations between versions
-- Forwards and backwards compatibility tests
+-   Two or more test apps built on Shared Tree that are used to validate every significant update
+-   Code for types and persisting state is isolated and policies are in place to ensure stable migrations between versions
+-   Forwards and backwards compatibility tests
 
 # Roadmap
 
@@ -141,9 +141,9 @@ While this is an important architectural milestone to build in early, the benefi
 Developers often want to group changes to the Shared Tree into logical units.
 Reasons for doing so include:
 
-- Atomicity: a set of changes should be applied without any other changes (local or remote) being interleaved with them.
-- App semantics: a set of changes represents a logical edit in the application model that must be applied atomically, and tree-level operations (such as undo/redo or history) should never result in an intermediate state being exposed.
-- Dependencies between changes: changes within a grouping depend on some invariant (e.g., an insert should be applied only if none of the other changes in its group fail to apply due to concurrent edits).
+-   Atomicity: a set of changes should be applied without any other changes (local or remote) being interleaved with them.
+-   App semantics: a set of changes represents a logical edit in the application model that must be applied atomically, and tree-level operations (such as undo/redo or history) should never result in an intermediate state being exposed.
+-   Dependencies between changes: changes within a grouping depend on some invariant (e.g., an insert should be applied only if none of the other changes in its group fail to apply due to concurrent edits).
 
 This milestone enables the creation of a single synchronous transaction per Shared Tree and guarantees atomicity (including for remote recipients of the edit).
 The other requirements will be satisfied by future milestones such as _Undo/redo_ and _Constraints_.
@@ -215,14 +215,14 @@ This milestone marks the point at which the Shared Tree is at parity (a superset
 At this stage, developers using the legacy tree DDS can (and should) switch to Shared Tree.
 To make this transition as painless as possible, the following will be true:
 
-- Developers will have access to a data migration system.
-This mechanism can be used to safely and losslessly migrate data from the legacy tree to the Shared Tree. The migration is performed client-side and can be run on demand (at load time, in response to a user action, etc.).
-- The persisted format is stable and backward compatibility is guaranteed.
-This means that all versions of data (ops and summaries) ever written by the new Shared Tree are supported for reading (loading) forever.
-- As the Shared Tree data format evolves, there will—for every new data version released—always exist a Shared Tree package that supports writing both the latest major version and the one just prior.
-This allows staged rollouts of the new version on the application side.
-For example, the release of version 2.0 will include the ability to write format 2.0 but will default to writing format 1.0; an adopting application with ship the 2.0 package in this state, wait until some satisfactorily high adoption rate is reached (e.g., 99.9% of clients are on the new version) and then enable the writing of version 2.0.
-This is safe to do, as all clients (even the ones who are still defaulting to writing version 1.0) can read the new version.
+-   Developers will have access to a data migration system.
+    This mechanism can be used to safely and losslessly migrate data from the legacy tree to the Shared Tree. The migration is performed client-side and can be run on demand (at load time, in response to a user action, etc.).
+-   The persisted format is stable and backward compatibility is guaranteed.
+    This means that all versions of data (ops and summaries) ever written by the new Shared Tree are supported for reading (loading) forever.
+-   As the Shared Tree data format evolves, there will—for every new data version released—always exist a Shared Tree package that supports writing both the latest major version and the one just prior.
+    This allows staged rollouts of the new version on the application side.
+    For example, the release of version 2.0 will include the ability to write format 2.0 but will default to writing format 1.0; an adopting application with ship the 2.0 package in this state, wait until some satisfactorily high adoption rate is reached (e.g., 99.9% of clients are on the new version) and then enable the writing of version 2.0.
+    This is safe to do, as all clients (even the ones who are still defaulting to writing version 1.0) can read the new version.
 
 ## Embedded collections (e.g., sets, maps)
 
@@ -266,9 +266,9 @@ Many customer scenarios include the need to migrate existing data into the Share
 Due to its ubiquity, JSON data is the focus of this milestone.
 The Shared Tree provides two mechanisms to import and export JSON data losslessly:
 
-- A [JSON domain](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/domains/json/jsonDomainSchema.ts) (schema) that defines the mapping between the Shared Tree data model and JSON.
-This includes a [low-level cursor](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/domains/json/jsonCursor.ts) to navigate the data as though it were native JSON.
-- APIs to ingest JSON data into a subtree typed as JSON as well as export a JSON-typed tree to raw JSON.
+-   A [JSON domain](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/domains/json/jsonDomainSchema.ts) (schema) that defines the mapping between the Shared Tree data model and JSON.
+    This includes a [low-level cursor](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/domains/json/jsonCursor.ts) to navigate the data as though it were native JSON.
+-   APIs to ingest JSON data into a subtree typed as JSON as well as export a JSON-typed tree to raw JSON.
 
 These APIs are as lossless as JavaScript's own JSON API, so the same [caveats](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) apply.
 
@@ -348,10 +348,10 @@ This milestone introduces the ability for developers to create branches from par
 Developers often need to make complex queries about the tree that may not align with the hierarchy/structure of their data model.
 Some examples of this type of query include:
 
-- Searching for all entities within a 2D plane that intersect some bounding box
-- Searching for all graph-like references that point to nodes of a particular type
-- Finding all nodes holding an integer with an odd value
-- Finding the best cached image for a sub-plane (i.e. tiling)
+-   Searching for all entities within a 2D plane that intersect some bounding box
+-   Searching for all graph-like references that point to nodes of a particular type
+-   Finding all nodes holding an integer with an odd value
+-   Finding the best cached image for a sub-plane (i.e. tiling)
 
 With small documents, it may be reasonable to compute an answer by navigating the tree directly (and perhaps exhaustively).
 As datasets scale, developers will likely need to accelerate these read operations in order to keep them performant.
@@ -392,8 +392,8 @@ Further, there is continuous discussion amongst Fluid Framework contributors foc
 
 To offer some insight into these discussions, here are some of those topics:
 
-- Extensible embedded data types would allow developers to extend Shared Tree types and merge semantics in very powerful ways
-- How could clients that do not run the Fluid Runtime consume and update Fluid data?
-- How might Fluid support service level features such as indexed queries and fine-grained, fully secure access control?
+-   Extensible embedded data types would allow developers to extend Shared Tree types and merge semantics in very powerful ways
+-   How could clients that do not run the Fluid Runtime consume and update Fluid data?
+-   How might Fluid support service level features such as indexed queries and fine-grained, fully secure access control?
 
 This is not a complete catalog of future looking work, and everyone interested in Fluid should feel empowered to bring their own voice to the conversation.


### PR DESCRIPTION
This PR brings the Shared Tree roadmap up to date with the project. It is intended for high-level consumption and thus contains quick (and possibly nit-pickable) explanations of the incoming feature set. 

For reviewers: 
The top priority for this document is clarity and pedagogy, and deeper explanations should be included via links to specialized documents. I'd like feedback on clarity, major issues in accuracy, and grammatical errors.