### PR TITLE
build: Replace npx only-allow

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -31,7 +31,7 @@
 		"clean:nyc": "rimraf nyc/**",
 		"commit": "git-cz",
 		"format": "npm run prettier:fix",
-		"preinstall": "npx only-allow pnpm",
+		"preinstall": "node ../scripts/only-pnpm.cjs",
 		"postinstall": "npm run build:compile",
 		"install:commitlint": "npm install --global @commitlint/config-conventional",
 		"lint": "lerna run lint --no-sort --stream",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"clean:nyc": "rimraf nyc/**",
 		"clean:r11s": "cd server/routerlicious && npm run clean",
 		"format": "npm run prettier:fix:root && lerna run format --parallel --stream",
-		"preinstall": "npx only-allow pnpm",
+		"preinstall": "node scripts/only-pnpm.cjs",
 		"layer-check": "fluid-layer-check --info build-tools/packages/build-tools/data/layerInfo.json",
 		"lerna": "lerna",
 		"lint": "npm run prettier:root && lerna run lint --no-sort --stream",

--- a/scripts/only-pnpm.cjs
+++ b/scripts/only-pnpm.cjs
@@ -19,5 +19,9 @@ const message = `
 ╚═════════════════════════════════════════════════════════════╝
 `;
 
-console.error(message);
-process.exit(1);
+const used_pnpm = process.env.npm_config_user_agent.startsWith(`pnpm`);
+
+if(!used_pnpm) {
+    console.error(message);
+    process.exit(1);
+}

--- a/scripts/only-pnpm.cjs
+++ b/scripts/only-pnpm.cjs
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * This script is used to prompt users to use pnpm in a project. This helps guide new contributors to the right tools.
+ * To use this script in a project, add a "preinstall" script to the package.json that calls this script.
+ */
+
+const message = `
+╔═════════════════════════════════════════════════════════════╗
+║                                                             ║
+║   Use "pnpm install" for installation in this project.      ║
+║                                                             ║
+║   If you don't have pnpm, install it via "npm i -g pnpm".   ║
+║   For more details, see the README.                         ║
+║                                                             ║
+╚═════════════════════════════════════════════════════════════╝
+`;
+
+console.error(message);
+process.exit(1);


### PR DESCRIPTION
Using `npx only-allow` is convenient, but we can reduce our dependencies and improve the security of our dev experience by using a local script to prompt users to install pnpm instead. This PR does just that.