### PR TITLE
style: Revert editorconfig change to fix build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,8 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_style = tab
+indent_size = 4
+indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
## Description

### UPDATED:

Seems like some interaction between prettier, eslint, and the editorconfig plugin for eslint, cause this change to actually affect the rules that prettier uses/expects for formatting and we have packages that are still using spaces instead of tabs. So reverting this change to unblock builds until all our packages are on tabs and then we can see about doing this again.

### ORIGINAL:

Convert spaces to tabs in `@fluid-example/multiview-coordinate-interface` so the build stops failing the linting step.

Just ran `npm run prettier:fix` in the package.