### PR TITLE
Disable polygon tree tests as they keep timing out

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/uniformChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/uniformChunk.spec.ts
@@ -114,7 +114,7 @@ describe("uniformChunk", () => {
 	];
 
 	for (const { name: cursorName, factory } of cursorSources) {
-		describe.skip(`${cursorName} bench`, () => {
+		describe(`${cursorName} bench`, () => {
 			let cursor: ITreeCursorSynchronous;
 			for (const { name, dataFactory: data } of testData) {
 				benchmark({

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/uniformChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/uniformChunk.spec.ts
@@ -114,7 +114,7 @@ describe("uniformChunk", () => {
 	];
 
 	for (const { name: cursorName, factory } of cursorSources) {
-		describe(`${cursorName} bench`, () => {
+		describe.skip(`${cursorName} bench`, () => {
 			let cursor: ITreeCursorSynchronous;
 			for (const { name, dataFactory: data } of testData) {
 				benchmark({

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/uniformChunkTestData.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/uniformChunkTestData.ts
@@ -115,10 +115,6 @@ const testTrees = [
 			},
 		],
 	},
-	{
-		...polygonTree,
-		reference: [polygonTree.reference],
-	},
 ];
 
 export const testData: readonly TestField<UniformChunk>[] = testTrees.map(


### PR DESCRIPTION
Disable polygon tests until timeout errors are fixed. [ADO#3374 ](https://dev.azure.com/fluidframework/internal/_workitems/edit/3374)