### PR TITLE
Decrease traffic volume for the large payload stress tests.

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -189,8 +189,8 @@
 		"ci_with_large_payloads": {
 			"opRatePerMin": 10,
 			"progressIntervalMs": 15000,
-			"numClients": 100,
-			"totalSendCount": 10000,
+			"numClients": 25,
+			"totalSendCount": 100,
 			"readWriteCycleMs": 30000,
 			"faultInjectionMs": {
 				"min": 0,
@@ -198,7 +198,7 @@
 			},
 			"useRandomContent": true,
 			"useVariableOpSize": true,
-			"opSizeinBytes": 1172864
+			"opSizeinBytes": 1572864
 		}
 	}
 }


### PR DESCRIPTION
## Description

The traffic from the stress tests risks exploding into even more traffic, as a large op may be split into smaller chunks, thus making the op count ultimately 3-10 times larger, making it problematic for containers to catch up. This change decreases the number of clients, number of ops and increases the possible op size.

Eventually, this code will end up in the regular pipeline with large ops being sent every 100-200 small ops.
