### PR TITLE
refactor(map): Migrate uses of explicit `any` to `unknown` in Map / Directory APIs

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -15,6 +15,17 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 - Avoid using code formatting in the title (it's fine to use in the body).
 - To explain the benefit of your change, use the [What's New](https://fluidframework.com/docs/updates/v1.0.0/) section on FluidFramework.com.
 
+# 2.0.0-internal.4.0.0
+
+## 2.0.0-internal.4.0.0 Breaking changes
+
+### @fluidframework/map `any` => `unknown`
+
+The `SharedMap` and `SharedDirectory` DDSes were updated to operate on `unknown` as their default value types, rather than `any`.
+
+Consumers who are using the type parameter defaults here will need to either specify a explicit type parameter, or appropriately handle values of type `unknown`.
+Providing `any` would yield parity with the previous behavior, though we recommend using a more concrete type if possible.
+
 # 2.0.0-internal.3.0.0
 
 ## 2.0.0-internal.3.0.0 Upcoming changes

--- a/api-report/map.api.md
+++ b/api-report/map.api.md
@@ -39,12 +39,12 @@ export class DirectoryFactory implements IChannelFactory {
 }
 
 // @public
-export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryEvents>, Partial<IDisposable> {
+export interface IDirectory extends Map<string, unknown>, IEventProvider<IDirectoryEvents>, Partial<IDisposable> {
     readonly absolutePath: string;
     countSubDirectory?(): number;
     createSubDirectory(subdirName: string): IDirectory;
     deleteSubDirectory(subdirName: string): boolean;
-    get<T = any>(key: string): T | undefined;
+    get<T = unknown>(key: string): T | undefined;
     getSubDirectory(subdirName: string): IDirectory | undefined;
     getWorkingDirectory(relativePath: string): IDirectory | undefined;
     hasSubDirectory(subdirName: string): boolean;
@@ -133,7 +133,7 @@ export interface IDirectoryValueChanged extends IValueChanged {
 export interface ILocalValue {
     makeSerialized(serializer: IFluidSerializer, bind: IFluidHandle): ISerializedValue;
     readonly type: string;
-    readonly value: any;
+    readonly value: unknown;
 }
 
 // @public @deprecated
@@ -151,7 +151,7 @@ export interface ISerializedValue {
 // @public
 export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents & IDirectoryEvents>, Omit<IDirectory, "on" | "once" | "off"> {
     // (undocumented)
-    [Symbol.iterator](): IterableIterator<[string, any]>;
+    [Symbol.iterator](): IterableIterator<[string, unknown]>;
     // (undocumented)
     readonly [Symbol.toStringTag]: string;
 }
@@ -165,8 +165,8 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
 }
 
 // @public
-export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string, any> {
-    get<T = any>(key: string): T | undefined;
+export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string, unknown> {
+    get<T = unknown>(key: string): T | undefined;
     set<T = unknown>(key: string, value: T): this;
 }
 
@@ -179,7 +179,7 @@ export interface ISharedMapEvents extends ISharedObjectEvents {
 // @public
 export interface IValueChanged {
     key: string;
-    previousValue: any;
+    previousValue: unknown;
 }
 
 // @public
@@ -207,7 +207,7 @@ export class MapFactory implements IChannelFactory {
 
 // @public @sealed
 export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implements ISharedDirectory {
-    [Symbol.iterator](): IterableIterator<[string, any]>;
+    [Symbol.iterator](): IterableIterator<[string, unknown]>;
     [Symbol.toStringTag]: string;
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
     get absolutePath(): string;
@@ -223,9 +223,9 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     dispose(error?: Error): void;
     // (undocumented)
     get disposed(): boolean;
-    entries(): IterableIterator<[string, any]>;
-    forEach(callback: (value: any, key: string, map: Map<string, any>) => void): void;
-    get<T = any>(key: string): T | undefined;
+    entries(): IterableIterator<[string, unknown]>;
+    forEach(callback: (value: unknown, key: string, map: Map<string, unknown>) => void): void;
+    get<T = unknown>(key: string): T | undefined;
     static getFactory(): IChannelFactory;
     getSubDirectory(subdirName: string): IDirectory | undefined;
     getWorkingDirectory(relativePath: string): IDirectory | undefined;
@@ -253,12 +253,12 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     submitDirectoryMessage(op: IDirectoryOperation, localOpMetadata: unknown): void;
     // @internal (undocumented)
     protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
-    values(): IterableIterator<any>;
+    values(): IterableIterator<unknown>;
 }
 
 // @public
 export class SharedMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
-    [Symbol.iterator](): IterableIterator<[string, any]>;
+    [Symbol.iterator](): IterableIterator<[string, unknown]>;
     readonly [Symbol.toStringTag]: string;
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
     // @internal (undocumented)
@@ -266,9 +266,9 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
     clear(): void;
     static create(runtime: IFluidDataStoreRuntime, id?: string): SharedMap;
     delete(key: string): boolean;
-    entries(): IterableIterator<[string, any]>;
-    forEach(callbackFn: (value: any, key: string, map: Map<string, any>) => void): void;
-    get<T = any>(key: string): T | undefined;
+    entries(): IterableIterator<[string, unknown]>;
+    forEach(callbackFn: (value: unknown, key: string, map: Map<string, unknown>) => void): void;
+    get<T = unknown>(key: string): T | undefined;
     static getFactory(): IChannelFactory;
     has(key: string): boolean;
     keys(): IterableIterator<string>;
@@ -286,7 +286,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
     get size(): number;
     // @internal (undocumented)
     protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
-    values(): IterableIterator<any>;
+    values(): IterableIterator<unknown>;
 }
 
 ```

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -377,9 +377,7 @@ export class SharedDirectory
 	/**
 	 * {@inheritDoc IDirectory.get}
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	public get<T = any>(key: string): T | undefined {
+	public get<T = unknown>(key: string): T | undefined {
 		return this.root.get<T>(key);
 	}
 
@@ -435,9 +433,9 @@ export class SharedDirectory
 	 * Issue a callback on each entry under this IDirectory.
 	 * @param callback - Callback to issue
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	public forEach(callback: (value: any, key: string, map: Map<string, any>) => void): void {
+	public forEach(
+		callback: (value: unknown, key: string, map: Map<string, unknown>) => void,
+	): void {
 		// eslint-disable-next-line unicorn/no-array-for-each, unicorn/no-array-callback-reference
 		this.root.forEach(callback);
 	}
@@ -446,9 +444,7 @@ export class SharedDirectory
 	 * Get an iterator over the entries under this IDirectory.
 	 * @returns The iterator
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	public [Symbol.iterator](): IterableIterator<[string, any]> {
+	public [Symbol.iterator](): IterableIterator<[string, unknown]> {
 		return this.root[Symbol.iterator]();
 	}
 
@@ -456,9 +452,7 @@ export class SharedDirectory
 	 * Get an iterator over the entries under this IDirectory.
 	 * @returns The iterator
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	public entries(): IterableIterator<[string, any]> {
+	public entries(): IterableIterator<[string, unknown]> {
 		return this.root.entries();
 	}
 
@@ -481,9 +475,7 @@ export class SharedDirectory
 	 * Get an iterator over the values under this IDirectory.
 	 * @returns The iterator
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	public values(): IterableIterator<any> {
+	public values(): IterableIterator<unknown> {
 		return this.root.values();
 	}
 

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -23,9 +23,7 @@ export interface IValueChanged {
 	/**
 	 * The value that was stored at the key prior to the change.
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	previousValue: any;
+	previousValue: unknown;
 }
 
 /**
@@ -33,10 +31,8 @@ export interface IValueChanged {
  *
  * @remarks When used as a Map, operates on its keys.
  */
-// TODO: Use `unknown` instead (breaking change).
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface IDirectory
-	extends Map<string, any>,
+	extends Map<string, unknown>,
 		IEventProvider<IDirectoryEvents>,
 		Partial<IDisposable> {
 	/**
@@ -49,9 +45,7 @@ export interface IDirectory
 	 * @param key - Key to retrieve from
 	 * @returns The stored value, or undefined if the key is not set
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	get<T = any>(key: string): T | undefined;
+	get<T = unknown>(key: string): T | undefined;
 
 	/**
 	 * Sets the value stored at key to the provided value.
@@ -271,9 +265,7 @@ export interface ISharedDirectory
 		Omit<IDirectory, "on" | "once" | "off"> {
 	// The Omit type excludes symbols, which we don't want to exclude.  Adding them back here manually.
 	// https://github.com/microsoft/TypeScript/issues/31671
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	[Symbol.iterator](): IterableIterator<[string, any]>;
+	[Symbol.iterator](): IterableIterator<[string, unknown]>;
 	readonly [Symbol.toStringTag]: string;
 }
 
@@ -328,17 +320,13 @@ export interface ISharedMapEvents extends ISharedObjectEvents {
  *
  * For more information, including example usages, see {@link https://fluidframework.com/docs/data-structures/map/}.
  */
-// TODO: Use `unknown` instead (breaking change).
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string, any> {
+export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string, unknown> {
 	/**
 	 * Retrieves the given key from the map if it exists.
 	 * @param key - Key to retrieve from
 	 * @returns The stored value, or undefined if the key is not set
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	get<T = any>(key: string): T | undefined;
+	get<T = unknown>(key: string): T | undefined;
 
 	/**
 	 * Sets the value stored at key to the provided value.

--- a/packages/dds/map/src/localValues.ts
+++ b/packages/dds/map/src/localValues.ts
@@ -25,9 +25,7 @@ export interface ILocalValue {
 	/**
 	 * The in-memory value stored within.
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	readonly value: any;
+	readonly value: unknown;
 
 	/**
 	 * Retrieve the serialized form of the value stored within.

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -159,9 +159,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	 * Get an iterator over the entries in this map.
 	 * @returns The iterator
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	public entries(): IterableIterator<[string, any]> {
+	public entries(): IterableIterator<[string, unknown]> {
 		return this.kernel.entries();
 	}
 
@@ -169,9 +167,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	 * Get an iterator over the values in this map.
 	 * @returns The iterator
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	public values(): IterableIterator<any> {
+	public values(): IterableIterator<unknown> {
 		return this.kernel.values();
 	}
 
@@ -179,9 +175,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	 * Get an iterator over the entries in this map.
 	 * @returns The iterator
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	public [Symbol.iterator](): IterableIterator<[string, any]> {
+	public [Symbol.iterator](): IterableIterator<[string, unknown]> {
 		return this.kernel.entries();
 	}
 
@@ -196,9 +190,9 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	 * Executes the given callback on each entry in the map.
 	 * @param callbackFn - Callback function
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	public forEach(callbackFn: (value: any, key: string, map: Map<string, any>) => void): void {
+	public forEach(
+		callbackFn: (value: unknown, key: string, map: Map<string, unknown>) => void,
+	): void {
 		// eslint-disable-next-line unicorn/no-array-for-each, unicorn/no-array-callback-reference
 		this.kernel.forEach(callbackFn);
 	}
@@ -206,9 +200,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	/**
 	 * {@inheritDoc ISharedMap.get}
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	public get<T = any>(key: string): T | undefined {
+	public get<T = unknown>(key: string): T | undefined {
 		return this.kernel.get<T>(key);
 	}
 

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -197,9 +197,7 @@ export class MapKernel {
 	 * Get an iterator over the entries in this map.
 	 * @returns The iterator
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	public entries(): IterableIterator<[string, any]> {
+	public entries(): IterableIterator<[string, unknown]> {
 		const localEntriesIterator = this.data.entries();
 		const iterator = {
 			next(): IteratorResult<[string, unknown]> {
@@ -220,9 +218,7 @@ export class MapKernel {
 	 * Get an iterator over the values in this map.
 	 * @returns The iterator
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	public values(): IterableIterator<any> {
+	public values(): IterableIterator<unknown> {
 		const localValuesIterator = this.data.values();
 		const iterator = {
 			next(): IteratorResult<unknown> {
@@ -230,7 +226,7 @@ export class MapKernel {
 				return nextVal.done
 					? { value: undefined, done: true }
 					: // Unpack the stored value
-					  { value: nextVal.value.value as unknown, done: false };
+					  { value: nextVal.value.value, done: false };
 			},
 			[Symbol.iterator](): IterableIterator<unknown> {
 				return this;
@@ -243,9 +239,7 @@ export class MapKernel {
 	 * Get an iterator over the entries in this map.
 	 * @returns The iterator
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	public [Symbol.iterator](): IterableIterator<[string, any]> {
+	public [Symbol.iterator](): IterableIterator<[string, unknown]> {
 		return this.entries();
 	}
 
@@ -265,9 +259,7 @@ export class MapKernel {
 	/**
 	 * {@inheritDoc ISharedMap.get}
 	 */
-	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	public get<T = any>(key: string): T | undefined {
+	public get<T = unknown>(key: string): T | undefined {
 		const localValue = this.data.get(key);
 		return localValue === undefined ? undefined : (localValue.value as T);
 	}

--- a/packages/dds/map/src/test/mocha/directory.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "assert";
 
 import { UsageError } from "@fluidframework/container-utils";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISummaryBlob, SummaryType } from "@fluidframework/protocol-definitions";
 import { IGCTestProvider, runGCTests } from "@fluid-internal/test-dds-utils";
 import {
@@ -1847,7 +1848,7 @@ describe("Directory", () => {
 				const subMapId = `subMap-${this.subMapCount}`;
 
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				const deletedHandle = fooDirectory.get(subMapId);
+				const deletedHandle = fooDirectory.get<IFluidHandle>(subMapId);
 				assert(deletedHandle, "Route must be added before deleting");
 
 				fooDirectory.delete(subMapId);

--- a/packages/dds/map/src/test/mocha/map.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.spec.ts
@@ -548,7 +548,8 @@ describe("Map", () => {
 
 					/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call */
 
-					const retrieved = map1.get("object");
+					const retrieved = map1.get<any>("object");
+					assert.notEqual(retrieved, undefined);
 					const retrievedSubMap: unknown = await retrieved.subMapHandle.get();
 					assert.equal(retrievedSubMap, subMap, "could not get nested map 1");
 					const retrievedSubMap2: unknown = await retrieved.nestedObj.subMap2Handle.get();


### PR DESCRIPTION
Follow-up to #13525

BREAKING CHANGE: Consumers of these APIs will either need to handle `unknown` map / directory values appropriately, or specify non-`unknown` type parameters.