### PR TITLE
ci(azure): Fix component governance paths

### DIFF
--- a/tools/pipelines/build-azure.yml
+++ b/tools/pipelines/build-azure.yml
@@ -115,9 +115,10 @@ extends:
       displayName: 'Generate Mono repo package json'
       inputs:
         targetType: 'inline'
-        workingDirectory: azure
+        # Must run in the root but creates files relative to the release group root
+        workingDirectory: $(Build.SourcesDirectory)
         script: |
           # Generate the package/package lock for the lerna project so we would scan it.
-          node node_modules/@fluidframework/build-tools/dist/genMonoRepoPackageJson/genMonoRepoPackageJson.js --azure
-          cp repo-package.json packages/package.json
-          cp repo-package-lock.json packages/package-lock.json
+          node azure/node_modules/@fluidframework/build-tools/dist/genMonoRepoPackageJson/genMonoRepoPackageJson.js --azure
+          cp azure/repo-package.json azure/packages/package.json
+          cp azure/repo-package-lock.json azure/packages/package-lock.json


### PR DESCRIPTION
PR #13908 was an incomplete fix. The generateMonorepoJson tool isn't very flexible and expects to be run from the root, and always creates its files in the root of the release group. Thus this PR corrects the paths and runs from the root as the tool expects.

Fortunately these weird tasks will no longer be needed once release groups all move to pnpm. That's also why it's not worth fixing the generateMonorepoJson tool to be more flexible.