### PR TITLE
build(client): Prepare and generate type tests

### DIFF
--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -51,7 +51,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.2.2.0",
+    "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -64,9 +64,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.2.0",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -44,7 +44,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.2.2.0",
+    "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -57,14 +57,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "InterfaceDeclaration_IFluidObject": {
-        "forwardCompat": false,
-        "backCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
+++ b/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
@@ -328,32 +328,6 @@ use_old_InterfaceDeclaration_IFluidLoadable(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IFluidObject": {"forwardCompat": false}
-*/
-declare function get_old_InterfaceDeclaration_IFluidObject():
-    TypeOnly<old.IFluidObject>;
-declare function use_current_InterfaceDeclaration_IFluidObject(
-    // @ts-expect-error removed interface
-    use: TypeOnly<current.IFluidObject>);
-use_current_InterfaceDeclaration_IFluidObject(
-    get_old_InterfaceDeclaration_IFluidObject());
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IFluidObject": {"backCompat": false}
-*/
-declare function get_current_InterfaceDeclaration_IFluidObject():
-    // @ts-expect-error removed interface
-    TypeOnly<current.IFluidObject>;
-declare function use_old_InterfaceDeclaration_IFluidObject(
-    use: TypeOnly<old.IFluidObject>);
-use_old_InterfaceDeclaration_IFluidObject(
-    get_current_InterfaceDeclaration_IFluidObject());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IFluidPackage": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IFluidPackage():

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -47,7 +47,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.2.2.0",
+    "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -59,34 +59,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "TypeAliasDeclaration_DriverError": {
-        "backCompat": false
-      },
-      "EnumDeclaration_DriverErrorType": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IDriverBasicError": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IGenericNetworkError": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IDriverErrorBase": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IThrottlingWarning": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IAuthorizationError": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_ILocationRedirectionError": {
-        "backCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.generated.ts
+++ b/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.generated.ts
@@ -35,7 +35,6 @@ declare function get_current_TypeAliasDeclaration_DriverError():
 declare function use_old_TypeAliasDeclaration_DriverError(
     use: TypeOnly<old.DriverError>);
 use_old_TypeAliasDeclaration_DriverError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_DriverError());
 
 /*
@@ -60,7 +59,6 @@ declare function get_current_EnumDeclaration_DriverErrorType():
 declare function use_old_EnumDeclaration_DriverErrorType(
     use: TypeOnly<old.DriverErrorType>);
 use_old_EnumDeclaration_DriverErrorType(
-    // @ts-expect-error compatibility expected to be broken
     get_current_EnumDeclaration_DriverErrorType());
 
 /*
@@ -205,7 +203,6 @@ declare function get_current_InterfaceDeclaration_IAuthorizationError():
 declare function use_old_InterfaceDeclaration_IAuthorizationError(
     use: TypeOnly<old.IAuthorizationError>);
 use_old_InterfaceDeclaration_IAuthorizationError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IAuthorizationError());
 
 /*
@@ -494,7 +491,6 @@ declare function get_current_InterfaceDeclaration_IDriverBasicError():
 declare function use_old_InterfaceDeclaration_IDriverBasicError(
     use: TypeOnly<old.IDriverBasicError>);
 use_old_InterfaceDeclaration_IDriverBasicError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDriverBasicError());
 
 /*
@@ -519,7 +515,6 @@ declare function get_current_InterfaceDeclaration_IDriverErrorBase():
 declare function use_old_InterfaceDeclaration_IDriverErrorBase(
     use: TypeOnly<old.IDriverErrorBase>);
 use_old_InterfaceDeclaration_IDriverErrorBase(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDriverErrorBase());
 
 /*
@@ -592,7 +587,6 @@ declare function get_current_InterfaceDeclaration_IGenericNetworkError():
 declare function use_old_InterfaceDeclaration_IGenericNetworkError(
     use: TypeOnly<old.IGenericNetworkError>);
 use_old_InterfaceDeclaration_IGenericNetworkError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IGenericNetworkError());
 
 /*
@@ -617,7 +611,6 @@ declare function get_current_InterfaceDeclaration_ILocationRedirectionError():
 declare function use_old_InterfaceDeclaration_ILocationRedirectionError(
     use: TypeOnly<old.ILocationRedirectionError>);
 use_old_InterfaceDeclaration_ILocationRedirectionError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ILocationRedirectionError());
 
 /*
@@ -762,7 +755,6 @@ declare function get_current_InterfaceDeclaration_IThrottlingWarning():
 declare function use_old_InterfaceDeclaration_IThrottlingWarning(
     use: TypeOnly<old.IThrottlingWarning>);
 use_old_InterfaceDeclaration_IThrottlingWarning(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IThrottlingWarning());
 
 /*

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -99,6 +99,13 @@
     "previousVersionStyle": "~previousMinor",
     "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
     "baselineVersion": "2.0.0-internal.3.0.0",
-    "broken": {}
+    "broken": {
+      "ClassDeclaration_SharedCell": {
+        "forwardCompat": false
+      },
+      "InterfaceDeclaration_ISharedCell": {
+        "forwardCompat": false
+      }
+    }
   }
 }

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -76,7 +76,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.2.2.0",
+    "@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
@@ -95,9 +95,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/cell/src/test/types/validateCellPrevious.generated.ts
+++ b/packages/dds/cell/src/test/types/validateCellPrevious.generated.ts
@@ -23,6 +23,7 @@ declare function get_old_InterfaceDeclaration_ISharedCell():
 declare function use_current_InterfaceDeclaration_ISharedCell(
     use: TypeOnly<current.ISharedCell>);
 use_current_InterfaceDeclaration_ISharedCell(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ISharedCell());
 
 /*
@@ -71,6 +72,7 @@ declare function get_old_ClassDeclaration_SharedCell():
 declare function use_current_ClassDeclaration_SharedCell(
     use: TypeOnly<current.SharedCell>);
 use_current_ClassDeclaration_SharedCell(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_SharedCell());
 
 /*

--- a/packages/dds/cell/src/test/types/validateCellPrevious.generated.ts
+++ b/packages/dds/cell/src/test/types/validateCellPrevious.generated.ts
@@ -23,7 +23,6 @@ declare function get_old_InterfaceDeclaration_ISharedCell():
 declare function use_current_InterfaceDeclaration_ISharedCell(
     use: TypeOnly<current.ISharedCell>);
 use_current_InterfaceDeclaration_ISharedCell(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ISharedCell());
 
 /*
@@ -72,7 +71,6 @@ declare function get_old_ClassDeclaration_SharedCell():
 declare function use_current_ClassDeclaration_SharedCell(
     use: TypeOnly<current.SharedCell>);
 use_current_ClassDeclaration_SharedCell(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_SharedCell());
 
 /*

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -74,7 +74,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.2.2.0",
+    "@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
@@ -93,9 +93,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -76,7 +76,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.2.2.0",
+    "@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -93,9 +93,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -85,7 +85,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.2.2.0",
+    "@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -104,9 +104,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -86,7 +86,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.2.2.0",
+    "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -110,9 +110,10 @@
     "uuid": "^8.3.1"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -84,7 +84,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.2.2.0",
+    "@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/test-pairwise-generator": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
@@ -108,21 +108,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "ClassDeclaration_Client": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "InterfaceDeclaration_SegmentGroup": {
-        "forwardCompat": false
-      },
-      "InterfaceDeclaration_MergeTreeStats": {
-        "forwardCompat": false,
-        "backCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
+++ b/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
@@ -64,6 +64,30 @@ use_old_FunctionDeclaration_appendToMergeTreeDeltaRevertibles(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_AttributionKey": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_AttributionKey():
+    TypeOnly<old.AttributionKey>;
+declare function use_current_InterfaceDeclaration_AttributionKey(
+    use: TypeOnly<current.AttributionKey>);
+use_current_InterfaceDeclaration_AttributionKey(
+    get_old_InterfaceDeclaration_AttributionKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_AttributionKey": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_AttributionKey():
+    TypeOnly<current.AttributionKey>;
+declare function use_old_InterfaceDeclaration_AttributionKey(
+    use: TypeOnly<old.AttributionKey>);
+use_old_InterfaceDeclaration_AttributionKey(
+    get_current_InterfaceDeclaration_AttributionKey());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_BaseSegment": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_BaseSegment():
@@ -143,7 +167,6 @@ declare function get_old_ClassDeclaration_Client():
 declare function use_current_ClassDeclaration_Client(
     use: TypeOnly<current.Client>);
 use_current_ClassDeclaration_Client(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_Client());
 
 /*
@@ -156,7 +179,6 @@ declare function get_current_ClassDeclaration_Client():
 declare function use_old_ClassDeclaration_Client(
     use: TypeOnly<old.Client>);
 use_old_ClassDeclaration_Client(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_Client());
 
 /*
@@ -666,6 +688,30 @@ use_old_FunctionDeclaration_extendIfUndefined(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IAttributionCollection": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IAttributionCollection():
+    TypeOnly<old.IAttributionCollection<any>>;
+declare function use_current_InterfaceDeclaration_IAttributionCollection(
+    use: TypeOnly<current.IAttributionCollection<any>>);
+use_current_InterfaceDeclaration_IAttributionCollection(
+    get_old_InterfaceDeclaration_IAttributionCollection());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IAttributionCollection": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IAttributionCollection():
+    TypeOnly<current.IAttributionCollection<any>>;
+declare function use_old_InterfaceDeclaration_IAttributionCollection(
+    use: TypeOnly<old.IAttributionCollection<any>>);
+use_old_InterfaceDeclaration_IAttributionCollection(
+    get_current_InterfaceDeclaration_IAttributionCollection());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ICombiningOp": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ICombiningOp():
@@ -1002,6 +1048,30 @@ use_old_InterfaceDeclaration_IMergeTreeAnnotateMsg(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IMergeTreeAttributionOptions": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IMergeTreeAttributionOptions():
+    TypeOnly<old.IMergeTreeAttributionOptions>;
+declare function use_current_InterfaceDeclaration_IMergeTreeAttributionOptions(
+    use: TypeOnly<current.IMergeTreeAttributionOptions>);
+use_current_InterfaceDeclaration_IMergeTreeAttributionOptions(
+    get_old_InterfaceDeclaration_IMergeTreeAttributionOptions());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IMergeTreeAttributionOptions": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IMergeTreeAttributionOptions():
+    TypeOnly<current.IMergeTreeAttributionOptions>;
+declare function use_old_InterfaceDeclaration_IMergeTreeAttributionOptions(
+    use: TypeOnly<old.IMergeTreeAttributionOptions>);
+use_old_InterfaceDeclaration_IMergeTreeAttributionOptions(
+    get_current_InterfaceDeclaration_IMergeTreeAttributionOptions());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IMergeTreeClientSequenceArgs": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IMergeTreeClientSequenceArgs():
@@ -1214,6 +1284,30 @@ declare function use_old_TypeAliasDeclaration_IMergeTreeOp(
     use: TypeOnly<old.IMergeTreeOp>);
 use_old_TypeAliasDeclaration_IMergeTreeOp(
     get_current_TypeAliasDeclaration_IMergeTreeOp());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IMergeTreeOptions": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IMergeTreeOptions():
+    TypeOnly<old.IMergeTreeOptions>;
+declare function use_current_InterfaceDeclaration_IMergeTreeOptions(
+    use: TypeOnly<current.IMergeTreeOptions>);
+use_current_InterfaceDeclaration_IMergeTreeOptions(
+    get_old_InterfaceDeclaration_IMergeTreeOptions());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IMergeTreeOptions": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IMergeTreeOptions():
+    TypeOnly<current.IMergeTreeOptions>;
+declare function use_old_InterfaceDeclaration_IMergeTreeOptions(
+    use: TypeOnly<old.IMergeTreeOptions>);
+use_old_InterfaceDeclaration_IMergeTreeOptions(
+    get_current_InterfaceDeclaration_IMergeTreeOptions());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -2130,32 +2224,6 @@ use_old_InterfaceDeclaration_MergeTreeRevertibleDriver(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_MergeTreeStats": {"forwardCompat": false}
-*/
-declare function get_old_InterfaceDeclaration_MergeTreeStats():
-    TypeOnly<old.MergeTreeStats>;
-declare function use_current_InterfaceDeclaration_MergeTreeStats(
-    // @ts-expect-error removed
-    use: TypeOnly<current.MergeTreeStats>);
-use_current_InterfaceDeclaration_MergeTreeStats(
-    get_old_InterfaceDeclaration_MergeTreeStats());
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_MergeTreeStats": {"backCompat": false}
-*/
-declare function get_current_InterfaceDeclaration_MergeTreeStats():
-    // @ts-expect-error removed
-    TypeOnly<current.MergeTreeStats>;
-declare function use_old_InterfaceDeclaration_MergeTreeStats(
-    use: TypeOnly<old.MergeTreeStats>);
-use_old_InterfaceDeclaration_MergeTreeStats(
-    get_current_InterfaceDeclaration_MergeTreeStats());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_MinListener": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_MinListener():
@@ -2979,7 +3047,6 @@ declare function get_old_InterfaceDeclaration_SegmentGroup():
 declare function use_current_InterfaceDeclaration_SegmentGroup(
     use: TypeOnly<current.SegmentGroup>);
 use_current_InterfaceDeclaration_SegmentGroup(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_SegmentGroup());
 
 /*

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -78,7 +78,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.2.2.0",
+    "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -95,9 +95,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -77,7 +77,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.2.2.0",
+    "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -94,9 +94,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -92,7 +92,7 @@
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/gitresources": "^0.1038.2000",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.2.2.0",
+    "@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.3.0.0",
     "@fluidframework/server-services-client": "^0.1038.2000",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -114,9 +114,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -83,7 +83,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.2.2.0",
+    "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -103,9 +103,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -77,7 +77,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.2.2.0",
+    "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -96,9 +96,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -83,7 +83,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.2.2.0",
+    "@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -101,9 +101,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.2.0",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -46,7 +46,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.2.2.0",
+    "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -61,9 +61,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.2.2.0",
+    "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -58,9 +58,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.2.0",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -48,7 +48,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.2.2.0",
+    "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -64,9 +64,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.2.2.0",
+    "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.36",
@@ -59,9 +59,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.8.0",
-    "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.2.1.1",
+    "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
@@ -64,9 +64,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -80,7 +80,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.2.2.0",
+    "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
@@ -97,9 +97,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.2.2.0",
+    "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.3.0.0",
     "@fluidframework/protocol-definitions": "^1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -58,13 +58,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "TypeAliasDeclaration_OdspError": {
-        "backCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.generated.ts
+++ b/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.generated.ts
@@ -467,7 +467,6 @@ declare function get_current_TypeAliasDeclaration_OdspError():
 declare function use_old_TypeAliasDeclaration_OdspError(
     use: TypeOnly<old.OdspError>);
 use_old_TypeAliasDeclaration_OdspError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_OdspError());
 
 /*

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -85,7 +85,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.2.2.0",
+    "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -105,9 +105,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -50,7 +50,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.2.2.0",
+    "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.36",
@@ -63,9 +63,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -48,7 +48,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.2.2.0",
+    "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -64,9 +64,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -85,7 +85,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.2.2.0",
+    "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -108,9 +108,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -52,7 +52,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.2.2.0",
+    "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/nconf": "^0.10.0",
@@ -67,9 +67,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.2.1.1",
+    "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^9.1.1",
@@ -63,9 +63,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.8.0",
-    "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.2.1.1",
+    "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
@@ -94,9 +94,10 @@
     }
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.8.0",
-    "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.2.2.0",
+    "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
@@ -105,13 +105,10 @@
   },
   "module:es5": "es5/index.js",
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "InterfaceDeclaration_IDataObjectProps": {
-        "forwardCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
+++ b/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
@@ -335,7 +335,6 @@ declare function get_old_InterfaceDeclaration_IDataObjectProps():
 declare function use_current_InterfaceDeclaration_IDataObjectProps(
     use: TypeOnly<current.IDataObjectProps>);
 use_current_InterfaceDeclaration_IDataObjectProps(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IDataObjectProps());
 
 /*

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.2.2.0",
+    "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -93,9 +93,10 @@
   },
   "module:es5": "es5/index.js",
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -73,7 +73,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.2.2.0",
+    "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
@@ -96,9 +96,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -79,7 +79,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.2.2.0",
+    "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.3.0.0",
     "@fluidframework/map": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/sequence": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
@@ -98,9 +98,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/fluid-static/src/test/tsconfig.json
+++ b/packages/framework/fluid-static/src/test/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../dist/test",
-		"types": ["mocha"],
+		"types": ["mocha", "node"],
 		"declaration": false,
 		"declarationMap": false,
 		"skipLibCheck": true,

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -74,7 +74,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.2.2.0",
+    "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -95,9 +95,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.2.2.0",
+    "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -88,9 +88,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/uuid": "^8.3.0",
@@ -61,9 +61,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/test-client-utils/src/test/types/validateTestClientUtilsPrevious.generated.ts
+++ b/packages/framework/test-client-utils/src/test/types/validateTestClientUtilsPrevious.generated.ts
@@ -36,27 +36,3 @@ declare function use_old_VariableDeclaration_generateTestUser(
     use: TypeOnly<typeof old.generateTestUser>);
 use_old_VariableDeclaration_generateTestUser(
     get_current_VariableDeclaration_generateTestUser());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_InsecureTokenProvider": {"forwardCompat": false}
-*/
-declare function get_old_ClassDeclaration_InsecureTokenProvider():
-    TypeOnly<old.InsecureTokenProvider>;
-declare function use_current_ClassDeclaration_InsecureTokenProvider(
-    use: TypeOnly<current.InsecureTokenProvider>);
-use_current_ClassDeclaration_InsecureTokenProvider(
-    get_old_ClassDeclaration_InsecureTokenProvider());
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_InsecureTokenProvider": {"backCompat": false}
-*/
-declare function get_current_ClassDeclaration_InsecureTokenProvider():
-    TypeOnly<current.InsecureTokenProvider>;
-declare function use_old_ClassDeclaration_InsecureTokenProvider(
-    use: TypeOnly<old.InsecureTokenProvider>);
-use_old_ClassDeclaration_InsecureTokenProvider(
-    get_current_ClassDeclaration_InsecureTokenProvider());

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/test-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.2.2.0",
+    "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -83,9 +83,10 @@
     "fluid-framework": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.2.2.0",
