### PR TITLE
Remove use of npx

### DIFF
--- a/build-tools/package-lock.json
+++ b/build-tools/package-lock.json
@@ -1,0 +1,1 @@
+Use pnpm not npm!

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -31,7 +31,6 @@
     "clean:nyc": "rimraf nyc/**",
     "commit": "git-cz",
     "format": "lerna run format --parallel --stream",
-    "preinstall": "npx only-allow pnpm",
     "postinstall": "npm run build:compile",
     "install:commitlint": "npm install --global @commitlint/config-conventional",
     "lint": "lerna run lint --no-sort --stream",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1 @@
+Use pnpm not npm!

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "clean:nyc": "rimraf nyc/**",
     "clean:r11s": "cd server/routerlicious && npm run clean",
     "format": "lerna run format --parallel --stream",
-    "preinstall": "npx only-allow pnpm",
     "layer-check": "fluid-layer-check --info build-tools/packages/build-tools/data/layerInfo.json",
     "lerna": "lerna",
     "lint": "lerna run lint --no-sort --stream",


### PR DESCRIPTION
## Description

This replaces:

```
$ npm i

> root@0.14.0 preinstall /home/craig/Work/FluidFramework.git/2
> npx only-allow pnpm

npx: installed 20 in 0.883s
╔═════════════════════════════════════════════════════════════╗
║                                                             ║
║   Use "pnpm install" for installation in this project.      ║
║                                                             ║
║   If you don't have pnpm, install it via "npm i -g pnpm".   ║
║   For more details, go to https://pnpm.js.org/              ║
║                                                             ║
╚═════════════════════════════════════════════════════════════╝
```

With:
```
$ npm i
npm ERR! Unexpected token U in JSON at position 0 while parsing near 'Use pnpm not npm!
npm ERR! '

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/craig/.npm/_logs/2023-02-02T01_36_05_535Z-debug.log
```
