### PR TITLE
Change ContainerDispose event to always be generic

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -890,7 +890,7 @@ export class Container
 				this.mc.logger.sendTelemetryEvent(
 					{
 						eventName: "ContainerDispose",
-						category: error === undefined ? "generic" : "error",
+						category: "generic",
 					},
 					error,
 				);


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

**Problem:** When we close and dispose a container, we end up sending 2 error events for the same error/flow.

If we are disposing a resource/container, we likely shouldn't care about if there was an error in terms of sending an error event (since that will be handled by close flow on unexpected exceptions).
So, the `"ContainerDispose"` should always be a "generic" event.

See https://github.com/microsoft/FluidFramework/pull/13726