### PR TITLE
build: Explicitly disable insert spaces rule, which is true by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,6 +35,7 @@
         "unaugmented"
     ],
 
-    // Enable prettier as default formatter
+    // Enable prettier as default formatter, and disable rules that disagree with it
     "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.insertSpaces": false
 }


### PR DESCRIPTION
Previous commit (#13819) removed the rule, rather than changing the value from true to false, thinking that the default was false. The default appears to be true, so spaces were still be inserted by vscode.