+    "@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/diff": "^3.5.1",
@@ -96,9 +96,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -42,7 +42,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.2.2.0",
+    "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^17.0.44",
@@ -55,9 +55,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -39,7 +39,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.2.2.0",
+    "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^17.0.44",
@@ -52,9 +52,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -84,7 +84,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.2.2.0",
+    "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/test-loader-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
@@ -108,9 +108,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -73,7 +73,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
@@ -92,9 +92,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -78,7 +78,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
@@ -99,31 +99,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "ClassDeclaration_AuthorizationError": {
-        "backCompat": false
-      },
-      "ClassDeclaration_DeltaStreamConnectionForbiddenError": {
-        "backCompat": false
-      },
-      "ClassDeclaration_FluidInvalidSchemaError": {
-        "backCompat": false
-      },
-      "ClassDeclaration_GenericNetworkError": {
-        "backCompat": false
-      },
-      "ClassDeclaration_LocationRedirectionError": {
-        "backCompat": false
-      },
-      "ClassDeclaration_ThrottlingError": {
-        "backCompat": false
-      },
-      "ClassDeclaration_UsageError": {
-        "backCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.generated.ts
+++ b/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.generated.ts
@@ -35,7 +35,6 @@ declare function get_current_ClassDeclaration_AuthorizationError():
 declare function use_old_ClassDeclaration_AuthorizationError(
     use: TypeOnly<old.AuthorizationError>);
 use_old_ClassDeclaration_AuthorizationError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_AuthorizationError());
 
 /*
@@ -324,7 +323,6 @@ declare function get_current_ClassDeclaration_DeltaStreamConnectionForbiddenErro
 declare function use_old_ClassDeclaration_DeltaStreamConnectionForbiddenError(
     use: TypeOnly<old.DeltaStreamConnectionForbiddenError>);
 use_old_ClassDeclaration_DeltaStreamConnectionForbiddenError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_DeltaStreamConnectionForbiddenError());
 
 /*
@@ -469,7 +467,6 @@ declare function get_current_ClassDeclaration_FluidInvalidSchemaError():
 declare function use_old_ClassDeclaration_FluidInvalidSchemaError(
     use: TypeOnly<old.FluidInvalidSchemaError>);
 use_old_ClassDeclaration_FluidInvalidSchemaError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_FluidInvalidSchemaError());
 
 /*
@@ -494,7 +491,6 @@ declare function get_current_ClassDeclaration_GenericNetworkError():
 declare function use_old_ClassDeclaration_GenericNetworkError(
     use: TypeOnly<old.GenericNetworkError>);
 use_old_ClassDeclaration_GenericNetworkError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_GenericNetworkError());
 
 /*
@@ -807,7 +803,6 @@ declare function get_current_ClassDeclaration_LocationRedirectionError():
 declare function use_old_ClassDeclaration_LocationRedirectionError(
     use: TypeOnly<old.LocationRedirectionError>);
 use_old_ClassDeclaration_LocationRedirectionError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_LocationRedirectionError());
 
 /*
@@ -833,6 +828,30 @@ declare function use_old_FunctionDeclaration_logNetworkFailure(
     use: TypeOnly<typeof old.logNetworkFailure>);
 use_old_FunctionDeclaration_logNetworkFailure(
     get_current_FunctionDeclaration_logNetworkFailure());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_MapWithExpiration": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_MapWithExpiration():
+    TypeOnly<old.MapWithExpiration>;
+declare function use_current_ClassDeclaration_MapWithExpiration(
+    use: TypeOnly<current.MapWithExpiration>);
+use_current_ClassDeclaration_MapWithExpiration(
+    get_old_ClassDeclaration_MapWithExpiration());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_MapWithExpiration": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_MapWithExpiration():
+    TypeOnly<current.MapWithExpiration>;
+declare function use_old_ClassDeclaration_MapWithExpiration(
+    use: TypeOnly<old.MapWithExpiration>);
+use_old_ClassDeclaration_MapWithExpiration(
+    get_current_ClassDeclaration_MapWithExpiration());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1288,7 +1307,6 @@ declare function get_current_ClassDeclaration_ThrottlingError():
 declare function use_old_ClassDeclaration_ThrottlingError(
     use: TypeOnly<old.ThrottlingError>);
 use_old_ClassDeclaration_ThrottlingError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_ThrottlingError());
 
 /*
@@ -1313,7 +1331,6 @@ declare function get_current_ClassDeclaration_UsageError():
 declare function use_old_ClassDeclaration_UsageError(
     use: TypeOnly<old.UsageError>);
 use_old_ClassDeclaration_UsageError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_UsageError());
 
 /*

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -73,7 +73,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -91,9 +91,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -42,7 +42,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
     "eslint": "~8.6.0",
@@ -51,9 +51,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/protocol-definitions": "^1.1.0",
-    "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@2.0.0-internal.2.1.1",
+    "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/isomorphic-fetch": "^0.0.35",
@@ -56,9 +56,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -45,7 +45,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.2.2.0",
+    "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -57,9 +57,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -87,7 +87,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.2.2.0",
+    "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
@@ -110,42 +110,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.2.0",
-    "broken": {
-      "RemovedVariableDeclaration_gcBlobPrefix": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "RemovedVariableDeclaration_gcTombstoneBlobKey": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "RemovedVariableDeclaration_gcTreeKey": {
-        "forwardCompat": false
-      },
-      "VariableDeclaration_DefaultSummaryConfiguration": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_ISummaryBaseConfiguration": {
-        "backCompat": false
-      },
-      "TypeAliasDeclaration_ISummaryConfiguration": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_ISummaryConfigurationDisableHeuristics": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_ISummaryConfigurationHeuristics": {
-        "backCompat": false
-      },
-      "ClassDeclaration_ContainerRuntime": {
-        "forwardCompat": false
-      },
-      "InterfaceDeclaration_ISummarizerRuntime": {
-        "backCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -40,6 +40,54 @@ use_old_VariableDeclaration_agentSchedulerId(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_AllowTombstoneRequestHeaderKey": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_AllowTombstoneRequestHeaderKey():
+    TypeOnly<typeof old.AllowTombstoneRequestHeaderKey>;
+declare function use_current_VariableDeclaration_AllowTombstoneRequestHeaderKey(
+    use: TypeOnly<typeof current.AllowTombstoneRequestHeaderKey>);
+use_current_VariableDeclaration_AllowTombstoneRequestHeaderKey(
+    get_old_VariableDeclaration_AllowTombstoneRequestHeaderKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_AllowTombstoneRequestHeaderKey": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_AllowTombstoneRequestHeaderKey():
+    TypeOnly<typeof current.AllowTombstoneRequestHeaderKey>;
+declare function use_old_VariableDeclaration_AllowTombstoneRequestHeaderKey(
+    use: TypeOnly<typeof old.AllowTombstoneRequestHeaderKey>);
+use_old_VariableDeclaration_AllowTombstoneRequestHeaderKey(
+    get_current_VariableDeclaration_AllowTombstoneRequestHeaderKey());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "EnumDeclaration_CompressionAlgorithms": {"forwardCompat": false}
+*/
+declare function get_old_EnumDeclaration_CompressionAlgorithms():
+    TypeOnly<old.CompressionAlgorithms>;
+declare function use_current_EnumDeclaration_CompressionAlgorithms(
+    use: TypeOnly<current.CompressionAlgorithms>);
+use_current_EnumDeclaration_CompressionAlgorithms(
+    get_old_EnumDeclaration_CompressionAlgorithms());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "EnumDeclaration_CompressionAlgorithms": {"backCompat": false}
+*/
+declare function get_current_EnumDeclaration_CompressionAlgorithms():
+    TypeOnly<current.CompressionAlgorithms>;
+declare function use_old_EnumDeclaration_CompressionAlgorithms(
+    use: TypeOnly<old.CompressionAlgorithms>);
+use_old_EnumDeclaration_CompressionAlgorithms(
+    get_current_EnumDeclaration_CompressionAlgorithms());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "EnumDeclaration_ContainerMessageType": {"forwardCompat": false}
 */
 declare function get_old_EnumDeclaration_ContainerMessageType():
@@ -71,7 +119,6 @@ declare function get_old_ClassDeclaration_ContainerRuntime():
 declare function use_current_ClassDeclaration_ContainerRuntime(
     use: TypeOnly<current.ContainerRuntime>);
 use_current_ClassDeclaration_ContainerRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_ContainerRuntime());
 
 /*
@@ -132,7 +179,6 @@ declare function get_current_VariableDeclaration_DefaultSummaryConfiguration():
 declare function use_old_VariableDeclaration_DefaultSummaryConfiguration(
     use: TypeOnly<typeof old.DefaultSummaryConfiguration>);
 use_old_VariableDeclaration_DefaultSummaryConfiguration(
-    // @ts-expect-error compatibility expected to be broken
     get_current_VariableDeclaration_DefaultSummaryConfiguration());
 
 /*
@@ -182,42 +228,6 @@ declare function use_old_ClassDeclaration_FluidDataStoreRegistry(
     use: TypeOnly<old.FluidDataStoreRegistry>);
 use_old_ClassDeclaration_FluidDataStoreRegistry(
     get_current_ClassDeclaration_FluidDataStoreRegistry());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcBlobPrefix": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcBlobPrefix": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcTombstoneBlobKey": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcTombstoneBlobKey": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcTreeKey": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcTreeKey": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1057,7 +1067,6 @@ declare function get_current_InterfaceDeclaration_ISummarizerRuntime():
 declare function use_old_InterfaceDeclaration_ISummarizerRuntime(
     use: TypeOnly<old.ISummarizerRuntime>);
 use_old_InterfaceDeclaration_ISummarizerRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISummarizerRuntime());
 
 /*
@@ -1154,7 +1163,6 @@ declare function get_current_InterfaceDeclaration_ISummaryBaseConfiguration():
 declare function use_old_InterfaceDeclaration_ISummaryBaseConfiguration(
     use: TypeOnly<old.ISummaryBaseConfiguration>);
 use_old_InterfaceDeclaration_ISummaryBaseConfiguration(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISummaryBaseConfiguration());
 
 /*
@@ -1227,7 +1235,6 @@ declare function get_current_TypeAliasDeclaration_ISummaryConfiguration():
 declare function use_old_TypeAliasDeclaration_ISummaryConfiguration(
     use: TypeOnly<old.ISummaryConfiguration>);
 use_old_TypeAliasDeclaration_ISummaryConfiguration(
-    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_ISummaryConfiguration());
 
 /*
@@ -1252,7 +1259,6 @@ declare function get_current_InterfaceDeclaration_ISummaryConfigurationDisableHe
 declare function use_old_InterfaceDeclaration_ISummaryConfigurationDisableHeuristics(
     use: TypeOnly<old.ISummaryConfigurationDisableHeuristics>);
 use_old_InterfaceDeclaration_ISummaryConfigurationDisableHeuristics(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISummaryConfigurationDisableHeuristics());
 
 /*
@@ -1301,7 +1307,6 @@ declare function get_current_InterfaceDeclaration_ISummaryConfigurationHeuristic
 declare function use_old_InterfaceDeclaration_ISummaryConfigurationHeuristics(
     use: TypeOnly<old.ISummaryConfigurationHeuristics>);
 use_old_InterfaceDeclaration_ISummaryConfigurationHeuristics(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISummaryConfigurationHeuristics());
 
 /*
@@ -1639,6 +1644,30 @@ declare function use_old_ClassDeclaration_SummaryCollection(
     use: TypeOnly<old.SummaryCollection>);
 use_old_ClassDeclaration_SummaryCollection(
     get_current_ClassDeclaration_SummaryCollection());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_TombstoneResponseHeaderKey": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_TombstoneResponseHeaderKey():
+    TypeOnly<typeof old.TombstoneResponseHeaderKey>;
+declare function use_current_VariableDeclaration_TombstoneResponseHeaderKey(
+    use: TypeOnly<typeof current.TombstoneResponseHeaderKey>);
+use_current_VariableDeclaration_TombstoneResponseHeaderKey(
+    get_old_VariableDeclaration_TombstoneResponseHeaderKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_TombstoneResponseHeaderKey": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_TombstoneResponseHeaderKey():
+    TypeOnly<typeof current.TombstoneResponseHeaderKey>;
+declare function use_old_VariableDeclaration_TombstoneResponseHeaderKey(
+    use: TypeOnly<typeof old.TombstoneResponseHeaderKey>);
+use_old_VariableDeclaration_TombstoneResponseHeaderKey(
+    get_current_VariableDeclaration_TombstoneResponseHeaderKey());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -45,7 +45,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.2.2.0",
+    "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -57,13 +57,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "InterfaceDeclaration_IFluidDataStoreRuntime": {
-        "forwardCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
@@ -191,7 +191,6 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreRuntime():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreRuntime(
     use: TypeOnly<current.IFluidDataStoreRuntime>);
 use_current_InterfaceDeclaration_IFluidDataStoreRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -84,7 +84,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.2.2.0",
+    "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
@@ -104,13 +104,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "ClassDeclaration_FluidDataStoreRuntime": {
-        "forwardCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
+++ b/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
@@ -47,7 +47,6 @@ declare function get_old_ClassDeclaration_FluidDataStoreRuntime():
 declare function use_current_ClassDeclaration_FluidDataStoreRuntime(
     use: TypeOnly<current.FluidDataStoreRuntime>);
 use_current_ClassDeclaration_FluidDataStoreRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_FluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -78,7 +78,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@2.0.0-internal.2.2.0",
+    "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -96,9 +96,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/runtime/garbage-collector/src/test/types/validateGarbageCollectorPrevious.generated.ts
+++ b/packages/runtime/garbage-collector/src/test/types/validateGarbageCollectorPrevious.generated.ts
@@ -112,6 +112,30 @@ use_old_ClassDeclaration_GCDataBuilder(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_getGCDataFromSnapshot": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_getGCDataFromSnapshot():
+    TypeOnly<typeof old.getGCDataFromSnapshot>;
+declare function use_current_FunctionDeclaration_getGCDataFromSnapshot(
+    use: TypeOnly<typeof current.getGCDataFromSnapshot>);
+use_current_FunctionDeclaration_getGCDataFromSnapshot(
+    get_old_FunctionDeclaration_getGCDataFromSnapshot());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_getGCDataFromSnapshot": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_getGCDataFromSnapshot():
+    TypeOnly<typeof current.getGCDataFromSnapshot>;
+declare function use_old_FunctionDeclaration_getGCDataFromSnapshot(
+    use: TypeOnly<typeof old.getGCDataFromSnapshot>);
+use_old_FunctionDeclaration_getGCDataFromSnapshot(
+    get_current_FunctionDeclaration_getGCDataFromSnapshot());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IGCResult": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IGCResult():

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.2.2.0",
+    "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
@@ -57,20 +57,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "RemovedVariableDeclaration_gcBlobKey": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IFluidDataStoreContext": {
-        "forwardCompat": false
-      },
-      "InterfaceDeclaration_IFluidDataStoreContextDetached": {
-        "forwardCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -232,14 +232,98 @@ use_old_EnumDeclaration_FlushMode(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcBlobKey": {"forwardCompat": false}
+* "VariableDeclaration_gcBlobPrefix": {"forwardCompat": false}
 */
