### PR TITLE
build: Update and add missing "format" scripts 

### DIFF
--- a/azure/package.json
+++ b/azure/package.json
@@ -31,7 +31,7 @@
     "clean": "lerna run clean --stream --parallel && npm run clean:docs && npm run clean:nyc",
     "clean:docs": "rimraf **/_api-extractor-temp docs/api/*/**",
     "clean:nyc": "rimraf nyc/**",
-    "format": "lerna run format --no-sort --stream -- -- -- --color",
+    "format": "lerna run format --parallel --stream",
     "postinstall": "npm run postinstall:lerna",
     "layer-check": "fluid-layer-check --info ../build-tools/packages/build-tools/data/layerInfo.json",
     "lerna": "lerna",

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -30,7 +30,7 @@
     "clean:docs": "rimraf **/_api-extractor-temp docs/api/*/**",
     "clean:nyc": "rimraf nyc/**",
     "commit": "git-cz",
-    "format": "lerna run format --parallel --no-sort --stream",
+    "format": "lerna run format --parallel --stream",
     "preinstall": "npx only-allow pnpm",
     "postinstall": "npm run build:compile",
     "install:commitlint": "npm install --global @commitlint/config-conventional",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "clean:docs": "rimraf **/_api-extractor-temp docs/api/*/**",
     "clean:nyc": "rimraf nyc/**",
     "clean:r11s": "cd server/routerlicious && npm run clean",
+    "format": "lerna run format --parallel --stream",
     "preinstall": "npx only-allow pnpm",
     "layer-check": "fluid-layer-check --info build-tools/packages/build-tools/data/layerInfo.json",
     "lerna": "lerna",

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -29,7 +29,7 @@
     "clean:nyc": "rimraf nyc/**",
     "docker-build": "docker-compose build",
     "docker-clean": "docker-compose down --rmi local -v",
-    "format": "lerna run format --no-sort --stream -- -- -- --color",
+    "format": "lerna run format --parallel --stream",
     "postinstall": "npm run postinstall:lerna",
     "lint": "lerna run lint --no-sort --stream",
     "lint:fix": "lerna run lint:fix --no-sort --stream",


### PR DESCRIPTION
Adds missing "format" script to client release group, and updates other release group "format" scripts to use the same command line arguments (removes some redundant and unused flags).