### PR TITLE
Decrease max batch size in the stress tests

### DIFF
--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -93,7 +93,7 @@ export function generateRuntimeOptions(
 		compressionOptions: [
 			{ minimumBatchSizeInBytes: 500, compressionAlgorithm: CompressionAlgorithms.lz4 },
 		],
-		maxBatchSizeInBytes: [undefined],
+		maxBatchSizeInBytes: [716800],
 		enableOpReentryCheck: [true],
 		// Compressed payloads over 1MB will be split into chunked ops of this size
 		chunkSizeInBytes: [1024, 38400, 614400],


### PR DESCRIPTION
## Description

Seeing some errors of the form:

```
Nack (BadRequestError): Message size too large. Boxcar message count: 1, size: 933394, max message size: 921600.
```

This is due to the fact that our max batch limit (if unspecified 972800) which will trigger chunking if exceeded is too high for the server-side limit of a message boxcar.

What happens is that the batch gets compressed and the payload becomes 933394 bytes. 933394 < 972800, therefore chunking will not be activated. The payload is sent as-is and the server rejects it with the message above.

**The default limit will also be made permanent in the runtime**