### PR TITLE
Fix deprecated endpoints in FRS Perf Tests

### DIFF
--- a/azure/packages/test/scenario-runner/README.md
+++ b/azure/packages/test/scenario-runner/README.md
@@ -32,7 +32,8 @@ This scenario loads a set of previously created docs multiple times and measures
 2. Set the `azure__fluid__relay__service__tenantKey` environment variable to equal your FRS Tenant's Primary Key
 3. Set the `azure__fluid__relay__service__function__url` environment variable to equal your FRS Service Function URL
 4. Set the `azure__fluid__relay__service__endpoint` environment variable to equal the Alfred endpoint of your FRS tenant
-5. Run the test with `npm run start`
+5. (Optional) Set the `azure__fluid__relay__service__region` environment variable to equal the region of your FRS tenant (eg. `westus2`, `westus3`, `eastus`, `westeurope`)
+6. Run the test with `npm run start`
 
 ## Configuring the test configuration
 

--- a/azure/packages/test/scenario-runner/src/DocCreatorRunner.ts
+++ b/azure/packages/test/scenario-runner/src/DocCreatorRunner.ts
@@ -15,6 +15,7 @@ export interface AzureClientConfig {
 	key?: string;
 	tenantId?: string;
 	useSecureTokenProvider?: boolean;
+	region?: string;
 }
 
 export interface DocSchema {
@@ -63,6 +64,7 @@ export class DocCreatorRunner extends TypedEventEmitter<IRunnerEvents> implement
 				connection.type,
 				...(connection.endpoint ? ["--connEndpoint", connection.endpoint] : []),
 				...(connection.useSecureTokenProvider ? ["--secureTokenProvider"] : []),
+				...(connection.region ? ["--region", connection.region] : []),
 			];
 			childArgs.push("--verbose");
 			runnerArgs.push(childArgs);

--- a/azure/packages/test/scenario-runner/src/DocLoaderRunner.ts
+++ b/azure/packages/test/scenario-runner/src/DocLoaderRunner.ts
@@ -15,6 +15,7 @@ export interface AzureClientConfig {
 	key?: string;
 	tenantId?: string;
 	useSecureTokenProvider?: boolean;
+	region?: string;
 }
 
 export interface DocLoaderSchema {
@@ -64,6 +65,7 @@ export class DocLoaderRunner extends TypedEventEmitter<IRunnerEvents> implements
 				connection.type,
 				...(connection.endpoint ? ["--connEndpoint", connection.endpoint] : []),
 				...(connection.useSecureTokenProvider ? ["--secureTokenProvider"] : []),
+				...(connection.region ? ["--region", connection.region] : []),
 			];
 			childArgs.push("--verbose");
 			runnerArgs.push(childArgs);

--- a/azure/packages/test/scenario-runner/src/MapTrafficRunner.ts
+++ b/azure/packages/test/scenario-runner/src/MapTrafficRunner.ts
@@ -15,6 +15,7 @@ export interface AzureClientConfig {
 	key?: string;
 	tenantId?: string;
 	useSecureTokenProvider?: boolean;
+	region?: string;
 }
 
 export interface ContainerTrafficSchema {
@@ -73,6 +74,7 @@ export class MapTrafficRunner extends TypedEventEmitter<IRunnerEvents> implement
 				connection.type,
 				...(connection.endpoint ? ["--connEndpoint", connection.endpoint] : []),
 				...(connection.useSecureTokenProvider ? ["--secureTokenProvider"] : []),
+				...(connection.region ? ["--region", connection.region] : []),
 			];
 			childArgs.push("--verbose");
 			runnerArgs.push(childArgs);

