### PR TITLE
Reconnect message is no longer relevant.

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1791,7 +1791,7 @@ export class ContainerRuntime
 			if (!this.shouldContinueReconnecting()) {
 				this.closeFn(
 					DataProcessingError.create(
-						"Runtime detected too many reconnects with no progress syncing local ops. Batch of ops is likely too large (over 1Mb)",
+						"Runtime detected too many reconnects with no progress syncing local ops.",
 						"setConnectionState",
 						undefined,
 						{
@@ -1804,6 +1804,7 @@ export class ContainerRuntime
 				return;
 			}
 		}
+
 
 		if (changeOfState) {
 			this.replayPendingStates();

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1805,7 +1805,6 @@ export class ContainerRuntime
 			}
 		}
 
-
 		if (changeOfState) {
 			this.replayPendingStates();
 		}


### PR DESCRIPTION
## Description

The error message for the reconnection tracker is no longer relevant, as large ops/batches fail earlier with a different message. Adding another end-to-end test to showcase this and retiring an obsolete test (we don't have a max op size anymore). The runtime can still close when it enters a tight feedback loop with no progress.