### PR TITLE
fix: Prevent editorconfig from forcing spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,8 +4,7 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
-indent_style = space
+indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
## Description

With the previous settings and the [EditorConfig extension](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) installed, any line added to any file would default to spaces for indentation (ask me how I know 😝). With the new settings I get tabs instead, to match what we're converging towards in our code style.

With `indent_style=tab`, `indent_size` forces the _visual_ width of a tab. I lean towards not forcing that and let people decide how they best interact with their code (`"editor.tabSize"` in VSCode will control this). Happy to hear feedback on that. I didn't change the hardcoded values (further down in `.editorconfig`) for the files that we use most commonly.