### PR TITLE
build: Remove / update .editorconfig files to accommodate prettier / tsdoc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,18 +4,4 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
-indent_style = space
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-# C-style doc comments
-block_comment_start = /*
-block_comment = *
-block_comment_end = */
-
-[*.{js,jsx,ts,tsx}]
-indent_size = 4
-
-[{*.yml,package.json}]
-indent_size = 2
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,0 @@
-# Don't go up further looking for more .editorconfig files
-root = true
-
-[*]
-charset = utf-8
-end_of_line = lf
-indent_style = tab

--- a/azure/.editorconfig
+++ b/azure/.editorconfig
@@ -4,18 +4,4 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
-indent_style = space
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-# C-style doc comments
-block_comment_start = /*
-block_comment = *
-block_comment_end = */
-
-[*.{js,jsx,ts,tsx}]
-indent_size = 4
-
-[{*.yml,package.json}]
-indent_size = 2
+indent_style = tab

--- a/azure/.editorconfig
+++ b/azure/.editorconfig
@@ -1,7 +1,0 @@
-# Don't go up further looking for more .editorconfig files
-root = true
-
-[*]
-charset = utf-8
-end_of_line = lf
-indent_style = tab

--- a/azure/packages/external-controller/.editorconfig
+++ b/azure/packages/external-controller/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/common/build/eslint-config-fluid/.editorconfig
+++ b/common/build/eslint-config-fluid/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/docs/.editorconfig
+++ b/docs/.editorconfig
@@ -1,9 +1,7 @@
-[*]
-trim_trailing_whitespace = true
-insert_final_newline = true
-indent_style = space
-indent_size = 4
+# Don't go up further looking for more .editorconfig files
+root = true
 
-[*.{json,md,scss,toml,yml}]
-indent_style = space
-indent_size = 2
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab

--- a/docs/.editorconfig
+++ b/docs/.editorconfig
@@ -1,7 +1,0 @@
-# Don't go up further looking for more .editorconfig files
-root = true
-
-[*]
-charset = utf-8
-end_of_line = lf
-indent_style = tab

--- a/examples/apps/contact-collection/.editorconfig
+++ b/examples/apps/contact-collection/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/apps/data-object-grid/.editorconfig
+++ b/examples/apps/data-object-grid/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/apps/view-framework-sampler/.editorconfig
+++ b/examples/apps/view-framework-sampler/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/data-objects/diceroller/.editorconfig
+++ b/examples/data-objects/diceroller/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/data-objects/monaco/.editorconfig
+++ b/examples/data-objects/monaco/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/data-objects/multiview/constellation-model/.editorconfig
+++ b/examples/data-objects/multiview/constellation-model/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/data-objects/multiview/constellation-view/.editorconfig
+++ b/examples/data-objects/multiview/constellation-view/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/data-objects/multiview/container/.editorconfig
+++ b/examples/data-objects/multiview/container/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/data-objects/multiview/coordinate-model/.editorconfig
+++ b/examples/data-objects/multiview/coordinate-model/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/data-objects/multiview/interface/.editorconfig
+++ b/examples/data-objects/multiview/interface/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/data-objects/multiview/plot-coordinate-view/.editorconfig
+++ b/examples/data-objects/multiview/plot-coordinate-view/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/data-objects/multiview/slider-coordinate-view/.editorconfig
+++ b/examples/data-objects/multiview/slider-coordinate-view/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/data-objects/multiview/triangle-view/.editorconfig
+++ b/examples/data-objects/multiview/triangle-view/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/data-objects/shared-text/.editorconfig
+++ b/examples/data-objects/shared-text/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/data-objects/task-selection/.editorconfig
+++ b/examples/data-objects/task-selection/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/data-objects/todo/.editorconfig
+++ b/examples/data-objects/todo/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/hosts/app-integration/container-views/.editorconfig
+++ b/examples/hosts/app-integration/container-views/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/hosts/app-integration/external-data/.editorconfig
+++ b/examples/hosts/app-integration/external-data/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/hosts/app-integration/external-views/.editorconfig
+++ b/examples/hosts/app-integration/external-views/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/hosts/app-integration/schema-upgrade/.editorconfig
+++ b/examples/hosts/app-integration/schema-upgrade/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/examples/utils/bundle-size-tests/.editorconfig
+++ b/examples/utils/bundle-size-tests/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/experimental/dds/sequence-deprecated/.editorconfig
+++ b/experimental/dds/sequence-deprecated/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/experimental/examples/bubblebench/baseline/.editorconfig
+++ b/experimental/examples/bubblebench/baseline/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/experimental/examples/bubblebench/common/.editorconfig
+++ b/experimental/examples/bubblebench/common/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/experimental/examples/bubblebench/ot/.editorconfig
+++ b/experimental/examples/bubblebench/ot/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/experimental/examples/bubblebench/sharedtree/.editorconfig
+++ b/experimental/examples/bubblebench/sharedtree/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/packages/dds/sequence/.editorconfig
+++ b/packages/dds/sequence/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/packages/drivers/odsp-driver-definitions/.editorconfig
+++ b/packages/drivers/odsp-driver-definitions/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/packages/drivers/odsp-driver/.editorconfig
+++ b/packages/drivers/odsp-driver/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-indent_size = 4
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[package.json]
-indent_size = 2

--- a/server/gitrest/.editorconfig
+++ b/server/gitrest/.editorconfig
@@ -9,11 +9,6 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-# C-style doc comments
-block_comment_start = /*
-block_comment = *
-block_comment_end = */
-
 [*.{js,jsx,ts,tsx}]
 indent_size = 4
 

--- a/server/historian/.editorconfig
+++ b/server/historian/.editorconfig
@@ -9,11 +9,6 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-# C-style doc comments
-block_comment_start = /*
-block_comment = *
-block_comment_end = */
-
 [*.{js,jsx,ts,tsx}]
 indent_size = 4
 

--- a/server/routerlicious/.editorconfig
+++ b/server/routerlicious/.editorconfig
@@ -9,11 +9,6 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-# C-style doc comments
-block_comment_start = /*
-block_comment = *
-block_comment_end = */
-
 [*.{js,jsx,ts,tsx}]
 indent_size = 4
 


### PR DESCRIPTION
The recent prettier changes updated our formatting defaults (everywhere except for `server`, for now) to use tabs instead of spaces. While our vscode settings were updated to reflect this change, our `.editorconfig` files were not.

Additionally, removes settings around c-style comment blocks, as we use jsdoc/tsdoc comment syntax.

This PR removes the `.editorconfig` files from areas of the codebase that are now using prettier for formatting, and updates the remainder to remove tsdoc-incompatible rules.