### PR TITLE
GC Stress Test: Fail task on failed tests

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -299,4 +299,5 @@ jobs:
           testResultsFiles: '**/*junit-report.xml'
           searchFolder: ${{ variables.testPackageDir }}
           mergeTestResults: false
+          failTaskOnFailedTests: true
         condition: succeededOrFailed()


### PR DESCRIPTION
## Description

This should fail the pipeline task if any failures are included in the test results XML, according to [these docs](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-test-results-v2).