### PR TITLE
Revert "Increase timeout for tree/basicChunk tests to mitigate timeout failures"

### DIFF
--- a/packages/dds/tree/src/test/cursorTestSuite.ts
+++ b/packages/dds/tree/src/test/cursorTestSuite.ts
@@ -143,13 +143,13 @@ export function testGeneralPurposeTreeCursor<TData, TCursor extends ITreeCursor>
 	cursorFactory: (data: TData) => TCursor,
 	dataFromCursor: (cursor: ITreeCursor) => TData,
 	extraRoot?: true,
-): Mocha.Suite {
+): void {
 	function dataFromJsonableTree(data: JsonableTree): TData {
 		// Use text cursor to provide input data
 		return dataFromCursor(singleTextCursor(data));
 	}
 
-	return testTreeCursor<TData, TCursor>({
+	testTreeCursor<TData, TCursor>({
 		cursorName,
 		cursorFactory,
 		builders: dataFromJsonableTree,

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
@@ -56,7 +56,7 @@ describe("basic chunk", () => {
 		},
 		jsonableTreeFromCursor,
 		true,
-	).timeout(10000);
+	);
 
 	const schema: TreeSchemaIdentifier = brand("fakeSchema");
 
@@ -88,5 +88,5 @@ describe("basic chunk", () => {
 		},
 		cursorFactory: (data: TreeChunk): ITreeCursorSynchronous => data.cursor(),
 		testData: hybridData,
-	}).timeout(10000);
+	});
 });


### PR DESCRIPTION
Reverts microsoft/FluidFramework#13962

This PR doesn't seem to have actually increased the timeout, as a merge to main failed with the complaint that the tests are still timing out after 4s. So, reverting this PR as it's basically not made any difference at all!