### PR TITLE
Attempt to force refreshSummary to happen before summarize when lastSummaryAck exists

### DIFF
--- a/packages/runtime/container-runtime/src/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/runningSummarizer.ts
@@ -249,29 +249,29 @@ export class RunningSummarizer implements IDisposable {
 						summaryRefSeq: refSequenceNumber,
 						summaryLogger,
 					}).catch(async (error) => {
-                        // If the error is 404, so maybe the fetched version no longer exists on server. We just
-                        // ignore this error in that case, as that means we will have another summaryAck for the
-                        // latest version with which we will refresh the state. However in case of single commit
-                        // summary, we might me missing a summary ack, so in that case we are still fine as the
-                        // code in `submitSummary` function in container runtime, will refresh the latest state
-                        // by calling `refreshLatestSummaryAckFromServer` and we will be fine.
-                        if (
-                            isFluidError(error) &&
-                            error.errorType === DriverErrorType.fileNotFoundOrAccessDeniedError
-                        ) {
-                            summaryLogger.sendTelemetryEvent(
-                                {
-                                    eventName: "HandleSummaryAckErrorIgnored",
-                                    referenceSequenceNumber: refSequenceNumber,
-                                    proposalHandle: summaryOpHandle,
-                                    ackHandle: summaryAckHandle,
-                                },
-                                error,
-                            );
-                        } else {
-                            throw error;
-                        }
-                    }),
+						// If the error is 404, so maybe the fetched version no longer exists on server. We just
+						// ignore this error in that case, as that means we will have another summaryAck for the
+						// latest version with which we will refresh the state. However in case of single commit
+						// summary, we might me missing a summary ack, so in that case we are still fine as the
+						// code in `submitSummary` function in container runtime, will refresh the latest state
+						// by calling `refreshLatestSummaryAckFromServer` and we will be fine.
+						if (
+							isFluidError(error) &&
+							error.errorType === DriverErrorType.fileNotFoundOrAccessDeniedError
+						) {
+							summaryLogger.sendTelemetryEvent(
+								{
+									eventName: "HandleSummaryAckErrorIgnored",
+									referenceSequenceNumber: refSequenceNumber,
+									proposalHandle: summaryOpHandle,
+									ackHandle: summaryAckHandle,
+								},
+								error,
+							);
+						} else {
+							throw error;
+						}
+					}),
 				);
 			} catch (error) {
 				summaryLogger.sendErrorEvent(

--- a/packages/runtime/container-runtime/src/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summarizer.ts
@@ -388,28 +388,26 @@ export class Summarizer extends EventEmitter implements ISummarizer {
 		}
 		return this.runningSummarizer.enqueueSummarize(...args);
 	};
-    /**
-     * Responsible for receiving and processing all the summaryAcks.
-     * @param lastAckRefNumber - Before initializing the summarization, if there is a last Ack to be processed, use it.
-     */
+	/**
+	 * Responsible for receiving and processing all the summaryAcks.
+	 * @param lastAckRefNumber - Before initializing the summarization, if there is a last Ack to be processed, use it.
+	 */
 	private async handleSummaryAcks(lastAckRefNumber: number) {
 		let refSequenceNumber = this.runtime.deltaManager.initialSequenceNumber;
 		while (this.runningSummarizer) {
 			const summaryLogger =
 				this.runningSummarizer.tryGetCorrelatedLogger(refSequenceNumber) ?? this.logger;
-            summaryLogger.sendTelemetryEvent(
-                {
-                    eventName: "handleSummaryAcks",
-                    referenceSequenceNumber: refSequenceNumber,
-                }
-            );
+			summaryLogger.sendTelemetryEvent({
+				eventName: "handleSummaryAcks",
+				referenceSequenceNumber: refSequenceNumber,
+			});
 			// Initialize ack with undefined if exception happens inside of waitSummaryAck on second iteration,
-            // we record undefined, not previous handles.
-            await this.summaryCollection.waitSummaryAck(
-                lastAckRefNumber > 0 ? lastAckRefNumber : refSequenceNumber,
-            );
+			// we record undefined, not previous handles.
+			await this.summaryCollection.waitSummaryAck(
+				lastAckRefNumber > 0 ? lastAckRefNumber : refSequenceNumber,
+			);
 
-            refSequenceNumber = await this.runningSummarizer.handleSummaryAck();
-    	}
+			refSequenceNumber = await this.runningSummarizer.handleSummaryAck();
+		}
 	}
 }

--- a/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runningSummarizer.spec.ts
@@ -235,6 +235,7 @@ describe("Runtime", () => {
 							forcedFullTree: false,
 						} as const;
 					},
+					async (options) => {},
 					heuristicData,
 					() => {},
 					summaryCollection,

--- a/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summaryManager.spec.ts
@@ -150,6 +150,7 @@ describe("Summary Manager", () => {
 						error: undefined,
 					} as const;
 				},
+				async (options) => {},
 				new SummarizeHeuristicData(0, { refSequenceNumber: 0, summaryTime: Date.now() }),
 				() => {},
 				summaryCollection,


### PR DESCRIPTION
Due to the asynchronicity of our events, the summarization can start just before the refresh of the latest summary gets invoked.
The call refreshSummaryAckLock (runningSummarizer.ts) happens before the actual lock is taken by the call to lockedRefreshSummaryAckAction. 

The only possible scenario where it can happen is the one in which a summarizer is loaded for the first time and there were a summarized ack op processed during the catch up. In that case we need to make sure we process the summary ack before proceeding with the summarization. 
The proposal fix, is to make sure we retrieve the latestAck before running the summarizer by creating a call to handleSummaryAck 
 that will refresh the latest summary before going into a loop of waiting for a new handleSummaryAck.

I'm creating this change as a draft to receive feedback in case I'm missing something. 