### PR TITLE
Stress: Increase Offline Delay Min

### DIFF
--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -274,6 +274,7 @@ export class FaultInjectionDocumentDeltaConnection
 
 	public goOffline() {
 		this.online = false;
+		this.injectDisconnect();
 	}
 
 	public goOnline() {

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -17,7 +17,7 @@
 			"offline": {
 				"delayMs": {
 					"min": 1000,
-					"max": 1000
+					"max": 150000
 				},
 				"durationMs": {
 					"min": 5000,

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -16,8 +16,8 @@
 			},
 			"offline": {
 				"delayMs": {
-					"min": 0,
-					"max": 150000
+					"min": 1000,
+					"max": 1000
 				},
 				"durationMs": {
 					"min": 5000,


### PR DESCRIPTION
This increases the min delay before going offline. The goal is to avoid going offline during that data store initialization phase as that leads to errors where the datastore can't fully load. e.x.: Failed to get Channel: Error: simulated offline error: /aa97abba-25cb-42df-984e-16c0f5cd16da

Also, disconnecting the delta stream when we enter offline mode to more accurately represent being offline.