### PR TITLE
ci: Update test stability pipeline to use pnpm

### DIFF
--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -99,7 +99,7 @@ jobs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
-          ${{ parameters.packageManagerInstallCommand }}
+          pnpm i --frozen-lockfile
 
     # Build
     - ${{ if ne(parameters.taskBuild, 'false') }}:

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -32,6 +32,14 @@ parameters:
   type: number
   default: 60
 
+- name: packageManager
+  type: string
+  default: npm
+
+- name: packageManagerInstallCommand
+  type: string
+  default: 'npm ci --unsafe-perm'
+
 jobs:
   # Job - Build
   - job: build
@@ -73,13 +81,30 @@ jobs:
       displayName: Use Node 14.x
       inputs:
         version: 14.x
-    - task: Npm@1
-      displayName: npm ci
+
+    - ${{ if eq(parameters.packageManager, 'pnpm') }}:
+      - task: Cache@2
+        displayName: Cache pnpm store
+        inputs:
+          key: '"pnpm-store" | "$(Agent.OS)" | "${{ parameters.tagName }}" | ${{ parameters.buildDirectory }}/pnpm-lock.yaml'
+          path: ${{ variables.pnpmStorePath }}
+
+      - task: Bash@3
+        displayName: Install and configure pnpm
+        inputs:
+          targetType: 'inline'
+          workingDirectory: ${{ parameters.buildDirectory }}
+          script: |
+            npm i -g pnpm
+            pnpm config set store-dir $(pnpmStorePath)
+
+    - task: Bash@3
+      displayName: Install dependencies
       inputs:
-        command: 'custom'
-        workingDir: ${{ parameters.buildDirectory }}
-        customCommand: 'ci --unsafe-perm'
-        customRegistry: 'useNpmrc'
+        targetType: 'inline'
+        workingDirectory: ${{ parameters.buildDirectory }}
+        script: |
+          ${{ parameters.packageManagerInstallCommand }}
 
     # Build
     - ${{ if ne(parameters.taskBuild, 'false') }}:

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -36,9 +36,6 @@ parameters:
   type: string
   default: client
 
-variables:
-  - template: include-vars.yml
-
 jobs:
   # Job - Build
   - job: build

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -36,6 +36,9 @@ parameters:
   type: string
   default: client
 
+variables:
+  - template: include-vars.yml
+
 jobs:
   # Job - Build
   - job: build

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -32,13 +32,9 @@ parameters:
   type: number
   default: 60
 
-- name: packageManager
+- name: tagName
   type: string
-  default: npm
-
-- name: packageManagerInstallCommand
-  type: string
-  default: 'npm ci --unsafe-perm'
+  default: client
 
 jobs:
   # Job - Build
@@ -82,21 +78,20 @@ jobs:
       inputs:
         version: 14.x
 
-    - ${{ if eq(parameters.packageManager, 'pnpm') }}:
-      - task: Cache@2
-        displayName: Cache pnpm store
-        inputs:
-          key: '"pnpm-store" | "$(Agent.OS)" | "${{ parameters.tagName }}" | ${{ parameters.buildDirectory }}/pnpm-lock.yaml'
-          path: ${{ variables.pnpmStorePath }}
+    - task: Cache@2
+      displayName: Cache pnpm store
+      inputs:
+        key: '"pnpm-store" | "$(Agent.OS)" | "${{ parameters.tagName }}" | ${{ parameters.buildDirectory }}/pnpm-lock.yaml'
+        path: ${{ variables.pnpmStorePath }}
 
-      - task: Bash@3
-        displayName: Install and configure pnpm
-        inputs:
-          targetType: 'inline'
-          workingDirectory: ${{ parameters.buildDirectory }}
-          script: |
-            npm i -g pnpm
-            pnpm config set store-dir $(pnpmStorePath)
+    - task: Bash@3
+      displayName: Install and configure pnpm
+      inputs:
+        targetType: 'inline'
+        workingDirectory: ${{ parameters.buildDirectory }}
+        script: |
+          npm i -g pnpm
+          pnpm config set store-dir $(pnpmStorePath)
 
     - task: Bash@3
       displayName: Install dependencies

--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -151,6 +151,8 @@ variables:
   # basic ANSI color support though, so force that in the pipeline
 - name: FORCE_COLOR
   value: 1
+- name: pnpmStorePath
+  value: $(Pipeline.Workspace)/.pnpm-store
 
 stages:
   - ${{ each stageName in parameters.stageNames }}:

--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -164,7 +164,5 @@ stages:
           poolBuild: ${{ parameters.poolBuild }}
           checkoutSubmodules: ${{ parameters.checkoutSubmodules }}
           timeoutInMinutes: 360
-          packageManager: pnpm
-          packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
           taskBuild : ${{ parameters.taskBuild }}
           taskTest: ${{ parameters.taskTest }}

--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -164,5 +164,7 @@ stages:
           poolBuild: ${{ parameters.poolBuild }}
           checkoutSubmodules: ${{ parameters.checkoutSubmodules }}
           timeoutInMinutes: 360
+          packageManager: pnpm
+          packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
           taskBuild : ${{ parameters.taskBuild }}
           taskTest: ${{ parameters.taskTest }}


### PR DESCRIPTION
This pipeline was missed when we switched to pnpm for package management in the client release group.

Test CI run (internal): https://dev.azure.com/fluidframework/internal/_build?definitionId=123