### PR TITLE
Document Container Close Errors

### DIFF
--- a/api-report/odsp-driver-definitions.api.md
+++ b/api-report/odsp-driver-definitions.api.md
@@ -170,19 +170,15 @@ export const isTokenFromCache: (tokenResponse: string | TokenResponse | null) =>
 // @public (undocumented)
 export type OdspError = IOdspError | (DriverError & IOdspErrorAugmentations);
 
-// @public (undocumented)
+// @public
 export enum OdspErrorType {
-    // (undocumented)
     cannotCatchUp = "cannotCatchUp",
-    // (undocumented)
     fetchTimeout = "fetchTimeout",
     // (undocumented)
     fetchTokenError = "fetchTokenError",
-    // (undocumented)
     fluidNotEnabled = "fluidNotEnabled",
     invalidFileNameError = "invalidFileNameError",
     outOfStorageError = "outOfStorageError",
-    // (undocumented)
     serviceReadOnly = "serviceReadOnly",
     snapshotTooBig = "snapshotTooBig"
 }

--- a/api-report/routerlicious-driver.api.md
+++ b/api-report/routerlicious-driver.api.md
@@ -62,14 +62,6 @@ export interface ITokenService {
     extractClaims(token: string): ITokenClaims;
 }
 
-// @public (undocumented)
-export enum R11sErrorType {
-    // (undocumented)
-    fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
-    // (undocumented)
-    sslCertError = "sslCertError"
-}
-
 // @public
 export class RouterliciousDocumentServiceFactory implements IDocumentServiceFactory {
     constructor(tokenProvider: ITokenProvider, driverPolicies?: Partial<IRouterliciousDriverPolicies>);
@@ -79,6 +71,13 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
     createDocumentService(resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean, session?: ISession): Promise<IDocumentService>;
     // (undocumented)
     readonly protocolName = "fluid:";
+}
+
+// @public
+export enum RouterliciousErrorType {
+    fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
+    // (undocumented)
+    sslCertError = "sslCertError"
 }
 
 // (No @packageDocumentation comment for this package)

--- a/api-report/routerlicious-driver.api.md
+++ b/api-report/routerlicious-driver.api.md
@@ -62,6 +62,14 @@ export interface ITokenService {
     extractClaims(token: string): ITokenClaims;
 }
 
