### PR TITLE
ci(azure): Correct component governance working dirs

### DIFF
--- a/tools/pipelines/build-azure.yml
+++ b/tools/pipelines/build-azure.yml
@@ -108,14 +108,16 @@ extends:
       displayName: npm ci
       inputs:
         command: 'custom'
+        workingDir: azure
         customCommand: 'ci --ignore-scripts'
         customRegistry: 'useNpmrc'
     - task: Bash@3
       displayName: 'Generate Mono repo package json'
       inputs:
         targetType: 'inline'
+        workingDirectory: azure
         script: |
           # Generate the package/package lock for the lerna project so we would scan it.
           node node_modules/@fluidframework/build-tools/dist/genMonoRepoPackageJson/genMonoRepoPackageJson.js --azure
-          cp azure/repo-package.json azure/packages/package.json
-          cp azure/repo-package-lock.json azure/packages/package-lock.json
+          cp repo-package.json packages/package.json
+          cp repo-package-lock.json packages/package-lock.json


### PR DESCRIPTION
Our upgrade to pnpm in the root of the repo has caused the component governance task for the azure release group pipeline to fail because the task previously assumed it was running from the root.

This PR updates the tasks to run in the azure folder and install dependencies from there. The pipeline no longer relies on dependencies from the root.