### PR TITLE
Rebase ops when we detect a reference sequence number mismatch - WORK IN PROGRESS

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -23,6 +23,7 @@ export class BatchManager {
 	private readonly logger;
 	private pendingBatch: BatchMessage[] = [];
 	private batchContentSize = 0;
+	private pendingBatchOutOfSync = false;
 	/**
 	 * Track the number of ops which were detected to have a mismatched
 	 * reference sequence number, in order to self-throttle the telemetry events.
@@ -86,10 +87,12 @@ export class BatchManager {
 		const batch: IBatch = {
 			content: this.pendingBatch,
 			contentSizeInBytes: this.batchContentSize,
+			outOfSync: this.pendingBatchOutOfSync,
 		};
 
 		this.pendingBatch = [];
 		this.batchContentSize = 0;
+		this.pendingBatchOutOfSync = false;
 
 		return addBatchMetadata(batch);
 	}
@@ -122,6 +125,7 @@ export class BatchManager {
 			return;
 		}
 
+		this.pendingBatchOutOfSync = true;
 		const telemetryProperties = {
 			referenceSequenceNumber: this.pendingBatch[0].referenceSequenceNumber,
 			messageReferenceSequenceNumber: message.referenceSequenceNumber,

--- a/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
@@ -30,6 +30,11 @@ export interface IBatch {
 	 * All the messages in the batch
 	 */
 	readonly content: BatchMessage[];
+	/**
+	 * 'true' if the batch contains messages with different reference sequence numbers,
+	 * 'false' otherwise.
+	 */
+	readonly outOfSync?: boolean;
 }
 
 export interface IBatchCheckpoint {

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -112,10 +112,15 @@ export class Outbox {
 	}
 
 	private flushInternal(rawBatch: IBatch) {
-		const processedBatch = this.compressBatch(rawBatch);
-		const clientSequenceNumber = this.sendBatch(processedBatch);
+		if (rawBatch.outOfSync === true) {
+			this.persistBatch(-1, rawBatch.content);
+			this.params.pendingStateManager.replayPendingStates();
+		} else {
+			const processedBatch = this.compressBatch(rawBatch);
+			const clientSequenceNumber = this.sendBatch(processedBatch);
 
-		this.persistBatch(clientSequenceNumber, rawBatch.content);
+			this.persistBatch(clientSequenceNumber, rawBatch.content);
+		}
 	}
 
 	private compressBatch(batch: IBatch): IBatch {


### PR DESCRIPTION
## Description

If we detect ops to be out of sync, we could probably rebase them by using the same logic as when we reconnect.