### PR TITLE
stress: return blobs while offline

### DIFF
--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -340,7 +340,11 @@ export class FaultInjectionDocumentStorageService implements IDocumentStorageSer
 	}
 
 	public async readBlob(id: string): Promise<ArrayBufferLike> {
-		this.throwIfOffline();
+		// Intentionally return blobs even while offline. Current driver behavior is to cache the initial
+		// snapshot which means readBlob() calls will succeed regardless of connection status. While
+		// depending on this behavior is not advised, it's more accurate to real usage. Additionally, very
+		// long service response delays can cause offline injection to interfere with Container load, which
+		// is not expected to succeed offline, as well as interfering with the test setup itself.
 		return this.internal.readBlob(id);
 	}
 


### PR DESCRIPTION
Change `FaultInjectionDocumentStorageService.readBlob()` to return blobs when in simulated offline mode. This matches behavior of ODSP driver, which caches the initial snapshot.

Fix [AB#2590](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2590)