### PR TITLE
Stress: Add Profile Name to Logs

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -25,6 +25,7 @@ import { LeaderElection } from "./leaderElection";
 
 export interface IRunConfig {
 	runId: number;
+	profileName: string,
 	testConfig: ILoadTestConfig;
 	verbose: boolean;
 	randEng: random.Engine;
@@ -32,7 +33,7 @@ export interface IRunConfig {
 
 export interface ILoadTest {
 	run(config: IRunConfig, reset: boolean, logger): Promise<boolean>;
-	detached(config: Omit<IRunConfig, "runId">, logger): Promise<LoadTestDataStoreModel>;
+	detached(config: Omit<IRunConfig, "runId" | "profileName">, logger): Promise<LoadTestDataStoreModel>;
 	getRuntime(): Promise<IFluidDataStoreRuntime>;
 }
 

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -25,7 +25,7 @@ import { LeaderElection } from "./leaderElection";
 
 export interface IRunConfig {
 	runId: number;
-	profileName: string,
+	profileName: string;
 	testConfig: ILoadTestConfig;
 	verbose: boolean;
 	randEng: random.Engine;
@@ -33,7 +33,10 @@ export interface IRunConfig {
 
 export interface ILoadTest {
 	run(config: IRunConfig, reset: boolean, logger): Promise<boolean>;
-	detached(config: Omit<IRunConfig, "runId" | "profileName">, logger): Promise<LoadTestDataStoreModel>;
+	detached(
+		config: Omit<IRunConfig, "runId" | "profileName">,
+		logger,
+	): Promise<LoadTestDataStoreModel>;
 	getRuntime(): Promise<IFluidDataStoreRuntime>;
 }
 

--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -90,12 +90,17 @@ async function main() {
 
 	const testUsers = await getTestUsers(credFile);
 
-	await orchestratorProcess(
-		driver,
-		endpoint,
-		profile,
-		{ testId, debug, verbose, seed, browserAuth, enableMetrics, createTestId, testUsers, profileName },
-	);
+	await orchestratorProcess(driver, endpoint, profile, {
+		testId,
+		debug,
+		verbose,
+		seed,
+		browserAuth,
+		enableMetrics,
+		createTestId,
+		testUsers,
+		profileName,
+	});
 }
 
 /**
@@ -195,9 +200,7 @@ async function orchestratorProcess(
 
 	try {
 		const usernames =
-			args.testUsers !== undefined
-				? Object.keys(args.testUsers.credentials)
-				: undefined;
+			args.testUsers !== undefined ? Object.keys(args.testUsers.credentials) : undefined;
 		await Promise.all(
 			runnerArgs.map(async (childArgs, index) => {
 				const username =

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -68,7 +68,7 @@ async function main() {
 
 	const driver: TestDriverTypes = commander.driver;
 	const endpoint: DriverEndpoint | undefined = commander.driverEndpoint;
-	const profileArg: string = commander.profile;
+	const profileName: string = commander.profile;
 	const url: string = commander.url;
 	const runId: number = commander.runId;
 	const log: string | undefined = commander.log;
@@ -76,7 +76,7 @@ async function main() {
 	const seed: number = commander.seed;
 	const enableOpsMetrics: boolean = commander.enableOpsMetrics ?? false;
 
-	const profile = getProfile(profileArg);
+	const profile = getProfile(profileName);
 
 	if (log !== undefined) {
 		process.env.DEBUG = log;
@@ -101,6 +101,7 @@ async function main() {
 			testConfig: profile,
 			verbose,
 			randEng,
+			profileName,
 		},
 		url,
 		seed,
@@ -185,6 +186,7 @@ async function runnerProcess(
 				runId: runConfig.runId,
 				driverType: testDriver.type,
 				driverEndpointName: testDriver.endpointName,
+				profile: runConfig.profileName,
 			},
 		});
 		process.on("uncaughtExceptionMonitor", (error, origin) => {

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -144,6 +144,7 @@ export async function initialize(
 	testConfig: ILoadTestConfig,
 	verbose: boolean,
 	testIdn?: string,
+	profileName?: string,
 ) {
 	const randEng = random.engines.mt19937();
 	randEng.seed(seed);
@@ -168,6 +169,7 @@ export async function initialize(
 		all: {
 			driverType: testDriver.type,
 			driverEndpointName: testDriver.endpointName,
+			profile: profileName,
 		},
 	});
 	// Construct the loader


### PR DESCRIPTION
Add the profile name to the logs, so we can differentiate different stress profiles in the runs