--- a/azure/packages/test/scenario-runner/src/TestOrchestrator.ts
+++ b/azure/packages/test/scenario-runner/src/TestOrchestrator.ts
@@ -94,7 +94,8 @@ export class TestOrchestrator {
 			runId: this.runId,
 			scenarioName: this.doc?.title,
 			namespace: "scenario:runner",
-			endpoint: connConfig.endpoint,
+			endpoint: connConfig.endpoint ?? process.env.azure__fluid__relay__service__endpoint,
+			region: connConfig.endpoint ?? process.env.azure__fluid__relay__service__region,
 		});
 
 		const success = await PerformanceEvent.timedExecAsync(

--- a/azure/packages/test/scenario-runner/src/docCreatorRunnerClient.ts
+++ b/azure/packages/test/scenario-runner/src/docCreatorRunnerClient.ts
@@ -52,6 +52,7 @@ export interface DocCreatorRunnerConfig {
 	childId: number;
 	connType: string;
 	connEndpoint: string;
+	region?: string;
 }
 
 async function main() {
@@ -73,6 +74,7 @@ async function main() {
 		.option("-tk, --tenantKey <tenantKey>", "Tenant Key")
 		.option("-furl, --functionUrl <functionUrl>", "Azure Function URL")
 		.option("-st, --secureTokenProvider", "Enable use of secure token provider")
+		.option("-rg, --region <region>", "Alias of Azure region where the tenant is running from")
 		.option(
 			"-l, --log <filter>",
 			"Filter debug logging. If not provided, uses DEBUG env variable.",
@@ -91,6 +93,7 @@ async function main() {
 		functionUrl:
 			commander.functionUrl ?? process.env.azure__fluid__relay__service__function__url,
 		secureTokenProvider: commander.secureTokenProvider,
+		region: commander.region ?? process.env.azure__fluid__relay__service__region,
 	};
 
 	if (commander.log !== undefined) {
@@ -102,6 +105,7 @@ async function main() {
 			runId: config.runId,
 			scenarioName: config.scenarioName,
 			endpoint: config.connEndpoint,
+			region: config.region,
 		},
 		["scenario:runner"],
 		eventMap,
@@ -131,6 +135,7 @@ async function execRun(ac: AzureClient, config: DocCreatorRunnerConfig): Promise
 			scenarioName: config.scenarioName,
 			namespace: "scenario:runner:DocCreator",
 			endpoint: config.connEndpoint,
+			region: config.region,
 		},
 		["scenario:runner"],
 		eventMap,

--- a/azure/packages/test/scenario-runner/src/docLoaderRunnerClient.ts
+++ b/azure/packages/test/scenario-runner/src/docLoaderRunnerClient.ts
@@ -55,6 +55,7 @@ export interface DocLoaderRunnerConfig {
 	docId: string;
 	connType: string;
 	connEndpoint: string;
+	region?: string;
 }
 
 async function main() {
@@ -77,6 +78,7 @@ async function main() {
 		.option("-tk, --tenantKey <tenantKey>", "Tenant Key")
 		.option("-furl, --functionUrl <functionUrl>", "Azure Function URL")
 		.option("-st, --secureTokenProvider", "Enable use of secure token provider")
+		.option("-rg, --region <region>", "Alias of Azure region where the tenant is running from")
 		.option(
 			"-l, --log <filter>",
 			"Filter debug logging. If not provided, uses DEBUG env variable.",
@@ -96,6 +98,7 @@ async function main() {
 		functionUrl:
 			commander.functionUrl ?? process.env.azure__fluid__relay__service__function__url,
 		secureTokenProvider: commander.secureTokenProvider,
+		region: commander.region ?? process.env.azure__fluid__relay__service__region,
 	};
 
 	if (commander.log !== undefined) {
@@ -107,6 +110,7 @@ async function main() {
 			runId: config.runId,
 			scenarioName: config.scenarioName,
 			endpoint: config.connEndpoint,
+			region: config.region,
 		},
 		["scenario:runner"],
 		eventMap,
@@ -136,6 +140,7 @@ async function execRun(ac: AzureClient, config: DocLoaderRunnerConfig): Promise<
 			scenarioName: config.scenarioName,
 			namespace: "scenario:runner:DocLoader",
 			endpoint: config.connEndpoint,
+			region: config.region,
 		},
 		["scenario:runner"],
 		eventMap,

--- a/azure/packages/test/scenario-runner/src/logger.ts
+++ b/azure/packages/test/scenario-runner/src/logger.ts
@@ -17,6 +17,7 @@ export interface LoggerConfig {
 	namespace?: string;
 	runId?: string;
 	endpoint?: string;
+	region?: string;
 }
 
 class ScenarioRunnerLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
@@ -114,18 +115,6 @@ export const loggerP = new LazyPromise<ScenarioRunnerLogger>(async () => {
 	}
 });
 
-function getRegionFromEndpointUrl(endpointUrl: string): string | undefined {
-	const definedRegions = ["westus2", "westus3", "eastus", "europe"];
-
-	for (const region of definedRegions) {
-		if (endpointUrl.includes(region)) {
-			return region;
-		}
-	}
-
-	return undefined;
-}
-
 export async function getLogger(
 	config: LoggerConfig,
 	events?: string[],
@@ -142,7 +131,8 @@ export async function getLogger(
 		all: {
 			runId: config.runId,
 			scenarioName: config.scenarioName,
-			endpoint: config.endpoint && getRegionFromEndpointUrl(config.endpoint), // parse URL to only contain the region
+			endpoint: config.endpoint,
+			region: config.region,
 		},
 	});
 }

--- a/azure/packages/test/scenario-runner/src/mapTrafficRunnerClient.ts
+++ b/azure/packages/test/scenario-runner/src/mapTrafficRunnerClient.ts
@@ -14,6 +14,39 @@ import { ContainerFactorySchema } from "./interface";
 import { getLogger } from "./logger";
 import { createAzureClient, delay, loadInitialObjSchema } from "./utils";
 
+const eventMap = new Map([
+	[
+		"fluid:telemetry:RouterliciousDriver:FetchOrdererToken",
+		"scenario:runner:DocLoader:Load:FetchOrdererToken",
+	],
+	[
+		"fluid:telemetry:RouterliciousDriver:DiscoverSession",
+		"scenario:runner:DocLoader:Load:DiscoverSession",
+	],
+	[
+		"fluid:telemetry:RouterliciousDriver:FetchStorageToken",
+		"scenario:runner:DocLoader:Load:FetchStorageToken",
+	],
+	[
+		"fluid:telemetry:RouterliciousDriver:getWholeFlatSummary",
+		"scenario:runner:DocLoader:Load:GetSummary",
+	],
+	["fluid:telemetry:RouterliciousDriver:GetDeltas", "scenario:runner:DocLoader:Load:GetDeltas"],
+	["fluid:telemetry:Container:Request", "scenario:runner:DocLoader:Load:RequestDataObject"],
+	[
+		"fluid:telemetry:RouterliciousDriver:GetDeltaStreamToken",
+		"scenario:runner:DocLoader:Connection:GetDeltaStreamToken",
+	],
+	[
+		"fluid:telemetry:RouterliciousDriver:ConnectToDeltaStream",
+		"scenario:runner:DocLoader:Connection:ConnectToDeltaStream",
+	],
+	[
+		"fluid:telemetry:Container:ConnectionStateChange",
+		"scenario:runner:DocLoader:Connection:ConnectionStateChange",
+	],
+]);
+
 export interface MapTrafficRunnerConfig {
 	runId: string;
 	scenarioName: string;
@@ -24,6 +57,7 @@ export interface MapTrafficRunnerConfig {
 	sharedMapKey: string;
 	connType: string;
 	connEndpoint: string;
+	region?: string;
 }
 
 async function main() {
@@ -53,6 +87,7 @@ async function main() {
 		.option("-tk, --tenantKey <tenantKey>", "Tenant Key")
 		.option("-furl, --functionUrl <functionUrl>", "Azure Function URL")
 		.option("-st, --secureTokenProvider", "Enable use of secure token provider")
+		.option("-rg, --region <region>", "Alias of Azure region where the tenant is running from")
 		.option(
 			"-l, --log <filter>",
 			"Filter debug logging. If not provided, uses DEBUG env variable.",
@@ -75,6 +110,7 @@ async function main() {
 		functionUrl:
 			commander.functionUrl ?? process.env.azure__fluid__relay__service__function__url,
 		secureTokenProvider: commander.secureTokenProvider,
+		region: commander.region ?? process.env.azure__fluid__relay__service__region,
 	};
 
 	if (commander.log !== undefined) {
@@ -90,11 +126,10 @@ async function main() {
 		{
 			runId: config.runId,
 			scenarioName: config.scenarioName,
+			endpoint: config.connEndpoint,
+			region: config.region,
 		},
-		[
-			"scenario:runner",
-			// "fluid:telemetry:OpPerf"
-		],
+		["scenario:runner", eventMap],
 	);
 
 	const ac = await createAzureClient({
@@ -115,11 +150,17 @@ async function main() {
 
 async function execRun(ac: AzureClient, config: MapTrafficRunnerConfig): Promise<void> {
 	const msBetweenWrites = 60000 / config.writeRatePerMin;
-	const logger = await getLogger({
-		runId: config.runId,
-		scenarioName: config.scenarioName,
-		namespace: "scenario:runner:MapTraffic",
-	});
+	const logger = await getLogger(
+		{
+			runId: config.runId,
+			scenarioName: config.scenarioName,
+			namespace: "scenario:runner:MapTraffic",
+			endpoint: config.connEndpoint,
+			region: config.region,
+		},
+		["scenario:runner"],
+		eventMap,
+	);
 
 	const s = loadInitialObjSchema(JSON.parse(commander.schema) as ContainerFactorySchema);
 	const { container } = await PerformanceEvent.timedExecAsync(

--- a/azure/packages/test/scenario-runner/src/mapTrafficRunnerClient.ts
+++ b/azure/packages/test/scenario-runner/src/mapTrafficRunnerClient.ts
@@ -129,7 +129,8 @@ async function main() {
 			endpoint: config.connEndpoint,
 			region: config.region,
 		},
-		["scenario:runner", eventMap],
+		["scenario:runner"],
+		eventMap,
 	);
 
 	const ac = await createAzureClient({

--- a/tools/pipelines/fluid-afr-perf-test.yml
+++ b/tools/pipelines/fluid-afr-perf-test.yml
@@ -51,7 +51,6 @@ stages:
             azure__fluid__relay__service__tenantKey: $(fluid-afr-perf-test-westus2-tenantKey)
             azure__fluid__relay__service__function__url: $(fluid-afr-perf-test-westus2-function-url)
   # Run Azure Client FRS Tests (WestUS3)
-  # TODO: This region hangs indefinitely on the first test. Re-enable when we can figure out why.
   - stage:
     displayName: AFR Perf Tests (WestUS3)
     dependsOn: []
@@ -72,7 +71,6 @@ stages:
             azure__fluid__relay__service__tenantKey: $(fluid-afr-perf-test-westus3-tenantKey)
             azure__fluid__relay__service__function__url: $(fluid-afr-perf-test-westus3-function-url)
   # Run Azure Client FRS Tests (EastUS)
-  # TODO: This region hangs indefinitely on the first test. Re-enable when we can figure out why.
   - stage:
     displayName: AFR Perf Tests (EastUS)
     dependsOn: []

--- a/tools/pipelines/fluid-afr-perf-test.yml
+++ b/tools/pipelines/fluid-afr-perf-test.yml
@@ -45,6 +45,7 @@ stages:
           artifactBuildId: $(resources.pipeline.azure.runID)
           env:
             FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+            azure__fluid__relay__service__region: westus2
             azure__fluid__relay__service__endpoint: $(fluid-afr-perf-test-westus2-endpoint)
             azure__fluid__relay__service__tenantId: $(fluid-afr-perf-test-westus2-tenantId)
             azure__fluid__relay__service__tenantKey: $(fluid-afr-perf-test-westus2-tenantKey)
@@ -65,6 +66,7 @@ stages:
   #         artifactBuildId: $(resources.pipeline.azure.runID)
   #         env:
   #           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+  #           azure__fluid__relay__service__region: westus3
   #           azure__fluid__relay__service__endpoint: $(fluid-afr-perf-test-westus3-endpoint)
   #           azure__fluid__relay__service__tenantId: $(fluid-afr-perf-test-westus3-tenantId)
   #           azure__fluid__relay__service__tenantKey: $(fluid-afr-perf-test-westus3-tenantKey)
@@ -85,6 +87,7 @@ stages:
   #         artifactBuildId: $(resources.pipeline.azure.runID)
   #         env:
   #           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+  #           azure__fluid__relay__service__region: eastus
   #           azure__fluid__relay__service__endpoint: $(fluid-afr-perf-test-eastus-endpoint)
   #           azure__fluid__relay__service__tenantId: $(fluid-afr-perf-test-eastus-tenantId)
   #           azure__fluid__relay__service__tenantKey: $(fluid-afr-perf-test-eastus-tenantKey)
@@ -104,6 +107,7 @@ stages:
           artifactBuildId: $(resources.pipeline.azure.runID)
           env:
             FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+            azure__fluid__relay__service__region: westeurope
             azure__fluid__relay__service__endpoint: $(fluid-afr-perf-test-westeurope-endpoint)
             azure__fluid__relay__service__tenantId: $(fluid-afr-perf-test-westeurope-tenantId)
             azure__fluid__relay__service__tenantKey: $(fluid-afr-perf-test-westeurope-tenantKey)

--- a/tools/pipelines/fluid-afr-perf-test.yml
+++ b/tools/pipelines/fluid-afr-perf-test.yml
@@ -52,46 +52,46 @@ stages:
             azure__fluid__relay__service__function__url: $(fluid-afr-perf-test-westus2-function-url)
   # Run Azure Client FRS Tests (WestUS3)
   # TODO: This region hangs indefinitely on the first test. Re-enable when we can figure out why.
-  # - stage:
-  #   displayName: AFR Perf Tests (WestUS3)
-  #   dependsOn: []
-  #   jobs:
-  #     - template: templates/include-test-real-service.yml
-  #       parameters:
-  #         poolBuild: Small
-  #         testPackage: "@fluidframework/azure-scenario-runner"
-  #         testWorkspace: ${{ variables.testWorkspace }}
-  #         testCommand: start
-  #         downloadAzureTestArtifacts: true
-  #         artifactBuildId: $(resources.pipeline.azure.runID)
-  #         env:
-  #           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-  #           azure__fluid__relay__service__region: westus3
-  #           azure__fluid__relay__service__endpoint: $(fluid-afr-perf-test-westus3-endpoint)
-  #           azure__fluid__relay__service__tenantId: $(fluid-afr-perf-test-westus3-tenantId)
-  #           azure__fluid__relay__service__tenantKey: $(fluid-afr-perf-test-westus3-tenantKey)
-  #           azure__fluid__relay__service__function__url: $(fluid-afr-perf-test-westus3-function-url)
+  - stage:
+    displayName: AFR Perf Tests (WestUS3)
+    dependsOn: []
+    jobs:
+      - template: templates/include-test-real-service.yml
+        parameters:
+          poolBuild: Small
+          testPackage: "@fluidframework/azure-scenario-runner"
+          testWorkspace: ${{ variables.testWorkspace }}
+          testCommand: start
+          downloadAzureTestArtifacts: true
+          artifactBuildId: $(resources.pipeline.azure.runID)
+          env:
+            FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+            azure__fluid__relay__service__region: westus3
+            azure__fluid__relay__service__endpoint: $(fluid-afr-perf-test-westus3-endpoint)
+            azure__fluid__relay__service__tenantId: $(fluid-afr-perf-test-westus3-tenantId)
+            azure__fluid__relay__service__tenantKey: $(fluid-afr-perf-test-westus3-tenantKey)
+            azure__fluid__relay__service__function__url: $(fluid-afr-perf-test-westus3-function-url)
   # Run Azure Client FRS Tests (EastUS)
   # TODO: This region hangs indefinitely on the first test. Re-enable when we can figure out why.
-  # - stage:
-  #   displayName: AFR Perf Tests (EastUS)
-  #   dependsOn: []
-  #   jobs:
-  #     - template: templates/include-test-real-service.yml
-  #       parameters:
-  #         poolBuild: Small
-  #         testPackage: "@fluidframework/azure-scenario-runner"
-  #         testWorkspace: ${{ variables.testWorkspace }}
-  #         testCommand: start
-  #         downloadAzureTestArtifacts: true
-  #         artifactBuildId: $(resources.pipeline.azure.runID)
-  #         env:
-  #           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-  #           azure__fluid__relay__service__region: eastus
-  #           azure__fluid__relay__service__endpoint: $(fluid-afr-perf-test-eastus-endpoint)
-  #           azure__fluid__relay__service__tenantId: $(fluid-afr-perf-test-eastus-tenantId)
-  #           azure__fluid__relay__service__tenantKey: $(fluid-afr-perf-test-eastus-tenantKey)
-  #           azure__fluid__relay__service__function__url: $(fluid-afr-perf-test-eastus-function-url)
+  - stage:
+    displayName: AFR Perf Tests (EastUS)
+    dependsOn: []
+    jobs:
+      - template: templates/include-test-real-service.yml
+        parameters:
+          poolBuild: Small
+          testPackage: "@fluidframework/azure-scenario-runner"
+          testWorkspace: ${{ variables.testWorkspace }}
+          testCommand: start
+          downloadAzureTestArtifacts: true
+          artifactBuildId: $(resources.pipeline.azure.runID)
+          env:
+            FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+            azure__fluid__relay__service__region: eastus
+            azure__fluid__relay__service__endpoint: $(fluid-afr-perf-test-eastus-endpoint)
+            azure__fluid__relay__service__tenantId: $(fluid-afr-perf-test-eastus-tenantId)
+            azure__fluid__relay__service__tenantKey: $(fluid-afr-perf-test-eastus-tenantKey)
+            azure__fluid__relay__service__function__url: $(fluid-afr-perf-test-eastus-function-url)
   # Run Azure Client FRS Tests (WestEurope)
   - stage:
     displayName: AFR Perf Tests (WestEurope)


### PR DESCRIPTION
## Description

The AFR endpoint that was previously being used (`https://alfred.westus2.fluidrelay.azure.com`) has been deprecated.
Replaced with the new endpoint: `https://us.fluidrelay.azure.com`

## Changes

* Added a new `region` env variable to specify the region since the endpoint URL no longer contains the specific region name rather it clusters multiple regions (eg. eastus, westus2, westus3 all use the us.fluidrelay.azure.com endpoint)
* In Aria logs, renamed the `endpoint` field (`Data_endpoint`) which was actually used to represent the region to `region` (`Data_region`)
* In Aria logs added a new `endpoint` field (`Data_endpoint`) used to represent the actual URL endpoint used (eg. `https://us.fluidrelay.azure.com`)
* Added eventMap to mapTrafficRunner
* Re-enabled previously failing regions as they're now working with the new endpoint (WestUS3, EastUS)
