### PR TITLE
Fix "browser/process" configure in webpack

### DIFF
--- a/packages/tools/client-debugger/client-debugger-view/webpack.config.js
+++ b/packages/tools/client-debugger/client-debugger-view/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = (env) => {
 			},
 			plugins: [
 				new webpack.ProvidePlugin({
-					process: "process/browser",
+					process: require.resolve("process/browser"),
 				}),
 			],
 			// This impacts which files are watched by the dev server (and likely by webpack if watch is true).


### PR DESCRIPTION
This is to fix test class can't find /node_modules. By configuring this in webpack, `process` will be required to resolve.
```
Sample log:
Field 'browser' doesn't contain a valid alias configuration
    resolve as module
      /home/tong/workspace/FluidFramework/packages/tools/client-debugger/client-debugger-view/src/test/node_modules doesn't exist or is not a directory
      /home/tong/workspace/FluidFramework/packages/tools/client-debugger/client-debugger-view/src/node_modules doesn't exist or is not a directory
      looking for modules in /home/tong/workspace/FluidFramework/packages/tools/client-debugger/client-debugger-view/node_modules
        /home/tong/workspace/FluidFramework/packages/tools/client-debugger/client-debugger-view/node_modules/process doesn't exist
      /home/tong/workspace/FluidFramework/packages/tools/client-debugger/node_modules doesn't exist or is not a directory
      /home/tong/workspace/FluidFramework/packages/tools/node_modules doesn't exist or is not a directory
      /home/tong/workspace/FluidFramework/packages/node_modules doesn't exist or is not a directory
      looking for modules in /home/tong/workspace/FluidFramework/node_modules
        /home/tong/workspace/FluidFramework/node_modules/process doesn't exist
      /home/tong/workspace/node_modules doesn't exist or is not a directory
      /home/tong/node_modules doesn't exist or is not a directory
      /home/node_modules doesn't exist or is not a directory
      /node_modules doesn't exist or is not a directory
@ ./src/test/app/App.tsx 27:26-55
```