### PR TITLE
Use optional chaining on merge-tree callbacks

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1150,15 +1150,13 @@ export class MergeTree {
                     segment: pendingSegment,
                 });
             });
-            if (this.mergeTreeMaintenanceCallback) {
-                this.mergeTreeMaintenanceCallback(
-                    {
-                        deltaSegments,
-                        operation: MergeTreeMaintenanceType.ACKNOWLEDGED,
-                    },
-                    opArgs,
-                );
-            }
+            this.mergeTreeMaintenanceCallback?.(
+                {
+                    deltaSegments,
+                    operation: MergeTreeMaintenanceType.ACKNOWLEDGED,
+                },
+                opArgs,
+            );
             const clientId = this.collabWindow.clientId;
             for (const node of nodesToUpdate) {
                 this.blockUpdatePathLengths(node, seq, clientId, overwrite);
@@ -1246,8 +1244,8 @@ export class MergeTree {
         this.blockInsert(pos, refSeq, clientId, seq, localSeq, segments);
 
         // opArgs == undefined => loading snapshot or test code
-        if (this.mergeTreeDeltaCallback && opArgs !== undefined) {
-            this.mergeTreeDeltaCallback(
+        if (opArgs !== undefined) {
+            this.mergeTreeDeltaCallback?.(
                 opArgs,
                 {
                     operation: MergeTreeDeltaType.INSERT,
@@ -1361,14 +1359,12 @@ export class MergeTree {
 
         rebalanceTree(insertSegment);
 
-        if (this.mergeTreeDeltaCallback) {
-            this.mergeTreeDeltaCallback(
-                opArgs,
-                {
-                    deltaSegments: [{ segment: insertSegment }],
-                    operation: MergeTreeDeltaType.INSERT,
-                });
-        }
+        this.mergeTreeDeltaCallback?.(
+            opArgs,
+            {
+                deltaSegments: [{ segment: insertSegment }],
+                operation: MergeTreeDeltaType.INSERT,
+            });
 
         if (this.collabWindow.collaborating) {
             this.addToPendingList(insertSegment, undefined, insertSegment.localSeq);
@@ -1523,13 +1519,12 @@ export class MergeTree {
         }
 
         const next = segment.splitAt(pos)!;
-        if (this.mergeTreeMaintenanceCallback) {
-            this.mergeTreeMaintenanceCallback({
+        this.mergeTreeMaintenanceCallback?.({
                 operation: MergeTreeMaintenanceType.SPLIT,
                 deltaSegments: [{ segment }, { segment: next }],
             },
-                undefined);
-        }
+            undefined
+        );
 
         return { next };
     };
@@ -1729,8 +1724,8 @@ export class MergeTree {
         this.nodeMap(refSeq, clientId, annotateSegment, undefined, undefined, start, end);
 
         // OpArgs == undefined => test code
-        if (this.mergeTreeDeltaCallback && deltaSegments.length > 0) {
-            this.mergeTreeDeltaCallback(
+        if (deltaSegments.length > 0) {
+            this.mergeTreeDeltaCallback?.(
                 opArgs,
                 {
                     operation: MergeTreeDeltaType.ANNOTATE,
@@ -1814,8 +1809,8 @@ export class MergeTree {
             (s) => this.slideAckedRemovedSegmentReferences(s),
         );
         // opArgs == undefined => test code
-        if (this.mergeTreeDeltaCallback && removedSegments.length > 0) {
-            this.mergeTreeDeltaCallback(
+        if (removedSegments.length > 0) {
+            this.mergeTreeDeltaCallback?.(
                 opArgs,
                 {
                     operation: MergeTreeDeltaType.REMOVE,

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1853,15 +1853,14 @@ export class MergeTree {
                 segment.removedSeq = undefined;
                 segment.localRemovedSeq = undefined;
 
-                if (this.mergeTreeDeltaCallback) {
-                    const insertOp = createInsertSegmentOp(this.findRollbackPosition(segment), segment);
-                    this.mergeTreeDeltaCallback(
-                        { op: insertOp },
-                        {
-                            operation: MergeTreeDeltaType.INSERT,
-                            deltaSegments: [{ segment }],
-                        });
-                }
+                // Note: optional chaining short-circuits:
+                // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#short-circuiting
+                this.mergeTreeDeltaCallback?.(
+                    { op: createInsertSegmentOp(this.findRollbackPosition(segment), segment) },
+                    {
+                        operation: MergeTreeDeltaType.INSERT,
+                        deltaSegments: [{ segment }],
+                    });
 
                 for (let updateNode = segment.parent; updateNode !== undefined; updateNode = updateNode.parent) {
                     this.blockUpdateLength(updateNode, UnassignedSequenceNumber, this.collabWindow.clientId);


### PR DESCRIPTION
## Description

Uses more concise syntax for merge-tree callbacks. Note that our current compiler settings transpile this down to the more verbose syntax, but on ES2020 or later this would be a bundle size win. See #10922 for some related commentary.

