### PR TITLE
Document Container Close Errors

### DIFF
--- a/api-report/azure-client.api.md
+++ b/api-report/azure-client.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { ContainerErrorType } from '@fluidframework/container-definitions';
 import { ContainerSchema } from '@fluidframework/fluid-static';
 import { IClient } from '@fluidframework/protocol-definitions';
 import { IFluidContainer } from '@fluidframework/fluid-static';
@@ -105,6 +106,8 @@ export interface AzureUser<T = any> extends IUser {
     additionalDetails?: T;
     name: string;
 }
+
+export { ContainerErrorType }
 
 // @public
 export type IAzureAudience = IServiceAudience<AzureMember>;

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { ConnectionMode } from '@fluidframework/protocol-definitions';
+import { DriverErrorType } from '@fluidframework/driver-definitions';
 import { EventEmitter } from 'events';
 import { FluidObject } from '@fluidframework/core-interfaces';
 import { IClient } from '@fluidframework/protocol-definitions';
@@ -51,6 +52,9 @@ export namespace ConnectionState {
 
 // @public
 export type ConnectionState = ConnectionState.Disconnected | ConnectionState.EstablishingConnection | ConnectionState.CatchingUp | ConnectionState.Connected;
+
+// @public
+export type ContainerCloseError = ContainerErrorType | DriverErrorType | string;
 
 // @public
 export enum ContainerErrorType {
@@ -228,7 +232,7 @@ export interface IContainerLoadMode {
 }
 
 // @public
-export type ICriticalContainerError = IErrorBase;
+export type ICriticalContainerError = IErrorBase<ContainerCloseError>;
 
 // @public
 export interface IDeltaHandlerStrategy {
@@ -303,8 +307,8 @@ export interface IDeltaSender {
 }
 
 // @public
-export interface IErrorBase extends Partial<Error> {
-    readonly errorType: string;
+export interface IErrorBase<T extends string = string> extends Partial<Error> {
+    readonly errorType: T;
     getTelemetryProperties?(): ITelemetryProperties;
     readonly message: string;
     readonly name?: string;

--- a/azure/packages/azure-client/src/index.ts
+++ b/azure/packages/azure-client/src/index.ts
@@ -28,5 +28,6 @@ export {
 	ITelemetryBaseLogger,
 } from "./interfaces";
 
+export { ContainerErrorType } from "@fluidframework/container-definitions";
 export { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
 export { ITokenClaims, IUser, ScopeType } from "@fluidframework/protocol-definitions";

--- a/docs/content/docs/build/containers.md
+++ b/docs/content/docs/build/containers.md
@@ -203,12 +203,14 @@ container.dispose();
 
 const disposed = container.disposed;
 
-container.on("disposed", () => {
+container.on("disposed", (error?: ICriticalContainerError) => {
     // handle event cleanup to prevent memory leaks
 });
 ```
 
 As mentioned above, you probably want to make sure all pending changes are saved prior to calling `dispose`.
+
+To learn more about the possible errors that can be thrown when disposing a container, see the [ContainerCloseError](/docs/apis/azure-client/#containercloseerror-typealias) type.
 
 ### Deleting a container
 

--- a/docs/rollup-api-data.js
+++ b/docs/rollup-api-data.js
@@ -27,6 +27,7 @@ const memberCombineInstructions = [
     {
         package: "@fluidframework/azure-client",
         sourceImports: new Map([
+            ["@fluidframework/container-definitions", ["ContainerCloseError"]],
             ["@fluidframework/routerlicious-driver", ["ITokenProvider", "ITokenResponse"]],
             ["@fluidframework/protocol-definitions", ["ScopeType", "ITokenClaims", "IUser"]],
         ])
@@ -40,7 +41,7 @@ const memberCombineInstructions = [
         package: "@fluidframework/container-definitions",
         cleanOrigMembers: true,
         sourceImports: new Map([
-            ["@fluidframework/container-definitions", ["AttachState"]],
+            ["@fluidframework/container-definitions", ["AttachState", "ContainerCloseError"]],
         ])
     },
     {

--- a/docs/rollup-api-data.js
+++ b/docs/rollup-api-data.js
@@ -27,7 +27,7 @@ const memberCombineInstructions = [
     {
         package: "@fluidframework/azure-client",
         sourceImports: new Map([
-            ["@fluidframework/container-definitions", ["ContainerCloseError"]],
+            ["@fluidframework/container-definitions", ["ContainerCloseError", "ContainerErrorType"]],
             ["@fluidframework/routerlicious-driver", ["ITokenProvider", "ITokenResponse"]],
             ["@fluidframework/protocol-definitions", ["ScopeType", "ITokenClaims", "IUser"]],
         ])

--- a/packages/common/container-definitions/src/error.ts
+++ b/packages/common/container-definitions/src/error.ts
@@ -4,6 +4,7 @@
  */
 
 import { ITelemetryProperties } from "@fluidframework/common-definitions";
+import { DriverErrorType } from "@fluidframework/driver-definitions";
 
 /**
  * Different error types the Container may report out to the Host
@@ -44,13 +45,13 @@ export enum ContainerErrorType {
 /**
  * Base interface for all errors and warnings at container level
  */
-export interface IErrorBase extends Partial<Error> {
+export interface IErrorBase<T extends string = string> extends Partial<Error> {
 	/** errorType is a union of error types from
 	 * - container
 	 * - runtime
 	 * - drivers
 	 */
-	readonly errorType: string;
+	readonly errorType: T;
 
 	/**
 	 * See Error.message
@@ -83,9 +84,26 @@ export interface ContainerWarning extends IErrorBase {
 }
 
 /**
- * Represents errors raised on container.
+ * Represents error objects raised on container.
+ *
+ * @see
+ *
+ * * {@link IErrorBase}
+ *
+ * * {@link ContainerCloseError}
  */
-export type ICriticalContainerError = IErrorBase;
+export type ICriticalContainerError = IErrorBase<ContainerCloseError>;
+
+/**
+ * Represents errors raised that closed the container.
+ *
+ * @see
+ *
+ * * {@link ContainerErrorType}
+ *
+ * * {@link @fluidframework/driver-definitions#DriverErrorType}
+ */
+export type ContainerCloseError = ContainerErrorType | DriverErrorType | string;
 
 /**
  * Generic wrapper for an unrecognized/uncategorized error object

--- a/packages/common/container-definitions/src/error.ts
+++ b/packages/common/container-definitions/src/error.ts
@@ -99,7 +99,7 @@ export type ICriticalContainerError = IErrorBase<ContainerCloseError>;
  *
  * @see
  *
- * * {@link ContainerErrorType}
+ * * {@link @fluidframework/container-definitions#ContainerErrorType}
  *
  * * {@link @fluidframework/driver-definitions#DriverErrorType}
  */

--- a/packages/common/container-definitions/src/index.ts
+++ b/packages/common/container-definitions/src/index.ts
@@ -26,6 +26,7 @@ export {
 	ReadOnlyInfo,
 } from "./deltas";
 export {
+	ContainerCloseError,
 	ContainerErrorType,
 	ContainerWarning,
 	ICriticalContainerError,


### PR DESCRIPTION
## Description

This PR adjusts `IErrorBase` and `ICriticalContainerError` in order to better expose the potential error types through the API extractor. This is done by adding the `ContainerCloseError` type which contains the union of `ContainerErrorType`, `DriverErrorType`, and `string` (miscellaneous errors thrown that aren't documented yet).

## TODO

- Include `OdspErrorType` and `R11sErrorType`. This is currently an issue since importing those types into `container-definitions` causes a circular depedency.

## Reviewer Guidance

- Thoughts on where to put note directing users to the error types (currently in docs/content/build/containers.md)
- Different naming suggestions for `ContainerCloseError` type

## Misc
[AB#2630](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2630)