+// @public (undocumented)
+export enum R11sErrorType {
+    // (undocumented)
+    fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
+    // (undocumented)
+    sslCertError = "sslCertError"
+}
+
 // @public
 export class RouterliciousDocumentServiceFactory implements IDocumentServiceFactory {
     constructor(tokenProvider: ITokenProvider, driverPolicies?: Partial<IRouterliciousDriverPolicies>);

--- a/docs/content/docs/build/containers.md
+++ b/docs/content/docs/build/containers.md
@@ -210,7 +210,7 @@ container.on("disposed", (error?: ICriticalContainerError) => {
 
 As mentioned above, you probably want to make sure all pending changes are saved prior to calling `dispose`.
 
-To learn more about the possible errors that can be emitted from the `disposed` event, see [ICriticalContainerError](/docs/apis/azure-client/#icriticalcontainererror-interface).
+To learn more about the possible errors that can be emitted from the `disposed` event, see [ICriticalContainerError](/docs/apis/azure-client/#icriticalcontainererror-typealias).
 
 ### Deleting a container
 

--- a/docs/content/docs/build/containers.md
+++ b/docs/content/docs/build/containers.md
@@ -203,12 +203,14 @@ container.dispose();
 
 const disposed = container.disposed;
 
-container.on("disposed", () => {
+container.on("disposed", (error?: ICriticalContainerError) => {
     // handle event cleanup to prevent memory leaks
 });
 ```
 
 As mentioned above, you probably want to make sure all pending changes are saved prior to calling `dispose`.
+
+To learn more about the possible errors that can be thrown when disposing a container, see [ICriticalContainerError](/docs/apis/azure-client/#icriticalcontainererror-interface).
 
 ### Deleting a container
 

--- a/docs/content/docs/build/containers.md
+++ b/docs/content/docs/build/containers.md
@@ -210,7 +210,7 @@ container.on("disposed", (error?: ICriticalContainerError) => {
 
 As mentioned above, you probably want to make sure all pending changes are saved prior to calling `dispose`.
 
-To learn more about the possible errors that can be thrown when disposing a container, see [ICriticalContainerError](/docs/apis/azure-client/#icriticalcontainererror-interface).
+To learn more about the possible errors that can be emitted from the `disposed` event, see [ICriticalContainerError](/docs/apis/azure-client/#icriticalcontainererror-interface).
 
 ### Deleting a container
 

--- a/docs/rollup-api-data.js
+++ b/docs/rollup-api-data.js
@@ -27,6 +27,7 @@ const memberCombineInstructions = [
     {
         package: "@fluidframework/azure-client",
         sourceImports: new Map([
+            ["@fluidframework/container-definitions", ["ContainerErrorType", "ICriticalContainerError"]],
             ["@fluidframework/routerlicious-driver", ["ITokenProvider", "ITokenResponse"]],
             ["@fluidframework/protocol-definitions", ["ScopeType", "ITokenClaims", "IUser"]],
         ])
@@ -40,7 +41,7 @@ const memberCombineInstructions = [
         package: "@fluidframework/container-definitions",
         cleanOrigMembers: true,
         sourceImports: new Map([
-            ["@fluidframework/container-definitions", ["AttachState"]],
+            ["@fluidframework/container-definitions", ["AttachState", "ContainerErrorType", "ICriticalContainerError"]],
         ])
     },
     {

--- a/packages/common/container-definitions/src/error.ts
+++ b/packages/common/container-definitions/src/error.ts
@@ -87,7 +87,7 @@ export interface ContainerWarning extends IErrorBase {
  *
  * @see
  *
- * The following are commonly thrown error types.
+ * The following are commonly thrown error types, but `errorType` could be any string.
  *
  * - {@link @fluidframework/container-definitions#ContainerErrorType}
  *

--- a/packages/common/container-definitions/src/error.ts
+++ b/packages/common/container-definitions/src/error.ts
@@ -83,7 +83,18 @@ export interface ContainerWarning extends IErrorBase {
 }
 
 /**
- * Represents errors raised on container.
+ * Represents errors raised on container. Check the "See below" section for commonly thrown error types.
+ *
+ * @see
+ *
+ * * {@link @fluidframework/container-definitions#ContainerErrorType}
+ *
+ * * {@link @fluidframework/driver-definitions#DriverErrorType}
+ *
+ * * {@link @fluidframework/odsp-driver-definitions#OdspErrorType}
+ *
+ * * {@link @fluidframework/routerlicious-driver#R11sErrorType}
+ *
  */
 export type ICriticalContainerError = IErrorBase;
 

--- a/packages/common/container-definitions/src/error.ts
+++ b/packages/common/container-definitions/src/error.ts
@@ -83,17 +83,19 @@ export interface ContainerWarning extends IErrorBase {
 }
 
 /**
- * Represents errors raised on container. Check the "See below" section for commonly thrown error types.
+ * Represents errors raised on container.
  *
  * @see
  *
- * * {@link @fluidframework/container-definitions#ContainerErrorType}
+ * The following are commonly thrown error types.
  *
- * * {@link @fluidframework/driver-definitions#DriverErrorType}
+ * - {@link @fluidframework/container-definitions#ContainerErrorType}
  *
- * * {@link @fluidframework/odsp-driver-definitions#OdspErrorType}
+ * - {@link @fluidframework/driver-definitions#DriverErrorType}
  *
- * * {@link @fluidframework/routerlicious-driver#R11sErrorType}
+ * - {@link @fluidframework/odsp-driver-definitions#OdspErrorType}
+ *
+ * - {@link @fluidframework/routerlicious-driver#RouterliciousErrorType}
  *
  */
 export type ICriticalContainerError = IErrorBase;

--- a/packages/drivers/odsp-driver-definitions/src/errors.ts
+++ b/packages/drivers/odsp-driver-definitions/src/errors.ts
@@ -5,8 +5,8 @@
 import { DriverError, IDriverErrorBase } from "@fluidframework/driver-definitions";
 
 /**
- * ODSP Error types
- * Different error types that may be thrown by the ODSP driver
+ * ODSP Error types.
+ * Different error types that may be thrown by the ODSP driver.
  */
 export enum OdspErrorType {
 	/**

--- a/packages/drivers/odsp-driver-definitions/src/errors.ts
+++ b/packages/drivers/odsp-driver-definitions/src/errors.ts
@@ -4,6 +4,10 @@
  */
 import { DriverError, IDriverErrorBase } from "@fluidframework/driver-definitions";
 
+/**
+ * ODSP Error types
+ * Different error types that may be thrown by the ODSP driver
+ */
 export enum OdspErrorType {
 	/**
 	 * Storage is out of space
@@ -22,29 +26,33 @@ export enum OdspErrorType {
 	 */
 	snapshotTooBig = "snapshotTooBig",
 
-	/*
+	/**
 	 * Maximum time limit to fetch reached. Host application specified limit for fetching of snapshot, when
 	 * that limit is reached, request fails. Hosting application is expected to have fall-back behavior for
 	 * such case.
 	 */
 	fetchTimeout = "fetchTimeout",
 
-	/*
+	/**
 	 * SPO admin toggle: fluid service is not enabled.
 	 */
 	fluidNotEnabled = "fluidNotEnabled",
 
 	fetchTokenError = "fetchTokenError",
 
-	// This error will be raised when client is too behind with no way to catch up.
-	// This condition will happen when user was offline for too long, resulting in old ops / blobs being deleted
-	// by storage, and thus removing an ability for client to catch up.
-	// This condition will result in any local changes being lost (i.e. only way to save state is by user
-	// copying it over manually)
+	/**
+	 * This error will be raised when client is too behind with no way to catch up.
+	 * This condition will happen when user was offline for too long, resulting in old ops / blobs being deleted
+	 * by storage, and thus removing an ability for client to catch up.
+	 * This condition will result in any local changes being lost (i.e. only way to save state is by user
+	 * copying it over manually)
+	 */
 	cannotCatchUp = "cannotCatchUp",
 
-	// SPO can occasionally return 403 for r/w operations on document when there is a fail over to another data center.
-	// So to preserve integrity of the data, the data becomes readonly.
+	/**
+	 * SPO can occasionally return 403 for r/w operations on document when there is a fail over to another data center.
+	 * So to preserve integrity of the data, the data becomes readonly.
+	 */
 	serviceReadOnly = "serviceReadOnly",
 }
 

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -12,8 +12,16 @@ import {
 } from "@fluidframework/driver-utils";
 import { pkgVersion as driverVersion } from "./packageVersion";
 
-export enum R11sErrorType {
+/**
+ * Routerlicious Error types
+ * Different error types that may be thrown by the routerlicious driver
+ */
+export enum RouterliciousErrorType {
+	/**
+	 * File not found, or file deleted during session
+	 */
 	fileNotFoundOrAccessDeniedError = "fileNotFoundOrAccessDeniedError",
+
 	sslCertError = "sslCertError",
 }
 
@@ -48,7 +56,7 @@ export interface IR11sSocketError {
 }
 
 export interface IR11sError {
-	readonly errorType: R11sErrorType;
+	readonly errorType: RouterliciousErrorType;
 	readonly message: string;
 	canRetry: boolean;
 }
@@ -69,7 +77,11 @@ export function createR11sNetworkError(
 			// If there exists a self-signed SSL certificates error, throw a NonRetryableError
 			// TODO: instead of relying on string matching, filter error based on the error code like we do for websocket connections
 			if (errorMessage.includes("failed, reason: self signed certificate")) {
-				return new NonRetryableError(errorMessage, R11sErrorType.sslCertError, props);
+				return new NonRetryableError(
+					errorMessage,
+					RouterliciousErrorType.sslCertError,
+					props,
+				);
 			}
 			return new GenericNetworkError(
 				errorMessage,
@@ -82,7 +94,7 @@ export function createR11sNetworkError(
 		case 403:
 			return new AuthorizationError(errorMessage, undefined, undefined, props);
 		case 404:
-			const errorType = R11sErrorType.fileNotFoundOrAccessDeniedError;
+			const errorType = RouterliciousErrorType.fileNotFoundOrAccessDeniedError;
 			return new NonRetryableError(errorMessage, errorType, props);
 		case 429:
 			return createGenericNetworkError(errorMessage, { canRetry: true, retryAfterMs }, props);

--- a/packages/drivers/routerlicious-driver/src/index.ts
+++ b/packages/drivers/routerlicious-driver/src/index.ts
@@ -8,7 +8,7 @@ export { DefaultTokenProvider } from "./defaultTokenProvider";
 export { ITokenProvider, ITokenResponse, ITokenService } from "./tokens";
 
 // Errors
-export { R11sErrorType } from "./errorUtils";
+export { RouterliciousErrorType } from "./errorUtils";
 
 // Factory
 export {

--- a/packages/drivers/routerlicious-driver/src/index.ts
+++ b/packages/drivers/routerlicious-driver/src/index.ts
@@ -7,6 +7,9 @@
 export { DefaultTokenProvider } from "./defaultTokenProvider";
 export { ITokenProvider, ITokenResponse, ITokenService } from "./tokens";
 
+// Errors
+export { R11sErrorType } from "./errorUtils";
+
 // Factory
 export {
 	DocumentPostCreateError,

--- a/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
@@ -8,7 +8,7 @@ import { DriverErrorType, IThrottlingWarning } from "@fluidframework/driver-defi
 import {
 	createR11sNetworkError,
 	throwR11sNetworkError,
-	R11sErrorType,
+	RouterliciousErrorType,
 	errorObjectFromSocketError,
 } from "../errorUtils";
 
@@ -29,7 +29,10 @@ describe("ErrorUtils", () => {
 		it("creates non-retriable not-found error on 404", () => {
 			const message = "test error";
 			const error = createR11sNetworkError(message, 404);
-			assert.strictEqual(error.errorType, R11sErrorType.fileNotFoundOrAccessDeniedError);
+			assert.strictEqual(
+				error.errorType,
+				RouterliciousErrorType.fileNotFoundOrAccessDeniedError,
+			);
 			assert.strictEqual(error.canRetry, false);
 		});
 		it("creates retriable error on 429 with retry-after", () => {
@@ -106,7 +109,7 @@ describe("ErrorUtils", () => {
 					throwR11sNetworkError(message, 404);
 				},
 				{
-					errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
+					errorType: RouterliciousErrorType.fileNotFoundOrAccessDeniedError,
 					canRetry: false,
 				},
 			);
@@ -240,7 +243,10 @@ describe("ErrorUtils", () => {
 				handler,
 			);
 			assertExpectedMessage(error.message);
-			assert.strictEqual(error.errorType, R11sErrorType.fileNotFoundOrAccessDeniedError);
+			assert.strictEqual(
+				error.errorType,
+				RouterliciousErrorType.fileNotFoundOrAccessDeniedError,
+			);
 			assert.strictEqual(error.canRetry, false);
 			assert.strictEqual((error as any).statusCode, 404);
 		});

--- a/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
@@ -9,7 +9,7 @@ import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { RateLimiter } from "@fluidframework/driver-utils";
 import nock from "nock";
 import { RouterliciousOrdererRestWrapper } from "../restWrapper";
-import { R11sErrorType } from "../errorUtils";
+import { RouterliciousErrorType } from "../errorUtils";
 import { DefaultTokenProvider } from "../defaultTokenProvider";
 import { ITokenResponse } from "../tokens";
 
@@ -121,7 +121,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 			nock(testHost).get(testPath).reply(404);
 			await assert.rejects(restWrapper.get(testUrl), {
 				canRetry: false,
-				errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
+				errorType: RouterliciousErrorType.fileNotFoundOrAccessDeniedError,
 			});
 		});
 		it("throws retriable error on Network Error", async () => {
@@ -184,7 +184,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 			nock(testHost).post(testPath).reply(404);
 			await assert.rejects(restWrapper.post(testUrl, { test: "payload" }), {
 				canRetry: false,
-				errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
+				errorType: RouterliciousErrorType.fileNotFoundOrAccessDeniedError,
 			});
 		});
 		it("throws retriable error on Network Error", async () => {
@@ -247,7 +247,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 			nock(testHost).patch(testPath).reply(404);
 			await assert.rejects(restWrapper.patch(testUrl, { test: "payload" }), {
 				canRetry: false,
-				errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
+				errorType: RouterliciousErrorType.fileNotFoundOrAccessDeniedError,
 			});
 		});
 		it("throws retriable error on Network Error", async () => {
@@ -310,7 +310,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 			nock(testHost).delete(testPath).reply(404);
 			await assert.rejects(restWrapper.delete(testUrl), {
 				canRetry: false,
-				errorType: R11sErrorType.fileNotFoundOrAccessDeniedError,
+				errorType: RouterliciousErrorType.fileNotFoundOrAccessDeniedError,
 			});
 		});
 		it("throws retriable error on Network Error", async () => {

--- a/packages/loader/container-loader/README.md
+++ b/packages/loader/container-loader/README.md
@@ -10,6 +10,8 @@
         -   [Loading](#loading)
         -   [Connectivity](#connectivity)
         -   [Closure](#closure)
+            -   [`Container.close()`](#containerclose)
+            -   [`Container.dispose()`](#containerdispose)
     -   [Audience](#audience)
     -   [ClientID and client identification](#clientid-and-client-identification)
     -   [Error handling](#error-handling)
@@ -141,13 +143,14 @@ Errors are of [ICriticalContainerError](../../../common/lib/container-definition
      readonly errorType: string;
 ```
 
-There are 3 sources of errors:
+There are 4 sources of errors:
 
 1. [ContainerErrorType](../../../common/lib/container-definitions/src/error.ts) - errors & warnings raised at loader level
-2. [OdspErrorType](../../drivers/odsp-driver/src/odspError.ts) and [RouterliciousErrorType](../../drivers/routerlicious-driver/src/documentDeltaConnection.ts) - errors raised by ODSP and R11S drivers.
-3. Runtime errors, like `"summarizingError"`, `"dataCorruptionError"`. This class of errors is not pre-determined and depends on type of container loaded.
+2. [DriverErrorType](../../common/driver-definitions/src/driverError.ts) - errors that are likely to be raised from the driver level
+3. [OdspErrorType](../../drivers/odsp-driver/src/odspError.ts) and [RouterliciousErrorType](../../drivers/routerlicious-driver/src/documentDeltaConnection.ts) - errors raised by ODSP and R11S drivers.
+4. Runtime errors, like `"summarizingError"`, `"dataCorruptionError"`. This class of errors is not pre-determined and depends on type of container loaded.
 
-`ICriticalContainerError.errorType` is a string, which represents a union of 3 error types described above. Hosting application may package different drivers and open different types of containers, and only hosting application may have enough information to enumerate all possible error codes in such scenarios.
+`ICriticalContainerError.errorType` is a string, which represents a union of 4 error types described above. Hosting application may package different drivers and open different types of containers, and only hosting application may have enough information to enumerate all possible error codes in such scenarios.
 
 Hosts must listen to `"closed"` event. If error object is present there, container was closed due to error and this information needs to be communicated to user in some way. If there is no error object, it was closed due to host application calling Container.close() (without specifying error).
 When container is closed, it is no longer connected to ordering service. It is also in read-only state, communicating to data stores not to allow user to make changes to container.

--- a/packages/loader/container-loader/README.md
+++ b/packages/loader/container-loader/README.md
@@ -144,7 +144,7 @@ Errors are of [ICriticalContainerError](../../../common/lib/container-definition
 There are 3 sources of errors:
 
 1. [ContainerErrorType](../../../common/lib/container-definitions/src/error.ts) - errors & warnings raised at loader level
-2. [OdspErrorType](../../drivers/odsp-driver/src/odspError.ts) and [R11sErrorType](../../drivers/routerlicious-driver/src/documentDeltaConnection.ts) - errors raised by ODSP and R11S drivers.
+2. [OdspErrorType](../../drivers/odsp-driver/src/odspError.ts) and [RouterliciousErrorType](../../drivers/routerlicious-driver/src/documentDeltaConnection.ts) - errors raised by ODSP and R11S drivers.
 3. Runtime errors, like `"summarizingError"`, `"dataCorruptionError"`. This class of errors is not pre-determined and depends on type of container loaded.
 
 `ICriticalContainerError.errorType` is a string, which represents a union of 3 error types described above. Hosting application may package different drivers and open different types of containers, and only hosting application may have enough information to enumerate all possible error codes in such scenarios.


### PR DESCRIPTION
## Description

This PR adds a TSDoc to `ICriticalContainerError` to link the possible error types thrown when a container closes. This PR also adds a reference to it in the "Containers" ff.com document.

Error enums linked:
- `ContainerErrorType`
- `DriverErrorType`
- `OdspErrorType`
- `R11sErrorType`

## Reviewer Guidance

- TSDoc comment wording/info
- Potential places to reference the extracted API doc for `ICriticalContainerError`. Currently this PR adds it to `/docs/content/docs/build/containers.md`.
- Error descriptions for `RouterliciousErrorType.sslCertError` and `OdspErrorType.fetchTokenError` (currently undocumented)

## Misc

[AB#2630](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2630)
