### PR TITLE
[Port v2int 3.0] Fix child summary tree not available during refreshing GC state from snapshot (#13858)

### DIFF
--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -363,7 +363,9 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
         const gcDetailsMap = unpackChildNodesGCDetails(gcDetails);
         const { childrenTree } = parseSummaryForSubtrees(snapshotTree);
         gcDetailsMap.forEach((childGCDetails: IGarbageCollectionDetailsBase, childId: string) => {
-            childrenTree.trees[childId].blobs[gcTreeKey] = JSON.stringify(childGCDetails);
+            if (childrenTree.trees[childId] !== undefined) {
+                childrenTree.trees[childId].blobs[gcTreeKey] = JSON.stringify(childGCDetails);
+            }
         });
     }
 


### PR DESCRIPTION
Ported fix https://github.com/microsoft/FluidFramework/pull/13858.

## Bug
There have been some errors in stress tests (see the next section). This is because when refreshing GC state from snapshot, the downloaded snapshot may not have certain child snapshot trees. `SummarizerNodeWithGC::refreshGCStateFromSnapshot` assumed that child tree always exist which results in an error if the tree doesn't exist.

## Error in stress tests
<html>
<body>
<!--StartFragment--><span><span class="ui-provider cqb cqc va cqd cqe cqf cqg cqh cqi cqj cqk cql cqm cqn cqo cqp cqq cqr cqs cqt cqu cqv cqw cqx cqy cqz cra crb crc crd cre crf crg crh cri" dir="ltr"><p></p>

Data_eventName | Data_error | Data_errorType | Data_message | count_ | Data_stack
-- | -- | -- | -- | -- | --
fluid:telemetry:Summarizer:HandleSummaryAckError | Cannot read property 'blobs' of undefined |   |   | 3 | TypeError at /mnt/vss/_work/1/test/node_modules/@fluidframework/runtime-utils/dist/summarizerNode/summarizerNodeWithGc.js:243:41 at Map.forEach (<anonymous>) at SummarizerNodeWithGC.refreshGCStateFromSnapshot (/mnt/vss/_work/1/test/node_modules/@fluidframework/runtime-utils/dist/summarizerNode/summarizerNodeWithGc.js:242:22) at processTicksAndRejections (internal/process/task_queues.js:95:5) at async SummarizerNodeWithGC.refreshLatestSummaryFromSnapshot (/mnt/vss/_work/1/test/node_modules/@fluidframework/runtime-utils/dist/summarizerNode/summarizerNodeWithGc.js:175:9) at async SummarizerNodeWithGC.refreshLatestSummary (/mnt/vss/_work/1/test/node_modules/@fluidframework/runtime-utils/dist/summarizerNode/summarizerNode.js:198:9) at async ContainerRuntime.refreshLatestSummaryAck (/mnt/vss/_work/1/test/node_modules/@fluidframework/container-runtime/dist/containerRuntime.js:1850:24) at async Summarizer.handleSummaryAcks (/mnt/vss/_work/1/test/node_modules/@fluidframework/container-runtime/dist/summarizer.js:304:17)

<p>&nbsp;</p></span></span><!--EndFragment-->
</body>
</html>

## Fix
In `SummarizerNodeWithGC::refreshGCStateFromSnapshot`, check that a child sanpshot tree exists before using it.