+declare function get_old_VariableDeclaration_gcBlobPrefix():
+    TypeOnly<typeof old.gcBlobPrefix>;
+declare function use_current_VariableDeclaration_gcBlobPrefix(
+    use: TypeOnly<typeof current.gcBlobPrefix>);
+use_current_VariableDeclaration_gcBlobPrefix(
+    get_old_VariableDeclaration_gcBlobPrefix());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcBlobKey": {"backCompat": false}
+* "VariableDeclaration_gcBlobPrefix": {"backCompat": false}
 */
+declare function get_current_VariableDeclaration_gcBlobPrefix():
+    TypeOnly<typeof current.gcBlobPrefix>;
+declare function use_old_VariableDeclaration_gcBlobPrefix(
+    use: TypeOnly<typeof old.gcBlobPrefix>);
+use_old_VariableDeclaration_gcBlobPrefix(
+    get_current_VariableDeclaration_gcBlobPrefix());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_gcDeletedBlobKey": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_gcDeletedBlobKey():
+    TypeOnly<typeof old.gcDeletedBlobKey>;
+declare function use_current_VariableDeclaration_gcDeletedBlobKey(
+    use: TypeOnly<typeof current.gcDeletedBlobKey>);
+use_current_VariableDeclaration_gcDeletedBlobKey(
+    get_old_VariableDeclaration_gcDeletedBlobKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_gcDeletedBlobKey": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_gcDeletedBlobKey():
+    TypeOnly<typeof current.gcDeletedBlobKey>;
+declare function use_old_VariableDeclaration_gcDeletedBlobKey(
+    use: TypeOnly<typeof old.gcDeletedBlobKey>);
+use_old_VariableDeclaration_gcDeletedBlobKey(
+    get_current_VariableDeclaration_gcDeletedBlobKey());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_gcTombstoneBlobKey": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_gcTombstoneBlobKey():
+    TypeOnly<typeof old.gcTombstoneBlobKey>;
+declare function use_current_VariableDeclaration_gcTombstoneBlobKey(
+    use: TypeOnly<typeof current.gcTombstoneBlobKey>);
+use_current_VariableDeclaration_gcTombstoneBlobKey(
+    get_old_VariableDeclaration_gcTombstoneBlobKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_gcTombstoneBlobKey": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_gcTombstoneBlobKey():
+    TypeOnly<typeof current.gcTombstoneBlobKey>;
+declare function use_old_VariableDeclaration_gcTombstoneBlobKey(
+    use: TypeOnly<typeof old.gcTombstoneBlobKey>);
+use_old_VariableDeclaration_gcTombstoneBlobKey(
+    get_current_VariableDeclaration_gcTombstoneBlobKey());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_gcTreeKey": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_gcTreeKey():
+    TypeOnly<typeof old.gcTreeKey>;
+declare function use_current_VariableDeclaration_gcTreeKey(
+    use: TypeOnly<typeof current.gcTreeKey>);
+use_current_VariableDeclaration_gcTreeKey(
+    get_old_VariableDeclaration_gcTreeKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_gcTreeKey": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_gcTreeKey():
+    TypeOnly<typeof current.gcTreeKey>;
+declare function use_old_VariableDeclaration_gcTreeKey(
+    use: TypeOnly<typeof old.gcTreeKey>);
+use_old_VariableDeclaration_gcTreeKey(
+    get_current_VariableDeclaration_gcTreeKey());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -395,7 +479,6 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContext(
     use: TypeOnly<current.IFluidDataStoreContext>);
 use_current_InterfaceDeclaration_IFluidDataStoreContext(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -420,7 +503,6 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContextDetached():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: TypeOnly<current.IFluidDataStoreContextDetached>);
 use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*
@@ -630,6 +712,30 @@ use_old_InterfaceDeclaration_IGarbageCollectionNodeData(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IGarbageCollectionSnapshotData": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IGarbageCollectionSnapshotData():
+    TypeOnly<old.IGarbageCollectionSnapshotData>;
+declare function use_current_InterfaceDeclaration_IGarbageCollectionSnapshotData(
+    use: TypeOnly<current.IGarbageCollectionSnapshotData>);
+use_current_InterfaceDeclaration_IGarbageCollectionSnapshotData(
+    get_old_InterfaceDeclaration_IGarbageCollectionSnapshotData());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IGarbageCollectionSnapshotData": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IGarbageCollectionSnapshotData():
+    TypeOnly<current.IGarbageCollectionSnapshotData>;
+declare function use_old_InterfaceDeclaration_IGarbageCollectionSnapshotData(
+    use: TypeOnly<old.IGarbageCollectionSnapshotData>);
+use_old_InterfaceDeclaration_IGarbageCollectionSnapshotData(
+    get_current_InterfaceDeclaration_IGarbageCollectionSnapshotData());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IGarbageCollectionState": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IGarbageCollectionState():
@@ -650,6 +756,30 @@ declare function use_old_InterfaceDeclaration_IGarbageCollectionState(
     use: TypeOnly<old.IGarbageCollectionState>);
 use_old_InterfaceDeclaration_IGarbageCollectionState(
     get_current_InterfaceDeclaration_IGarbageCollectionState());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy():
+    TypeOnly<old.IGarbageCollectionSummaryDetailsLegacy>;
+declare function use_current_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy(
+    use: TypeOnly<current.IGarbageCollectionSummaryDetailsLegacy>);
+use_current_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy(
+    get_old_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy():
+    TypeOnly<current.IGarbageCollectionSummaryDetailsLegacy>;
+declare function use_old_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy(
+    use: TypeOnly<old.IGarbageCollectionSummaryDetailsLegacy>);
+use_old_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy(
+    get_current_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -80,7 +80,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -98,9 +98,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.2.0",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -83,7 +83,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
@@ -101,16 +101,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "ClassDeclaration_MockFluidDataStoreContext": {
-        "forwardCompat": false
-      },
-      "ClassDeclaration_MockFluidDataStoreRuntime": {
-        "forwardCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -16,6 +16,30 @@ type TypeOnly<T> = {
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IInsecureUser": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IInsecureUser():
+    TypeOnly<old.IInsecureUser>;
+declare function use_current_InterfaceDeclaration_IInsecureUser(
+    use: TypeOnly<current.IInsecureUser>);
+use_current_InterfaceDeclaration_IInsecureUser(
+    get_old_InterfaceDeclaration_IInsecureUser());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IInsecureUser": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IInsecureUser():
+    TypeOnly<current.IInsecureUser>;
+declare function use_old_InterfaceDeclaration_IInsecureUser(
+    use: TypeOnly<old.IInsecureUser>);
+use_old_InterfaceDeclaration_IInsecureUser(
+    get_current_InterfaceDeclaration_IInsecureUser());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IMockContainerRuntimePendingMessage": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IMockContainerRuntimePendingMessage():
@@ -263,7 +287,6 @@ declare function get_old_ClassDeclaration_MockFluidDataStoreContext():
 declare function use_current_ClassDeclaration_MockFluidDataStoreContext(
     use: TypeOnly<current.MockFluidDataStoreContext>);
 use_current_ClassDeclaration_MockFluidDataStoreContext(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockFluidDataStoreContext());
 
 /*
@@ -288,7 +311,6 @@ declare function get_old_ClassDeclaration_MockFluidDataStoreRuntime():
 declare function use_current_ClassDeclaration_MockFluidDataStoreRuntime(
     use: TypeOnly<current.MockFluidDataStoreRuntime>);
 use_current_ClassDeclaration_MockFluidDataStoreRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockFluidDataStoreRuntime());
 
 /*

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -63,7 +63,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.2.2.0",
+    "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -77,9 +77,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -84,7 +84,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@2.0.0-internal.2.2.0",
+    "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -99,9 +99,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@2.0.0-internal.2.2.0",
+    "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.36",
@@ -75,9 +75,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -92,7 +92,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
@@ -114,9 +114,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/test/test-utils/src/test/tsconfig.json
+++ b/packages/test/test-utils/src/test/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../dist/test",
-		"types": ["mocha"],
+		"types": ["mocha", "node"],
 		"declaration": false,
 		"declarationMap": false,
 		"skipLibCheck": true,

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -92,7 +92,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/nock": "^9.3.0",
@@ -114,13 +114,10 @@
     "webpack-cli": "^4.9.2"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "InterfaceDeclaration_ITestDataObject": {
-        "forwardCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/test/test-version-utils/src/test/types/validateTestVersionUtilsPrevious.generated.ts
+++ b/packages/test/test-version-utils/src/test/types/validateTestVersionUtilsPrevious.generated.ts
@@ -88,6 +88,30 @@ use_old_VariableDeclaration_describeFullCompat(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_describeInstallVersions": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_describeInstallVersions():
+    TypeOnly<typeof old.describeInstallVersions>;
+declare function use_current_FunctionDeclaration_describeInstallVersions(
+    use: TypeOnly<typeof current.describeInstallVersions>);
+use_current_FunctionDeclaration_describeInstallVersions(
+    get_old_FunctionDeclaration_describeInstallVersions());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_describeInstallVersions": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_describeInstallVersions():
+    TypeOnly<typeof current.describeInstallVersions>;
+declare function use_old_FunctionDeclaration_describeInstallVersions(
+    use: TypeOnly<typeof old.describeInstallVersions>);
+use_old_FunctionDeclaration_describeInstallVersions(
+    get_current_FunctionDeclaration_describeInstallVersions());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "VariableDeclaration_describeLoaderCompat": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_describeLoaderCompat():
@@ -359,7 +383,6 @@ declare function get_old_InterfaceDeclaration_ITestDataObject():
 declare function use_current_InterfaceDeclaration_ITestDataObject(
     use: TypeOnly<current.ITestDataObject>);
 use_current_InterfaceDeclaration_ITestDataObject(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ITestDataObject());
 
 /*

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -74,7 +74,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.2.2.0",
+    "@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -90,9 +90,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -95,7 +95,7 @@
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.8.0",
-    "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.2.2.0",
+    "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
@@ -120,9 +120,10 @@
     "webpack-cli": "^4.9.2"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.36",
@@ -90,13 +90,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "ClassDeclaration_OdspRedirectError": {
-        "backCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/utils/odsp-doclib-utils/src/test/types/validateOdspDoclibUtilsPrevious.generated.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/types/validateOdspDoclibUtilsPrevious.generated.ts
@@ -779,7 +779,6 @@ declare function get_current_ClassDeclaration_OdspRedirectError():
 declare function use_old_ClassDeclaration_OdspRedirectError(
     use: TypeOnly<old.OdspRedirectError>);
 use_old_ClassDeclaration_OdspRedirectError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_OdspRedirectError());
 
 /*

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -80,7 +80,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
@@ -100,13 +100,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "ClassDeclaration_MockLogger": {
-        "forwardCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
+++ b/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
@@ -544,6 +544,126 @@ use_old_FunctionDeclaration_isValidLegacyError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt():
+    TypeOnly<old.ITaggedTelemetryPropertyTypeExt>;
+declare function use_current_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt(
+    use: TypeOnly<current.ITaggedTelemetryPropertyTypeExt>);
+use_current_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt(
+    get_old_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt():
+    TypeOnly<current.ITaggedTelemetryPropertyTypeExt>;
+declare function use_old_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt(
+    use: TypeOnly<old.ITaggedTelemetryPropertyTypeExt>);
+use_old_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt(
+    get_current_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryErrorEventExt": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITelemetryErrorEventExt():
+    TypeOnly<old.ITelemetryErrorEventExt>;
+declare function use_current_InterfaceDeclaration_ITelemetryErrorEventExt(
+    use: TypeOnly<current.ITelemetryErrorEventExt>);
+use_current_InterfaceDeclaration_ITelemetryErrorEventExt(
+    get_old_InterfaceDeclaration_ITelemetryErrorEventExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryErrorEventExt": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITelemetryErrorEventExt():
+    TypeOnly<current.ITelemetryErrorEventExt>;
+declare function use_old_InterfaceDeclaration_ITelemetryErrorEventExt(
+    use: TypeOnly<old.ITelemetryErrorEventExt>);
+use_old_InterfaceDeclaration_ITelemetryErrorEventExt(
+    get_current_InterfaceDeclaration_ITelemetryErrorEventExt());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryEventExt": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITelemetryEventExt():
+    TypeOnly<old.ITelemetryEventExt>;
+declare function use_current_InterfaceDeclaration_ITelemetryEventExt(
+    use: TypeOnly<current.ITelemetryEventExt>);
+use_current_InterfaceDeclaration_ITelemetryEventExt(
+    get_old_InterfaceDeclaration_ITelemetryEventExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryEventExt": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITelemetryEventExt():
+    TypeOnly<current.ITelemetryEventExt>;
+declare function use_old_InterfaceDeclaration_ITelemetryEventExt(
+    use: TypeOnly<old.ITelemetryEventExt>);
+use_old_InterfaceDeclaration_ITelemetryEventExt(
+    get_current_InterfaceDeclaration_ITelemetryEventExt());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryGenericEventExt": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITelemetryGenericEventExt():
+    TypeOnly<old.ITelemetryGenericEventExt>;
+declare function use_current_InterfaceDeclaration_ITelemetryGenericEventExt(
+    use: TypeOnly<current.ITelemetryGenericEventExt>);
+use_current_InterfaceDeclaration_ITelemetryGenericEventExt(
+    get_old_InterfaceDeclaration_ITelemetryGenericEventExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryGenericEventExt": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITelemetryGenericEventExt():
+    TypeOnly<current.ITelemetryGenericEventExt>;
+declare function use_old_InterfaceDeclaration_ITelemetryGenericEventExt(
+    use: TypeOnly<old.ITelemetryGenericEventExt>);
+use_old_InterfaceDeclaration_ITelemetryGenericEventExt(
+    get_current_InterfaceDeclaration_ITelemetryGenericEventExt());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryLoggerExt": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITelemetryLoggerExt():
+    TypeOnly<old.ITelemetryLoggerExt>;
+declare function use_current_InterfaceDeclaration_ITelemetryLoggerExt(
+    use: TypeOnly<current.ITelemetryLoggerExt>);
+use_current_InterfaceDeclaration_ITelemetryLoggerExt(
+    get_old_InterfaceDeclaration_ITelemetryLoggerExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryLoggerExt": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITelemetryLoggerExt():
+    TypeOnly<current.ITelemetryLoggerExt>;
+declare function use_old_InterfaceDeclaration_ITelemetryLoggerExt(
+    use: TypeOnly<old.ITelemetryLoggerExt>);
+use_old_InterfaceDeclaration_ITelemetryLoggerExt(
+    get_current_InterfaceDeclaration_ITelemetryLoggerExt());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ITelemetryLoggerPropertyBag": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ITelemetryLoggerPropertyBag():
@@ -588,6 +708,54 @@ declare function use_old_InterfaceDeclaration_ITelemetryLoggerPropertyBags(
     use: TypeOnly<old.ITelemetryLoggerPropertyBags>);
 use_old_InterfaceDeclaration_ITelemetryLoggerPropertyBags(
     get_current_InterfaceDeclaration_ITelemetryLoggerPropertyBags());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryPerformanceEventExt": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITelemetryPerformanceEventExt():
+    TypeOnly<old.ITelemetryPerformanceEventExt>;
+declare function use_current_InterfaceDeclaration_ITelemetryPerformanceEventExt(
+    use: TypeOnly<current.ITelemetryPerformanceEventExt>);
+use_current_InterfaceDeclaration_ITelemetryPerformanceEventExt(
+    get_old_InterfaceDeclaration_ITelemetryPerformanceEventExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryPerformanceEventExt": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITelemetryPerformanceEventExt():
+    TypeOnly<current.ITelemetryPerformanceEventExt>;
+declare function use_old_InterfaceDeclaration_ITelemetryPerformanceEventExt(
+    use: TypeOnly<old.ITelemetryPerformanceEventExt>);
+use_old_InterfaceDeclaration_ITelemetryPerformanceEventExt(
+    get_current_InterfaceDeclaration_ITelemetryPerformanceEventExt());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryPropertiesExt": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITelemetryPropertiesExt():
+    TypeOnly<old.ITelemetryPropertiesExt>;
+declare function use_current_InterfaceDeclaration_ITelemetryPropertiesExt(
+    use: TypeOnly<current.ITelemetryPropertiesExt>);
+use_current_InterfaceDeclaration_ITelemetryPropertiesExt(
+    get_old_InterfaceDeclaration_ITelemetryPropertiesExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryPropertiesExt": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITelemetryPropertiesExt():
+    TypeOnly<current.ITelemetryPropertiesExt>;
+declare function use_old_InterfaceDeclaration_ITelemetryPropertiesExt(
+    use: TypeOnly<old.ITelemetryPropertiesExt>);
+use_old_InterfaceDeclaration_ITelemetryPropertiesExt(
+    get_current_InterfaceDeclaration_ITelemetryPropertiesExt());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -695,7 +863,6 @@ declare function get_old_ClassDeclaration_MockLogger():
 declare function use_current_ClassDeclaration_MockLogger(
     use: TypeOnly<current.MockLogger>);
 use_current_ClassDeclaration_MockLogger(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockLogger());
 
 /*
@@ -973,6 +1140,30 @@ declare function use_old_EnumDeclaration_TelemetryDataTag(
     use: TypeOnly<old.TelemetryDataTag>);
 use_old_EnumDeclaration_TelemetryDataTag(
     get_current_EnumDeclaration_TelemetryDataTag());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_TelemetryEventPropertyTypeExt": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_TelemetryEventPropertyTypeExt():
+    TypeOnly<old.TelemetryEventPropertyTypeExt>;
+declare function use_current_TypeAliasDeclaration_TelemetryEventPropertyTypeExt(
+    use: TypeOnly<current.TelemetryEventPropertyTypeExt>);
+use_current_TypeAliasDeclaration_TelemetryEventPropertyTypeExt(
+    get_old_TypeAliasDeclaration_TelemetryEventPropertyTypeExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_TelemetryEventPropertyTypeExt": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_TelemetryEventPropertyTypeExt():
+    TypeOnly<current.TelemetryEventPropertyTypeExt>;
+declare function use_old_TypeAliasDeclaration_TelemetryEventPropertyTypeExt(
+    use: TypeOnly<old.TelemetryEventPropertyTypeExt>);
+use_old_TypeAliasDeclaration_TelemetryEventPropertyTypeExt(
+    get_current_TypeAliasDeclaration_TelemetryEventPropertyTypeExt());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -78,7 +78,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
-    "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
@@ -96,9 +96,10 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.1.0",
+    "previousVersionStyle": "~previousMinor",
+    "baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
+    "baselineVersion": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4736,7 +4736,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.8.0
       '@fluidframework/common-definitions': ^0.20.1
-      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.3.0.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -4761,7 +4761,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -4778,7 +4778,7 @@ importers:
       '@fluid-tools/build-cli': ^0.8.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.8.0
-      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -4793,7 +4793,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -4858,7 +4858,7 @@ importers:
       '@fluidframework/build-tools': ^0.8.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.2.2.0
+      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@microsoft/api-extractor': ^7.22.2
@@ -4877,7 +4877,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.2.2.0
+      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -4894,7 +4894,7 @@ importers:
       '@fluid-tools/build-cli': ^0.8.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.8.0
-      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.2.2.0
+      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.3.0.0
       '@fluidframework/common-utils': ^1.0.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -4933,7 +4933,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.2.2.0
+      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -4958,7 +4958,7 @@ importers:
       '@fluidframework/build-tools': ^0.8.0
       '@fluidframework/common-utils': ^1.0.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.2.2.0
+      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.3.0.0
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -4992,7 +4992,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.2.2.0
+      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -5020,7 +5020,7 @@ importers:
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.2.2.0
+      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -5053,7 +5053,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.2.2.0
+      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
@@ -5084,7 +5084,7 @@ importers:
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.2.2.0
+      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -5126,7 +5126,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.2.2.0
+      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
@@ -5156,7 +5156,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.2.2.0
+      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.3.0.0
       '@fluidframework/merge-tree': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.2000
@@ -5210,7 +5210,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.2.2.0
+      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
@@ -5247,7 +5247,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.2.2.0
+      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -5293,7 +5293,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.2.2.0
+      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-pairwise-generator': link:../../test/test-pairwise-generator
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -5327,7 +5327,7 @@ importers:
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.2.2.0
+      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -5363,7 +5363,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.2.2.0
+      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.3.0.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -5455,7 +5455,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.2000
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.2.2.0
+      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.3.0.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/shared-object-base': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -5487,7 +5487,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.2.2.0
+      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.3.0.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -5524,7 +5524,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.2.2.0
+      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.3.0.0
       '@fluidframework/server-services-client': ^0.1038.2000
       '@fluidframework/shared-object-base': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -5571,7 +5571,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/gitresources': 0.1038.2000
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.2.2.0
+      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.3.0.0
       '@fluidframework/server-services-client': 0.1038.2000
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
@@ -5610,7 +5610,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.2.2.0
+      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.3.0.0
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
@@ -5650,7 +5650,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.2.2.0
+      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.3.0.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -5683,7 +5683,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/shared-object-base': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.2.2.0
+      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.3.0.0
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -5714,7 +5714,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.2.2.0
+      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.3.0.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -5752,7 +5752,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/shared-object-base': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.2.2.0
+      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.3.0.0
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -5790,7 +5790,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.2.2.0
+      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.3.0.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -5943,7 +5943,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.8.0
       '@fluidframework/common-utils': ^1.0.0
-      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.2.2.0
+      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.3.0.0
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -5972,7 +5972,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.2.2.0
+      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -5992,7 +5992,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.0.0
-      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.2.2.0
+      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.3.0.0
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -6018,7 +6018,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
-      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.2.2.0
+      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -6037,7 +6037,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.8.0
       '@fluidframework/common-definitions': ^0.20.1
-      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.2.2.0
+      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -6063,7 +6063,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.2.2.0
+      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -6088,7 +6088,7 @@ importers:
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.2.2.0
+      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/replay-driver': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
@@ -6112,7 +6112,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.2.2.0
+      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/node': 14.18.36
@@ -6126,7 +6126,7 @@ importers:
   packages/drivers/fluidapp-odsp-urlResolver:
     specifiers:
       '@fluid-tools/build-cli': ^0.8.0
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.2.1.1
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.3.0.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.8.0
       '@fluidframework/common-utils': ^1.0.0
@@ -6154,7 +6154,7 @@ importers:
       '@fluidframework/odsp-driver-definitions': link:../odsp-driver-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.8.0
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.2.1.1
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.0.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -6181,7 +6181,7 @@ importers:
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.2.2.0
+      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.2000
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -6231,7 +6231,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.2.2.0
+      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/jsrsasign': 8.0.13
@@ -6263,7 +6263,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-doclib-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.2.2.0
+      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.3.0.0
       '@fluidframework/protocol-base': ^0.1038.2000
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -6311,7 +6311,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.2.2.0
+      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -6337,7 +6337,7 @@ importers:
       '@fluidframework/build-tools': ^0.8.0
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.2.2.0
+      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -6355,7 +6355,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.2.2.0
+      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -6378,7 +6378,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.2.2.0
+      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.3.0.0
       '@rushstack/eslint-config': ^2.5.1
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.36
@@ -6400,7 +6400,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.2.2.0
+      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.3.0.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
       '@types/node': 14.18.36
@@ -6423,7 +6423,7 @@ importers:
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.2.2.0
+      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.3.0.0
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -6450,7 +6450,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.2.2.0
+      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -6480,7 +6480,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.2000
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.2.2.0
+      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.3.0.0
       '@fluidframework/server-services-client': ^0.1038.2000
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
@@ -6532,7 +6532,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.2.2.0
+      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -6565,7 +6565,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.2.2.0
+      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.3.0.0
       '@rushstack/eslint-config': ^2.5.1
       '@types/mocha': ^9.1.1
       '@types/nconf': ^0.10.0
@@ -6593,7 +6593,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.2.2.0
+      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.0.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
       '@types/nconf': 0.10.3
@@ -6620,7 +6620,7 @@ importers:
       '@fluidframework/routerlicious-driver': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/server-services-client': ^0.1038.2000
       '@fluidframework/test-tools': ^0.2.3074
-      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.2.1.1
+      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.3.0.0
       '@rushstack/eslint-config': ^2.5.1
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
@@ -6649,7 +6649,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/test-tools': 0.2.3074
-      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.2.1.1
+      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.3.0.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
@@ -6665,7 +6665,7 @@ importers:
   packages/framework/agent-scheduler:
     specifiers:
       '@fluid-tools/build-cli': ^0.8.0
-      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.2.1.1
+      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.3.0.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.8.0
       '@fluidframework/common-definitions': ^0.20.1
@@ -6704,7 +6704,7 @@ importers:
       uuid: 8.3.2
     devDependencies:
       '@fluid-tools/build-cli': 0.8.0
-      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.2.1.1
+      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.3.0.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -6722,7 +6722,7 @@ importers:
   packages/framework/aqueduct:
     specifiers:
       '@fluid-tools/build-cli': ^0.8.0
-      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.2.2.0
+      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.3.0.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.8.0
       '@fluidframework/common-definitions': ^0.20.1
@@ -6775,7 +6775,7 @@ importers:
       uuid: 8.3.2
     devDependencies:
       '@fluid-tools/build-cli': 0.8.0
-      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.2.2.0
+      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.3.0.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -6876,7 +6876,7 @@ importers:
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/container-runtime': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.2.2.0
+      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.3.0.0
       '@fluidframework/datastore': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -6912,7 +6912,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
-      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.2.2.0
+      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.22.2
@@ -6934,7 +6934,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.8.0
       '@fluidframework/common-utils': ^1.0.0
-      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.2.2.0
+      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/merge-tree': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -6969,7 +6969,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.2.2.0
+      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -7054,7 +7054,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.2.2.0
+      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.3.0.0
       '@fluidframework/map': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -7093,7 +7093,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.2.2.0
+      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.3.0.0
       '@fluidframework/map': link:../../dds/map
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/sequence': link:../../dds/sequence
@@ -7176,7 +7176,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.2.2.0
+      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.3.0.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -7209,7 +7209,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.2.2.0
+      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.3.0.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -7238,7 +7238,7 @@ importers:
       '@fluidframework/datastore': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.2.2.0
+      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.3.0.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/mocha': ^9.1.1
@@ -7260,7 +7260,7 @@ importers:
       '@fluidframework/datastore': link:../../runtime/datastore
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.2.2.0
+      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -7282,7 +7282,7 @@ importers:
       '@fluidframework/build-tools': ^0.8.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/test-client-utils-previous': npm:@fluidframework/test-client-utils@2.0.0-internal.2.2.0
+      '@fluidframework/test-client-utils-previous': npm:@fluidframework/test-client-utils@2.0.0-internal.3.0.0
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -7305,7 +7305,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-client-utils-previous': /@fluidframework/test-client-utils/2.0.0-internal.2.2.0
+      '@fluidframework/test-client-utils-previous': /@fluidframework/test-client-utils/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/uuid': 8.3.4
@@ -7337,7 +7337,7 @@ importers:
       '@fluidframework/routerlicious-driver': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.2.2.0
+      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.3.0.0
       '@fluidframework/tinylicious-driver': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -7376,7 +7376,7 @@ importers:
       '@fluidframework/container-runtime-definitions': link:../../runtime/container-runtime-definitions
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/test-utils': link:../../test/test-utils
-      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.2.2.0
+      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -7403,7 +7403,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/sequence': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.2.2.0
+      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.3.0.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/diff': ^3.5.1
@@ -7436,7 +7436,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.2.2.0
+      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/diff': 3.5.5
@@ -7462,7 +7462,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.2.2.0
+      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.3.0.0
       '@fluidframework/view-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -7485,7 +7485,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.2.2.0
+      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/react': 17.0.52
@@ -7503,7 +7503,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.2.2.0
+      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.3.0.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/react': ^17.0.44
@@ -7520,7 +7520,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.2.2.0
+      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/react': 17.0.52
@@ -7540,7 +7540,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.0.0
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.2.2.0
+      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.3.0.0
       '@fluidframework/container-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -7596,7 +7596,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.2.2.0
+      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-loader-utils': link:../test-loader-utils
@@ -7627,7 +7627,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.0.0
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/container-utils-previous': npm:@fluidframework/container-utils@2.0.0-internal.2.2.0
+      '@fluidframework/container-utils-previous': npm:@fluidframework/container-utils@2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -7656,7 +7656,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/container-utils-previous': /@fluidframework/container-utils/2.0.0-internal.2.2.0
+      '@fluidframework/container-utils-previous': /@fluidframework/container-utils/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -7683,7 +7683,7 @@ importers:
       '@fluidframework/common-utils': ^1.0.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.2.2.0
+      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources': ^0.1038.2000
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -7725,7 +7725,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.2.2.0
+      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
@@ -7754,7 +7754,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.2.2.0
+      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -7781,7 +7781,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.2.2.0
+      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
@@ -7808,7 +7808,7 @@ importers:
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/test-loader-utils-previous': npm:@fluidframework/test-loader-utils@2.0.0-internal.2.2.0
+      '@fluidframework/test-loader-utils-previous': npm:@fluidframework/test-loader-utils@2.0.0-internal.3.0.0
       '@rushstack/eslint-config': ^2.5.1
       concurrently: ^6.2.0
       eslint: ~8.6.0
@@ -7825,7 +7825,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-loader-utils-previous': /@fluidframework/test-loader-utils/2.0.0-internal.2.2.0
+      '@fluidframework/test-loader-utils-previous': /@fluidframework/test-loader-utils/2.0.0-internal.3.0.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       concurrently: 6.3.0
       eslint: 8.6.0
@@ -7841,7 +7841,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/web-code-loader-previous': npm:@fluidframework/web-code-loader@2.0.0-internal.2.1.1
+      '@fluidframework/web-code-loader-previous': npm:@fluidframework/web-code-loader@2.0.0-internal.3.0.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/isomorphic-fetch': ^0.0.35
@@ -7862,7 +7862,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/web-code-loader-previous': /@fluidframework/web-code-loader/2.0.0-internal.2.1.1
+      '@fluidframework/web-code-loader-previous': /@fluidframework/web-code-loader/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/isomorphic-fetch': 0.0.35
@@ -7883,7 +7883,7 @@ importers:
       '@fluidframework/common-utils': ^1.0.0
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/container-runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.2.2.0
+      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.3.0.0
       '@fluidframework/container-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -7943,7 +7943,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.2.2.0
+      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -7972,7 +7972,7 @@ importers:
       '@fluidframework/build-tools': ^0.8.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.2.2.0
+      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.3.0.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -7997,7 +7997,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.2.2.0
+      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -8019,7 +8019,7 @@ importers:
       '@fluidframework/container-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.2.2.0
+      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.3.0.0
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -8068,7 +8068,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.2.2.0
+      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -8096,7 +8096,7 @@ importers:
       '@fluidframework/common-utils': ^1.0.0
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.2.2.0
+      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -8119,7 +8119,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
-      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.2.2.0
+      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.3.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -8138,7 +8138,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/garbage-collector-previous': npm:@fluidframework/garbage-collector@2.0.0-internal.2.2.0
+      '@fluidframework/garbage-collector-previous': npm:@fluidframework/garbage-collector@2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -8166,7 +8166,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/garbage-collector-previous': /@fluidframework/garbage-collector/2.0.0-internal.2.2.0
+      '@fluidframework/garbage-collector-previous': /@fluidframework/garbage-collector/2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -8195,7 +8195,7 @@ importers:
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.2.2.0
+      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.3.0.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       concurrently: ^6.2.0
@@ -8216,7 +8216,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.2.2.0
+      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       concurrently: 6.3.0
@@ -8243,7 +8243,7 @@ importers:
       '@fluidframework/protocol-base': ^0.1038.2000
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.2.2.0
+      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.3.0.0
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -8278,7 +8278,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.2.2.0
+      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -8314,7 +8314,7 @@ importers:
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.2.2.0
+      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.3.0.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/jsrsasign': ^8.0.8
@@ -8357,7 +8357,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.2.2.0
+      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/jsrsasign': 8.0.13
@@ -8559,7 +8559,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.2.2.0
+      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.3.0.0
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -8581,7 +8581,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.2.2.0
+      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -8825,7 +8825,7 @@ importers:
       '@fluidframework/routerlicious-driver': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/server-local-server': ^0.1038.2000
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-drivers-previous': npm:@fluidframework/test-drivers@2.0.0-internal.2.2.0
+      '@fluidframework/test-drivers-previous': npm:@fluidframework/test-drivers@2.0.0-internal.3.0.0
       '@fluidframework/test-pairwise-generator': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/tinylicious-driver': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -8871,7 +8871,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-drivers-previous': /@fluidframework/test-drivers/2.0.0-internal.2.2.0
+      '@fluidframework/test-drivers-previous': /@fluidframework/test-drivers/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -9118,7 +9118,7 @@ importers:
       '@fluidframework/common-utils': ^1.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-pairwise-generator-previous': npm:@fluidframework/test-pairwise-generator@2.0.0-internal.2.2.0
+      '@fluidframework/test-pairwise-generator-previous': npm:@fluidframework/test-pairwise-generator@2.0.0-internal.3.0.0
       '@rushstack/eslint-config': ^2.5.1
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.36
@@ -9139,7 +9139,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@fluidframework/test-pairwise-generator-previous': /@fluidframework/test-pairwise-generator/2.0.0-internal.2.2.0
+      '@fluidframework/test-pairwise-generator-previous': /@fluidframework/test-pairwise-generator/2.0.0-internal.3.0.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
       '@types/node': 14.18.36
@@ -9272,7 +9272,7 @@ importers:
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.2.2.0
+      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.3.0.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/debug': ^4.1.5
@@ -9327,7 +9327,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.2.2.0
+      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/debug': 4.1.7
@@ -9380,7 +9380,7 @@ importers:
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-drivers': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-version-utils-previous': npm:@fluidframework/test-version-utils@2.0.0-internal.2.2.0
+      '@fluidframework/test-version-utils-previous': npm:@fluidframework/test-version-utils@2.0.0-internal.3.0.0
       '@rushstack/eslint-config': ^2.5.1
       '@types/mocha': ^9.1.1
       '@types/nock': ^9.3.0
@@ -9438,7 +9438,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@fluidframework/test-version-utils-previous': /@fluidframework/test-version-utils/2.0.0-internal.2.2.0
+      '@fluidframework/test-version-utils-previous': /@fluidframework/test-version-utils/2.0.0-internal.3.0.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -9772,7 +9772,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.2.2.0
+      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -9807,7 +9807,7 @@ importers:
       '@fluid-tools/build-cli': 0.8.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.2.2.0
+      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.3.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -9914,7 +9914,7 @@ importers:
   packages/tools/webpack-fluid-loader:
     specifiers:
       '@fluid-tools/build-cli': ^0.8.0
-      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.2.2.0
+      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.3.0.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.8.0
       '@fluidframework/common-utils': ^1.0.0
@@ -9996,7 +9996,7 @@ importers:
       webpack-dev-server: 4.6.0_nsornugb7ycligvwdpxm6xbgzi
     devDependencies:
       '@fluid-tools/build-cli': 0.8.0_webpack-cli@4.10.0
-      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.2.2.0_nsornugb7ycligvwdpxm6xbgzi
+      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.3.0.0_nsornugb7ycligvwdpxm6xbgzi
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.8.0_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -10031,7 +10031,7 @@ importers:
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.2.2.0
+      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.3.0.0
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@rushstack/eslint-config': ^2.5.1
@@ -10061,7 +10061,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.2.2.0
+      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.0.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
       '@types/node': 14.18.36
@@ -10084,7 +10084,7 @@ importers:
       '@fluidframework/common-utils': ^1.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.2.2.0
+      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.3.0.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/debug': ^4.1.5
@@ -10117,7 +10117,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.2.2.0
+      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/debug': 4.1.7
@@ -10147,7 +10147,7 @@ importers:
       '@fluidframework/odsp-doclib-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.2000
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.2.2.0
+      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.3.0.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/debug': ^4.1.5
@@ -10182,7 +10182,7 @@ importers:
       '@fluidframework/build-tools': 0.8.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.2.2.0
+      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.3.0.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/debug': 4.1.7
@@ -12488,25 +12488,25 @@ packages:
   /@fluid-experimental/sequence-deprecated/2.0.0-internal.2.0.0:
     resolution: {integrity: sha512-l2UdVP3sZRlqm0FD0GRVF5VJGrFI2FgD9hYzCMRXCk1m6jaNmkNB0rtf8LboczoTu3NMad3IEz+bOKbLCHrr/Q==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/merge-tree': 2.0.0-internal.2.2.0
-      '@fluidframework/sequence': 2.0.0-internal.2.2.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/merge-tree': 2.0.0-internal.3.0.0
+      '@fluidframework/sequence': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/sequence-deprecated/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-UPzhbLJc/XcaXUvMEghaB/6RtJnr70bXFkeKQAaH5ZxF0mCrFzugSU2g9besVshJbWzT6od9Qu3J8Qd33rW9Qg==}
+  /@fluid-experimental/sequence-deprecated/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-Ssbf1s4urGs354mx6Kn33rCji7AbLfkrjkD364bDTv3JphuwClNIADemH4hCJwKyk7TJ+90muj1KBDi/5srwWw==}
     dependencies:
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/merge-tree': 2.0.0-internal.2.2.0
-      '@fluidframework/sequence': 2.0.0-internal.2.2.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/merge-tree': 2.0.0-internal.3.0.0
+      '@fluidframework/sequence': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -12624,14 +12624,14 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.2.1.1:
-    resolution: {integrity: sha512-ydY6VjoGdxEjJEgqI/Eg+BvaXUFkqOA4nQ0rk8wTHqobDskM8PFkJY/e1XRAjrIr/VC2O0n6I8QT7ryobhRw9A==}
+  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-MjhERKrorACUG6qdlCu9PC3ObrEOCQuSwL870dEf0t9xBDvMAezFxRyDd2UbTBWOdes/lMleoE+3pgA2I0FZmQ==}
     dependencies:
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.0.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -12659,30 +12659,30 @@ packages:
       - supports-color
     dev: true
 
-  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.2.2.0_nsornugb7ycligvwdpxm6xbgzi:
-    resolution: {integrity: sha512-8qXfA+nGBqZ+BAxTC10jpoBfhBPhM5uiirwmqU3t+iNWzH8/x1/q9gULem1OcZ/NGfETjCYG6GXSSw8/jb9KeA==}
+  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.3.0.0_nsornugb7ycligvwdpxm6xbgzi:
+    resolution: {integrity: sha512-L0BxacIPa1Zmd14Kdfq/KW3RIApApZF3kA9ITHOMTMG3NKjKRm0Xt3xL/6c9VeYlmdpu9nvDpWTainVRfrlvaA==}
     dependencies:
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/container-loader': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/local-driver': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/local-driver': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
       '@fluidframework/server-local-server': 0.1038.2000
       '@fluidframework/server-services-client': 0.1038.2000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/tool-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/view-adapters': 2.0.0-internal.2.2.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/web-code-loader': 2.0.0-internal.2.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/tool-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/view-adapters': 2.0.0-internal.3.0.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/web-code-loader': 2.0.0-internal.3.0.0
       axios: 0.26.1
       buffer: 6.0.3
       express: 4.18.2
@@ -12701,19 +12701,19 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/agent-scheduler/2.0.0-internal.2.1.1:
-    resolution: {integrity: sha512-m1t00P4fDpMB7e3zVdjBO0G+TQ2EKAHuiBgNR4+dGr+Sx7Vs2/uc6A5LBeIGtDVRaxqs8LbCfWTaCgQPhXeeGg==}
+  /@fluidframework/agent-scheduler/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-ho0sipdKODk6KS2mPjhqq521yaLoLE4YKL+YnAlnizQpLHCzLBToXAL1saxx/lgOtOi11xAG0wxo5S2uIEw0gQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/map': 2.0.0-internal.2.2.0
-      '@fluidframework/register-collection': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/map': 2.0.0-internal.3.0.0
+      '@fluidframework/register-collection': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -12744,25 +12744,69 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.2.2.0_debug@4.3.4:
-    resolution: {integrity: sha512-PAEnL928V5eJH3Z8A2GBMRe5OMQ4gYmlBxJvL5NBX7xKoyEmFPvfMQi8qfGYWQAQRKJN3+r+U+z2QUlQGHkHPA==}
+  /@fluidframework/aqueduct/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-1L60qAOrOLzkn0E7Ho4g8pvh3v4timLupptLq4VokfK4SJoKjW1bIrtWmG3wB9A/n0zMSDqj3vi5yYzi7lRZVA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/container-loader': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/container-runtime': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/map': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/request-handler': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/synthesize': 2.0.0-internal.2.2.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.3.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/map': 2.0.0-internal.3.0.0
+      '@fluidframework/request-handler': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/synthesize': 2.0.0-internal.3.0.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.3.0.0
       uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/aqueduct/2.0.0-internal.3.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-1L60qAOrOLzkn0E7Ho4g8pvh3v4timLupptLq4VokfK4SJoKjW1bIrtWmG3wB9A/n0zMSDqj3vi5yYzi7lRZVA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/container-runtime': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/map': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/synthesize': 2.0.0-internal.3.0.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.3.0.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/attributor/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-wa1pPDN1ItggsvsuL0rns24+x2t5jpAMQkSAawlbk9HRkdNYUzNK89tWNeym0OosB1p1NacnnwOSB3ag4qY63A==}
+    dependencies:
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.3.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
+      lz4js: 0.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -12885,16 +12929,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/cell/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-/UxOkxbM26bpZeqFNGZRDAD7p7foUH84yFC/ZUxLvzSUDVEA59Torefe9hjwWEBuny06qdI4eFkHX47A+zKtNQ==}
+  /@fluidframework/cell/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-3PvCUKL4X1ieBggKCbAYYppTewAUovFctJGqqVYDxYvh6loHj3v5UrrsPMRo0pXD2T5rhn+Mp9qtdyuR6HEmkQ==}
     dependencies:
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.2.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -12923,6 +12967,16 @@ packages:
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
+  /@fluidframework/container-definitions/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-QG4M1dNzop3WMxc9v5Dn6+zRyiUbqjeVMVlARq9DNpHaqSOrvKR3lW+zhgoxd9VptVR7onbiSMSDV63uIEHKfw==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/protocol-definitions': 1.1.0
+      events: 3.3.0
+    dev: true
+
   /@fluidframework/container-loader/2.0.0-internal.2.2.0:
     resolution: {integrity: sha512-rgIl4qBK0R86lvx3nVvPfgvw6onzORkGVbOimuzk9ePoX0Er7KKF3qAcVMfL7+LWwllHF2dFzyMRv7OtKfTxxQ==}
     dependencies:
@@ -12946,21 +13000,46 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-loader/2.0.0-internal.2.2.0_debug@4.3.4:
-    resolution: {integrity: sha512-rgIl4qBK0R86lvx3nVvPfgvw6onzORkGVbOimuzk9ePoX0Er7KKF3qAcVMfL7+LWwllHF2dFzyMRv7OtKfTxxQ==}
+  /@fluidframework/container-loader/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-RBP4yJHe9xjqK9dMHmlcH9ukbQyKpckvz49j/+O5VovroVzNLrH8l+TAuLtt3DsJBLLzBzv1/CIiNuZ7DVEBTw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/container-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-base': 0.1038.2000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       abort-controller: 3.0.0
       double-ended-queue: 2.1.0-0
+      events: 3.3.0
+      lodash: 4.17.21
+      url: 0.11.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/container-loader/2.0.0-internal.3.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-RBP4yJHe9xjqK9dMHmlcH9ukbQyKpckvz49j/+O5VovroVzNLrH8l+TAuLtt3DsJBLLzBzv1/CIiNuZ7DVEBTw==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/protocol-base': 0.1038.2000
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
+      abort-controller: 3.0.0
+      double-ended-queue: 2.1.0-0
+      events: 3.3.0
       lodash: 4.17.21
       url: 0.11.0
       uuid: 8.3.2
@@ -12979,6 +13058,17 @@ packages:
       '@fluidframework/protocol-definitions': 1.1.0
       '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
       '@types/node': 14.18.36
+    dev: true
+
+  /@fluidframework/container-runtime-definitions/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-tKnQqHdhBXmMCrmFx53B6VQ9QBJUxYx6WbsJGtxSFylNS/YNLtN4/WPr/MvmHgzqSEYu3fL5IHHk9R3kldwrLw==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
     dev: true
 
   /@fluidframework/container-runtime/2.0.0-internal.2.2.0:
@@ -13007,25 +13097,53 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.2.2.0_debug@4.3.4:
-    resolution: {integrity: sha512-5g3ZwBf2K/D95DXx+kfOKg1gCWYp5aIDtiqg7F4+JJFsdt2Vit42D35WBJBPyZ/P8eHy1fYA/Jm/zAJ7nwZXYQ==}
+  /@fluidframework/container-runtime/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-VgItZM0zbmT6gvN102zuOKjaTwCeJZIiE3ReXZh4CzB3YklsVvZ8Md5Caq9hnEBLmTwdXOat72flKQW+EZV/BQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/container-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/garbage-collector': 2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-base': 0.1038.2000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       double-ended-queue: 2.1.0-0
+      events: 3.3.0
+      lz4js: 0.2.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/container-runtime/2.0.0-internal.3.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-VgItZM0zbmT6gvN102zuOKjaTwCeJZIiE3ReXZh4CzB3YklsVvZ8Md5Caq9hnEBLmTwdXOat72flKQW+EZV/BQ==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.0.0
+      '@fluidframework/protocol-base': 0.1038.2000
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
+      double-ended-queue: 2.1.0-0
+      events: 3.3.0
       lz4js: 0.2.0
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -13045,39 +13163,55 @@ packages:
       - supports-color
     dev: true
 
+  /@fluidframework/container-utils/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-qKBvbotMTAZ2bZLUqATbyQyE+fpL2MsX51DEQNW8PF0g+fZixbch/gMakCcz76H0/FLfxCW35F2cQZ0ABytREw==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@fluidframework/core-interfaces/2.0.0-internal.2.2.0:
     resolution: {integrity: sha512-B7JNJWkR/0y6CJn90Kk8vTMmZDRKR81OEd82a3CUuYbfAJBsVcMeTPFdh9obrLiH7FS9/f1MxQHFXy7zLOAOWw==}
     dev: true
 
-  /@fluidframework/counter/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-jUIWY63RZvMrP+o3HcjBtovbji2HTo3W8M8lPD13taoI6XBmzo619mG7PLmGtCMl7eQ6+hJ++nOvenP4uGWOKQ==}
+  /@fluidframework/core-interfaces/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-WuV3EeKNLjVKoF+X09hj9NC7y9Z2V+l7KU9ojO1oRABkatL/XvtkS8ArX9CCOU0zHg7By28hGP7eZXhVyngf8Q==}
+    dev: true
+
+  /@fluidframework/counter/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-/iLnTo5fYsiMBxIE/gORUPNTzo9G1+K+BNOe2ieQj09YY8Ft/iuO2rLLDCkFDu6B8IY3eVvQo/yzehXiQcJWdw==}
     dependencies:
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.2.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/data-object-base/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-n2xAF0KBFxk0B+4WNDO3JYwsXS94fVL7KUkkgAzLU7I1rGTkzJ+HhlVO0r4nkKItKH5ZPmmD2CcFPxzoPSytYA==}
+  /@fluidframework/data-object-base/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-neFuWndhzffx8zr8J/kiuNWzpHXF4//MhR6R1X7SM884VHoGNF6Ys/KKcTlzyLEdNn25VQau071/WZm7fdkF0A==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/container-runtime': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/request-handler': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/request-handler': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13093,6 +13227,17 @@ packages:
       '@fluidframework/protocol-definitions': 1.1.0
       '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
       '@types/node': 14.18.36
+    dev: true
+
+  /@fluidframework/datastore-definitions/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-LTAYWtLqf/MXwLYmkM7dhwfAq7FHnRl4A1eghP63+rFFZOhoth26UXP8FTsm4tZUXmGPb0pfE9FdKvi7KvvwVA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
     dev: true
 
   /@fluidframework/datastore/2.0.0-internal.2.2.0:
@@ -13119,23 +13264,23 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.2.2.0_debug@4.3.4:
-    resolution: {integrity: sha512-cbQHCNWoTNVDOOZX5Oq9pni0KgYSN5zAnGoYr5YTON3D+tGKPTIShp75UHyIzsWWFEYZrg/ybvqCMRAfPuoeoQ==}
+  /@fluidframework/datastore/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-OIwHzbylP5kg0Wp57m3JwKsvj7kmg2tcTPm6zS6+AFYeHxZNVXARZOHxTfDx/KQY1BkBidqtHIP8dYs7JESF2Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/container-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/garbage-collector': 2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-base': 0.1038.2000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       lodash: 4.17.21
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -13143,56 +13288,80 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/dds-interceptions/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-IFIvT/5P8Y6TYm3KbLhNiyCwjIJEMp53QfB7fobchmblHor7/rqoXhAI5BPwwld3+q33BcSBK/bx/x6T3uQXvw==}
+  /@fluidframework/datastore/2.0.0-internal.3.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-OIwHzbylP5kg0Wp57m3JwKsvj7kmg2tcTPm6zS6+AFYeHxZNVXARZOHxTfDx/KQY1BkBidqtHIP8dYs7JESF2Q==}
     dependencies:
+      '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/map': 2.0.0-internal.2.2.0
-      '@fluidframework/merge-tree': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/sequence': 2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.0.0
+      '@fluidframework/protocol-base': 0.1038.2000
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
+      lodash: 4.17.21
+      uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/debugger/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-YsTjwLMJnSh9q4QbtIUEOsoRV2Heq1ePQUsrKEnu+wR9HGP5r/pSb1sWrirwMsYeSdHjLdBYMhq67WiCF2IKpQ==}
+  /@fluidframework/dds-interceptions/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-HjZ5wQs3OLln3fhCTSQYatGIPIRPCPvEh6yMkv+9ej9ESKirz1pzfd5uX+i4Om6pR1W2UZtGZnpLfKd7U9OpPw==}
     dependencies:
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/map': 2.0.0-internal.3.0.0
+      '@fluidframework/merge-tree': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/sequence': 2.0.0-internal.3.0.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/debugger/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-LRSzjdGWynnb0ec7LMp47y+JthzyKByig2HrJVCfTxaBidW9MMi8b5N1PJZdCqyesyfywfQ+IGyzfm24C7BW3Q==}
+    dependencies:
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/replay-driver': 2.0.0-internal.2.2.0
+      '@fluidframework/replay-driver': 2.0.0-internal.3.0.0
       jsonschema: 1.4.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-3bFBZGjtF0saMia4EeLzjpbT3MURCwyLpDN72Bc6DeelmcRXsr+kOriwk/9PV6AyO7Yjyk7y5fCTTQJSjFO3/w==}
+  /@fluidframework/driver-base/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-IVALkemyc9/sy/WkzqGmwLpCE0fJp+M3Fr5haslh4W+rlF4O3hSyzgNm5hDLKV+ZEDqRnBAzRFTcGR74umX2KQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.2.2.0_debug@4.3.4:
-    resolution: {integrity: sha512-3bFBZGjtF0saMia4EeLzjpbT3MURCwyLpDN72Bc6DeelmcRXsr+kOriwk/9PV6AyO7Yjyk7y5fCTTQJSjFO3/w==}
+  /@fluidframework/driver-base/2.0.0-internal.3.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-IVALkemyc9/sy/WkzqGmwLpCE0fJp+M3Fr5haslh4W+rlF4O3hSyzgNm5hDLKV+ZEDqRnBAzRFTcGR74umX2KQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13203,6 +13372,14 @@ packages:
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
+      '@fluidframework/protocol-definitions': 1.1.0
+    dev: true
+
+  /@fluidframework/driver-definitions/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-TXgFzgADjtpu6iQSBVAdFGcYJ4LNoW995Qfphjqb60rO5Zzk9d5E4UzX9Wedvu5Cra6hRm7ddv+9esbJ2fhp0A==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
@@ -13225,17 +13402,36 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.2.2.0_debug@4.3.4:
-    resolution: {integrity: sha512-x0cIgwWETVttS5BxEYWBRsV6JiFWRnOzuWsBAtuFrhkRZO04d4hobEc/UWgJgcZaBrtqY7ba4fMmAwU5cWPFSA==}
+  /@fluidframework/driver-utils/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-PrDMHppC6a/IgQ2IrP0Xl1IgH+vHBiIKvhRPpkyFsNtT05ReAsXQC4qhr3cE/GhX3xso+qsGOkPBw7I9Fd2FtA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
       '@fluidframework/gitresources': 0.1038.2000
       '@fluidframework/protocol-base': 0.1038.2000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
+      axios: 0.26.1
+      url: 0.11.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/driver-utils/2.0.0-internal.3.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-PrDMHppC6a/IgQ2IrP0Xl1IgH+vHBiIKvhRPpkyFsNtT05ReAsXQC4qhr3cE/GhX3xso+qsGOkPBw7I9Fd2FtA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/gitresources': 0.1038.2000
+      '@fluidframework/protocol-base': 0.1038.2000
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       axios: 0.26.1_debug@4.3.4
       url: 0.11.0
       uuid: 8.3.2
@@ -13244,12 +13440,12 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-web-cache/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-IfzcYzofia5RBI/PqO8orO9TPA7hYY5NIT+izKE9ZV6BQQnh9Y19LaLxpAAZAiOVllpv/iUd8tLUirahsdl5Fw==}
+  /@fluidframework/driver-web-cache/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-LnbGT3f9NpVHd5LcaVzDg+yj9DkVxne2uMlooQZm/4HvisJnCEEzruSHP5br5JysztoGljKt/tMP0tHAK153qw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -13281,33 +13477,33 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/file-driver/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-nNy7veICX/9RRZPK7wiiotTNEK1KhcVQ+d5cDjplRfOMvEMuDRMnx783Br5mc4O9YLlrbP3YAO+0lI2fd0vrdQ==}
+  /@fluidframework/file-driver/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-vOqyv7T/4bclA/Zp6pEgRK4n9PcjfrtRVIcyt/W3Qo9a7EEx5iic8EjbzGoXB7xRPYgZfgHMnL+qnahzC+bEPg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/replay-driver': 2.0.0-internal.2.2.0
+      '@fluidframework/replay-driver': 2.0.0-internal.3.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/fluid-runner/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-Bdunrbr+dyjJzcjrxCXwjo/rDfaUI8j45VhT9N41QKL+vhOF0C5Ri9WQKwJX2Qr5YWBJwfCHYNj8AnuTJyhv+g==}
+  /@fluidframework/fluid-runner/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-TDkFR/N1QpD5OBpPHbg5v3b9+UNeSECjp5kDw0gB4fco0SnjYVFkks4XmZWS4M/P8saZB29L84zqbMSHU6q8bQ==}
     hasBin: true
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.2.2.0
+      '@fluidframework/aqueduct': 2.0.0-internal.3.0.0
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/container-loader': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       json2csv: 5.0.7
       yargs: 13.2.2
     transitivePeerDependencies:
@@ -13338,6 +13534,26 @@ packages:
       - supports-color
     dev: true
 
+  /@fluidframework/fluid-static/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-HP9YGv4X+vd7e6dNn9TtX1Q1GSfD0hyXpS2yrIwm7ez/psUHa9j3UOOXGrkm9MQ35msp129wJ6pGZZOHVwloIQ==}
+    dependencies:
+      '@fluidframework/aqueduct': 2.0.0-internal.3.0.0
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/request-handler': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
   /@fluidframework/garbage-collector/2.0.0-internal.2.2.0:
     resolution: {integrity: sha512-6ZHbBEIbljtMqAjnP/R3MP7MyrPfyWut2q84mKeX8XymXHQoq3S8ApHUyso3NEBTfTxn1hkXvqLq86eumCwqxw==}
     dependencies:
@@ -13346,42 +13562,52 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
     dev: true
 
+  /@fluidframework/garbage-collector/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-ut7kJm/VCsZswI0c5BVGyBXcLLO3o8gDnfe/cIja0EIiz4niBtP7M2EQ5O5uG+5l8+xwWvEEOOJBEhmqXVUsyA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+    dev: true
+
   /@fluidframework/gitresources/0.1038.2000:
     resolution: {integrity: sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w==}
 
-  /@fluidframework/ink/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-E+1pBFwK2H+w61wENQG+GyvX9ud/AcsU7wFFvYiJcGSxr9HizEwD03CSK2lhOjyklMc+WG5xNkpMDEOe5PoAtg==}
+  /@fluidframework/ink/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-RAGPYk6jc4/qHAT6VaFT2snW9PXC6449jlmmdd5ZXuHURBB7e6giinM0CfsYnJwt1YucU6J26qi4YMYuqf/7Sg==}
     dependencies:
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.2.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-Y72ZLmFtRxsraymJWhedtE6iJ9lsH02PcsrsqpQcqEYD9I4o3mdVCaJFCGNpgKjYgc3ljPjou4IXHYqTsiJ2NA==}
+  /@fluidframework/local-driver/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-0n9twrel34UX8VwzUwJSqDkawSOpYwO+MS9QEoe+7eUxb57uxB0AS/ctGYIKTNGTGrHHTH1VWKQs8EIgQopz2g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-base': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-base': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-base': 0.1038.2000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.2.2.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.0.0
       '@fluidframework/server-local-server': 0.1038.2000
       '@fluidframework/server-services-client': 0.1038.2000
       '@fluidframework/server-services-core': 0.1038.2000
       '@fluidframework/server-test-utils': 0.1038.2000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
+      events: 3.3.0
       jsrsasign: 10.6.1
       url: 0.11.0
       uuid: 8.3.2
@@ -13393,23 +13619,24 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.2.2.0_debug@4.3.4:
-    resolution: {integrity: sha512-Y72ZLmFtRxsraymJWhedtE6iJ9lsH02PcsrsqpQcqEYD9I4o3mdVCaJFCGNpgKjYgc3ljPjou4IXHYqTsiJ2NA==}
+  /@fluidframework/local-driver/2.0.0-internal.3.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-0n9twrel34UX8VwzUwJSqDkawSOpYwO+MS9QEoe+7eUxb57uxB0AS/ctGYIKTNGTGrHHTH1VWKQs8EIgQopz2g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-base': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0_debug@4.3.4
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-base': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0_debug@4.3.4
       '@fluidframework/protocol-base': 0.1038.2000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.2.2.0_debug@4.3.4
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.0.0_debug@4.3.4
       '@fluidframework/server-local-server': 0.1038.2000
       '@fluidframework/server-services-client': 0.1038.2000
       '@fluidframework/server-services-core': 0.1038.2000
       '@fluidframework/server-test-utils': 0.1038.2000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
+      events: 3.3.0
       jsrsasign: 10.6.1
       url: 0.11.0
       uuid: 8.3.2
@@ -13421,13 +13648,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/location-redirection-utils/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-r+/yKBAzOJwOXGfngB/jw8wap/W2TmelCTB88xAiCigasYbDR+alf7ByhlcD6Xn4mhpaV71IIUYqk91r6t8B8g==}
+  /@fluidframework/location-redirection-utils/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-1cX+dmULnnJf9iVg5O97rphIX2/075a5Rqe8yo2rmqJM2QmZbalYmCKfcpNaZdtQFitilr0Sea6+ky99ZowIUQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13451,40 +13678,60 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/map/2.0.0-internal.2.2.0_debug@4.3.4:
-    resolution: {integrity: sha512-27wFQeJUwwubgUyZMj555q+0LgeNqTI72y8zd5B+RJTBAMDGENY2ZK/vjZkTFBIHFrEpvHFmF+ZmzN6W0P35mQ==}
+  /@fluidframework/map/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-CmUUZCmsC68BwoCv5pMmqSRgQHurCObalqo/h3LPVukNXvb+VaLWLY9wAvTMlRS9TuqHFghkXsH6Y94BCzGIkw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0_debug@4.3.4
+      '@fluidframework/container-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.2.2.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/matrix/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-dLeh+0Q1SL9c7dwbNTOyfgxsOVB7GdL3dReLqf3Md6eiT1wwMu7wAOgIq7gfc49P3GHRLjMlGseIV3ccrxezBQ==}
+  /@fluidframework/map/2.0.0-internal.3.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-CmUUZCmsC68BwoCv5pMmqSRgQHurCObalqo/h3LPVukNXvb+VaLWLY9wAvTMlRS9TuqHFghkXsH6Y94BCzGIkw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/merge-tree': 2.0.0-internal.2.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0_debug@4.3.4
+      path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/matrix/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-b+NFqqzdWb6GEBNtMi8pfE/F7ZKygaV0kIQrAbhoSUp5NRgje0cb9LX1B1dhBdPhRo+3dfq3imJXrn0iICbxWA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/merge-tree': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-base': 0.1038.2000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.2.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       '@tiny-calc/nano': 0.0.0-alpha.5
+      events: 3.3.0
       tslib: 1.14.1
     transitivePeerDependencies:
       - debug
@@ -13510,23 +13757,42 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/mocha-test-setup/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-OOZf8cdm3R29cFoBSKWsuQ+/PJpKUxuVzHaeS/Xqkf9HxCOr9Y7XDg5/jVoVLdPcHdNhTwKykSpMOFSCfhTfFQ==}
+  /@fluidframework/merge-tree/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-UXEIClsn+9VYAF7Rbd6AduAv+3TWKoZtRJFGA70ro/ZifvFx9ciQAgDnKfgEhddbjabgqAkeqI9VcWexobCACA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.2.2.0
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/mocha-test-setup/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-OzOLiGZ5xIxYapJ9NCICpGlH6muvst6IywR6lW8nBIN16TxVebWuNMNltDhFeZ0DMN3UPohWLigLKjlllJ9KkQ==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.0.0
       mocha: 10.2.0
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-94eIjEythnG8/OI9PIMaA2Jd3VyUa6m2TOW+KwtHENVqBTa4/ZEDpWkVc39rRv1VKU4GEvx4V1+lRjhzN17j5Q==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-xUc4xrnwrDNY8t4BLK0l6ZRhIxRC+m2yqQG37MKtvRE79h1Q2+Xt+sG5VtD/G3TZ33ZP6SY31+4T151grWfEew==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       node-fetch: 2.6.7
     transitivePeerDependencies:
       - debug
@@ -13534,15 +13800,15 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.2.2.0_debug@4.3.4:
-    resolution: {integrity: sha512-94eIjEythnG8/OI9PIMaA2Jd3VyUa6m2TOW+KwtHENVqBTa4/ZEDpWkVc39rRv1VKU4GEvx4V1+lRjhzN17j5Q==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-xUc4xrnwrDNY8t4BLK0l6ZRhIxRC+m2yqQG37MKtvRE79h1Q2+Xt+sG5VtD/G3TZ33ZP6SY31+4T151grWfEew==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       node-fetch: 2.6.7
     transitivePeerDependencies:
       - debug
@@ -13550,27 +13816,27 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-driver-definitions/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-8O683idVdX+0FCDXuwdoAF50TGKr/SgEgngHjcWOfkSLlXBx8OkbPfypBJ+lsYSE6aVvOjzVxNN6Od72KnCDrQ==}
+  /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-ggjQBOjwEQD2GSCkpj48az32zecYACeo1hYdYPQ0Uh6wXP36zBV1YlgYnlZWXXq2CuLV51Ks+HxKmSFRYawFmA==}
     dependencies:
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
     dev: true
 
-  /@fluidframework/odsp-driver/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-zYqiXUcxQYGlobKLPNS2WdpSrK/1PB/cimitqWQ9yh66dY/p0z2qG2xdKfm2FWNew7k9pnJbCkZzxqR3NQ5G/w==}
+  /@fluidframework/odsp-driver/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-awbLN3E1j4zwSmL7E8S+ECaZRNIFiGJ7elLTnjx645tBy5JI4drVnFygtuGoaXCCwQ+bwhbQd6Ml1FDQAduxbg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-base': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-base': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/gitresources': 0.1038.2000
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.2.2.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-base': 0.1038.2000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       abort-controller: 3.0.0
       node-fetch: 2.6.7
       socket.io-client: 4.5.4
@@ -13583,13 +13849,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/odsp-urlresolver/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-FBaxclM18yqbPjhXuozqsQCkf6OvPySfxw2tEUDnLS0xxuOHv/g/HiCiDdVVbCosytFVRKTrNIbJGY9HGSFBHg==}
+  /@fluidframework/odsp-urlresolver/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-g1Zi0cIH2S0Z/nPQIKCtLWLlFMSUoGN4dfT327iSbV1xj19nBMaqGXy3Dc/dGOblbKDmSPkuSvj2icVkeNbkfg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.0.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -13598,16 +13864,16 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/ordered-collection/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-uVwA9R3Zrp1BHU4QKDF91eKYeAq7HpKE7BSGdbAzpdibHknCx6fad5TKW9rgB5/CYRXiTpR77X07cY59KG7GFg==}
+  /@fluidframework/ordered-collection/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-I8X4wVv1yJYROla2RKVpWUVvWFBwiTBXT/Aku6fwqpco8ZsJm+r4N5h9aeixbEhqvoKiFQpBWjlfRJzQbRr5ww==}
     dependencies:
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.2.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -13627,30 +13893,30 @@ packages:
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
 
-  /@fluidframework/register-collection/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-8gBxZCeO0T+X9Jd9FBIjyvbb38a29jialMewljjp1HmvYY9mq0hczkOsqdDGkX7mEXJjKFh0t3FNL8aXD1SOkA==}
+  /@fluidframework/register-collection/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-vpIG/WQOz5V4mllVT/GwYLUpvBjDQVs1U00KKE2dc/AN5lVN1ckfTAZWtpSKHstRbpKxnOkD6aNJj741m7vyjg==}
     dependencies:
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-base': 0.1038.2000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.2.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/replay-driver/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-9PoxCnCuVvwuB1MI+GP+0bDfBNpdW4Hc/8Q4QDVYLvKsMtzd03W4TmmGJkglzjGj/MgR6WlU2jRATECnqXbc3g==}
+  /@fluidframework/replay-driver/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-5O65gs0pjzFJ7rZBXz2gzLaBRXjSWeQNZDr9a0qIyiVwPkTtel0coxI+AB1SGgRcH/wOcxxlyqu3fdJdrUODwQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13668,19 +13934,31 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-cAHwV48LFAsONXy+8+CD1wMgM7O0qd24DRBclqOleQzmB7f1lojhcxgSAloeI0busMegb0X3bJ71/jZ5U28JCg==}
+  /@fluidframework/request-handler/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-LzIqECFuKItGh7po5zKw1m4XBs6+BktC2+DsfzdpBwxVDZAPK14eBudwhZqIyKzhWo7NalNXngcmbiZMeXL4Jw==}
+    dependencies:
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/routerlicious-driver/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-9LWlZUXqdVoaPyQRZXp8kHu5Bz52EKAsXpdK5tX5JvUXTK7afACoTAEfNxoKHtvk/or9okg84Ol9nLHp2naVGg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/driver-base': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/driver-base': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/gitresources': 0.1038.2000
       '@fluidframework/protocol-base': 0.1038.2000
       '@fluidframework/protocol-definitions': 1.1.0
       '@fluidframework/server-services-client': 0.1038.2000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       cross-fetch: 3.1.5
       json-stringify-safe: 5.0.1
       querystring: 0.2.0
@@ -13695,19 +13973,19 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.2.2.0_debug@4.3.4:
-    resolution: {integrity: sha512-cAHwV48LFAsONXy+8+CD1wMgM7O0qd24DRBclqOleQzmB7f1lojhcxgSAloeI0busMegb0X3bJ71/jZ5U28JCg==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.3.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-9LWlZUXqdVoaPyQRZXp8kHu5Bz52EKAsXpdK5tX5JvUXTK7afACoTAEfNxoKHtvk/or9okg84Ol9nLHp2naVGg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/driver-base': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0_debug@4.3.4
+      '@fluidframework/driver-base': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0_debug@4.3.4
       '@fluidframework/gitresources': 0.1038.2000
       '@fluidframework/protocol-base': 0.1038.2000
       '@fluidframework/protocol-definitions': 1.1.0
       '@fluidframework/server-services-client': 0.1038.2000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       cross-fetch: 3.1.5
       json-stringify-safe: 5.0.1
       querystring: 0.2.0
@@ -13722,12 +14000,12 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-kI7YPiyGNcBdWi4U00Xr4/hGVV4eystNxsXO0oDHknksukadSzzbDtPlyWQUgR8vRr2SkvuwgTwlHSi38thqPQ==}
+  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-MAIVaNPtx1luAy2ie5QRC63fOuSekUAvOaFxpjJikPWmSJaNeClZsGYK6kB1whgi8TY2PXFws5kTxH+ESI4m4Q==}
     dependencies:
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
       nconf: 0.12.0
       url: 0.11.0
@@ -13743,6 +14021,17 @@ packages:
       '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
       '@fluidframework/protocol-definitions': 1.1.0
       '@types/node': 14.18.36
+    dev: true
+
+  /@fluidframework/runtime-definitions/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-ATZdgKDf4UuXKZwpE+bXAkvYvQkPQQzeGcBrVKRnkg6zKaQIOzQx0aP2+WycEPz07aTfewo321MX1HzTLrxfdw==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
   /@fluidframework/runtime-utils/2.0.0-internal.2.2.0:
@@ -13763,6 +14052,24 @@ packages:
       - supports-color
     dev: true
 
+  /@fluidframework/runtime-utils/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-ygijs7mVbKDC2wpl3DDkq9bdXRjlMLgVoiIMnKTc5MKwtum3gw7bMmy+VoCCIzjKUjtsWKXt2ZvlkVeH2E8QoA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.0.0
+      '@fluidframework/protocol-base': 0.1038.2000
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@fluidframework/sequence/2.0.0-internal.2.2.0:
     resolution: {integrity: sha512-KZASJO8bo6Ksz9enDc+Jl0RkN2wfxV8vEO0j0Zw53VGzskhDV4ZiwOw4t3WUS2QYV3FNLGHttWZWKy3AESEZyw==}
     dependencies:
@@ -13777,6 +14084,27 @@ packages:
       '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
       '@fluidframework/shared-object-base': 2.0.0-internal.2.2.0
       '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/sequence/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-QGrwdaS4ub0fp7A25Px9F8VdqR8G3oqRPgpmpENnWI5RxDtlGZ3pXbELSjkER6NgaCnnTS1n681SuZKro3n6gQ==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/merge-tree': 2.0.0-internal.3.0.0
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -14025,37 +14353,58 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/shared-object-base/2.0.0-internal.2.2.0_debug@4.3.4:
-    resolution: {integrity: sha512-oZ5S8ZpPHoM0Au0alaXxTD+pqf6MnopDIlQ1ER2dA+MfvGtR3/Rg1jdyOn/dmpx83lXdKA942uQv0zzND0hX7A==}
+  /@fluidframework/shared-object-base/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-oVcw1hJfHH8KLJfiFyFgZeEv18vAoBKLcFoN23KCGTKaIL82Wh5QWeTNax/Aq0AUH7v23/9SUjbNz1CzL15XMA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/container-runtime': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/container-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.3.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-summary-block/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-Tw2nhgazY/M+Y4dmLffffi+GKgWvMbX66yLnI1HYOsHZGXcGGZKORBi1VWQOz5P8cIuX8k8e5bJ05rAU8G239A==}
+  /@fluidframework/shared-object-base/2.0.0-internal.3.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-oVcw1hJfHH8KLJfiFyFgZeEv18vAoBKLcFoN23KCGTKaIL82Wh5QWeTNax/Aq0AUH7v23/9SUjbNz1CzL15XMA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.0.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/container-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/shared-summary-block/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-i8r28ofR0TDZQ9LXZbjzRjqtCY2MEfcL+ZjYblD2/MsUSCtw67Swza7dZkAL9LJ+ZooWok9Lx5hiUXOIIG1Wtg==}
     dependencies:
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.2.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -14065,19 +14414,24 @@ packages:
     resolution: {integrity: sha512-Z1PdSOr9PrpcU8tCG+INGzS5RFMoe9sO+IrGgACJ1tFDpja29gs3su9JfIWcgnDIAtL2lbP/i8ezxBGDbJZPxQ==}
     dev: true
 
-  /@fluidframework/task-manager/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-/Drvtblg00+OH7y8hyFeQKu76UYBG1/07Yf+b7R/hiESplSk/0XIQ2kRxK/vXyelwFUT7PUowgPI3ytLCHFLrQ==}
+  /@fluidframework/synthesize/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-YXjv2ra75ZsKOr9833BkdoYUHcZ0S/JTPz8195oFIQWcZmYAVW+oep3a38iLGpS9DOKx5JEyUs85QM3v34FYqg==}
+    dev: true
+
+  /@fluidframework/task-manager/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-pIisKggfDTgfs2cSlVSCrx2jaJSaiHoUITXMUgXKpxG3HdBnrRmWwiPumejZEvwUFcvcHwowjvCBhK4Iuv3hfA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.2.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.0.0
+      events: 3.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -14095,12 +14449,25 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/test-client-utils/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-oxotV13eQhNUpZ4iz9UHESjBJYB/Ca7Y4796IC3kCaX49LMjgEMQXiM8sbnOgDt8RkUHE2ZeDTO+QLshPO5myw==}
+  /@fluidframework/telemetry-utils/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-cYCw+A8x92NOPCQHiOUfIHHxToTLsqCKW4RWvLV7m6hGnH/Q3cwmgQcPESpPGZrdQSCW0HNHf2CjxSmN7rqKQQ==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.0.0
+      debug: 4.3.4
+      events: 3.3.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/test-client-utils/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-+3IvBTwbkj3ZClmwpWwSsz2onpWZ3yI2NMzQFLm3O+rrb9NoqFJDopFxxHamjTCD3Q3p7pED3fdIaGqcwBFjBg==}
     dependencies:
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.0.0
       sillyname: 0.1.0
+      uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -14119,36 +14486,36 @@ packages:
       uuid: 8.3.2
     dev: true
 
-  /@fluidframework/test-driver-definitions/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-GmMSQnzCyie9RGWNX/sBn1jXvxgEmJNtJUaxy9MglW6wBFfuHwFwpn9hP7VGn2V24H2fk5Fo33rYJtsa9t9yNw==}
+  /@fluidframework/test-driver-definitions/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-WD97fyn+tnOeFoe/fV2VWkbc2/drxfz4rbBzszUKyDhbgkSLjaQADoNNvzw3u/wZ41SgXkDn7jUQv1RMRgR/vA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
       uuid: 8.3.2
     dev: true
 
-  /@fluidframework/test-drivers/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-8ISe9b8iwcwJVrDZrEsWa/C/0tbNeSozIz2nHuYelFNhDEJMGVCBqxrHT+OL5YODf+ZVKcSAdZY1afiHZJbgAg==}
+  /@fluidframework/test-drivers/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-1k+tjib7A+ZD9UHoih4lrQZLIoHG/JlB2NPcB7ws9vicQSqLuGLxORds+ldCPZ+COxnJRFWNQTPveZ3YO0ki3g==}
     dependencies:
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/local-driver': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/odsp-urlresolver': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/local-driver': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/odsp-urlresolver': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.2.2.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.0.0
       '@fluidframework/server-local-server': 0.1038.2000
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/test-pairwise-generator': 2.0.0-internal.2.2.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/tinylicious-driver': 2.0.0-internal.2.2.0
-      '@fluidframework/tool-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/test-pairwise-generator': 2.0.0-internal.3.0.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/tinylicious-driver': 2.0.0-internal.3.0.0
+      '@fluidframework/tool-utils': 2.0.0-internal.3.0.0
       axios: 0.26.1
       semver: 7.3.8
       uuid: 8.3.2
@@ -14160,42 +14527,43 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-loader-utils/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-MhkIO3fm3EKqlNFiEufRPL5weKnFApnnRRxg23EiddYo1OhAtqqGccf3pTghEQT8EhmscgJmnNMPo1KQb6xW0g==}
+  /@fluidframework/test-loader-utils/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-1OPRj/HrkUPC3l8N3xwf2HnTWV7QyEmhaaZkahQttZFlWSin2qlR4yVhBXlhiNYXfdyfXiTiD91lA7owNM1qtQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/test-pairwise-generator/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-z+h0VM12B5HESqdr4jfAS7qxzmCUuueoUnH56yztHT+cbgbQrIunN2tTWpog+PCGVx5vMwd7fAo9UNoZDYI/+w==}
+  /@fluidframework/test-pairwise-generator/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-Tpnc2nbTzQyj9LzWprQgbqY0yC9sijvHt5YkvMrlnBQADpxYQ4tM0pXg9izyJwSibHK+TKxym/6OrOm1Bl2XiQ==}
     dependencies:
       '@fluidframework/common-utils': 1.0.0
       random-js: 1.0.8
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-nBBuFCLqM6RKylZj1aeEl4XhhwuXTj1PXgfMZJfhHV5pPJ434W6KDFtq2OwXagwLLOsuDfDjBlyppy6P5ByKKg==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-EdDyv13YXAB7krOdPB1xv/dH9cQy3r6QiqTWxK8Ed6Yy6LZjk3f93ff1k4mw6LSGCjBw5Ncw1r6Vft/NWVnyDQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       axios: 0.26.1
+      events: 3.3.0
       jsrsasign: 10.6.1
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -14206,22 +14574,23 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.2.2.0_debug@4.3.4:
-    resolution: {integrity: sha512-nBBuFCLqM6RKylZj1aeEl4XhhwuXTj1PXgfMZJfhHV5pPJ434W6KDFtq2OwXagwLLOsuDfDjBlyppy6P5ByKKg==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.3.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-EdDyv13YXAB7krOdPB1xv/dH9cQy3r6QiqTWxK8Ed6Yy6LZjk3f93ff1k4mw6LSGCjBw5Ncw1r6Vft/NWVnyDQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
       axios: 0.26.1_debug@4.3.4
+      events: 3.3.0
       jsrsasign: 10.6.1
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -14237,31 +14606,32 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/test-utils/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-3y0WtePiPqQKGIO1VYfQi8jMyhdH92RG5xUPqpYWtAi8pj3456CuVXAOGY7vxEW/unkLCmF/1BIPFk0fA2jLNw==}
+  /@fluidframework/test-utils/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-31q4d8LBRoc2R0xSiOgDwSmvdZ6gMs2CysrzZqCB7+/5EP5lwyIhYghQIX1WpjkF7iHjHWzvRADwMgwiu/g5PA==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.2.2.0_debug@4.3.4
+      '@fluidframework/aqueduct': 2.0.0-internal.3.0.0_debug@4.3.4
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/container-loader': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/container-runtime': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/local-driver': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/map': 2.0.0-internal.2.2.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/container-runtime': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/local-driver': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/map': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/mocha-test-setup': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.2.2.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.2.2.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.2.2.0_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.3.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.0.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.0.0_debug@4.3.4
       best-random: 1.0.3
       debug: 4.3.4
       uuid: 8.3.2
@@ -14272,33 +14642,34 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-version-utils/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-pc6+OdalaX+qmLcTtf+QfZxmqln8xG5yjAsb8goWDnOFk1dsxEtxx9E8m6jj8mmFNa+/vUAQHsNtJJUYOWtd3Q==}
+  /@fluidframework/test-version-utils/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-TNQPRrLIDWGknVJ+ZWUp63e79nUW5RKuIePT+PQidsBDpUGtBmQ1/I1NmhjQ2cwQx7riqGHu0ecA29u2FcSMMg==}
     dependencies:
-      '@fluid-experimental/sequence-deprecated': 2.0.0-internal.2.2.0
-      '@fluidframework/aqueduct': 2.0.0-internal.2.2.0
-      '@fluidframework/cell': 2.0.0-internal.2.2.0
+      '@fluid-experimental/sequence-deprecated': 2.0.0-internal.3.0.0
+      '@fluidframework/aqueduct': 2.0.0-internal.3.0.0
+      '@fluidframework/attributor': 2.0.0-internal.3.0.0
+      '@fluidframework/cell': 2.0.0-internal.3.0.0
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/container-loader': 2.0.0-internal.2.2.0
-      '@fluidframework/container-runtime': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/counter': 2.0.0-internal.2.2.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/ink': 2.0.0-internal.2.2.0
-      '@fluidframework/map': 2.0.0-internal.2.2.0
-      '@fluidframework/matrix': 2.0.0-internal.2.2.0
-      '@fluidframework/ordered-collection': 2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/counter': 2.0.0-internal.3.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/ink': 2.0.0-internal.3.0.0
+      '@fluidframework/map': 2.0.0-internal.3.0.0
+      '@fluidframework/matrix': 2.0.0-internal.3.0.0
+      '@fluidframework/ordered-collection': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/register-collection': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/sequence': 2.0.0-internal.2.2.0
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/test-drivers': 2.0.0-internal.2.2.0
-      '@fluidframework/test-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/register-collection': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/sequence': 2.0.0-internal.3.0.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/test-drivers': 2.0.0-internal.3.0.0
+      '@fluidframework/test-utils': 2.0.0-internal.3.0.0
       nconf: 0.12.0
       proper-lockfile: 4.1.2
       semver: 7.3.8
@@ -14310,23 +14681,23 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-client/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-HmtW7Tn2Djpw4ZUjMG89IfJotCKf7EJX20XPnCmO3ED5J40L7VZAtL+If/lxaq/9q37IsiQCEOyEX9Ib6YMf6Q==}
+  /@fluidframework/tinylicious-client/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-j6h6m+0dYKywfT8zFTGAD0nq0SolUqM6KvDqL0YCAQqsSxVHK7HmhG38CUbJBiQdMaW/j/n4naLKXx01oQB+aQ==}
     peerDependencies:
       fluid-framework: '>=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0'
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/container-loader': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/fluid-static': 2.0.0-internal.2.2.0
-      '@fluidframework/map': 2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/fluid-static': 2.0.0-internal.3.0.0
+      '@fluidframework/map': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.2.2.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/tinylicious-driver': 2.0.0-internal.2.2.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.0.0
+      '@fluidframework/tinylicious-driver': 2.0.0-internal.3.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -14336,14 +14707,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-driver/2.0.0-internal.2.1.1:
-    resolution: {integrity: sha512-BDX2wLnyn0UYc2UfzOCGBvtRfTQrVuzhdwZeE3Na5PtH3ypuyItJ21EYiUqHjEKjEV2MDDf0IFeu/FeAkMYzfQ==}
+  /@fluidframework/tinylicious-driver/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-gkdSaZXhzy+mkT3I6ZUlzW80oZbmzwvwUC/Olk4b4M8dnuxi0qxjHzWBTEK93aYW/lA8rnuFaZR3HFLTn6u0UA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.2.2.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.0.0
       '@fluidframework/server-services-client': 0.1038.2000
       jsrsasign: 10.6.1
       uuid: 8.3.2
@@ -14355,30 +14726,11 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-driver/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-CUGTvw2x8N1WQo7EdCcSgUkQnbFHEJlmVeSRVGtOVB+Fb0BiFEbLmfXJEHONXt8IKuQtfw/ZB4UHQL8EF6NoSA==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/driver-utils': 2.0.0-internal.2.2.0
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.2.2.0
-      '@fluidframework/server-services-client': 0.1038.2000
-      jsrsasign: 10.6.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/tool-utils/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-2VYa5c/OQgLzgK2mQw2alIEoqk190KMo2ybQR8UUSAog/AMH96hD/NR3Oj7Kze9fyU0NWzIcXBMIMkQDEZHZfA==}
+  /@fluidframework/tool-utils/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-JdypYLgG8gLeotVEnDRKwd1DTMw1Xw5PwP0K+nf6rxmVU/UdVTEpdpCx1Fxu/8S9dwnUXSYY+JXUdy0pt2DCtA==}
     dependencies:
       '@fluidframework/common-utils': 1.0.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.2.2.0_debug@4.3.4
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.0.0_debug@4.3.4
       '@fluidframework/protocol-base': 0.1038.2000
       '@fluidframework/protocol-definitions': 1.1.0
       async-mutex: 0.3.2
@@ -14390,23 +14742,24 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/undo-redo/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-avQTBoqLIbGRuY41odSzaFXY3OPsp+fpc72jKRhuikRRwyX3SNJsKs2PevEokH1bYqgw7oIPpjL+f3mtG9BMVw==}
+  /@fluidframework/undo-redo/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-m5Oxz+R/cODHL10umy/UcAwryAa67zpuMxIZISRv9N8tYaJABRodPls99BK/dLW93KypFTW5kPq33PESD4JYpA==}
     dependencies:
-      '@fluidframework/map': 2.0.0-internal.2.2.0
-      '@fluidframework/matrix': 2.0.0-internal.2.2.0
-      '@fluidframework/merge-tree': 2.0.0-internal.2.2.0
-      '@fluidframework/sequence': 2.0.0-internal.2.2.0
+      '@fluidframework/map': 2.0.0-internal.3.0.0
+      '@fluidframework/matrix': 2.0.0-internal.3.0.0
+      '@fluidframework/merge-tree': 2.0.0-internal.3.0.0
+      '@fluidframework/sequence': 2.0.0-internal.3.0.0
+      events: 3.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/view-adapters/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-4uJNgrFidEg5310Zy3/ZaHpXMBK13mynQhTnDIQ7PqhnVjy+Jswfz9AcnO1hm/NGdlh2CUC+9GGYGmi8s+QMNA==}
+  /@fluidframework/view-adapters/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-e3fisAFHB/7z+ca2JDVgGChGoufLKlvCEmPv1IvDpswQG0UuWjqcanIn0d1b/ObrdaYikKhS9NfFv6PLgo0CCA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.2.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.3.0.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: true
@@ -14417,21 +14770,17 @@ packages:
       '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
     dev: true
 
-  /@fluidframework/web-code-loader/2.0.0-internal.2.1.1:
-    resolution: {integrity: sha512-I+Whj5q77X82exkZCuRABGV0emuonAn3A9TUdFRSKsWrLR6VQzw+O+ixNun7Dzu4RHEo/tvIOIgJAvBiMfIJKQ==}
+  /@fluidframework/view-interfaces/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-HOvqcf1aLLncc7Vpq5ItiprpiB8RfQj+mVgxet/dgSNbsrwbp/J409ydPBjjJFYQH2Dg80Fo7avM29iditwhhQ==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
-      isomorphic-fetch: 3.0.0
-    transitivePeerDependencies:
-      - encoding
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
     dev: true
 
-  /@fluidframework/web-code-loader/2.0.0-internal.2.2.0:
-    resolution: {integrity: sha512-mmmiCg29wlkN1NYEKYTg+zFSpyCKGS6DeL5UNwMSiJN7kjY0ypRFWTis6WG1mDOSU9qFQBT5eEj/6LA8lTyqaQ==}
+  /@fluidframework/web-code-loader/2.0.0-internal.3.0.0:
+    resolution: {integrity: sha512-QpgJS+/1iyBWtV2UYAUes8NJHXcRsidrSnoBkqOAjh/q863n0YAByOJuBB92XHbREnn6mN5m3qLMqvLGdfQ0ug==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.2.2.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.2.2.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.0.0
       isomorphic-fetch: 3.0.0
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
Commands used:

```shell
npm run typetests:prepare -- --reset --branch main
npm run typetests:gen -- --branch main
```

Then I ran `npm run build:fast` and adjusted the SharedCell type test overrides since there are broken forwardCompat changes -- but that's OK since they're not backCompat breaking changes.