### PR TITLE
[R11s] adding EventHubs support for rdkafka client code

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -131,6 +131,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
         const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
         const kafkaMaxBatchSize = config.get("kafka:lib:maxBatchSize");
         const kafkaSslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
+        const eventHubConnString: string = config.get("kafka:lib:eventHubConnString");
 
         const producer = services.createProducer(
             kafkaLibrary,
@@ -142,7 +143,8 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
             kafkaNumberOfPartitions,
             kafkaReplicationFactor,
             kafkaMaxBatchSize,
-            kafkaSslCACertFilePath);
+            kafkaSslCACertFilePath,
+            eventHubConnString);
 
         const redisConfig = config.get("redis");
         const webSocketLibrary = config.get("alfred:webSocketLib");

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -21,6 +21,7 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
     const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
     const kafkaMaxBatchSize = config.get("kafka:lib:maxBatchSize");
     const kafkaSslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
+    const eventHubConnString: string = config.get("kafka:lib:eventHubConnString");
 
     const kafkaForwardClientId = config.get("deli:kafkaClientId");
     const kafkaReverseClientId = config.get("alfred:kafkaClientId");
@@ -71,7 +72,8 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
         kafkaNumberOfPartitions,
         kafkaReplicationFactor,
         kafkaMaxBatchSize,
-        kafkaSslCACertFilePath);
+        kafkaSslCACertFilePath,
+        eventHubConnString);
     const reverseProducer = services.createProducer(
         kafkaLibrary,
         kafkaEndpoint,
@@ -82,7 +84,8 @@ export async function deliCreate(config: Provider): Promise<core.IPartitionLambd
         kafkaNumberOfPartitions,
         kafkaReplicationFactor,
         kafkaMaxBatchSize,
-        kafkaSslCACertFilePath);
+        kafkaSslCACertFilePath,
+        eventHubConnString);
 
     const redisConfig = config.get("redis");
     const redisOptions: RedisOptions = {

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -33,6 +33,8 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
     const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
     const kafkaMaxBatchSize = config.get("kafka:lib:maxBatchSize");
     const kafkaSslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
+    const eventHubConnString: string = config.get("kafka:lib:eventHubConnString");
+
     const sendTopic = config.get("lambdas:deli:topic");
     const kafkaClientId = config.get("scribe:kafkaClientId");
     const mongoExpireAfterSeconds = config.get("mongo:expireAfterSeconds") as number;
@@ -99,7 +101,8 @@ export async function scribeCreate(config: Provider): Promise<IPartitionLambdaFa
         kafkaNumberOfPartitions,
         kafkaReplicationFactor,
         kafkaMaxBatchSize,
-        kafkaSslCACertFilePath);
+        kafkaSslCACertFilePath,
+        eventHubConnString);
 
     const externalOrdererUrl = config.get("worker:serverUrl");
     const enforceDiscoveryFlow: boolean = config.get("worker:enforceDiscoveryFlow");

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts
@@ -14,6 +14,7 @@ export interface IKafkaBaseOptions {
     disableTopicCreation?: boolean;
     sslCACertFilePath?: string;
     restartOnKafkaErrorCodes?: number[];
+    eventHubConnString?: string;
 }
 
 export interface IKafkaEndpoints {
@@ -67,6 +68,19 @@ export abstract class RdkafkaBase extends EventEmitter {
             this.sslOptions = {
                 "security.protocol": "ssl",
                 "ssl.ca.location": options?.sslCACertFilePath,
+            };
+        } else if (options?.eventHubConnString) {
+            if (!kafka.features.filter((feature) => feature.toLowerCase().includes("sasl_ssl"))) {
+                throw new Error(
+                    "Attempted to configure SASL_SSL for Event Hubs, but rdkafka has not been built to support it. " +
+                    "Please make sure OpenSSL is available and build rdkafka again.");
+            }
+
+            this.sslOptions = {
+                "security.protocol": "sasl_ssl",
+                "sasl.mechanisms": "PLAIN",
+                "sasl.username": "$ConnectionString",
+                "sasl.password": options?.eventHubConnString,
             };
         }
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -29,6 +29,7 @@ export interface IKafkaConsumerOptions extends Partial<IKafkaBaseOptions> {
      * See https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
      */
     additionalOptions?: kafkaTypes.ConsumerGlobalConfig;
+    eventHubConnString?: string;
 }
 
 /**
@@ -93,7 +94,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
         }
 
         const zookeeperEndpoints = this.endpoints.zooKeeper;
-        if (zookeeperEndpoints && zookeeperEndpoints.length > 0 && this.consumerOptions.zooKeeperClientConstructor) {
+        if (!this.consumerOptions.eventHubConnString && zookeeperEndpoints && zookeeperEndpoints.length > 0 && this.consumerOptions.zooKeeperClientConstructor) {
             const zooKeeperEndpoint = zookeeperEndpoints[Math.floor(Math.random() % zookeeperEndpoints.length)];
             this.zooKeeperClient = new this.consumerOptions.zooKeeperClientConstructor(zooKeeperEndpoint);
         }

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -44,6 +44,7 @@ export interface IKafkaProducerOptions extends Partial<IKafkaBaseOptions> {
 
 	pollIntervalMs: number;
 	maxMessageSize: number;
+    eventHubConnString?: string;
 }
 
 /**

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
@@ -60,6 +60,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
         const consumeTimeout = config.get("kafka:lib:rdkafkaConsumeTimeout");
         const maxConsumerCommitRetries = config.get("kafka:lib:rdkafkaMaxConsumerCommitRetries");
         const sslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
+        const eventHubConnString: string = config.get("kafka:lib:eventHubConnString");
 
         // Receive topic and group - for now we will assume an entry in config mapping
         // to the given name. Later though the lambda config will likely be split from the stream config
@@ -88,6 +89,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
                 maxConsumerCommitRetries,
                 sslCACertFilePath,
                 zooKeeperClientConstructor: this.zookeeperClientConstructor,
+                eventHubConnString,
             },
         );
 

--- a/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
@@ -26,7 +26,8 @@ export function createProducer(
     numberOfPartitions?: number,
     replicationFactor?: number,
     maxBatchSize?: number,
-    sslCACertFilePath?: string): IProducer {
+    sslCACertFilePath?: string,
+    eventHubConnString?: string): IProducer {
     let producer: IProducer;
 
     if (type === "rdkafka") {
@@ -41,6 +42,7 @@ export function createProducer(
                 replicationFactor,
                 maxMessageSize: MaxKafkaMessageSize,
                 sslCACertFilePath,
+                eventHubConnString,
             });
 
         producer.on("error", (error, errorData: IContextErrorData) => {


### PR DESCRIPTION
## Description

Azure EventHubs support for rdkafka client code. This PR uses connection string approach but might be later changed to support AMI with OAuth2.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

> List any specific things you want to get reviewer opinions on, and anything a reviewer would need to know to review this PR effectively.
> Things you might want to include:
>
> -   Questions about how to properly make automated tests for your changes.
> -   Questions about design choices you made.
> -   Descriptions of how to manually test the changes (and how much of that you have done).
> -   etc.
>
> If you have any questions in this section, consider making the PR a draft until all questions have been resolved.
