### PR TITLE
ci: Update bundle-size-artifacts pipeline for pnpm

### DIFF
--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -22,6 +22,8 @@ trigger:
     - package-lock.json
     - lerna.json
     - lerna-package-lock.json
+    - pnpm-lock.yaml
+    - pnpm-workspace.yaml
     - tools/pipelines/build-bundle-size-artifacts.yml
     - tools/pipelines/build-client.yml
     - tools/pipelines/templates/build-npm-package.yml
@@ -41,6 +43,8 @@ extends:
     taskBundleAnalysis: true
     taskPublishBundleSizeArtifacts: true
     taskBuildDocs: false
+    packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
+    packageManager: pnpm
     buildDirectory: .
     tagName: bundle-artifacts
     poolBuild: Large


### PR DESCRIPTION
This pipeline is unique in that it runs from the root (client) directory and installs the client dependencies. This PR corrects it to use pnpm now that the client is using pnpm.