### PR TITLE
gitrest: manually reset in-memory volume

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/utils/filesystems.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/filesystems.ts
@@ -14,7 +14,8 @@ export class NodeFsManagerFactory implements IFileSystemManagerFactory {
 }
 
 export class MemFsManagerFactory implements IFileSystemManagerFactory {
+    public readonly volume = new Volume();
     public create(params?: IFileSystemManagerParams): IFileSystemManager {
-        return (new Volume() as unknown) as IFileSystemManager;
+        return (this.volume as unknown) as IFileSystemManager;
     }
 }

--- a/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
@@ -575,7 +575,35 @@ export class GitWholeSummaryManager {
                 },
             }
         );
+        try {
+            const fullGitTree = await this.inMemorySummaryTreeComputationCore(
+                wholeSummaryTreeEntries,
+                existingRef,
+                inMemoryRepoManager,
+            );
+            return this.writeSummaryTreeCore(
+                [{
+                    path: fullTreePath,
+                    type: "blob",
+                    value: {
+                        type: "blob",
+                        content: JSON.stringify(fullGitTree),
+                        encoding: "utf-8",
+                    }
+                }],
+                this.repoManager,
+            );
+        } finally {
+            // Ensure temporary in-memory volume is destroyed.
+            inMemoryFsManagerFactory.volume.reset();
+        }
+    }
 
+    private async inMemorySummaryTreeComputationCore(
+        wholeSummaryTreeEntries: WholeSummaryTreeEntry[],
+        existingRef: IRef | undefined,
+        inMemoryRepoManager: IRepositoryManager,
+    ) {
         if (existingRef) {
             // Update in-memory repo manager with previous summary for handle references.
             const previousSummary = await this.readSummary(existingRef.object.sha);
@@ -652,19 +680,7 @@ export class GitWholeSummaryManager {
             inMemoryRepoManager,
             false, /* parseInnerFullGitTrees */
         );
-        const summaryTreeHandle = this.writeSummaryTreeCore(
-            [{
-                path: fullTreePath,
-                type: "blob",
-                value: {
-                    type: "blob",
-                    content: JSON.stringify(fullGitTree),
-                    encoding: "utf-8",
-                }
-            }],
-            this.repoManager,
-        );
-        return summaryTreeHandle;
+        return fullGitTree;
     }
 
     private async writeSummaryTreeCore(


### PR DESCRIPTION
## Description

In theory, the `memfs` `Volume` object used in the new Gitrest optimizations from #13249 should be garbage collected by Node.js after the function ends. However, we see symptoms of a new memory leak in Gitrest following this change, so I am adding a manual reset of the created memfs Volume after its usage is complete. We do this in another service in FRS that uses similar functionality, but I did not think it would be necessary in Gitrest due to the differences in implementation.
