### PR TITLE
Update testObjectProvider's allowedErrors to support downgrading log category

### DIFF
--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -155,14 +155,17 @@ function getDocumentIdStrategy(type?: TestDriverTypes): IDocumentIdStrategy {
  */
 export class EventAndErrorTrackingLogger extends TelemetryLogger {
 	/**
-     * Even if these error events are logged, tests should still be allowed to pass
-     * Additionally, if downgrade is true, then log as generic (e.g. to avoid polluting the e2e test logs)
-     */
-	private readonly allowedErrors: { eventName: string; downgrade?: true; }[] = [
+	 * Even if these error events are logged, tests should still be allowed to pass
+	 * Additionally, if downgrade is true, then log as generic (e.g. to avoid polluting the e2e test logs)
+	 */
+	private readonly allowedErrors: { eventName: string; downgrade?: true }[] = [
 		// This log was removed in current version as unnecessary, but it's still present in previous versions
-		{ eventName: "fluid:telemetry:Container:NoRealStorageInDetachedContainer", downgrade: true },
+		{
+			eventName: "fluid:telemetry:Container:NoRealStorageInDetachedContainer",
+			downgrade: true,
+		},
 		// This log's category changes depending on the op latency. test results shouldn't be affected but if we see lots we'd like an alert from the logs.
-        { eventName: "fluid:telemetry:OpPerf:OpRoundtripTime" },
+		{ eventName: "fluid:telemetry:OpPerf:OpRoundtripTime" },
 	];
 
 	constructor(private readonly baseLogger: ITelemetryBaseLogger) {
@@ -212,14 +215,16 @@ export class EventAndErrorTrackingLogger extends TelemetryLogger {
 			}
 		}
 		if (event.category === "error") {
-            // Check to see if this error is allowed and if its category should be downgraded
-			const allowedError = this.allowedErrors.find(({ eventName }) => eventName === event.eventName);
+			// Check to see if this error is allowed and if its category should be downgraded
+			const allowedError = this.allowedErrors.find(
+				({ eventName }) => eventName === event.eventName,
+			);
 
-            if (allowedError === undefined) {
-                this.unexpectedErrors.push(event);
-            } else if (allowedError.downgrade) {
-                event.category = "generic";
-            }
+			if (allowedError === undefined) {
+				this.unexpectedErrors.push(event);
+			} else if (allowedError.downgrade) {
+				event.category = "generic";
+			}
 		}
 
 		this.baseLogger.send(event);

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -154,10 +154,15 @@ function getDocumentIdStrategy(type?: TestDriverTypes): IDocumentIdStrategy {
  * any expected events that have not occurred.
  */
 export class EventAndErrorTrackingLogger extends TelemetryLogger {
-	/** Even if these error events are logged, tests should still be allowed to pass */
-	private readonly allowedErrors: string[] = [
+	/**
+     * Even if these error events are logged, tests should still be allowed to pass
+     * Additionally, if downgrade is true, then log as generic (e.g. to avoid polluting the e2e test logs)
+     */
+	private readonly allowedErrors: { eventName: string; downgrade?: true; }[] = [
 		// This log was removed in current version as unnecessary, but it's still present in previous versions
-		"fluid:telemetry:Container:NoRealStorageInDetachedContainer",
+		{ eventName: "fluid:telemetry:Container:NoRealStorageInDetachedContainer", downgrade: true },
+		// This log's category changes depending on the op latency. test results shouldn't be affected but if we see lots we'd like an alert from the logs.
+        { eventName: "fluid:telemetry:OpPerf:OpRoundtripTime" },
 	];
 
 	constructor(private readonly baseLogger: ITelemetryBaseLogger) {
@@ -207,11 +212,14 @@ export class EventAndErrorTrackingLogger extends TelemetryLogger {
 			}
 		}
 		if (event.category === "error") {
-			if (this.allowedErrors.includes(event.eventName)) {
-				event.category = "generic";
-			} else {
-				this.unexpectedErrors.push(event);
-			}
+            // Check to see if this error is allowed and if its category should be downgraded
+			const allowedError = this.allowedErrors.find(({ eventName }) => eventName === event.eventName);
+
+            if (allowedError === undefined) {
+                this.unexpectedErrors.push(event);
+            } else if (allowedError.downgrade) {
+                event.category = "generic";
+            }
 		}
 
 		this.baseLogger.send(event);


### PR DESCRIPTION
## Description

See [AB#2535](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2535)

Any event listed in `allowedErrors` will not cause a test failure if it's logged.  This PR adds a flag to each error to specify whether to downgrade the event category from error -> generic.

This matters because in addition to test results, we also monitor volume of error logs generated during e2e test runs, and so some errors we would not like to trigger that alert.  But others we may want to know about if the volume grows too high.

## Reviewer Guidance

I am not sure we want to add this capability.

The feedback in the ADO item linked above seemed to be more about ensuring the stress test still alerts on these.  Stress test doesn't use this logger.  Do we really care to get an e2e test alert if this starts happening a bunch?  Seems like a really strange/obtuse metric.  I suppose that feedback applies to the notion of the e2e error log monitor as a whole.  Anyway, it's a simple change so we could just do it.