### PR TITLE
GC Tombstone: Add option for apps to pass to disable GC enforcement for old files

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -367,7 +367,6 @@ export interface IGCRuntimeOptions {
     [key: string]: any;
     disableGC?: boolean;
     gcAllowed?: boolean;
-    readonly gcContainerGeneration?: number;
     runFullGC?: boolean;
     sessionExpiryTimeoutMs?: number;
     sweepAllowed?: boolean;

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -367,6 +367,7 @@ export interface IGCRuntimeOptions {
     [key: string]: any;
     disableGC?: boolean;
     gcAllowed?: boolean;
+    readonly gcContainerGeneration?: number;
     runFullGC?: boolean;
     sessionExpiryTimeoutMs?: number;
     sweepAllowed?: boolean;

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -787,7 +787,8 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 						: "GC_Deleted_Blob_Requested",
 				category: shouldFail ? "error" : "generic",
 				isSummarizerClient: this.runtime.clientDetails.type === summarizerClientType,
-				gcEnforcementDisabled: (this.runtime as ContainerRuntime).disableGcTombstoneEnforcement,
+				gcEnforcementDisabled: (this.runtime as ContainerRuntime)
+					.disableGcTombstoneEnforcement,
 			},
 			[BlobManager.basePath],
 			error,

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -40,7 +40,7 @@ import {
 	ISummaryTreeWithStats,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions";
-import { TombstoneResponseHeaderKey } from "./containerRuntime";
+import { ContainerRuntime, TombstoneResponseHeaderKey } from "./containerRuntime";
 import { Throttler, formExponentialFn, IThrottler } from "./throttler";
 import { summarizerClientType } from "./summarizerClientElection";
 import { throwOnTombstoneLoadKey } from "./garbageCollectionConstants";
@@ -225,6 +225,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 		// Read the feature flag that tells whether to throw when a tombstone blob is requested.
 		this.throwOnTombstoneLoad =
 			this.mc.config.getBoolean(throwOnTombstoneLoadKey) === true &&
+			!(this.runtime as ContainerRuntime).disableGcTombstoneEnforcement &&
 			this.runtime.clientDetails.type !== summarizerClientType;
 
 		this.runtime.on("disconnected", () => this.onDisconnected());
@@ -786,6 +787,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 						: "GC_Deleted_Blob_Requested",
 				category: shouldFail ? "error" : "generic",
 				isSummarizerClient: this.runtime.clientDetails.type === summarizerClientType,
+				gcEnforcementDisabled: (this.runtime as ContainerRuntime).disableGcTombstoneEnforcement,
 			},
 			[BlobManager.basePath],
 			error,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -335,20 +335,20 @@ export interface IGCRuntimeOptions {
 	 */
 	sweepAllowed?: boolean;
 
-    /**
-     * The "GC Container Generation" is provided by the container author to denote GC-impacting changes to the container's structure.
-     * The value provided at creation time is persisted, and compared with the value provided at each load.
-     *
-     * If the persisted value doesn't match the value provided on load, GC Sweep will be disabled to protect against dataloss in case
-     * containers with an older Generation were found to have GC-impacting bugs.
-     */
-    readonly gcContainerGeneration?: number;
+	/**
+	 * The "GC Container Generation" is provided by the container author to denote GC-impacting changes to the container's structure.
+	 * The value provided at creation time is persisted, and compared with the value provided at each load.
+	 *
+	 * If the persisted value doesn't match the value provided on load, GC Sweep will be disabled to protect against dataloss in case
+	 * containers with an older Generation were found to have GC-impacting bugs.
+	 */
+	readonly gcContainerGeneration?: number;
 
-    /**
-     * Flag that if true, will disable garbage collection for the session.
-     * Can be used to disable running GC on containers where it is allowed via the gcAllowed option.
-     */
-    disableGC?: boolean;
+	/**
+	 * Flag that if true, will disable garbage collection for the session.
+	 * Can be used to disable running GC on containers where it is allowed via the gcAllowed option.
+	 */
+	disableGC?: boolean;
 
 	/**
 	 * Flag that will bypass optimizations and generate GC data for all nodes irrespective of whether a node

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1092,10 +1092,13 @@ export class ContainerRuntime
 
 		this._connected = this.context.connected;
 
-		const rawGcEnforcementMinVersionOption = this.runtimeOptions.gcOptions[gcEnforcementMinCreateContainerRuntimeVersionOption];
+		const rawGcEnforcementMinVersionOption =
+			this.runtimeOptions.gcOptions[gcEnforcementMinCreateContainerRuntimeVersionOption];
 		this.disableGcTombstoneEnforcement = shouldDisableGcEnforcementForOldContainer(
 			this.createContainerMetadata.createContainerRuntimeVersion,
-			typeof rawGcEnforcementMinVersionOption === "string" ? rawGcEnforcementMinVersionOption : undefined,
+			typeof rawGcEnforcementMinVersionOption === "string"
+				? rawGcEnforcementMinVersionOption
+				: undefined,
 		);
 
 		this.mc = loggerToMonitoringContext(ChildLogger.create(this.logger, "ContainerRuntime"));

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -358,15 +358,6 @@ export interface IGCRuntimeOptions {
 	 * Allows additional GC options to be passed.
 	 */
 	[key: string]: any;
-
-	/**
-	 * UNDOCUMENTED (will delete this comment)
-	 * gcContainerMinGeneration can be provided by the container author to specify the min runtime version required at creation time.
-	 * The value provided at creation time is persisted, and compared with the value provided at each load.
-	 *
-	 * If the persisted value doesn't match the value provided on load, GC Sweep will be disabled to protect against dataloss in case
-	 * containers with an older Generation were found to have GC-impacting bugs.
-	 */
 }
 
 export interface ISummaryRuntimeOptions {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -335,11 +335,20 @@ export interface IGCRuntimeOptions {
 	 */
 	sweepAllowed?: boolean;
 
-	/**
-	 * Flag that if true, will disable garbage collection for the session.
-	 * Can be used to disable running GC on containers where it is allowed via the gcAllowed option.
-	 */
-	disableGC?: boolean;
+    /**
+     * The "GC Container Generation" is provided by the container author to denote GC-impacting changes to the container's structure.
+     * The value provided at creation time is persisted, and compared with the value provided at each load.
+     *
+     * If the persisted value doesn't match the value provided on load, GC Sweep will be disabled to protect against dataloss in case
+     * containers with an older Generation were found to have GC-impacting bugs.
+     */
+    readonly gcContainerGeneration?: number;
+
+    /**
+     * Flag that if true, will disable garbage collection for the session.
+     * Can be used to disable running GC on containers where it is allowed via the gcAllowed option.
+     */
+    disableGC?: boolean;
 
 	/**
 	 * Flag that will bypass optimizations and generate GC data for all nodes irrespective of whether a node

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -361,7 +361,7 @@ export interface IGCRuntimeOptions {
 
 	/**
 	 * UNDOCUMENTED (will delete this comment)
-	 * gcContainerMinGeneraion can be provided by the container author to specify the min runtime version required at creation time.
+	 * gcContainerMinGeneration can be provided by the container author to specify the min runtime version required at creation time.
 	 * The value provided at creation time is persisted, and compared with the value provided at each load.
 	 *
 	 * If the persisted value doesn't match the value provided on load, GC Sweep will be disabled to protect against dataloss in case

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -336,15 +336,6 @@ export interface IGCRuntimeOptions {
 	sweepAllowed?: boolean;
 
 	/**
-	 * The "GC Container Generation" is provided by the container author to denote GC-impacting changes to the container's structure.
-	 * The value provided at creation time is persisted, and compared with the value provided at each load.
-	 *
-	 * If the persisted value doesn't match the value provided on load, GC Sweep will be disabled to protect against dataloss in case
-	 * containers with an older Generation were found to have GC-impacting bugs.
-	 */
-	readonly gcContainerGeneration?: number;
-
-	/**
 	 * Flag that if true, will disable garbage collection for the session.
 	 * Can be used to disable running GC on containers where it is allowed via the gcAllowed option.
 	 */
@@ -367,6 +358,15 @@ export interface IGCRuntimeOptions {
 	 * Allows additional GC options to be passed.
 	 */
 	[key: string]: any;
+
+	/**
+	 * UNDOCUMENTED (will delete this comment)
+	 * gcContainerMinGeneraion can be provided by the container author to specify the min runtime version required at creation time.
+	 * The value provided at creation time is persisted, and compared with the value provided at each load.
+	 *
+	 * If the persisted value doesn't match the value provided on load, GC Sweep will be disabled to protect against dataloss in case
+	 * containers with an older Generation were found to have GC-impacting bugs.
+	 */
 }
 
 export interface ISummaryRuntimeOptions {

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -854,7 +854,8 @@ export abstract class FluidDataStoreContext
 					eventName: "GC_Tombstone_DataStore_Changed",
 					category: this.throwOnTombstoneUsage ? "error" : "generic",
 					isSummarizerClient: this.clientDetails.type === summarizerClientType,
-					gcEnforcementDisabled: (this.containerRuntime as ContainerRuntime).disableGcTombstoneEnforcement,
+					gcEnforcementDisabled: (this.containerRuntime as ContainerRuntime)
+						.disableGcTombstoneEnforcement,
 					callSite,
 				},
 				this.pkg,
@@ -1101,7 +1102,8 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
 				category: "error",
 				isSummarizerClient:
 					this.containerRuntime.clientDetails.type === summarizerClientType,
-				gcEnforcementDisabled: (this.containerRuntime as ContainerRuntime).disableGcTombstoneEnforcement,
+				gcEnforcementDisabled: (this.containerRuntime as ContainerRuntime)
+					.disableGcTombstoneEnforcement,
 			},
 			this.pkg,
 		);

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -326,6 +326,7 @@ export abstract class FluidDataStoreContext
 		// Tombstone should only throw when the feature flag is enabled and the client isn't a summarizer
 		this.throwOnTombstoneUsage =
 			this.mc.config.getBoolean(throwOnTombstoneUsageKey) === true &&
+			!this._containerRuntime.disableGcTombstoneEnforcement &&
 			this.clientDetails.type !== summarizerClientType;
 	}
 
@@ -853,6 +854,7 @@ export abstract class FluidDataStoreContext
 					eventName: "GC_Tombstone_DataStore_Changed",
 					category: this.throwOnTombstoneUsage ? "error" : "generic",
 					isSummarizerClient: this.clientDetails.type === summarizerClientType,
+					gcEnforcementDisabled: (this.containerRuntime as ContainerRuntime).disableGcTombstoneEnforcement,
 					callSite,
 				},
 				this.pkg,
@@ -1099,6 +1101,7 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
 				category: "error",
 				isSummarizerClient:
 					this.containerRuntime.clientDetails.type === summarizerClientType,
+				gcEnforcementDisabled: (this.containerRuntime as ContainerRuntime).disableGcTombstoneEnforcement,
 			},
 			this.pkg,
 		);

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -151,6 +151,7 @@ export class DataStores implements IDisposable {
 		// Tombstone should only throw when the feature flag is enabled and the client isn't a summarizer
 		this.throwOnTombstoneLoad =
 			this.mc.config.getBoolean(throwOnTombstoneLoadKey) === true &&
+			!this.runtime.disableGcTombstoneEnforcement &&
 			this.runtime.clientDetails.type !== summarizerClientType;
 
 		// Extract stores stored inside the snapshot
@@ -489,6 +490,7 @@ export class DataStores implements IDisposable {
 					category: shouldFail ? "error" : "generic",
 					isSummarizerClient: this.runtime.clientDetails.type === summarizerClientType,
 					headers: JSON.stringify(requestHeaderData),
+					gcEnforcementDisabled: this.runtime.disableGcTombstoneEnforcement,
 				},
 				context.isLoaded ? context.packagePath : undefined,
 				error,

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -140,6 +140,10 @@ export interface IGarbageCollectionRuntime {
 	getNodeType(nodePath: string): GCNodeType;
 	/** Called when the runtime should close because of an error. */
 	closeFn: (error?: ICriticalContainerError) => void;
+
+	//* Unsure about the naming/semantics here. In here, this applies to Sweep not Tombstone. Maybe just remove "Tombstone" and it's ok.
+	/** If true, loading or using a Tombstoned object should merely log, not fail */
+	disableGcTombstoneEnforcement: boolean;
 }
 
 /** Defines the contract for the garbage collector. */
@@ -576,7 +580,7 @@ export class GarbageCollector implements IGarbageCollector {
 			// Existing documents which did not have metadata blob or had GC disabled have version as 0. For all
 			// other existing documents, GC is enabled.
 			this.gcEnabled = prevSummaryGCVersion > 0;
-			this.sweepEnabled = metadata?.sweepEnabled ?? false;
+			this.sweepEnabled = (metadata?.sweepEnabled ?? false) && !this.runtime.disableGcTombstoneEnforcement;
 			this.sessionExpiryTimeoutMs = metadata?.sessionExpiryTimeoutMs;
 			this.sweepTimeoutMs =
 				metadata?.sweepTimeoutMs ?? computeSweepTimeout(this.sessionExpiryTimeoutMs); // Backfill old documents that didn't persist this
@@ -1408,6 +1412,7 @@ export class GarbageCollector implements IGarbageCollector {
 					isSummarizerClient: this.isSummarizerClient,
 					url: trimLeadingSlashes(toNodePath),
 					nodeType,
+					gcEnforcementDisabled: this.runtime.disableGcTombstoneEnforcement,
 				},
 				undefined /* packagePath */,
 			);

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -580,7 +580,8 @@ export class GarbageCollector implements IGarbageCollector {
 			// Existing documents which did not have metadata blob or had GC disabled have version as 0. For all
 			// other existing documents, GC is enabled.
 			this.gcEnabled = prevSummaryGCVersion > 0;
-			this.sweepEnabled = (metadata?.sweepEnabled ?? false) && !this.runtime.disableGcTombstoneEnforcement;
+			this.sweepEnabled =
+				(metadata?.sweepEnabled ?? false) && !this.runtime.disableGcTombstoneEnforcement;
 			this.sessionExpiryTimeoutMs = metadata?.sessionExpiryTimeoutMs;
 			this.sweepTimeoutMs =
 				metadata?.sweepTimeoutMs ?? computeSweepTimeout(this.sessionExpiryTimeoutMs); // Backfill old documents that didn't persist this

--- a/packages/runtime/container-runtime/src/garbageCollectionConstants.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionConstants.ts
@@ -10,6 +10,9 @@ export const stableGCVersion: GCVersion = 1;
 /** The current version of garbage collection. */
 export const currentGCVersion: GCVersion = 2;
 
+/** This undocumented GC Option (on ContainerRuntime Options) allows an app to disable enforcing GC on old documents */
+export const gcEnforcementMinCreateContainerRuntimeVersionOption = "gcEnforcementMinCreateContainerRuntimeVersion";
+
 // Feature gate key to turn GC on / off.
 export const runGCKey = "Fluid.GarbageCollection.RunGC";
 // Feature gate key to turn GC sweep on / off.

--- a/packages/runtime/container-runtime/src/garbageCollectionConstants.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionConstants.ts
@@ -11,7 +11,8 @@ export const stableGCVersion: GCVersion = 1;
 export const currentGCVersion: GCVersion = 2;
 
 /** This undocumented GC Option (on ContainerRuntime Options) allows an app to disable enforcing GC on old documents */
-export const gcEnforcementMinCreateContainerRuntimeVersionOption = "gcEnforcementMinCreateContainerRuntimeVersion";
+export const gcEnforcementMinCreateContainerRuntimeVersionOption =
+	"gcEnforcementMinCreateContainerRuntimeVersion";
 
 // Feature gate key to turn GC on / off.
 export const runGCKey = "Fluid.GarbageCollection.RunGC";

--- a/packages/runtime/container-runtime/src/garbageCollectionHelpers.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionHelpers.ts
@@ -19,7 +19,11 @@ import {
  */
 export function sendGCUnexpectedUsageEvent(
 	mc: MonitoringContext,
-	event: ITelemetryGenericEvent & { category: "error" | "generic"; isSummarizerClient: boolean; gcEnforcementDisabled: boolean },
+	event: ITelemetryGenericEvent & {
+		category: "error" | "generic";
+		isSummarizerClient: boolean;
+		gcEnforcementDisabled: boolean;
+	},
 	packagePath: readonly string[] | undefined,
 	error?: unknown,
 ) {
@@ -55,10 +59,15 @@ export function shouldDisableGcEnforcementForOldContainer(
 	const r = /^(\d{1,4}\.\d{1,4}\.\d{1,4})(?:-internal\.(\d{1,4}\.\d{1,4}\.\d{1,4}))?$/;
 
 	function padSemVer(semver: string): string {
-		return semver.split(".").map((x) => x.padStart(4, "0")).join(".");
+		return semver
+			.split(".")
+			.map((x) => x.padStart(4, "0"))
+			.join(".");
 	}
-	
-	function makeVersionComparableAsString(version: string | undefined): string | { fail: "undefined" | "invalid" } {
+
+	function makeVersionComparableAsString(
+		version: string | undefined,
+	): string | { fail: "undefined" | "invalid" } {
 		if (version === undefined) {
 			return { fail: "undefined" };
 		}
@@ -69,23 +78,27 @@ export function shouldDisableGcEnforcementForOldContainer(
 		}
 		const [_full, external, internal] = m;
 		const paddedExternal = padSemVer(external);
-		return internal !== undefined ? `${paddedExternal}-internal.${padSemVer(internal)}` : `${paddedExternal}RELEASE`;
+		return internal !== undefined
+			? `${paddedExternal}-internal.${padSemVer(internal)}`
+			: `${paddedExternal}RELEASE`;
 	}
 
-	const comparableMinVersion = makeVersionComparableAsString(gcEnforcementMinCreateContainerRuntimeVersion);
+	const comparableMinVersion = makeVersionComparableAsString(
+		gcEnforcementMinCreateContainerRuntimeVersion,
+	);
 	if (typeof comparableMinVersion !== "string") {
 		// No valid min version was provided, so don't disable
 		return false;
 	}
-	
-	const comparablePersistedVersion = makeVersionComparableAsString(createContainerRuntimeVersion); //*  ?? "0.0.0-internal.0.0.0";
+
+	const comparablePersistedVersion = makeVersionComparableAsString(createContainerRuntimeVersion);
 
 	if (typeof comparablePersistedVersion !== "string") {
 		// If undefined, this file predates the createContainerRuntimeVersion metadata, so it's older than whatever min version was provided, so we should disable
 		// Otherwise it's invalid (e.g. -dev version) and we should NOT disable
 		return comparablePersistedVersion.fail === "undefined";
 	}
-	
+
 	// If the persisted version is less than the min version according to string comparison rules, then we need to disable GC enforcement
-	return comparablePersistedVersion < comparableMinVersion;	
+	return comparablePersistedVersion < comparableMinVersion;
 }

--- a/packages/runtime/container-runtime/src/garbageCollectionHelpers.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionHelpers.ts
@@ -49,5 +49,43 @@ export function shouldDisableGcEnforcementForOldContainer(
 	createContainerRuntimeVersion: string | undefined,
 	gcEnforcementMinCreateContainerRuntimeVersion: string | undefined,
 ): boolean {
-	return false;	
+	//* Probably support more than 4 digit version segments, why not
+	//* Fix this regex per the lint warning
+	// eslint-disable-next-line unicorn/no-unsafe-regex, unicorn/better-regex
+	const r = /^(\d{1,4}\.\d{1,4}\.\d{1,4})(?:-internal\.(\d{1,4}\.\d{1,4}\.\d{1,4}))?$/;
+
+	function padSemVer(semver: string): string {
+		return semver.split(".").map((x) => x.padStart(4, "0")).join(".");
+	}
+	
+	function makeVersionComparableAsString(version: string | undefined): string | { fail: "undefined" | "invalid" } {
+		if (version === undefined) {
+			return { fail: "undefined" };
+		}
+
+		const m = version.match(r);
+		if (m === null) {
+			return { fail: "invalid" };
+		}
+		const [_full, external, internal] = m;
+		const paddedExternal = padSemVer(external);
+		return internal !== undefined ? `${paddedExternal}-internal.${padSemVer(internal)}` : `${paddedExternal}RELEASE`;
+	}
+
+	const comparableMinVersion = makeVersionComparableAsString(gcEnforcementMinCreateContainerRuntimeVersion);
+	if (typeof comparableMinVersion !== "string") {
+		// No valid min version was provided, so don't disable
+		return false;
+	}
+	
+	const comparablePersistedVersion = makeVersionComparableAsString(createContainerRuntimeVersion); //*  ?? "0.0.0-internal.0.0.0";
+
+	if (typeof comparablePersistedVersion !== "string") {
+		// If undefined, this file predates the createContainerRuntimeVersion metadata, so it's older than whatever min version was provided, so we should disable
+		// Otherwise it's invalid (e.g. -dev version) and we should NOT disable
+		return comparablePersistedVersion.fail === "undefined";
+	}
+	
+	// If the persisted version is less than the min version according to string comparison rules, then we need to disable GC enforcement
+	return comparablePersistedVersion < comparableMinVersion;	
 }

--- a/packages/runtime/container-runtime/src/garbageCollectionHelpers.ts
+++ b/packages/runtime/container-runtime/src/garbageCollectionHelpers.ts
@@ -19,7 +19,7 @@ import {
  */
 export function sendGCUnexpectedUsageEvent(
 	mc: MonitoringContext,
-	event: ITelemetryGenericEvent & { category: "error" | "generic"; isSummarizerClient: boolean },
+	event: ITelemetryGenericEvent & { category: "error" | "generic"; isSummarizerClient: boolean; gcEnforcementDisabled: boolean },
 	packagePath: readonly string[] | undefined,
 	error?: unknown,
 ) {
@@ -34,4 +34,20 @@ export function sendGCUnexpectedUsageEvent(
 	});
 
 	mc.logger.sendTelemetryEvent(event, error);
+}
+
+/**
+ * In order to protect old documents that were created at a time when known bugs exist that violate invariants GC depends on
+ * such that enforcing GC (Fail on Tombstone load/usage, GC Sweep) would cause legitimate data loss,
+ * the container author may pass in a min version such that containers created before this point will not be subjected
+ * to GC enforcement.
+ * @param createContainerRuntimeVersion - The persisted runtimeVersion that was in effect when the container was created
+ * @param gcEnforcementMinCreateContainerRuntimeVersion - The app-provided min version (via an undocumented ContainerRuntimeOption)
+ * @returns true if GC Enforcement (Fail on Tombstone load/usage, GC Sweep) should be disabled
+ */
+export function shouldDisableGcEnforcementForOldContainer(
+	createContainerRuntimeVersion: string | undefined,
+	gcEnforcementMinCreateContainerRuntimeVersion: string | undefined,
+): boolean {
+	return false;	
 }

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -99,23 +99,31 @@ export interface ICreateContainerMetadata {
 
 export type GCVersion = number;
 export interface IGCMetadata {
-	/**
-	 * The version of the GC code that was run to generate the GC data that is written in the summary.
-	 * Also, used to determine whether GC is enabled for this container or not:
-	 * - A value of 0 or undefined means GC is disabled.
-	 * - A value greater than 0 means GC is enabled.
-	 */
-	readonly gcFeature?: GCVersion;
-	/**
-	 * Tells whether the GC sweep phase is enabled for this container.
-	 * - True means sweep phase is enabled.
-	 * - False means sweep phase is disabled. If GC is disabled as per gcFeature, sweep is also disabled.
-	 */
-	readonly sweepEnabled?: boolean;
-	/** If this is present, the session for this container will expire after this time and the container will close */
-	readonly sessionExpiryTimeoutMs?: number;
-	/** How long to wait after an object is unreferenced before deleting it via GC Sweep */
-	readonly sweepTimeoutMs?: number;
+    /**
+     * The version of the GC code that was run to generate the GC data that is written in the summary.
+     * If the persisted value doesn't match the current value in the code, saved GC data will be discarded and regenerated from scratch.
+     * Also, used to determine whether GC is enabled for this container or not:
+     * - A value of 0 or undefined means GC is disabled.
+     * - A value greater than 0 means GC is enabled.
+     */
+    readonly gcFeature?: GCVersion;
+    /**
+     * The "GC Container Generation" is provided by the container author to denote GC-impacting changes to the container's structure.
+     * The value provided at creation time is persisted, and compared with the value provided at each load.
+     * If the persisted value doesn't match the value provided on load, GC Sweep will be disabled to protect against dataloss in case
+     * containers with an older Generation were found to have GC-impacting bugs.
+     */
+    readonly gcContainerGeneration?: number;
+    /**
+     * Tells whether the GC sweep phase is enabled for this container.
+     * - True means sweep phase is enabled.
+     * - False means sweep phase is disabled. If GC is disabled as per gcFeature, sweep is also disabled.
+     */
+    readonly sweepEnabled?: boolean;
+    /** If this is present, the session for this container will expire after this time and the container will close */
+    readonly sessionExpiryTimeoutMs?: number;
+    /** How long to wait after an object is unreferenced before deleting it via GC Sweep */
+    readonly sweepTimeoutMs?: number;
 }
 
 /** The properties of an ISequencedDocumentMessage to be stored in the metadata blob in summary. */

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -108,13 +108,6 @@ export interface IGCMetadata {
 	 */
 	readonly gcFeature?: GCVersion;
 	/**
-	 * The "GC Container Generation" is provided by the container author to denote GC-impacting changes to the container's structure.
-	 * The value provided at creation time is persisted, and compared with the value provided at each load.
-	 * If the persisted value doesn't match the value provided on load, GC Sweep will be disabled to protect against dataloss in case
-	 * containers with an older Generation were found to have GC-impacting bugs.
-	 */
-	readonly gcContainerGeneration?: number;
-	/**
 	 * Tells whether the GC sweep phase is enabled for this container.
 	 * - True means sweep phase is enabled.
 	 * - False means sweep phase is disabled. If GC is disabled as per gcFeature, sweep is also disabled.

--- a/packages/runtime/container-runtime/src/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summaryFormat.ts
@@ -99,31 +99,31 @@ export interface ICreateContainerMetadata {
 
 export type GCVersion = number;
 export interface IGCMetadata {
-    /**
-     * The version of the GC code that was run to generate the GC data that is written in the summary.
-     * If the persisted value doesn't match the current value in the code, saved GC data will be discarded and regenerated from scratch.
-     * Also, used to determine whether GC is enabled for this container or not:
-     * - A value of 0 or undefined means GC is disabled.
-     * - A value greater than 0 means GC is enabled.
-     */
-    readonly gcFeature?: GCVersion;
-    /**
-     * The "GC Container Generation" is provided by the container author to denote GC-impacting changes to the container's structure.
-     * The value provided at creation time is persisted, and compared with the value provided at each load.
-     * If the persisted value doesn't match the value provided on load, GC Sweep will be disabled to protect against dataloss in case
-     * containers with an older Generation were found to have GC-impacting bugs.
-     */
-    readonly gcContainerGeneration?: number;
-    /**
-     * Tells whether the GC sweep phase is enabled for this container.
-     * - True means sweep phase is enabled.
-     * - False means sweep phase is disabled. If GC is disabled as per gcFeature, sweep is also disabled.
-     */
-    readonly sweepEnabled?: boolean;
-    /** If this is present, the session for this container will expire after this time and the container will close */
-    readonly sessionExpiryTimeoutMs?: number;
-    /** How long to wait after an object is unreferenced before deleting it via GC Sweep */
-    readonly sweepTimeoutMs?: number;
+	/**
+	 * The version of the GC code that was run to generate the GC data that is written in the summary.
+	 * If the persisted value doesn't match the current value in the code, saved GC data will be discarded and regenerated from scratch.
+	 * Also, used to determine whether GC is enabled for this container or not:
+	 * - A value of 0 or undefined means GC is disabled.
+	 * - A value greater than 0 means GC is enabled.
+	 */
+	readonly gcFeature?: GCVersion;
+	/**
+	 * The "GC Container Generation" is provided by the container author to denote GC-impacting changes to the container's structure.
+	 * The value provided at creation time is persisted, and compared with the value provided at each load.
+	 * If the persisted value doesn't match the value provided on load, GC Sweep will be disabled to protect against dataloss in case
+	 * containers with an older Generation were found to have GC-impacting bugs.
+	 */
+	readonly gcContainerGeneration?: number;
+	/**
+	 * Tells whether the GC sweep phase is enabled for this container.
+	 * - True means sweep phase is enabled.
+	 * - False means sweep phase is disabled. If GC is disabled as per gcFeature, sweep is also disabled.
+	 */
+	readonly sweepEnabled?: boolean;
+	/** If this is present, the session for this container will expire after this time and the container will close */
+	readonly sessionExpiryTimeoutMs?: number;
+	/** How long to wait after an object is unreferenced before deleting it via GC Sweep */
+	readonly sweepTimeoutMs?: number;
 }
 
 /** The properties of an ISequencedDocumentMessage to be stored in the metadata blob in summary. */

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -291,7 +291,7 @@ describe("Garbage Collection Tests", () => {
 				}) => {
 					it(description, () => {
 						gc = createGcWithPrivateMembers(
-							{ createContainerRuntimeVersion, sweepEnabled: true },
+							{ createContainerRuntimeVersion, gcFeature: 1, sweepEnabled: true },
 							{ gcEnforcementMinCreateContainerRuntimeVersion },
 						);
 						assert(gc.gcEnabled, "gcEnabled incorrect");

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -76,2164 +76,1694 @@ type GcWithPrivates = IGarbageCollector & {
 };
 
 describe("Garbage Collection Tests", () => {
-	const defaultSnapshotCacheExpiryMs = 5 * 24 * 60 * 60 * 1000;
-
-	// Nodes in the reference graph.
-	const nodes: string[] = ["/node1", "/node2", "/node3", "/node4"];
-
-	const mockLogger: MockLogger = new MockLogger();
-	const testPkgPath = ["testPkg"];
-	// The package data is tagged in the telemetry event.
-	const eventPkg = { value: testPkgPath.join("/"), tag: TelemetryDataTag.CodeArtifact };
-
-	const oldRawConfig = sessionStorageConfigProvider.value.getRawConfig;
-	let injectedSettings: Record<string, ConfigTypes> = {};
-	let clock: SinonFakeTimers;
-
-	// The default GC data returned by `getGCData` on which GC is run. Update this to update the referenced graph.
-	let defaultGCData: IGarbageCollectionData = { gcNodes: {} };
-
-	// Returns a dummy snapshot tree to be built upon.
-	const getDummySnapshotTree = (): ISnapshotTree => {
-		return {
-			blobs: {},
-			trees: {},
-		};
-	};
-
-	const parseNothing: ReadAndParseBlob = async <T>() => {
-		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-		const x: T = {} as T;
-		return x;
-	};
-
-	function createGarbageCollector(
-		createParams: Partial<IGarbageCollectorCreateParams> = {},
-		gcBlobsMap: Map<
-			string,
-			IGarbageCollectionState | IGarbageCollectionDetailsBase | string[]
-		> = new Map(),
-		closeFn: (error?: ICriticalContainerError) => void = () => {},
-		isSummarizerClient: boolean = true,
-	) {
-		const getNodeType = (nodePath: string) => {
-			if (nodePath.split("/").length !== 2) {
-				return GCNodeType.Other;
-			}
-			return GCNodeType.DataStore;
-		};
-
-		// The runtime to be passed to the garbage collector.
-		const gcRuntime: IGarbageCollectionRuntime = {
-			updateStateBeforeGC: async () => {},
-			getGCData: async (fullGC?: boolean) => defaultGCData,
-			updateUsedRoutes: (usedRoutes: string[]) => {
-				return { totalNodeCount: 0, unusedNodeCount: 0 };
-			},
-			updateUnusedRoutes: (unusedRoutes: string[]) => {},
-			deleteUnusedNodes: (deletableRoutes: string[]): string[] => {
-				return [];
-			},
-			updateTombstonedRoutes: (tombstoneRoutes: string[]) => {},
-			getNodeType,
-			getCurrentReferenceTimestampMs: () => Date.now(),
-			closeFn,
-		};
-
-		return GarbageCollector.create({
-			...createParams,
-			runtime: gcRuntime,
-			gcOptions: createParams.gcOptions ?? {},
-			baseSnapshot: createParams.baseSnapshot,
-			baseLogger: mockLogger,
-			existing: createParams.metadata !== undefined /* existing */,
-			metadata: createParams.metadata,
-			createContainerMetadata: {
-				createContainerRuntimeVersion: pkgVersion,
-				createContainerTimestamp: Date.now(),
-			},
-			isSummarizerClient,
-			readAndParseBlob: async <T>(id: string) => gcBlobsMap.get(id) as T,
-			getNodePackagePath: async (nodeId: string) => testPkgPath,
-			getLastSummaryTimestampMs: () => Date.now(),
-			activeConnection: () => true,
-			getContainerDiagnosticId: () => "someDocId",
-		});
-	}
-	let gc: GcWithPrivates | undefined;
-
-	before(() => {
-		clock = useFakeTimers();
-		sessionStorageConfigProvider.value.getRawConfig = (name) => injectedSettings[name];
-	});
-
-	beforeEach(() => {
-		gc = undefined;
-	});
-
-	afterEach(() => {
-		clock.reset();
-		mockLogger.clear();
-		injectedSettings = {};
-		defaultGCData = { gcNodes: {} };
-		gc?.dispose();
-	});
-
-	after(() => {
-		clock.restore();
-		sessionStorageConfigProvider.value.getRawConfig = oldRawConfig;
-	});
-
-	describe("Configuration", () => {
-		const testOverrideSweepTimeoutKey = "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs";
-		const testOverrideSessionExpiryMsKey =
-			"Fluid.GarbageCollection.TestOverride.SessionExpiryMs";
-		const createGcWithPrivateMembers = (
-			gcMetadata?: IGCMetadata,
-			gcOptions?: IGCRuntimeOptions,
-		): GcWithPrivates => {
-			const metadata: IContainerRuntimeMetadata | undefined = gcMetadata && {
-				summaryFormatVersion: 1,
-				message: undefined,
-				...gcMetadata,
-			};
-			return createGarbageCollector({ metadata, gcOptions }) as GcWithPrivates;
-		};
-		const customSessionExpiryDurationMs = defaultSessionExpiryDurationMs + 1;
-
-		beforeEach(() => {
-			injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = 1; // To ensure it's less than sweep timeout
-		});
-
-		describe("Existing container", () => {
-			it("No metadata", () => {
-				gc = createGcWithPrivateMembers({});
-				assert(!gc.gcEnabled, "gcEnabled incorrect");
-				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-				assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
-				assert(gc.sweepTimeoutMs === undefined, "sweepTimeoutMs incorrect");
-				assert.equal(gc.latestSummaryGCVersion, 0, "latestSummaryGCVersion incorrect");
-			});
-			it("gcFeature 0", () => {
-				gc = createGcWithPrivateMembers({ gcFeature: 0 });
-				assert(!gc.gcEnabled, "gcEnabled incorrect");
-				assert.equal(gc.latestSummaryGCVersion, 0, "latestSummaryGCVersion incorrect");
-			});
-			it("gcFeature 0, sweepEnabled true", () => {
-				gc = createGcWithPrivateMembers({ gcFeature: 0, sweepEnabled: true });
-				assert(!gc.gcEnabled, "gcEnabled incorrect");
-				assert(gc.sweepEnabled, "sweepEnabled incorrect");
-				assert.equal(gc.latestSummaryGCVersion, 0, "latestSummaryGCVersion incorrect");
-			});
-			it("gcFeature 1", () => {
-				gc = createGcWithPrivateMembers({ gcFeature: 1 });
-				assert(gc.gcEnabled, "gcEnabled incorrect");
-				assert.equal(gc.latestSummaryGCVersion, 1, "latestSummaryGCVersion incorrect");
-			});
-			it("sweepEnabled false", () => {
-				gc = createGcWithPrivateMembers({ sweepEnabled: false });
-				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-			});
-			it("sessionExpiryTimeoutMs set (sweepTimeoutMs unset)", () => {
-				gc = createGcWithPrivateMembers({
-					sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
-				});
-				assert.equal(
-					gc.sessionExpiryTimeoutMs,
-					customSessionExpiryDurationMs,
-					"sessionExpiryTimeoutMs incorrect",
-				);
-				assert.equal(
-					gc.sweepTimeoutMs,
-					customSessionExpiryDurationMs + 6 * oneDayMs,
-					"sweepTimeoutMs incorrect",
-				);
-			});
-			it("sweepTimeoutMs set", () => {
-				gc = createGcWithPrivateMembers({ sweepTimeoutMs: 123 });
-				assert.equal(gc.sweepTimeoutMs, 123, "sweepTimeoutMs incorrect");
-			});
-			it("Metadata Roundtrip", () => {
-				const inputMetadata: IGCMetadata = {
-					sweepEnabled: true,
-					gcFeature: 1,
-					sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
-					sweepTimeoutMs: 123,
-				};
-				gc = createGcWithPrivateMembers(inputMetadata);
-				const outputMetadata = gc.getMetadata();
-				const expectedOutputMetadata: IGCMetadata = {
-					...inputMetadata,
-					gcFeature: stableGCVersion,
-				};
-				assert.deepEqual(
-					outputMetadata,
-					expectedOutputMetadata,
-					"getMetadata returned different metadata than loaded from",
-				);
-			});
-			it("Metadata Roundtrip with GC version upgrade to v2 enabled", () => {
-				injectedSettings[gcVersionUpgradeToV2Key] = true;
-				const inputMetadata: IGCMetadata = {
-					sweepEnabled: true,
-					gcFeature: 1,
-					sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
-					sweepTimeoutMs: 123,
-				};
-				gc = createGcWithPrivateMembers(inputMetadata);
-				const outputMetadata = gc.getMetadata();
-				const expectedOutputMetadata: IGCMetadata = {
-					...inputMetadata,
-					gcFeature: currentGCVersion,
-				};
-				assert.deepEqual(
-					outputMetadata,
-					expectedOutputMetadata,
-					"getMetadata returned different metadata than loaded from",
-				);
-			});
-		});
-
-		describe("New Container", () => {
-			it("No options", () => {
-				injectedSettings[runSessionExpiryKey] = true;
-				gc = createGcWithPrivateMembers(undefined /* metadata */, {});
-				assert(gc.gcEnabled, "gcEnabled incorrect");
-				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-				assert(gc.sessionExpiryTimeoutMs !== undefined, "sessionExpiryTimeoutMs incorrect");
-				assert(gc.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
-				assert.equal(
-					gc.latestSummaryGCVersion,
-					stableGCVersion,
-					"latestSummaryGCVersion incorrect",
-				);
-			});
-			it("gcAllowed true", () => {
-				gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: true });
-				assert(gc.gcEnabled, "gcEnabled incorrect");
-			});
-			it("gcAllowed false", () => {
-				gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: false });
-				assert(!gc.gcEnabled, "gcEnabled incorrect");
-			});
-			it("sweepAllowed true, gcAllowed false", () => {
-				assert.throws(
-					() => {
-						gc = createGcWithPrivateMembers(undefined /* metadata */, {
-							gcAllowed: false,
-							sweepAllowed: true,
-						});
-					},
-					(e) => e.errorType === "usageError",
-					"Should be unsupported",
-				);
-			});
-			it("sweepAllowed true, gcAllowed true", () => {
-				injectedSettings[runSessionExpiryKey] = true;
-				gc = createGcWithPrivateMembers(undefined /* metadata */, {
-					gcAllowed: true,
-					sweepAllowed: true,
-				});
-				assert(gc.gcEnabled, "gcEnabled incorrect");
-				assert(gc.sweepEnabled, "sweepEnabled incorrect");
-				assert(gc.shouldRunSweep, "shouldRunSweep incorrect");
-				assert(gc.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
-				assert(gc.sessionExpiryTimeoutMs !== undefined, "sessionExpiryTimeoutMs incorrect");
-			});
-			it("sweepAllowed true, gcAllowed true, sessionExpiry off", () => {
-				injectedSettings[runSessionExpiryKey] = false;
-				gc = createGcWithPrivateMembers(undefined /* metadata */, {
-					gcAllowed: true,
-					sweepAllowed: true,
-				});
-				assert(gc.gcEnabled, "gcEnabled incorrect");
-				assert(gc.sweepEnabled, "sweepEnabled incorrect");
-				assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
-				assert(gc.sweepTimeoutMs === undefined, "sweepTimeoutMs incorrect");
-			});
-			it("sweepAllowed false, sessionExpiry on", () => {
-				injectedSettings[runSessionExpiryKey] = true;
-				gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
-				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-				assert(gc.sessionExpiryTimeoutMs !== undefined, "sessionExpiryTimeoutMs incorrect");
-				assert(gc.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
-			});
-			it("sweepAllowed false, sessionExpiry off", () => {
-				injectedSettings[runSessionExpiryKey] = false;
-				gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
-				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-				assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
-				assert(gc.sweepTimeoutMs === undefined, "sweepTimeoutMs incorrect");
-			});
-			it("TestOverride.SweepTimeout set, sweepAllowed false, sessionExpiry on", () => {
-				injectedSettings[testOverrideSweepTimeoutKey] = 123;
-				injectedSettings[runSessionExpiryKey] = true;
-				gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
-				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-				assert(
-					gc.sessionExpiryTimeoutMs === defaultSessionExpiryDurationMs,
-					"sessionExpiryTimeoutMs incorrect",
-				);
-				assert(gc.sweepTimeoutMs === 123, "sweepTimeoutMs incorrect");
-			});
-			it("TestOverride.SweepTimeout set, sweepAllowed false, sessionExpiry off", () => {
-				injectedSettings[testOverrideSweepTimeoutKey] = 123;
-				injectedSettings[runSessionExpiryKey] = false;
-				gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
-				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-				assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
-				assert(gc.sweepTimeoutMs === 123, "sweepTimeoutMs incorrect");
-			});
-			it("Metadata Roundtrip", () => {
-				injectedSettings[runSessionExpiryKey] = true;
-				const expectedMetadata: IGCMetadata = {
-					sweepEnabled: true,
-					gcFeature: 1,
-					sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
-					sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
-				};
-				gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: true });
-				const outputMetadata = gc.getMetadata();
-				assert.deepEqual(
-					outputMetadata,
-					expectedMetadata,
-					"getMetadata returned different metadata than expected",
-				);
-			});
-			it("Metadata Roundtrip with GC version upgrade to v2 enabled", () => {
-				injectedSettings[runSessionExpiryKey] = true;
-				injectedSettings[gcVersionUpgradeToV2Key] = true;
-				const expectedMetadata: IGCMetadata = {
-					sweepEnabled: true,
-					gcFeature: currentGCVersion,
-					sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
-					sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
-				};
-				gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: true });
-				const outputMetadata = gc.getMetadata();
-				assert.deepEqual(
-					outputMetadata,
-					expectedMetadata,
-					"getMetadata returned different metadata than expected",
-				);
-			});
-		});
-
-		describe("Session Expiry and Sweep Timeout", () => {
-			beforeEach(() => {
-				injectedSettings[runSessionExpiryKey] = true;
-				injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = 1; // To ensure it's less than sweep timeout
-			});
-
-			// Config sources for Session Expiry:
-			// 1. defaultSessionExpiryDurationMs in code
-			// 2. IGCRuntimeOptions.sessionExpiryTimeoutMs
-			// 3. IGCMetadata.sessionExpiryTimeoutMs
-			// 4. "Fluid.GarbageCollection.TestOverride.SessionExpiryMs" setting
-			// 5. boolean setting: runSessionExpiryKey
-			// Config sources for Sweep Timeout:
-			// 1. IGCMetadata.sweepTimeoutMs
-			// 2. Computed from Session Expiry, fixed upper bound for Snapshot Expiry and a fixed buffer (on create, or to backfill existing)
-			// 3. "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs" setting (only applicable on create)
-
-			it("defaultSessionExpiryDurationMs", () => {
-				gc = createGcWithPrivateMembers();
-				assert.equal(
-					gc.sessionExpiryTimeoutMs,
-					defaultSessionExpiryDurationMs,
-					"sessionExpiryTimeoutMs incorrect",
-				);
-				assert.equal(
-					gc.sessionExpiryTimer.defaultTimeout,
-					defaultSessionExpiryDurationMs,
-					"sessionExpiryTimer incorrect",
-				);
-				assert.equal(
-					gc.sweepTimeoutMs,
-					defaultSessionExpiryDurationMs + 6 * oneDayMs,
-					"sweepTimeoutMs incorrect",
-				);
-			});
-			it("defaultSessionExpiryDurationMs, TestOverride.SweepTimeout set", () => {
-				injectedSettings[testOverrideSweepTimeoutKey] = 7890;
-				gc = createGcWithPrivateMembers();
-				assert.equal(
-					gc.sessionExpiryTimeoutMs,
-					defaultSessionExpiryDurationMs,
-					"sessionExpiryTimeoutMs incorrect",
-				);
-				assert.equal(
-					gc.sessionExpiryTimer.defaultTimeout,
-					defaultSessionExpiryDurationMs,
-					"sessionExpiryTimer incorrect",
-				);
-				assert.equal(gc.sweepTimeoutMs, 7890, "sweepTimeoutMs incorrect");
-			});
-			it("IGCRuntimeOptions.sessionExpiryTimeoutMs", () => {
-				gc = createGcWithPrivateMembers(undefined /* metadata */, {
-					sessionExpiryTimeoutMs: 123,
-				});
-				assert.equal(gc.sessionExpiryTimeoutMs, 123, "sessionExpiryTimeoutMs incorrect");
-				assert.equal(
-					gc.sessionExpiryTimer.defaultTimeout,
-					123,
-					"sessionExpiryTimer incorrect",
-				);
-				assert.equal(gc.sweepTimeoutMs, 123 + 6 * oneDayMs, "sweepTimeoutMs incorrect");
-			});
-			it("IGCMetadata.sessionExpiryTimeoutMs, backfill sweepTimeoutMs", () => {
-				injectedSettings[testOverrideSweepTimeoutKey] = 1337; // Should be ignored
-				gc = createGcWithPrivateMembers({ sessionExpiryTimeoutMs: 456 } /* metadata */);
-				assert.equal(gc.sessionExpiryTimeoutMs, 456, "sessionExpiryTimeoutMs incorrect");
-				assert.equal(
-					gc.sessionExpiryTimer.defaultTimeout,
-					456,
-					"sessionExpiryTimer incorrect",
-				);
-				assert.equal(gc.sweepTimeoutMs, 456 + 6 * oneDayMs, "sweepTimeoutMs incorrect");
-			});
-			it("IGCMetadata.sessionExpiryTimeoutMs and IGCMetadata.sweepTimeoutMs", () => {
-				injectedSettings[testOverrideSweepTimeoutKey] = 1337; // Should be ignored
-				gc = createGcWithPrivateMembers(
-					{ sessionExpiryTimeoutMs: 456, sweepTimeoutMs: 789 } /* metadata */,
-				);
-				assert.equal(gc.sessionExpiryTimeoutMs, 456, "sessionExpiryTimeoutMs incorrect");
-				assert.equal(
-					gc.sessionExpiryTimer.defaultTimeout,
-					456,
-					"sessionExpiryTimer incorrect",
-				);
-				assert.equal(gc.sweepTimeoutMs, 789, "sweepTimeoutMs incorrect");
-			});
-			it("IGCMetadata.sweepTimeoutMs only", () => {
-				injectedSettings[testOverrideSweepTimeoutKey] = 1337; // Should be ignored
-				// This could happen if you used TestOverride.SweepTimeoutMs but had SessionExpiry disabled, then loaded that container.
-				gc = createGcWithPrivateMembers({ sweepTimeoutMs: 789 } /* metadata */);
-				assert.equal(
-					gc.sessionExpiryTimeoutMs,
-					undefined,
-					"sessionExpiryTimeoutMs incorrect",
-				);
-				assert.equal(gc.sessionExpiryTimer, undefined, "sessionExpiryTimer incorrect");
-				assert.equal(gc.sweepTimeoutMs, 789, "sweepTimeoutMs incorrect");
-			});
-			function testSessionExpiryMsOverride() {
-				const expectedSweepTimeoutMs = defaultSessionExpiryDurationMs + 6 * oneDayMs;
-				assert(!!gc, "PRECONDITION: gc must be set before calling this helper");
-				assert.equal(
-					gc.sessionExpiryTimeoutMs,
-					defaultSessionExpiryDurationMs,
-					"sessionExpiryTimeoutMs incorrect",
-				);
-				assert.equal(
-					gc.sessionExpiryTimer.defaultTimeout,
-					789,
-					"sessionExpiry used for timer should be the override value",
-				);
-				assert.equal(gc.sweepTimeoutMs, expectedSweepTimeoutMs, "sweepTimeoutMs incorrect");
-
-				const expectedMetadata: IGCMetadata = {
-					sweepEnabled: false,
-					gcFeature: 1,
-					sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
-					sweepTimeoutMs: expectedSweepTimeoutMs,
-				};
-				const outputMetadata = gc.getMetadata();
-				assert.deepEqual(
-					outputMetadata,
-					expectedMetadata,
-					"getMetadata returned different metadata than expected",
-				);
-			}
-			it("TestOverride.SessionExpiryMs setting applied to timeout but not written to file - New Container", () => {
-				injectedSettings[testOverrideSessionExpiryMsKey] = 789;
-				gc = createGcWithPrivateMembers();
-				testSessionExpiryMsOverride();
-			});
-			it("TestOverride.SessionExpiryMs setting applied to timeout but not written to file - Existing Container", () => {
-				injectedSettings[testOverrideSessionExpiryMsKey] = 789;
-				gc = createGcWithPrivateMembers(
-					{
-						sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
-						gcFeature: 1,
-					} /* metadata */,
-				);
-				testSessionExpiryMsOverride();
-			});
-			it("RunSessionExpiry setting turned off", () => {
-				injectedSettings[runSessionExpiryKey] = false;
-				injectedSettings[testOverrideSessionExpiryMsKey] = 1234; // This override should be ignored
-				gc = createGcWithPrivateMembers();
-				assert.equal(
-					gc.sessionExpiryTimeoutMs,
-					undefined,
-					"sessionExpiryTimeoutMs should be undefined if runSessionExpiryKey setting is false",
-				);
-				assert.equal(
-					gc.sessionExpiryTimer,
-					undefined,
-					"sessionExpiryTimer should be undefined if it's disabled",
-				);
-				assert.equal(gc.sweepTimeoutMs, undefined, "sweepTimeoutMs incorrect");
-			});
-			it("RunSessionExpiry setting turned off, TestOverride.SweepTimeout set", () => {
-				injectedSettings[runSessionExpiryKey] = false;
-				injectedSettings[testOverrideSweepTimeoutKey] = 7890;
-				injectedSettings[testOverrideSessionExpiryMsKey] = 1234; // This override should be ignored
-				gc = createGcWithPrivateMembers();
-				assert.equal(
-					gc.sessionExpiryTimeoutMs,
-					undefined,
-					"sessionExpiryTimeoutMs should be undefined if runSessionExpiryKey setting is false",
-				);
-				assert.equal(
-					gc.sessionExpiryTimer,
-					undefined,
-					"sessionExpiryTimer should be undefined if it's disabled",
-				);
-				assert.equal(gc.sweepTimeoutMs, 7890, "sweepTimeoutMs incorrect");
-			});
-		});
-
-		describe("Session Behavior (e.g. 'shouldRun' fields)", () => {
-			beforeEach(() => {
-				injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = 1; // To ensure it's less than sweep timeout
-			});
-
-			describe("shouldRunGC", () => {
-				const testCases: {
-					gcEnabled: boolean;
-					disableGC?: boolean;
-					runGC?: boolean;
-					expectedResult: boolean;
-				}[] = [
-					{ gcEnabled: false, disableGC: true, runGC: true, expectedResult: true },
-					{ gcEnabled: true, disableGC: false, runGC: false, expectedResult: false },
-					{ gcEnabled: true, disableGC: true, expectedResult: false },
-					{ gcEnabled: true, disableGC: false, expectedResult: true },
-					{ gcEnabled: true, expectedResult: true },
-					{ gcEnabled: false, expectedResult: false },
-				];
-				testCases.forEach((testCase) => {
-					it(`Test Case ${JSON.stringify(testCase)}`, () => {
-						injectedSettings[runGCKey] = testCase.runGC;
-						gc = createGcWithPrivateMembers(undefined /* metadata */, {
-							gcAllowed: testCase.gcEnabled,
-							disableGC: testCase.disableGC,
-						});
-						assert.equal(
-							gc.gcEnabled,
-							testCase.gcEnabled,
-							"PRECONDITION: gcEnabled set incorrectly",
-						);
-						assert.equal(
-							gc.shouldRunGC,
-							testCase.expectedResult,
-							"shouldRunGC not set as expected",
-						);
-					});
-				});
-			});
-			describe("shouldRunSweep", () => {
-				const testCases: {
-					shouldRunGC: boolean;
-					setSweepTimeout: boolean;
-					sweepEnabled: boolean;
-					runSweep?: boolean;
-					expectedResult: boolean;
-				}[] = [
-					{
-						shouldRunGC: false,
-						setSweepTimeout: true,
-						sweepEnabled: true,
-						runSweep: true,
-						expectedResult: false,
-					},
-					{
-						shouldRunGC: true,
-						setSweepTimeout: false,
-						sweepEnabled: true,
-						runSweep: true,
-						expectedResult: false,
-					},
-					{
-						shouldRunGC: true,
-						setSweepTimeout: true,
-						sweepEnabled: true,
-						runSweep: false,
-						expectedResult: false,
-					},
-					{
-						shouldRunGC: true,
-						setSweepTimeout: true,
-						sweepEnabled: false,
-						runSweep: true,
-						expectedResult: true,
-					},
-					{
-						shouldRunGC: true,
-						setSweepTimeout: true,
-						sweepEnabled: true,
-						expectedResult: true,
-					},
-					{
-						shouldRunGC: true,
-						setSweepTimeout: true,
-						sweepEnabled: false,
-						expectedResult: false,
-					},
-				];
-				testCases.forEach((testCase) => {
-					it(`Test Case ${JSON.stringify(testCase)}`, () => {
-						injectedSettings[runGCKey] = testCase.shouldRunGC;
-						injectedSettings[runSweepKey] = testCase.runSweep;
-						injectedSettings[runSessionExpiryKey] = testCase.setSweepTimeout; // Sweep timeout is set iff sessionExpiry runs (under other default inputs)
-						gc = createGcWithPrivateMembers(undefined /* metadata */, {
-							sweepAllowed: testCase.sweepEnabled,
-						});
-						assert.equal(
-							gc.shouldRunGC,
-							testCase.shouldRunGC,
-							"PRECONDITION: shouldRunGC set incorrectly",
-						);
-						assert.equal(
-							gc.sweepTimeoutMs !== undefined,
-							testCase.setSweepTimeout,
-							"PRECONDITION: sweep timeout set incorrectly",
-						);
-						assert.equal(
-							gc.sweepEnabled,
-							testCase.sweepEnabled,
-							"PRECONDITION: sweepEnabled set incorrectly",
-						);
-						assert.equal(
-							gc.shouldRunSweep,
-							testCase.expectedResult,
-							"shouldRunSweep not set as expected",
-						);
-					});
-				});
-			});
-			describe("inactiveTimeoutMs", () => {
-				beforeEach(() => {
-					// Remove setting added in outer describe block
-					injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
-						undefined;
-				});
-				const testCases: {
-					testOverride?: number;
-					option?: number;
-					expectedResult: number;
-				}[] = [
-					{ testOverride: 123, option: 456, expectedResult: 123 },
-					{ option: 456, expectedResult: 456 },
-					{ expectedResult: defaultInactiveTimeoutMs },
-				];
-				testCases.forEach((testCase) => {
-					it(`Test Case ${JSON.stringify(testCase)}`, () => {
-						injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
-							testCase.testOverride;
-						gc = createGcWithPrivateMembers(undefined /* metadata */, {
-							inactiveTimeoutMs: testCase.option,
-						});
-						assert.equal(
-							gc.inactiveTimeoutMs,
-							testCase.expectedResult,
-							"inactiveTimeoutMs not set as expected",
-						);
-					});
-				});
-				it("inactiveTimeout must not be greater than sweepTimeout", () => {
-					injectedSettings[runSessionExpiryKey] = true;
-					injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
-						Number.MAX_VALUE;
-					assert.throws(
-						() => {
-							gc = createGcWithPrivateMembers();
-						},
-						(e) => e.errorType === "usageError",
-						"inactiveTimeout must not be greater than sweepTimeout",
-					);
-				});
-			});
-			describe("testMode", () => {
-				const testCases: {
-					setting?: boolean;
-					option?: boolean;
-					expectedResult: boolean;
-				}[] = [
-					{ setting: true, option: false, expectedResult: true },
-					{ setting: false, option: true, expectedResult: false },
-					{ option: true, expectedResult: true },
-					{ expectedResult: false },
-				];
-				testCases.forEach((testCase) => {
-					it(`Test Case ${JSON.stringify(testCase)}`, () => {
-						injectedSettings[gcTestModeKey] = testCase.setting;
-						gc = createGcWithPrivateMembers(undefined /* metadata */, {
-							runGCInTestMode: testCase.option,
-						});
-						assert.equal(
-							gc.testMode,
-							testCase.expectedResult,
-							"testMode not set as expected",
-						);
-					});
-				});
-			});
-		});
-	});
-
-	it("Session expiry closes container", () => {
-		injectedSettings[runSessionExpiryKey] = "true";
-
-		let closeCalled = false;
-		function closeCalledAfterExactTicks(ticks: number) {
-			clock.tick(ticks - 1);
-			if (closeCalled) {
-				return false;
-			}
-			clock.tick(1);
-			return closeCalled;
-		}
-
-		gc = createGarbageCollector({}, undefined /* gcBlobsMap */, () => {
-			closeCalled = true;
-		}) as GcWithPrivates;
-		assert(
-			closeCalledAfterExactTicks(defaultSessionExpiryDurationMs),
-			"Close should have been called at exactly defaultSessionExpiryDurationMs",
-		);
-	});
-
-	describe("errors when unreferenced objects are used after they are inactive / deleted", () => {
-		// Mock node loaded and changed activity for all the nodes in the graph.
-		async function updateAllNodesAndRunGC(garbageCollector: IGarbageCollector) {
-			nodes.forEach((nodeId) => {
-				garbageCollector.nodeUpdated(nodeId, "Changed", Date.now(), testPkgPath);
-				garbageCollector.nodeUpdated(nodeId, "Loaded", Date.now(), testPkgPath);
-			});
-			await garbageCollector.collectGarbage({});
-		}
-
-		beforeEach(async () => {
-			// Set up the reference graph such that all nodes are referenced. Add in a couple of cycles in the graph.
-			// Here's a diagram showing the references:
-			// 0 - 1 - 2 - 3
-			// |  /       /
-			// |-/-------/
-			defaultGCData.gcNodes["/"] = [nodes[0]];
-			defaultGCData.gcNodes[nodes[0]] = [nodes[1]];
-			defaultGCData.gcNodes[nodes[1]] = [nodes[0], nodes[2]];
-			defaultGCData.gcNodes[nodes[2]] = [nodes[3]];
-			defaultGCData.gcNodes[nodes[3]] = [nodes[0]];
-		});
-
-		const summarizerContainerTests = (
-			timeout: number,
-			revivedEventName: string,
-			changedEventName: string,
-			loadedEventName: string,
-			expectDeleteLogs?: boolean,
-		) => {
-			const deleteEventName = "GarbageCollector:GCObjectDeleted";
-			// Validates that no unexpected event has been fired.
-			function validateNoUnexpectedEvents() {
-				mockLogger.assertMatchNone(
-					[
-						{ eventName: revivedEventName },
-						{ eventName: changedEventName },
-						{ eventName: loadedEventName },
-						{ eventName: deleteEventName },
-					],
-					"unexpected events logged",
-				);
-			}
-
-			const createGCOverride = (
-				baseSnapshot?: ISnapshotTree,
-				gcBlobsMap?: Map<string, IGarbageCollectionState | IGarbageCollectionDetailsBase>,
-			) => {
-				return createGarbageCollector({ baseSnapshot }, gcBlobsMap);
-			};
-
-			it("doesn't generate events for referenced nodes", async () => {
-				const garbageCollector = createGCOverride();
-
-				// Run garbage collection on the default GC data where everything is referenced.
-				await garbageCollector.collectGarbage({});
-
-				// Advance the clock just before the timeout and validate no events are generated.
-				clock.tick(timeout - 1);
-				await updateAllNodesAndRunGC(garbageCollector);
-				validateNoUnexpectedEvents();
-
-				// Advance the clock to expire the timeout.
-				clock.tick(1);
-
-				// Update all nodes again. Validate that no unexpected events are generated since everything is referenced.
-				await updateAllNodesAndRunGC(garbageCollector);
-				validateNoUnexpectedEvents();
-			});
-
-			it("generates events for nodes that are used after time out", async () => {
-				const garbageCollector = createGCOverride();
-
-				// Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
-				defaultGCData.gcNodes[nodes[1]] = [];
-
-				await garbageCollector.collectGarbage({});
-
-				// Advance the clock just before the timeout and validate no unexpected events are logged.
-				clock.tick(timeout - 1);
-				await updateAllNodesAndRunGC(garbageCollector);
-				validateNoUnexpectedEvents();
-
-				// Expire the timeout and validate that all events for node 2 and node 3 are logged.
-				clock.tick(1);
-				await updateAllNodesAndRunGC(garbageCollector);
-				const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [];
-
-				if (expectDeleteLogs) {
-					expectedEvents.push(
-						{ eventName: deleteEventName, timeout, id: nodes[2] },
-						{ eventName: deleteEventName, timeout, id: nodes[3] },
-					);
-				} else {
-					assert(
-						!mockLogger.events.some((event) => event.eventName === deleteEventName),
-						"Should not have any delete events logged",
-					);
-				}
-				expectedEvents.push(
-					{
-						eventName: changedEventName,
-						timeout,
-						id: nodes[2],
-						pkg: eventPkg,
-						createContainerRuntimeVersion: pkgVersion,
-					},
-					{
-						eventName: loadedEventName,
-						timeout,
-						id: nodes[2],
-						pkg: eventPkg,
-						createContainerRuntimeVersion: pkgVersion,
-					},
-					{
-						eventName: changedEventName,
-						timeout,
-						id: nodes[3],
-						pkg: eventPkg,
-						createContainerRuntimeVersion: pkgVersion,
-					},
-					{
-						eventName: loadedEventName,
-						timeout,
-						id: nodes[3],
-						pkg: eventPkg,
-						createContainerRuntimeVersion: pkgVersion,
-					},
-				);
-				mockLogger.assertMatch(expectedEvents, "all events not generated as expected");
-
-				// Add reference from node 1 to node 3 and validate that we get a revived event.
-				garbageCollector.addedOutboundReference(nodes[1], nodes[3]);
-				await garbageCollector.collectGarbage({});
-				mockLogger.assertMatch(
-					[
-						{
-							eventName: revivedEventName,
-							timeout,
-							id: nodes[3],
-							pkg: eventPkg,
-							fromId: nodes[1],
-						},
-					],
-					"revived event not generated as expected",
-				);
-			});
-
-			it("generates only revived event when an inactive node is changed and revived", async () => {
-				const garbageCollector = createGCOverride();
-
-				// Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
-				defaultGCData.gcNodes[nodes[1]] = [];
-
-				await garbageCollector.collectGarbage({});
-
-				// Advance the clock just before the timeout and validate no unexpected events are logged.
-				clock.tick(timeout - 1);
-				await updateAllNodesAndRunGC(garbageCollector);
-				validateNoUnexpectedEvents();
-
-				// Expire the timeout and validate that only revived event is generated for node 2.
-				clock.tick(1);
-				garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
-				garbageCollector.nodeUpdated(nodes[2], "Loaded", Date.now(), testPkgPath);
-				garbageCollector.addedOutboundReference(nodes[1], nodes[2]);
-				await garbageCollector.collectGarbage({});
-
-				for (const event of mockLogger.events) {
-					assert.notStrictEqual(
-						event.eventName,
-						changedEventName,
-						"Unexpected changed event logged",
-					);
-					assert.notStrictEqual(
-						event.eventName,
-						loadedEventName,
-						"Unexpected loaded event logged",
-					);
-				}
-				mockLogger.assertMatch(
-					[
-						{
-							eventName: revivedEventName,
-							timeout,
-							id: nodes[2],
-							pkg: eventPkg,
-							fromId: nodes[1],
-						},
-					],
-					"revived event not logged as expected",
-				);
-			});
-
-			it("generates events once per node", async () => {
-				const garbageCollector = createGCOverride();
-
-				// Remove node 3's reference from node 2.
-				defaultGCData.gcNodes[nodes[2]] = [];
-
-				await garbageCollector.collectGarbage({});
-
-				// Advance the clock just before the timeout and validate no unexpected events are logged.
-				clock.tick(timeout - 1);
-				await updateAllNodesAndRunGC(garbageCollector);
-				validateNoUnexpectedEvents();
-
-				// Expire the timeout and validate that all events for node 2 and node 3 are logged.
-				clock.tick(1);
-				await updateAllNodesAndRunGC(garbageCollector);
-				const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [];
-				if (expectDeleteLogs) {
-					expectedEvents.push({ eventName: deleteEventName, timeout, id: nodes[3] });
-				} else {
-					assert(
-						!mockLogger.events.some((event) => event.eventName === deleteEventName),
-						"Should not have any delete events logged",
-					);
-				}
-				expectedEvents.push(
-					{ eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
-					{ eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
-				);
-				mockLogger.assertMatch(expectedEvents, "all events not generated as expected");
-
-				// Update all nodes again. There shouldn't be any more events since for each node the event is only once.
-				await updateAllNodesAndRunGC(garbageCollector);
-				validateNoUnexpectedEvents();
-			});
-
-			/**
-			 * Here, the base snapshot contains nodes that have timed out. The test validates that we generate errors
-			 * when these nodes are used.
-			 */
-			it("generates events for nodes that time out on load", async () => {
-				// Create GC state where node 3's unreferenced time was > timeout ms ago.
-				// This means this node should time out as soon as its data is loaded.
-
-				// Create a snapshot tree to be used as the GC snapshot tree.
-				const gcSnapshotTree = getDummySnapshotTree();
-				const gcBlobId = "root";
-				// Add a GC blob with key that start with `gcBlobPrefix` to the GC snapshot tree. The blob Id for this
-				// is generated by server in real scenarios but we use a static id here for testing.
-				gcSnapshotTree.blobs[`${gcBlobPrefix}_${gcBlobId}`] = gcBlobId;
-
-				// Create a base snapshot that contains the GC snapshot tree.
-				const baseSnapshot = getDummySnapshotTree();
-				baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
-
-				// Create GC state with node 3 expired. This will be returned when the garbage collector asks
-				// for the GC blob with `gcBlobId`.
-				const gcState: IGarbageCollectionState = { gcNodes: {} };
-				const node3Data: IGarbageCollectionNodeData = {
-					outboundRoutes: [],
-					unreferencedTimestampMs: Date.now() - (timeout + 100),
-				};
-				gcState.gcNodes[nodes[3]] = node3Data;
-
-				const gcBlobMap: Map<string, IGarbageCollectionState> = new Map([
-					[gcBlobId, gcState],
-				]);
-				const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
-
-				// Remove node 3's reference from node 2 so that it is still unreferenced.
-				defaultGCData.gcNodes[nodes[2]] = [];
-
-				// Run GC to trigger loading the GC details from the base summary. Will also generate Delete logs
-				await garbageCollector.collectGarbage({});
-				// Validate that the sweep ready event is logged when GC runs after load.
-				if (expectDeleteLogs) {
-					mockLogger.assertMatch(
-						[{ eventName: deleteEventName, timeout, id: nodes[3] }],
-						"sweep ready event not generated as expected",
-					);
-				} else {
-					mockLogger.assertMatchNone(
-						[{ eventName: deleteEventName }],
-						"Should not have any delete events logged",
-					);
-				}
-
-				// Validate that all events are logged as expected.
-				garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
-				garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
-				await garbageCollector.collectGarbage({});
-				mockLogger.assertMatch(
-					[
-						{ eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
-						{ eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
-					],
-					"all events not generated as expected",
-				);
-
-				// Add reference from node 2 to node 3 and validate that revived event is logged.
-				garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
-				await garbageCollector.collectGarbage({});
-				mockLogger.assertMatch(
-					[
-						{
-							eventName: revivedEventName,
-							timeout,
-							id: nodes[3],
-							pkg: eventPkg,
-							fromId: nodes[2],
-						},
-					],
-					"revived event not generated as expected",
-				);
-			});
-
-			/**
-			 * Here, the base snapshot contains nodes that have timed out and the GC blob in snapshot is in old format. The
-			 * test validates that we generate errors when these nodes are used.
-			 */
-			it("generates events for nodes that time out on load - old snapshot format", async () => {
-				// Create GC details for node 3's GC blob whose unreferenced time was > timeout ms ago.
-				// This means this node should time out as soon as its data is loaded.
-				const node3GCDetails: IGarbageCollectionSummaryDetailsLegacy = {
-					gcData: { gcNodes: { "/": [] } },
-					unrefTimestamp: Date.now() - (timeout + 100),
-				};
-				const node3Snapshot = getDummySnapshotTree();
-				const gcBlobId = "node3GCDetails";
-				const attributesBlobId = "attributesBlob";
-				node3Snapshot.blobs[gcTreeKey] = gcBlobId;
-				node3Snapshot.blobs[dataStoreAttributesBlobName] = attributesBlobId;
-
-				// Create a base snapshot that contains snapshot tree of node 3.
-				const baseSnapshot = getDummySnapshotTree();
-				baseSnapshot.trees[nodes[3].slice(1)] = node3Snapshot;
-
-				// Set up the getNodeGCDetails function to return the GC details for node 3 when asked by garbage collector.
-				const gcBlobMap = new Map([
-					[gcBlobId, node3GCDetails],
-					[attributesBlobId, {}],
-				]);
-				const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
-
-				// Remove node 3's reference from node 2 so that it is still unreferenced. The GC details from the base
-				// summary is not loaded until the first time GC is run, so do that immediately.
-				defaultGCData.gcNodes[nodes[2]] = [];
-				await garbageCollector.collectGarbage({});
-
-				// Validate that the sweep ready event is logged when GC runs after load.
-				if (expectDeleteLogs) {
-					mockLogger.assertMatch(
-						[{ eventName: deleteEventName, timeout, id: nodes[3] }],
-						"sweep ready event not generated as expected",
-					);
-				} else {
-					mockLogger.assertMatchNone(
-						[{ eventName: deleteEventName }],
-						"Should not have any delete events logged",
-					);
-				}
-
-				// Validate that all events are logged as expected.
-				garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
-				garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
-				await garbageCollector.collectGarbage({});
-				mockLogger.assertMatch(
-					[
-						{ eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
-						{ eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
-					],
-					"all events not generated as expected",
-				);
-
-				// Add reference from node 2 to node 3 and validate that revived event is logged.
-				garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
-				await garbageCollector.collectGarbage({});
-				mockLogger.assertMatch(
-					[
-						{
-							eventName: revivedEventName,
-							timeout,
-							id: nodes[3],
-							pkg: eventPkg,
-							fromId: nodes[2],
-						},
-					],
-					"revived event not generated as expected",
-				);
-			});
-
-			/**
-			 * Here, the base snapshot contains nodes that have timed out and the GC data in snapshot is present in multiple
-			 * blobs. The test validates that we generate errors when these nodes are used.
-			 */
-			it(`generates events for nodes that time out on load - multi blob GC data`, async () => {
-				const gcBlobMap: Map<string, IGarbageCollectionState> = new Map();
-				const expiredTimestampMs = Date.now() - (timeout + 100);
-
-				// Create three GC states to be added into separate GC blobs. Each GC state has a node whose unreferenced
-				// time was > timeout ms ago. These three GC blobs are the added to the GC tree in summary.
-				const blob1Id = "blob1";
-				const blob1GCState: IGarbageCollectionState = { gcNodes: {} };
-				blob1GCState.gcNodes[nodes[1]] = {
-					outboundRoutes: [],
-					unreferencedTimestampMs: expiredTimestampMs,
-				};
-				gcBlobMap.set(blob1Id, blob1GCState);
-
-				const blob2Id = "blob2";
-				const blob2GCState: IGarbageCollectionState = { gcNodes: {} };
-				blob2GCState.gcNodes[nodes[2]] = {
-					outboundRoutes: [],
-					unreferencedTimestampMs: expiredTimestampMs,
-				};
-				gcBlobMap.set(blob2Id, blob2GCState);
-
-				const blob3Id = "blob3";
-				const blob3GCState: IGarbageCollectionState = { gcNodes: {} };
-				blob3GCState.gcNodes[nodes[3]] = {
-					outboundRoutes: [],
-					unreferencedTimestampMs: expiredTimestampMs,
-				};
-				gcBlobMap.set(blob3Id, blob3GCState);
-
-				// Create a GC snapshot tree and add the above three GC blob ids to it.
-				const gcSnapshotTree = getDummySnapshotTree();
-				gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob1Id}`] = blob1Id;
-				gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob2Id}`] = blob2Id;
-				gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob3Id}`] = blob3Id;
-
-				// Create a base snapshot that contains the above GC snapshot tree.
-				const baseSnapshot = getDummySnapshotTree();
-				baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
-
-				const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
-
-				// For the nodes in the GC snapshot blobs, remove their references from the default GC data.
-				defaultGCData.gcNodes[nodes[0]] = [];
-				defaultGCData.gcNodes[nodes[1]] = [];
-				defaultGCData.gcNodes[nodes[2]] = [];
-
-				await garbageCollector.collectGarbage({});
-				// Validate that the sweep ready event is logged when GC runs after load.
-				if (expectDeleteLogs) {
-					mockLogger.assertMatch(
-						[
-							{ eventName: deleteEventName, timeout, id: nodes[1] },
-							{ eventName: deleteEventName, timeout, id: nodes[2] },
-							{ eventName: deleteEventName, timeout, id: nodes[3] },
-						],
-						"sweep ready event not generated as expected",
-					);
-				} else {
-					mockLogger.assertMatchNone(
-						[{ eventName: deleteEventName }],
-						"Should not have any delete events logged",
-					);
-				}
-
-				// Validate that all events are logged as expected.
-				garbageCollector.nodeUpdated(nodes[1], "Changed", Date.now(), testPkgPath);
-				garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
-				garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
-				await garbageCollector.collectGarbage({});
-				mockLogger.assertMatch(
-					[
-						{ eventName: changedEventName, timeout, id: nodes[1], pkg: eventPkg },
-						{ eventName: changedEventName, timeout, id: nodes[2], pkg: eventPkg },
-						{ eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
-					],
-					"all events not generated as expected",
-				);
-			});
-		};
-
-		describe("Inactive events (summarizer container)", () => {
-			const inactiveTimeoutMs = 500;
-
-			beforeEach(() => {
-				injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
-					inactiveTimeoutMs;
-			});
-
-			summarizerContainerTests(
-				inactiveTimeoutMs,
-				"GarbageCollector:InactiveObject_Revived",
-				"GarbageCollector:InactiveObject_Changed",
-				"GarbageCollector:InactiveObject_Loaded",
-			);
-		});
-
-		describe("SweepReady events (summarizer container)", () => {
-			const sweepTimeoutMs =
-				defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
-
-			beforeEach(() => {
-				injectedSettings[runSessionExpiryKey] = true;
-			});
-
-			summarizerContainerTests(
-				sweepTimeoutMs,
-				"GarbageCollector:SweepReadyObject_Revived",
-				"GarbageCollector:SweepReadyObject_Changed",
-				"GarbageCollector:SweepReadyObject_Loaded",
-				true, // expectDeleteLogs
-			);
-		});
-
-		describe("SweepReady events - Delete log disabled (summarizer container)", () => {
-			const sweepTimeoutMs =
-				defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
-
-			beforeEach(() => {
-				injectedSettings[runSessionExpiryKey] = true;
-				injectedSettings[disableSweepLogKey] = true;
-			});
-
-			summarizerContainerTests(
-				sweepTimeoutMs,
-				"GarbageCollector:SweepReadyObject_Revived",
-				"GarbageCollector:SweepReadyObject_Changed",
-				"GarbageCollector:SweepReadyObject_Loaded",
-				false, // expectDeleteLogs
-			);
-		});
-
-		describe("Interactive Client Behavior", () => {
-			function updateAllNodes(garbageCollector) {
-				nodes.forEach((nodeId) => {
-					garbageCollector.nodeUpdated(nodeId, "Changed", Date.now(), testPkgPath);
-					garbageCollector.nodeUpdated(nodeId, "Loaded", Date.now(), testPkgPath);
-				});
-			}
-
-			async function interactiveClientTestCode(
-				timeout: number,
-				loadedEventName: string,
-				sweepReadyUsageErrorExpected: boolean,
-			) {
-				let lastCloseErrorType: string = "N/A";
-
-				// Create GC state where node 3's unreferenced time was > timeout ms ago.
-				// This is important since we shouldn't run GC on the interactive container,
-				// but rather load from a snapshot in which SweepReady state is already reached.
-
-				// Create a snapshot tree to be used as the GC snapshot tree.
-				const gcSnapshotTree = getDummySnapshotTree();
-				const gcBlobId = "root";
-				// Add a GC blob with key that start with `gcBlobPrefix` to the GC snapshot tree. The blob Id for this
-				// is generated by server in real scenarios but we use a static id here for testing.
-				gcSnapshotTree.blobs[`${gcBlobPrefix}_${gcBlobId}`] = gcBlobId;
-
-				// Create a base snapshot that contains the GC snapshot tree.
-				const baseSnapshot = getDummySnapshotTree();
-				baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
-
-				// Create GC state with node 3 expired. This will be returned when the garbage collector asks
-				// for the GC blob with `gcBlobId`.
-				const gcState: IGarbageCollectionState = { gcNodes: {} };
-				const unrefTime = Date.now() - (timeout + 100);
-				const node3Data: IGarbageCollectionNodeData = {
-					outboundRoutes: [],
-					unreferencedTimestampMs: unrefTime,
-				};
-				gcState.gcNodes[nodes[3]] = node3Data;
-
-				const gcBlobMap: Map<string, IGarbageCollectionState> = new Map([
-					[gcBlobId, gcState],
-				]);
-				const garbageCollector = createGarbageCollector(
-					{ baseSnapshot },
-					gcBlobMap,
-					(error) => {
-						lastCloseErrorType = error?.errorType ?? "NONE";
-					},
-					false /* isSummarizerClient */,
-				);
-
-				// Trigger loading GC state from base snapshot - but don't call GC since that's not what happens in real flow
-				await (garbageCollector as any).initializeGCStateFromBaseSnapshotP;
-
-				// Update nodes and validate that all events for node 3 are logged.
-				updateAllNodes(garbageCollector);
-				assert(
-					!mockLogger.events.some(
-						(event) =>
-							event.eventName !== loadedEventName && event.unrefTime === unrefTime,
-					),
-					"shouldn't see any unreference events besides Loaded",
-				);
-				mockLogger.assertMatch(
-					[
-						{
-							eventName: loadedEventName,
-							timeout,
-							id: nodes[3],
-							pkg: eventPkg,
-							unrefTime,
-						},
-					],
-					"all events not generated as expected",
-				);
-
-				const expectedErrorType = sweepReadyUsageErrorExpected
-					? "unreferencedObjectUsedAfterGarbageCollected"
-					: "N/A";
-				assert.equal(
-					lastCloseErrorType,
-					expectedErrorType,
-					"Incorrect lastCloseReason after using unreferenced nodes",
-				);
-			}
-
-			beforeEach(() => {
-				injectedSettings[runSessionExpiryKey] = true;
-			});
-
-			it("Inactive object used - generates events but does not close container (SweepReadyUsageDetection enabled)", async () => {
-				const inactiveTimeoutMs = 400;
-				injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
-					inactiveTimeoutMs;
-				injectedSettings[SweepReadyUsageDetectionKey] = "interactiveClient";
-
-				await interactiveClientTestCode(
-					inactiveTimeoutMs,
-					"GarbageCollector:InactiveObject_Loaded",
-					false,
-				);
-			});
-
-			it("SweepReady object used - generates events and closes container (SweepReadyUsageDetection enabled)", async () => {
-				const sweepTimeoutMs =
-					defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
-				injectedSettings[SweepReadyUsageDetectionKey] = "interactiveClient";
-
-				await interactiveClientTestCode(
-					sweepTimeoutMs,
-					"GarbageCollector:SweepReadyObject_Loaded",
-					true,
-				);
-			});
-
-			it("SweepReady object used - generates events but does not close container (SweepReadyUsageDetection disabled)", async () => {
-				const sweepTimeoutMs =
-					defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
-				injectedSettings[SweepReadyUsageDetectionKey] = "something else";
-
-				await interactiveClientTestCode(
-					sweepTimeoutMs,
-					"GarbageCollector:SweepReadyObject_Loaded",
-					false,
-				);
-			});
-		});
-
-		it("generates both inactive and sweep ready events when nodes are used after time out", async () => {
-			const inactiveTimeoutMs = 500;
-			const sweepTimeoutMs =
-				defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
-			injectedSettings[runSessionExpiryKey] = "true";
-			injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
-				inactiveTimeoutMs;
-
-			const garbageCollector = createGarbageCollector({});
-
-			// Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
-			defaultGCData.gcNodes[nodes[1]] = [];
-			await garbageCollector.collectGarbage({});
-
-			// Advance the clock to trigger inactive timeout and validate that we get inactive events.
-			clock.tick(inactiveTimeoutMs + 1);
-			await updateAllNodesAndRunGC(garbageCollector);
-			mockLogger.assertMatch(
-				[
-					{
-						eventName: "GarbageCollector:InactiveObject_Changed",
-						timeout: inactiveTimeoutMs,
-						id: nodes[2],
-					},
-					{
-						eventName: "GarbageCollector:InactiveObject_Loaded",
-						timeout: inactiveTimeoutMs,
-						id: nodes[2],
-					},
-					{
-						eventName: "GarbageCollector:InactiveObject_Changed",
-						timeout: inactiveTimeoutMs,
-						id: nodes[3],
-					},
-					{
-						eventName: "GarbageCollector:InactiveObject_Loaded",
-						timeout: inactiveTimeoutMs,
-						id: nodes[3],
-					},
-				],
-				"inactive events not generated as expected",
-			);
-
-			// Advance the clock to trigger sweep timeout and validate that we get sweep ready events.
-			clock.tick(sweepTimeoutMs - inactiveTimeoutMs);
-			await updateAllNodesAndRunGC(garbageCollector);
-			mockLogger.assertMatch(
-				[
-					{
-						eventName: "GarbageCollector:SweepReadyObject_Changed",
-						timeout: sweepTimeoutMs,
-						id: nodes[2],
-					},
-					{
-						eventName: "GarbageCollector:SweepReadyObject_Loaded",
-						timeout: sweepTimeoutMs,
-						id: nodes[2],
-					},
-					{
-						eventName: "GarbageCollector:SweepReadyObject_Changed",
-						timeout: sweepTimeoutMs,
-						id: nodes[3],
-					},
-					{
-						eventName: "GarbageCollector:SweepReadyObject_Loaded",
-						timeout: sweepTimeoutMs,
-						id: nodes[3],
-					},
-				],
-				"sweep ready events not generated as expected",
-			);
-		});
-	});
-
-	describe("Deleted blobs in GC summary tree", () => {
-		beforeEach(() => {
-			injectedSettings["Fluid.GarbageCollection.TrackGCState"] = true;
-		});
-
-		it("correctly reads and write deleted blobs in summary", async () => {
-			// Set up the GC reference graph to have something to work with.
-			defaultGCData.gcNodes["/"] = [nodes[0]];
-
-			// Create a snapshot tree to be used as the GC snapshot tree.
-			const gcSnapshotTree = getDummySnapshotTree();
-			// Add a blob to the tree for deleted nodes.
-			const deletedNodesBlobId = "deletedNodes";
-			gcSnapshotTree.blobs[gcDeletedBlobKey] = deletedNodesBlobId;
-			const deletedNodeIds = [...nodes];
-			// Add deleted nodes list the blobs map that will service read and parse blob calls from GC.
-			const gcBlobsMap: Map<string, string[]> = new Map([
-				[deletedNodesBlobId, deletedNodeIds],
-			]);
-			// Create a base snapshot that contains the GC snapshot tree.
-			const baseSnapshot = getDummySnapshotTree();
-			baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
-
-			// Create and initialize garbage collector.
-			const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobsMap);
-			await garbageCollector.initializeBaseState();
-
-			// The nodes in deletedNodeIds should be marked as deleted.
-			for (const nodeId of deletedNodeIds) {
-				assert(
-					garbageCollector.isNodeDeleted(nodeId) === true,
-					`${nodeId} should be marked deleted`,
-				);
-			}
-
-			await garbageCollector.collectGarbage({});
-			// Summarize with fullTree as true so that the deleted nodes are written as a blob and can be validated.
-			const summaryTree = garbageCollector.summarize(
-				true /* fullTree */,
-				true /* trackState */,
-			);
-			assert(summaryTree?.summary.type === SummaryType.Tree, "The summary should be a tree");
-
-			// Get the deleted node ids from summary and validate that its the same as the one GC loaded from.
-			const deletedNodesBlob = summaryTree.summary.tree[gcDeletedBlobKey];
-			assert(
-				deletedNodesBlob.type === SummaryType.Blob,
-				"Deleted blob not present in summary",
-			);
-			const deletedNodeIdsInSummary = JSON.parse(
-				deletedNodesBlob.content as string,
-			) as string[];
-			assert.deepStrictEqual(
-				deletedNodeIdsInSummary,
-				deletedNodeIds,
-				"Unexpected deleted nodes in summary",
-			);
-		});
-
-		it("writes handle for deleted blobs when its unchanged", async () => {
-			// Set up the GC reference graph to have something to work with.
-			defaultGCData.gcNodes["/"] = [nodes[0]];
-
-			// Create a snapshot tree to be used as the GC snapshot tree.
-			const gcSnapshotTree = getDummySnapshotTree();
-			// Add a blob to the tree for deleted nodes.
-			const deletedNodesBlobId = "deletedNodes";
-			gcSnapshotTree.blobs[gcDeletedBlobKey] = deletedNodesBlobId;
-			const deletedNodeIds = [...nodes];
-			// Add deleted nodes list the blobs map that will service read and parse blob calls from GC.
-			const gcBlobsMap: Map<string, string[]> = new Map([
-				[deletedNodesBlobId, deletedNodeIds],
-			]);
-			// Create a base snapshot that contains the GC snapshot tree.
-			const baseSnapshot = getDummySnapshotTree();
-			baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
-
-			// Create and initialize garbage collector.
-			const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobsMap);
-			await garbageCollector.initializeBaseState();
-
-			// Run GC and summarize. The summary should contain the deleted nodes.
-			await garbageCollector.collectGarbage({});
-			const gcSummary = garbageCollector.summarize(
-				false /* fullTree */,
-				true /* trackState */,
-			);
-			assert(gcSummary?.summary.type === SummaryType.Tree, "The summary should be a tree");
-
-			// Get the deleted node ids from summary and validate that its the same as the one GC loaded from.
-			const deletedNodesBlob = gcSummary.summary.tree[gcDeletedBlobKey];
-			assert(
-				deletedNodesBlob.type === SummaryType.Handle,
-				"Deleted nodes state should be a handle",
-			);
-
-			const refreshSummaryResult: RefreshSummaryResult = {
-				latestSummaryUpdated: true,
-				wasSummaryTracked: true,
-			};
-			await garbageCollector.refreshLatestSummary(
-				refreshSummaryResult,
-				undefined,
-				0,
-				parseNothing,
-			);
-
-			// Run GC and summarize again. The whole GC summary should now be a summary handle.
-			await garbageCollector.collectGarbage({});
-			const gcSummary2 = garbageCollector.summarize(
-				false /* fullTree */,
-				true /* trackState */,
-			);
-			assert(
-				gcSummary2?.summary.type === SummaryType.Handle,
-				"The summary should be a handle",
-			);
-		});
-	});
-
-	describe("GC completed runs", () => {
-		const gcEndEvent = "GarbageCollector:GarbageCollection_end";
-
-		it("increments GC completed runs in logged events correctly", async () => {
-			const garbageCollector = createGarbageCollector();
-
-			await garbageCollector.collectGarbage({});
-			mockLogger.assertMatch(
-				[{ eventName: gcEndEvent, completedGCRuns: 0 }],
-				"completedGCRuns should be 0 since this event was logged before first GC run completed",
-			);
-
-			await garbageCollector.collectGarbage({});
-			mockLogger.assertMatch(
-				[{ eventName: gcEndEvent, completedGCRuns: 1 }],
-				"completedGCRuns should be 1 since this event was logged after first GC run completed",
-			);
-
-			await garbageCollector.collectGarbage({});
-			mockLogger.assertMatch(
-				[{ eventName: gcEndEvent, completedGCRuns: 2 }],
-				"completedGCRuns should be 2 since this event was logged after second GC run completed",
-			);
-
-			// The GC run count should reset for new garbage collector.
-			const garbageCollector2 = createGarbageCollector();
-			await garbageCollector2.collectGarbage({});
-			mockLogger.assertMatch(
-				[{ eventName: gcEndEvent, completedGCRuns: 0 }],
-				"completedGCRuns should be 0 since this event was logged before first GC run in new garbage collector",
-			);
-		});
-	});
-
-	/*
-	 * These tests validate scenarios where nodes that are referenced between summaries have their unreferenced
-	 * timestamp updated. These scenarios fall into the following categories:
-	 * 1. Nodes transition from unreferenced -> referenced -> unreferenced between 2 summaries - In these scenarios
-	 *    when GC runs, it should detect that the node was referenced and update its unreferenced timestamp.
-	 * 2. Unreferenced nodes are referenced from other unreferenced nodes - In this case, even though the node remains
-	 *    unreferenced, its unreferenced timestamp should be updated.
-	 *
-	 * In these tests, V = nodes and E = edges between nodes. Root nodes that are always referenced are marked as *.
-	 */
-	describe("References between summaries", () => {
-		let garbageCollector: IGarbageCollector;
-		const nodeA = "/A";
-		const nodeB = "/B";
-		const nodeC = "/C";
-		const nodeD = "/D";
-		const nodeE = "/A/E";
-
-		// Runs GC and returns the unreferenced timestamps of all nodes in the GC summary.
-		async function getUnreferencedTimestamps() {
-			// Advance the clock by 1 tick so that the unreferenced timestamp is updated in between runs.
-			clock.tick(1);
-
-			await garbageCollector.collectGarbage({});
-
-			const summaryTree = garbageCollector.summarize(true, false)?.summary;
-			assert(summaryTree !== undefined, "Nothing to summarize after running GC");
-			assert(summaryTree.type === SummaryType.Tree, "Expecting a summary tree!");
-
-			let rootGCState: IGarbageCollectionState = { gcNodes: {} };
-			for (const key of Object.keys(summaryTree.tree)) {
-				// Skip blobs that do not start with the GC prefix.
-				if (!key.startsWith(gcBlobPrefix)) {
-					continue;
-				}
-
-				const gcBlob = summaryTree.tree[key];
-				assert(gcBlob?.type === SummaryType.Blob, `GC blob not available`);
-				const gcState = JSON.parse(gcBlob.content as string) as IGarbageCollectionState;
-				// Merge the GC state of this blob into the root GC state.
-				rootGCState = concatGarbageCollectionStates(rootGCState, gcState);
-			}
-			const nodeTimestamps: Map<string, number | undefined> = new Map();
-			for (const [nodeId, nodeData] of Object.entries(rootGCState.gcNodes)) {
-				nodeTimestamps.set(nodeId, nodeData.unreferencedTimestampMs);
-			}
-			return nodeTimestamps;
-		}
-
-		beforeEach(() => {
-			defaultGCData.gcNodes = {};
-			garbageCollector = createGarbageCollector();
-		});
-
-		describe("Nodes transitioning from unreferenced -> referenced -> unreferenced", () => {
-			/**
-			 * Validates that we can detect references that were added and then removed.
-			 * 1. Summary 1 at t1. V = [A*, B]. E = []. B has unreferenced time t1.
-			 * 2. Reference from A to B added. E = [A -\> B].
-			 * 3. Reference from A to B removed. E = [].
-			 * 4. Summary 2 at t2. V = [A*, B]. E = []. B has unreferenced time t2.
-			 * Validates that the unreferenced time for B is t2 which is \> t1.
-			 */
-			it(`Scenario 1 - Reference added and then removed`, async () => {
-				// Initialize nodes A and B.
-				defaultGCData.gcNodes["/"] = [nodeA];
-				defaultGCData.gcNodes[nodeA] = [];
-				defaultGCData.gcNodes[nodeB] = [];
-
-				// 1. Run GC and generate summary 1. E = [].
-				const timestamps1 = await getUnreferencedTimestamps();
-				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeBTime1 = timestamps1.get(nodeB);
-				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-
-				// 2. Add reference from A to B. E = [A -\> B].
-				garbageCollector.addedOutboundReference(nodeA, nodeB);
-				defaultGCData.gcNodes[nodeA] = [nodeB];
-
-				// 3. Remove reference from A to B. E = [].
-				defaultGCData.gcNodes[nodeA] = [];
-
-				// 4. Run GC and generate summary 2. E = [].
-				const timestamps2 = await getUnreferencedTimestamps();
-				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeBTime2 = timestamps2.get(nodeB);
-
-				assert(
-					nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1,
-					"B's timestamp should have updated",
-				);
-			});
-
-			/**
-			 * Validates that we can detect references that were added transitively and then removed.
-			 * 1. Summary 1 at t1. V = [A*, B, C]. E = [B -\> C]. B and C have unreferenced time t2.
-			 * 2. Reference from A to B added. E = [A -\> B, B -\> C].
-			 * 3. Reference from B to C removed. E = [A -\> B].
-			 * 4. Reference from A to B removed. E = [].
-			 * 5. Summary 2 at t2. V = [A*, B, C]. E = []. B and C have unreferenced time t2.
-			 * Validates that the unreferenced time for B and C is t2 which is \> t1.
-			 */
-			it(`Scenario 2 - Reference transitively added and removed`, async () => {
-				// Initialize nodes A, B and C.
-				defaultGCData.gcNodes["/"] = [nodeA];
-				defaultGCData.gcNodes[nodeA] = [];
-				defaultGCData.gcNodes[nodeB] = [nodeC];
-				defaultGCData.gcNodes[nodeC] = [];
-
-				// 1. Run GC and generate summary 1. E = [B -\> C].
-				const timestamps1 = await getUnreferencedTimestamps();
-				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeBTime1 = timestamps1.get(nodeB);
-				const nodeCTime1 = timestamps1.get(nodeC);
-				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-
-				// 2. Add reference from A to B. E = [A -\> B, B -\> C].
-				garbageCollector.addedOutboundReference(nodeA, nodeB);
-				defaultGCData.gcNodes[nodeA] = [nodeB];
-
-				// 3. Remove reference from B to C. E = [A -\> B].
-				defaultGCData.gcNodes[nodeB] = [];
-
-				// 4. Remove reference from A to B. E = [].
-				defaultGCData.gcNodes[nodeA] = [];
-
-				// 5. Run GC and generate summary 2. E = [].
-				const timestamps2 = await getUnreferencedTimestamps();
-				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeBTime2 = timestamps2.get(nodeB);
-				const nodeCTime2 = timestamps2.get(nodeC);
-				assert(
-					nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1,
-					"B's timestamp should have updated",
-				);
-				assert(
-					nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1,
-					"C's timestamp should have updated",
-				);
-			});
-
-			/**
-			 * Validates that we can detect chain of references in which the first reference was added and then removed.
-			 * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [B -\> C, C -\> D]. B, C and D have unreferenced time t2.
-			 * 2. Reference from A to B added. E = [A -\> B, B -\> C, C -\> D].
-			 * 3. Reference from A to B removed. E = [B -\> C, C -\> D].
-			 * 4. Summary 2 at t2. V = [A*, B, C, D]. E = [B -\> C, C -\> D]. B, C and D have unreferenced time t2.
-			 * Validates that the unreferenced time for B, C and D is t2 which is \> t1.
-			 */
-			it(`Scenario 3 - Reference added through chain of references and removed`, async () => {
-				// Initialize nodes A, B, C and D.
-				defaultGCData.gcNodes["/"] = [nodeA];
-				defaultGCData.gcNodes[nodeA] = [];
-				defaultGCData.gcNodes[nodeB] = [nodeC];
-				defaultGCData.gcNodes[nodeC] = [nodeD];
-				defaultGCData.gcNodes[nodeD] = [];
-
-				// 1. Run GC and generate summary 1. E = [B -\> C, C -\> D].
-				const timestamps1 = await getUnreferencedTimestamps();
-				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeBTime1 = timestamps1.get(nodeB);
-				const nodeCTime1 = timestamps1.get(nodeC);
-				const nodeDTime1 = timestamps1.get(nodeD);
-				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-				assert(nodeDTime1 !== undefined, "D should have unreferenced timestamp");
-
-				// 2. Add reference from A to B. E = [A -\> B, B -\> C, C -\> D].
-				garbageCollector.addedOutboundReference(nodeA, nodeB);
-				defaultGCData.gcNodes[nodeA] = [nodeB];
-
-				// 3. Remove reference from A to B. E = [B -\> C, C -\> D].
-				defaultGCData.gcNodes[nodeA] = [];
-
-				// 4. Run GC and generate summary 2. E = [B -\> C, C -\> D].
-				const timestamps2 = await getUnreferencedTimestamps();
-				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeBTime2 = timestamps2.get(nodeB);
-				const nodeCTime2 = timestamps2.get(nodeC);
-				const nodeDTime2 = timestamps2.get(nodeD);
-				assert(
-					nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1,
-					"B's timestamp should have updated",
-				);
-				assert(
-					nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1,
-					"C's timestamp should have updated",
-				);
-				assert(
-					nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1,
-					"D's timestamp should have updated",
-				);
-			});
-
-			/**
-			 * Validates that we can detect references that were added and removed via new nodes.
-			 * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
-			 * 2. Node B is created. E = [].
-			 * 3. Reference from A to B added. E = [A -\> B].
-			 * 4. Reference from B to C added. E = [A -\> B, B -\> C].
-			 * 5. Reference from B to C removed. E = [A -\> B].
-			 * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -\> B]. C has unreferenced time t2.
-			 * Validates that the unreferenced time for C is t2 which is \> t1.
-			 */
-			it(`Scenario 4 - Reference added via new nodes and removed`, async () => {
-				// Initialize nodes A, B and C.
-				defaultGCData.gcNodes["/"] = [nodeA];
-				defaultGCData.gcNodes[nodeA] = [];
-				defaultGCData.gcNodes[nodeC] = [];
-
-				// 1. Run GC and generate summary 1. E = [].
-				const timestamps1 = await getUnreferencedTimestamps();
-				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeCTime1 = timestamps1.get(nodeC);
-				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-
-				// 2. Create node B, i.e., add B to GC data. E = [].
-				defaultGCData.gcNodes[nodeB] = [];
-
-				// 3. Add reference from A to B. E = [A -\> B].
-				garbageCollector.addedOutboundReference(nodeA, nodeB);
-				defaultGCData.gcNodes[nodeA] = [nodeB];
-
-				// 4. Add reference from B to C. E = [A -\> B, B -\> C].
-				garbageCollector.addedOutboundReference(nodeB, nodeC);
-				defaultGCData.gcNodes[nodeB] = [nodeC];
-
-				// 5. Remove reference from B to C. E = [A -\> B].
-				defaultGCData.gcNodes[nodeB] = [];
-
-				// 6. Run GC and generate summary 2. E = [A -\> B].
-				const timestamps2 = await getUnreferencedTimestamps();
-				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-				assert(timestamps2.get(nodeB) === undefined, "B should be referenced");
-
-				const nodeCTime2 = timestamps2.get(nodeC);
-				assert(
-					nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1,
-					"C's timestamp should have updated",
-				);
-			});
-
-			/**
-			 * Validates that we can detect multiple references that were added and then removed by the same node.
-			 * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
-			 * 2. Reference from A to B added. E = [A -\> B].
-			 * 3. Reference from A to C added. E = [A -\> B, A -\> C].
-			 * 4. Reference from A to B removed. E = [A -\> C].
-			 * 5. Reference from A to C removed. E = [].
-			 * 6. Summary 2 at t2. V = [A*, B]. E = []. B and C have unreferenced time t2.
-			 * Validates that the unreferenced time for B and C is t2 which is \> t1.
-			 */
-			it(`Scenario 5 - Multiple references added and then removed by same node`, async () => {
-				// Initialize nodes A, B and C.
-				defaultGCData.gcNodes["/"] = [nodeA];
-				defaultGCData.gcNodes[nodeA] = [];
-				defaultGCData.gcNodes[nodeB] = [];
-				defaultGCData.gcNodes[nodeC] = [];
-
-				// 1. Run GC and generate summary 1. E = [].
-				const timestamps1 = await getUnreferencedTimestamps();
-				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeBTime1 = timestamps1.get(nodeB);
-				const nodeCTime1 = timestamps1.get(nodeC);
-				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-
-				// 2. Add reference from A to B. E = [A -\> B].
-				garbageCollector.addedOutboundReference(nodeA, nodeB);
-				defaultGCData.gcNodes[nodeA] = [nodeB];
-
-				// 3. Add reference from A to C. E = [A -\> B, A -\> C].
-				garbageCollector.addedOutboundReference(nodeA, nodeC);
-				defaultGCData.gcNodes[nodeA] = [nodeB, nodeC];
-
-				// 4. Remove reference from A to B. E = [A -\> C].
-				defaultGCData.gcNodes[nodeA] = [nodeC];
-
-				// 5. Remove reference from A to C. E = [].
-				defaultGCData.gcNodes[nodeA] = [];
-
-				// 6. Run GC and generate summary 2. E = [].
-				const timestamps2 = await getUnreferencedTimestamps();
-				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeBTime2 = timestamps2.get(nodeB);
-				const nodeCTime2 = timestamps2.get(nodeC);
-				assert(
-					nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1,
-					"C's timestamp should have updated",
-				);
-				assert(
-					nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1,
-					"B's timestamp should have updated",
-				);
-			});
-
-			/**
-			 * Validates that we generate error on detecting reference during GC that was not notified explicitly.
-			 * 1. Summary 1 at t1. V = [A*]. E = [].
-			 * 2. Node B is created. E = [].
-			 * 3. Reference from A to B added without notifying GC. E = [A -\> B].
-			 * 4. Summary 2 at t2. V = [A*, B]. E = [A -\> B].
-			 * Validates that we log an error since B is detected as a referenced node but its reference was notified
-			 * to GC.
-			 */
-			it(`Scenario 6 - Reference added without notifying GC`, async () => {
-				// Initialize nodes A & D.
-				defaultGCData.gcNodes["/"] = [nodeA, nodeD];
-				defaultGCData.gcNodes[nodeA] = [];
-				defaultGCData.gcNodes[nodeD] = [];
-
-				// 1. Run GC and generate summary 1. E = [].
-				const timestamps1 = await getUnreferencedTimestamps();
-				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-				assert(timestamps1.get(nodeD) === undefined, "D should be referenced");
-
-				// 2. Create nodes B & C. E = [].
-				defaultGCData.gcNodes[nodeB] = [];
-				defaultGCData.gcNodes[nodeC] = [];
-
-				// 3. Add reference from A to B, A to C, A to E, D to C, and E to A without calling addedOutboundReference.
-				// E = [A -\> B, A -\> C, A -\> E, D -\> C, E -\> A].
-				defaultGCData.gcNodes[nodeA] = [nodeB, nodeC, nodeE];
-				defaultGCData.gcNodes[nodeD] = [nodeC];
-				defaultGCData.gcNodes[nodeE] = [nodeA];
-
-				// 4. Add reference from A to D with calling addedOutboundReference
-				defaultGCData.gcNodes[nodeA].push(nodeD);
-				garbageCollector.addedOutboundReference(nodeA, nodeD);
-
-				// 5. Run GC and generate summary 2. E = [A -\> B, A -\> C, A -\> E, D -\> C, E -\> A].
-				await getUnreferencedTimestamps();
-
-				// Validate that we got the "gcUnknownOutboundReferences" error.
-				const unknownReferencesEvent = "GarbageCollector:gcUnknownOutboundReferences";
-				const eventsFound = mockLogger.matchEvents([
-					{
-						eventName: unknownReferencesEvent,
-						gcNodeId: "/A",
-						gcRoutes: JSON.stringify(["/B", "/C"]),
-					},
-					{
-						eventName: unknownReferencesEvent,
-						gcNodeId: "/D",
-						gcRoutes: JSON.stringify(["/C"]),
-					},
-				]);
-				assert(eventsFound, `Expected unknownReferenceEvent event!`);
-			});
-		});
-
-		describe("References to unreferenced nodes", () => {
-			/**
-			 * Validates that we can detect references that are added from an unreferenced node to another.
-			 * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
-			 * 2. Reference from B to C. E = [B -\> C].
-			 * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -\> C]. B and C have unreferenced time t1.
-			 * Validates that the unreferenced time for B and C is still t1.
-			 */
-			it(`Scenario 1 - Reference added to unreferenced node`, async () => {
-				// Initialize nodes A, B and C.
-				defaultGCData.gcNodes["/"] = [nodeA];
-				defaultGCData.gcNodes[nodeA] = [];
-				defaultGCData.gcNodes[nodeB] = [];
-				defaultGCData.gcNodes[nodeC] = [];
-
-				// 1. Run GC and generate summary 1. E = [B -\> C].
-				const timestamps1 = await getUnreferencedTimestamps();
-				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeBTime1 = timestamps1.get(nodeB);
-				const nodeCTime1 = timestamps1.get(nodeC);
-				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-
-				// 2. Add reference from B to C. E = [B -\> C].
-				garbageCollector.addedOutboundReference(nodeB, nodeC);
-				defaultGCData.gcNodes[nodeB] = [nodeC];
-
-				// 3. Run GC and generate summary 2. E = [B -\> C].
-				const timestamps2 = await getUnreferencedTimestamps();
-				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeBTime2 = timestamps2.get(nodeB);
-				const nodeCTime2 = timestamps2.get(nodeC);
-				assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
-				assert(
-					nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1,
-					"C's timestamp should have updated",
-				);
-			});
-
-			/*
-			 * Validates that we can detect references that are added from an unreferenced node to a list of
-			 * unreferenced nodes, i.e., nodes with references to each other but are overall unreferenced.
-			 * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [C -\> D]. B, C and D have unreferenced time t1.
-			 * 2. Op adds reference from B to C. E = [B -\> C, C -\> D].
-			 * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -\> C, C -\> D]. C and D have unreferenced time t2.
-			 * Validates that the unreferenced time for C and D is t2 which is > t1.
-			 */
-			it(`Scenario 2 - Reference added to a list of unreferenced nodes from an unreferenced node`, async () => {
-				// Initialize nodes A, B and C.
-				defaultGCData.gcNodes["/"] = [nodeA];
-				defaultGCData.gcNodes[nodeA] = [];
-				defaultGCData.gcNodes[nodeB] = [];
-				defaultGCData.gcNodes[nodeC] = [nodeD];
-				defaultGCData.gcNodes[nodeD] = [];
-
-				// 1. Run GC and generate summary 1. E = [B -\> C].
-				const timestamps1 = await getUnreferencedTimestamps();
-				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeBTime1 = timestamps1.get(nodeB);
-				const nodeCTime1 = timestamps1.get(nodeC);
-				const nodeDTime1 = timestamps1.get(nodeC);
-				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-				assert(nodeDTime1 !== undefined, "C should have unreferenced timestamp");
-
-				// 2. Add reference from B to C. E = [B -\> C, C-\> D].
-				garbageCollector.addedOutboundReference(nodeB, nodeC);
-				defaultGCData.gcNodes[nodeB] = [nodeC];
-
-				// 3. Run GC and generate summary 2. E = [B -\> C. C -\> D].
-				const timestamps2 = await getUnreferencedTimestamps();
-				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeBTime2 = timestamps2.get(nodeB);
-				const nodeCTime2 = timestamps2.get(nodeC);
-				const nodeDTime2 = timestamps2.get(nodeD);
-				assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
-				assert(
-					nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1,
-					"C's timestamp should have updated",
-				);
-				assert(
-					nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1,
-					"D's timestamp should have updated",
-				);
-			});
-
-			/*
-			 * Validates that we can detect references that are added from an unreferenced node to a list of
-			 * unreferenced nodes, i.e., nodes with references to each other but are overall unreferenced. Then
-			 * a reference between the list is removed
-			 * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [C -> D]. B, C and D have unreferenced time t1.
-			 * 2. Op adds reference from B to C. E = [B -> C, C -> D].
-			 * 3. Op removes reference from C to D. E = [B -> C].
-			 * 4. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. C and D have unreferenced time t2.
-			 * Validates that the unreferenced time for C and D is t2 which is > t1.
-			 */
-			it(`Scenario 3 - Reference added to a list of unreferenced nodes and a reference is removed`, async () => {
-				// Initialize nodes A, B and C.
-				defaultGCData.gcNodes["/"] = [nodeA];
-				defaultGCData.gcNodes[nodeA] = [];
-				defaultGCData.gcNodes[nodeB] = [];
-				defaultGCData.gcNodes[nodeC] = [nodeD];
-				defaultGCData.gcNodes[nodeD] = [];
-
-				// 1. Run GC and generate summary 1. E = [B -\> C].
-				const timestamps1 = await getUnreferencedTimestamps();
-				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeBTime1 = timestamps1.get(nodeB);
-				const nodeCTime1 = timestamps1.get(nodeC);
-				const nodeDTime1 = timestamps1.get(nodeC);
-				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-				assert(nodeDTime1 !== undefined, "C should have unreferenced timestamp");
-
-				// 2. Add reference from B to C. E = [B -\> C, C-\> D].
-				garbageCollector.addedOutboundReference(nodeB, nodeC);
-				defaultGCData.gcNodes[nodeB] = [nodeC];
-
-				// 3. Remove reference from C to D. E = [B -\> C].
-				defaultGCData.gcNodes[nodeC] = [];
-
-				// 3. Run GC and generate summary 2. E = [B -\> C].
-				const timestamps2 = await getUnreferencedTimestamps();
-				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-				const nodeBTime2 = timestamps2.get(nodeB);
-				const nodeCTime2 = timestamps2.get(nodeC);
-				const nodeDTime2 = timestamps2.get(nodeD);
-				assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
-				assert(
-					nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1,
-					"C's timestamp should have updated",
-				);
-				assert(
-					nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1,
-					"D's timestamp should have updated",
-				);
-			});
-		});
-	});
-
-	describe("No changes to GC between summaries", () => {
-		const fullTree = false;
-		const trackState = true;
-		let garbageCollector: IGarbageCollector;
-
-		beforeEach(() => {
-			injectedSettings["Fluid.GarbageCollection.TrackGCState"] = true;
-			// Initialize nodes A & D.
-			defaultGCData.gcNodes = {};
-			defaultGCData.gcNodes["/"] = nodes;
-		});
-
-		const checkGCSummaryType = (
-			summary: ISummarizeResult | undefined,
-			expectedBlobType: SummaryType,
-			summaryNumber: string,
-		) => {
-			assert(summary !== undefined, `Expected a summary on ${summaryNumber} summarize`);
-			assert(
-				summary.summary.type === expectedBlobType,
-				`Expected summary type ${expectedBlobType} on ${summaryNumber} summarize, got ${summary.summary.type}`,
-			);
-		};
-
-		it("creates a blob handle when no version specified", async () => {
-			garbageCollector = createGarbageCollector();
-
-			await garbageCollector.collectGarbage({});
-			const tree1 = garbageCollector.summarize(fullTree, trackState);
-
-			checkGCSummaryType(tree1, SummaryType.Tree, "first");
-
-			await garbageCollector.refreshLatestSummary(
-				{ wasSummaryTracked: true, latestSummaryUpdated: true },
-				undefined,
-				0,
-				parseNothing,
-			);
-
-			await garbageCollector.collectGarbage({});
-			const tree2 = garbageCollector.summarize(fullTree, trackState);
-
-			checkGCSummaryType(tree2, SummaryType.Handle, "second");
-		});
-	});
+    const defaultSnapshotCacheExpiryMs = 5 * 24 * 60 * 60 * 1000;
+
+    // Nodes in the reference graph.
+    const nodes: string[] = [
+        "/node1",
+        "/node2",
+        "/node3",
+        "/node4",
+    ];
+
+    const mockLogger: MockLogger = new MockLogger();
+    const testPkgPath = ["testPkg"];
+    // The package data is tagged in the telemetry event.
+    const eventPkg = { value: testPkgPath.join("/"), tag: TelemetryDataTag.CodeArtifact };
+
+    const oldRawConfig = sessionStorageConfigProvider.value.getRawConfig;
+    let injectedSettings: Record<string, ConfigTypes> = {};
+    let clock: SinonFakeTimers;
+
+    // The default GC data returned by `getGCData` on which GC is run. Update this to update the referenced graph.
+    let defaultGCData: IGarbageCollectionData = { gcNodes: {} };
+
+    // Returns a dummy snapshot tree to be built upon.
+    const getDummySnapshotTree = (): ISnapshotTree => {
+        return {
+            blobs: {},
+            trees: {},
+        };
+    };
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const parseNothing: ReadAndParseBlob = async <T>() => { const x: T = {} as T; return x; };
+
+    function createGarbageCollector(
+        createParams: Partial<IGarbageCollectorCreateParams> = {},
+        gcBlobsMap: Map<string, IGarbageCollectionState | IGarbageCollectionDetailsBase | string[]> = new Map(),
+        closeFn: (error?: ICriticalContainerError) => void = () => {},
+        isSummarizerClient: boolean = true,
+    ) {
+        const getNodeType = (nodePath: string) => {
+            if (nodePath.split("/").length !== 2) {
+                return GCNodeType.Other;
+            }
+            return GCNodeType.DataStore;
+        };
+
+        // The runtime to be passed to the garbage collector.
+        const gcRuntime: IGarbageCollectionRuntime = {
+            updateStateBeforeGC: async () => {},
+            getGCData: async (fullGC?: boolean) => defaultGCData,
+            updateUsedRoutes: (usedRoutes: string[]) => { return { totalNodeCount: 0, unusedNodeCount: 0 }; },
+            updateUnusedRoutes: (unusedRoutes: string[]) => {},
+            updateTombstonedRoutes: (tombstoneRoutes: string[]) => {},
+            getNodeType,
+            getCurrentReferenceTimestampMs: () => Date.now(),
+            closeFn,
+        };
+
+        return GarbageCollector.create({
+            ...createParams,
+            runtime: gcRuntime,
+            gcOptions: createParams.gcOptions ?? {},
+            baseSnapshot: createParams.baseSnapshot,
+            baseLogger: mockLogger,
+            existing: createParams.metadata !== undefined /* existing */,
+            metadata: createParams.metadata,
+            createContainerMetadata: {
+                createContainerRuntimeVersion: pkgVersion,
+                createContainerTimestamp: Date.now(),
+            },
+            isSummarizerClient,
+            readAndParseBlob: async <T>(id: string) => gcBlobsMap.get(id) as T,
+            getNodePackagePath: async (nodeId: string) => testPkgPath,
+            getLastSummaryTimestampMs: () => Date.now(),
+            activeConnection: () => true,
+            getContainerDiagnosticId: () => "someDocId",
+        });
+    }
+    let gc: GcWithPrivates | undefined;
+
+    before(() => {
+        clock = useFakeTimers();
+        sessionStorageConfigProvider.value.getRawConfig = (name) => injectedSettings[name];
+    });
+
+    beforeEach(() => {
+        gc = undefined;
+    });
+
+    afterEach(() => {
+        clock.reset();
+        mockLogger.clear();
+        injectedSettings = {};
+        defaultGCData = { gcNodes: {} };
+        gc?.dispose();
+    });
+
+    after(() => {
+        clock.restore();
+        sessionStorageConfigProvider.value.getRawConfig = oldRawConfig;
+    });
+
+    describe("Configuration", () => {
+        const testOverrideSweepTimeoutKey = "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs";
+        const testOverrideSessionExpiryMsKey = "Fluid.GarbageCollection.TestOverride.SessionExpiryMs";
+        const createGcWithPrivateMembers = (gcMetadata?: IGCMetadata, gcOptions?: IGCRuntimeOptions): GcWithPrivates => {
+            const metadata: IContainerRuntimeMetadata | undefined = gcMetadata && { summaryFormatVersion: 1, message: undefined, ...gcMetadata };
+            return createGarbageCollector({ metadata, gcOptions }) as GcWithPrivates;
+        };
+        const customSessionExpiryDurationMs = defaultSessionExpiryDurationMs + 1;
+
+        beforeEach(() => {
+            injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = 1; // To ensure it's less than sweep timeout
+        });
+
+        describe("Existing container", () => {
+            it("No metadata", () => {
+                gc = createGcWithPrivateMembers({});
+                assert(!gc.gcEnabled, "gcEnabled incorrect");
+                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+                assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
+                assert(gc.sweepTimeoutMs === undefined, "sweepTimeoutMs incorrect");
+                assert.equal(gc.latestSummaryGCVersion, 0, "latestSummaryGCVersion incorrect");
+            });
+            it("gcFeature 0", () => {
+                gc = createGcWithPrivateMembers({ gcFeature: 0 });
+                assert(!gc.gcEnabled, "gcEnabled incorrect");
+                assert.equal(gc.latestSummaryGCVersion, 0, "latestSummaryGCVersion incorrect");
+            });
+            it("gcFeature 0, sweepEnabled true", () => {
+                gc = createGcWithPrivateMembers({ gcFeature: 0, sweepEnabled: true });
+                assert(!gc.gcEnabled, "gcEnabled incorrect");
+                assert(gc.sweepEnabled, "sweepEnabled incorrect");
+                assert.equal(gc.latestSummaryGCVersion, 0, "latestSummaryGCVersion incorrect");
+            });
+            it("gcFeature 1", () => {
+                gc = createGcWithPrivateMembers({ gcFeature: 1 });
+                assert(gc.gcEnabled, "gcEnabled incorrect");
+                assert.equal(gc.latestSummaryGCVersion, 1, "latestSummaryGCVersion incorrect");
+            });
+            it("gcContainerGeneration mismatch, sweepEnabled true", () => {
+                gc = createGcWithPrivateMembers({ gcContainerGeneration: 0, sweepEnabled: true }, { gcContainerGeneration: 1 });
+                assert(gc.gcEnabled, "gcEnabled incorrect");
+                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+            });
+            it("gcContainerGeneration matches", () => {
+                gc = createGcWithPrivateMembers({ gcContainerGeneration: 2, sweepEnabled: true }, { gcContainerGeneration: 2 });
+                assert(gc.sweepEnabled, "sweepEnabled incorrect");
+            });
+            it("sweepEnabled false", () => {
+                gc = createGcWithPrivateMembers({ sweepEnabled: false });
+                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+            });
+            it("sessionExpiryTimeoutMs set (sweepTimeoutMs unset)", () => {
+                gc = createGcWithPrivateMembers({ sessionExpiryTimeoutMs: customSessionExpiryDurationMs });
+                assert.equal(gc.sessionExpiryTimeoutMs, customSessionExpiryDurationMs, "sessionExpiryTimeoutMs incorrect");
+                assert.equal(gc.sweepTimeoutMs, customSessionExpiryDurationMs + 6 * oneDayMs, "sweepTimeoutMs incorrect");
+            });
+            it("sweepTimeoutMs set", () => {
+                gc = createGcWithPrivateMembers({ sweepTimeoutMs: 123 });
+                assert.equal(gc.sweepTimeoutMs, 123, "sweepTimeoutMs incorrect");
+            });
+            it("Metadata Roundtrip", () => {
+                const inputMetadata: IGCMetadata = {
+                    sweepEnabled: true,
+                    gcFeature: 1,
+                    gcContainerGeneration: 2,
+                    sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
+                    sweepTimeoutMs: 123,
+                };
+                gc = createGcWithPrivateMembers(inputMetadata, { gcContainerGeneration: 2 });
+                const outputMetadata = gc.getMetadata();
+                const expectedOutputMetadata: IGCMetadata = { ...inputMetadata, gcFeature: stableGCVersion };
+                assert.deepEqual(outputMetadata, expectedOutputMetadata, "getMetadata returned different metadata than loaded from");
+            });
+            it("Metadata Roundtrip with GC version upgrade to v2 enabled", () => {
+                injectedSettings[gcVersionUpgradeToV2Key] = true;
+                const inputMetadata: IGCMetadata = {
+                    sweepEnabled: true,
+                    gcFeature: 1,
+                    gcContainerGeneration: 2,
+                    sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
+                    sweepTimeoutMs: 123,
+                };
+                gc = createGcWithPrivateMembers(inputMetadata, { gcContainerGeneration: 2 });
+                const outputMetadata = gc.getMetadata();
+                const expectedOutputMetadata: IGCMetadata = { ...inputMetadata, gcFeature: currentGCVersion };
+                assert.deepEqual(outputMetadata, expectedOutputMetadata, "getMetadata returned different metadata than loaded from");
+            });
+        });
+
+        describe("New Container", () => {
+            it("No options", () => {
+                injectedSettings[runSessionExpiryKey] = true;
+                gc = createGcWithPrivateMembers(undefined /* metadata */, {});
+                assert(gc.gcEnabled, "gcEnabled incorrect");
+                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+                assert(gc.sessionExpiryTimeoutMs !== undefined, "sessionExpiryTimeoutMs incorrect");
+                assert(gc.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
+                assert.equal(gc.latestSummaryGCVersion, stableGCVersion, "latestSummaryGCVersion incorrect");
+            });
+            it("gcAllowed true", () => {
+                gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: true });
+                assert(gc.gcEnabled, "gcEnabled incorrect");
+            });
+            it("gcAllowed false", () => {
+                gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: false });
+                assert(!gc.gcEnabled, "gcEnabled incorrect");
+            });
+            it("sweepAllowed true, gcAllowed false", () => {
+                assert.throws(
+                    () => { gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: false, sweepAllowed: true }); },
+                    (e) => e.errorType === "usageError",
+                    "Should be unsupported");
+            });
+            it("sweepAllowed true, gcAllowed true", () => {
+                injectedSettings[runSessionExpiryKey] = true;
+                gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: true, sweepAllowed: true });
+                assert(gc.gcEnabled, "gcEnabled incorrect");
+                assert(gc.sweepEnabled, "sweepEnabled incorrect");
+                assert(gc.shouldRunSweep, "shouldRunSweep incorrect");
+                assert(gc.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
+                assert(gc.sessionExpiryTimeoutMs !== undefined, "sessionExpiryTimeoutMs incorrect");
+            });
+            it("sweepAllowed true, gcAllowed true, sessionExpiry off", () => {
+                injectedSettings[runSessionExpiryKey] = false;
+                gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: true, sweepAllowed: true });
+                assert(gc.gcEnabled, "gcEnabled incorrect");
+                assert(gc.sweepEnabled, "sweepEnabled incorrect");
+                assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
+                assert(gc.sweepTimeoutMs === undefined, "sweepTimeoutMs incorrect");
+            });
+            it("sweepAllowed false, sessionExpiry on", () => {
+                injectedSettings[runSessionExpiryKey] = true;
+                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
+                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+                assert(gc.sessionExpiryTimeoutMs !== undefined, "sessionExpiryTimeoutMs incorrect");
+                assert(gc.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
+            });
+            it("sweepAllowed false, sessionExpiry off", () => {
+                injectedSettings[runSessionExpiryKey] = false;
+                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
+                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+                assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
+                assert(gc.sweepTimeoutMs === undefined, "sweepTimeoutMs incorrect");
+            });
+            it("TestOverride.SweepTimeout set, sweepAllowed false, sessionExpiry on", () => {
+                injectedSettings[testOverrideSweepTimeoutKey] = 123;
+                injectedSettings[runSessionExpiryKey] = true;
+                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
+                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+                assert(gc.sessionExpiryTimeoutMs === defaultSessionExpiryDurationMs, "sessionExpiryTimeoutMs incorrect");
+                assert(gc.sweepTimeoutMs === 123, "sweepTimeoutMs incorrect");
+            });
+            it("TestOverride.SweepTimeout set, sweepAllowed false, sessionExpiry off", () => {
+                injectedSettings[testOverrideSweepTimeoutKey] = 123;
+                injectedSettings[runSessionExpiryKey] = false;
+                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
+                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+                assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
+                assert(gc.sweepTimeoutMs === 123, "sweepTimeoutMs incorrect");
+            });
+            it("Metadata Roundtrip", () => {
+                injectedSettings[runSessionExpiryKey] = true;
+                const expectedMetadata: IGCMetadata = {
+                    sweepEnabled: true,
+                    gcFeature: 1,
+                    gcContainerGeneration: 2,
+                    sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
+                    sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
+                };
+                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: true, gcContainerGeneration: 2 });
+                const outputMetadata = gc.getMetadata();
+                assert.deepEqual(outputMetadata, expectedMetadata, "getMetadata returned different metadata than expected");
+            });
+            it("Metadata Roundtrip with GC version upgrade to v2 enabled", () => {
+                injectedSettings[runSessionExpiryKey] = true;
+                injectedSettings[gcVersionUpgradeToV2Key] = true;
+                const expectedMetadata: IGCMetadata = {
+                    sweepEnabled: true,
+                    gcFeature: currentGCVersion,
+                    gcContainerGeneration: 2,
+                    sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
+                    sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
+                };
+                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: true, gcContainerGeneration: 2 });
+                const outputMetadata = gc.getMetadata();
+                assert.deepEqual(outputMetadata, expectedMetadata, "getMetadata returned different metadata than expected");
+            });
+        });
+
+        describe("Session Expiry and Sweep Timeout", () => {
+            beforeEach(() => {
+                injectedSettings[runSessionExpiryKey] = true;
+                injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = 1; // To ensure it's less than sweep timeout
+            });
+
+            // Config sources for Session Expiry:
+            // 1. defaultSessionExpiryDurationMs in code
+            // 2. IGCRuntimeOptions.sessionExpiryTimeoutMs
+            // 3. IGCMetadata.sessionExpiryTimeoutMs
+            // 4. "Fluid.GarbageCollection.TestOverride.SessionExpiryMs" setting
+            // 5. boolean setting: runSessionExpiryKey
+            // Config sources for Sweep Timeout:
+            // 1. IGCMetadata.sweepTimeoutMs
+            // 2. Computed from Session Expiry, fixed upper bound for Snapshot Expiry and a fixed buffer (on create, or to backfill existing)
+            // 3. "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs" setting (only applicable on create)
+
+            it("defaultSessionExpiryDurationMs", () => {
+                gc = createGcWithPrivateMembers();
+                assert.equal(gc.sessionExpiryTimeoutMs, defaultSessionExpiryDurationMs, "sessionExpiryTimeoutMs incorrect");
+                assert.equal(gc.sessionExpiryTimer.defaultTimeout, defaultSessionExpiryDurationMs, "sessionExpiryTimer incorrect");
+                assert.equal(gc.sweepTimeoutMs, defaultSessionExpiryDurationMs + 6 * oneDayMs, "sweepTimeoutMs incorrect");
+            });
+            it("defaultSessionExpiryDurationMs, TestOverride.SweepTimeout set", () => {
+                injectedSettings[testOverrideSweepTimeoutKey] = 7890;
+                gc = createGcWithPrivateMembers();
+                assert.equal(gc.sessionExpiryTimeoutMs, defaultSessionExpiryDurationMs, "sessionExpiryTimeoutMs incorrect");
+                assert.equal(gc.sessionExpiryTimer.defaultTimeout, defaultSessionExpiryDurationMs, "sessionExpiryTimer incorrect");
+                assert.equal(gc.sweepTimeoutMs, 7890, "sweepTimeoutMs incorrect");
+            });
+            it("IGCRuntimeOptions.sessionExpiryTimeoutMs", () => {
+                gc = createGcWithPrivateMembers(undefined /* metadata */, { sessionExpiryTimeoutMs: 123 });
+                assert.equal(gc.sessionExpiryTimeoutMs, 123, "sessionExpiryTimeoutMs incorrect");
+                assert.equal(gc.sessionExpiryTimer.defaultTimeout, 123, "sessionExpiryTimer incorrect");
+                assert.equal(gc.sweepTimeoutMs, 123 + 6 * oneDayMs, "sweepTimeoutMs incorrect");
+            });
+            it("IGCMetadata.sessionExpiryTimeoutMs, backfill sweepTimeoutMs", () => {
+                injectedSettings[testOverrideSweepTimeoutKey] = 1337; // Should be ignored
+                gc = createGcWithPrivateMembers({ sessionExpiryTimeoutMs: 456 } /* metadata */);
+                assert.equal(gc.sessionExpiryTimeoutMs, 456, "sessionExpiryTimeoutMs incorrect");
+                assert.equal(gc.sessionExpiryTimer.defaultTimeout, 456, "sessionExpiryTimer incorrect");
+                assert.equal(gc.sweepTimeoutMs, 456 + 6 * oneDayMs, "sweepTimeoutMs incorrect");
+            });
+            it("IGCMetadata.sessionExpiryTimeoutMs and IGCMetadata.sweepTimeoutMs", () => {
+                injectedSettings[testOverrideSweepTimeoutKey] = 1337; // Should be ignored
+                gc = createGcWithPrivateMembers({ sessionExpiryTimeoutMs: 456, sweepTimeoutMs: 789 } /* metadata */);
+                assert.equal(gc.sessionExpiryTimeoutMs, 456, "sessionExpiryTimeoutMs incorrect");
+                assert.equal(gc.sessionExpiryTimer.defaultTimeout, 456, "sessionExpiryTimer incorrect");
+                assert.equal(gc.sweepTimeoutMs, 789, "sweepTimeoutMs incorrect");
+            });
+            it("IGCMetadata.sweepTimeoutMs only", () => {
+                injectedSettings[testOverrideSweepTimeoutKey] = 1337; // Should be ignored
+                // This could happen if you used TestOverride.SweepTimeoutMs but had SessionExpiry disabled, then loaded that container.
+                gc = createGcWithPrivateMembers({ sweepTimeoutMs: 789 } /* metadata */);
+                assert.equal(gc.sessionExpiryTimeoutMs, undefined, "sessionExpiryTimeoutMs incorrect");
+                assert.equal(gc.sessionExpiryTimer, undefined, "sessionExpiryTimer incorrect");
+                assert.equal(gc.sweepTimeoutMs, 789, "sweepTimeoutMs incorrect");
+            });
+            function testSessionExpiryMsOverride() {
+                const expectedSweepTimeoutMs = defaultSessionExpiryDurationMs + 6 * oneDayMs;
+                assert(!!gc, "PRECONDITION: gc must be set before calling this helper");
+                assert.equal(gc.sessionExpiryTimeoutMs, defaultSessionExpiryDurationMs, "sessionExpiryTimeoutMs incorrect");
+                assert.equal(gc.sessionExpiryTimer.defaultTimeout, 789, "sessionExpiry used for timer should be the override value");
+                assert.equal(gc.sweepTimeoutMs, expectedSweepTimeoutMs, "sweepTimeoutMs incorrect");
+
+                const expectedMetadata: IGCMetadata = {
+                    sweepEnabled: false,
+                    gcFeature: 1,
+                    sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
+                    sweepTimeoutMs: expectedSweepTimeoutMs,
+                };
+                const outputMetadata = gc.getMetadata();
+                assert.deepEqual(outputMetadata, expectedMetadata, "getMetadata returned different metadata than expected");
+            }
+            it("TestOverride.SessionExpiryMs setting applied to timeout but not written to file - New Container", () => {
+                injectedSettings[testOverrideSessionExpiryMsKey] = 789;
+                gc = createGcWithPrivateMembers();
+                testSessionExpiryMsOverride();
+            });
+            it("TestOverride.SessionExpiryMs setting applied to timeout but not written to file - Existing Container", () => {
+                injectedSettings[testOverrideSessionExpiryMsKey] = 789;
+                gc = createGcWithPrivateMembers({ sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs, gcFeature: 1 } /* metadata */);
+                testSessionExpiryMsOverride();
+            });
+            it("RunSessionExpiry setting turned off", () => {
+                injectedSettings[runSessionExpiryKey] = false;
+                injectedSettings[testOverrideSessionExpiryMsKey] = 1234; // This override should be ignored
+                gc = createGcWithPrivateMembers();
+                assert.equal(gc.sessionExpiryTimeoutMs, undefined, "sessionExpiryTimeoutMs should be undefined if runSessionExpiryKey setting is false");
+                assert.equal(gc.sessionExpiryTimer, undefined, "sessionExpiryTimer should be undefined if it's disabled");
+                assert.equal(gc.sweepTimeoutMs, undefined, "sweepTimeoutMs incorrect");
+            });
+            it("RunSessionExpiry setting turned off, TestOverride.SweepTimeout set", () => {
+                injectedSettings[runSessionExpiryKey] = false;
+                injectedSettings[testOverrideSweepTimeoutKey] = 7890;
+                injectedSettings[testOverrideSessionExpiryMsKey] = 1234; // This override should be ignored
+                gc = createGcWithPrivateMembers();
+                assert.equal(gc.sessionExpiryTimeoutMs, undefined, "sessionExpiryTimeoutMs should be undefined if runSessionExpiryKey setting is false");
+                assert.equal(gc.sessionExpiryTimer, undefined, "sessionExpiryTimer should be undefined if it's disabled");
+                assert.equal(gc.sweepTimeoutMs, 7890, "sweepTimeoutMs incorrect");
+            });
+        });
+
+        describe("Session Behavior (e.g. 'shouldRun' fields)", () => {
+            beforeEach(() => {
+                injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = 1; // To ensure it's less than sweep timeout
+            });
+
+            describe("shouldRunGC", () => {
+                const testCases: { gcEnabled: boolean; disableGC?: boolean; runGC?: boolean; expectedResult: boolean; }[] = [
+                    { gcEnabled: false, disableGC: true, runGC: true, expectedResult: true },
+                    { gcEnabled: true, disableGC: false, runGC: false, expectedResult: false },
+                    { gcEnabled: true, disableGC: true, expectedResult: false },
+                    { gcEnabled: true, disableGC: false, expectedResult: true },
+                    { gcEnabled: true, expectedResult: true },
+                    { gcEnabled: false, expectedResult: false },
+                ];
+                testCases.forEach((testCase) => {
+                    it(`Test Case ${JSON.stringify(testCase)}`, () => {
+                        injectedSettings[runGCKey] = testCase.runGC;
+                        gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: testCase.gcEnabled, disableGC: testCase.disableGC });
+                        assert.equal(gc.gcEnabled, testCase.gcEnabled, "PRECONDITION: gcEnabled set incorrectly");
+                        assert.equal(gc.shouldRunGC, testCase.expectedResult, "shouldRunGC not set as expected");
+                    });
+                });
+            });
+            describe("shouldRunSweep", () => {
+                const testCases: { shouldRunGC: boolean; setSweepTimeout: boolean; sweepEnabled: boolean; runSweep?: boolean; expectedResult: boolean; }[] = [
+                    { shouldRunGC: false, setSweepTimeout: true, sweepEnabled: true, runSweep: true, expectedResult: false },
+                    { shouldRunGC: true, setSweepTimeout: false, sweepEnabled: true, runSweep: true, expectedResult: false },
+                    { shouldRunGC: true, setSweepTimeout: true, sweepEnabled: true, runSweep: false, expectedResult: false },
+                    { shouldRunGC: true, setSweepTimeout: true, sweepEnabled: false, runSweep: true, expectedResult: true },
+                    { shouldRunGC: true, setSweepTimeout: true, sweepEnabled: true, expectedResult: true },
+                    { shouldRunGC: true, setSweepTimeout: true, sweepEnabled: false, expectedResult: false },
+                ];
+                testCases.forEach((testCase) => {
+                    it(`Test Case ${JSON.stringify(testCase)}`, () => {
+                        injectedSettings[runGCKey] = testCase.shouldRunGC;
+                        injectedSettings[runSweepKey] = testCase.runSweep;
+                        injectedSettings[runSessionExpiryKey] = testCase.setSweepTimeout; // Sweep timeout is set iff sessionExpiry runs (under other default inputs)
+                        gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: testCase.sweepEnabled });
+                        assert.equal(gc.shouldRunGC, testCase.shouldRunGC, "PRECONDITION: shouldRunGC set incorrectly");
+                        assert.equal(gc.sweepTimeoutMs !== undefined, testCase.setSweepTimeout, "PRECONDITION: sweep timeout set incorrectly");
+                        assert.equal(gc.sweepEnabled, testCase.sweepEnabled, "PRECONDITION: sweepEnabled set incorrectly");
+                        assert.equal(gc.shouldRunSweep, testCase.expectedResult, "shouldRunSweep not set as expected");
+                    });
+                });
+            });
+            describe("inactiveTimeoutMs", () => {
+                beforeEach(() => {
+                    // Remove setting added in outer describe block
+                    injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = undefined;
+                });
+                const testCases: { testOverride?: number; option?: number; expectedResult: number; }[] = [
+                    { testOverride: 123, option: 456, expectedResult: 123 },
+                    { option: 456, expectedResult: 456 },
+                    { expectedResult: defaultInactiveTimeoutMs },
+                ];
+                testCases.forEach((testCase) => {
+                    it(`Test Case ${JSON.stringify(testCase)}`, () => {
+                        injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = testCase.testOverride;
+                        gc = createGcWithPrivateMembers(undefined /* metadata */, { inactiveTimeoutMs: testCase.option });
+                        assert.equal(gc.inactiveTimeoutMs, testCase.expectedResult, "inactiveTimeoutMs not set as expected");
+                    });
+                });
+                it("inactiveTimeout must not be greater than sweepTimeout", () => {
+                    injectedSettings[runSessionExpiryKey] = true;
+                    injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = Number.MAX_VALUE;
+                    assert.throws(
+                        () => { gc = createGcWithPrivateMembers(); },
+                        (e) => e.errorType === "usageError",
+                        "inactiveTimeout must not be greater than sweepTimeout");
+                });
+            });
+            describe("testMode", () => {
+                const testCases: { setting?: boolean; option?: boolean; expectedResult: boolean; }[] = [
+                    { setting: true, option: false, expectedResult: true },
+                    { setting: false, option: true, expectedResult: false },
+                    { option: true, expectedResult: true },
+                    { expectedResult: false },
+                ];
+                testCases.forEach((testCase) => {
+                    it(`Test Case ${JSON.stringify(testCase)}`, () => {
+                        injectedSettings[gcTestModeKey] = testCase.setting;
+                        gc = createGcWithPrivateMembers(undefined /* metadata */, { runGCInTestMode: testCase.option });
+                        assert.equal(gc.testMode, testCase.expectedResult, "testMode not set as expected");
+                    });
+                });
+            });
+        });
+    });
+
+    it("Session expiry closes container", () => {
+        injectedSettings[runSessionExpiryKey] = "true";
+
+        let closeCalled = false;
+        function closeCalledAfterExactTicks(ticks: number) {
+            clock.tick(ticks - 1);
+            if (closeCalled) {
+                return false;
+            }
+            clock.tick(1);
+            return closeCalled;
+        }
+
+        gc = createGarbageCollector({ }, undefined /* gcBlobsMap */, () => { closeCalled = true; }) as GcWithPrivates;
+        assert(closeCalledAfterExactTicks(defaultSessionExpiryDurationMs), "Close should have been called at exactly defaultSessionExpiryDurationMs");
+    });
+
+    describe("errors when unreferenced objects are used after they are inactive / deleted", () => {
+        // Mock node loaded and changed activity for all the nodes in the graph.
+         async function updateAllNodesAndRunGC(garbageCollector: IGarbageCollector) {
+            nodes.forEach((nodeId) => {
+                garbageCollector.nodeUpdated(nodeId, "Changed", Date.now(), testPkgPath);
+                garbageCollector.nodeUpdated(nodeId, "Loaded", Date.now(), testPkgPath);
+            });
+            await garbageCollector.collectGarbage({});
+        }
+
+        beforeEach(async () => {
+            // Set up the reference graph such that all nodes are referenced. Add in a couple of cycles in the graph.
+            // Here's a diagram showing the references:
+            // 0 - 1 - 2 - 3
+            // |  /       /
+            // |-/-------/
+            defaultGCData.gcNodes["/"] = [nodes[0]];
+            defaultGCData.gcNodes[nodes[0]] = [nodes[1]];
+            defaultGCData.gcNodes[nodes[1]] = [nodes[0], nodes[2]];
+            defaultGCData.gcNodes[nodes[2]] = [nodes[3]];
+            defaultGCData.gcNodes[nodes[3]] = [nodes[0]];
+        });
+
+        const summarizerContainerTests = (
+            timeout: number,
+            revivedEventName: string,
+            changedEventName: string,
+            loadedEventName: string,
+            expectDeleteLogs?: boolean,
+        ) => {
+            const deleteEventName = "GarbageCollector:GCObjectDeleted";
+            // Validates that no unexpected event has been fired.
+            function validateNoUnexpectedEvents() {
+                mockLogger.assertMatchNone([
+                        { eventName: revivedEventName },
+                        { eventName: changedEventName },
+                        { eventName: loadedEventName },
+                        { eventName: deleteEventName },
+                    ],
+                    "unexpected events logged",
+                );
+            }
+
+            const createGCOverride = (
+                baseSnapshot?: ISnapshotTree,
+                gcBlobsMap?: Map<string, IGarbageCollectionState | IGarbageCollectionDetailsBase>,
+            ) => {
+                return createGarbageCollector({ baseSnapshot }, gcBlobsMap);
+            };
+
+            it("doesn't generate events for referenced nodes", async () => {
+                const garbageCollector = createGCOverride();
+
+                // Run garbage collection on the default GC data where everything is referenced.
+                await garbageCollector.collectGarbage({});
+
+                // Advance the clock just before the timeout and validate no events are generated.
+                clock.tick(timeout - 1);
+                await updateAllNodesAndRunGC(garbageCollector);
+                validateNoUnexpectedEvents();
+
+                // Advance the clock to expire the timeout.
+                clock.tick(1);
+
+                // Update all nodes again. Validate that no unexpected events are generated since everything is referenced.
+                await updateAllNodesAndRunGC(garbageCollector);
+                validateNoUnexpectedEvents();
+            });
+
+            it("generates events for nodes that are used after time out", async () => {
+                const garbageCollector = createGCOverride();
+
+                // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
+                defaultGCData.gcNodes[nodes[1]] = [];
+
+                await garbageCollector.collectGarbage({});
+
+                // Advance the clock just before the timeout and validate no unexpected events are logged.
+                clock.tick(timeout - 1);
+                await updateAllNodesAndRunGC(garbageCollector);
+                validateNoUnexpectedEvents();
+
+                // Expire the timeout and validate that all events for node 2 and node 3 are logged.
+                clock.tick(1);
+                await updateAllNodesAndRunGC(garbageCollector);
+                const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [];
+
+                if (expectDeleteLogs) {
+                    expectedEvents.push(
+                        { eventName: deleteEventName, timeout, id: nodes[2] },
+                        { eventName: deleteEventName, timeout, id: nodes[3] },
+                    );
+                } else {
+                    assert(!mockLogger.events.some((event) => event.eventName === deleteEventName), "Should not have any delete events logged");
+                }
+                expectedEvents.push(
+                    { eventName: changedEventName, timeout, id: nodes[2], pkg: eventPkg, createContainerRuntimeVersion: pkgVersion },
+                    { eventName: loadedEventName, timeout, id: nodes[2], pkg: eventPkg, createContainerRuntimeVersion: pkgVersion },
+                    { eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg, createContainerRuntimeVersion: pkgVersion },
+                    { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg, createContainerRuntimeVersion: pkgVersion },
+                );
+                mockLogger.assertMatch(expectedEvents, "all events not generated as expected");
+
+                // Add reference from node 1 to node 3 and validate that we get a revived event.
+                garbageCollector.addedOutboundReference(nodes[1], nodes[3]);
+                await garbageCollector.collectGarbage({});
+                mockLogger.assertMatch(
+                    [{ eventName: revivedEventName, timeout, id: nodes[3], pkg: eventPkg, fromId: nodes[1] }],
+                    "revived event not generated as expected",
+                );
+            });
+
+            it("generates only revived event when an inactive node is changed and revived", async () => {
+                const garbageCollector = createGCOverride();
+
+                // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
+                defaultGCData.gcNodes[nodes[1]] = [];
+
+                await garbageCollector.collectGarbage({});
+
+                // Advance the clock just before the timeout and validate no unexpected events are logged.
+                clock.tick(timeout - 1);
+                await updateAllNodesAndRunGC(garbageCollector);
+                validateNoUnexpectedEvents();
+
+                // Expire the timeout and validate that only revived event is generated for node 2.
+                clock.tick(1);
+                garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
+                garbageCollector.nodeUpdated(nodes[2], "Loaded", Date.now(), testPkgPath);
+                garbageCollector.addedOutboundReference(nodes[1], nodes[2]);
+                await garbageCollector.collectGarbage({});
+
+                for (const event of mockLogger.events) {
+                    assert.notStrictEqual(event.eventName, changedEventName, "Unexpected changed event logged");
+                    assert.notStrictEqual(event.eventName, loadedEventName, "Unexpected loaded event logged");
+                }
+                mockLogger.assertMatch(
+                    [{ eventName: revivedEventName, timeout, id: nodes[2], pkg: eventPkg, fromId: nodes[1] }],
+                    "revived event not logged as expected",
+                );
+            });
+
+            it("generates events once per node", async () => {
+                const garbageCollector = createGCOverride();
+
+                // Remove node 3's reference from node 2.
+                defaultGCData.gcNodes[nodes[2]] = [];
+
+                await garbageCollector.collectGarbage({});
+
+                // Advance the clock just before the timeout and validate no unexpected events are logged.
+                clock.tick(timeout - 1);
+                await updateAllNodesAndRunGC(garbageCollector);
+                validateNoUnexpectedEvents();
+
+                // Expire the timeout and validate that all events for node 2 and node 3 are logged.
+                clock.tick(1);
+                await updateAllNodesAndRunGC(garbageCollector);
+                const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [];
+                if (expectDeleteLogs) {
+                    expectedEvents.push({ eventName: deleteEventName, timeout, id: nodes[3] });
+                } else {
+                    assert(!mockLogger.events.some((event) => event.eventName === deleteEventName), "Should not have any delete events logged");
+                }
+                expectedEvents.push(
+                    { eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                    { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                );
+                mockLogger.assertMatch(expectedEvents, "all events not generated as expected");
+
+                // Update all nodes again. There shouldn't be any more events since for each node the event is only once.
+                await updateAllNodesAndRunGC(garbageCollector);
+                validateNoUnexpectedEvents();
+            });
+
+            /**
+             * Here, the base snapshot contains nodes that have timed out. The test validates that we generate errors
+             * when these nodes are used.
+             */
+            it("generates events for nodes that time out on load", async () => {
+                // Create GC state where node 3's unreferenced time was > timeout ms ago.
+                // This means this node should time out as soon as its data is loaded.
+
+                // Create a snapshot tree to be used as the GC snapshot tree.
+                const gcSnapshotTree = getDummySnapshotTree();
+                const gcBlobId = "root";
+                // Add a GC blob with key that start with `gcBlobPrefix` to the GC snapshot tree. The blob Id for this
+                // is generated by server in real scenarios but we use a static id here for testing.
+                gcSnapshotTree.blobs[`${gcBlobPrefix}_${gcBlobId}`] = gcBlobId;
+
+                // Create a base snapshot that contains the GC snapshot tree.
+                const baseSnapshot = getDummySnapshotTree();
+                baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+
+                // Create GC state with node 3 expired. This will be returned when the garbage collector asks
+                // for the GC blob with `gcBlobId`.
+                const gcState: IGarbageCollectionState = { gcNodes: {} };
+                const node3Data: IGarbageCollectionNodeData = {
+                    outboundRoutes: [],
+                    unreferencedTimestampMs: Date.now() - (timeout + 100),
+                };
+                gcState.gcNodes[nodes[3]] = node3Data;
+
+                const gcBlobMap: Map<string, IGarbageCollectionState> = new Map([[gcBlobId, gcState]]);
+                const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
+
+                // Remove node 3's reference from node 2 so that it is still unreferenced.
+                defaultGCData.gcNodes[nodes[2]] = [];
+
+                // Run GC to trigger loading the GC details from the base summary. Will also generate Delete logs
+                await garbageCollector.collectGarbage({});
+                // Validate that the sweep ready event is logged when GC runs after load.
+                if (expectDeleteLogs) {
+                    mockLogger.assertMatch(
+                        [{ eventName: deleteEventName, timeout, id: nodes[3] }],
+                        "sweep ready event not generated as expected",
+                    );
+                } else {
+                    mockLogger.assertMatchNone([{ eventName: deleteEventName }], "Should not have any delete events logged");
+                }
+
+                // Validate that all events are logged as expected.
+                garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
+                garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
+                await garbageCollector.collectGarbage({});
+                mockLogger.assertMatch(
+                    [
+                        { eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                        { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                    ],
+                    "all events not generated as expected",
+                );
+
+                // Add reference from node 2 to node 3 and validate that revived event is logged.
+                garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
+                await garbageCollector.collectGarbage({});
+                mockLogger.assertMatch(
+                    [{ eventName: revivedEventName, timeout, id: nodes[3], pkg: eventPkg, fromId: nodes[2] }],
+                    "revived event not generated as expected",
+                );
+            });
+
+            /**
+             * Here, the base snapshot contains nodes that have timed out and the GC blob in snapshot is in old format. The
+             * test validates that we generate errors when these nodes are used.
+             */
+            it("generates events for nodes that time out on load - old snapshot format", async () => {
+                // Create GC details for node 3's GC blob whose unreferenced time was > timeout ms ago.
+                // This means this node should time out as soon as its data is loaded.
+                const node3GCDetails: IGarbageCollectionSummaryDetailsLegacy = {
+                    gcData: { gcNodes: { "/": [] } },
+                    unrefTimestamp: Date.now() - (timeout + 100),
+                };
+                const node3Snapshot = getDummySnapshotTree();
+                const gcBlobId = "node3GCDetails";
+                const attributesBlobId = "attributesBlob";
+                node3Snapshot.blobs[gcTreeKey] = gcBlobId;
+                node3Snapshot.blobs[dataStoreAttributesBlobName] = attributesBlobId;
+
+                // Create a base snapshot that contains snapshot tree of node 3.
+                const baseSnapshot = getDummySnapshotTree();
+                baseSnapshot.trees[nodes[3].slice(1)] = node3Snapshot;
+
+                // Set up the getNodeGCDetails function to return the GC details for node 3 when asked by garbage collector.
+                const gcBlobMap = new Map([
+                    [gcBlobId, node3GCDetails],
+                    [attributesBlobId, {}],
+                ]);
+                const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
+
+                // Remove node 3's reference from node 2 so that it is still unreferenced. The GC details from the base
+                // summary is not loaded until the first time GC is run, so do that immediately.
+                defaultGCData.gcNodes[nodes[2]] = [];
+                await garbageCollector.collectGarbage({});
+
+                // Validate that the sweep ready event is logged when GC runs after load.
+                if (expectDeleteLogs) {
+                    mockLogger.assertMatch(
+                        [{ eventName: deleteEventName, timeout, id: nodes[3] }],
+                        "sweep ready event not generated as expected",
+                    );
+                } else {
+                    mockLogger.assertMatchNone([{ eventName: deleteEventName }], "Should not have any delete events logged");
+                }
+
+                // Validate that all events are logged as expected.
+                garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
+                garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
+                await garbageCollector.collectGarbage({});
+                mockLogger.assertMatch(
+                    [
+                        { eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                        { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                    ],
+                    "all events not generated as expected",
+                );
+
+                // Add reference from node 2 to node 3 and validate that revived event is logged.
+                garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
+                await garbageCollector.collectGarbage({});
+                mockLogger.assertMatch(
+                    [{ eventName: revivedEventName, timeout, id: nodes[3], pkg: eventPkg, fromId: nodes[2] }],
+                    "revived event not generated as expected",
+                );
+            });
+
+            /**
+             * Here, the base snapshot contains nodes that have timed out and the GC data in snapshot is present in multiple
+             * blobs. The test validates that we generate errors when these nodes are used.
+             */
+            it(`generates events for nodes that time out on load - multi blob GC data`, async () => {
+                const gcBlobMap: Map<string, IGarbageCollectionState> = new Map();
+                const expiredTimestampMs = Date.now() - (timeout + 100);
+
+                // Create three GC states to be added into separate GC blobs. Each GC state has a node whose unreferenced
+                // time was > timeout ms ago. These three GC blobs are the added to the GC tree in summary.
+                const blob1Id = "blob1";
+                const blob1GCState: IGarbageCollectionState = { gcNodes: {} };
+                blob1GCState.gcNodes[nodes[1]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
+                gcBlobMap.set(blob1Id, blob1GCState);
+
+                const blob2Id = "blob2";
+                const blob2GCState: IGarbageCollectionState = { gcNodes: {} };
+                blob2GCState.gcNodes[nodes[2]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
+                gcBlobMap.set(blob2Id, blob2GCState);
+
+                const blob3Id = "blob3";
+                const blob3GCState: IGarbageCollectionState = { gcNodes: {} };
+                blob3GCState.gcNodes[nodes[3]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
+                gcBlobMap.set(blob3Id, blob3GCState);
+
+                // Create a GC snapshot tree and add the above three GC blob ids to it.
+                const gcSnapshotTree = getDummySnapshotTree();
+                gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob1Id}`] = blob1Id;
+                gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob2Id}`] = blob2Id;
+                gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob3Id}`] = blob3Id;
+
+                // Create a base snapshot that contains the above GC snapshot tree.
+                const baseSnapshot = getDummySnapshotTree();
+                baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+
+                const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
+
+                // For the nodes in the GC snapshot blobs, remove their references from the default GC data.
+                defaultGCData.gcNodes[nodes[0]] = [];
+                defaultGCData.gcNodes[nodes[1]] = [];
+                defaultGCData.gcNodes[nodes[2]] = [];
+
+                await garbageCollector.collectGarbage({});
+                 // Validate that the sweep ready event is logged when GC runs after load.
+                 if (expectDeleteLogs) {
+                    mockLogger.assertMatch(
+                        [
+                            { eventName: deleteEventName, timeout, id: nodes[1] },
+                            { eventName: deleteEventName, timeout, id: nodes[2] },
+                            { eventName: deleteEventName, timeout, id: nodes[3] },
+                        ],
+                        "sweep ready event not generated as expected",
+                    );
+                } else {
+                    mockLogger.assertMatchNone([{ eventName: deleteEventName }], "Should not have any delete events logged");
+                }
+
+                // Validate that all events are logged as expected.
+                garbageCollector.nodeUpdated(nodes[1], "Changed", Date.now(), testPkgPath);
+                garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
+                garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
+                await garbageCollector.collectGarbage({});
+                mockLogger.assertMatch(
+                    [
+                        { eventName: changedEventName, timeout, id: nodes[1], pkg: eventPkg },
+                        { eventName: changedEventName, timeout, id: nodes[2], pkg: eventPkg },
+                        { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
+                    ],
+                    "all events not generated as expected",
+                );
+            });
+        };
+
+        describe("Inactive events (summarizer container)", () => {
+            const inactiveTimeoutMs = 500;
+
+            beforeEach(() => {
+                injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = inactiveTimeoutMs;
+            });
+
+            summarizerContainerTests(
+                inactiveTimeoutMs,
+                "GarbageCollector:InactiveObject_Revived",
+                "GarbageCollector:InactiveObject_Changed",
+                "GarbageCollector:InactiveObject_Loaded",
+            );
+        });
+
+        describe("SweepReady events (summarizer container)", () => {
+            const sweepTimeoutMs = defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
+
+            beforeEach(() => {
+                injectedSettings[runSessionExpiryKey] = true;
+            });
+
+            summarizerContainerTests(
+                sweepTimeoutMs,
+                "GarbageCollector:SweepReadyObject_Revived",
+                "GarbageCollector:SweepReadyObject_Changed",
+                "GarbageCollector:SweepReadyObject_Loaded",
+                true, // expectDeleteLogs
+            );
+        });
+
+        describe("SweepReady events - Delete log disabled (summarizer container)", () => {
+            const sweepTimeoutMs = defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
+
+            beforeEach(() => {
+                injectedSettings[runSessionExpiryKey] = true;
+                injectedSettings[disableSweepLogKey] = true;
+            });
+
+            summarizerContainerTests(
+                sweepTimeoutMs,
+                "GarbageCollector:SweepReadyObject_Revived",
+                "GarbageCollector:SweepReadyObject_Changed",
+                "GarbageCollector:SweepReadyObject_Loaded",
+                false, // expectDeleteLogs
+            );
+        });
+
+        describe("Interactive Client Behavior", () => {
+            function updateAllNodes(garbageCollector) {
+                nodes.forEach((nodeId) => {
+                    garbageCollector.nodeUpdated(nodeId, "Changed", Date.now(), testPkgPath);
+                    garbageCollector.nodeUpdated(nodeId, "Loaded", Date.now(), testPkgPath);
+                });
+            }
+
+            async function interactiveClientTestCode(
+                timeout: number,
+                loadedEventName: string,
+                sweepReadyUsageErrorExpected: boolean,
+            ) {
+                let lastCloseErrorType: string = "N/A";
+
+                // Create GC state where node 3's unreferenced time was > timeout ms ago.
+                // This is important since we shouldn't run GC on the interactive container,
+                // but rather load from a snapshot in which SweepReady state is already reached.
+
+                // Create a snapshot tree to be used as the GC snapshot tree.
+                const gcSnapshotTree = getDummySnapshotTree();
+                const gcBlobId = "root";
+                // Add a GC blob with key that start with `gcBlobPrefix` to the GC snapshot tree. The blob Id for this
+                // is generated by server in real scenarios but we use a static id here for testing.
+                gcSnapshotTree.blobs[`${gcBlobPrefix}_${gcBlobId}`] = gcBlobId;
+
+                // Create a base snapshot that contains the GC snapshot tree.
+                const baseSnapshot = getDummySnapshotTree();
+                baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+
+                // Create GC state with node 3 expired. This will be returned when the garbage collector asks
+                // for the GC blob with `gcBlobId`.
+                const gcState: IGarbageCollectionState = { gcNodes: {} };
+                const unrefTime = Date.now() - (timeout + 100);
+                const node3Data: IGarbageCollectionNodeData = {
+                    outboundRoutes: [],
+                    unreferencedTimestampMs: unrefTime,
+                };
+                gcState.gcNodes[nodes[3]] = node3Data;
+
+                const gcBlobMap: Map<string, IGarbageCollectionState> = new Map([[gcBlobId, gcState]]);
+                const garbageCollector = createGarbageCollector(
+                    { baseSnapshot },
+                    gcBlobMap,
+                    (error) => { lastCloseErrorType = error?.errorType ?? "NONE"; },
+                    false /* isSummarizerClient */,
+                );
+
+                // Trigger loading GC state from base snapshot - but don't call GC since that's not what happens in real flow
+                await (garbageCollector as any).initializeGCStateFromBaseSnapshotP;
+
+                // Update nodes and validate that all events for node 3 are logged.
+                updateAllNodes(garbageCollector);
+                assert(!mockLogger.events.some((event) => event.eventName !== loadedEventName && event.unrefTime === unrefTime), "shouldn't see any unreference events besides Loaded");
+                mockLogger.assertMatch([{ eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg, unrefTime }], "all events not generated as expected");
+
+                const expectedErrorType = sweepReadyUsageErrorExpected ? "unreferencedObjectUsedAfterGarbageCollected" : "N/A";
+                assert.equal(lastCloseErrorType, expectedErrorType, "Incorrect lastCloseReason after using unreferenced nodes");
+            }
+
+            beforeEach(() => {
+                injectedSettings[runSessionExpiryKey] = true;
+            });
+
+            it("Inactive object used - generates events but does not close container (SweepReadyUsageDetection enabled)", async () => {
+                const inactiveTimeoutMs = 400;
+                injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = inactiveTimeoutMs;
+                injectedSettings[SweepReadyUsageDetectionKey] = "interactiveClient";
+
+                await interactiveClientTestCode(
+                    inactiveTimeoutMs,
+                    "GarbageCollector:InactiveObject_Loaded",
+                    false,
+                );
+            });
+
+            it("SweepReady object used - generates events and closes container (SweepReadyUsageDetection enabled)", async () => {
+                const sweepTimeoutMs = defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
+                injectedSettings[SweepReadyUsageDetectionKey] = "interactiveClient";
+
+                await interactiveClientTestCode(
+                    sweepTimeoutMs,
+                    "GarbageCollector:SweepReadyObject_Loaded",
+                    true,
+                );
+            });
+
+            it("SweepReady object used - generates events but does not close container (SweepReadyUsageDetection disabled)", async () => {
+                const sweepTimeoutMs = defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
+                injectedSettings[SweepReadyUsageDetectionKey] = "something else";
+
+                await interactiveClientTestCode(
+                    sweepTimeoutMs,
+                    "GarbageCollector:SweepReadyObject_Loaded",
+                    false,
+                );
+            });
+        });
+
+        it("generates both inactive and sweep ready events when nodes are used after time out", async () => {
+            const inactiveTimeoutMs = 500;
+            const sweepTimeoutMs = defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
+            injectedSettings[runSessionExpiryKey] = "true";
+            injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = inactiveTimeoutMs;
+
+            const garbageCollector = createGarbageCollector({});
+
+            // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
+            defaultGCData.gcNodes[nodes[1]] = [];
+            await garbageCollector.collectGarbage({});
+
+            // Advance the clock to trigger inactive timeout and validate that we get inactive events.
+            clock.tick(inactiveTimeoutMs + 1);
+            await updateAllNodesAndRunGC(garbageCollector);
+            mockLogger.assertMatch(
+                [
+                    { eventName: "GarbageCollector:InactiveObject_Changed", timeout: inactiveTimeoutMs, id: nodes[2] },
+                    { eventName: "GarbageCollector:InactiveObject_Loaded", timeout: inactiveTimeoutMs, id: nodes[2] },
+                    { eventName: "GarbageCollector:InactiveObject_Changed", timeout: inactiveTimeoutMs, id: nodes[3] },
+                    { eventName: "GarbageCollector:InactiveObject_Loaded", timeout: inactiveTimeoutMs, id: nodes[3] },
+                ],
+                "inactive events not generated as expected",
+            );
+
+            // Advance the clock to trigger sweep timeout and validate that we get sweep ready events.
+            clock.tick(sweepTimeoutMs - inactiveTimeoutMs);
+            await updateAllNodesAndRunGC(garbageCollector);
+            mockLogger.assertMatch(
+                [
+                    { eventName: "GarbageCollector:SweepReadyObject_Changed", timeout: sweepTimeoutMs, id: nodes[2] },
+                    { eventName: "GarbageCollector:SweepReadyObject_Loaded", timeout: sweepTimeoutMs, id: nodes[2] },
+                    { eventName: "GarbageCollector:SweepReadyObject_Changed", timeout: sweepTimeoutMs, id: nodes[3] },
+                    { eventName: "GarbageCollector:SweepReadyObject_Loaded", timeout: sweepTimeoutMs, id: nodes[3] },
+                ],
+                "sweep ready events not generated as expected",
+            );
+        });
+    });
+
+    describe("Deleted blobs in GC summary tree", () => {
+        beforeEach(() => {
+            injectedSettings["Fluid.GarbageCollection.TrackGCState"] = true;
+        });
+
+        it("correctly reads and write deleted blobs in summary", async () => {
+            // Set up the GC reference graph to have something to work with.
+            defaultGCData.gcNodes["/"] = [nodes[0]];
+
+            // Create a snapshot tree to be used as the GC snapshot tree.
+            const gcSnapshotTree = getDummySnapshotTree();
+            // Add a blob to the tree for deleted nodes.
+            const deletedNodesBlobId = "deletedNodes";
+            gcSnapshotTree.blobs[gcDeletedBlobKey] = deletedNodesBlobId;
+            const deletedNodeIds = [...nodes];
+            // Add deleted nodes list the blobs map that will service read and parse blob calls from GC.
+            const gcBlobsMap: Map<string, string[]> = new Map([[deletedNodesBlobId, deletedNodeIds]]);
+            // Create a base snapshot that contains the GC snapshot tree.
+            const baseSnapshot = getDummySnapshotTree();
+            baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+
+            // Create and initialize garbage collector.
+            const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobsMap);
+            await garbageCollector.initializeBaseState();
+
+            // The nodes in deletedNodeIds should be marked as deleted.
+            for (const nodeId of deletedNodeIds) {
+                assert(garbageCollector.isNodeDeleted(nodeId) === true, `${nodeId} should be marked deleted`);
+            }
+
+            await garbageCollector.collectGarbage({});
+            // Summarize with fullTree as true so that the deleted nodes are written as a blob and can be validated.
+            const summaryTree = garbageCollector.summarize(true /* fullTree */, true /* trackState */);
+            assert(summaryTree?.summary.type === SummaryType.Tree, "The summary should be a tree");
+
+            // Get the deleted node ids from summary and validate that its the same as the one GC loaded from.
+            const deletedNodesBlob = summaryTree.summary.tree[gcDeletedBlobKey];
+            assert(deletedNodesBlob.type === SummaryType.Blob, "Deleted blob not present in summary");
+            const deletedNodeIdsInSummary = JSON.parse(deletedNodesBlob.content as string) as string[];
+            assert.deepStrictEqual(deletedNodeIdsInSummary, deletedNodeIds, "Unexpected deleted nodes in summary");
+        });
+
+        it("writes handle for deleted blobs when its unchanged", async () => {
+            // Set up the GC reference graph to have something to work with.
+            defaultGCData.gcNodes["/"] = [nodes[0]];
+
+            // Create a snapshot tree to be used as the GC snapshot tree.
+            const gcSnapshotTree = getDummySnapshotTree();
+            // Add a blob to the tree for deleted nodes.
+            const deletedNodesBlobId = "deletedNodes";
+            gcSnapshotTree.blobs[gcDeletedBlobKey] = deletedNodesBlobId;
+            const deletedNodeIds = [...nodes];
+            // Add deleted nodes list the blobs map that will service read and parse blob calls from GC.
+            const gcBlobsMap: Map<string, string[]> = new Map([[deletedNodesBlobId, deletedNodeIds]]);
+            // Create a base snapshot that contains the GC snapshot tree.
+            const baseSnapshot = getDummySnapshotTree();
+            baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+
+            // Create and initialize garbage collector.
+            const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobsMap);
+            await garbageCollector.initializeBaseState();
+
+            // Run GC and summarize. The summary should contain the deleted nodes.
+            await garbageCollector.collectGarbage({});
+            const gcSummary = garbageCollector.summarize(false /* fullTree */, true /* trackState */);
+            assert(gcSummary?.summary.type === SummaryType.Tree, "The summary should be a tree");
+
+            // Get the deleted node ids from summary and validate that its the same as the one GC loaded from.
+            const deletedNodesBlob = gcSummary.summary.tree[gcDeletedBlobKey];
+            assert(deletedNodesBlob.type === SummaryType.Handle, "Deleted nodes state should be a handle");
+
+            const refreshSummaryResult: RefreshSummaryResult = { latestSummaryUpdated: true, wasSummaryTracked: true};
+            await garbageCollector.refreshLatestSummary(refreshSummaryResult, undefined, 0, parseNothing);
+
+            // Run GC and summarize again. The whole GC summary should now be a summary handle.
+            await garbageCollector.collectGarbage({});
+            const gcSummary2 = garbageCollector.summarize(false /* fullTree */, true /* trackState */);
+            assert(gcSummary2?.summary.type === SummaryType.Handle, "The summary should be a handle");
+        });
+    });
+
+    describe("GC completed runs", () => {
+        const gcEndEvent = "GarbageCollector:GarbageCollection_end";
+
+        it("increments GC completed runs in logged events correctly", async () => {
+            const garbageCollector = createGarbageCollector();
+
+            await garbageCollector.collectGarbage({});
+            mockLogger.assertMatch(
+                [{ eventName: gcEndEvent, completedGCRuns: 0 }],
+                "completedGCRuns should be 0 since this event was logged before first GC run completed",
+            );
+
+            await garbageCollector.collectGarbage({});
+            mockLogger.assertMatch(
+                [{ eventName: gcEndEvent, completedGCRuns: 1 }],
+                "completedGCRuns should be 1 since this event was logged after first GC run completed",
+            );
+
+            await garbageCollector.collectGarbage({});
+            mockLogger.assertMatch(
+                [{ eventName: gcEndEvent, completedGCRuns: 2 }],
+                "completedGCRuns should be 2 since this event was logged after second GC run completed",
+            );
+
+            // The GC run count should reset for new garbage collector.
+            const garbageCollector2 = createGarbageCollector();
+            await garbageCollector2.collectGarbage({});
+            mockLogger.assertMatch(
+                [{ eventName: gcEndEvent, completedGCRuns: 0 }],
+                "completedGCRuns should be 0 since this event was logged before first GC run in new garbage collector",
+            );
+        });
+    });
+
+    /*
+     * These tests validate scenarios where nodes that are referenced between summaries have their unreferenced
+     * timestamp updated. These scenarios fall into the following categories:
+     * 1. Nodes transition from unreferenced -> referenced -> unreferenced between 2 summaries - In these scenarios
+     *    when GC runs, it should detect that the node was referenced and update its unreferenced timestamp.
+     * 2. Unreferenced nodes are referenced from other unreferenced nodes - In this case, even though the node remains
+     *    unreferenced, its unreferenced timestamp should be updated.
+     *
+     * In these tests, V = nodes and E = edges between nodes. Root nodes that are always referenced are marked as *.
+     */
+    describe("References between summaries", () => {
+        let garbageCollector: IGarbageCollector;
+        const nodeA = "/A";
+        const nodeB = "/B";
+        const nodeC = "/C";
+        const nodeD = "/D";
+        const nodeE = "/A/E";
+
+        // Runs GC and returns the unreferenced timestamps of all nodes in the GC summary.
+        async function getUnreferencedTimestamps() {
+            // Advance the clock by 1 tick so that the unreferenced timestamp is updated in between runs.
+            clock.tick(1);
+
+            await garbageCollector.collectGarbage({});
+
+            const summaryTree = garbageCollector.summarize(true, false)?.summary;
+            assert(summaryTree !== undefined, "Nothing to summarize after running GC");
+            assert(summaryTree.type === SummaryType.Tree, "Expecting a summary tree!");
+
+            let rootGCState: IGarbageCollectionState = { gcNodes: {} };
+            for (const key of Object.keys(summaryTree.tree)) {
+                // Skip blobs that do not start with the GC prefix.
+                if (!key.startsWith(gcBlobPrefix)) {
+                    continue;
+                }
+
+                const gcBlob = summaryTree.tree[key];
+                assert(gcBlob?.type === SummaryType.Blob, `GC blob not available`);
+                const gcState = JSON.parse(gcBlob.content as string) as IGarbageCollectionState;
+                // Merge the GC state of this blob into the root GC state.
+                rootGCState = concatGarbageCollectionStates(rootGCState, gcState);
+            }
+            const nodeTimestamps: Map<string, number | undefined> = new Map();
+            for (const [nodeId, nodeData] of Object.entries(rootGCState.gcNodes)) {
+                nodeTimestamps.set(nodeId, nodeData.unreferencedTimestampMs);
+            }
+            return nodeTimestamps;
+        }
+
+        beforeEach(() => {
+            defaultGCData.gcNodes = {};
+            garbageCollector = createGarbageCollector();
+        });
+
+        describe("Nodes transitioning from unreferenced -> referenced -> unreferenced", () => {
+            /**
+             * Validates that we can detect references that were added and then removed.
+             * 1. Summary 1 at t1. V = [A*, B]. E = []. B has unreferenced time t1.
+             * 2. Reference from A to B added. E = [A -\> B].
+             * 3. Reference from A to B removed. E = [].
+             * 4. Summary 2 at t2. V = [A*, B]. E = []. B has unreferenced time t2.
+             * Validates that the unreferenced time for B is t2 which is \> t1.
+             */
+            it(`Scenario 1 - Reference added and then removed`, async () => {
+                // Initialize nodes A and B.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeB] = [];
+
+                // 1. Run GC and generate summary 1. E = [].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime1 = timestamps1.get(nodeB);
+                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+
+                // 2. Add reference from A to B. E = [A -\> B].
+                garbageCollector.addedOutboundReference(nodeA, nodeB);
+                defaultGCData.gcNodes[nodeA] = [nodeB];
+
+                // 3. Remove reference from A to B. E = [].
+                defaultGCData.gcNodes[nodeA] = [];
+
+                // 4. Run GC and generate summary 2. E = [].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime2 = timestamps2.get(nodeB);
+
+                assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
+            });
+
+            /**
+             * Validates that we can detect references that were added transitively and then removed.
+             * 1. Summary 1 at t1. V = [A*, B, C]. E = [B -\> C]. B and C have unreferenced time t2.
+             * 2. Reference from A to B added. E = [A -\> B, B -\> C].
+             * 3. Reference from B to C removed. E = [A -\> B].
+             * 4. Reference from A to B removed. E = [].
+             * 5. Summary 2 at t2. V = [A*, B, C]. E = []. B and C have unreferenced time t2.
+             * Validates that the unreferenced time for B and C is t2 which is \> t1.
+             */
+            it(`Scenario 2 - Reference transitively added and removed`, async () => {
+                // Initialize nodes A, B and C.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeB] = [nodeC];
+                defaultGCData.gcNodes[nodeC] = [];
+
+                // 1. Run GC and generate summary 1. E = [B -\> C].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime1 = timestamps1.get(nodeB);
+                const nodeCTime1 = timestamps1.get(nodeC);
+                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+
+                // 2. Add reference from A to B. E = [A -\> B, B -\> C].
+                garbageCollector.addedOutboundReference(nodeA, nodeB);
+                defaultGCData.gcNodes[nodeA] = [nodeB];
+
+                // 3. Remove reference from B to C. E = [A -\> B].
+                defaultGCData.gcNodes[nodeB] = [];
+
+                // 4. Remove reference from A to B. E = [].
+                defaultGCData.gcNodes[nodeA] = [];
+
+                // 5. Run GC and generate summary 2. E = [].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime2 = timestamps2.get(nodeB);
+                const nodeCTime2 = timestamps2.get(nodeC);
+                assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
+                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+            });
+
+            /**
+             * Validates that we can detect chain of references in which the first reference was added and then removed.
+             * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [B -\> C, C -\> D]. B, C and D have unreferenced time t2.
+             * 2. Reference from A to B added. E = [A -\> B, B -\> C, C -\> D].
+             * 3. Reference from A to B removed. E = [B -\> C, C -\> D].
+             * 4. Summary 2 at t2. V = [A*, B, C, D]. E = [B -\> C, C -\> D]. B, C and D have unreferenced time t2.
+             * Validates that the unreferenced time for B, C and D is t2 which is \> t1.
+             */
+            it(`Scenario 3 - Reference added through chain of references and removed`, async () => {
+                // Initialize nodes A, B, C and D.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeB] = [nodeC];
+                defaultGCData.gcNodes[nodeC] = [nodeD];
+                defaultGCData.gcNodes[nodeD] = [];
+
+                // 1. Run GC and generate summary 1. E = [B -\> C, C -\> D].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime1 = timestamps1.get(nodeB);
+                const nodeCTime1 = timestamps1.get(nodeC);
+                const nodeDTime1 = timestamps1.get(nodeD);
+                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+                assert(nodeDTime1 !== undefined, "D should have unreferenced timestamp");
+
+                // 2. Add reference from A to B. E = [A -\> B, B -\> C, C -\> D].
+                garbageCollector.addedOutboundReference(nodeA, nodeB);
+                defaultGCData.gcNodes[nodeA] = [nodeB];
+
+                // 3. Remove reference from A to B. E = [B -\> C, C -\> D].
+                defaultGCData.gcNodes[nodeA] = [];
+
+                // 4. Run GC and generate summary 2. E = [B -\> C, C -\> D].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime2 = timestamps2.get(nodeB);
+                const nodeCTime2 = timestamps2.get(nodeC);
+                const nodeDTime2 = timestamps2.get(nodeD);
+                assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
+                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+                assert(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
+            });
+
+            /**
+             * Validates that we can detect references that were added and removed via new nodes.
+             * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
+             * 2. Node B is created. E = [].
+             * 3. Reference from A to B added. E = [A -\> B].
+             * 4. Reference from B to C added. E = [A -\> B, B -\> C].
+             * 5. Reference from B to C removed. E = [A -\> B].
+             * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -\> B]. C has unreferenced time t2.
+             * Validates that the unreferenced time for C is t2 which is \> t1.
+             */
+            it(`Scenario 4 - Reference added via new nodes and removed`, async () => {
+                // Initialize nodes A, B and C.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeC] = [];
+
+                // 1. Run GC and generate summary 1. E = [].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeCTime1 = timestamps1.get(nodeC);
+                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+
+                // 2. Create node B, i.e., add B to GC data. E = [].
+                defaultGCData.gcNodes[nodeB] = [];
+
+                // 3. Add reference from A to B. E = [A -\> B].
+                garbageCollector.addedOutboundReference(nodeA, nodeB);
+                defaultGCData.gcNodes[nodeA] = [nodeB];
+
+                // 4. Add reference from B to C. E = [A -\> B, B -\> C].
+                garbageCollector.addedOutboundReference(nodeB, nodeC);
+                defaultGCData.gcNodes[nodeB] = [nodeC];
+
+                // 5. Remove reference from B to C. E = [A -\> B].
+                defaultGCData.gcNodes[nodeB] = [];
+
+                // 6. Run GC and generate summary 2. E = [A -\> B].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+                assert(timestamps2.get(nodeB) === undefined, "B should be referenced");
+
+                const nodeCTime2 = timestamps2.get(nodeC);
+                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+            });
+
+            /**
+             * Validates that we can detect multiple references that were added and then removed by the same node.
+             * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
+             * 2. Reference from A to B added. E = [A -\> B].
+             * 3. Reference from A to C added. E = [A -\> B, A -\> C].
+             * 4. Reference from A to B removed. E = [A -\> C].
+             * 5. Reference from A to C removed. E = [].
+             * 6. Summary 2 at t2. V = [A*, B]. E = []. B and C have unreferenced time t2.
+             * Validates that the unreferenced time for B and C is t2 which is \> t1.
+             */
+            it(`Scenario 5 - Multiple references added and then removed by same node`, async () => {
+                // Initialize nodes A, B and C.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeB] = [];
+                defaultGCData.gcNodes[nodeC] = [];
+
+                // 1. Run GC and generate summary 1. E = [].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime1 = timestamps1.get(nodeB);
+                const nodeCTime1 = timestamps1.get(nodeC);
+                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+
+                // 2. Add reference from A to B. E = [A -\> B].
+                garbageCollector.addedOutboundReference(nodeA, nodeB);
+                defaultGCData.gcNodes[nodeA] = [nodeB];
+
+                // 3. Add reference from A to C. E = [A -\> B, A -\> C].
+                garbageCollector.addedOutboundReference(nodeA, nodeC);
+                defaultGCData.gcNodes[nodeA] = [nodeB, nodeC];
+
+                // 4. Remove reference from A to B. E = [A -\> C].
+                defaultGCData.gcNodes[nodeA] = [nodeC];
+
+                // 5. Remove reference from A to C. E = [].
+                defaultGCData.gcNodes[nodeA] = [];
+
+                // 6. Run GC and generate summary 2. E = [].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime2 = timestamps2.get(nodeB);
+                const nodeCTime2 = timestamps2.get(nodeC);
+                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+                assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
+            });
+
+            /**
+             * Validates that we generate error on detecting reference during GC that was not notified explicitly.
+             * 1. Summary 1 at t1. V = [A*]. E = [].
+             * 2. Node B is created. E = [].
+             * 3. Reference from A to B added without notifying GC. E = [A -\> B].
+             * 4. Summary 2 at t2. V = [A*, B]. E = [A -\> B].
+             * Validates that we log an error since B is detected as a referenced node but its reference was notified
+             * to GC.
+             */
+            it(`Scenario 6 - Reference added without notifying GC`, async () => {
+                // Initialize nodes A & D.
+                defaultGCData.gcNodes["/"] = [nodeA, nodeD];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeD] = [];
+
+                // 1. Run GC and generate summary 1. E = [].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+                assert(timestamps1.get(nodeD) === undefined, "D should be referenced");
+
+                // 2. Create nodes B & C. E = [].
+                defaultGCData.gcNodes[nodeB] = [];
+                defaultGCData.gcNodes[nodeC] = [];
+
+                // 3. Add reference from A to B, A to C, A to E, D to C, and E to A without calling addedOutboundReference.
+                // E = [A -\> B, A -\> C, A -\> E, D -\> C, E -\> A].
+                defaultGCData.gcNodes[nodeA] = [nodeB, nodeC, nodeE];
+                defaultGCData.gcNodes[nodeD] = [nodeC];
+                defaultGCData.gcNodes[nodeE] = [nodeA];
+
+                // 4. Add reference from A to D with calling addedOutboundReference
+                defaultGCData.gcNodes[nodeA].push(nodeD);
+                garbageCollector.addedOutboundReference(nodeA, nodeD);
+
+                // 5. Run GC and generate summary 2. E = [A -\> B, A -\> C, A -\> E, D -\> C, E -\> A].
+                await getUnreferencedTimestamps();
+
+                // Validate that we got the "gcUnknownOutboundReferences" error.
+                const unknownReferencesEvent = "GarbageCollector:gcUnknownOutboundReferences";
+                const eventsFound = mockLogger.matchEvents([
+                    {
+                        eventName: unknownReferencesEvent,
+                        gcNodeId: "/A",
+                        gcRoutes: JSON.stringify(["/B", "/C"]),
+                    },
+                    {
+                        eventName: unknownReferencesEvent,
+                        gcNodeId: "/D",
+                        gcRoutes: JSON.stringify(["/C"]),
+                    },
+                ]);
+                assert(eventsFound, `Expected unknownReferenceEvent event!`);
+            });
+        });
+
+        describe("References to unreferenced nodes", () => {
+            /**
+             * Validates that we can detect references that are added from an unreferenced node to another.
+             * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
+             * 2. Reference from B to C. E = [B -\> C].
+             * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -\> C]. B and C have unreferenced time t1.
+             * Validates that the unreferenced time for B and C is still t1.
+             */
+             it(`Scenario 1 - Reference added to unreferenced node`, async () => {
+                // Initialize nodes A, B and C.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeB] = [];
+                defaultGCData.gcNodes[nodeC] = [];
+
+                // 1. Run GC and generate summary 1. E = [B -\> C].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime1 = timestamps1.get(nodeB);
+                const nodeCTime1 = timestamps1.get(nodeC);
+                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+
+                // 2. Add reference from B to C. E = [B -\> C].
+                garbageCollector.addedOutboundReference(nodeB, nodeC);
+                defaultGCData.gcNodes[nodeB] = [nodeC];
+
+                // 3. Run GC and generate summary 2. E = [B -\> C].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime2 = timestamps2.get(nodeB);
+                const nodeCTime2 = timestamps2.get(nodeC);
+                assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
+                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+            });
+
+            /*
+             * Validates that we can detect references that are added from an unreferenced node to a list of
+             * unreferenced nodes, i.e., nodes with references to each other but are overall unreferenced.
+             * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [C -\> D]. B, C and D have unreferenced time t1.
+             * 2. Op adds reference from B to C. E = [B -\> C, C -\> D].
+             * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -\> C, C -\> D]. C and D have unreferenced time t2.
+             * Validates that the unreferenced time for C and D is t2 which is > t1.
+             */
+            it(`Scenario 2 - Reference added to a list of unreferenced nodes from an unreferenced node`, async () => {
+                // Initialize nodes A, B and C.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeB] = [];
+                defaultGCData.gcNodes[nodeC] = [nodeD];
+                defaultGCData.gcNodes[nodeD] = [];
+
+                // 1. Run GC and generate summary 1. E = [B -\> C].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime1 = timestamps1.get(nodeB);
+                const nodeCTime1 = timestamps1.get(nodeC);
+                const nodeDTime1 = timestamps1.get(nodeC);
+                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+                assert(nodeDTime1 !== undefined, "C should have unreferenced timestamp");
+
+                // 2. Add reference from B to C. E = [B -\> C, C-\> D].
+                garbageCollector.addedOutboundReference(nodeB, nodeC);
+                defaultGCData.gcNodes[nodeB] = [nodeC];
+
+                // 3. Run GC and generate summary 2. E = [B -\> C. C -\> D].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime2 = timestamps2.get(nodeB);
+                const nodeCTime2 = timestamps2.get(nodeC);
+                const nodeDTime2 = timestamps2.get(nodeD);
+                assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
+                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+                assert(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
+            });
+
+            /*
+             * Validates that we can detect references that are added from an unreferenced node to a list of
+             * unreferenced nodes, i.e., nodes with references to each other but are overall unreferenced. Then
+             * a reference between the list is removed
+             * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [C -> D]. B, C and D have unreferenced time t1.
+             * 2. Op adds reference from B to C. E = [B -> C, C -> D].
+             * 3. Op removes reference from C to D. E = [B -> C].
+             * 4. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. C and D have unreferenced time t2.
+             * Validates that the unreferenced time for C and D is t2 which is > t1.
+             */
+            it(`Scenario 3 - Reference added to a list of unreferenced nodes and a reference is removed`, async () => {
+                // Initialize nodes A, B and C.
+                defaultGCData.gcNodes["/"] = [nodeA];
+                defaultGCData.gcNodes[nodeA] = [];
+                defaultGCData.gcNodes[nodeB] = [];
+                defaultGCData.gcNodes[nodeC] = [nodeD];
+                defaultGCData.gcNodes[nodeD] = [];
+
+                // 1. Run GC and generate summary 1. E = [B -\> C].
+                const timestamps1 = await getUnreferencedTimestamps();
+                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime1 = timestamps1.get(nodeB);
+                const nodeCTime1 = timestamps1.get(nodeC);
+                const nodeDTime1 = timestamps1.get(nodeC);
+                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+                assert(nodeDTime1 !== undefined, "C should have unreferenced timestamp");
+
+                // 2. Add reference from B to C. E = [B -\> C, C-\> D].
+                garbageCollector.addedOutboundReference(nodeB, nodeC);
+                defaultGCData.gcNodes[nodeB] = [nodeC];
+
+                // 3. Remove reference from C to D. E = [B -\> C].
+                defaultGCData.gcNodes[nodeC] = [];
+
+                // 3. Run GC and generate summary 2. E = [B -\> C].
+                const timestamps2 = await getUnreferencedTimestamps();
+                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+                const nodeBTime2 = timestamps2.get(nodeB);
+                const nodeCTime2 = timestamps2.get(nodeC);
+                const nodeDTime2 = timestamps2.get(nodeD);
+                assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
+                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
+                assert(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
+            });
+        });
+    });
+
+    describe("No changes to GC between summaries", () => {
+        const fullTree = false;
+        const trackState = true;
+        let garbageCollector: IGarbageCollector;
+
+        beforeEach(() => {
+            injectedSettings["Fluid.GarbageCollection.TrackGCState"] = true;
+            // Initialize nodes A & D.
+            defaultGCData.gcNodes = {};
+            defaultGCData.gcNodes["/"] = nodes;
+        });
+
+        const checkGCSummaryType = (
+            summary: ISummarizeResult | undefined,
+            expectedBlobType: SummaryType,
+            summaryNumber: string,
+        ) => {
+            assert(summary !== undefined, `Expected a summary on ${summaryNumber} summarize`);
+            assert(
+                summary.summary.type === expectedBlobType,
+                `Expected summary type ${expectedBlobType} on ${summaryNumber} summarize, got ${summary.summary.type}`,
+            );
+        };
+
+        it("creates a blob handle when no version specified", async () => {
+            garbageCollector = createGarbageCollector();
+
+            await garbageCollector.collectGarbage({});
+            const tree1 = garbageCollector.summarize(fullTree, trackState);
+
+            checkGCSummaryType(tree1, SummaryType.Tree, "first");
+
+            await garbageCollector.refreshLatestSummary(
+                { wasSummaryTracked: true, latestSummaryUpdated: true },
+                undefined,
+                0,
+                parseNothing,
+            );
+
+            await garbageCollector.collectGarbage({});
+            const tree2 = garbageCollector.summarize(fullTree, trackState);
+
+            checkGCSummaryType(tree2, SummaryType.Handle, "second");
+        });
+    });
 });

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -231,27 +231,43 @@ describe("Garbage Collection Tests", () => {
 				assert(gc.gcEnabled, "gcEnabled incorrect");
 				assert.equal(gc.latestSummaryGCVersion, 1, "latestSummaryGCVersion incorrect");
 			});
-			it("gcEnforcementMinCreateContainerRuntimeVersion later than persisted value, sweepEnabled false", () => {
-				gc = createGcWithPrivateMembers(
-					{ createContainerRuntimeVersion: "1.2.3", sweepEnabled: true },
-					{ gcEnforcementMinCreateContainerRuntimeVersion: "2.0.0" },
-				);
-				assert(gc.gcEnabled, "gcEnabled incorrect");
-				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-			});
-			it("gcEnforcementMinCreateContainerRuntimeVersion equal to persisted value, sweepEnabled true", () => {
-				gc = createGcWithPrivateMembers(
-					{ createContainerRuntimeVersion: "1.2.3", sweepEnabled: true },
-					{ gcEnforcementMinCreateContainerRuntimeVersion: "1.2.3" },
-				);
-				assert(gc.sweepEnabled, "sweepEnabled incorrect");
-			});
-			it("gcEnforcementMinCreateContainerRuntimeVersion earlier than persisted value, sweepEnabled true", () => {
-				gc = createGcWithPrivateMembers(
-					{ createContainerRuntimeVersion: "1.2.3", sweepEnabled: true },
-					{ gcEnforcementMinCreateContainerRuntimeVersion: "1.0.0" },
-				);
-				assert(gc.sweepEnabled, "sweepEnabled incorrect");
+			describe("gcEnforcementMinCreateContainerRuntimeVersion overriding sweepEnabled true for some existing containers", () => {
+				it("gcEnforcementMinCreateContainerRuntimeVersion later than persisted value: sweepEnabled false", () => {
+					gc = createGcWithPrivateMembers(
+						{ createContainerRuntimeVersion: "1.2.3", sweepEnabled: true },
+						{ gcEnforcementMinCreateContainerRuntimeVersion: "2.0.0" },
+					);
+					assert(gc.gcEnabled, "gcEnabled incorrect");
+					assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+				});
+				it("gcEnforcementMinCreateContainerRuntimeVersion equal to persisted value: sweepEnabled true", () => {
+					gc = createGcWithPrivateMembers(
+						{ createContainerRuntimeVersion: "1.2.3", sweepEnabled: true },
+						{ gcEnforcementMinCreateContainerRuntimeVersion: "1.2.3" },
+					);
+					assert(gc.sweepEnabled, "sweepEnabled incorrect");
+				});
+				it("gcEnforcementMinCreateContainerRuntimeVersion earlier than persisted value: sweepEnabled true", () => {
+					gc = createGcWithPrivateMembers(
+						{ createContainerRuntimeVersion: "1.2.3", sweepEnabled: true },
+						{ gcEnforcementMinCreateContainerRuntimeVersion: "1.0.0" },
+					);
+					assert(gc.sweepEnabled, "sweepEnabled incorrect");
+				});
+				it("gcEnforcementMinCreateContainerRuntimeVersion set, createContainerRuntimeVersion missing: sweepEnabled false", () => {
+					gc = createGcWithPrivateMembers(
+						{ createContainerRuntimeVersion: undefined, sweepEnabled: true },
+						{ gcEnforcementMinCreateContainerRuntimeVersion: "0.0.0" },
+					);
+					assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+				});
+				it("gcEnforcementMinCreateContainerRuntimeVersion missing: sweepEnabled true", () => {
+					gc = createGcWithPrivateMembers(
+						{ createContainerRuntimeVersion: "1.2.3", sweepEnabled: true },
+						{ },
+					);
+					assert(gc.sweepEnabled, "sweepEnabled incorrect");
+				});
 			});
 			it("sweepEnabled false", () => {
 				gc = createGcWithPrivateMembers({ sweepEnabled: false });

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -231,15 +231,21 @@ describe("Garbage Collection Tests", () => {
 				assert(gc.gcEnabled, "gcEnabled incorrect");
 				assert.equal(gc.latestSummaryGCVersion, 1, "latestSummaryGCVersion incorrect");
 			});
-            it("gcContainerGeneration mismatch, sweepEnabled true", () => {
-                gc = createGcWithPrivateMembers({ createContainerRuntimeVersion: "2.0.0-internal.2.3.1", sweepEnabled: true }, { gcContainerGeneration: 1 });
-                assert(gc.gcEnabled, "gcEnabled incorrect");
-                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-            });
-            it("gcContainerGeneration matches", () => {
-                gc = createGcWithPrivateMembers({ createContainerRuntimeVersion: "2.0.0-internal.2.3.1", sweepEnabled: true }, { gcContainerGeneration: 2 });
-                assert(gc.sweepEnabled, "sweepEnabled incorrect");
-            });
+			it("gcContainerGeneration mismatch, sweepEnabled true", () => {
+				gc = createGcWithPrivateMembers(
+					{ createContainerRuntimeVersion: "2.0.0-internal.2.3.1", sweepEnabled: true },
+					{ gcContainerGeneration: 1 },
+				);
+				assert(gc.gcEnabled, "gcEnabled incorrect");
+				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+			});
+			it("gcContainerGeneration matches", () => {
+				gc = createGcWithPrivateMembers(
+					{ createContainerRuntimeVersion: "2.0.0-internal.2.3.1", sweepEnabled: true },
+					{ gcContainerGeneration: 2 },
+				);
+				assert(gc.sweepEnabled, "sweepEnabled incorrect");
+			});
 			it("sweepEnabled false", () => {
 				gc = createGcWithPrivateMembers({ sweepEnabled: false });
 				assert(!gc.sweepEnabled, "sweepEnabled incorrect");

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -139,6 +139,8 @@ describe("Garbage Collection Tests", () => {
 			getNodeType,
 			getCurrentReferenceTimestampMs: () => Date.now(),
 			closeFn,
+			//* Need to plumb through properly... or move test cases elsewhere
+			disableGcTombstoneEnforcement: false,
 		};
 
 		return GarbageCollector.create({

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -193,12 +193,12 @@ describe("Garbage Collection Tests", () => {
 			metadata?: IGCMetadata & ICreateContainerMetadata,
 			gcOptions?: IGCRuntimeOptions,
 		): GcWithPrivates => {
-			const crMetadata: IContainerRuntimeMetadata | undefined = metadata && {
+			const allMetadata: IContainerRuntimeMetadata | undefined = metadata && {
 				summaryFormatVersion: 1,
 				message: undefined,
 				...metadata,
 			};
-			return createGarbageCollector({ metadata: crMetadata, gcOptions }) as GcWithPrivates;
+			return createGarbageCollector({ metadata: allMetadata, gcOptions }) as GcWithPrivates;
 		};
 		const customSessionExpiryDurationMs = defaultSessionExpiryDurationMs + 1;
 
@@ -231,18 +231,25 @@ describe("Garbage Collection Tests", () => {
 				assert(gc.gcEnabled, "gcEnabled incorrect");
 				assert.equal(gc.latestSummaryGCVersion, 1, "latestSummaryGCVersion incorrect");
 			});
-			it("gcContainerGeneration mismatch, sweepEnabled true", () => {
+			it("gcFailureMinCreateContainerRuntimeVersion later than persisted value, sweepEnabled false", () => {
 				gc = createGcWithPrivateMembers(
-					{ createContainerRuntimeVersion: "2.0.0-internal.2.3.1", sweepEnabled: true },
-					{ gcContainerGeneration: 1 },
+					{ createContainerRuntimeVersion: "1.2.3", sweepEnabled: true },
+					{ gcFailureMinCreateContainerRuntimeVersion: "2.0.0" },
 				);
 				assert(gc.gcEnabled, "gcEnabled incorrect");
 				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
 			});
-			it("gcContainerGeneration matches", () => {
+			it("gcFailureMinCreateContainerRuntimeVersion equal to persisted value, sweepEnabled true", () => {
 				gc = createGcWithPrivateMembers(
-					{ createContainerRuntimeVersion: "2.0.0-internal.2.3.1", sweepEnabled: true },
-					{ gcContainerGeneration: 2 },
+					{ createContainerRuntimeVersion: "1.2.3", sweepEnabled: true },
+					{ gcFailureMinCreateContainerRuntimeVersion: "1.2.3" },
+				);
+				assert(gc.sweepEnabled, "sweepEnabled incorrect");
+			});
+			it("gcFailureMinCreateContainerRuntimeVersion earlier than persisted value, sweepEnabled true", () => {
+				gc = createGcWithPrivateMembers(
+					{ createContainerRuntimeVersion: "1.2.3", sweepEnabled: true },
+					{ gcFailureMinCreateContainerRuntimeVersion: "1.0.0" },
 				);
 				assert(gc.sweepEnabled, "sweepEnabled incorrect");
 			});

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -53,6 +53,7 @@ import {
 	dataStoreAttributesBlobName,
 	GCVersion,
 	IContainerRuntimeMetadata,
+	ICreateContainerMetadata,
 	IGCMetadata,
 } from "../summaryFormat";
 import { IGCRuntimeOptions } from "../containerRuntime";
@@ -76,1694 +77,2173 @@ type GcWithPrivates = IGarbageCollector & {
 };
 
 describe("Garbage Collection Tests", () => {
-    const defaultSnapshotCacheExpiryMs = 5 * 24 * 60 * 60 * 1000;
+	const defaultSnapshotCacheExpiryMs = 5 * 24 * 60 * 60 * 1000;
 
-    // Nodes in the reference graph.
-    const nodes: string[] = [
-        "/node1",
-        "/node2",
-        "/node3",
-        "/node4",
-    ];
+	// Nodes in the reference graph.
+	const nodes: string[] = ["/node1", "/node2", "/node3", "/node4"];
 
-    const mockLogger: MockLogger = new MockLogger();
-    const testPkgPath = ["testPkg"];
-    // The package data is tagged in the telemetry event.
-    const eventPkg = { value: testPkgPath.join("/"), tag: TelemetryDataTag.CodeArtifact };
+	const mockLogger: MockLogger = new MockLogger();
+	const testPkgPath = ["testPkg"];
+	// The package data is tagged in the telemetry event.
+	const eventPkg = { value: testPkgPath.join("/"), tag: TelemetryDataTag.CodeArtifact };
 
-    const oldRawConfig = sessionStorageConfigProvider.value.getRawConfig;
-    let injectedSettings: Record<string, ConfigTypes> = {};
-    let clock: SinonFakeTimers;
+	const oldRawConfig = sessionStorageConfigProvider.value.getRawConfig;
+	let injectedSettings: Record<string, ConfigTypes> = {};
+	let clock: SinonFakeTimers;
 
-    // The default GC data returned by `getGCData` on which GC is run. Update this to update the referenced graph.
-    let defaultGCData: IGarbageCollectionData = { gcNodes: {} };
+	// The default GC data returned by `getGCData` on which GC is run. Update this to update the referenced graph.
+	let defaultGCData: IGarbageCollectionData = { gcNodes: {} };
 
-    // Returns a dummy snapshot tree to be built upon.
-    const getDummySnapshotTree = (): ISnapshotTree => {
-        return {
-            blobs: {},
-            trees: {},
-        };
-    };
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const parseNothing: ReadAndParseBlob = async <T>() => { const x: T = {} as T; return x; };
+	// Returns a dummy snapshot tree to be built upon.
+	const getDummySnapshotTree = (): ISnapshotTree => {
+		return {
+			blobs: {},
+			trees: {},
+		};
+	};
 
-    function createGarbageCollector(
-        createParams: Partial<IGarbageCollectorCreateParams> = {},
-        gcBlobsMap: Map<string, IGarbageCollectionState | IGarbageCollectionDetailsBase | string[]> = new Map(),
-        closeFn: (error?: ICriticalContainerError) => void = () => {},
-        isSummarizerClient: boolean = true,
-    ) {
-        const getNodeType = (nodePath: string) => {
-            if (nodePath.split("/").length !== 2) {
-                return GCNodeType.Other;
-            }
-            return GCNodeType.DataStore;
-        };
+	const parseNothing: ReadAndParseBlob = async <T>() => {
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+		const x: T = {} as T;
+		return x;
+	};
 
-        // The runtime to be passed to the garbage collector.
-        const gcRuntime: IGarbageCollectionRuntime = {
-            updateStateBeforeGC: async () => {},
-            getGCData: async (fullGC?: boolean) => defaultGCData,
-            updateUsedRoutes: (usedRoutes: string[]) => { return { totalNodeCount: 0, unusedNodeCount: 0 }; },
-            updateUnusedRoutes: (unusedRoutes: string[]) => {},
-            updateTombstonedRoutes: (tombstoneRoutes: string[]) => {},
-            getNodeType,
-            getCurrentReferenceTimestampMs: () => Date.now(),
-            closeFn,
-        };
+	function createGarbageCollector(
+		createParams: Partial<IGarbageCollectorCreateParams> = {},
+		gcBlobsMap: Map<
+			string,
+			IGarbageCollectionState | IGarbageCollectionDetailsBase | string[]
+		> = new Map(),
+		closeFn: (error?: ICriticalContainerError) => void = () => {},
+		isSummarizerClient: boolean = true,
+	) {
+		const getNodeType = (nodePath: string) => {
+			if (nodePath.split("/").length !== 2) {
+				return GCNodeType.Other;
+			}
+			return GCNodeType.DataStore;
+		};
 
-        return GarbageCollector.create({
-            ...createParams,
-            runtime: gcRuntime,
-            gcOptions: createParams.gcOptions ?? {},
-            baseSnapshot: createParams.baseSnapshot,
-            baseLogger: mockLogger,
-            existing: createParams.metadata !== undefined /* existing */,
-            metadata: createParams.metadata,
-            createContainerMetadata: {
-                createContainerRuntimeVersion: pkgVersion,
-                createContainerTimestamp: Date.now(),
-            },
-            isSummarizerClient,
-            readAndParseBlob: async <T>(id: string) => gcBlobsMap.get(id) as T,
-            getNodePackagePath: async (nodeId: string) => testPkgPath,
-            getLastSummaryTimestampMs: () => Date.now(),
-            activeConnection: () => true,
-            getContainerDiagnosticId: () => "someDocId",
-        });
-    }
-    let gc: GcWithPrivates | undefined;
+		// The runtime to be passed to the garbage collector.
+		const gcRuntime: IGarbageCollectionRuntime = {
+			updateStateBeforeGC: async () => {},
+			getGCData: async (fullGC?: boolean) => defaultGCData,
+			updateUsedRoutes: (usedRoutes: string[]) => {
+				return { totalNodeCount: 0, unusedNodeCount: 0 };
+			},
+			updateUnusedRoutes: (unusedRoutes: string[]) => {},
+			deleteUnusedNodes: (deletableRoutes: string[]): string[] => {
+				return [];
+			},
+			updateTombstonedRoutes: (tombstoneRoutes: string[]) => {},
+			getNodeType,
+			getCurrentReferenceTimestampMs: () => Date.now(),
+			closeFn,
+		};
 
-    before(() => {
-        clock = useFakeTimers();
-        sessionStorageConfigProvider.value.getRawConfig = (name) => injectedSettings[name];
-    });
+		return GarbageCollector.create({
+			...createParams,
+			runtime: gcRuntime,
+			gcOptions: createParams.gcOptions ?? {},
+			baseSnapshot: createParams.baseSnapshot,
+			baseLogger: mockLogger,
+			existing: createParams.metadata !== undefined /* existing */,
+			metadata: createParams.metadata,
+			createContainerMetadata: {
+				createContainerRuntimeVersion: pkgVersion,
+				createContainerTimestamp: Date.now(),
+			},
+			isSummarizerClient,
+			readAndParseBlob: async <T>(id: string) => gcBlobsMap.get(id) as T,
+			getNodePackagePath: async (nodeId: string) => testPkgPath,
+			getLastSummaryTimestampMs: () => Date.now(),
+			activeConnection: () => true,
+			getContainerDiagnosticId: () => "someDocId",
+		});
+	}
+	let gc: GcWithPrivates | undefined;
 
-    beforeEach(() => {
-        gc = undefined;
-    });
+	before(() => {
+		clock = useFakeTimers();
+		sessionStorageConfigProvider.value.getRawConfig = (name) => injectedSettings[name];
+	});
 
-    afterEach(() => {
-        clock.reset();
-        mockLogger.clear();
-        injectedSettings = {};
-        defaultGCData = { gcNodes: {} };
-        gc?.dispose();
-    });
+	beforeEach(() => {
+		gc = undefined;
+	});
 
-    after(() => {
-        clock.restore();
-        sessionStorageConfigProvider.value.getRawConfig = oldRawConfig;
-    });
+	afterEach(() => {
+		clock.reset();
+		mockLogger.clear();
+		injectedSettings = {};
+		defaultGCData = { gcNodes: {} };
+		gc?.dispose();
+	});
 
-    describe("Configuration", () => {
-        const testOverrideSweepTimeoutKey = "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs";
-        const testOverrideSessionExpiryMsKey = "Fluid.GarbageCollection.TestOverride.SessionExpiryMs";
-        const createGcWithPrivateMembers = (gcMetadata?: IGCMetadata, gcOptions?: IGCRuntimeOptions): GcWithPrivates => {
-            const metadata: IContainerRuntimeMetadata | undefined = gcMetadata && { summaryFormatVersion: 1, message: undefined, ...gcMetadata };
-            return createGarbageCollector({ metadata, gcOptions }) as GcWithPrivates;
-        };
-        const customSessionExpiryDurationMs = defaultSessionExpiryDurationMs + 1;
+	after(() => {
+		clock.restore();
+		sessionStorageConfigProvider.value.getRawConfig = oldRawConfig;
+	});
 
-        beforeEach(() => {
-            injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = 1; // To ensure it's less than sweep timeout
-        });
+	describe("Configuration", () => {
+		const testOverrideSweepTimeoutKey = "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs";
+		const testOverrideSessionExpiryMsKey =
+			"Fluid.GarbageCollection.TestOverride.SessionExpiryMs";
+		const createGcWithPrivateMembers = (
+			metadata?: IGCMetadata & ICreateContainerMetadata,
+			gcOptions?: IGCRuntimeOptions,
+		): GcWithPrivates => {
+			const crMetadata: IContainerRuntimeMetadata | undefined = metadata && {
+				summaryFormatVersion: 1,
+				message: undefined,
+				...metadata,
+			};
+			return createGarbageCollector({ metadata: crMetadata, gcOptions }) as GcWithPrivates;
+		};
+		const customSessionExpiryDurationMs = defaultSessionExpiryDurationMs + 1;
 
-        describe("Existing container", () => {
-            it("No metadata", () => {
-                gc = createGcWithPrivateMembers({});
-                assert(!gc.gcEnabled, "gcEnabled incorrect");
-                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-                assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
-                assert(gc.sweepTimeoutMs === undefined, "sweepTimeoutMs incorrect");
-                assert.equal(gc.latestSummaryGCVersion, 0, "latestSummaryGCVersion incorrect");
-            });
-            it("gcFeature 0", () => {
-                gc = createGcWithPrivateMembers({ gcFeature: 0 });
-                assert(!gc.gcEnabled, "gcEnabled incorrect");
-                assert.equal(gc.latestSummaryGCVersion, 0, "latestSummaryGCVersion incorrect");
-            });
-            it("gcFeature 0, sweepEnabled true", () => {
-                gc = createGcWithPrivateMembers({ gcFeature: 0, sweepEnabled: true });
-                assert(!gc.gcEnabled, "gcEnabled incorrect");
-                assert(gc.sweepEnabled, "sweepEnabled incorrect");
-                assert.equal(gc.latestSummaryGCVersion, 0, "latestSummaryGCVersion incorrect");
-            });
-            it("gcFeature 1", () => {
-                gc = createGcWithPrivateMembers({ gcFeature: 1 });
-                assert(gc.gcEnabled, "gcEnabled incorrect");
-                assert.equal(gc.latestSummaryGCVersion, 1, "latestSummaryGCVersion incorrect");
-            });
+		beforeEach(() => {
+			injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = 1; // To ensure it's less than sweep timeout
+		});
+
+		describe("Existing container", () => {
+			it("No metadata", () => {
+				gc = createGcWithPrivateMembers({});
+				assert(!gc.gcEnabled, "gcEnabled incorrect");
+				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+				assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
+				assert(gc.sweepTimeoutMs === undefined, "sweepTimeoutMs incorrect");
+				assert.equal(gc.latestSummaryGCVersion, 0, "latestSummaryGCVersion incorrect");
+			});
+			it("gcFeature 0", () => {
+				gc = createGcWithPrivateMembers({ gcFeature: 0 });
+				assert(!gc.gcEnabled, "gcEnabled incorrect");
+				assert.equal(gc.latestSummaryGCVersion, 0, "latestSummaryGCVersion incorrect");
+			});
+			it("gcFeature 0, sweepEnabled true", () => {
+				gc = createGcWithPrivateMembers({ gcFeature: 0, sweepEnabled: true });
+				assert(!gc.gcEnabled, "gcEnabled incorrect");
+				assert(gc.sweepEnabled, "sweepEnabled incorrect");
+				assert.equal(gc.latestSummaryGCVersion, 0, "latestSummaryGCVersion incorrect");
+			});
+			it("gcFeature 1", () => {
+				gc = createGcWithPrivateMembers({ gcFeature: 1 });
+				assert(gc.gcEnabled, "gcEnabled incorrect");
+				assert.equal(gc.latestSummaryGCVersion, 1, "latestSummaryGCVersion incorrect");
+			});
             it("gcContainerGeneration mismatch, sweepEnabled true", () => {
-                gc = createGcWithPrivateMembers({ gcContainerGeneration: 0, sweepEnabled: true }, { gcContainerGeneration: 1 });
+                gc = createGcWithPrivateMembers({ createContainerRuntimeVersion: "2.0.0-internal.2.3.1", sweepEnabled: true }, { gcContainerGeneration: 1 });
                 assert(gc.gcEnabled, "gcEnabled incorrect");
                 assert(!gc.sweepEnabled, "sweepEnabled incorrect");
             });
             it("gcContainerGeneration matches", () => {
-                gc = createGcWithPrivateMembers({ gcContainerGeneration: 2, sweepEnabled: true }, { gcContainerGeneration: 2 });
+                gc = createGcWithPrivateMembers({ createContainerRuntimeVersion: "2.0.0-internal.2.3.1", sweepEnabled: true }, { gcContainerGeneration: 2 });
                 assert(gc.sweepEnabled, "sweepEnabled incorrect");
             });
-            it("sweepEnabled false", () => {
-                gc = createGcWithPrivateMembers({ sweepEnabled: false });
-                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-            });
-            it("sessionExpiryTimeoutMs set (sweepTimeoutMs unset)", () => {
-                gc = createGcWithPrivateMembers({ sessionExpiryTimeoutMs: customSessionExpiryDurationMs });
-                assert.equal(gc.sessionExpiryTimeoutMs, customSessionExpiryDurationMs, "sessionExpiryTimeoutMs incorrect");
-                assert.equal(gc.sweepTimeoutMs, customSessionExpiryDurationMs + 6 * oneDayMs, "sweepTimeoutMs incorrect");
-            });
-            it("sweepTimeoutMs set", () => {
-                gc = createGcWithPrivateMembers({ sweepTimeoutMs: 123 });
-                assert.equal(gc.sweepTimeoutMs, 123, "sweepTimeoutMs incorrect");
-            });
-            it("Metadata Roundtrip", () => {
-                const inputMetadata: IGCMetadata = {
-                    sweepEnabled: true,
-                    gcFeature: 1,
-                    gcContainerGeneration: 2,
-                    sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
-                    sweepTimeoutMs: 123,
-                };
-                gc = createGcWithPrivateMembers(inputMetadata, { gcContainerGeneration: 2 });
-                const outputMetadata = gc.getMetadata();
-                const expectedOutputMetadata: IGCMetadata = { ...inputMetadata, gcFeature: stableGCVersion };
-                assert.deepEqual(outputMetadata, expectedOutputMetadata, "getMetadata returned different metadata than loaded from");
-            });
-            it("Metadata Roundtrip with GC version upgrade to v2 enabled", () => {
-                injectedSettings[gcVersionUpgradeToV2Key] = true;
-                const inputMetadata: IGCMetadata = {
-                    sweepEnabled: true,
-                    gcFeature: 1,
-                    gcContainerGeneration: 2,
-                    sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
-                    sweepTimeoutMs: 123,
-                };
-                gc = createGcWithPrivateMembers(inputMetadata, { gcContainerGeneration: 2 });
-                const outputMetadata = gc.getMetadata();
-                const expectedOutputMetadata: IGCMetadata = { ...inputMetadata, gcFeature: currentGCVersion };
-                assert.deepEqual(outputMetadata, expectedOutputMetadata, "getMetadata returned different metadata than loaded from");
-            });
-        });
-
-        describe("New Container", () => {
-            it("No options", () => {
-                injectedSettings[runSessionExpiryKey] = true;
-                gc = createGcWithPrivateMembers(undefined /* metadata */, {});
-                assert(gc.gcEnabled, "gcEnabled incorrect");
-                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-                assert(gc.sessionExpiryTimeoutMs !== undefined, "sessionExpiryTimeoutMs incorrect");
-                assert(gc.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
-                assert.equal(gc.latestSummaryGCVersion, stableGCVersion, "latestSummaryGCVersion incorrect");
-            });
-            it("gcAllowed true", () => {
-                gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: true });
-                assert(gc.gcEnabled, "gcEnabled incorrect");
-            });
-            it("gcAllowed false", () => {
-                gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: false });
-                assert(!gc.gcEnabled, "gcEnabled incorrect");
-            });
-            it("sweepAllowed true, gcAllowed false", () => {
-                assert.throws(
-                    () => { gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: false, sweepAllowed: true }); },
-                    (e) => e.errorType === "usageError",
-                    "Should be unsupported");
-            });
-            it("sweepAllowed true, gcAllowed true", () => {
-                injectedSettings[runSessionExpiryKey] = true;
-                gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: true, sweepAllowed: true });
-                assert(gc.gcEnabled, "gcEnabled incorrect");
-                assert(gc.sweepEnabled, "sweepEnabled incorrect");
-                assert(gc.shouldRunSweep, "shouldRunSweep incorrect");
-                assert(gc.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
-                assert(gc.sessionExpiryTimeoutMs !== undefined, "sessionExpiryTimeoutMs incorrect");
-            });
-            it("sweepAllowed true, gcAllowed true, sessionExpiry off", () => {
-                injectedSettings[runSessionExpiryKey] = false;
-                gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: true, sweepAllowed: true });
-                assert(gc.gcEnabled, "gcEnabled incorrect");
-                assert(gc.sweepEnabled, "sweepEnabled incorrect");
-                assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
-                assert(gc.sweepTimeoutMs === undefined, "sweepTimeoutMs incorrect");
-            });
-            it("sweepAllowed false, sessionExpiry on", () => {
-                injectedSettings[runSessionExpiryKey] = true;
-                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
-                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-                assert(gc.sessionExpiryTimeoutMs !== undefined, "sessionExpiryTimeoutMs incorrect");
-                assert(gc.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
-            });
-            it("sweepAllowed false, sessionExpiry off", () => {
-                injectedSettings[runSessionExpiryKey] = false;
-                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
-                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-                assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
-                assert(gc.sweepTimeoutMs === undefined, "sweepTimeoutMs incorrect");
-            });
-            it("TestOverride.SweepTimeout set, sweepAllowed false, sessionExpiry on", () => {
-                injectedSettings[testOverrideSweepTimeoutKey] = 123;
-                injectedSettings[runSessionExpiryKey] = true;
-                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
-                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-                assert(gc.sessionExpiryTimeoutMs === defaultSessionExpiryDurationMs, "sessionExpiryTimeoutMs incorrect");
-                assert(gc.sweepTimeoutMs === 123, "sweepTimeoutMs incorrect");
-            });
-            it("TestOverride.SweepTimeout set, sweepAllowed false, sessionExpiry off", () => {
-                injectedSettings[testOverrideSweepTimeoutKey] = 123;
-                injectedSettings[runSessionExpiryKey] = false;
-                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
-                assert(!gc.sweepEnabled, "sweepEnabled incorrect");
-                assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
-                assert(gc.sweepTimeoutMs === 123, "sweepTimeoutMs incorrect");
-            });
-            it("Metadata Roundtrip", () => {
-                injectedSettings[runSessionExpiryKey] = true;
-                const expectedMetadata: IGCMetadata = {
-                    sweepEnabled: true,
-                    gcFeature: 1,
-                    gcContainerGeneration: 2,
-                    sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
-                    sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
-                };
-                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: true, gcContainerGeneration: 2 });
-                const outputMetadata = gc.getMetadata();
-                assert.deepEqual(outputMetadata, expectedMetadata, "getMetadata returned different metadata than expected");
-            });
-            it("Metadata Roundtrip with GC version upgrade to v2 enabled", () => {
-                injectedSettings[runSessionExpiryKey] = true;
-                injectedSettings[gcVersionUpgradeToV2Key] = true;
-                const expectedMetadata: IGCMetadata = {
-                    sweepEnabled: true,
-                    gcFeature: currentGCVersion,
-                    gcContainerGeneration: 2,
-                    sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
-                    sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
-                };
-                gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: true, gcContainerGeneration: 2 });
-                const outputMetadata = gc.getMetadata();
-                assert.deepEqual(outputMetadata, expectedMetadata, "getMetadata returned different metadata than expected");
-            });
-        });
-
-        describe("Session Expiry and Sweep Timeout", () => {
-            beforeEach(() => {
-                injectedSettings[runSessionExpiryKey] = true;
-                injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = 1; // To ensure it's less than sweep timeout
-            });
-
-            // Config sources for Session Expiry:
-            // 1. defaultSessionExpiryDurationMs in code
-            // 2. IGCRuntimeOptions.sessionExpiryTimeoutMs
-            // 3. IGCMetadata.sessionExpiryTimeoutMs
-            // 4. "Fluid.GarbageCollection.TestOverride.SessionExpiryMs" setting
-            // 5. boolean setting: runSessionExpiryKey
-            // Config sources for Sweep Timeout:
-            // 1. IGCMetadata.sweepTimeoutMs
-            // 2. Computed from Session Expiry, fixed upper bound for Snapshot Expiry and a fixed buffer (on create, or to backfill existing)
-            // 3. "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs" setting (only applicable on create)
-
-            it("defaultSessionExpiryDurationMs", () => {
-                gc = createGcWithPrivateMembers();
-                assert.equal(gc.sessionExpiryTimeoutMs, defaultSessionExpiryDurationMs, "sessionExpiryTimeoutMs incorrect");
-                assert.equal(gc.sessionExpiryTimer.defaultTimeout, defaultSessionExpiryDurationMs, "sessionExpiryTimer incorrect");
-                assert.equal(gc.sweepTimeoutMs, defaultSessionExpiryDurationMs + 6 * oneDayMs, "sweepTimeoutMs incorrect");
-            });
-            it("defaultSessionExpiryDurationMs, TestOverride.SweepTimeout set", () => {
-                injectedSettings[testOverrideSweepTimeoutKey] = 7890;
-                gc = createGcWithPrivateMembers();
-                assert.equal(gc.sessionExpiryTimeoutMs, defaultSessionExpiryDurationMs, "sessionExpiryTimeoutMs incorrect");
-                assert.equal(gc.sessionExpiryTimer.defaultTimeout, defaultSessionExpiryDurationMs, "sessionExpiryTimer incorrect");
-                assert.equal(gc.sweepTimeoutMs, 7890, "sweepTimeoutMs incorrect");
-            });
-            it("IGCRuntimeOptions.sessionExpiryTimeoutMs", () => {
-                gc = createGcWithPrivateMembers(undefined /* metadata */, { sessionExpiryTimeoutMs: 123 });
-                assert.equal(gc.sessionExpiryTimeoutMs, 123, "sessionExpiryTimeoutMs incorrect");
-                assert.equal(gc.sessionExpiryTimer.defaultTimeout, 123, "sessionExpiryTimer incorrect");
-                assert.equal(gc.sweepTimeoutMs, 123 + 6 * oneDayMs, "sweepTimeoutMs incorrect");
-            });
-            it("IGCMetadata.sessionExpiryTimeoutMs, backfill sweepTimeoutMs", () => {
-                injectedSettings[testOverrideSweepTimeoutKey] = 1337; // Should be ignored
-                gc = createGcWithPrivateMembers({ sessionExpiryTimeoutMs: 456 } /* metadata */);
-                assert.equal(gc.sessionExpiryTimeoutMs, 456, "sessionExpiryTimeoutMs incorrect");
-                assert.equal(gc.sessionExpiryTimer.defaultTimeout, 456, "sessionExpiryTimer incorrect");
-                assert.equal(gc.sweepTimeoutMs, 456 + 6 * oneDayMs, "sweepTimeoutMs incorrect");
-            });
-            it("IGCMetadata.sessionExpiryTimeoutMs and IGCMetadata.sweepTimeoutMs", () => {
-                injectedSettings[testOverrideSweepTimeoutKey] = 1337; // Should be ignored
-                gc = createGcWithPrivateMembers({ sessionExpiryTimeoutMs: 456, sweepTimeoutMs: 789 } /* metadata */);
-                assert.equal(gc.sessionExpiryTimeoutMs, 456, "sessionExpiryTimeoutMs incorrect");
-                assert.equal(gc.sessionExpiryTimer.defaultTimeout, 456, "sessionExpiryTimer incorrect");
-                assert.equal(gc.sweepTimeoutMs, 789, "sweepTimeoutMs incorrect");
-            });
-            it("IGCMetadata.sweepTimeoutMs only", () => {
-                injectedSettings[testOverrideSweepTimeoutKey] = 1337; // Should be ignored
-                // This could happen if you used TestOverride.SweepTimeoutMs but had SessionExpiry disabled, then loaded that container.
-                gc = createGcWithPrivateMembers({ sweepTimeoutMs: 789 } /* metadata */);
-                assert.equal(gc.sessionExpiryTimeoutMs, undefined, "sessionExpiryTimeoutMs incorrect");
-                assert.equal(gc.sessionExpiryTimer, undefined, "sessionExpiryTimer incorrect");
-                assert.equal(gc.sweepTimeoutMs, 789, "sweepTimeoutMs incorrect");
-            });
-            function testSessionExpiryMsOverride() {
-                const expectedSweepTimeoutMs = defaultSessionExpiryDurationMs + 6 * oneDayMs;
-                assert(!!gc, "PRECONDITION: gc must be set before calling this helper");
-                assert.equal(gc.sessionExpiryTimeoutMs, defaultSessionExpiryDurationMs, "sessionExpiryTimeoutMs incorrect");
-                assert.equal(gc.sessionExpiryTimer.defaultTimeout, 789, "sessionExpiry used for timer should be the override value");
-                assert.equal(gc.sweepTimeoutMs, expectedSweepTimeoutMs, "sweepTimeoutMs incorrect");
-
-                const expectedMetadata: IGCMetadata = {
-                    sweepEnabled: false,
-                    gcFeature: 1,
-                    sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
-                    sweepTimeoutMs: expectedSweepTimeoutMs,
-                };
-                const outputMetadata = gc.getMetadata();
-                assert.deepEqual(outputMetadata, expectedMetadata, "getMetadata returned different metadata than expected");
-            }
-            it("TestOverride.SessionExpiryMs setting applied to timeout but not written to file - New Container", () => {
-                injectedSettings[testOverrideSessionExpiryMsKey] = 789;
-                gc = createGcWithPrivateMembers();
-                testSessionExpiryMsOverride();
-            });
-            it("TestOverride.SessionExpiryMs setting applied to timeout but not written to file - Existing Container", () => {
-                injectedSettings[testOverrideSessionExpiryMsKey] = 789;
-                gc = createGcWithPrivateMembers({ sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs, gcFeature: 1 } /* metadata */);
-                testSessionExpiryMsOverride();
-            });
-            it("RunSessionExpiry setting turned off", () => {
-                injectedSettings[runSessionExpiryKey] = false;
-                injectedSettings[testOverrideSessionExpiryMsKey] = 1234; // This override should be ignored
-                gc = createGcWithPrivateMembers();
-                assert.equal(gc.sessionExpiryTimeoutMs, undefined, "sessionExpiryTimeoutMs should be undefined if runSessionExpiryKey setting is false");
-                assert.equal(gc.sessionExpiryTimer, undefined, "sessionExpiryTimer should be undefined if it's disabled");
-                assert.equal(gc.sweepTimeoutMs, undefined, "sweepTimeoutMs incorrect");
-            });
-            it("RunSessionExpiry setting turned off, TestOverride.SweepTimeout set", () => {
-                injectedSettings[runSessionExpiryKey] = false;
-                injectedSettings[testOverrideSweepTimeoutKey] = 7890;
-                injectedSettings[testOverrideSessionExpiryMsKey] = 1234; // This override should be ignored
-                gc = createGcWithPrivateMembers();
-                assert.equal(gc.sessionExpiryTimeoutMs, undefined, "sessionExpiryTimeoutMs should be undefined if runSessionExpiryKey setting is false");
-                assert.equal(gc.sessionExpiryTimer, undefined, "sessionExpiryTimer should be undefined if it's disabled");
-                assert.equal(gc.sweepTimeoutMs, 7890, "sweepTimeoutMs incorrect");
-            });
-        });
-
-        describe("Session Behavior (e.g. 'shouldRun' fields)", () => {
-            beforeEach(() => {
-                injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = 1; // To ensure it's less than sweep timeout
-            });
-
-            describe("shouldRunGC", () => {
-                const testCases: { gcEnabled: boolean; disableGC?: boolean; runGC?: boolean; expectedResult: boolean; }[] = [
-                    { gcEnabled: false, disableGC: true, runGC: true, expectedResult: true },
-                    { gcEnabled: true, disableGC: false, runGC: false, expectedResult: false },
-                    { gcEnabled: true, disableGC: true, expectedResult: false },
-                    { gcEnabled: true, disableGC: false, expectedResult: true },
-                    { gcEnabled: true, expectedResult: true },
-                    { gcEnabled: false, expectedResult: false },
-                ];
-                testCases.forEach((testCase) => {
-                    it(`Test Case ${JSON.stringify(testCase)}`, () => {
-                        injectedSettings[runGCKey] = testCase.runGC;
-                        gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: testCase.gcEnabled, disableGC: testCase.disableGC });
-                        assert.equal(gc.gcEnabled, testCase.gcEnabled, "PRECONDITION: gcEnabled set incorrectly");
-                        assert.equal(gc.shouldRunGC, testCase.expectedResult, "shouldRunGC not set as expected");
-                    });
-                });
-            });
-            describe("shouldRunSweep", () => {
-                const testCases: { shouldRunGC: boolean; setSweepTimeout: boolean; sweepEnabled: boolean; runSweep?: boolean; expectedResult: boolean; }[] = [
-                    { shouldRunGC: false, setSweepTimeout: true, sweepEnabled: true, runSweep: true, expectedResult: false },
-                    { shouldRunGC: true, setSweepTimeout: false, sweepEnabled: true, runSweep: true, expectedResult: false },
-                    { shouldRunGC: true, setSweepTimeout: true, sweepEnabled: true, runSweep: false, expectedResult: false },
-                    { shouldRunGC: true, setSweepTimeout: true, sweepEnabled: false, runSweep: true, expectedResult: true },
-                    { shouldRunGC: true, setSweepTimeout: true, sweepEnabled: true, expectedResult: true },
-                    { shouldRunGC: true, setSweepTimeout: true, sweepEnabled: false, expectedResult: false },
-                ];
-                testCases.forEach((testCase) => {
-                    it(`Test Case ${JSON.stringify(testCase)}`, () => {
-                        injectedSettings[runGCKey] = testCase.shouldRunGC;
-                        injectedSettings[runSweepKey] = testCase.runSweep;
-                        injectedSettings[runSessionExpiryKey] = testCase.setSweepTimeout; // Sweep timeout is set iff sessionExpiry runs (under other default inputs)
-                        gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: testCase.sweepEnabled });
-                        assert.equal(gc.shouldRunGC, testCase.shouldRunGC, "PRECONDITION: shouldRunGC set incorrectly");
-                        assert.equal(gc.sweepTimeoutMs !== undefined, testCase.setSweepTimeout, "PRECONDITION: sweep timeout set incorrectly");
-                        assert.equal(gc.sweepEnabled, testCase.sweepEnabled, "PRECONDITION: sweepEnabled set incorrectly");
-                        assert.equal(gc.shouldRunSweep, testCase.expectedResult, "shouldRunSweep not set as expected");
-                    });
-                });
-            });
-            describe("inactiveTimeoutMs", () => {
-                beforeEach(() => {
-                    // Remove setting added in outer describe block
-                    injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = undefined;
-                });
-                const testCases: { testOverride?: number; option?: number; expectedResult: number; }[] = [
-                    { testOverride: 123, option: 456, expectedResult: 123 },
-                    { option: 456, expectedResult: 456 },
-                    { expectedResult: defaultInactiveTimeoutMs },
-                ];
-                testCases.forEach((testCase) => {
-                    it(`Test Case ${JSON.stringify(testCase)}`, () => {
-                        injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = testCase.testOverride;
-                        gc = createGcWithPrivateMembers(undefined /* metadata */, { inactiveTimeoutMs: testCase.option });
-                        assert.equal(gc.inactiveTimeoutMs, testCase.expectedResult, "inactiveTimeoutMs not set as expected");
-                    });
-                });
-                it("inactiveTimeout must not be greater than sweepTimeout", () => {
-                    injectedSettings[runSessionExpiryKey] = true;
-                    injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = Number.MAX_VALUE;
-                    assert.throws(
-                        () => { gc = createGcWithPrivateMembers(); },
-                        (e) => e.errorType === "usageError",
-                        "inactiveTimeout must not be greater than sweepTimeout");
-                });
-            });
-            describe("testMode", () => {
-                const testCases: { setting?: boolean; option?: boolean; expectedResult: boolean; }[] = [
-                    { setting: true, option: false, expectedResult: true },
-                    { setting: false, option: true, expectedResult: false },
-                    { option: true, expectedResult: true },
-                    { expectedResult: false },
-                ];
-                testCases.forEach((testCase) => {
-                    it(`Test Case ${JSON.stringify(testCase)}`, () => {
-                        injectedSettings[gcTestModeKey] = testCase.setting;
-                        gc = createGcWithPrivateMembers(undefined /* metadata */, { runGCInTestMode: testCase.option });
-                        assert.equal(gc.testMode, testCase.expectedResult, "testMode not set as expected");
-                    });
-                });
-            });
-        });
-    });
-
-    it("Session expiry closes container", () => {
-        injectedSettings[runSessionExpiryKey] = "true";
-
-        let closeCalled = false;
-        function closeCalledAfterExactTicks(ticks: number) {
-            clock.tick(ticks - 1);
-            if (closeCalled) {
-                return false;
-            }
-            clock.tick(1);
-            return closeCalled;
-        }
-
-        gc = createGarbageCollector({ }, undefined /* gcBlobsMap */, () => { closeCalled = true; }) as GcWithPrivates;
-        assert(closeCalledAfterExactTicks(defaultSessionExpiryDurationMs), "Close should have been called at exactly defaultSessionExpiryDurationMs");
-    });
-
-    describe("errors when unreferenced objects are used after they are inactive / deleted", () => {
-        // Mock node loaded and changed activity for all the nodes in the graph.
-         async function updateAllNodesAndRunGC(garbageCollector: IGarbageCollector) {
-            nodes.forEach((nodeId) => {
-                garbageCollector.nodeUpdated(nodeId, "Changed", Date.now(), testPkgPath);
-                garbageCollector.nodeUpdated(nodeId, "Loaded", Date.now(), testPkgPath);
-            });
-            await garbageCollector.collectGarbage({});
-        }
-
-        beforeEach(async () => {
-            // Set up the reference graph such that all nodes are referenced. Add in a couple of cycles in the graph.
-            // Here's a diagram showing the references:
-            // 0 - 1 - 2 - 3
-            // |  /       /
-            // |-/-------/
-            defaultGCData.gcNodes["/"] = [nodes[0]];
-            defaultGCData.gcNodes[nodes[0]] = [nodes[1]];
-            defaultGCData.gcNodes[nodes[1]] = [nodes[0], nodes[2]];
-            defaultGCData.gcNodes[nodes[2]] = [nodes[3]];
-            defaultGCData.gcNodes[nodes[3]] = [nodes[0]];
-        });
-
-        const summarizerContainerTests = (
-            timeout: number,
-            revivedEventName: string,
-            changedEventName: string,
-            loadedEventName: string,
-            expectDeleteLogs?: boolean,
-        ) => {
-            const deleteEventName = "GarbageCollector:GCObjectDeleted";
-            // Validates that no unexpected event has been fired.
-            function validateNoUnexpectedEvents() {
-                mockLogger.assertMatchNone([
-                        { eventName: revivedEventName },
-                        { eventName: changedEventName },
-                        { eventName: loadedEventName },
-                        { eventName: deleteEventName },
-                    ],
-                    "unexpected events logged",
-                );
-            }
-
-            const createGCOverride = (
-                baseSnapshot?: ISnapshotTree,
-                gcBlobsMap?: Map<string, IGarbageCollectionState | IGarbageCollectionDetailsBase>,
-            ) => {
-                return createGarbageCollector({ baseSnapshot }, gcBlobsMap);
-            };
-
-            it("doesn't generate events for referenced nodes", async () => {
-                const garbageCollector = createGCOverride();
-
-                // Run garbage collection on the default GC data where everything is referenced.
-                await garbageCollector.collectGarbage({});
-
-                // Advance the clock just before the timeout and validate no events are generated.
-                clock.tick(timeout - 1);
-                await updateAllNodesAndRunGC(garbageCollector);
-                validateNoUnexpectedEvents();
-
-                // Advance the clock to expire the timeout.
-                clock.tick(1);
-
-                // Update all nodes again. Validate that no unexpected events are generated since everything is referenced.
-                await updateAllNodesAndRunGC(garbageCollector);
-                validateNoUnexpectedEvents();
-            });
-
-            it("generates events for nodes that are used after time out", async () => {
-                const garbageCollector = createGCOverride();
-
-                // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
-                defaultGCData.gcNodes[nodes[1]] = [];
-
-                await garbageCollector.collectGarbage({});
-
-                // Advance the clock just before the timeout and validate no unexpected events are logged.
-                clock.tick(timeout - 1);
-                await updateAllNodesAndRunGC(garbageCollector);
-                validateNoUnexpectedEvents();
-
-                // Expire the timeout and validate that all events for node 2 and node 3 are logged.
-                clock.tick(1);
-                await updateAllNodesAndRunGC(garbageCollector);
-                const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [];
-
-                if (expectDeleteLogs) {
-                    expectedEvents.push(
-                        { eventName: deleteEventName, timeout, id: nodes[2] },
-                        { eventName: deleteEventName, timeout, id: nodes[3] },
-                    );
-                } else {
-                    assert(!mockLogger.events.some((event) => event.eventName === deleteEventName), "Should not have any delete events logged");
-                }
-                expectedEvents.push(
-                    { eventName: changedEventName, timeout, id: nodes[2], pkg: eventPkg, createContainerRuntimeVersion: pkgVersion },
-                    { eventName: loadedEventName, timeout, id: nodes[2], pkg: eventPkg, createContainerRuntimeVersion: pkgVersion },
-                    { eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg, createContainerRuntimeVersion: pkgVersion },
-                    { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg, createContainerRuntimeVersion: pkgVersion },
-                );
-                mockLogger.assertMatch(expectedEvents, "all events not generated as expected");
-
-                // Add reference from node 1 to node 3 and validate that we get a revived event.
-                garbageCollector.addedOutboundReference(nodes[1], nodes[3]);
-                await garbageCollector.collectGarbage({});
-                mockLogger.assertMatch(
-                    [{ eventName: revivedEventName, timeout, id: nodes[3], pkg: eventPkg, fromId: nodes[1] }],
-                    "revived event not generated as expected",
-                );
-            });
-
-            it("generates only revived event when an inactive node is changed and revived", async () => {
-                const garbageCollector = createGCOverride();
-
-                // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
-                defaultGCData.gcNodes[nodes[1]] = [];
-
-                await garbageCollector.collectGarbage({});
-
-                // Advance the clock just before the timeout and validate no unexpected events are logged.
-                clock.tick(timeout - 1);
-                await updateAllNodesAndRunGC(garbageCollector);
-                validateNoUnexpectedEvents();
-
-                // Expire the timeout and validate that only revived event is generated for node 2.
-                clock.tick(1);
-                garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
-                garbageCollector.nodeUpdated(nodes[2], "Loaded", Date.now(), testPkgPath);
-                garbageCollector.addedOutboundReference(nodes[1], nodes[2]);
-                await garbageCollector.collectGarbage({});
-
-                for (const event of mockLogger.events) {
-                    assert.notStrictEqual(event.eventName, changedEventName, "Unexpected changed event logged");
-                    assert.notStrictEqual(event.eventName, loadedEventName, "Unexpected loaded event logged");
-                }
-                mockLogger.assertMatch(
-                    [{ eventName: revivedEventName, timeout, id: nodes[2], pkg: eventPkg, fromId: nodes[1] }],
-                    "revived event not logged as expected",
-                );
-            });
-
-            it("generates events once per node", async () => {
-                const garbageCollector = createGCOverride();
-
-                // Remove node 3's reference from node 2.
-                defaultGCData.gcNodes[nodes[2]] = [];
-
-                await garbageCollector.collectGarbage({});
-
-                // Advance the clock just before the timeout and validate no unexpected events are logged.
-                clock.tick(timeout - 1);
-                await updateAllNodesAndRunGC(garbageCollector);
-                validateNoUnexpectedEvents();
-
-                // Expire the timeout and validate that all events for node 2 and node 3 are logged.
-                clock.tick(1);
-                await updateAllNodesAndRunGC(garbageCollector);
-                const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [];
-                if (expectDeleteLogs) {
-                    expectedEvents.push({ eventName: deleteEventName, timeout, id: nodes[3] });
-                } else {
-                    assert(!mockLogger.events.some((event) => event.eventName === deleteEventName), "Should not have any delete events logged");
-                }
-                expectedEvents.push(
-                    { eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
-                    { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
-                );
-                mockLogger.assertMatch(expectedEvents, "all events not generated as expected");
-
-                // Update all nodes again. There shouldn't be any more events since for each node the event is only once.
-                await updateAllNodesAndRunGC(garbageCollector);
-                validateNoUnexpectedEvents();
-            });
-
-            /**
-             * Here, the base snapshot contains nodes that have timed out. The test validates that we generate errors
-             * when these nodes are used.
-             */
-            it("generates events for nodes that time out on load", async () => {
-                // Create GC state where node 3's unreferenced time was > timeout ms ago.
-                // This means this node should time out as soon as its data is loaded.
-
-                // Create a snapshot tree to be used as the GC snapshot tree.
-                const gcSnapshotTree = getDummySnapshotTree();
-                const gcBlobId = "root";
-                // Add a GC blob with key that start with `gcBlobPrefix` to the GC snapshot tree. The blob Id for this
-                // is generated by server in real scenarios but we use a static id here for testing.
-                gcSnapshotTree.blobs[`${gcBlobPrefix}_${gcBlobId}`] = gcBlobId;
-
-                // Create a base snapshot that contains the GC snapshot tree.
-                const baseSnapshot = getDummySnapshotTree();
-                baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
-
-                // Create GC state with node 3 expired. This will be returned when the garbage collector asks
-                // for the GC blob with `gcBlobId`.
-                const gcState: IGarbageCollectionState = { gcNodes: {} };
-                const node3Data: IGarbageCollectionNodeData = {
-                    outboundRoutes: [],
-                    unreferencedTimestampMs: Date.now() - (timeout + 100),
-                };
-                gcState.gcNodes[nodes[3]] = node3Data;
-
-                const gcBlobMap: Map<string, IGarbageCollectionState> = new Map([[gcBlobId, gcState]]);
-                const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
-
-                // Remove node 3's reference from node 2 so that it is still unreferenced.
-                defaultGCData.gcNodes[nodes[2]] = [];
-
-                // Run GC to trigger loading the GC details from the base summary. Will also generate Delete logs
-                await garbageCollector.collectGarbage({});
-                // Validate that the sweep ready event is logged when GC runs after load.
-                if (expectDeleteLogs) {
-                    mockLogger.assertMatch(
-                        [{ eventName: deleteEventName, timeout, id: nodes[3] }],
-                        "sweep ready event not generated as expected",
-                    );
-                } else {
-                    mockLogger.assertMatchNone([{ eventName: deleteEventName }], "Should not have any delete events logged");
-                }
-
-                // Validate that all events are logged as expected.
-                garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
-                garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
-                await garbageCollector.collectGarbage({});
-                mockLogger.assertMatch(
-                    [
-                        { eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
-                        { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
-                    ],
-                    "all events not generated as expected",
-                );
-
-                // Add reference from node 2 to node 3 and validate that revived event is logged.
-                garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
-                await garbageCollector.collectGarbage({});
-                mockLogger.assertMatch(
-                    [{ eventName: revivedEventName, timeout, id: nodes[3], pkg: eventPkg, fromId: nodes[2] }],
-                    "revived event not generated as expected",
-                );
-            });
-
-            /**
-             * Here, the base snapshot contains nodes that have timed out and the GC blob in snapshot is in old format. The
-             * test validates that we generate errors when these nodes are used.
-             */
-            it("generates events for nodes that time out on load - old snapshot format", async () => {
-                // Create GC details for node 3's GC blob whose unreferenced time was > timeout ms ago.
-                // This means this node should time out as soon as its data is loaded.
-                const node3GCDetails: IGarbageCollectionSummaryDetailsLegacy = {
-                    gcData: { gcNodes: { "/": [] } },
-                    unrefTimestamp: Date.now() - (timeout + 100),
-                };
-                const node3Snapshot = getDummySnapshotTree();
-                const gcBlobId = "node3GCDetails";
-                const attributesBlobId = "attributesBlob";
-                node3Snapshot.blobs[gcTreeKey] = gcBlobId;
-                node3Snapshot.blobs[dataStoreAttributesBlobName] = attributesBlobId;
-
-                // Create a base snapshot that contains snapshot tree of node 3.
-                const baseSnapshot = getDummySnapshotTree();
-                baseSnapshot.trees[nodes[3].slice(1)] = node3Snapshot;
-
-                // Set up the getNodeGCDetails function to return the GC details for node 3 when asked by garbage collector.
-                const gcBlobMap = new Map([
-                    [gcBlobId, node3GCDetails],
-                    [attributesBlobId, {}],
-                ]);
-                const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
-
-                // Remove node 3's reference from node 2 so that it is still unreferenced. The GC details from the base
-                // summary is not loaded until the first time GC is run, so do that immediately.
-                defaultGCData.gcNodes[nodes[2]] = [];
-                await garbageCollector.collectGarbage({});
-
-                // Validate that the sweep ready event is logged when GC runs after load.
-                if (expectDeleteLogs) {
-                    mockLogger.assertMatch(
-                        [{ eventName: deleteEventName, timeout, id: nodes[3] }],
-                        "sweep ready event not generated as expected",
-                    );
-                } else {
-                    mockLogger.assertMatchNone([{ eventName: deleteEventName }], "Should not have any delete events logged");
-                }
-
-                // Validate that all events are logged as expected.
-                garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
-                garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
-                await garbageCollector.collectGarbage({});
-                mockLogger.assertMatch(
-                    [
-                        { eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
-                        { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
-                    ],
-                    "all events not generated as expected",
-                );
-
-                // Add reference from node 2 to node 3 and validate that revived event is logged.
-                garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
-                await garbageCollector.collectGarbage({});
-                mockLogger.assertMatch(
-                    [{ eventName: revivedEventName, timeout, id: nodes[3], pkg: eventPkg, fromId: nodes[2] }],
-                    "revived event not generated as expected",
-                );
-            });
-
-            /**
-             * Here, the base snapshot contains nodes that have timed out and the GC data in snapshot is present in multiple
-             * blobs. The test validates that we generate errors when these nodes are used.
-             */
-            it(`generates events for nodes that time out on load - multi blob GC data`, async () => {
-                const gcBlobMap: Map<string, IGarbageCollectionState> = new Map();
-                const expiredTimestampMs = Date.now() - (timeout + 100);
-
-                // Create three GC states to be added into separate GC blobs. Each GC state has a node whose unreferenced
-                // time was > timeout ms ago. These three GC blobs are the added to the GC tree in summary.
-                const blob1Id = "blob1";
-                const blob1GCState: IGarbageCollectionState = { gcNodes: {} };
-                blob1GCState.gcNodes[nodes[1]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
-                gcBlobMap.set(blob1Id, blob1GCState);
-
-                const blob2Id = "blob2";
-                const blob2GCState: IGarbageCollectionState = { gcNodes: {} };
-                blob2GCState.gcNodes[nodes[2]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
-                gcBlobMap.set(blob2Id, blob2GCState);
-
-                const blob3Id = "blob3";
-                const blob3GCState: IGarbageCollectionState = { gcNodes: {} };
-                blob3GCState.gcNodes[nodes[3]] = { outboundRoutes: [], unreferencedTimestampMs: expiredTimestampMs };
-                gcBlobMap.set(blob3Id, blob3GCState);
-
-                // Create a GC snapshot tree and add the above three GC blob ids to it.
-                const gcSnapshotTree = getDummySnapshotTree();
-                gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob1Id}`] = blob1Id;
-                gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob2Id}`] = blob2Id;
-                gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob3Id}`] = blob3Id;
-
-                // Create a base snapshot that contains the above GC snapshot tree.
-                const baseSnapshot = getDummySnapshotTree();
-                baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
-
-                const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
-
-                // For the nodes in the GC snapshot blobs, remove their references from the default GC data.
-                defaultGCData.gcNodes[nodes[0]] = [];
-                defaultGCData.gcNodes[nodes[1]] = [];
-                defaultGCData.gcNodes[nodes[2]] = [];
-
-                await garbageCollector.collectGarbage({});
-                 // Validate that the sweep ready event is logged when GC runs after load.
-                 if (expectDeleteLogs) {
-                    mockLogger.assertMatch(
-                        [
-                            { eventName: deleteEventName, timeout, id: nodes[1] },
-                            { eventName: deleteEventName, timeout, id: nodes[2] },
-                            { eventName: deleteEventName, timeout, id: nodes[3] },
-                        ],
-                        "sweep ready event not generated as expected",
-                    );
-                } else {
-                    mockLogger.assertMatchNone([{ eventName: deleteEventName }], "Should not have any delete events logged");
-                }
-
-                // Validate that all events are logged as expected.
-                garbageCollector.nodeUpdated(nodes[1], "Changed", Date.now(), testPkgPath);
-                garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
-                garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
-                await garbageCollector.collectGarbage({});
-                mockLogger.assertMatch(
-                    [
-                        { eventName: changedEventName, timeout, id: nodes[1], pkg: eventPkg },
-                        { eventName: changedEventName, timeout, id: nodes[2], pkg: eventPkg },
-                        { eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
-                    ],
-                    "all events not generated as expected",
-                );
-            });
-        };
-
-        describe("Inactive events (summarizer container)", () => {
-            const inactiveTimeoutMs = 500;
-
-            beforeEach(() => {
-                injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = inactiveTimeoutMs;
-            });
-
-            summarizerContainerTests(
-                inactiveTimeoutMs,
-                "GarbageCollector:InactiveObject_Revived",
-                "GarbageCollector:InactiveObject_Changed",
-                "GarbageCollector:InactiveObject_Loaded",
-            );
-        });
-
-        describe("SweepReady events (summarizer container)", () => {
-            const sweepTimeoutMs = defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
-
-            beforeEach(() => {
-                injectedSettings[runSessionExpiryKey] = true;
-            });
-
-            summarizerContainerTests(
-                sweepTimeoutMs,
-                "GarbageCollector:SweepReadyObject_Revived",
-                "GarbageCollector:SweepReadyObject_Changed",
-                "GarbageCollector:SweepReadyObject_Loaded",
-                true, // expectDeleteLogs
-            );
-        });
-
-        describe("SweepReady events - Delete log disabled (summarizer container)", () => {
-            const sweepTimeoutMs = defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
-
-            beforeEach(() => {
-                injectedSettings[runSessionExpiryKey] = true;
-                injectedSettings[disableSweepLogKey] = true;
-            });
-
-            summarizerContainerTests(
-                sweepTimeoutMs,
-                "GarbageCollector:SweepReadyObject_Revived",
-                "GarbageCollector:SweepReadyObject_Changed",
-                "GarbageCollector:SweepReadyObject_Loaded",
-                false, // expectDeleteLogs
-            );
-        });
-
-        describe("Interactive Client Behavior", () => {
-            function updateAllNodes(garbageCollector) {
-                nodes.forEach((nodeId) => {
-                    garbageCollector.nodeUpdated(nodeId, "Changed", Date.now(), testPkgPath);
-                    garbageCollector.nodeUpdated(nodeId, "Loaded", Date.now(), testPkgPath);
-                });
-            }
-
-            async function interactiveClientTestCode(
-                timeout: number,
-                loadedEventName: string,
-                sweepReadyUsageErrorExpected: boolean,
-            ) {
-                let lastCloseErrorType: string = "N/A";
-
-                // Create GC state where node 3's unreferenced time was > timeout ms ago.
-                // This is important since we shouldn't run GC on the interactive container,
-                // but rather load from a snapshot in which SweepReady state is already reached.
-
-                // Create a snapshot tree to be used as the GC snapshot tree.
-                const gcSnapshotTree = getDummySnapshotTree();
-                const gcBlobId = "root";
-                // Add a GC blob with key that start with `gcBlobPrefix` to the GC snapshot tree. The blob Id for this
-                // is generated by server in real scenarios but we use a static id here for testing.
-                gcSnapshotTree.blobs[`${gcBlobPrefix}_${gcBlobId}`] = gcBlobId;
-
-                // Create a base snapshot that contains the GC snapshot tree.
-                const baseSnapshot = getDummySnapshotTree();
-                baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
-
-                // Create GC state with node 3 expired. This will be returned when the garbage collector asks
-                // for the GC blob with `gcBlobId`.
-                const gcState: IGarbageCollectionState = { gcNodes: {} };
-                const unrefTime = Date.now() - (timeout + 100);
-                const node3Data: IGarbageCollectionNodeData = {
-                    outboundRoutes: [],
-                    unreferencedTimestampMs: unrefTime,
-                };
-                gcState.gcNodes[nodes[3]] = node3Data;
-
-                const gcBlobMap: Map<string, IGarbageCollectionState> = new Map([[gcBlobId, gcState]]);
-                const garbageCollector = createGarbageCollector(
-                    { baseSnapshot },
-                    gcBlobMap,
-                    (error) => { lastCloseErrorType = error?.errorType ?? "NONE"; },
-                    false /* isSummarizerClient */,
-                );
-
-                // Trigger loading GC state from base snapshot - but don't call GC since that's not what happens in real flow
-                await (garbageCollector as any).initializeGCStateFromBaseSnapshotP;
-
-                // Update nodes and validate that all events for node 3 are logged.
-                updateAllNodes(garbageCollector);
-                assert(!mockLogger.events.some((event) => event.eventName !== loadedEventName && event.unrefTime === unrefTime), "shouldn't see any unreference events besides Loaded");
-                mockLogger.assertMatch([{ eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg, unrefTime }], "all events not generated as expected");
-
-                const expectedErrorType = sweepReadyUsageErrorExpected ? "unreferencedObjectUsedAfterGarbageCollected" : "N/A";
-                assert.equal(lastCloseErrorType, expectedErrorType, "Incorrect lastCloseReason after using unreferenced nodes");
-            }
-
-            beforeEach(() => {
-                injectedSettings[runSessionExpiryKey] = true;
-            });
-
-            it("Inactive object used - generates events but does not close container (SweepReadyUsageDetection enabled)", async () => {
-                const inactiveTimeoutMs = 400;
-                injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = inactiveTimeoutMs;
-                injectedSettings[SweepReadyUsageDetectionKey] = "interactiveClient";
-
-                await interactiveClientTestCode(
-                    inactiveTimeoutMs,
-                    "GarbageCollector:InactiveObject_Loaded",
-                    false,
-                );
-            });
-
-            it("SweepReady object used - generates events and closes container (SweepReadyUsageDetection enabled)", async () => {
-                const sweepTimeoutMs = defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
-                injectedSettings[SweepReadyUsageDetectionKey] = "interactiveClient";
-
-                await interactiveClientTestCode(
-                    sweepTimeoutMs,
-                    "GarbageCollector:SweepReadyObject_Loaded",
-                    true,
-                );
-            });
-
-            it("SweepReady object used - generates events but does not close container (SweepReadyUsageDetection disabled)", async () => {
-                const sweepTimeoutMs = defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
-                injectedSettings[SweepReadyUsageDetectionKey] = "something else";
-
-                await interactiveClientTestCode(
-                    sweepTimeoutMs,
-                    "GarbageCollector:SweepReadyObject_Loaded",
-                    false,
-                );
-            });
-        });
-
-        it("generates both inactive and sweep ready events when nodes are used after time out", async () => {
-            const inactiveTimeoutMs = 500;
-            const sweepTimeoutMs = defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
-            injectedSettings[runSessionExpiryKey] = "true";
-            injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = inactiveTimeoutMs;
-
-            const garbageCollector = createGarbageCollector({});
-
-            // Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
-            defaultGCData.gcNodes[nodes[1]] = [];
-            await garbageCollector.collectGarbage({});
-
-            // Advance the clock to trigger inactive timeout and validate that we get inactive events.
-            clock.tick(inactiveTimeoutMs + 1);
-            await updateAllNodesAndRunGC(garbageCollector);
-            mockLogger.assertMatch(
-                [
-                    { eventName: "GarbageCollector:InactiveObject_Changed", timeout: inactiveTimeoutMs, id: nodes[2] },
-                    { eventName: "GarbageCollector:InactiveObject_Loaded", timeout: inactiveTimeoutMs, id: nodes[2] },
-                    { eventName: "GarbageCollector:InactiveObject_Changed", timeout: inactiveTimeoutMs, id: nodes[3] },
-                    { eventName: "GarbageCollector:InactiveObject_Loaded", timeout: inactiveTimeoutMs, id: nodes[3] },
-                ],
-                "inactive events not generated as expected",
-            );
-
-            // Advance the clock to trigger sweep timeout and validate that we get sweep ready events.
-            clock.tick(sweepTimeoutMs - inactiveTimeoutMs);
-            await updateAllNodesAndRunGC(garbageCollector);
-            mockLogger.assertMatch(
-                [
-                    { eventName: "GarbageCollector:SweepReadyObject_Changed", timeout: sweepTimeoutMs, id: nodes[2] },
-                    { eventName: "GarbageCollector:SweepReadyObject_Loaded", timeout: sweepTimeoutMs, id: nodes[2] },
-                    { eventName: "GarbageCollector:SweepReadyObject_Changed", timeout: sweepTimeoutMs, id: nodes[3] },
-                    { eventName: "GarbageCollector:SweepReadyObject_Loaded", timeout: sweepTimeoutMs, id: nodes[3] },
-                ],
-                "sweep ready events not generated as expected",
-            );
-        });
-    });
-
-    describe("Deleted blobs in GC summary tree", () => {
-        beforeEach(() => {
-            injectedSettings["Fluid.GarbageCollection.TrackGCState"] = true;
-        });
-
-        it("correctly reads and write deleted blobs in summary", async () => {
-            // Set up the GC reference graph to have something to work with.
-            defaultGCData.gcNodes["/"] = [nodes[0]];
-
-            // Create a snapshot tree to be used as the GC snapshot tree.
-            const gcSnapshotTree = getDummySnapshotTree();
-            // Add a blob to the tree for deleted nodes.
-            const deletedNodesBlobId = "deletedNodes";
-            gcSnapshotTree.blobs[gcDeletedBlobKey] = deletedNodesBlobId;
-            const deletedNodeIds = [...nodes];
-            // Add deleted nodes list the blobs map that will service read and parse blob calls from GC.
-            const gcBlobsMap: Map<string, string[]> = new Map([[deletedNodesBlobId, deletedNodeIds]]);
-            // Create a base snapshot that contains the GC snapshot tree.
-            const baseSnapshot = getDummySnapshotTree();
-            baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
-
-            // Create and initialize garbage collector.
-            const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobsMap);
-            await garbageCollector.initializeBaseState();
-
-            // The nodes in deletedNodeIds should be marked as deleted.
-            for (const nodeId of deletedNodeIds) {
-                assert(garbageCollector.isNodeDeleted(nodeId) === true, `${nodeId} should be marked deleted`);
-            }
-
-            await garbageCollector.collectGarbage({});
-            // Summarize with fullTree as true so that the deleted nodes are written as a blob and can be validated.
-            const summaryTree = garbageCollector.summarize(true /* fullTree */, true /* trackState */);
-            assert(summaryTree?.summary.type === SummaryType.Tree, "The summary should be a tree");
-
-            // Get the deleted node ids from summary and validate that its the same as the one GC loaded from.
-            const deletedNodesBlob = summaryTree.summary.tree[gcDeletedBlobKey];
-            assert(deletedNodesBlob.type === SummaryType.Blob, "Deleted blob not present in summary");
-            const deletedNodeIdsInSummary = JSON.parse(deletedNodesBlob.content as string) as string[];
-            assert.deepStrictEqual(deletedNodeIdsInSummary, deletedNodeIds, "Unexpected deleted nodes in summary");
-        });
-
-        it("writes handle for deleted blobs when its unchanged", async () => {
-            // Set up the GC reference graph to have something to work with.
-            defaultGCData.gcNodes["/"] = [nodes[0]];
-
-            // Create a snapshot tree to be used as the GC snapshot tree.
-            const gcSnapshotTree = getDummySnapshotTree();
-            // Add a blob to the tree for deleted nodes.
-            const deletedNodesBlobId = "deletedNodes";
-            gcSnapshotTree.blobs[gcDeletedBlobKey] = deletedNodesBlobId;
-            const deletedNodeIds = [...nodes];
-            // Add deleted nodes list the blobs map that will service read and parse blob calls from GC.
-            const gcBlobsMap: Map<string, string[]> = new Map([[deletedNodesBlobId, deletedNodeIds]]);
-            // Create a base snapshot that contains the GC snapshot tree.
-            const baseSnapshot = getDummySnapshotTree();
-            baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
-
-            // Create and initialize garbage collector.
-            const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobsMap);
-            await garbageCollector.initializeBaseState();
-
-            // Run GC and summarize. The summary should contain the deleted nodes.
-            await garbageCollector.collectGarbage({});
-            const gcSummary = garbageCollector.summarize(false /* fullTree */, true /* trackState */);
-            assert(gcSummary?.summary.type === SummaryType.Tree, "The summary should be a tree");
-
-            // Get the deleted node ids from summary and validate that its the same as the one GC loaded from.
-            const deletedNodesBlob = gcSummary.summary.tree[gcDeletedBlobKey];
-            assert(deletedNodesBlob.type === SummaryType.Handle, "Deleted nodes state should be a handle");
-
-            const refreshSummaryResult: RefreshSummaryResult = { latestSummaryUpdated: true, wasSummaryTracked: true};
-            await garbageCollector.refreshLatestSummary(refreshSummaryResult, undefined, 0, parseNothing);
-
-            // Run GC and summarize again. The whole GC summary should now be a summary handle.
-            await garbageCollector.collectGarbage({});
-            const gcSummary2 = garbageCollector.summarize(false /* fullTree */, true /* trackState */);
-            assert(gcSummary2?.summary.type === SummaryType.Handle, "The summary should be a handle");
-        });
-    });
-
-    describe("GC completed runs", () => {
-        const gcEndEvent = "GarbageCollector:GarbageCollection_end";
-
-        it("increments GC completed runs in logged events correctly", async () => {
-            const garbageCollector = createGarbageCollector();
-
-            await garbageCollector.collectGarbage({});
-            mockLogger.assertMatch(
-                [{ eventName: gcEndEvent, completedGCRuns: 0 }],
-                "completedGCRuns should be 0 since this event was logged before first GC run completed",
-            );
-
-            await garbageCollector.collectGarbage({});
-            mockLogger.assertMatch(
-                [{ eventName: gcEndEvent, completedGCRuns: 1 }],
-                "completedGCRuns should be 1 since this event was logged after first GC run completed",
-            );
-
-            await garbageCollector.collectGarbage({});
-            mockLogger.assertMatch(
-                [{ eventName: gcEndEvent, completedGCRuns: 2 }],
-                "completedGCRuns should be 2 since this event was logged after second GC run completed",
-            );
-
-            // The GC run count should reset for new garbage collector.
-            const garbageCollector2 = createGarbageCollector();
-            await garbageCollector2.collectGarbage({});
-            mockLogger.assertMatch(
-                [{ eventName: gcEndEvent, completedGCRuns: 0 }],
-                "completedGCRuns should be 0 since this event was logged before first GC run in new garbage collector",
-            );
-        });
-    });
-
-    /*
-     * These tests validate scenarios where nodes that are referenced between summaries have their unreferenced
-     * timestamp updated. These scenarios fall into the following categories:
-     * 1. Nodes transition from unreferenced -> referenced -> unreferenced between 2 summaries - In these scenarios
-     *    when GC runs, it should detect that the node was referenced and update its unreferenced timestamp.
-     * 2. Unreferenced nodes are referenced from other unreferenced nodes - In this case, even though the node remains
-     *    unreferenced, its unreferenced timestamp should be updated.
-     *
-     * In these tests, V = nodes and E = edges between nodes. Root nodes that are always referenced are marked as *.
-     */
-    describe("References between summaries", () => {
-        let garbageCollector: IGarbageCollector;
-        const nodeA = "/A";
-        const nodeB = "/B";
-        const nodeC = "/C";
-        const nodeD = "/D";
-        const nodeE = "/A/E";
-
-        // Runs GC and returns the unreferenced timestamps of all nodes in the GC summary.
-        async function getUnreferencedTimestamps() {
-            // Advance the clock by 1 tick so that the unreferenced timestamp is updated in between runs.
-            clock.tick(1);
-
-            await garbageCollector.collectGarbage({});
-
-            const summaryTree = garbageCollector.summarize(true, false)?.summary;
-            assert(summaryTree !== undefined, "Nothing to summarize after running GC");
-            assert(summaryTree.type === SummaryType.Tree, "Expecting a summary tree!");
-
-            let rootGCState: IGarbageCollectionState = { gcNodes: {} };
-            for (const key of Object.keys(summaryTree.tree)) {
-                // Skip blobs that do not start with the GC prefix.
-                if (!key.startsWith(gcBlobPrefix)) {
-                    continue;
-                }
-
-                const gcBlob = summaryTree.tree[key];
-                assert(gcBlob?.type === SummaryType.Blob, `GC blob not available`);
-                const gcState = JSON.parse(gcBlob.content as string) as IGarbageCollectionState;
-                // Merge the GC state of this blob into the root GC state.
-                rootGCState = concatGarbageCollectionStates(rootGCState, gcState);
-            }
-            const nodeTimestamps: Map<string, number | undefined> = new Map();
-            for (const [nodeId, nodeData] of Object.entries(rootGCState.gcNodes)) {
-                nodeTimestamps.set(nodeId, nodeData.unreferencedTimestampMs);
-            }
-            return nodeTimestamps;
-        }
-
-        beforeEach(() => {
-            defaultGCData.gcNodes = {};
-            garbageCollector = createGarbageCollector();
-        });
-
-        describe("Nodes transitioning from unreferenced -> referenced -> unreferenced", () => {
-            /**
-             * Validates that we can detect references that were added and then removed.
-             * 1. Summary 1 at t1. V = [A*, B]. E = []. B has unreferenced time t1.
-             * 2. Reference from A to B added. E = [A -\> B].
-             * 3. Reference from A to B removed. E = [].
-             * 4. Summary 2 at t2. V = [A*, B]. E = []. B has unreferenced time t2.
-             * Validates that the unreferenced time for B is t2 which is \> t1.
-             */
-            it(`Scenario 1 - Reference added and then removed`, async () => {
-                // Initialize nodes A and B.
-                defaultGCData.gcNodes["/"] = [nodeA];
-                defaultGCData.gcNodes[nodeA] = [];
-                defaultGCData.gcNodes[nodeB] = [];
-
-                // 1. Run GC and generate summary 1. E = [].
-                const timestamps1 = await getUnreferencedTimestamps();
-                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeBTime1 = timestamps1.get(nodeB);
-                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-
-                // 2. Add reference from A to B. E = [A -\> B].
-                garbageCollector.addedOutboundReference(nodeA, nodeB);
-                defaultGCData.gcNodes[nodeA] = [nodeB];
-
-                // 3. Remove reference from A to B. E = [].
-                defaultGCData.gcNodes[nodeA] = [];
-
-                // 4. Run GC and generate summary 2. E = [].
-                const timestamps2 = await getUnreferencedTimestamps();
-                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeBTime2 = timestamps2.get(nodeB);
-
-                assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
-            });
-
-            /**
-             * Validates that we can detect references that were added transitively and then removed.
-             * 1. Summary 1 at t1. V = [A*, B, C]. E = [B -\> C]. B and C have unreferenced time t2.
-             * 2. Reference from A to B added. E = [A -\> B, B -\> C].
-             * 3. Reference from B to C removed. E = [A -\> B].
-             * 4. Reference from A to B removed. E = [].
-             * 5. Summary 2 at t2. V = [A*, B, C]. E = []. B and C have unreferenced time t2.
-             * Validates that the unreferenced time for B and C is t2 which is \> t1.
-             */
-            it(`Scenario 2 - Reference transitively added and removed`, async () => {
-                // Initialize nodes A, B and C.
-                defaultGCData.gcNodes["/"] = [nodeA];
-                defaultGCData.gcNodes[nodeA] = [];
-                defaultGCData.gcNodes[nodeB] = [nodeC];
-                defaultGCData.gcNodes[nodeC] = [];
-
-                // 1. Run GC and generate summary 1. E = [B -\> C].
-                const timestamps1 = await getUnreferencedTimestamps();
-                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeBTime1 = timestamps1.get(nodeB);
-                const nodeCTime1 = timestamps1.get(nodeC);
-                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-
-                // 2. Add reference from A to B. E = [A -\> B, B -\> C].
-                garbageCollector.addedOutboundReference(nodeA, nodeB);
-                defaultGCData.gcNodes[nodeA] = [nodeB];
-
-                // 3. Remove reference from B to C. E = [A -\> B].
-                defaultGCData.gcNodes[nodeB] = [];
-
-                // 4. Remove reference from A to B. E = [].
-                defaultGCData.gcNodes[nodeA] = [];
-
-                // 5. Run GC and generate summary 2. E = [].
-                const timestamps2 = await getUnreferencedTimestamps();
-                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeBTime2 = timestamps2.get(nodeB);
-                const nodeCTime2 = timestamps2.get(nodeC);
-                assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
-                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
-            });
-
-            /**
-             * Validates that we can detect chain of references in which the first reference was added and then removed.
-             * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [B -\> C, C -\> D]. B, C and D have unreferenced time t2.
-             * 2. Reference from A to B added. E = [A -\> B, B -\> C, C -\> D].
-             * 3. Reference from A to B removed. E = [B -\> C, C -\> D].
-             * 4. Summary 2 at t2. V = [A*, B, C, D]. E = [B -\> C, C -\> D]. B, C and D have unreferenced time t2.
-             * Validates that the unreferenced time for B, C and D is t2 which is \> t1.
-             */
-            it(`Scenario 3 - Reference added through chain of references and removed`, async () => {
-                // Initialize nodes A, B, C and D.
-                defaultGCData.gcNodes["/"] = [nodeA];
-                defaultGCData.gcNodes[nodeA] = [];
-                defaultGCData.gcNodes[nodeB] = [nodeC];
-                defaultGCData.gcNodes[nodeC] = [nodeD];
-                defaultGCData.gcNodes[nodeD] = [];
-
-                // 1. Run GC and generate summary 1. E = [B -\> C, C -\> D].
-                const timestamps1 = await getUnreferencedTimestamps();
-                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeBTime1 = timestamps1.get(nodeB);
-                const nodeCTime1 = timestamps1.get(nodeC);
-                const nodeDTime1 = timestamps1.get(nodeD);
-                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-                assert(nodeDTime1 !== undefined, "D should have unreferenced timestamp");
-
-                // 2. Add reference from A to B. E = [A -\> B, B -\> C, C -\> D].
-                garbageCollector.addedOutboundReference(nodeA, nodeB);
-                defaultGCData.gcNodes[nodeA] = [nodeB];
-
-                // 3. Remove reference from A to B. E = [B -\> C, C -\> D].
-                defaultGCData.gcNodes[nodeA] = [];
-
-                // 4. Run GC and generate summary 2. E = [B -\> C, C -\> D].
-                const timestamps2 = await getUnreferencedTimestamps();
-                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeBTime2 = timestamps2.get(nodeB);
-                const nodeCTime2 = timestamps2.get(nodeC);
-                const nodeDTime2 = timestamps2.get(nodeD);
-                assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
-                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
-                assert(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
-            });
-
-            /**
-             * Validates that we can detect references that were added and removed via new nodes.
-             * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
-             * 2. Node B is created. E = [].
-             * 3. Reference from A to B added. E = [A -\> B].
-             * 4. Reference from B to C added. E = [A -\> B, B -\> C].
-             * 5. Reference from B to C removed. E = [A -\> B].
-             * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -\> B]. C has unreferenced time t2.
-             * Validates that the unreferenced time for C is t2 which is \> t1.
-             */
-            it(`Scenario 4 - Reference added via new nodes and removed`, async () => {
-                // Initialize nodes A, B and C.
-                defaultGCData.gcNodes["/"] = [nodeA];
-                defaultGCData.gcNodes[nodeA] = [];
-                defaultGCData.gcNodes[nodeC] = [];
-
-                // 1. Run GC and generate summary 1. E = [].
-                const timestamps1 = await getUnreferencedTimestamps();
-                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeCTime1 = timestamps1.get(nodeC);
-                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-
-                // 2. Create node B, i.e., add B to GC data. E = [].
-                defaultGCData.gcNodes[nodeB] = [];
-
-                // 3. Add reference from A to B. E = [A -\> B].
-                garbageCollector.addedOutboundReference(nodeA, nodeB);
-                defaultGCData.gcNodes[nodeA] = [nodeB];
-
-                // 4. Add reference from B to C. E = [A -\> B, B -\> C].
-                garbageCollector.addedOutboundReference(nodeB, nodeC);
-                defaultGCData.gcNodes[nodeB] = [nodeC];
-
-                // 5. Remove reference from B to C. E = [A -\> B].
-                defaultGCData.gcNodes[nodeB] = [];
-
-                // 6. Run GC and generate summary 2. E = [A -\> B].
-                const timestamps2 = await getUnreferencedTimestamps();
-                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-                assert(timestamps2.get(nodeB) === undefined, "B should be referenced");
-
-                const nodeCTime2 = timestamps2.get(nodeC);
-                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
-            });
-
-            /**
-             * Validates that we can detect multiple references that were added and then removed by the same node.
-             * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
-             * 2. Reference from A to B added. E = [A -\> B].
-             * 3. Reference from A to C added. E = [A -\> B, A -\> C].
-             * 4. Reference from A to B removed. E = [A -\> C].
-             * 5. Reference from A to C removed. E = [].
-             * 6. Summary 2 at t2. V = [A*, B]. E = []. B and C have unreferenced time t2.
-             * Validates that the unreferenced time for B and C is t2 which is \> t1.
-             */
-            it(`Scenario 5 - Multiple references added and then removed by same node`, async () => {
-                // Initialize nodes A, B and C.
-                defaultGCData.gcNodes["/"] = [nodeA];
-                defaultGCData.gcNodes[nodeA] = [];
-                defaultGCData.gcNodes[nodeB] = [];
-                defaultGCData.gcNodes[nodeC] = [];
-
-                // 1. Run GC and generate summary 1. E = [].
-                const timestamps1 = await getUnreferencedTimestamps();
-                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeBTime1 = timestamps1.get(nodeB);
-                const nodeCTime1 = timestamps1.get(nodeC);
-                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-
-                // 2. Add reference from A to B. E = [A -\> B].
-                garbageCollector.addedOutboundReference(nodeA, nodeB);
-                defaultGCData.gcNodes[nodeA] = [nodeB];
-
-                // 3. Add reference from A to C. E = [A -\> B, A -\> C].
-                garbageCollector.addedOutboundReference(nodeA, nodeC);
-                defaultGCData.gcNodes[nodeA] = [nodeB, nodeC];
-
-                // 4. Remove reference from A to B. E = [A -\> C].
-                defaultGCData.gcNodes[nodeA] = [nodeC];
-
-                // 5. Remove reference from A to C. E = [].
-                defaultGCData.gcNodes[nodeA] = [];
-
-                // 6. Run GC and generate summary 2. E = [].
-                const timestamps2 = await getUnreferencedTimestamps();
-                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeBTime2 = timestamps2.get(nodeB);
-                const nodeCTime2 = timestamps2.get(nodeC);
-                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
-                assert(nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1, "B's timestamp should have updated");
-            });
-
-            /**
-             * Validates that we generate error on detecting reference during GC that was not notified explicitly.
-             * 1. Summary 1 at t1. V = [A*]. E = [].
-             * 2. Node B is created. E = [].
-             * 3. Reference from A to B added without notifying GC. E = [A -\> B].
-             * 4. Summary 2 at t2. V = [A*, B]. E = [A -\> B].
-             * Validates that we log an error since B is detected as a referenced node but its reference was notified
-             * to GC.
-             */
-            it(`Scenario 6 - Reference added without notifying GC`, async () => {
-                // Initialize nodes A & D.
-                defaultGCData.gcNodes["/"] = [nodeA, nodeD];
-                defaultGCData.gcNodes[nodeA] = [];
-                defaultGCData.gcNodes[nodeD] = [];
-
-                // 1. Run GC and generate summary 1. E = [].
-                const timestamps1 = await getUnreferencedTimestamps();
-                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-                assert(timestamps1.get(nodeD) === undefined, "D should be referenced");
-
-                // 2. Create nodes B & C. E = [].
-                defaultGCData.gcNodes[nodeB] = [];
-                defaultGCData.gcNodes[nodeC] = [];
-
-                // 3. Add reference from A to B, A to C, A to E, D to C, and E to A without calling addedOutboundReference.
-                // E = [A -\> B, A -\> C, A -\> E, D -\> C, E -\> A].
-                defaultGCData.gcNodes[nodeA] = [nodeB, nodeC, nodeE];
-                defaultGCData.gcNodes[nodeD] = [nodeC];
-                defaultGCData.gcNodes[nodeE] = [nodeA];
-
-                // 4. Add reference from A to D with calling addedOutboundReference
-                defaultGCData.gcNodes[nodeA].push(nodeD);
-                garbageCollector.addedOutboundReference(nodeA, nodeD);
-
-                // 5. Run GC and generate summary 2. E = [A -\> B, A -\> C, A -\> E, D -\> C, E -\> A].
-                await getUnreferencedTimestamps();
-
-                // Validate that we got the "gcUnknownOutboundReferences" error.
-                const unknownReferencesEvent = "GarbageCollector:gcUnknownOutboundReferences";
-                const eventsFound = mockLogger.matchEvents([
-                    {
-                        eventName: unknownReferencesEvent,
-                        gcNodeId: "/A",
-                        gcRoutes: JSON.stringify(["/B", "/C"]),
-                    },
-                    {
-                        eventName: unknownReferencesEvent,
-                        gcNodeId: "/D",
-                        gcRoutes: JSON.stringify(["/C"]),
-                    },
-                ]);
-                assert(eventsFound, `Expected unknownReferenceEvent event!`);
-            });
-        });
-
-        describe("References to unreferenced nodes", () => {
-            /**
-             * Validates that we can detect references that are added from an unreferenced node to another.
-             * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
-             * 2. Reference from B to C. E = [B -\> C].
-             * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -\> C]. B and C have unreferenced time t1.
-             * Validates that the unreferenced time for B and C is still t1.
-             */
-             it(`Scenario 1 - Reference added to unreferenced node`, async () => {
-                // Initialize nodes A, B and C.
-                defaultGCData.gcNodes["/"] = [nodeA];
-                defaultGCData.gcNodes[nodeA] = [];
-                defaultGCData.gcNodes[nodeB] = [];
-                defaultGCData.gcNodes[nodeC] = [];
-
-                // 1. Run GC and generate summary 1. E = [B -\> C].
-                const timestamps1 = await getUnreferencedTimestamps();
-                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeBTime1 = timestamps1.get(nodeB);
-                const nodeCTime1 = timestamps1.get(nodeC);
-                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-
-                // 2. Add reference from B to C. E = [B -\> C].
-                garbageCollector.addedOutboundReference(nodeB, nodeC);
-                defaultGCData.gcNodes[nodeB] = [nodeC];
-
-                // 3. Run GC and generate summary 2. E = [B -\> C].
-                const timestamps2 = await getUnreferencedTimestamps();
-                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeBTime2 = timestamps2.get(nodeB);
-                const nodeCTime2 = timestamps2.get(nodeC);
-                assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
-                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
-            });
-
-            /*
-             * Validates that we can detect references that are added from an unreferenced node to a list of
-             * unreferenced nodes, i.e., nodes with references to each other but are overall unreferenced.
-             * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [C -\> D]. B, C and D have unreferenced time t1.
-             * 2. Op adds reference from B to C. E = [B -\> C, C -\> D].
-             * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -\> C, C -\> D]. C and D have unreferenced time t2.
-             * Validates that the unreferenced time for C and D is t2 which is > t1.
-             */
-            it(`Scenario 2 - Reference added to a list of unreferenced nodes from an unreferenced node`, async () => {
-                // Initialize nodes A, B and C.
-                defaultGCData.gcNodes["/"] = [nodeA];
-                defaultGCData.gcNodes[nodeA] = [];
-                defaultGCData.gcNodes[nodeB] = [];
-                defaultGCData.gcNodes[nodeC] = [nodeD];
-                defaultGCData.gcNodes[nodeD] = [];
-
-                // 1. Run GC and generate summary 1. E = [B -\> C].
-                const timestamps1 = await getUnreferencedTimestamps();
-                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeBTime1 = timestamps1.get(nodeB);
-                const nodeCTime1 = timestamps1.get(nodeC);
-                const nodeDTime1 = timestamps1.get(nodeC);
-                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-                assert(nodeDTime1 !== undefined, "C should have unreferenced timestamp");
-
-                // 2. Add reference from B to C. E = [B -\> C, C-\> D].
-                garbageCollector.addedOutboundReference(nodeB, nodeC);
-                defaultGCData.gcNodes[nodeB] = [nodeC];
-
-                // 3. Run GC and generate summary 2. E = [B -\> C. C -\> D].
-                const timestamps2 = await getUnreferencedTimestamps();
-                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeBTime2 = timestamps2.get(nodeB);
-                const nodeCTime2 = timestamps2.get(nodeC);
-                const nodeDTime2 = timestamps2.get(nodeD);
-                assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
-                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
-                assert(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
-            });
-
-            /*
-             * Validates that we can detect references that are added from an unreferenced node to a list of
-             * unreferenced nodes, i.e., nodes with references to each other but are overall unreferenced. Then
-             * a reference between the list is removed
-             * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [C -> D]. B, C and D have unreferenced time t1.
-             * 2. Op adds reference from B to C. E = [B -> C, C -> D].
-             * 3. Op removes reference from C to D. E = [B -> C].
-             * 4. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. C and D have unreferenced time t2.
-             * Validates that the unreferenced time for C and D is t2 which is > t1.
-             */
-            it(`Scenario 3 - Reference added to a list of unreferenced nodes and a reference is removed`, async () => {
-                // Initialize nodes A, B and C.
-                defaultGCData.gcNodes["/"] = [nodeA];
-                defaultGCData.gcNodes[nodeA] = [];
-                defaultGCData.gcNodes[nodeB] = [];
-                defaultGCData.gcNodes[nodeC] = [nodeD];
-                defaultGCData.gcNodes[nodeD] = [];
-
-                // 1. Run GC and generate summary 1. E = [B -\> C].
-                const timestamps1 = await getUnreferencedTimestamps();
-                assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeBTime1 = timestamps1.get(nodeB);
-                const nodeCTime1 = timestamps1.get(nodeC);
-                const nodeDTime1 = timestamps1.get(nodeC);
-                assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
-                assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
-                assert(nodeDTime1 !== undefined, "C should have unreferenced timestamp");
-
-                // 2. Add reference from B to C. E = [B -\> C, C-\> D].
-                garbageCollector.addedOutboundReference(nodeB, nodeC);
-                defaultGCData.gcNodes[nodeB] = [nodeC];
-
-                // 3. Remove reference from C to D. E = [B -\> C].
-                defaultGCData.gcNodes[nodeC] = [];
-
-                // 3. Run GC and generate summary 2. E = [B -\> C].
-                const timestamps2 = await getUnreferencedTimestamps();
-                assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
-
-                const nodeBTime2 = timestamps2.get(nodeB);
-                const nodeCTime2 = timestamps2.get(nodeC);
-                const nodeDTime2 = timestamps2.get(nodeD);
-                assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
-                assert(nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1, "C's timestamp should have updated");
-                assert(nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1, "D's timestamp should have updated");
-            });
-        });
-    });
-
-    describe("No changes to GC between summaries", () => {
-        const fullTree = false;
-        const trackState = true;
-        let garbageCollector: IGarbageCollector;
-
-        beforeEach(() => {
-            injectedSettings["Fluid.GarbageCollection.TrackGCState"] = true;
-            // Initialize nodes A & D.
-            defaultGCData.gcNodes = {};
-            defaultGCData.gcNodes["/"] = nodes;
-        });
-
-        const checkGCSummaryType = (
-            summary: ISummarizeResult | undefined,
-            expectedBlobType: SummaryType,
-            summaryNumber: string,
-        ) => {
-            assert(summary !== undefined, `Expected a summary on ${summaryNumber} summarize`);
-            assert(
-                summary.summary.type === expectedBlobType,
-                `Expected summary type ${expectedBlobType} on ${summaryNumber} summarize, got ${summary.summary.type}`,
-            );
-        };
-
-        it("creates a blob handle when no version specified", async () => {
-            garbageCollector = createGarbageCollector();
-
-            await garbageCollector.collectGarbage({});
-            const tree1 = garbageCollector.summarize(fullTree, trackState);
-
-            checkGCSummaryType(tree1, SummaryType.Tree, "first");
-
-            await garbageCollector.refreshLatestSummary(
-                { wasSummaryTracked: true, latestSummaryUpdated: true },
-                undefined,
-                0,
-                parseNothing,
-            );
-
-            await garbageCollector.collectGarbage({});
-            const tree2 = garbageCollector.summarize(fullTree, trackState);
-
-            checkGCSummaryType(tree2, SummaryType.Handle, "second");
-        });
-    });
+			it("sweepEnabled false", () => {
+				gc = createGcWithPrivateMembers({ sweepEnabled: false });
+				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+			});
+			it("sessionExpiryTimeoutMs set (sweepTimeoutMs unset)", () => {
+				gc = createGcWithPrivateMembers({
+					sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
+				});
+				assert.equal(
+					gc.sessionExpiryTimeoutMs,
+					customSessionExpiryDurationMs,
+					"sessionExpiryTimeoutMs incorrect",
+				);
+				assert.equal(
+					gc.sweepTimeoutMs,
+					customSessionExpiryDurationMs + 6 * oneDayMs,
+					"sweepTimeoutMs incorrect",
+				);
+			});
+			it("sweepTimeoutMs set", () => {
+				gc = createGcWithPrivateMembers({ sweepTimeoutMs: 123 });
+				assert.equal(gc.sweepTimeoutMs, 123, "sweepTimeoutMs incorrect");
+			});
+			it("Metadata Roundtrip", () => {
+				const inputMetadata: IGCMetadata = {
+					sweepEnabled: true,
+					gcFeature: 1,
+					sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
+					sweepTimeoutMs: 123,
+				};
+				gc = createGcWithPrivateMembers(inputMetadata);
+				const outputMetadata = gc.getMetadata();
+				const expectedOutputMetadata: IGCMetadata = {
+					...inputMetadata,
+					gcFeature: stableGCVersion,
+				};
+				assert.deepEqual(
+					outputMetadata,
+					expectedOutputMetadata,
+					"getMetadata returned different metadata than loaded from",
+				);
+			});
+			it("Metadata Roundtrip with GC version upgrade to v2 enabled", () => {
+				injectedSettings[gcVersionUpgradeToV2Key] = true;
+				const inputMetadata: IGCMetadata = {
+					sweepEnabled: true,
+					gcFeature: 1,
+					sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
+					sweepTimeoutMs: 123,
+				};
+				gc = createGcWithPrivateMembers(inputMetadata);
+				const outputMetadata = gc.getMetadata();
+				const expectedOutputMetadata: IGCMetadata = {
+					...inputMetadata,
+					gcFeature: currentGCVersion,
+				};
+				assert.deepEqual(
+					outputMetadata,
+					expectedOutputMetadata,
+					"getMetadata returned different metadata than loaded from",
+				);
+			});
+		});
+
+		describe("New Container", () => {
+			it("No options", () => {
+				injectedSettings[runSessionExpiryKey] = true;
+				gc = createGcWithPrivateMembers(undefined /* metadata */, {});
+				assert(gc.gcEnabled, "gcEnabled incorrect");
+				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+				assert(gc.sessionExpiryTimeoutMs !== undefined, "sessionExpiryTimeoutMs incorrect");
+				assert(gc.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
+				assert.equal(
+					gc.latestSummaryGCVersion,
+					stableGCVersion,
+					"latestSummaryGCVersion incorrect",
+				);
+			});
+			it("gcAllowed true", () => {
+				gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: true });
+				assert(gc.gcEnabled, "gcEnabled incorrect");
+			});
+			it("gcAllowed false", () => {
+				gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: false });
+				assert(!gc.gcEnabled, "gcEnabled incorrect");
+			});
+			it("sweepAllowed true, gcAllowed false", () => {
+				assert.throws(
+					() => {
+						gc = createGcWithPrivateMembers(undefined /* metadata */, {
+							gcAllowed: false,
+							sweepAllowed: true,
+						});
+					},
+					(e) => e.errorType === "usageError",
+					"Should be unsupported",
+				);
+			});
+			it("sweepAllowed true, gcAllowed true", () => {
+				injectedSettings[runSessionExpiryKey] = true;
+				gc = createGcWithPrivateMembers(undefined /* metadata */, {
+					gcAllowed: true,
+					sweepAllowed: true,
+				});
+				assert(gc.gcEnabled, "gcEnabled incorrect");
+				assert(gc.sweepEnabled, "sweepEnabled incorrect");
+				assert(gc.shouldRunSweep, "shouldRunSweep incorrect");
+				assert(gc.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
+				assert(gc.sessionExpiryTimeoutMs !== undefined, "sessionExpiryTimeoutMs incorrect");
+			});
+			it("sweepAllowed true, gcAllowed true, sessionExpiry off", () => {
+				injectedSettings[runSessionExpiryKey] = false;
+				gc = createGcWithPrivateMembers(undefined /* metadata */, {
+					gcAllowed: true,
+					sweepAllowed: true,
+				});
+				assert(gc.gcEnabled, "gcEnabled incorrect");
+				assert(gc.sweepEnabled, "sweepEnabled incorrect");
+				assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
+				assert(gc.sweepTimeoutMs === undefined, "sweepTimeoutMs incorrect");
+			});
+			it("sweepAllowed false, sessionExpiry on", () => {
+				injectedSettings[runSessionExpiryKey] = true;
+				gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
+				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+				assert(gc.sessionExpiryTimeoutMs !== undefined, "sessionExpiryTimeoutMs incorrect");
+				assert(gc.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
+			});
+			it("sweepAllowed false, sessionExpiry off", () => {
+				injectedSettings[runSessionExpiryKey] = false;
+				gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
+				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+				assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
+				assert(gc.sweepTimeoutMs === undefined, "sweepTimeoutMs incorrect");
+			});
+			it("TestOverride.SweepTimeout set, sweepAllowed false, sessionExpiry on", () => {
+				injectedSettings[testOverrideSweepTimeoutKey] = 123;
+				injectedSettings[runSessionExpiryKey] = true;
+				gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
+				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+				assert(
+					gc.sessionExpiryTimeoutMs === defaultSessionExpiryDurationMs,
+					"sessionExpiryTimeoutMs incorrect",
+				);
+				assert(gc.sweepTimeoutMs === 123, "sweepTimeoutMs incorrect");
+			});
+			it("TestOverride.SweepTimeout set, sweepAllowed false, sessionExpiry off", () => {
+				injectedSettings[testOverrideSweepTimeoutKey] = 123;
+				injectedSettings[runSessionExpiryKey] = false;
+				gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
+				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
+				assert(gc.sessionExpiryTimeoutMs === undefined, "sessionExpiryTimeoutMs incorrect");
+				assert(gc.sweepTimeoutMs === 123, "sweepTimeoutMs incorrect");
+			});
+			it("Metadata Roundtrip", () => {
+				injectedSettings[runSessionExpiryKey] = true;
+				const expectedMetadata: IGCMetadata = {
+					sweepEnabled: true,
+					gcFeature: 1,
+					sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
+					sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
+				};
+				gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: true });
+				const outputMetadata = gc.getMetadata();
+				assert.deepEqual(
+					outputMetadata,
+					expectedMetadata,
+					"getMetadata returned different metadata than expected",
+				);
+			});
+			it("Metadata Roundtrip with GC version upgrade to v2 enabled", () => {
+				injectedSettings[runSessionExpiryKey] = true;
+				injectedSettings[gcVersionUpgradeToV2Key] = true;
+				const expectedMetadata: IGCMetadata = {
+					sweepEnabled: true,
+					gcFeature: currentGCVersion,
+					sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
+					sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
+				};
+				gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: true });
+				const outputMetadata = gc.getMetadata();
+				assert.deepEqual(
+					outputMetadata,
+					expectedMetadata,
+					"getMetadata returned different metadata than expected",
+				);
+			});
+		});
+
+		describe("Session Expiry and Sweep Timeout", () => {
+			beforeEach(() => {
+				injectedSettings[runSessionExpiryKey] = true;
+				injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = 1; // To ensure it's less than sweep timeout
+			});
+
+			// Config sources for Session Expiry:
+			// 1. defaultSessionExpiryDurationMs in code
+			// 2. IGCRuntimeOptions.sessionExpiryTimeoutMs
+			// 3. IGCMetadata.sessionExpiryTimeoutMs
+			// 4. "Fluid.GarbageCollection.TestOverride.SessionExpiryMs" setting
+			// 5. boolean setting: runSessionExpiryKey
+			// Config sources for Sweep Timeout:
+			// 1. IGCMetadata.sweepTimeoutMs
+			// 2. Computed from Session Expiry, fixed upper bound for Snapshot Expiry and a fixed buffer (on create, or to backfill existing)
+			// 3. "Fluid.GarbageCollection.TestOverride.SweepTimeoutMs" setting (only applicable on create)
+
+			it("defaultSessionExpiryDurationMs", () => {
+				gc = createGcWithPrivateMembers();
+				assert.equal(
+					gc.sessionExpiryTimeoutMs,
+					defaultSessionExpiryDurationMs,
+					"sessionExpiryTimeoutMs incorrect",
+				);
+				assert.equal(
+					gc.sessionExpiryTimer.defaultTimeout,
+					defaultSessionExpiryDurationMs,
+					"sessionExpiryTimer incorrect",
+				);
+				assert.equal(
+					gc.sweepTimeoutMs,
+					defaultSessionExpiryDurationMs + 6 * oneDayMs,
+					"sweepTimeoutMs incorrect",
+				);
+			});
+			it("defaultSessionExpiryDurationMs, TestOverride.SweepTimeout set", () => {
+				injectedSettings[testOverrideSweepTimeoutKey] = 7890;
+				gc = createGcWithPrivateMembers();
+				assert.equal(
+					gc.sessionExpiryTimeoutMs,
+					defaultSessionExpiryDurationMs,
+					"sessionExpiryTimeoutMs incorrect",
+				);
+				assert.equal(
+					gc.sessionExpiryTimer.defaultTimeout,
+					defaultSessionExpiryDurationMs,
+					"sessionExpiryTimer incorrect",
+				);
+				assert.equal(gc.sweepTimeoutMs, 7890, "sweepTimeoutMs incorrect");
+			});
+			it("IGCRuntimeOptions.sessionExpiryTimeoutMs", () => {
+				gc = createGcWithPrivateMembers(undefined /* metadata */, {
+					sessionExpiryTimeoutMs: 123,
+				});
+				assert.equal(gc.sessionExpiryTimeoutMs, 123, "sessionExpiryTimeoutMs incorrect");
+				assert.equal(
+					gc.sessionExpiryTimer.defaultTimeout,
+					123,
+					"sessionExpiryTimer incorrect",
+				);
+				assert.equal(gc.sweepTimeoutMs, 123 + 6 * oneDayMs, "sweepTimeoutMs incorrect");
+			});
+			it("IGCMetadata.sessionExpiryTimeoutMs, backfill sweepTimeoutMs", () => {
+				injectedSettings[testOverrideSweepTimeoutKey] = 1337; // Should be ignored
+				gc = createGcWithPrivateMembers({ sessionExpiryTimeoutMs: 456 } /* metadata */);
+				assert.equal(gc.sessionExpiryTimeoutMs, 456, "sessionExpiryTimeoutMs incorrect");
+				assert.equal(
+					gc.sessionExpiryTimer.defaultTimeout,
+					456,
+					"sessionExpiryTimer incorrect",
+				);
+				assert.equal(gc.sweepTimeoutMs, 456 + 6 * oneDayMs, "sweepTimeoutMs incorrect");
+			});
+			it("IGCMetadata.sessionExpiryTimeoutMs and IGCMetadata.sweepTimeoutMs", () => {
+				injectedSettings[testOverrideSweepTimeoutKey] = 1337; // Should be ignored
+				gc = createGcWithPrivateMembers(
+					{ sessionExpiryTimeoutMs: 456, sweepTimeoutMs: 789 } /* metadata */,
+				);
+				assert.equal(gc.sessionExpiryTimeoutMs, 456, "sessionExpiryTimeoutMs incorrect");
+				assert.equal(
+					gc.sessionExpiryTimer.defaultTimeout,
+					456,
+					"sessionExpiryTimer incorrect",
+				);
+				assert.equal(gc.sweepTimeoutMs, 789, "sweepTimeoutMs incorrect");
+			});
+			it("IGCMetadata.sweepTimeoutMs only", () => {
+				injectedSettings[testOverrideSweepTimeoutKey] = 1337; // Should be ignored
+				// This could happen if you used TestOverride.SweepTimeoutMs but had SessionExpiry disabled, then loaded that container.
+				gc = createGcWithPrivateMembers({ sweepTimeoutMs: 789 } /* metadata */);
+				assert.equal(
+					gc.sessionExpiryTimeoutMs,
+					undefined,
+					"sessionExpiryTimeoutMs incorrect",
+				);
+				assert.equal(gc.sessionExpiryTimer, undefined, "sessionExpiryTimer incorrect");
+				assert.equal(gc.sweepTimeoutMs, 789, "sweepTimeoutMs incorrect");
+			});
+			function testSessionExpiryMsOverride() {
+				const expectedSweepTimeoutMs = defaultSessionExpiryDurationMs + 6 * oneDayMs;
+				assert(!!gc, "PRECONDITION: gc must be set before calling this helper");
+				assert.equal(
+					gc.sessionExpiryTimeoutMs,
+					defaultSessionExpiryDurationMs,
+					"sessionExpiryTimeoutMs incorrect",
+				);
+				assert.equal(
+					gc.sessionExpiryTimer.defaultTimeout,
+					789,
+					"sessionExpiry used for timer should be the override value",
+				);
+				assert.equal(gc.sweepTimeoutMs, expectedSweepTimeoutMs, "sweepTimeoutMs incorrect");
+
+				const expectedMetadata: IGCMetadata = {
+					sweepEnabled: false,
+					gcFeature: 1,
+					sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
+					sweepTimeoutMs: expectedSweepTimeoutMs,
+				};
+				const outputMetadata = gc.getMetadata();
+				assert.deepEqual(
+					outputMetadata,
+					expectedMetadata,
+					"getMetadata returned different metadata than expected",
+				);
+			}
+			it("TestOverride.SessionExpiryMs setting applied to timeout but not written to file - New Container", () => {
+				injectedSettings[testOverrideSessionExpiryMsKey] = 789;
+				gc = createGcWithPrivateMembers();
+				testSessionExpiryMsOverride();
+			});
+			it("TestOverride.SessionExpiryMs setting applied to timeout but not written to file - Existing Container", () => {
+				injectedSettings[testOverrideSessionExpiryMsKey] = 789;
+				gc = createGcWithPrivateMembers(
+					{
+						sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
+						gcFeature: 1,
+					} /* metadata */,
+				);
+				testSessionExpiryMsOverride();
+			});
+			it("RunSessionExpiry setting turned off", () => {
+				injectedSettings[runSessionExpiryKey] = false;
+				injectedSettings[testOverrideSessionExpiryMsKey] = 1234; // This override should be ignored
+				gc = createGcWithPrivateMembers();
+				assert.equal(
+					gc.sessionExpiryTimeoutMs,
+					undefined,
+					"sessionExpiryTimeoutMs should be undefined if runSessionExpiryKey setting is false",
+				);
+				assert.equal(
+					gc.sessionExpiryTimer,
+					undefined,
+					"sessionExpiryTimer should be undefined if it's disabled",
+				);
+				assert.equal(gc.sweepTimeoutMs, undefined, "sweepTimeoutMs incorrect");
+			});
+			it("RunSessionExpiry setting turned off, TestOverride.SweepTimeout set", () => {
+				injectedSettings[runSessionExpiryKey] = false;
+				injectedSettings[testOverrideSweepTimeoutKey] = 7890;
+				injectedSettings[testOverrideSessionExpiryMsKey] = 1234; // This override should be ignored
+				gc = createGcWithPrivateMembers();
+				assert.equal(
+					gc.sessionExpiryTimeoutMs,
+					undefined,
+					"sessionExpiryTimeoutMs should be undefined if runSessionExpiryKey setting is false",
+				);
+				assert.equal(
+					gc.sessionExpiryTimer,
+					undefined,
+					"sessionExpiryTimer should be undefined if it's disabled",
+				);
+				assert.equal(gc.sweepTimeoutMs, 7890, "sweepTimeoutMs incorrect");
+			});
+		});
+
+		describe("Session Behavior (e.g. 'shouldRun' fields)", () => {
+			beforeEach(() => {
+				injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] = 1; // To ensure it's less than sweep timeout
+			});
+
+			describe("shouldRunGC", () => {
+				const testCases: {
+					gcEnabled: boolean;
+					disableGC?: boolean;
+					runGC?: boolean;
+					expectedResult: boolean;
+				}[] = [
+					{ gcEnabled: false, disableGC: true, runGC: true, expectedResult: true },
+					{ gcEnabled: true, disableGC: false, runGC: false, expectedResult: false },
+					{ gcEnabled: true, disableGC: true, expectedResult: false },
+					{ gcEnabled: true, disableGC: false, expectedResult: true },
+					{ gcEnabled: true, expectedResult: true },
+					{ gcEnabled: false, expectedResult: false },
+				];
+				testCases.forEach((testCase) => {
+					it(`Test Case ${JSON.stringify(testCase)}`, () => {
+						injectedSettings[runGCKey] = testCase.runGC;
+						gc = createGcWithPrivateMembers(undefined /* metadata */, {
+							gcAllowed: testCase.gcEnabled,
+							disableGC: testCase.disableGC,
+						});
+						assert.equal(
+							gc.gcEnabled,
+							testCase.gcEnabled,
+							"PRECONDITION: gcEnabled set incorrectly",
+						);
+						assert.equal(
+							gc.shouldRunGC,
+							testCase.expectedResult,
+							"shouldRunGC not set as expected",
+						);
+					});
+				});
+			});
+			describe("shouldRunSweep", () => {
+				const testCases: {
+					shouldRunGC: boolean;
+					setSweepTimeout: boolean;
+					sweepEnabled: boolean;
+					runSweep?: boolean;
+					expectedResult: boolean;
+				}[] = [
+					{
+						shouldRunGC: false,
+						setSweepTimeout: true,
+						sweepEnabled: true,
+						runSweep: true,
+						expectedResult: false,
+					},
+					{
+						shouldRunGC: true,
+						setSweepTimeout: false,
+						sweepEnabled: true,
+						runSweep: true,
+						expectedResult: false,
+					},
+					{
+						shouldRunGC: true,
+						setSweepTimeout: true,
+						sweepEnabled: true,
+						runSweep: false,
+						expectedResult: false,
+					},
+					{
+						shouldRunGC: true,
+						setSweepTimeout: true,
+						sweepEnabled: false,
+						runSweep: true,
+						expectedResult: true,
+					},
+					{
+						shouldRunGC: true,
+						setSweepTimeout: true,
+						sweepEnabled: true,
+						expectedResult: true,
+					},
+					{
+						shouldRunGC: true,
+						setSweepTimeout: true,
+						sweepEnabled: false,
+						expectedResult: false,
+					},
+				];
+				testCases.forEach((testCase) => {
+					it(`Test Case ${JSON.stringify(testCase)}`, () => {
+						injectedSettings[runGCKey] = testCase.shouldRunGC;
+						injectedSettings[runSweepKey] = testCase.runSweep;
+						injectedSettings[runSessionExpiryKey] = testCase.setSweepTimeout; // Sweep timeout is set iff sessionExpiry runs (under other default inputs)
+						gc = createGcWithPrivateMembers(undefined /* metadata */, {
+							sweepAllowed: testCase.sweepEnabled,
+						});
+						assert.equal(
+							gc.shouldRunGC,
+							testCase.shouldRunGC,
+							"PRECONDITION: shouldRunGC set incorrectly",
+						);
+						assert.equal(
+							gc.sweepTimeoutMs !== undefined,
+							testCase.setSweepTimeout,
+							"PRECONDITION: sweep timeout set incorrectly",
+						);
+						assert.equal(
+							gc.sweepEnabled,
+							testCase.sweepEnabled,
+							"PRECONDITION: sweepEnabled set incorrectly",
+						);
+						assert.equal(
+							gc.shouldRunSweep,
+							testCase.expectedResult,
+							"shouldRunSweep not set as expected",
+						);
+					});
+				});
+			});
+			describe("inactiveTimeoutMs", () => {
+				beforeEach(() => {
+					// Remove setting added in outer describe block
+					injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
+						undefined;
+				});
+				const testCases: {
+					testOverride?: number;
+					option?: number;
+					expectedResult: number;
+				}[] = [
+					{ testOverride: 123, option: 456, expectedResult: 123 },
+					{ option: 456, expectedResult: 456 },
+					{ expectedResult: defaultInactiveTimeoutMs },
+				];
+				testCases.forEach((testCase) => {
+					it(`Test Case ${JSON.stringify(testCase)}`, () => {
+						injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
+							testCase.testOverride;
+						gc = createGcWithPrivateMembers(undefined /* metadata */, {
+							inactiveTimeoutMs: testCase.option,
+						});
+						assert.equal(
+							gc.inactiveTimeoutMs,
+							testCase.expectedResult,
+							"inactiveTimeoutMs not set as expected",
+						);
+					});
+				});
+				it("inactiveTimeout must not be greater than sweepTimeout", () => {
+					injectedSettings[runSessionExpiryKey] = true;
+					injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
+						Number.MAX_VALUE;
+					assert.throws(
+						() => {
+							gc = createGcWithPrivateMembers();
+						},
+						(e) => e.errorType === "usageError",
+						"inactiveTimeout must not be greater than sweepTimeout",
+					);
+				});
+			});
+			describe("testMode", () => {
+				const testCases: {
+					setting?: boolean;
+					option?: boolean;
+					expectedResult: boolean;
+				}[] = [
+					{ setting: true, option: false, expectedResult: true },
+					{ setting: false, option: true, expectedResult: false },
+					{ option: true, expectedResult: true },
+					{ expectedResult: false },
+				];
+				testCases.forEach((testCase) => {
+					it(`Test Case ${JSON.stringify(testCase)}`, () => {
+						injectedSettings[gcTestModeKey] = testCase.setting;
+						gc = createGcWithPrivateMembers(undefined /* metadata */, {
+							runGCInTestMode: testCase.option,
+						});
+						assert.equal(
+							gc.testMode,
+							testCase.expectedResult,
+							"testMode not set as expected",
+						);
+					});
+				});
+			});
+		});
+	});
+
+	it("Session expiry closes container", () => {
+		injectedSettings[runSessionExpiryKey] = "true";
+
+		let closeCalled = false;
+		function closeCalledAfterExactTicks(ticks: number) {
+			clock.tick(ticks - 1);
+			if (closeCalled) {
+				return false;
+			}
+			clock.tick(1);
+			return closeCalled;
+		}
+
+		gc = createGarbageCollector({}, undefined /* gcBlobsMap */, () => {
+			closeCalled = true;
+		}) as GcWithPrivates;
+		assert(
+			closeCalledAfterExactTicks(defaultSessionExpiryDurationMs),
+			"Close should have been called at exactly defaultSessionExpiryDurationMs",
+		);
+	});
+
+	describe("errors when unreferenced objects are used after they are inactive / deleted", () => {
+		// Mock node loaded and changed activity for all the nodes in the graph.
+		async function updateAllNodesAndRunGC(garbageCollector: IGarbageCollector) {
+			nodes.forEach((nodeId) => {
+				garbageCollector.nodeUpdated(nodeId, "Changed", Date.now(), testPkgPath);
+				garbageCollector.nodeUpdated(nodeId, "Loaded", Date.now(), testPkgPath);
+			});
+			await garbageCollector.collectGarbage({});
+		}
+
+		beforeEach(async () => {
+			// Set up the reference graph such that all nodes are referenced. Add in a couple of cycles in the graph.
+			// Here's a diagram showing the references:
+			// 0 - 1 - 2 - 3
+			// |  /       /
+			// |-/-------/
+			defaultGCData.gcNodes["/"] = [nodes[0]];
+			defaultGCData.gcNodes[nodes[0]] = [nodes[1]];
+			defaultGCData.gcNodes[nodes[1]] = [nodes[0], nodes[2]];
+			defaultGCData.gcNodes[nodes[2]] = [nodes[3]];
+			defaultGCData.gcNodes[nodes[3]] = [nodes[0]];
+		});
+
+		const summarizerContainerTests = (
+			timeout: number,
+			revivedEventName: string,
+			changedEventName: string,
+			loadedEventName: string,
+			expectDeleteLogs?: boolean,
+		) => {
+			const deleteEventName = "GarbageCollector:GCObjectDeleted";
+			// Validates that no unexpected event has been fired.
+			function validateNoUnexpectedEvents() {
+				mockLogger.assertMatchNone(
+					[
+						{ eventName: revivedEventName },
+						{ eventName: changedEventName },
+						{ eventName: loadedEventName },
+						{ eventName: deleteEventName },
+					],
+					"unexpected events logged",
+				);
+			}
+
+			const createGCOverride = (
+				baseSnapshot?: ISnapshotTree,
+				gcBlobsMap?: Map<string, IGarbageCollectionState | IGarbageCollectionDetailsBase>,
+			) => {
+				return createGarbageCollector({ baseSnapshot }, gcBlobsMap);
+			};
+
+			it("doesn't generate events for referenced nodes", async () => {
+				const garbageCollector = createGCOverride();
+
+				// Run garbage collection on the default GC data where everything is referenced.
+				await garbageCollector.collectGarbage({});
+
+				// Advance the clock just before the timeout and validate no events are generated.
+				clock.tick(timeout - 1);
+				await updateAllNodesAndRunGC(garbageCollector);
+				validateNoUnexpectedEvents();
+
+				// Advance the clock to expire the timeout.
+				clock.tick(1);
+
+				// Update all nodes again. Validate that no unexpected events are generated since everything is referenced.
+				await updateAllNodesAndRunGC(garbageCollector);
+				validateNoUnexpectedEvents();
+			});
+
+			it("generates events for nodes that are used after time out", async () => {
+				const garbageCollector = createGCOverride();
+
+				// Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
+				defaultGCData.gcNodes[nodes[1]] = [];
+
+				await garbageCollector.collectGarbage({});
+
+				// Advance the clock just before the timeout and validate no unexpected events are logged.
+				clock.tick(timeout - 1);
+				await updateAllNodesAndRunGC(garbageCollector);
+				validateNoUnexpectedEvents();
+
+				// Expire the timeout and validate that all events for node 2 and node 3 are logged.
+				clock.tick(1);
+				await updateAllNodesAndRunGC(garbageCollector);
+				const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [];
+
+				if (expectDeleteLogs) {
+					expectedEvents.push(
+						{ eventName: deleteEventName, timeout, id: nodes[2] },
+						{ eventName: deleteEventName, timeout, id: nodes[3] },
+					);
+				} else {
+					assert(
+						!mockLogger.events.some((event) => event.eventName === deleteEventName),
+						"Should not have any delete events logged",
+					);
+				}
+				expectedEvents.push(
+					{
+						eventName: changedEventName,
+						timeout,
+						id: nodes[2],
+						pkg: eventPkg,
+						createContainerRuntimeVersion: pkgVersion,
+					},
+					{
+						eventName: loadedEventName,
+						timeout,
+						id: nodes[2],
+						pkg: eventPkg,
+						createContainerRuntimeVersion: pkgVersion,
+					},
+					{
+						eventName: changedEventName,
+						timeout,
+						id: nodes[3],
+						pkg: eventPkg,
+						createContainerRuntimeVersion: pkgVersion,
+					},
+					{
+						eventName: loadedEventName,
+						timeout,
+						id: nodes[3],
+						pkg: eventPkg,
+						createContainerRuntimeVersion: pkgVersion,
+					},
+				);
+				mockLogger.assertMatch(expectedEvents, "all events not generated as expected");
+
+				// Add reference from node 1 to node 3 and validate that we get a revived event.
+				garbageCollector.addedOutboundReference(nodes[1], nodes[3]);
+				await garbageCollector.collectGarbage({});
+				mockLogger.assertMatch(
+					[
+						{
+							eventName: revivedEventName,
+							timeout,
+							id: nodes[3],
+							pkg: eventPkg,
+							fromId: nodes[1],
+						},
+					],
+					"revived event not generated as expected",
+				);
+			});
+
+			it("generates only revived event when an inactive node is changed and revived", async () => {
+				const garbageCollector = createGCOverride();
+
+				// Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
+				defaultGCData.gcNodes[nodes[1]] = [];
+
+				await garbageCollector.collectGarbage({});
+
+				// Advance the clock just before the timeout and validate no unexpected events are logged.
+				clock.tick(timeout - 1);
+				await updateAllNodesAndRunGC(garbageCollector);
+				validateNoUnexpectedEvents();
+
+				// Expire the timeout and validate that only revived event is generated for node 2.
+				clock.tick(1);
+				garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
+				garbageCollector.nodeUpdated(nodes[2], "Loaded", Date.now(), testPkgPath);
+				garbageCollector.addedOutboundReference(nodes[1], nodes[2]);
+				await garbageCollector.collectGarbage({});
+
+				for (const event of mockLogger.events) {
+					assert.notStrictEqual(
+						event.eventName,
+						changedEventName,
+						"Unexpected changed event logged",
+					);
+					assert.notStrictEqual(
+						event.eventName,
+						loadedEventName,
+						"Unexpected loaded event logged",
+					);
+				}
+				mockLogger.assertMatch(
+					[
+						{
+							eventName: revivedEventName,
+							timeout,
+							id: nodes[2],
+							pkg: eventPkg,
+							fromId: nodes[1],
+						},
+					],
+					"revived event not logged as expected",
+				);
+			});
+
+			it("generates events once per node", async () => {
+				const garbageCollector = createGCOverride();
+
+				// Remove node 3's reference from node 2.
+				defaultGCData.gcNodes[nodes[2]] = [];
+
+				await garbageCollector.collectGarbage({});
+
+				// Advance the clock just before the timeout and validate no unexpected events are logged.
+				clock.tick(timeout - 1);
+				await updateAllNodesAndRunGC(garbageCollector);
+				validateNoUnexpectedEvents();
+
+				// Expire the timeout and validate that all events for node 2 and node 3 are logged.
+				clock.tick(1);
+				await updateAllNodesAndRunGC(garbageCollector);
+				const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [];
+				if (expectDeleteLogs) {
+					expectedEvents.push({ eventName: deleteEventName, timeout, id: nodes[3] });
+				} else {
+					assert(
+						!mockLogger.events.some((event) => event.eventName === deleteEventName),
+						"Should not have any delete events logged",
+					);
+				}
+				expectedEvents.push(
+					{ eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
+					{ eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
+				);
+				mockLogger.assertMatch(expectedEvents, "all events not generated as expected");
+
+				// Update all nodes again. There shouldn't be any more events since for each node the event is only once.
+				await updateAllNodesAndRunGC(garbageCollector);
+				validateNoUnexpectedEvents();
+			});
+
+			/**
+			 * Here, the base snapshot contains nodes that have timed out. The test validates that we generate errors
+			 * when these nodes are used.
+			 */
+			it("generates events for nodes that time out on load", async () => {
+				// Create GC state where node 3's unreferenced time was > timeout ms ago.
+				// This means this node should time out as soon as its data is loaded.
+
+				// Create a snapshot tree to be used as the GC snapshot tree.
+				const gcSnapshotTree = getDummySnapshotTree();
+				const gcBlobId = "root";
+				// Add a GC blob with key that start with `gcBlobPrefix` to the GC snapshot tree. The blob Id for this
+				// is generated by server in real scenarios but we use a static id here for testing.
+				gcSnapshotTree.blobs[`${gcBlobPrefix}_${gcBlobId}`] = gcBlobId;
+
+				// Create a base snapshot that contains the GC snapshot tree.
+				const baseSnapshot = getDummySnapshotTree();
+				baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+
+				// Create GC state with node 3 expired. This will be returned when the garbage collector asks
+				// for the GC blob with `gcBlobId`.
+				const gcState: IGarbageCollectionState = { gcNodes: {} };
+				const node3Data: IGarbageCollectionNodeData = {
+					outboundRoutes: [],
+					unreferencedTimestampMs: Date.now() - (timeout + 100),
+				};
+				gcState.gcNodes[nodes[3]] = node3Data;
+
+				const gcBlobMap: Map<string, IGarbageCollectionState> = new Map([
+					[gcBlobId, gcState],
+				]);
+				const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
+
+				// Remove node 3's reference from node 2 so that it is still unreferenced.
+				defaultGCData.gcNodes[nodes[2]] = [];
+
+				// Run GC to trigger loading the GC details from the base summary. Will also generate Delete logs
+				await garbageCollector.collectGarbage({});
+				// Validate that the sweep ready event is logged when GC runs after load.
+				if (expectDeleteLogs) {
+					mockLogger.assertMatch(
+						[{ eventName: deleteEventName, timeout, id: nodes[3] }],
+						"sweep ready event not generated as expected",
+					);
+				} else {
+					mockLogger.assertMatchNone(
+						[{ eventName: deleteEventName }],
+						"Should not have any delete events logged",
+					);
+				}
+
+				// Validate that all events are logged as expected.
+				garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
+				garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
+				await garbageCollector.collectGarbage({});
+				mockLogger.assertMatch(
+					[
+						{ eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
+						{ eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
+					],
+					"all events not generated as expected",
+				);
+
+				// Add reference from node 2 to node 3 and validate that revived event is logged.
+				garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
+				await garbageCollector.collectGarbage({});
+				mockLogger.assertMatch(
+					[
+						{
+							eventName: revivedEventName,
+							timeout,
+							id: nodes[3],
+							pkg: eventPkg,
+							fromId: nodes[2],
+						},
+					],
+					"revived event not generated as expected",
+				);
+			});
+
+			/**
+			 * Here, the base snapshot contains nodes that have timed out and the GC blob in snapshot is in old format. The
+			 * test validates that we generate errors when these nodes are used.
+			 */
+			it("generates events for nodes that time out on load - old snapshot format", async () => {
+				// Create GC details for node 3's GC blob whose unreferenced time was > timeout ms ago.
+				// This means this node should time out as soon as its data is loaded.
+				const node3GCDetails: IGarbageCollectionSummaryDetailsLegacy = {
+					gcData: { gcNodes: { "/": [] } },
+					unrefTimestamp: Date.now() - (timeout + 100),
+				};
+				const node3Snapshot = getDummySnapshotTree();
+				const gcBlobId = "node3GCDetails";
+				const attributesBlobId = "attributesBlob";
+				node3Snapshot.blobs[gcTreeKey] = gcBlobId;
+				node3Snapshot.blobs[dataStoreAttributesBlobName] = attributesBlobId;
+
+				// Create a base snapshot that contains snapshot tree of node 3.
+				const baseSnapshot = getDummySnapshotTree();
+				baseSnapshot.trees[nodes[3].slice(1)] = node3Snapshot;
+
+				// Set up the getNodeGCDetails function to return the GC details for node 3 when asked by garbage collector.
+				const gcBlobMap = new Map([
+					[gcBlobId, node3GCDetails],
+					[attributesBlobId, {}],
+				]);
+				const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
+
+				// Remove node 3's reference from node 2 so that it is still unreferenced. The GC details from the base
+				// summary is not loaded until the first time GC is run, so do that immediately.
+				defaultGCData.gcNodes[nodes[2]] = [];
+				await garbageCollector.collectGarbage({});
+
+				// Validate that the sweep ready event is logged when GC runs after load.
+				if (expectDeleteLogs) {
+					mockLogger.assertMatch(
+						[{ eventName: deleteEventName, timeout, id: nodes[3] }],
+						"sweep ready event not generated as expected",
+					);
+				} else {
+					mockLogger.assertMatchNone(
+						[{ eventName: deleteEventName }],
+						"Should not have any delete events logged",
+					);
+				}
+
+				// Validate that all events are logged as expected.
+				garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
+				garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
+				await garbageCollector.collectGarbage({});
+				mockLogger.assertMatch(
+					[
+						{ eventName: changedEventName, timeout, id: nodes[3], pkg: eventPkg },
+						{ eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
+					],
+					"all events not generated as expected",
+				);
+
+				// Add reference from node 2 to node 3 and validate that revived event is logged.
+				garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
+				await garbageCollector.collectGarbage({});
+				mockLogger.assertMatch(
+					[
+						{
+							eventName: revivedEventName,
+							timeout,
+							id: nodes[3],
+							pkg: eventPkg,
+							fromId: nodes[2],
+						},
+					],
+					"revived event not generated as expected",
+				);
+			});
+
+			/**
+			 * Here, the base snapshot contains nodes that have timed out and the GC data in snapshot is present in multiple
+			 * blobs. The test validates that we generate errors when these nodes are used.
+			 */
+			it(`generates events for nodes that time out on load - multi blob GC data`, async () => {
+				const gcBlobMap: Map<string, IGarbageCollectionState> = new Map();
+				const expiredTimestampMs = Date.now() - (timeout + 100);
+
+				// Create three GC states to be added into separate GC blobs. Each GC state has a node whose unreferenced
+				// time was > timeout ms ago. These three GC blobs are the added to the GC tree in summary.
+				const blob1Id = "blob1";
+				const blob1GCState: IGarbageCollectionState = { gcNodes: {} };
+				blob1GCState.gcNodes[nodes[1]] = {
+					outboundRoutes: [],
+					unreferencedTimestampMs: expiredTimestampMs,
+				};
+				gcBlobMap.set(blob1Id, blob1GCState);
+
+				const blob2Id = "blob2";
+				const blob2GCState: IGarbageCollectionState = { gcNodes: {} };
+				blob2GCState.gcNodes[nodes[2]] = {
+					outboundRoutes: [],
+					unreferencedTimestampMs: expiredTimestampMs,
+				};
+				gcBlobMap.set(blob2Id, blob2GCState);
+
+				const blob3Id = "blob3";
+				const blob3GCState: IGarbageCollectionState = { gcNodes: {} };
+				blob3GCState.gcNodes[nodes[3]] = {
+					outboundRoutes: [],
+					unreferencedTimestampMs: expiredTimestampMs,
+				};
+				gcBlobMap.set(blob3Id, blob3GCState);
+
+				// Create a GC snapshot tree and add the above three GC blob ids to it.
+				const gcSnapshotTree = getDummySnapshotTree();
+				gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob1Id}`] = blob1Id;
+				gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob2Id}`] = blob2Id;
+				gcSnapshotTree.blobs[`${gcBlobPrefix}_${blob3Id}`] = blob3Id;
+
+				// Create a base snapshot that contains the above GC snapshot tree.
+				const baseSnapshot = getDummySnapshotTree();
+				baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+
+				const garbageCollector = createGCOverride(baseSnapshot, gcBlobMap);
+
+				// For the nodes in the GC snapshot blobs, remove their references from the default GC data.
+				defaultGCData.gcNodes[nodes[0]] = [];
+				defaultGCData.gcNodes[nodes[1]] = [];
+				defaultGCData.gcNodes[nodes[2]] = [];
+
+				await garbageCollector.collectGarbage({});
+				// Validate that the sweep ready event is logged when GC runs after load.
+				if (expectDeleteLogs) {
+					mockLogger.assertMatch(
+						[
+							{ eventName: deleteEventName, timeout, id: nodes[1] },
+							{ eventName: deleteEventName, timeout, id: nodes[2] },
+							{ eventName: deleteEventName, timeout, id: nodes[3] },
+						],
+						"sweep ready event not generated as expected",
+					);
+				} else {
+					mockLogger.assertMatchNone(
+						[{ eventName: deleteEventName }],
+						"Should not have any delete events logged",
+					);
+				}
+
+				// Validate that all events are logged as expected.
+				garbageCollector.nodeUpdated(nodes[1], "Changed", Date.now(), testPkgPath);
+				garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
+				garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
+				await garbageCollector.collectGarbage({});
+				mockLogger.assertMatch(
+					[
+						{ eventName: changedEventName, timeout, id: nodes[1], pkg: eventPkg },
+						{ eventName: changedEventName, timeout, id: nodes[2], pkg: eventPkg },
+						{ eventName: loadedEventName, timeout, id: nodes[3], pkg: eventPkg },
+					],
+					"all events not generated as expected",
+				);
+			});
+		};
+
+		describe("Inactive events (summarizer container)", () => {
+			const inactiveTimeoutMs = 500;
+
+			beforeEach(() => {
+				injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
+					inactiveTimeoutMs;
+			});
+
+			summarizerContainerTests(
+				inactiveTimeoutMs,
+				"GarbageCollector:InactiveObject_Revived",
+				"GarbageCollector:InactiveObject_Changed",
+				"GarbageCollector:InactiveObject_Loaded",
+			);
+		});
+
+		describe("SweepReady events (summarizer container)", () => {
+			const sweepTimeoutMs =
+				defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
+
+			beforeEach(() => {
+				injectedSettings[runSessionExpiryKey] = true;
+			});
+
+			summarizerContainerTests(
+				sweepTimeoutMs,
+				"GarbageCollector:SweepReadyObject_Revived",
+				"GarbageCollector:SweepReadyObject_Changed",
+				"GarbageCollector:SweepReadyObject_Loaded",
+				true, // expectDeleteLogs
+			);
+		});
+
+		describe("SweepReady events - Delete log disabled (summarizer container)", () => {
+			const sweepTimeoutMs =
+				defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
+
+			beforeEach(() => {
+				injectedSettings[runSessionExpiryKey] = true;
+				injectedSettings[disableSweepLogKey] = true;
+			});
+
+			summarizerContainerTests(
+				sweepTimeoutMs,
+				"GarbageCollector:SweepReadyObject_Revived",
+				"GarbageCollector:SweepReadyObject_Changed",
+				"GarbageCollector:SweepReadyObject_Loaded",
+				false, // expectDeleteLogs
+			);
+		});
+
+		describe("Interactive Client Behavior", () => {
+			function updateAllNodes(garbageCollector) {
+				nodes.forEach((nodeId) => {
+					garbageCollector.nodeUpdated(nodeId, "Changed", Date.now(), testPkgPath);
+					garbageCollector.nodeUpdated(nodeId, "Loaded", Date.now(), testPkgPath);
+				});
+			}
+
+			async function interactiveClientTestCode(
+				timeout: number,
+				loadedEventName: string,
+				sweepReadyUsageErrorExpected: boolean,
+			) {
+				let lastCloseErrorType: string = "N/A";
+
+				// Create GC state where node 3's unreferenced time was > timeout ms ago.
+				// This is important since we shouldn't run GC on the interactive container,
+				// but rather load from a snapshot in which SweepReady state is already reached.
+
+				// Create a snapshot tree to be used as the GC snapshot tree.
+				const gcSnapshotTree = getDummySnapshotTree();
+				const gcBlobId = "root";
+				// Add a GC blob with key that start with `gcBlobPrefix` to the GC snapshot tree. The blob Id for this
+				// is generated by server in real scenarios but we use a static id here for testing.
+				gcSnapshotTree.blobs[`${gcBlobPrefix}_${gcBlobId}`] = gcBlobId;
+
+				// Create a base snapshot that contains the GC snapshot tree.
+				const baseSnapshot = getDummySnapshotTree();
+				baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+
+				// Create GC state with node 3 expired. This will be returned when the garbage collector asks
+				// for the GC blob with `gcBlobId`.
+				const gcState: IGarbageCollectionState = { gcNodes: {} };
+				const unrefTime = Date.now() - (timeout + 100);
+				const node3Data: IGarbageCollectionNodeData = {
+					outboundRoutes: [],
+					unreferencedTimestampMs: unrefTime,
+				};
+				gcState.gcNodes[nodes[3]] = node3Data;
+
+				const gcBlobMap: Map<string, IGarbageCollectionState> = new Map([
+					[gcBlobId, gcState],
+				]);
+				const garbageCollector = createGarbageCollector(
+					{ baseSnapshot },
+					gcBlobMap,
+					(error) => {
+						lastCloseErrorType = error?.errorType ?? "NONE";
+					},
+					false /* isSummarizerClient */,
+				);
+
+				// Trigger loading GC state from base snapshot - but don't call GC since that's not what happens in real flow
+				await (garbageCollector as any).initializeGCStateFromBaseSnapshotP;
+
+				// Update nodes and validate that all events for node 3 are logged.
+				updateAllNodes(garbageCollector);
+				assert(
+					!mockLogger.events.some(
+						(event) =>
+							event.eventName !== loadedEventName && event.unrefTime === unrefTime,
+					),
+					"shouldn't see any unreference events besides Loaded",
+				);
+				mockLogger.assertMatch(
+					[
+						{
+							eventName: loadedEventName,
+							timeout,
+							id: nodes[3],
+							pkg: eventPkg,
+							unrefTime,
+						},
+					],
+					"all events not generated as expected",
+				);
+
+				const expectedErrorType = sweepReadyUsageErrorExpected
+					? "unreferencedObjectUsedAfterGarbageCollected"
+					: "N/A";
+				assert.equal(
+					lastCloseErrorType,
+					expectedErrorType,
+					"Incorrect lastCloseReason after using unreferenced nodes",
+				);
+			}
+
+			beforeEach(() => {
+				injectedSettings[runSessionExpiryKey] = true;
+			});
+
+			it("Inactive object used - generates events but does not close container (SweepReadyUsageDetection enabled)", async () => {
+				const inactiveTimeoutMs = 400;
+				injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
+					inactiveTimeoutMs;
+				injectedSettings[SweepReadyUsageDetectionKey] = "interactiveClient";
+
+				await interactiveClientTestCode(
+					inactiveTimeoutMs,
+					"GarbageCollector:InactiveObject_Loaded",
+					false,
+				);
+			});
+
+			it("SweepReady object used - generates events and closes container (SweepReadyUsageDetection enabled)", async () => {
+				const sweepTimeoutMs =
+					defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
+				injectedSettings[SweepReadyUsageDetectionKey] = "interactiveClient";
+
+				await interactiveClientTestCode(
+					sweepTimeoutMs,
+					"GarbageCollector:SweepReadyObject_Loaded",
+					true,
+				);
+			});
+
+			it("SweepReady object used - generates events but does not close container (SweepReadyUsageDetection disabled)", async () => {
+				const sweepTimeoutMs =
+					defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
+				injectedSettings[SweepReadyUsageDetectionKey] = "something else";
+
+				await interactiveClientTestCode(
+					sweepTimeoutMs,
+					"GarbageCollector:SweepReadyObject_Loaded",
+					false,
+				);
+			});
+		});
+
+		it("generates both inactive and sweep ready events when nodes are used after time out", async () => {
+			const inactiveTimeoutMs = 500;
+			const sweepTimeoutMs =
+				defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
+			injectedSettings[runSessionExpiryKey] = "true";
+			injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
+				inactiveTimeoutMs;
+
+			const garbageCollector = createGarbageCollector({});
+
+			// Remove node 2's reference from node 1. This should make node 2 and node 3 unreferenced.
+			defaultGCData.gcNodes[nodes[1]] = [];
+			await garbageCollector.collectGarbage({});
+
+			// Advance the clock to trigger inactive timeout and validate that we get inactive events.
+			clock.tick(inactiveTimeoutMs + 1);
+			await updateAllNodesAndRunGC(garbageCollector);
+			mockLogger.assertMatch(
+				[
+					{
+						eventName: "GarbageCollector:InactiveObject_Changed",
+						timeout: inactiveTimeoutMs,
+						id: nodes[2],
+					},
+					{
+						eventName: "GarbageCollector:InactiveObject_Loaded",
+						timeout: inactiveTimeoutMs,
+						id: nodes[2],
+					},
+					{
+						eventName: "GarbageCollector:InactiveObject_Changed",
+						timeout: inactiveTimeoutMs,
+						id: nodes[3],
+					},
+					{
+						eventName: "GarbageCollector:InactiveObject_Loaded",
+						timeout: inactiveTimeoutMs,
+						id: nodes[3],
+					},
+				],
+				"inactive events not generated as expected",
+			);
+
+			// Advance the clock to trigger sweep timeout and validate that we get sweep ready events.
+			clock.tick(sweepTimeoutMs - inactiveTimeoutMs);
+			await updateAllNodesAndRunGC(garbageCollector);
+			mockLogger.assertMatch(
+				[
+					{
+						eventName: "GarbageCollector:SweepReadyObject_Changed",
+						timeout: sweepTimeoutMs,
+						id: nodes[2],
+					},
+					{
+						eventName: "GarbageCollector:SweepReadyObject_Loaded",
+						timeout: sweepTimeoutMs,
+						id: nodes[2],
+					},
+					{
+						eventName: "GarbageCollector:SweepReadyObject_Changed",
+						timeout: sweepTimeoutMs,
+						id: nodes[3],
+					},
+					{
+						eventName: "GarbageCollector:SweepReadyObject_Loaded",
+						timeout: sweepTimeoutMs,
+						id: nodes[3],
+					},
+				],
+				"sweep ready events not generated as expected",
+			);
+		});
+	});
+
+	describe("Deleted blobs in GC summary tree", () => {
+		beforeEach(() => {
+			injectedSettings["Fluid.GarbageCollection.TrackGCState"] = true;
+		});
+
+		it("correctly reads and write deleted blobs in summary", async () => {
+			// Set up the GC reference graph to have something to work with.
+			defaultGCData.gcNodes["/"] = [nodes[0]];
+
+			// Create a snapshot tree to be used as the GC snapshot tree.
+			const gcSnapshotTree = getDummySnapshotTree();
+			// Add a blob to the tree for deleted nodes.
+			const deletedNodesBlobId = "deletedNodes";
+			gcSnapshotTree.blobs[gcDeletedBlobKey] = deletedNodesBlobId;
+			const deletedNodeIds = [...nodes];
+			// Add deleted nodes list the blobs map that will service read and parse blob calls from GC.
+			const gcBlobsMap: Map<string, string[]> = new Map([
+				[deletedNodesBlobId, deletedNodeIds],
+			]);
+			// Create a base snapshot that contains the GC snapshot tree.
+			const baseSnapshot = getDummySnapshotTree();
+			baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+
+			// Create and initialize garbage collector.
+			const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobsMap);
+			await garbageCollector.initializeBaseState();
+
+			// The nodes in deletedNodeIds should be marked as deleted.
+			for (const nodeId of deletedNodeIds) {
+				assert(
+					garbageCollector.isNodeDeleted(nodeId) === true,
+					`${nodeId} should be marked deleted`,
+				);
+			}
+
+			await garbageCollector.collectGarbage({});
+			// Summarize with fullTree as true so that the deleted nodes are written as a blob and can be validated.
+			const summaryTree = garbageCollector.summarize(
+				true /* fullTree */,
+				true /* trackState */,
+			);
+			assert(summaryTree?.summary.type === SummaryType.Tree, "The summary should be a tree");
+
+			// Get the deleted node ids from summary and validate that its the same as the one GC loaded from.
+			const deletedNodesBlob = summaryTree.summary.tree[gcDeletedBlobKey];
+			assert(
+				deletedNodesBlob.type === SummaryType.Blob,
+				"Deleted blob not present in summary",
+			);
+			const deletedNodeIdsInSummary = JSON.parse(
+				deletedNodesBlob.content as string,
+			) as string[];
+			assert.deepStrictEqual(
+				deletedNodeIdsInSummary,
+				deletedNodeIds,
+				"Unexpected deleted nodes in summary",
+			);
+		});
+
+		it("writes handle for deleted blobs when its unchanged", async () => {
+			// Set up the GC reference graph to have something to work with.
+			defaultGCData.gcNodes["/"] = [nodes[0]];
+
+			// Create a snapshot tree to be used as the GC snapshot tree.
+			const gcSnapshotTree = getDummySnapshotTree();
+			// Add a blob to the tree for deleted nodes.
+			const deletedNodesBlobId = "deletedNodes";
+			gcSnapshotTree.blobs[gcDeletedBlobKey] = deletedNodesBlobId;
+			const deletedNodeIds = [...nodes];
+			// Add deleted nodes list the blobs map that will service read and parse blob calls from GC.
+			const gcBlobsMap: Map<string, string[]> = new Map([
+				[deletedNodesBlobId, deletedNodeIds],
+			]);
+			// Create a base snapshot that contains the GC snapshot tree.
+			const baseSnapshot = getDummySnapshotTree();
+			baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
+
+			// Create and initialize garbage collector.
+			const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobsMap);
+			await garbageCollector.initializeBaseState();
+
+			// Run GC and summarize. The summary should contain the deleted nodes.
+			await garbageCollector.collectGarbage({});
+			const gcSummary = garbageCollector.summarize(
+				false /* fullTree */,
+				true /* trackState */,
+			);
+			assert(gcSummary?.summary.type === SummaryType.Tree, "The summary should be a tree");
+
+			// Get the deleted node ids from summary and validate that its the same as the one GC loaded from.
+			const deletedNodesBlob = gcSummary.summary.tree[gcDeletedBlobKey];
+			assert(
+				deletedNodesBlob.type === SummaryType.Handle,
+				"Deleted nodes state should be a handle",
+			);
+
+			const refreshSummaryResult: RefreshSummaryResult = {
+				latestSummaryUpdated: true,
+				wasSummaryTracked: true,
+			};
+			await garbageCollector.refreshLatestSummary(
+				refreshSummaryResult,
+				undefined,
+				0,
+				parseNothing,
+			);
+
+			// Run GC and summarize again. The whole GC summary should now be a summary handle.
+			await garbageCollector.collectGarbage({});
+			const gcSummary2 = garbageCollector.summarize(
+				false /* fullTree */,
+				true /* trackState */,
+			);
+			assert(
+				gcSummary2?.summary.type === SummaryType.Handle,
+				"The summary should be a handle",
+			);
+		});
+	});
+
+	describe("GC completed runs", () => {
+		const gcEndEvent = "GarbageCollector:GarbageCollection_end";
+
+		it("increments GC completed runs in logged events correctly", async () => {
+			const garbageCollector = createGarbageCollector();
+
+			await garbageCollector.collectGarbage({});
+			mockLogger.assertMatch(
+				[{ eventName: gcEndEvent, completedGCRuns: 0 }],
+				"completedGCRuns should be 0 since this event was logged before first GC run completed",
+			);
+
+			await garbageCollector.collectGarbage({});
+			mockLogger.assertMatch(
+				[{ eventName: gcEndEvent, completedGCRuns: 1 }],
+				"completedGCRuns should be 1 since this event was logged after first GC run completed",
+			);
+
+			await garbageCollector.collectGarbage({});
+			mockLogger.assertMatch(
+				[{ eventName: gcEndEvent, completedGCRuns: 2 }],
+				"completedGCRuns should be 2 since this event was logged after second GC run completed",
+			);
+
+			// The GC run count should reset for new garbage collector.
+			const garbageCollector2 = createGarbageCollector();
+			await garbageCollector2.collectGarbage({});
+			mockLogger.assertMatch(
+				[{ eventName: gcEndEvent, completedGCRuns: 0 }],
+				"completedGCRuns should be 0 since this event was logged before first GC run in new garbage collector",
+			);
+		});
+	});
+
+	/*
+	 * These tests validate scenarios where nodes that are referenced between summaries have their unreferenced
+	 * timestamp updated. These scenarios fall into the following categories:
+	 * 1. Nodes transition from unreferenced -> referenced -> unreferenced between 2 summaries - In these scenarios
+	 *    when GC runs, it should detect that the node was referenced and update its unreferenced timestamp.
+	 * 2. Unreferenced nodes are referenced from other unreferenced nodes - In this case, even though the node remains
+	 *    unreferenced, its unreferenced timestamp should be updated.
+	 *
+	 * In these tests, V = nodes and E = edges between nodes. Root nodes that are always referenced are marked as *.
+	 */
+	describe("References between summaries", () => {
+		let garbageCollector: IGarbageCollector;
+		const nodeA = "/A";
+		const nodeB = "/B";
+		const nodeC = "/C";
+		const nodeD = "/D";
+		const nodeE = "/A/E";
+
+		// Runs GC and returns the unreferenced timestamps of all nodes in the GC summary.
+		async function getUnreferencedTimestamps() {
+			// Advance the clock by 1 tick so that the unreferenced timestamp is updated in between runs.
+			clock.tick(1);
+
+			await garbageCollector.collectGarbage({});
+
+			const summaryTree = garbageCollector.summarize(true, false)?.summary;
+			assert(summaryTree !== undefined, "Nothing to summarize after running GC");
+			assert(summaryTree.type === SummaryType.Tree, "Expecting a summary tree!");
+
+			let rootGCState: IGarbageCollectionState = { gcNodes: {} };
+			for (const key of Object.keys(summaryTree.tree)) {
+				// Skip blobs that do not start with the GC prefix.
+				if (!key.startsWith(gcBlobPrefix)) {
+					continue;
+				}
+
+				const gcBlob = summaryTree.tree[key];
+				assert(gcBlob?.type === SummaryType.Blob, `GC blob not available`);
+				const gcState = JSON.parse(gcBlob.content as string) as IGarbageCollectionState;
+				// Merge the GC state of this blob into the root GC state.
+				rootGCState = concatGarbageCollectionStates(rootGCState, gcState);
+			}
+			const nodeTimestamps: Map<string, number | undefined> = new Map();
+			for (const [nodeId, nodeData] of Object.entries(rootGCState.gcNodes)) {
+				nodeTimestamps.set(nodeId, nodeData.unreferencedTimestampMs);
+			}
+			return nodeTimestamps;
+		}
+
+		beforeEach(() => {
+			defaultGCData.gcNodes = {};
+			garbageCollector = createGarbageCollector();
+		});
+
+		describe("Nodes transitioning from unreferenced -> referenced -> unreferenced", () => {
+			/**
+			 * Validates that we can detect references that were added and then removed.
+			 * 1. Summary 1 at t1. V = [A*, B]. E = []. B has unreferenced time t1.
+			 * 2. Reference from A to B added. E = [A -\> B].
+			 * 3. Reference from A to B removed. E = [].
+			 * 4. Summary 2 at t2. V = [A*, B]. E = []. B has unreferenced time t2.
+			 * Validates that the unreferenced time for B is t2 which is \> t1.
+			 */
+			it(`Scenario 1 - Reference added and then removed`, async () => {
+				// Initialize nodes A and B.
+				defaultGCData.gcNodes["/"] = [nodeA];
+				defaultGCData.gcNodes[nodeA] = [];
+				defaultGCData.gcNodes[nodeB] = [];
+
+				// 1. Run GC and generate summary 1. E = [].
+				const timestamps1 = await getUnreferencedTimestamps();
+				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeBTime1 = timestamps1.get(nodeB);
+				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+
+				// 2. Add reference from A to B. E = [A -\> B].
+				garbageCollector.addedOutboundReference(nodeA, nodeB);
+				defaultGCData.gcNodes[nodeA] = [nodeB];
+
+				// 3. Remove reference from A to B. E = [].
+				defaultGCData.gcNodes[nodeA] = [];
+
+				// 4. Run GC and generate summary 2. E = [].
+				const timestamps2 = await getUnreferencedTimestamps();
+				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeBTime2 = timestamps2.get(nodeB);
+
+				assert(
+					nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1,
+					"B's timestamp should have updated",
+				);
+			});
+
+			/**
+			 * Validates that we can detect references that were added transitively and then removed.
+			 * 1. Summary 1 at t1. V = [A*, B, C]. E = [B -\> C]. B and C have unreferenced time t2.
+			 * 2. Reference from A to B added. E = [A -\> B, B -\> C].
+			 * 3. Reference from B to C removed. E = [A -\> B].
+			 * 4. Reference from A to B removed. E = [].
+			 * 5. Summary 2 at t2. V = [A*, B, C]. E = []. B and C have unreferenced time t2.
+			 * Validates that the unreferenced time for B and C is t2 which is \> t1.
+			 */
+			it(`Scenario 2 - Reference transitively added and removed`, async () => {
+				// Initialize nodes A, B and C.
+				defaultGCData.gcNodes["/"] = [nodeA];
+				defaultGCData.gcNodes[nodeA] = [];
+				defaultGCData.gcNodes[nodeB] = [nodeC];
+				defaultGCData.gcNodes[nodeC] = [];
+
+				// 1. Run GC and generate summary 1. E = [B -\> C].
+				const timestamps1 = await getUnreferencedTimestamps();
+				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeBTime1 = timestamps1.get(nodeB);
+				const nodeCTime1 = timestamps1.get(nodeC);
+				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+
+				// 2. Add reference from A to B. E = [A -\> B, B -\> C].
+				garbageCollector.addedOutboundReference(nodeA, nodeB);
+				defaultGCData.gcNodes[nodeA] = [nodeB];
+
+				// 3. Remove reference from B to C. E = [A -\> B].
+				defaultGCData.gcNodes[nodeB] = [];
+
+				// 4. Remove reference from A to B. E = [].
+				defaultGCData.gcNodes[nodeA] = [];
+
+				// 5. Run GC and generate summary 2. E = [].
+				const timestamps2 = await getUnreferencedTimestamps();
+				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeBTime2 = timestamps2.get(nodeB);
+				const nodeCTime2 = timestamps2.get(nodeC);
+				assert(
+					nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1,
+					"B's timestamp should have updated",
+				);
+				assert(
+					nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1,
+					"C's timestamp should have updated",
+				);
+			});
+
+			/**
+			 * Validates that we can detect chain of references in which the first reference was added and then removed.
+			 * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [B -\> C, C -\> D]. B, C and D have unreferenced time t2.
+			 * 2. Reference from A to B added. E = [A -\> B, B -\> C, C -\> D].
+			 * 3. Reference from A to B removed. E = [B -\> C, C -\> D].
+			 * 4. Summary 2 at t2. V = [A*, B, C, D]. E = [B -\> C, C -\> D]. B, C and D have unreferenced time t2.
+			 * Validates that the unreferenced time for B, C and D is t2 which is \> t1.
+			 */
+			it(`Scenario 3 - Reference added through chain of references and removed`, async () => {
+				// Initialize nodes A, B, C and D.
+				defaultGCData.gcNodes["/"] = [nodeA];
+				defaultGCData.gcNodes[nodeA] = [];
+				defaultGCData.gcNodes[nodeB] = [nodeC];
+				defaultGCData.gcNodes[nodeC] = [nodeD];
+				defaultGCData.gcNodes[nodeD] = [];
+
+				// 1. Run GC and generate summary 1. E = [B -\> C, C -\> D].
+				const timestamps1 = await getUnreferencedTimestamps();
+				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeBTime1 = timestamps1.get(nodeB);
+				const nodeCTime1 = timestamps1.get(nodeC);
+				const nodeDTime1 = timestamps1.get(nodeD);
+				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+				assert(nodeDTime1 !== undefined, "D should have unreferenced timestamp");
+
+				// 2. Add reference from A to B. E = [A -\> B, B -\> C, C -\> D].
+				garbageCollector.addedOutboundReference(nodeA, nodeB);
+				defaultGCData.gcNodes[nodeA] = [nodeB];
+
+				// 3. Remove reference from A to B. E = [B -\> C, C -\> D].
+				defaultGCData.gcNodes[nodeA] = [];
+
+				// 4. Run GC and generate summary 2. E = [B -\> C, C -\> D].
+				const timestamps2 = await getUnreferencedTimestamps();
+				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeBTime2 = timestamps2.get(nodeB);
+				const nodeCTime2 = timestamps2.get(nodeC);
+				const nodeDTime2 = timestamps2.get(nodeD);
+				assert(
+					nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1,
+					"B's timestamp should have updated",
+				);
+				assert(
+					nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1,
+					"C's timestamp should have updated",
+				);
+				assert(
+					nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1,
+					"D's timestamp should have updated",
+				);
+			});
+
+			/**
+			 * Validates that we can detect references that were added and removed via new nodes.
+			 * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
+			 * 2. Node B is created. E = [].
+			 * 3. Reference from A to B added. E = [A -\> B].
+			 * 4. Reference from B to C added. E = [A -\> B, B -\> C].
+			 * 5. Reference from B to C removed. E = [A -\> B].
+			 * 6. Summary 2 at t2. V = [A*, B, C]. E = [A -\> B]. C has unreferenced time t2.
+			 * Validates that the unreferenced time for C is t2 which is \> t1.
+			 */
+			it(`Scenario 4 - Reference added via new nodes and removed`, async () => {
+				// Initialize nodes A, B and C.
+				defaultGCData.gcNodes["/"] = [nodeA];
+				defaultGCData.gcNodes[nodeA] = [];
+				defaultGCData.gcNodes[nodeC] = [];
+
+				// 1. Run GC and generate summary 1. E = [].
+				const timestamps1 = await getUnreferencedTimestamps();
+				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeCTime1 = timestamps1.get(nodeC);
+				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+
+				// 2. Create node B, i.e., add B to GC data. E = [].
+				defaultGCData.gcNodes[nodeB] = [];
+
+				// 3. Add reference from A to B. E = [A -\> B].
+				garbageCollector.addedOutboundReference(nodeA, nodeB);
+				defaultGCData.gcNodes[nodeA] = [nodeB];
+
+				// 4. Add reference from B to C. E = [A -\> B, B -\> C].
+				garbageCollector.addedOutboundReference(nodeB, nodeC);
+				defaultGCData.gcNodes[nodeB] = [nodeC];
+
+				// 5. Remove reference from B to C. E = [A -\> B].
+				defaultGCData.gcNodes[nodeB] = [];
+
+				// 6. Run GC and generate summary 2. E = [A -\> B].
+				const timestamps2 = await getUnreferencedTimestamps();
+				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+				assert(timestamps2.get(nodeB) === undefined, "B should be referenced");
+
+				const nodeCTime2 = timestamps2.get(nodeC);
+				assert(
+					nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1,
+					"C's timestamp should have updated",
+				);
+			});
+
+			/**
+			 * Validates that we can detect multiple references that were added and then removed by the same node.
+			 * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
+			 * 2. Reference from A to B added. E = [A -\> B].
+			 * 3. Reference from A to C added. E = [A -\> B, A -\> C].
+			 * 4. Reference from A to B removed. E = [A -\> C].
+			 * 5. Reference from A to C removed. E = [].
+			 * 6. Summary 2 at t2. V = [A*, B]. E = []. B and C have unreferenced time t2.
+			 * Validates that the unreferenced time for B and C is t2 which is \> t1.
+			 */
+			it(`Scenario 5 - Multiple references added and then removed by same node`, async () => {
+				// Initialize nodes A, B and C.
+				defaultGCData.gcNodes["/"] = [nodeA];
+				defaultGCData.gcNodes[nodeA] = [];
+				defaultGCData.gcNodes[nodeB] = [];
+				defaultGCData.gcNodes[nodeC] = [];
+
+				// 1. Run GC and generate summary 1. E = [].
+				const timestamps1 = await getUnreferencedTimestamps();
+				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeBTime1 = timestamps1.get(nodeB);
+				const nodeCTime1 = timestamps1.get(nodeC);
+				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+
+				// 2. Add reference from A to B. E = [A -\> B].
+				garbageCollector.addedOutboundReference(nodeA, nodeB);
+				defaultGCData.gcNodes[nodeA] = [nodeB];
+
+				// 3. Add reference from A to C. E = [A -\> B, A -\> C].
+				garbageCollector.addedOutboundReference(nodeA, nodeC);
+				defaultGCData.gcNodes[nodeA] = [nodeB, nodeC];
+
+				// 4. Remove reference from A to B. E = [A -\> C].
+				defaultGCData.gcNodes[nodeA] = [nodeC];
+
+				// 5. Remove reference from A to C. E = [].
+				defaultGCData.gcNodes[nodeA] = [];
+
+				// 6. Run GC and generate summary 2. E = [].
+				const timestamps2 = await getUnreferencedTimestamps();
+				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeBTime2 = timestamps2.get(nodeB);
+				const nodeCTime2 = timestamps2.get(nodeC);
+				assert(
+					nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1,
+					"C's timestamp should have updated",
+				);
+				assert(
+					nodeBTime2 !== undefined && nodeBTime2 > nodeBTime1,
+					"B's timestamp should have updated",
+				);
+			});
+
+			/**
+			 * Validates that we generate error on detecting reference during GC that was not notified explicitly.
+			 * 1. Summary 1 at t1. V = [A*]. E = [].
+			 * 2. Node B is created. E = [].
+			 * 3. Reference from A to B added without notifying GC. E = [A -\> B].
+			 * 4. Summary 2 at t2. V = [A*, B]. E = [A -\> B].
+			 * Validates that we log an error since B is detected as a referenced node but its reference was notified
+			 * to GC.
+			 */
+			it(`Scenario 6 - Reference added without notifying GC`, async () => {
+				// Initialize nodes A & D.
+				defaultGCData.gcNodes["/"] = [nodeA, nodeD];
+				defaultGCData.gcNodes[nodeA] = [];
+				defaultGCData.gcNodes[nodeD] = [];
+
+				// 1. Run GC and generate summary 1. E = [].
+				const timestamps1 = await getUnreferencedTimestamps();
+				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+				assert(timestamps1.get(nodeD) === undefined, "D should be referenced");
+
+				// 2. Create nodes B & C. E = [].
+				defaultGCData.gcNodes[nodeB] = [];
+				defaultGCData.gcNodes[nodeC] = [];
+
+				// 3. Add reference from A to B, A to C, A to E, D to C, and E to A without calling addedOutboundReference.
+				// E = [A -\> B, A -\> C, A -\> E, D -\> C, E -\> A].
+				defaultGCData.gcNodes[nodeA] = [nodeB, nodeC, nodeE];
+				defaultGCData.gcNodes[nodeD] = [nodeC];
+				defaultGCData.gcNodes[nodeE] = [nodeA];
+
+				// 4. Add reference from A to D with calling addedOutboundReference
+				defaultGCData.gcNodes[nodeA].push(nodeD);
+				garbageCollector.addedOutboundReference(nodeA, nodeD);
+
+				// 5. Run GC and generate summary 2. E = [A -\> B, A -\> C, A -\> E, D -\> C, E -\> A].
+				await getUnreferencedTimestamps();
+
+				// Validate that we got the "gcUnknownOutboundReferences" error.
+				const unknownReferencesEvent = "GarbageCollector:gcUnknownOutboundReferences";
+				const eventsFound = mockLogger.matchEvents([
+					{
+						eventName: unknownReferencesEvent,
+						gcNodeId: "/A",
+						gcRoutes: JSON.stringify(["/B", "/C"]),
+					},
+					{
+						eventName: unknownReferencesEvent,
+						gcNodeId: "/D",
+						gcRoutes: JSON.stringify(["/C"]),
+					},
+				]);
+				assert(eventsFound, `Expected unknownReferenceEvent event!`);
+			});
+		});
+
+		describe("References to unreferenced nodes", () => {
+			/**
+			 * Validates that we can detect references that are added from an unreferenced node to another.
+			 * 1. Summary 1 at t1. V = [A*, B, C]. E = []. B and C have unreferenced time t1.
+			 * 2. Reference from B to C. E = [B -\> C].
+			 * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -\> C]. B and C have unreferenced time t1.
+			 * Validates that the unreferenced time for B and C is still t1.
+			 */
+			it(`Scenario 1 - Reference added to unreferenced node`, async () => {
+				// Initialize nodes A, B and C.
+				defaultGCData.gcNodes["/"] = [nodeA];
+				defaultGCData.gcNodes[nodeA] = [];
+				defaultGCData.gcNodes[nodeB] = [];
+				defaultGCData.gcNodes[nodeC] = [];
+
+				// 1. Run GC and generate summary 1. E = [B -\> C].
+				const timestamps1 = await getUnreferencedTimestamps();
+				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeBTime1 = timestamps1.get(nodeB);
+				const nodeCTime1 = timestamps1.get(nodeC);
+				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+
+				// 2. Add reference from B to C. E = [B -\> C].
+				garbageCollector.addedOutboundReference(nodeB, nodeC);
+				defaultGCData.gcNodes[nodeB] = [nodeC];
+
+				// 3. Run GC and generate summary 2. E = [B -\> C].
+				const timestamps2 = await getUnreferencedTimestamps();
+				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeBTime2 = timestamps2.get(nodeB);
+				const nodeCTime2 = timestamps2.get(nodeC);
+				assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
+				assert(
+					nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1,
+					"C's timestamp should have updated",
+				);
+			});
+
+			/*
+			 * Validates that we can detect references that are added from an unreferenced node to a list of
+			 * unreferenced nodes, i.e., nodes with references to each other but are overall unreferenced.
+			 * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [C -\> D]. B, C and D have unreferenced time t1.
+			 * 2. Op adds reference from B to C. E = [B -\> C, C -\> D].
+			 * 3. Summary 2 at t2. V = [A*, B, C]. E = [B -\> C, C -\> D]. C and D have unreferenced time t2.
+			 * Validates that the unreferenced time for C and D is t2 which is > t1.
+			 */
+			it(`Scenario 2 - Reference added to a list of unreferenced nodes from an unreferenced node`, async () => {
+				// Initialize nodes A, B and C.
+				defaultGCData.gcNodes["/"] = [nodeA];
+				defaultGCData.gcNodes[nodeA] = [];
+				defaultGCData.gcNodes[nodeB] = [];
+				defaultGCData.gcNodes[nodeC] = [nodeD];
+				defaultGCData.gcNodes[nodeD] = [];
+
+				// 1. Run GC and generate summary 1. E = [B -\> C].
+				const timestamps1 = await getUnreferencedTimestamps();
+				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeBTime1 = timestamps1.get(nodeB);
+				const nodeCTime1 = timestamps1.get(nodeC);
+				const nodeDTime1 = timestamps1.get(nodeC);
+				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+				assert(nodeDTime1 !== undefined, "C should have unreferenced timestamp");
+
+				// 2. Add reference from B to C. E = [B -\> C, C-\> D].
+				garbageCollector.addedOutboundReference(nodeB, nodeC);
+				defaultGCData.gcNodes[nodeB] = [nodeC];
+
+				// 3. Run GC and generate summary 2. E = [B -\> C. C -\> D].
+				const timestamps2 = await getUnreferencedTimestamps();
+				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeBTime2 = timestamps2.get(nodeB);
+				const nodeCTime2 = timestamps2.get(nodeC);
+				const nodeDTime2 = timestamps2.get(nodeD);
+				assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
+				assert(
+					nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1,
+					"C's timestamp should have updated",
+				);
+				assert(
+					nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1,
+					"D's timestamp should have updated",
+				);
+			});
+
+			/*
+			 * Validates that we can detect references that are added from an unreferenced node to a list of
+			 * unreferenced nodes, i.e., nodes with references to each other but are overall unreferenced. Then
+			 * a reference between the list is removed
+			 * 1. Summary 1 at t1. V = [A*, B, C, D]. E = [C -> D]. B, C and D have unreferenced time t1.
+			 * 2. Op adds reference from B to C. E = [B -> C, C -> D].
+			 * 3. Op removes reference from C to D. E = [B -> C].
+			 * 4. Summary 2 at t2. V = [A*, B, C]. E = [B -> C]. C and D have unreferenced time t2.
+			 * Validates that the unreferenced time for C and D is t2 which is > t1.
+			 */
+			it(`Scenario 3 - Reference added to a list of unreferenced nodes and a reference is removed`, async () => {
+				// Initialize nodes A, B and C.
+				defaultGCData.gcNodes["/"] = [nodeA];
+				defaultGCData.gcNodes[nodeA] = [];
+				defaultGCData.gcNodes[nodeB] = [];
+				defaultGCData.gcNodes[nodeC] = [nodeD];
+				defaultGCData.gcNodes[nodeD] = [];
+
+				// 1. Run GC and generate summary 1. E = [B -\> C].
+				const timestamps1 = await getUnreferencedTimestamps();
+				assert(timestamps1.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeBTime1 = timestamps1.get(nodeB);
+				const nodeCTime1 = timestamps1.get(nodeC);
+				const nodeDTime1 = timestamps1.get(nodeC);
+				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
+				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
+				assert(nodeDTime1 !== undefined, "C should have unreferenced timestamp");
+
+				// 2. Add reference from B to C. E = [B -\> C, C-\> D].
+				garbageCollector.addedOutboundReference(nodeB, nodeC);
+				defaultGCData.gcNodes[nodeB] = [nodeC];
+
+				// 3. Remove reference from C to D. E = [B -\> C].
+				defaultGCData.gcNodes[nodeC] = [];
+
+				// 3. Run GC and generate summary 2. E = [B -\> C].
+				const timestamps2 = await getUnreferencedTimestamps();
+				assert(timestamps2.get(nodeA) === undefined, "A should be referenced");
+
+				const nodeBTime2 = timestamps2.get(nodeB);
+				const nodeCTime2 = timestamps2.get(nodeC);
+				const nodeDTime2 = timestamps2.get(nodeD);
+				assert(nodeBTime2 === nodeBTime1, "B's timestamp should be unchanged");
+				assert(
+					nodeCTime2 !== undefined && nodeCTime2 > nodeCTime1,
+					"C's timestamp should have updated",
+				);
+				assert(
+					nodeDTime2 !== undefined && nodeDTime2 > nodeDTime1,
+					"D's timestamp should have updated",
+				);
+			});
+		});
+	});
+
+	describe("No changes to GC between summaries", () => {
+		const fullTree = false;
+		const trackState = true;
+		let garbageCollector: IGarbageCollector;
+
+		beforeEach(() => {
+			injectedSettings["Fluid.GarbageCollection.TrackGCState"] = true;
+			// Initialize nodes A & D.
+			defaultGCData.gcNodes = {};
+			defaultGCData.gcNodes["/"] = nodes;
+		});
+
+		const checkGCSummaryType = (
+			summary: ISummarizeResult | undefined,
+			expectedBlobType: SummaryType,
+			summaryNumber: string,
+		) => {
+			assert(summary !== undefined, `Expected a summary on ${summaryNumber} summarize`);
+			assert(
+				summary.summary.type === expectedBlobType,
+				`Expected summary type ${expectedBlobType} on ${summaryNumber} summarize, got ${summary.summary.type}`,
+			);
+		};
+
+		it("creates a blob handle when no version specified", async () => {
+			garbageCollector = createGarbageCollector();
+
+			await garbageCollector.collectGarbage({});
+			const tree1 = garbageCollector.summarize(fullTree, trackState);
+
+			checkGCSummaryType(tree1, SummaryType.Tree, "first");
+
+			await garbageCollector.refreshLatestSummary(
+				{ wasSummaryTracked: true, latestSummaryUpdated: true },
+				undefined,
+				0,
+				parseNothing,
+			);
+
+			await garbageCollector.collectGarbage({});
+			const tree2 = garbageCollector.summarize(fullTree, trackState);
+
+			checkGCSummaryType(tree2, SummaryType.Handle, "second");
+		});
+	});
 });

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -231,25 +231,25 @@ describe("Garbage Collection Tests", () => {
 				assert(gc.gcEnabled, "gcEnabled incorrect");
 				assert.equal(gc.latestSummaryGCVersion, 1, "latestSummaryGCVersion incorrect");
 			});
-			it("gcFailureMinCreateContainerRuntimeVersion later than persisted value, sweepEnabled false", () => {
+			it("gcEnforcementMinCreateContainerRuntimeVersion later than persisted value, sweepEnabled false", () => {
 				gc = createGcWithPrivateMembers(
 					{ createContainerRuntimeVersion: "1.2.3", sweepEnabled: true },
-					{ gcFailureMinCreateContainerRuntimeVersion: "2.0.0" },
+					{ gcEnforcementMinCreateContainerRuntimeVersion: "2.0.0" },
 				);
 				assert(gc.gcEnabled, "gcEnabled incorrect");
 				assert(!gc.sweepEnabled, "sweepEnabled incorrect");
 			});
-			it("gcFailureMinCreateContainerRuntimeVersion equal to persisted value, sweepEnabled true", () => {
+			it("gcEnforcementMinCreateContainerRuntimeVersion equal to persisted value, sweepEnabled true", () => {
 				gc = createGcWithPrivateMembers(
 					{ createContainerRuntimeVersion: "1.2.3", sweepEnabled: true },
-					{ gcFailureMinCreateContainerRuntimeVersion: "1.2.3" },
+					{ gcEnforcementMinCreateContainerRuntimeVersion: "1.2.3" },
 				);
 				assert(gc.sweepEnabled, "sweepEnabled incorrect");
 			});
-			it("gcFailureMinCreateContainerRuntimeVersion earlier than persisted value, sweepEnabled true", () => {
+			it("gcEnforcementMinCreateContainerRuntimeVersion earlier than persisted value, sweepEnabled true", () => {
 				gc = createGcWithPrivateMembers(
 					{ createContainerRuntimeVersion: "1.2.3", sweepEnabled: true },
-					{ gcFailureMinCreateContainerRuntimeVersion: "1.0.0" },
+					{ gcEnforcementMinCreateContainerRuntimeVersion: "1.0.0" },
 				);
 				assert(gc.sweepEnabled, "sweepEnabled incorrect");
 			});

--- a/packages/runtime/container-runtime/src/test/gcHelpers.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gcHelpers.spec.ts
@@ -21,46 +21,58 @@ describe.only("Garbage Collection Helpers Tests", () => {
 			expectedShouldDisableValue: boolean;
 		}[] = [
 			{
-				description: "Min version undefined - DON'T disable GC enforcement",
+				description: "Both versions undefined - DON'T disable",
+				createContainerRuntimeVersion: undefined,
+				gcEnforcementMinCreateContainerRuntimeVersion: undefined,
+				expectedShouldDisableValue: false,
+			},
+			{
+				description: "Min version undefined - DON'T disable",
 				createContainerRuntimeVersion: "0.0.0",
 				gcEnforcementMinCreateContainerRuntimeVersion: undefined,
 				expectedShouldDisableValue: false,
 			},
 			{
-				description: "Min Version invalid - DON'T disable GC enforcement",
+				description: "Min Version invalid - DON'T disable",
 				createContainerRuntimeVersion: "0.0.0",
 				gcEnforcementMinCreateContainerRuntimeVersion: "not a valid version",
 				expectedShouldDisableValue: false,
 			},
 			{
-				description: "Persisted value unreleased; Min Version defined - DON'T disable GC enforcement",
+				description: "Persisted value unreleased; Min Version defined - DON'T disable",
 				createContainerRuntimeVersion: "2.0.0-dev.1.2.3.45678",
 				gcEnforcementMinCreateContainerRuntimeVersion: "3.0.0",
 				expectedShouldDisableValue: false,
 			},
 			{
-				description: "Persisted value newer than Min Version - DON'T disable GC enforcement",
+				description: "Persisted value newer than Min Version - DON'T disable",
 				createContainerRuntimeVersion: "2.0.0-internal.3.0.0",
 				gcEnforcementMinCreateContainerRuntimeVersion: "2.0.0-internal.2.3.1",
 				expectedShouldDisableValue: false,
 			},
 			{
-				description: "Persisted value equal to Min Version - DON'T disable GC enforcement",
+				description: "Persisted value equal to Min Version - DON'T disable",
 				createContainerRuntimeVersion: "2.0.0",
 				gcEnforcementMinCreateContainerRuntimeVersion: "2.0.0",
 				expectedShouldDisableValue: false,
 			},
 			{
-				description: "Persisted value older than Min Version - DO disable GC enforcement",
+				description: "Persisted value older than Min Version - DO disable",
 				createContainerRuntimeVersion: "1.0.0",
 				gcEnforcementMinCreateContainerRuntimeVersion: "2.0.0",
 				expectedShouldDisableValue: true,
 			},
 			{
-				description: "No persisted value; Min Version defined - DO disable GC enforcement",
+				description: "No persisted value; Min Version defined - DO disable",
 				createContainerRuntimeVersion: undefined,
 				gcEnforcementMinCreateContainerRuntimeVersion: "1.0.0",
 				expectedShouldDisableValue: true,
+			},
+			{
+				description: "Invalid persisted value - DON'T disable",
+				createContainerRuntimeVersion: "2.0.0-dev.3.0.0",
+				gcEnforcementMinCreateContainerRuntimeVersion: "3.0.0",
+				expectedShouldDisableValue: false,
 			},
 		];
 		testCases.forEach(({
@@ -76,5 +88,43 @@ describe.only("Garbage Collection Helpers Tests", () => {
 				assert.equal(shouldDisable, expectedShouldDisableValue, "sweepEnabled incorrect");
 			});
 		});
+
+		it("sort test", () => {
+			function compareFn(a: string, b: string) {
+				return shouldDisableGcEnforcementForOldContainer(a, b) ? -1 : 1;
+			}
+			const inputs = [
+				"2.0.0-internal.1.2.3",
+				"1.2.3",
+				"2.0.0-internal.1.2.4",
+				"2.0.0-internal.1.2.2",
+				"2.0.0-internal.1.3.2",
+				"2.0.0-internal.2.0.0",
+				"3.0.0-internal.0.0.1",
+				"1.0.0-internal.9.0.0",
+				"3.0.0",
+				"2.0.0",
+				"2.2.0",
+				"2.2.2-internal.1.2.3",
+				"2.2.2",
+			];
+			const sorted = [
+				"1.0.0-internal.9.0.0",
+				"1.2.3",
+				"2.0.0-internal.1.2.2",
+				"2.0.0-internal.1.2.3",
+				"2.0.0-internal.1.2.4",
+				"2.0.0-internal.1.3.2",
+				"2.0.0-internal.2.0.0",
+				"2.0.0",
+				"2.2.0",
+				"2.2.2-internal.1.2.3",
+				"2.2.2",
+				"3.0.0-internal.0.0.1",
+				"3.0.0",
+			];
+			const output = inputs.sort(compareFn);
+			assert.deepEqual(output, sorted, "Sort didn't go as expected");
+		})
 	});
 });

--- a/packages/runtime/container-runtime/src/test/gcHelpers.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gcHelpers.spec.ts
@@ -6,13 +6,7 @@
 import { strict as assert } from "assert";
 import { shouldDisableGcEnforcementForOldContainer } from "../garbageCollectionHelpers";
 
-//* ONLY
-//* ONLY
-//* ONLY
-//* ONLY
-//* ONLY
-//* ONLY
-describe.only("Garbage Collection Helpers Tests", () => {
+describe("Garbage Collection Helpers Tests", () => {
 	describe("shouldDisableGcEnforcementForOldContainer", () => {
 		const testCases: {
 			description: string;
@@ -75,19 +69,26 @@ describe.only("Garbage Collection Helpers Tests", () => {
 				expectedShouldDisableValue: false,
 			},
 		];
-		testCases.forEach(({
-			description,
-			createContainerRuntimeVersion,
-			gcEnforcementMinCreateContainerRuntimeVersion,
-			expectedShouldDisableValue,
-		}) => {
-			it(description, () => {
-				const shouldDisable = shouldDisableGcEnforcementForOldContainer(
-					createContainerRuntimeVersion,
-					gcEnforcementMinCreateContainerRuntimeVersion);
-				assert.equal(shouldDisable, expectedShouldDisableValue, "sweepEnabled incorrect");
-			});
-		});
+		testCases.forEach(
+			({
+				description,
+				createContainerRuntimeVersion,
+				gcEnforcementMinCreateContainerRuntimeVersion,
+				expectedShouldDisableValue,
+			}) => {
+				it(description, () => {
+					const shouldDisable = shouldDisableGcEnforcementForOldContainer(
+						createContainerRuntimeVersion,
+						gcEnforcementMinCreateContainerRuntimeVersion,
+					);
+					assert.equal(
+						shouldDisable,
+						expectedShouldDisableValue,
+						"sweepEnabled incorrect",
+					);
+				});
+			},
+		);
 
 		it("sort test", () => {
 			function compareFn(a: string, b: string) {

--- a/packages/runtime/container-runtime/src/test/gcHelpers.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gcHelpers.spec.ts
@@ -1,0 +1,80 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { shouldDisableGcEnforcementForOldContainer } from "../garbageCollectionHelpers";
+
+//* ONLY
+//* ONLY
+//* ONLY
+//* ONLY
+//* ONLY
+//* ONLY
+describe.only("Garbage Collection Helpers Tests", () => {
+	describe("shouldDisableGcEnforcementForOldContainer", () => {
+		const testCases: {
+			description: string;
+			createContainerRuntimeVersion: string | undefined;
+			gcEnforcementMinCreateContainerRuntimeVersion: string | undefined;
+			expectedShouldDisableValue: boolean;
+		}[] = [
+			{
+				description: "Min version undefined - DON'T disable GC enforcement",
+				createContainerRuntimeVersion: "0.0.0",
+				gcEnforcementMinCreateContainerRuntimeVersion: undefined,
+				expectedShouldDisableValue: false,
+			},
+			{
+				description: "Min Version invalid - DON'T disable GC enforcement",
+				createContainerRuntimeVersion: "0.0.0",
+				gcEnforcementMinCreateContainerRuntimeVersion: "not a valid version",
+				expectedShouldDisableValue: false,
+			},
+			{
+				description: "Persisted value unreleased; Min Version defined - DON'T disable GC enforcement",
+				createContainerRuntimeVersion: "2.0.0-dev.1.2.3.45678",
+				gcEnforcementMinCreateContainerRuntimeVersion: "3.0.0",
+				expectedShouldDisableValue: false,
+			},
+			{
+				description: "Persisted value newer than Min Version - DON'T disable GC enforcement",
+				createContainerRuntimeVersion: "2.0.0-internal.3.0.0",
+				gcEnforcementMinCreateContainerRuntimeVersion: "2.0.0-internal.2.3.1",
+				expectedShouldDisableValue: false,
+			},
+			{
+				description: "Persisted value equal to Min Version - DON'T disable GC enforcement",
+				createContainerRuntimeVersion: "2.0.0",
+				gcEnforcementMinCreateContainerRuntimeVersion: "2.0.0",
+				expectedShouldDisableValue: false,
+			},
+			{
+				description: "Persisted value older than Min Version - DO disable GC enforcement",
+				createContainerRuntimeVersion: "1.0.0",
+				gcEnforcementMinCreateContainerRuntimeVersion: "2.0.0",
+				expectedShouldDisableValue: true,
+			},
+			{
+				description: "No persisted value; Min Version defined - DO disable GC enforcement",
+				createContainerRuntimeVersion: undefined,
+				gcEnforcementMinCreateContainerRuntimeVersion: "1.0.0",
+				expectedShouldDisableValue: true,
+			},
+		];
+		testCases.forEach(({
+			description,
+			createContainerRuntimeVersion,
+			gcEnforcementMinCreateContainerRuntimeVersion,
+			expectedShouldDisableValue,
+		}) => {
+			it(description, () => {
+				const shouldDisable = shouldDisableGcEnforcementForOldContainer(
+					createContainerRuntimeVersion,
+					gcEnforcementMinCreateContainerRuntimeVersion);
+				assert.equal(shouldDisable, expectedShouldDisableValue, "sweepEnabled incorrect");
+			});
+		});
+	});
+});

--- a/packages/runtime/container-runtime/src/test/gcHelpers.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gcHelpers.spec.ts
@@ -94,6 +94,7 @@ describe.only("Garbage Collection Helpers Tests", () => {
 				return shouldDisableGcEnforcementForOldContainer(a, b) ? -1 : 1;
 			}
 			const inputs = [
+				"999.999.999",
 				"2.0.0-internal.1.2.3",
 				"1.2.3",
 				"2.0.0-internal.1.2.4",
@@ -122,9 +123,11 @@ describe.only("Garbage Collection Helpers Tests", () => {
 				"2.2.2",
 				"3.0.0-internal.0.0.1",
 				"3.0.0",
+				"999.999.999",
 			];
 			const output = inputs.sort(compareFn);
 			assert.deepEqual(output, sorted, "Sort didn't go as expected");
-		})
+		});
+		//* Add a test case that compares 2.0.0-internal.2.3.1 with the current pkgVersion to ensure it's always good
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -128,7 +128,9 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 		approximateUnreferenceTimestampMs: number,
 		disableTombstoneFailureViaOption: boolean = false,
 	) => {
-		const container = disableTombstoneFailureViaOption ? await makeContainer(testContainerConfigWithFutureMinGcOption) : await makeContainer();
+		const container = disableTombstoneFailureViaOption
+			? await makeContainer(testContainerConfigWithFutureMinGcOption)
+			: await makeContainer();
 		const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
 		await waitForContainerConnection(container);
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -43,23 +43,26 @@ import { getGCStateFromSummary, getGCTombstoneStateFromSummary } from "./gcTestS
  * to the summary and changing them (sending / receiving ops, loading, etc.) is not allowed.
  */
 describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
-    const remainingTimeUntilSweepMs = 100;
-    const sweepTimeoutMs = 200;
-    assert(remainingTimeUntilSweepMs < sweepTimeoutMs, "remainingTimeUntilSweepMs should be < sweepTimeoutMs");
-    const settings = {};
+	const remainingTimeUntilSweepMs = 100;
+	const sweepTimeoutMs = 200;
+	assert(
+		remainingTimeUntilSweepMs < sweepTimeoutMs,
+		"remainingTimeUntilSweepMs should be < sweepTimeoutMs",
+	);
+	const settings = {};
 
-    const gcOptions: IGCRuntimeOptions = { inactiveTimeoutMs: 0, gcContainerGeneration: 2 };
-    const testContainerConfig: ITestContainerConfig = {
-        runtimeOptions: {
-            summaryOptions: {
-                summaryConfigOverrides: {
-                    state: "disabled",
-                },
-            },
-            gcOptions,
-        },
-        loaderProps: { configProvider: mockConfigProvider(settings) },
-    };
+	const gcOptions: IGCRuntimeOptions = { inactiveTimeoutMs: 0, gcContainerGeneration: "2.0.0-internal.2.3.1" };
+	const testContainerConfig: ITestContainerConfig = {
+		runtimeOptions: {
+			summaryOptions: {
+				summaryConfigOverrides: {
+					state: "disabled",
+				},
+			},
+			gcOptions,
+		},
+		loaderProps: { configProvider: mockConfigProvider(settings) },
+	};
     const oldContainerConfig: ITestContainerConfig = {
         runtimeOptions: {
             summaryOptions: {
@@ -67,35 +70,34 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
                     state: "disabled",
                 },
             },
-            gcOptions: { ...gcOptions, gcContainerGeneration: 1 },
+            gcOptions: { ...gcOptions, gcContainerGeneration: "1.2.3" }, //* Rename (...MinGeneration?)
         },
         loaderProps: { configProvider: mockConfigProvider(settings) },
     };
 
-    let provider: ITestObjectProvider;
+	let provider: ITestObjectProvider;
 
-    beforeEach(async function() {
-        provider = getTestObjectProvider({ syncSummarizer: true });
-        if (provider.driver.type !== "local") {
-            this.skip();
-        }
-        settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
-    });
+	beforeEach(async function () {
+		provider = getTestObjectProvider({ syncSummarizer: true });
+		if (provider.driver.type !== "local") {
+			this.skip();
+		}
+		settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
+	});
 
-    async function loadContainer(summaryVersion: string) {
-        return provider.loadTestContainer(
-            testContainerConfig,
-            { [LoaderHeader.version]: summaryVersion },
-        );
-    }
+	async function loadContainer(summaryVersion: string) {
+		return provider.loadTestContainer(testContainerConfig, {
+			[LoaderHeader.version]: summaryVersion,
+		});
+	}
 
-    let documentAbsoluteUrl: string | undefined;
+	let documentAbsoluteUrl: string | undefined;
 
-    const makeContainer = async () => {
-        const container = await provider.makeTestContainer(testContainerConfig);
-        documentAbsoluteUrl = await container.getAbsoluteUrl("");
-        return container;
-    };
+	const makeContainer = async () => {
+		const container = await provider.makeTestContainer(testContainerConfig);
+		documentAbsoluteUrl = await container.getAbsoluteUrl("");
+		return container;
+	};
 
     const makeOldContainer = async () => {
         const container = await provider.makeTestContainer(oldContainerConfig);
@@ -103,425 +105,520 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
         return container;
     };
 
-    const loadSummarizerAndContainer = async (summaryVersion?: string) => {
-        return createSummarizerWithContainer(
-            provider,
-            documentAbsoluteUrl,
-            summaryVersion,
-            gcOptions,
-            mockConfigProvider(settings),
-        );
-    };
-    const summarize = async (summarizer: ISummarizer) => {
-        await provider.ensureSynchronized();
-        return summarizeNow(summarizer);
-    };
+	const loadSummarizerAndContainer = async (summaryVersion?: string) => {
+		return createSummarizerWithContainer(
+			provider,
+			documentAbsoluteUrl,
+			summaryVersion,
+			gcOptions,
+			mockConfigProvider(settings),
+		);
+	};
+	const summarize = async (summarizer: ISummarizer) => {
+		await provider.ensureSynchronized();
+		return summarizeNow(summarizer);
+	};
 
-    // This function creates an unreferenced datastore and returns the datastore's id and the summary version that
-    // datastore was unreferenced in.
-    const summarizationWithUnreferencedDataStoreAfterTime =
-        async (approximateUnreferenceTimestampMs: number, useOldGeneration: boolean = false) => {
-            const container = useOldGeneration ? await makeOldContainer() : await makeContainer();
-            const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
-            await waitForContainerConnection(container);
+	// This function creates an unreferenced datastore and returns the datastore's id and the summary version that
+	// datastore was unreferenced in.
+	const summarizationWithUnreferencedDataStoreAfterTime = async (
+		approximateUnreferenceTimestampMs: number,
+        useOldGeneration: boolean = false,
+	) => {
+        const container = useOldGeneration ? await makeOldContainer() : await makeContainer();
+		const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
+		await waitForContainerConnection(container);
 
-            const handleKey = "handle";
-            const dataStore = await defaultDataObject._context.containerRuntime.createDataStore(TestDataObjectType);
-            const testDataObject = await dataStore.entryPoint?.get() as ITestDataObject | undefined;
-            assert(testDataObject !== undefined, "Should have been able to retrieve testDataObject from entryPoint");
-            const unreferencedId = testDataObject._context.id;
+		const handleKey = "handle";
+		const dataStore = await defaultDataObject._context.containerRuntime.createDataStore(
+			TestDataObjectType,
+		);
+		const testDataObject = (await dataStore.entryPoint?.get()) as ITestDataObject | undefined;
+		assert(
+			testDataObject !== undefined,
+			"Should have been able to retrieve testDataObject from entryPoint",
+		);
+		const unreferencedId = testDataObject._context.id;
 
-            // Reference a datastore - important for making it live
-            defaultDataObject._root.set(handleKey, testDataObject.handle);
-            // Unreference a datastore
-            defaultDataObject._root.delete(handleKey);
+		// Reference a datastore - important for making it live
+		defaultDataObject._root.set(handleKey, testDataObject.handle);
+		// Unreference a datastore
+		defaultDataObject._root.delete(handleKey);
 
-            // Summarize
-            const {
-                container: summarizingContainer1,
-                summarizer: summarizer1,
-            } = await loadSummarizerAndContainer();
-            const summaryVersion = (await summarize(summarizer1)).summaryVersion;
+		// Summarize
+		const { container: summarizingContainer1, summarizer: summarizer1 } =
+			await loadSummarizerAndContainer();
+		const summaryVersion = (await summarize(summarizer1)).summaryVersion;
 
-            // TODO: trailing op test - note because of the way gc is currently structured, the error isn't logged,
-            // but it is detected - it's stored in the pending queue and the container closes before the error is sent.
-            testDataObject._root.set("send while unreferenced", "op");
-            await provider.ensureSynchronized();
+		// TODO: trailing op test - note because of the way gc is currently structured, the error isn't logged,
+		// but it is detected - it's stored in the pending queue and the container closes before the error is sent.
+		testDataObject._root.set("send while unreferenced", "op");
+		await provider.ensureSynchronized();
 
-            // Close the containers as these containers would be closed by session expiry before sweep ready ever occurs
-            container.close();
-            summarizingContainer1.close();
+		// Close the containers as these containers would be closed by session expiry before sweep ready ever occurs
+		container.close();
+		summarizingContainer1.close();
 
-            // Wait some time, the datastore can be in many different unreference states
-            await delay(approximateUnreferenceTimestampMs);
+		// Wait some time, the datastore can be in many different unreference states
+		await delay(approximateUnreferenceTimestampMs);
 
-            // Load a new container and summarizer based on the latest summary, summarize
-            const {
-                container: summarizingContainer2,
-                summarizer: summarizer2,
-            } = await loadSummarizerAndContainer(summaryVersion);
+		// Load a new container and summarizer based on the latest summary, summarize
+		const { container: summarizingContainer2, summarizer: summarizer2 } =
+			await loadSummarizerAndContainer(summaryVersion);
 
-            return {
-                unreferencedId,
-                summarizingContainer: summarizingContainer2,
-                summarizer: summarizer2,
-                summaryVersion,
-            };
-        };
+		return {
+			unreferencedId,
+			summarizingContainer: summarizingContainer2,
+			summarizer: summarizer2,
+			summaryVersion,
+		};
+	};
 
-    let opCount = 0;
-    // Sends a unique op that's guaranteed to change the DDS for this specific container.
-    // This can also be used to transition a client to write mode.
-    const sendOpToUpdateSummaryTimestampToNow = async (container: IContainer) => {
-        const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
-        defaultDataObject._root.set("send a", `op ${opCount++}`);
-    };
+	let opCount = 0;
+	// Sends a unique op that's guaranteed to change the DDS for this specific container.
+	// This can also be used to transition a client to write mode.
+	const sendOpToUpdateSummaryTimestampToNow = async (container: IContainer) => {
+		const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
+		defaultDataObject._root.set("send a", `op ${opCount++}`);
+	};
 
-    const getTombstonedDataObjectFromSummary = async (summaryVersion: string, id: string) => {
-        // Load a container with the data store tombstoned
-        const container = await loadContainer(summaryVersion);
+	const getTombstonedDataObjectFromSummary = async (summaryVersion: string, id: string) => {
+		// Load a container with the data store tombstoned
+		const container = await loadContainer(summaryVersion);
 
-        // Transition container to write mode
-        const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
-        defaultDataObject._root.set("send a", "op");
+		// Transition container to write mode
+		const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
+		defaultDataObject._root.set("send a", "op");
 
-        // Get dataObject
-        const containerRuntime = defaultDataObject._context.containerRuntime as any;
-        const dataStoreContext = containerRuntime.dataStores.contexts.get(id);
-        const dataStoreRuntime: IFluidDataStoreChannel = await dataStoreContext.realize();
-        return await dataStoreRuntime.entryPoint?.get() as ITestDataObject;
-    };
+		// Get dataObject
+		const containerRuntime = defaultDataObject._context.containerRuntime as any;
+		const dataStoreContext = containerRuntime.dataStores.contexts.get(id);
+		const dataStoreRuntime: IFluidDataStoreChannel = await dataStoreContext.realize();
+		return (await dataStoreRuntime.entryPoint?.get()) as ITestDataObject;
+	};
 
-    const setupContainerCloseErrorValidation = (container: IContainer, expectedCall: string) => {
-        container.on("closed", (error) => {
-            assert(error !== undefined, `Expecting an error!`);
-            assert(error.errorType === "dataCorruptionError");
-            assert(error.message === `Context is tombstoned! Call site [${expectedCall}]`);
-        });
-    };
+	const setupContainerCloseErrorValidation = (container: IContainer, expectedCall: string) => {
+		container.on("closed", (error) => {
+			assert(error !== undefined, `Expecting an error!`);
+			assert(error.errorType === "dataCorruptionError");
+			assert(error.message === `Context is tombstoned! Call site [${expectedCall}]`);
+		});
+	};
 
-    describe("Using tombstone data stores not allowed (per config)", () => {
-        beforeEach(() => {
-            // Allow Loading but not Usage
-            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
-            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
-        });
+	describe("Using tombstone data stores not allowed (per config)", () => {
+		beforeEach(() => {
+			// Allow Loading but not Usage
+			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
+			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
+		});
 
-        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-        itExpects("Send ops fails for tombstoned datastores in summarizing container loaded after sweep timeout",
-        [
-            { eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" },
-        ],
-        async () => {
-            const {
-                unreferencedId,
-                summarizer,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+		itExpects(
+			"Send ops fails for tombstoned datastores in summarizing container loaded after sweep timeout",
+			[{ eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" }],
+			async () => {
+				const { unreferencedId, summarizer } =
+					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
 
-            // The datastore should be tombstoned now
-            const { summaryVersion } = await summarize(summarizer);
+				// The datastore should be tombstoned now
+				const { summaryVersion } = await summarize(summarizer);
 
-            const dataObject = await getTombstonedDataObjectFromSummary(summaryVersion, unreferencedId);
+				const dataObject = await getTombstonedDataObjectFromSummary(
+					summaryVersion,
+					unreferencedId,
+				);
 
-            // Modifying a testDataObject substantiated from the request pattern should fail!
-            assert.throws(() => dataObject._root.set("send", "op"),
-                (error) => {
-                    const correctErrorType = error.errorType === "dataCorruptionError";
-                    const correctErrorMessage = error.message?.startsWith(`Context is tombstoned`) === true;
-                    return correctErrorType && correctErrorMessage;
-                },
-                `Should not be able to send ops for a tombstoned datastore.`,
-            );
-        });
+				// Modifying a testDataObject substantiated from the request pattern should fail!
+				assert.throws(
+					() => dataObject._root.set("send", "op"),
+					(error) => {
+						const correctErrorType = error.errorType === "dataCorruptionError";
+						const correctErrorMessage =
+							error.message?.startsWith(`Context is tombstoned`) === true;
+						return correctErrorType && correctErrorMessage;
+					},
+					`Should not be able to send ops for a tombstoned datastore.`,
+				);
+			},
+		);
 
-        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-        itExpects("Send ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
-        [
-            { eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" },
-        ],
-        async () => {
-            const {
-                unreferencedId,
-                summarizingContainer,
-                summarizer,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
-            // Wait enough time so that the datastore is sweep ready
-            await delay(remainingTimeUntilSweepMs);
+		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+		itExpects(
+			"Send ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
+			[{ eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" }],
+			async () => {
+				const { unreferencedId, summarizingContainer, summarizer } =
+					await summarizationWithUnreferencedDataStoreAfterTime(
+						sweepTimeoutMs - remainingTimeUntilSweepMs,
+					);
+				// Wait enough time so that the datastore is sweep ready
+				await delay(remainingTimeUntilSweepMs);
 
-            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 
-            // The datastore should be tombstoned now
-            const { summaryVersion } = await summarize(summarizer);
-            const dataObject = await getTombstonedDataObjectFromSummary(summaryVersion, unreferencedId);
+				// The datastore should be tombstoned now
+				const { summaryVersion } = await summarize(summarizer);
+				const dataObject = await getTombstonedDataObjectFromSummary(
+					summaryVersion,
+					unreferencedId,
+				);
 
-            // Sending an op from a datastore substantiated from the request pattern should fail!
-            assert.throws(() => dataObject._root.set("send", "op"),
-                (error) => {
-                    const correctErrorType = error.errorType === "dataCorruptionError";
-                    const correctErrorMessage = error.message?.startsWith(`Context is tombstoned`) === true;
-                    return correctErrorType && correctErrorMessage;
-                },
-                `Should not be able to send ops for a tombstoned datastore.`,
-            );
-        });
+				// Sending an op from a datastore substantiated from the request pattern should fail!
+				assert.throws(
+					() => dataObject._root.set("send", "op"),
+					(error) => {
+						const correctErrorType = error.errorType === "dataCorruptionError";
+						const correctErrorMessage =
+							error.message?.startsWith(`Context is tombstoned`) === true;
+						return correctErrorType && correctErrorMessage;
+					},
+					`Should not be able to send ops for a tombstoned datastore.`,
+				);
+			},
+		);
 
-        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-        itExpects("Receive ops fails for tombstoned datastores in summarizing container loaded after sweep time",
-        [
-            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
-            {
-                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-                error: "Context is tombstoned! Call site [process]",
-            },
-            {
-                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-                error: "Context is tombstoned! Call site [process]",
-            },
-            {
-                eventName: "fluid:telemetry:Container:ContainerClose",
-                error: "Context is tombstoned! Call site [process]",
-                errorType: "dataCorruptionError",
-            },
-            {
-                eventName: "fluid:telemetry:Container:ContainerDispose",
-                error: "Context is tombstoned! Call site [process]",
-                errorType: "dataCorruptionError",
-            },
-        ],
-        async () => {
-            const {
-                unreferencedId,
-                summarizer,
-                summaryVersion,
-                summarizingContainer,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-            // Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
-            const container = await loadContainer(summaryVersion);
-            // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-            // production application
-            // This does not cause a sweep ready changed error as the container has loaded from a summary before sweep
-            // ready was set
-            const senderObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
+		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+		itExpects(
+			"Receive ops fails for tombstoned datastores in summarizing container loaded after sweep time",
+			[
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
+				},
+				{
+					eventName:
+						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+					error: "Context is tombstoned! Call site [process]",
+				},
+				{
+					eventName:
+						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+					error: "Context is tombstoned! Call site [process]",
+				},
+				{
+					eventName: "fluid:telemetry:Container:ContainerClose",
+					error: "Context is tombstoned! Call site [process]",
+					errorType: "dataCorruptionError",
+				},
+				{
+					eventName: "fluid:telemetry:Container:ContainerDispose",
+					error: "Context is tombstoned! Call site [process]",
+					errorType: "dataCorruptionError",
+				},
+			],
+			async () => {
+				const { unreferencedId, summarizer, summaryVersion, summarizingContainer } =
+					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+				// Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
+				const container = await loadContainer(summaryVersion);
+				// Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
+				// production application
+				// This does not cause a sweep ready changed error as the container has loaded from a summary before sweep
+				// ready was set
+				const senderObject = await requestFluidObject<ITestDataObject>(
+					container,
+					unreferencedId,
+				);
 
-            // The datastore should be tombstoned now
-            const { summaryVersion: tombstoneVersion } = await summarize(summarizer);
+				// The datastore should be tombstoned now
+				const { summaryVersion: tombstoneVersion } = await summarize(summarizer);
 
-            // Load a client from the tombstone summary
-            const receivingContainer = await loadContainer(tombstoneVersion);
-            await sendOpToUpdateSummaryTimestampToNow(receivingContainer);
+				// Load a client from the tombstone summary
+				const receivingContainer = await loadContainer(tombstoneVersion);
+				await sendOpToUpdateSummaryTimestampToNow(receivingContainer);
 
-            setupContainerCloseErrorValidation(receivingContainer, "process");
+				setupContainerCloseErrorValidation(receivingContainer, "process");
 
-            // Receive an op - both the summarizer and the receiving client log a process error, only the receiving
-            // client closes
-            senderObject._root.set("send an op to be received", "op");
-            await provider.ensureSynchronized();
-            assert(receivingContainer.closed === true, `Reading container should close.`);
-            assert(summarizingContainer.closed !== true, `Summarizing container should not close.`);
-        });
+				// Receive an op - both the summarizer and the receiving client log a process error, only the receiving
+				// client closes
+				senderObject._root.set("send an op to be received", "op");
+				await provider.ensureSynchronized();
+				assert(receivingContainer.closed === true, `Reading container should close.`);
+				assert(
+					summarizingContainer.closed !== true,
+					`Summarizing container should not close.`,
+				);
+			},
+		);
 
-        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-        itExpects("Receive ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
-        [
-            {
-                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-                error: "Context is tombstoned! Call site [process]",
-            },
-            {
-                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-                error: "Context is tombstoned! Call site [process]",
-            },
-            {
-                eventName: "fluid:telemetry:Container:ContainerClose",
-                error: "Context is tombstoned! Call site [process]",
-                errorType: "dataCorruptionError",
-            },
-            {
-                eventName: "fluid:telemetry:Container:ContainerDispose",
-                error: "Context is tombstoned! Call site [process]",
-                errorType: "dataCorruptionError",
-            },
-        ],
-        async () => {
-            const {
-                unreferencedId,
-                summarizingContainer,
-                summarizer,
-                summaryVersion,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
-            // Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
-            const sendingContainer = await loadContainer(summaryVersion);
-            // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-            // production application. Causes an inactiveObject loaded error
-            const dataObject = await requestFluidObject<ITestDataObject>(sendingContainer, unreferencedId);
+		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+		itExpects(
+			"Receive ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
+			[
+				{
+					eventName:
+						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+					error: "Context is tombstoned! Call site [process]",
+				},
+				{
+					eventName:
+						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+					error: "Context is tombstoned! Call site [process]",
+				},
+				{
+					eventName: "fluid:telemetry:Container:ContainerClose",
+					error: "Context is tombstoned! Call site [process]",
+					errorType: "dataCorruptionError",
+				},
+				{
+					eventName: "fluid:telemetry:Container:ContainerDispose",
+					error: "Context is tombstoned! Call site [process]",
+					errorType: "dataCorruptionError",
+				},
+			],
+			async () => {
+				const { unreferencedId, summarizingContainer, summarizer, summaryVersion } =
+					await summarizationWithUnreferencedDataStoreAfterTime(
+						sweepTimeoutMs - remainingTimeUntilSweepMs,
+					);
+				// Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
+				const sendingContainer = await loadContainer(summaryVersion);
+				// Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
+				// production application. Causes an inactiveObject loaded error
+				const dataObject = await requestFluidObject<ITestDataObject>(
+					sendingContainer,
+					unreferencedId,
+				);
 
-            // Wait enough time so that the datastore is sweep ready
-            await delay(remainingTimeUntilSweepMs);
+				// Wait enough time so that the datastore is sweep ready
+				await delay(remainingTimeUntilSweepMs);
 
-            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 
-            // The datastore should be tombstoned now
-            const { summaryVersion: tombstoneVersion } = await summarize(summarizer);
+				// The datastore should be tombstoned now
+				const { summaryVersion: tombstoneVersion } = await summarize(summarizer);
 
-            // Load a client from the tombstone summary
-            const receivingContainer = await loadContainer(tombstoneVersion);
-            await sendOpToUpdateSummaryTimestampToNow(receivingContainer);
+				// Load a client from the tombstone summary
+				const receivingContainer = await loadContainer(tombstoneVersion);
+				await sendOpToUpdateSummaryTimestampToNow(receivingContainer);
 
-            setupContainerCloseErrorValidation(receivingContainer, "process");
+				setupContainerCloseErrorValidation(receivingContainer, "process");
 
-            // Send an op to be received - no sweep changed or loaded - the summarizing container does not log sweep
-            // ready errors as it closes before the op is processed and the datastore is realized
-            dataObject._root.set("send an op to be received", "op");
-            await provider.ensureSynchronized();
-            assert(receivingContainer.closed === true, `Container receiving messages to a tombstoned datastore should close.`);
-            assert(summarizingContainer.closed !== true, `Summarizing container should not close.`);
-        });
+				// Send an op to be received - no sweep changed or loaded - the summarizing container does not log sweep
+				// ready errors as it closes before the op is processed and the datastore is realized
+				dataObject._root.set("send an op to be received", "op");
+				await provider.ensureSynchronized();
+				assert(
+					receivingContainer.closed === true,
+					`Container receiving messages to a tombstoned datastore should close.`,
+				);
+				assert(
+					summarizingContainer.closed !== true,
+					`Summarizing container should not close.`,
+				);
+			},
+		);
 
-        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-        itExpects("Send signals fails for tombstoned datastores in summarizing container loaded after sweep timeout",
-        [
-            { eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" },
-        ],
-        async () => {
-            const {
-                unreferencedId,
-                summarizer,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-            // The datastore should be tombstoned now
-            const { summaryVersion } = await summarize(summarizer);
+		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+		itExpects(
+			"Send signals fails for tombstoned datastores in summarizing container loaded after sweep timeout",
+			[{ eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" }],
+			async () => {
+				const { unreferencedId, summarizer } =
+					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+				// The datastore should be tombstoned now
+				const { summaryVersion } = await summarize(summarizer);
 
-            const dataObject = await getTombstonedDataObjectFromSummary(summaryVersion, unreferencedId);
+				const dataObject = await getTombstonedDataObjectFromSummary(
+					summaryVersion,
+					unreferencedId,
+				);
 
-            // Sending a signal from a testDataObject substantiated from the request pattern should fail!
-            assert.throws(() => dataObject._runtime.submitSignal("send", "signal"),
-                (error) => {
-                    const correctErrorType = error.errorType === "dataCorruptionError";
-                    const correctErrorMessage = error.message?.startsWith(`Context is tombstoned`) === true;
-                    return correctErrorType && correctErrorMessage;
-                },
-                `Should not be able to send signals for a tombstoned datastore.`,
-            );
-        });
+				// Sending a signal from a testDataObject substantiated from the request pattern should fail!
+				assert.throws(
+					() => dataObject._runtime.submitSignal("send", "signal"),
+					(error) => {
+						const correctErrorType = error.errorType === "dataCorruptionError";
+						const correctErrorMessage =
+							error.message?.startsWith(`Context is tombstoned`) === true;
+						return correctErrorType && correctErrorMessage;
+					},
+					`Should not be able to send signals for a tombstoned datastore.`,
+				);
+			},
+		);
 
-        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-        itExpects("Receive signals fails for tombstoned datastores in summarizing container loaded after sweep timeout",
-        [
-            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
-            {
-                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-                error: "Context is tombstoned! Call site [processSignal]",
-            },
-            {
-                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-                error: "Context is tombstoned! Call site [processSignal]",
-            },
-            {
-                eventName: "fluid:telemetry:Container:ContainerClose",
-                error: "Context is tombstoned! Call site [processSignal]",
-                errorType: "dataCorruptionError",
-            },
-            {
-                eventName: "fluid:telemetry:Container:ContainerDispose",
-                error: "Context is tombstoned! Call site [processSignal]",
-                errorType: "dataCorruptionError",
-            },
-        ],
-        async () => {
-            const {
-                unreferencedId,
-                summarizer,
-                summaryVersion,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-            // The datastore should be tombstoned now
-            await summarize(summarizer);
+		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+		itExpects(
+			"Receive signals fails for tombstoned datastores in summarizing container loaded after sweep timeout",
+			[
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
+				},
+				{
+					eventName:
+						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+					error: "Context is tombstoned! Call site [processSignal]",
+				},
+				{
+					eventName:
+						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+					error: "Context is tombstoned! Call site [processSignal]",
+				},
+				{
+					eventName: "fluid:telemetry:Container:ContainerClose",
+					error: "Context is tombstoned! Call site [processSignal]",
+					errorType: "dataCorruptionError",
+				},
+				{
+					eventName: "fluid:telemetry:Container:ContainerDispose",
+					error: "Context is tombstoned! Call site [processSignal]",
+					errorType: "dataCorruptionError",
+				},
+			],
+			async () => {
+				const { unreferencedId, summarizer, summaryVersion } =
+					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+				// The datastore should be tombstoned now
+				await summarize(summarizer);
 
-            // Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
-            const container = await loadContainer(summaryVersion);
-            // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-            // production application
-            // This does not cause a sweep ready changed error as the container has loaded from a summary before sweep
-            // ready was set
-            const senderObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
+				// Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
+				const container = await loadContainer(summaryVersion);
+				// Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
+				// production application
+				// This does not cause a sweep ready changed error as the container has loaded from a summary before sweep
+				// ready was set
+				const senderObject = await requestFluidObject<ITestDataObject>(
+					container,
+					unreferencedId,
+				);
 
-            // The datastore should be tombstoned now
-            const { summaryVersion: tombstoneVersion } = await summarize(summarizer);
+				// The datastore should be tombstoned now
+				const { summaryVersion: tombstoneVersion } = await summarize(summarizer);
 
-            // Load a client from the tombstone summary
-            const receivingContainer = await loadContainer(tombstoneVersion);
-            await sendOpToUpdateSummaryTimestampToNow(receivingContainer);
+				// Load a client from the tombstone summary
+				const receivingContainer = await loadContainer(tombstoneVersion);
+				await sendOpToUpdateSummaryTimestampToNow(receivingContainer);
 
-            setupContainerCloseErrorValidation(receivingContainer, "processSignal");
+				setupContainerCloseErrorValidation(receivingContainer, "processSignal");
 
-            // Receive a signal by sending it from another container
-            senderObject._runtime.submitSignal("send a signal to be received", "signal");
-            await provider.ensureSynchronized();
-            assert(receivingContainer.closed === true, `Container receiving messages to a tombstoned datastore should close.`);
-        });
+				// Receive a signal by sending it from another container
+				senderObject._runtime.submitSignal("send a signal to be received", "signal");
+				await provider.ensureSynchronized();
+				assert(
+					receivingContainer.closed === true,
+					`Container receiving messages to a tombstoned datastore should close.`,
+				);
+			},
+		);
+	});
 
-    });
+	describe("Loading tombstone data stores not allowed (per config)", () => {
+		const expectedHeadersLogged = {
+			request: "{}",
+			handleGet: JSON.stringify({ viaHandle: true }),
+			request_allowTombstone: JSON.stringify({ allowTombstone: true }),
+		};
 
-    describe("Loading tombstone data stores not allowed (per config)", () => {
-        const expectedHeadersLogged = {
-            request: "{}",
-            handleGet: JSON.stringify({ viaHandle: true }),
-            request_allowTombstone: JSON.stringify({ allowTombstone: true }),
-        };
+		beforeEach(() => {
+			// Allow Usage but not Loading
+			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
+			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
+		});
 
-        beforeEach(() => {
-            // Allow Usage but not Loading
-            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
-            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
-        });
+		/**
+		 * Our partners use ContainerRuntime.resolveHandle to issue requests. We can't easily call it directly,
+		 * but the test containers are wired up to route requests to this function.
+		 * (See the innerRequestHandler used in LocalCodeLoader for how it works)
+		 */
+		async function containerRuntime_resolveHandle(
+			container: IContainer,
+			request: IRequest,
+		): Promise<IResponse> {
+			return container.request(request);
+		}
 
-        /**
-         * Our partners use ContainerRuntime.resolveHandle to issue requests. We can't easily call it directly,
-         * but the test containers are wired up to route requests to this function.
-         * (See the innerRequestHandler used in LocalCodeLoader for how it works)
-         */
-        async function containerRuntime_resolveHandle(container: IContainer, request: IRequest): Promise<IResponse> {
-            return container.request(request);
-        }
+		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+		itExpects(
+			"Requesting tombstoned datastores fails in interactive client loaded after sweep timeout",
+			[
+				// Interactive client's request
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+					headers: expectedHeadersLogged.request,
+				},
+				// Interactive client's request w/ allowTombstone
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+					category: "generic",
+					headers: expectedHeadersLogged.request_allowTombstone,
+				},
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
+				},
+				// Summarizer client's request
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+					category: "generic",
+					headers: expectedHeadersLogged.request,
+					isSummarizerClient: true,
+				},
+			],
+			async () => {
+				const { unreferencedId, summarizingContainer, summarizer } =
+					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 
-        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-        itExpects("Requesting tombstoned datastores fails in interactive client loaded after sweep timeout",
-        [
-            // Interactive client's request
-            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested", headers: expectedHeadersLogged.request },
-            // Interactive client's request w/ allowTombstone
-            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested", category: "generic", headers: expectedHeadersLogged.request_allowTombstone },
-            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
-            // Summarizer client's request
-            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested", category: "generic", headers: expectedHeadersLogged.request, isSummarizerClient: true },
-        ],
-        async () => {
-            const {
-                unreferencedId,
-                summarizingContainer,
-                summarizer,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+				// The datastore should be tombstoned now
+				const { summaryVersion } = await summarize(summarizer);
+				const container = await loadContainer(summaryVersion);
+				await sendOpToUpdateSummaryTimestampToNow(container);
 
-            // The datastore should be tombstoned now
-            const { summaryVersion } = await summarize(summarizer);
-            const container = await loadContainer(summaryVersion);
-            await sendOpToUpdateSummaryTimestampToNow(container);
+				// This request fails since the datastore is tombstoned
+				const tombstoneErrorResponse = await containerRuntime_resolveHandle(container, {
+					url: unreferencedId,
+				});
+				assert.equal(
+					tombstoneErrorResponse.status,
+					404,
+					"Should not be able to retrieve a tombstoned datastore in non-summarizer clients",
+				);
+				assert.equal(
+					tombstoneErrorResponse.value,
+					`DataStore was deleted: ${unreferencedId}`,
+					"Expected the Tombstone error message",
+				);
+				assert.equal(
+					tombstoneErrorResponse.headers?.[TombstoneResponseHeaderKey],
+					true,
+					"Expected the Tombstone header",
+				);
 
-            // This request fails since the datastore is tombstoned
-            const tombstoneErrorResponse = await containerRuntime_resolveHandle(container, { url: unreferencedId });
-            assert.equal(tombstoneErrorResponse.status, 404, "Should not be able to retrieve a tombstoned datastore in non-summarizer clients");
-            assert.equal(tombstoneErrorResponse.value, `DataStore was deleted: ${unreferencedId}`, "Expected the Tombstone error message");
-            assert.equal(tombstoneErrorResponse.headers?.[TombstoneResponseHeaderKey], true, "Expected the Tombstone header");
+				// This request succeeds because the "allowTombstone" header is set to true
+				const tombstoneSuccessResponse = await containerRuntime_resolveHandle(container, {
+					url: unreferencedId,
+					headers: { [AllowTombstoneRequestHeaderKey]: true },
+				});
+				assert.equal(
+					tombstoneSuccessResponse.status,
+					200,
+					"Should be able to retrieve a tombstoned datastore given the allowTombstone header",
+				);
+				assert.notEqual(
+					tombstoneSuccessResponse.headers?.[TombstoneResponseHeaderKey],
+					true,
+					"DID NOT Expect tombstone header to be set on the response",
+				);
 
-            // This request succeeds because the "allowTombstone" header is set to true
-            const tombstoneSuccessResponse = await containerRuntime_resolveHandle(container, { url: unreferencedId, headers: { [AllowTombstoneRequestHeaderKey]: true }});
-            assert.equal(tombstoneSuccessResponse.status, 200, "Should be able to retrieve a tombstoned datastore given the allowTombstone header");
-            assert.notEqual(tombstoneSuccessResponse.headers?.[TombstoneResponseHeaderKey], true, "DID NOT Expect tombstone header to be set on the response");
-
-            // This request succeeds because the summarizer never fails for tombstones
-            const summarizerResponse = await containerRuntime_resolveHandle(summarizingContainer, { url: unreferencedId });
-            assert.equal(summarizerResponse.status, 200, "Should be able to retrieve a tombstoned datastore in summarizer clients");
-            assert.notEqual(summarizerResponse.headers?.[TombstoneResponseHeaderKey], true, "DID NOT Expect tombstone header to be set on the response");
-        });
+				// This request succeeds because the summarizer never fails for tombstones
+				const summarizerResponse = await containerRuntime_resolveHandle(
+					summarizingContainer,
+					{ url: unreferencedId },
+				);
+				assert.equal(
+					summarizerResponse.status,
+					200,
+					"Should be able to retrieve a tombstoned datastore in summarizer clients",
+				);
+				assert.notEqual(
+					summarizerResponse.headers?.[TombstoneResponseHeaderKey],
+					true,
+					"DID NOT Expect tombstone header to be set on the response",
+				);
+			},
+		);
 
         // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
         itExpects("Requesting tombstoned datastores succeeds if gcContainerGeneration doesn't match",
@@ -549,537 +646,727 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
             assert.notEqual(tombstoneSuccessResponse.headers?.[TombstoneResponseHeaderKey], true, "DID NOT Expect tombstone header to be set on the response");
         });
 
-        // SKIPPED: This test is redundant with the previous one; SweepReady calculation/timers has coverage elsewhere
-        itExpects.skip("Requesting tombstoned datastores fails in summarizing container loaded before sweep timeout",
-        [
-            {
-                eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
-                viaHandle: false,
-            },
-        ],
-        async () => {
-            const {
-                unreferencedId,
-                summarizingContainer,
-                summarizer,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
-            // Wait enough time so that the datastore is sweep ready
-            await delay(remainingTimeUntilSweepMs);
-
-            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-            // The datastore should be tombstoned now
-            await summarize(summarizer);
-            const { summaryVersion } = await summarize(summarizer);
-            const container = await loadContainer(summaryVersion);
-            await sendOpToUpdateSummaryTimestampToNow(container);
-
-            // Requesting a tombstoned datastore should fail!
-            await assert.rejects(async () => requestFluidObject<ITestDataObject>(container, unreferencedId),
-                (error) => {
-                    const correctErrorType = error.code === 404;
-                    const correctErrorMessage = error.message === `DataStore was deleted: ${unreferencedId}`;
-                    return correctErrorType && correctErrorMessage;
-                },
-                `Should not be able to retrieve a tombstoned datastore.`,
-            );
-        });
-
-        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-        itExpects("Handle request for tombstoned datastores fails in summarizing container loaded after sweep timeout",
-        [
-            // Interactive client's handle.get
-            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested", headers: expectedHeadersLogged.handleGet },
-            // Interactive client's request w/ allowTombstone
-            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested", category: "generic", headers: expectedHeadersLogged.request_allowTombstone },
-            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
-        ],
-        async () => {
-            const {
-                unreferencedId,
-                summarizingContainer,
-                summarizer,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-            // The datastore should be tombstoned now
-            const { summaryVersion } = await summarize(summarizer);
-            const dataObject = await getTombstonedDataObjectFromSummary(summaryVersion, unreferencedId);
-
-            const serializer = new FluidSerializer(dataObject._context.IFluidHandleContext, () => {});
-            const handle: IFluidHandle = parseHandles({ type: "__fluid_handle__", url: unreferencedId }, serializer);
-
-            // This fails because the DataStore is tombstoned
-            let tombstoneError: Error & { code: number; underlyingResponseHeaders?: { [TombstoneResponseHeaderKey]: boolean; }; } | undefined;
-            try {
-                await handle.get();
-            } catch (error: any) {
-                tombstoneError = error
-            }
-            assert.equal(tombstoneError?.code, 404, "Tombstone error from handle.get should have 404 status code");
-            assert.equal(tombstoneError?.message, `DataStore was deleted: ${unreferencedId}`, "Incorrect message for Tombstone error from handle.get");
-            assert.equal(tombstoneError?.underlyingResponseHeaders?.[TombstoneResponseHeaderKey], true, "Tombstone error from handle.get should include the tombstone flag");
-
-            // This demonstrates how a consumer could then fetch the tombstoned object to facilitate recovery (actual revival is covered in another test below)
-            const tombstoneSuccessResponse = await (dataObject._context.containerRuntime as ContainerRuntime).resolveHandle({ url: unreferencedId, headers: { [AllowTombstoneRequestHeaderKey]: true }});
-            assert.equal(tombstoneSuccessResponse.status, 200, "Should be able to retrieve a tombstoned datastore given the allowTombstone header");
-            assert.notEqual(tombstoneSuccessResponse.headers?.[TombstoneResponseHeaderKey], true, "DID NOT Expect tombstone header to be set on the response");
-        });
-
-        // SKIPPED: This test is redundant with the previous one; SweepReady calculation/timers has coverage elsewhere
-        itExpects.skip("Handle request for tombstoned datastores fails in summarizing container loaded before sweep timeout",
-        [
-            {
-                eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
-                viaHandle: true,
-            },
-        ],
-        async () => {
-            const {
-                unreferencedId,
-                summarizingContainer,
-                summarizer,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
-            // Wait enough time so that the datastore is sweep ready
-            await delay(remainingTimeUntilSweepMs);
-
-            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-            // The datastore should be tombstoned now
-            const { summaryVersion } = await summarize(summarizer);
-            const dataObject = await getTombstonedDataObjectFromSummary(summaryVersion, unreferencedId);
-
-            // Note: if a user makes a request that looks like this, we will also think that the request is via handle
-            const request: IRequest = { url: unreferencedId, headers: { [RuntimeHeaders.viaHandle]: true } };
-            const response = await dataObject._context.IFluidHandleContext.resolveHandle(request);
-
-            assert(response !== undefined, `Expecting a response!`);
-            assert(response.status === 404);
-            assert(response.value === `DataStore was deleted: ${unreferencedId}`);
-        });
-
-        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-        itExpects("Can un-tombstone datastores by storing a handle",
-        [
-            // When confirming it's tombstoned
-            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested" },
-            // When reviving it
-            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested", category: "generic" },
-            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
-            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived", category: "generic" },
-            { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived" },
-        ],
-        async () => {
-            const {
-                unreferencedId,
-                summarizingContainer,
-                summarizer,
-            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
-            // Wait enough time so that the datastore is sweep ready
-            await delay(remainingTimeUntilSweepMs);
-
-            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-            // The datastore should be tombstoned now
-            const { summaryVersion } = await summarize(summarizer);
-            const tombstoneContainer = await loadContainer(summaryVersion);
-
-            // Datastore should be tombstoned, requesting should error
-            const tombstoneResponse = await containerRuntime_resolveHandle(tombstoneContainer, { url: unreferencedId });
-            assert.equal(tombstoneResponse.status, 404, "Expected 404 tombstone response")
-            assert.equal(tombstoneResponse.headers?.[TombstoneResponseHeaderKey], true, "Expected tombstone response with flag")
-
-            const requestAllowingTombstone: IRequest = {
-                url: unreferencedId,
-                headers: { [AllowTombstoneRequestHeaderKey]: true },
-            };
-            const tombstonedObject = await requestFluidObject<ITestDataObject>(tombstoneContainer, requestAllowingTombstone);
-            const defaultDataObject = await requestFluidObject<ITestDataObject>(tombstoneContainer, "default");
-            defaultDataObject._root.set("store", tombstonedObject.handle);
-
-            // The datastore should be un-tombstoned now
-            const { summaryVersion: revivalVersion } = await summarize(summarizer);
-            const revivalContainer = await loadContainer(revivalVersion);
-            const revivedObject = await requestFluidObject<ITestDataObject>(revivalContainer, unreferencedId);
-            revivedObject._root.set("can send", "op");
-            // This signal call closes the tombstoneContainer.
-            // The op above doesn't because the signal reaches the tombstone container faster
-            revivedObject._runtime.submitSignal("can submit", "signal");
-
-            const sendingContainer = await loadContainer(revivalVersion);
-            const sendDataObject = await requestFluidObject<ITestDataObject>(sendingContainer, unreferencedId);
-            sendDataObject._root.set("can receive", "an op");
-            sendDataObject._runtime.submitSignal("can receive", "a signal");
-            await provider.ensureSynchronized();
-            assert(tombstoneContainer.closed !== true, `Tombstone usage allowed, so container should not close.`);
-            assert(revivalContainer.closed !== true,
-                `Revived datastore should not close a container when requested, sending/receiving signals/ops.`);
-            assert(sendingContainer.closed !== true,
-                `Revived datastore should not close a container when sending signals and ops.`);
-        });
-    });
-
-    itExpects("Loading/Using tombstone allowed when configured",
-    [
-        { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested" },
-        { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
-        {
-            eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-            callSite: "submitMessage",
-        },
-        {
-            eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-            callSite: "process",
-            clientType: "noninteractive/summarizer",
-        },
-        {
-            eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-            callSite: "process",
-            clientType: "interactive",
-        },
-    ],
-    async () => {
-        settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
-        settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
-        const {
-            unreferencedId,
-            summarizingContainer,
-            summarizer,
-        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-        // The datastore should be tombstoned now
-        const { summaryVersion } = await summarize(summarizer);
-        const container = await loadContainer(summaryVersion);
-        // Requesting the tombstoned data store should succeed since ThrowOnTombstoneLoad is not enabled.
-        // Logs a tombstone and sweep ready error
-        let dataObject: ITestDataObject;
-        await assert.doesNotReject(
-            async () => { dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId); },
-            `Should be able to request a tombstoned datastore.`,
-        );
-        // Modifying the tombstoned datastore should not fail since ThrowOnTombstoneUsage is not enabled.
-        // Logs a submitMessage error
-        assert.doesNotThrow(() => dataObject._root.set("send", "op"),
-            `Should be able to send ops for a tombstoned datastore.`,
-        );
-
-        // Wait for the above op to be process. That will result in another error logged during process.
-        // Both the summarizing container and the submitting container log a process error
-        await provider.ensureSynchronized();
-    });
-
-    describe("Tombstone information in summary", () => {
-        /**
-         * Validates that the give summary tree contains correct information in the tombstone blob in GC tree.
-         * @param summaryTree - The summary tree that may contain the tombstone blob.
-         * @param tombstones - A list of ids that should be present in the tombstone blob.
-         * @param notTombstones - A list of ids that should not be present in the tombstone blob.
-         */
-        function validateTombstoneState(
-            summaryTree: ISummaryTree,
-            tombstones: string [] | undefined,
-            notTombstones: string[],
-        ) {
-            const actualTombstones = getGCTombstoneStateFromSummary(summaryTree);
-            if (tombstones === undefined) {
-                assert(actualTombstones === undefined, "GC tree should not have tombstones in summary");
-                return;
-            }
-            assert(actualTombstones !== undefined, "GC tree should have tombstones in summary");
-            for (const url of tombstones) {
-                assert(actualTombstones.includes(url), `${url} should be in tombstone blob`);
-            }
-            for (const url of notTombstones) {
-                assert(!actualTombstones.includes(url), `${url} should not be in tombstone blob`);
-            }
-        }
-
-        beforeEach(() => {
-            // This is not the typical configuration we expect (usage may be allowed), but keeping it more strict for the tests
-            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
-            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
-        });
-
-        it("adds tombstone data stores information to tombstone blob in summary", async () => {
-            const mainContainer = await provider.makeTestContainer(testContainerConfig);
-            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
-            const mainDataStoreUrl = `/${mainDataStore._context.id}`;
-            await waitForContainerConnection(mainContainer);
-
-            const summarizer = await createSummarizer(
-                provider,
-                mainContainer,
-                undefined /* summaryVersion */,
-                gcOptions,
-                mockConfigProvider(settings),
-            );
-
-            // Create couple of data stores.
-            const newDataStore = await requestFluidObject<ITestDataObject>(
-                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
-            const newDataStore2 = await requestFluidObject<ITestDataObject>(
-                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
-            const newDataStoreUrl = `/${newDataStore._context.id}`;
-            const newDataStore2Url = `/${newDataStore2._context.id}`;
-
-            // Add the data stores' handle so that they are live and referenced.
-            mainDataStore._root.set("newDataStore", newDataStore.handle);
-            mainDataStore._root.set("newDataStore2", newDataStore2.handle);
-
-            // Remove the data stores' handle to make them unreferenced.
-            mainDataStore._root.delete("newDataStore");
-            mainDataStore._root.delete("newDataStore2");
-
-            // Summarize so that the above data stores are marked unreferenced.
-            await provider.ensureSynchronized();
-            const summary = await summarizeNow(summarizer);
-            validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
-
-            // Wait for sweep timeout so that the data stores are tombstoned.
-            await delay(sweepTimeoutMs + 10);
-            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
-            mainDataStore._root.set("key", "value");
-            await provider.ensureSynchronized();
-
-            // Summarize. The tombstoned data stores should now be part of the summary.
-            const summary2 = await summarizeNow(summarizer);
-            validateTombstoneState(summary2.summaryTree, [newDataStoreUrl, newDataStore2Url], [mainDataStoreUrl]);
-        });
-
-        it("adds tombstone attachment blob information to tombstone blob in summary", async () => {
-            const mainContainer = await provider.makeTestContainer(testContainerConfig);
-            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
-            const mainDataStoreUrl = `/${mainDataStore._context.id}`;
-            await waitForContainerConnection(mainContainer);
-
-            const summarizer = await createSummarizer(
-                provider,
-                mainContainer,
-                undefined /* summaryVersion */,
-                gcOptions,
-                mockConfigProvider(settings),
-            );
-
-            // Upload an attachment blobs and mark it referenced.
-            const blobContents = "Blob contents";
-            const blobHandle = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
-            mainDataStore._root.set("blob", blobHandle);
-
-            // Remove the blob's handle to make it unreferenced.
-            mainDataStore._root.delete("blob");
-
-            // Summarize so that the above attachment blob is marked unreferenced.
-            await provider.ensureSynchronized();
-            const summary = await summarizeNow(summarizer);
-            validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
-
-            // Wait for sweep timeout so that the blob is tombstoned.
-            await delay(sweepTimeoutMs + 10);
-            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
-            mainDataStore._root.set("key", "value");
-            await provider.ensureSynchronized();
-
-            // Summarize. The tombstoned attachment blob should now be part of the tombstone blob.
-            const summary2 = await summarizeNow(summarizer);
-            validateTombstoneState(summary2.summaryTree, [blobHandle.absolutePath], [mainDataStoreUrl]);
-        });
-
-        itExpects("removes un-tombstoned data store and attachment blob from tombstone blob in summary",
-        [
-            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived", category: "generic" },
-            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived", category: "generic" },
-            { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived", type: "DataStore" },
-            { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived", type: "Blob" },
-        ],
-        async () => {
-            const mainContainer = await provider.makeTestContainer(testContainerConfig);
-            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
-            const mainDataStoreUrl = `/${mainDataStore._context.id}`;
-            await waitForContainerConnection(mainContainer);
-
-            const mockLogger = new MockLogger();
-
-            const summarizer = await createSummarizer(
-                provider,
-                mainContainer,
-                undefined /* summaryVersion */,
-                gcOptions,
-                mockConfigProvider(settings),
-                mockLogger,
-            );
-
-            // Create couple of data stores.
-            const newDataStore = await requestFluidObject<ITestDataObject>(
-                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
-            const newDataStore2 = await requestFluidObject<ITestDataObject>(
-                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
-            const newDataStoreUrl = `/${newDataStore._context.id}`;
-            const newDataStore2Url = `/${newDataStore2._context.id}`;
-
-            // Add the data stores' handles so that they are live and referenced.
-            mainDataStore._root.set("newDataStore", newDataStore.handle);
-            mainDataStore._root.set("newDataStore2", newDataStore2.handle);
-
-            // Remove the data stores' handles to make them unreferenced.
-            mainDataStore._root.delete("newDataStore");
-            mainDataStore._root.delete("newDataStore2");
-
-            // Upload an attachment blob and mark it referenced.
-            const blobContents = "Blob contents";
-            const blobHandle = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
-            mainDataStore._root.set("blob", blobHandle);
-
-            // Remove the blob's handle to make it unreferenced.
-            mainDataStore._root.delete("blob");
-
-            // Summarize so that the above data stores and blobs are marked unreferenced.
-            await provider.ensureSynchronized();
-            const summary = await summarizeNow(summarizer);
-            validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
-
-            // Wait for sweep timeout so that the data stores are tombstoned.
-            await delay(sweepTimeoutMs + 10);
-            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
-            mainDataStore._root.set("key", "value");
-            await provider.ensureSynchronized();
-
-            // Summarize. The tombstoned data stores should now be part of the tombstone blob.
-            const summary2 = await summarizeNow(summarizer);
-            validateTombstoneState(
-                summary2.summaryTree, [newDataStoreUrl, newDataStore2Url, blobHandle.absolutePath], [mainDataStoreUrl]);
-
-            mockLogger.assertMatchNone([
-                { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived" },
-                { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived" },
-            ]);
-
-            // Mark one of the data stores and attachment blob as referenced so that they are not tombstones anymore.
-            // Note that sweepTimeout was shrunk below sessionExpiry, otherwise we'd need to load a new container and
-            // use the allowTombstone header to even get the handle and revive these.
-            mainDataStore._root.set("newDataStore", newDataStore.handle);
-            mainDataStore._root.set("blob", blobHandle);
-            await provider.ensureSynchronized();
-            mockLogger.assertMatch([
-                { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived" },
-                { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived" },
-            ]);
-
-            // Summarize. The un-tombstoned data store and attachment blob should not be part of the tombstone blob.
-            const summary3 = await summarizeNow(summarizer);
-            validateTombstoneState(
-                summary3.summaryTree, [newDataStore2Url], [mainDataStoreUrl, newDataStoreUrl, blobHandle.absolutePath]);
-        });
-
-        it("does not re-summarize GC state on only tombstone state changed", async () => {
-            const mainContainer = await provider.makeTestContainer(testContainerConfig);
-            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
-            await waitForContainerConnection(mainContainer);
-
-            const summarizer = await createSummarizer(
-                provider,
-                mainContainer,
-                undefined /* summaryVersion */,
-                gcOptions,
-                mockConfigProvider(settings),
-            );
-
-            // Create a data store.
-            const newDataStore = await requestFluidObject<ITestDataObject>(
-                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
-
-            // Add the data store's handle so that it is live and referenced.
-            mainDataStore._root.set("newDataStore", newDataStore.handle);
-
-            // Remove the data store's handle to make it unreferenced.
-            mainDataStore._root.delete("newDataStore");
-
-            // Summarize so that the above data stores are marked unreferenced.
-            await provider.ensureSynchronized();
-            const summary = await summarizeNow(summarizer);
-            const gcState = getGCStateFromSummary(summary.summaryTree);
-            assert(gcState !== undefined, "GC state should be available and should not be a handle");
-
-            // Wait for sweep timeout so that the data stores are tombstoned.
-            await delay(sweepTimeoutMs + 10);
-            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
-            mainDataStore._root.set("key", "value");
-            await provider.ensureSynchronized();
-
-            // Summarize. The tombstoned data stores should now be part of the summary.
-            const summary2 = await summarizeNow(summarizer);
-            assert.throws(
-                () => getGCStateFromSummary(summary2.summaryTree),
-                (e) => validateAssertionError(e, "GC state is not a blob"),
-            );
-            const tombstoneState = getGCTombstoneStateFromSummary(summary2.summaryTree);
-            assert(tombstoneState !== undefined, "Tombstone state should be available and should be a blob");
-
-            // Summarize. The tombstoned state should be a handle.
-            const summary3 = await summarizeNow(summarizer);
-            assert.throws(
-                () => getGCTombstoneStateFromSummary(summary3.summaryTree),
-                (e) => validateAssertionError(e, "GC data should be a tree"),
-            );
-        });
-
-        itExpects("can mark data store from tombstone information in summary in non-summarizer container",
-        [
-            {
-                eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
-            },
-        ],
-        async () => {
-            const mainContainer = await provider.makeTestContainer(testContainerConfig);
-            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
-            const mainDataStoreUrl = `/${mainDataStore._context.id}`;
-            await waitForContainerConnection(mainContainer);
-
-            const summarizer = await createSummarizer(
-                provider,
-                mainContainer,
-                undefined /* summaryVersion */,
-                gcOptions,
-                mockConfigProvider(settings),
-            );
-
-            // Create a data store and mark it referenced.
-            const newDataStore = await requestFluidObject<ITestDataObject>(
-                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
-            const newDataStoreUrl = `/${newDataStore._context.id}`;
-            mainDataStore._root.set("newDataStore", newDataStore.handle);
-
-            // Remove the data store's handle to make it unreferenced.
-            mainDataStore._root.delete("newDataStore");
-
-            // Summarize so that the above data stores are marked unreferenced.
-            await provider.ensureSynchronized();
-            const summary = await summarizeNow(summarizer);
-            validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
-
-            // Wait for sweep timeout so that the data stores are tombstoned.
-            await delay(sweepTimeoutMs + 10);
-            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
-            mainDataStore._root.set("key", "value");
-            await provider.ensureSynchronized();
-
-            // Summarize. The tombstoned data stores should now be part of the summary.
-            const summary2 = await summarizeNow(summarizer);
-            validateTombstoneState(summary2.summaryTree, [newDataStoreUrl], [mainDataStoreUrl]);
-
-            // Load a container from the above summary. The tombstoned data store should be correctly marked.
-            const container2 = await loadContainer(summary2.summaryVersion);
-
-            // Requesting the tombstoned data store should result in an error.
-            const unreferencedId = newDataStore._context.id;
-            await assert.rejects(async () => requestFluidObject<ITestDataObject>(container2, unreferencedId),
-                (error) => {
-                    const correctErrorType = error.code === 404;
-                    const correctErrorMessage = error.message === `DataStore was deleted: ${unreferencedId}`;
-                    return correctErrorType && correctErrorMessage;
-                },
-                `Should not be able to retrieve a tombstoned datastore.`,
-            );
-        });
-    });
+		// SKIPPED: This test is redundant with the previous one; SweepReady calculation/timers has coverage elsewhere
+		itExpects.skip(
+			"Requesting tombstoned datastores fails in summarizing container loaded before sweep timeout",
+			[
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+					viaHandle: false,
+				},
+			],
+			async () => {
+				const { unreferencedId, summarizingContainer, summarizer } =
+					await summarizationWithUnreferencedDataStoreAfterTime(
+						sweepTimeoutMs - remainingTimeUntilSweepMs,
+					);
+				// Wait enough time so that the datastore is sweep ready
+				await delay(remainingTimeUntilSweepMs);
+
+				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+				// The datastore should be tombstoned now
+				await summarize(summarizer);
+				const { summaryVersion } = await summarize(summarizer);
+				const container = await loadContainer(summaryVersion);
+				await sendOpToUpdateSummaryTimestampToNow(container);
+
+				// Requesting a tombstoned datastore should fail!
+				await assert.rejects(
+					async () => requestFluidObject<ITestDataObject>(container, unreferencedId),
+					(error) => {
+						const correctErrorType = error.code === 404;
+						const correctErrorMessage =
+							error.message === `DataStore was deleted: ${unreferencedId}`;
+						return correctErrorType && correctErrorMessage;
+					},
+					`Should not be able to retrieve a tombstoned datastore.`,
+				);
+			},
+		);
+
+		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+		itExpects(
+			"Handle request for tombstoned datastores fails in summarizing container loaded after sweep timeout",
+			[
+				// Interactive client's handle.get
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+					headers: expectedHeadersLogged.handleGet,
+				},
+				// Interactive client's request w/ allowTombstone
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+					category: "generic",
+					headers: expectedHeadersLogged.request_allowTombstone,
+				},
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
+				},
+			],
+			async () => {
+				const { unreferencedId, summarizingContainer, summarizer } =
+					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+				// The datastore should be tombstoned now
+				const { summaryVersion } = await summarize(summarizer);
+				const dataObject = await getTombstonedDataObjectFromSummary(
+					summaryVersion,
+					unreferencedId,
+				);
+
+				const serializer = new FluidSerializer(
+					dataObject._context.IFluidHandleContext,
+					() => {},
+				);
+				const handle: IFluidHandle = parseHandles(
+					{ type: "__fluid_handle__", url: unreferencedId },
+					serializer,
+				);
+
+				// This fails because the DataStore is tombstoned
+				let tombstoneError:
+					| (Error & {
+							code: number;
+							underlyingResponseHeaders?: { [TombstoneResponseHeaderKey]: boolean };
+					  })
+					| undefined;
+				try {
+					await handle.get();
+				} catch (error: any) {
+					tombstoneError = error;
+				}
+				assert.equal(
+					tombstoneError?.code,
+					404,
+					"Tombstone error from handle.get should have 404 status code",
+				);
+				assert.equal(
+					tombstoneError?.message,
+					`DataStore was deleted: ${unreferencedId}`,
+					"Incorrect message for Tombstone error from handle.get",
+				);
+				assert.equal(
+					tombstoneError?.underlyingResponseHeaders?.[TombstoneResponseHeaderKey],
+					true,
+					"Tombstone error from handle.get should include the tombstone flag",
+				);
+
+				// This demonstrates how a consumer could then fetch the tombstoned object to facilitate recovery (actual revival is covered in another test below)
+				const tombstoneSuccessResponse = await (
+					dataObject._context.containerRuntime as ContainerRuntime
+				).resolveHandle({
+					url: unreferencedId,
+					headers: { [AllowTombstoneRequestHeaderKey]: true },
+				});
+				assert.equal(
+					tombstoneSuccessResponse.status,
+					200,
+					"Should be able to retrieve a tombstoned datastore given the allowTombstone header",
+				);
+				assert.notEqual(
+					tombstoneSuccessResponse.headers?.[TombstoneResponseHeaderKey],
+					true,
+					"DID NOT Expect tombstone header to be set on the response",
+				);
+			},
+		);
+
+		// SKIPPED: This test is redundant with the previous one; SweepReady calculation/timers has coverage elsewhere
+		itExpects.skip(
+			"Handle request for tombstoned datastores fails in summarizing container loaded before sweep timeout",
+			[
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+					viaHandle: true,
+				},
+			],
+			async () => {
+				const { unreferencedId, summarizingContainer, summarizer } =
+					await summarizationWithUnreferencedDataStoreAfterTime(
+						sweepTimeoutMs - remainingTimeUntilSweepMs,
+					);
+				// Wait enough time so that the datastore is sweep ready
+				await delay(remainingTimeUntilSweepMs);
+
+				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+				// The datastore should be tombstoned now
+				const { summaryVersion } = await summarize(summarizer);
+				const dataObject = await getTombstonedDataObjectFromSummary(
+					summaryVersion,
+					unreferencedId,
+				);
+
+				// Note: if a user makes a request that looks like this, we will also think that the request is via handle
+				const request: IRequest = {
+					url: unreferencedId,
+					headers: { [RuntimeHeaders.viaHandle]: true },
+				};
+				const response = await dataObject._context.IFluidHandleContext.resolveHandle(
+					request,
+				);
+
+				assert(response !== undefined, `Expecting a response!`);
+				assert(response.status === 404);
+				assert(response.value === `DataStore was deleted: ${unreferencedId}`);
+			},
+		);
+
+		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+		itExpects(
+			"Can un-tombstone datastores by storing a handle",
+			[
+				// When confirming it's tombstoned
+				{ eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested" },
+				// When reviving it
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+					category: "generic",
+				},
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
+				},
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived",
+					category: "generic",
+				},
+				{ eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived" },
+			],
+			async () => {
+				const { unreferencedId, summarizingContainer, summarizer } =
+					await summarizationWithUnreferencedDataStoreAfterTime(
+						sweepTimeoutMs - remainingTimeUntilSweepMs,
+					);
+				// Wait enough time so that the datastore is sweep ready
+				await delay(remainingTimeUntilSweepMs);
+
+				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+				// The datastore should be tombstoned now
+				const { summaryVersion } = await summarize(summarizer);
+				const tombstoneContainer = await loadContainer(summaryVersion);
+
+				// Datastore should be tombstoned, requesting should error
+				const tombstoneResponse = await containerRuntime_resolveHandle(tombstoneContainer, {
+					url: unreferencedId,
+				});
+				assert.equal(tombstoneResponse.status, 404, "Expected 404 tombstone response");
+				assert.equal(
+					tombstoneResponse.headers?.[TombstoneResponseHeaderKey],
+					true,
+					"Expected tombstone response with flag",
+				);
+
+				const requestAllowingTombstone: IRequest = {
+					url: unreferencedId,
+					headers: { [AllowTombstoneRequestHeaderKey]: true },
+				};
+				const tombstonedObject = await requestFluidObject<ITestDataObject>(
+					tombstoneContainer,
+					requestAllowingTombstone,
+				);
+				const defaultDataObject = await requestFluidObject<ITestDataObject>(
+					tombstoneContainer,
+					"default",
+				);
+				defaultDataObject._root.set("store", tombstonedObject.handle);
+
+				// The datastore should be un-tombstoned now
+				const { summaryVersion: revivalVersion } = await summarize(summarizer);
+				const revivalContainer = await loadContainer(revivalVersion);
+				const revivedObject = await requestFluidObject<ITestDataObject>(
+					revivalContainer,
+					unreferencedId,
+				);
+				revivedObject._root.set("can send", "op");
+				// This signal call closes the tombstoneContainer.
+				// The op above doesn't because the signal reaches the tombstone container faster
+				revivedObject._runtime.submitSignal("can submit", "signal");
+
+				const sendingContainer = await loadContainer(revivalVersion);
+				const sendDataObject = await requestFluidObject<ITestDataObject>(
+					sendingContainer,
+					unreferencedId,
+				);
+				sendDataObject._root.set("can receive", "an op");
+				sendDataObject._runtime.submitSignal("can receive", "a signal");
+				await provider.ensureSynchronized();
+				assert(
+					tombstoneContainer.closed !== true,
+					`Tombstone usage allowed, so container should not close.`,
+				);
+				assert(
+					revivalContainer.closed !== true,
+					`Revived datastore should not close a container when requested, sending/receiving signals/ops.`,
+				);
+				assert(
+					sendingContainer.closed !== true,
+					`Revived datastore should not close a container when sending signals and ops.`,
+				);
+			},
+		);
+	});
+
+	itExpects(
+		"Loading/Using tombstone allowed when configured",
+		[
+			{ eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested" },
+			{
+				eventName:
+					"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
+			},
+			{
+				eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+				callSite: "submitMessage",
+			},
+			{
+				eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+				callSite: "process",
+				clientType: "noninteractive/summarizer",
+			},
+			{
+				eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+				callSite: "process",
+				clientType: "interactive",
+			},
+		],
+		async () => {
+			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
+			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
+			const { unreferencedId, summarizingContainer, summarizer } =
+				await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+			await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+			// The datastore should be tombstoned now
+			const { summaryVersion } = await summarize(summarizer);
+			const container = await loadContainer(summaryVersion);
+			// Requesting the tombstoned data store should succeed since ThrowOnTombstoneLoad is not enabled.
+			// Logs a tombstone and sweep ready error
+			let dataObject: ITestDataObject;
+			await assert.doesNotReject(async () => {
+				dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
+			}, `Should be able to request a tombstoned datastore.`);
+			// Modifying the tombstoned datastore should not fail since ThrowOnTombstoneUsage is not enabled.
+			// Logs a submitMessage error
+			assert.doesNotThrow(
+				() => dataObject._root.set("send", "op"),
+				`Should be able to send ops for a tombstoned datastore.`,
+			);
+
+			// Wait for the above op to be process. That will result in another error logged during process.
+			// Both the summarizing container and the submitting container log a process error
+			await provider.ensureSynchronized();
+		},
+	);
+
+	describe("Tombstone information in summary", () => {
+		/**
+		 * Validates that the give summary tree contains correct information in the tombstone blob in GC tree.
+		 * @param summaryTree - The summary tree that may contain the tombstone blob.
+		 * @param tombstones - A list of ids that should be present in the tombstone blob.
+		 * @param notTombstones - A list of ids that should not be present in the tombstone blob.
+		 */
+		function validateTombstoneState(
+			summaryTree: ISummaryTree,
+			tombstones: string[] | undefined,
+			notTombstones: string[],
+		) {
+			const actualTombstones = getGCTombstoneStateFromSummary(summaryTree);
+			if (tombstones === undefined) {
+				assert(
+					actualTombstones === undefined,
+					"GC tree should not have tombstones in summary",
+				);
+				return;
+			}
+			assert(actualTombstones !== undefined, "GC tree should have tombstones in summary");
+			for (const url of tombstones) {
+				assert(actualTombstones.includes(url), `${url} should be in tombstone blob`);
+			}
+			for (const url of notTombstones) {
+				assert(!actualTombstones.includes(url), `${url} should not be in tombstone blob`);
+			}
+		}
+
+		beforeEach(() => {
+			// This is not the typical configuration we expect (usage may be allowed), but keeping it more strict for the tests
+			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
+			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
+		});
+
+		it("adds tombstone data stores information to tombstone blob in summary", async () => {
+			const mainContainer = await provider.makeTestContainer(testContainerConfig);
+			const mainDataStore = await requestFluidObject<ITestDataObject>(
+				mainContainer,
+				"default",
+			);
+			const mainDataStoreUrl = `/${mainDataStore._context.id}`;
+			await waitForContainerConnection(mainContainer);
+
+			const summarizer = await createSummarizer(
+				provider,
+				mainContainer,
+				undefined /* summaryVersion */,
+				gcOptions,
+				mockConfigProvider(settings),
+			);
+
+			// Create couple of data stores.
+			const newDataStore = await requestFluidObject<ITestDataObject>(
+				await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType),
+				"",
+			);
+			const newDataStore2 = await requestFluidObject<ITestDataObject>(
+				await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType),
+				"",
+			);
+			const newDataStoreUrl = `/${newDataStore._context.id}`;
+			const newDataStore2Url = `/${newDataStore2._context.id}`;
+
+			// Add the data stores' handle so that they are live and referenced.
+			mainDataStore._root.set("newDataStore", newDataStore.handle);
+			mainDataStore._root.set("newDataStore2", newDataStore2.handle);
+
+			// Remove the data stores' handle to make them unreferenced.
+			mainDataStore._root.delete("newDataStore");
+			mainDataStore._root.delete("newDataStore2");
+
+			// Summarize so that the above data stores are marked unreferenced.
+			await provider.ensureSynchronized();
+			const summary = await summarizeNow(summarizer);
+			validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
+
+			// Wait for sweep timeout so that the data stores are tombstoned.
+			await delay(sweepTimeoutMs + 10);
+			// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+			mainDataStore._root.set("key", "value");
+			await provider.ensureSynchronized();
+
+			// Summarize. The tombstoned data stores should now be part of the summary.
+			const summary2 = await summarizeNow(summarizer);
+			validateTombstoneState(
+				summary2.summaryTree,
+				[newDataStoreUrl, newDataStore2Url],
+				[mainDataStoreUrl],
+			);
+		});
+
+		it("adds tombstone attachment blob information to tombstone blob in summary", async () => {
+			const mainContainer = await provider.makeTestContainer(testContainerConfig);
+			const mainDataStore = await requestFluidObject<ITestDataObject>(
+				mainContainer,
+				"default",
+			);
+			const mainDataStoreUrl = `/${mainDataStore._context.id}`;
+			await waitForContainerConnection(mainContainer);
+
+			const summarizer = await createSummarizer(
+				provider,
+				mainContainer,
+				undefined /* summaryVersion */,
+				gcOptions,
+				mockConfigProvider(settings),
+			);
+
+			// Upload an attachment blobs and mark it referenced.
+			const blobContents = "Blob contents";
+			const blobHandle = await mainDataStore._context.uploadBlob(
+				stringToBuffer(blobContents, "utf-8"),
+			);
+			mainDataStore._root.set("blob", blobHandle);
+
+			// Remove the blob's handle to make it unreferenced.
+			mainDataStore._root.delete("blob");
+
+			// Summarize so that the above attachment blob is marked unreferenced.
+			await provider.ensureSynchronized();
+			const summary = await summarizeNow(summarizer);
+			validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
+
+			// Wait for sweep timeout so that the blob is tombstoned.
+			await delay(sweepTimeoutMs + 10);
+			// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+			mainDataStore._root.set("key", "value");
+			await provider.ensureSynchronized();
+
+			// Summarize. The tombstoned attachment blob should now be part of the tombstone blob.
+			const summary2 = await summarizeNow(summarizer);
+			validateTombstoneState(
+				summary2.summaryTree,
+				[blobHandle.absolutePath],
+				[mainDataStoreUrl],
+			);
+		});
+
+		itExpects(
+			"removes un-tombstoned data store and attachment blob from tombstone blob in summary",
+			[
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived",
+					category: "generic",
+				},
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived",
+					category: "generic",
+				},
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived",
+					type: "DataStore",
+				},
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived",
+					type: "Blob",
+				},
+			],
+			async () => {
+				const mainContainer = await provider.makeTestContainer(testContainerConfig);
+				const mainDataStore = await requestFluidObject<ITestDataObject>(
+					mainContainer,
+					"default",
+				);
+				const mainDataStoreUrl = `/${mainDataStore._context.id}`;
+				await waitForContainerConnection(mainContainer);
+
+				const mockLogger = new MockLogger();
+
+				const summarizer = await createSummarizer(
+					provider,
+					mainContainer,
+					undefined /* summaryVersion */,
+					gcOptions,
+					mockConfigProvider(settings),
+					mockLogger,
+				);
+
+				// Create couple of data stores.
+				const newDataStore = await requestFluidObject<ITestDataObject>(
+					await mainDataStore._context.containerRuntime.createDataStore(
+						TestDataObjectType,
+					),
+					"",
+				);
+				const newDataStore2 = await requestFluidObject<ITestDataObject>(
+					await mainDataStore._context.containerRuntime.createDataStore(
+						TestDataObjectType,
+					),
+					"",
+				);
+				const newDataStoreUrl = `/${newDataStore._context.id}`;
+				const newDataStore2Url = `/${newDataStore2._context.id}`;
+
+				// Add the data stores' handles so that they are live and referenced.
+				mainDataStore._root.set("newDataStore", newDataStore.handle);
+				mainDataStore._root.set("newDataStore2", newDataStore2.handle);
+
+				// Remove the data stores' handles to make them unreferenced.
+				mainDataStore._root.delete("newDataStore");
+				mainDataStore._root.delete("newDataStore2");
+
+				// Upload an attachment blob and mark it referenced.
+				const blobContents = "Blob contents";
+				const blobHandle = await mainDataStore._context.uploadBlob(
+					stringToBuffer(blobContents, "utf-8"),
+				);
+				mainDataStore._root.set("blob", blobHandle);
+
+				// Remove the blob's handle to make it unreferenced.
+				mainDataStore._root.delete("blob");
+
+				// Summarize so that the above data stores and blobs are marked unreferenced.
+				await provider.ensureSynchronized();
+				const summary = await summarizeNow(summarizer);
+				validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
+
+				// Wait for sweep timeout so that the data stores are tombstoned.
+				await delay(sweepTimeoutMs + 10);
+				// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+				mainDataStore._root.set("key", "value");
+				await provider.ensureSynchronized();
+
+				// Summarize. The tombstoned data stores should now be part of the tombstone blob.
+				const summary2 = await summarizeNow(summarizer);
+				validateTombstoneState(
+					summary2.summaryTree,
+					[newDataStoreUrl, newDataStore2Url, blobHandle.absolutePath],
+					[mainDataStoreUrl],
+				);
+
+				mockLogger.assertMatchNone([
+					{
+						eventName:
+							"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived",
+					},
+					{
+						eventName:
+							"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived",
+					},
+				]);
+
+				// Mark one of the data stores and attachment blob as referenced so that they are not tombstones anymore.
+				// Note that sweepTimeout was shrunk below sessionExpiry, otherwise we'd need to load a new container and
+				// use the allowTombstone header to even get the handle and revive these.
+				mainDataStore._root.set("newDataStore", newDataStore.handle);
+				mainDataStore._root.set("blob", blobHandle);
+				await provider.ensureSynchronized();
+				mockLogger.assertMatch([
+					{
+						eventName:
+							"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived",
+					},
+					{
+						eventName:
+							"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived",
+					},
+				]);
+
+				// Summarize. The un-tombstoned data store and attachment blob should not be part of the tombstone blob.
+				const summary3 = await summarizeNow(summarizer);
+				validateTombstoneState(
+					summary3.summaryTree,
+					[newDataStore2Url],
+					[mainDataStoreUrl, newDataStoreUrl, blobHandle.absolutePath],
+				);
+			},
+		);
+
+		it("does not re-summarize GC state on only tombstone state changed", async () => {
+			const mainContainer = await provider.makeTestContainer(testContainerConfig);
+			const mainDataStore = await requestFluidObject<ITestDataObject>(
+				mainContainer,
+				"default",
+			);
+			await waitForContainerConnection(mainContainer);
+
+			const summarizer = await createSummarizer(
+				provider,
+				mainContainer,
+				undefined /* summaryVersion */,
+				gcOptions,
+				mockConfigProvider(settings),
+			);
+
+			// Create a data store.
+			const newDataStore = await requestFluidObject<ITestDataObject>(
+				await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType),
+				"",
+			);
+
+			// Add the data store's handle so that it is live and referenced.
+			mainDataStore._root.set("newDataStore", newDataStore.handle);
+
+			// Remove the data store's handle to make it unreferenced.
+			mainDataStore._root.delete("newDataStore");
+
+			// Summarize so that the above data stores are marked unreferenced.
+			await provider.ensureSynchronized();
+			const summary = await summarizeNow(summarizer);
+			const gcState = getGCStateFromSummary(summary.summaryTree);
+			assert(
+				gcState !== undefined,
+				"GC state should be available and should not be a handle",
+			);
+
+			// Wait for sweep timeout so that the data stores are tombstoned.
+			await delay(sweepTimeoutMs + 10);
+			// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+			mainDataStore._root.set("key", "value");
+			await provider.ensureSynchronized();
+
+			// Summarize. The tombstoned data stores should now be part of the summary.
+			const summary2 = await summarizeNow(summarizer);
+			assert.throws(
+				() => getGCStateFromSummary(summary2.summaryTree),
+				(e) => validateAssertionError(e, "GC state is not a blob"),
+			);
+			const tombstoneState = getGCTombstoneStateFromSummary(summary2.summaryTree);
+			assert(
+				tombstoneState !== undefined,
+				"Tombstone state should be available and should be a blob",
+			);
+
+			// Summarize. The tombstoned state should be a handle.
+			const summary3 = await summarizeNow(summarizer);
+			assert.throws(
+				() => getGCTombstoneStateFromSummary(summary3.summaryTree),
+				(e) => validateAssertionError(e, "GC data should be a tree"),
+			);
+		});
+
+		itExpects(
+			"can mark data store from tombstone information in summary in non-summarizer container",
+			[
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+				},
+			],
+			async () => {
+				const mainContainer = await provider.makeTestContainer(testContainerConfig);
+				const mainDataStore = await requestFluidObject<ITestDataObject>(
+					mainContainer,
+					"default",
+				);
+				const mainDataStoreUrl = `/${mainDataStore._context.id}`;
+				await waitForContainerConnection(mainContainer);
+
+				const summarizer = await createSummarizer(
+					provider,
+					mainContainer,
+					undefined /* summaryVersion */,
+					gcOptions,
+					mockConfigProvider(settings),
+				);
+
+				// Create a data store and mark it referenced.
+				const newDataStore = await requestFluidObject<ITestDataObject>(
+					await mainDataStore._context.containerRuntime.createDataStore(
+						TestDataObjectType,
+					),
+					"",
+				);
+				const newDataStoreUrl = `/${newDataStore._context.id}`;
+				mainDataStore._root.set("newDataStore", newDataStore.handle);
+
+				// Remove the data store's handle to make it unreferenced.
+				mainDataStore._root.delete("newDataStore");
+
+				// Summarize so that the above data stores are marked unreferenced.
+				await provider.ensureSynchronized();
+				const summary = await summarizeNow(summarizer);
+				validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
+
+				// Wait for sweep timeout so that the data stores are tombstoned.
+				await delay(sweepTimeoutMs + 10);
+				// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+				mainDataStore._root.set("key", "value");
+				await provider.ensureSynchronized();
+
+				// Summarize. The tombstoned data stores should now be part of the summary.
+				const summary2 = await summarizeNow(summarizer);
+				validateTombstoneState(summary2.summaryTree, [newDataStoreUrl], [mainDataStoreUrl]);
+
+				// Load a container from the above summary. The tombstoned data store should be correctly marked.
+				const container2 = await loadContainer(summary2.summaryVersion);
+
+				// Requesting the tombstoned data store should result in an error.
+				const unreferencedId = newDataStore._context.id;
+				await assert.rejects(
+					async () => requestFluidObject<ITestDataObject>(container2, unreferencedId),
+					(error) => {
+						const correctErrorType = error.code === 404;
+						const correctErrorMessage =
+							error.message === `DataStore was deleted: ${unreferencedId}`;
+						return correctErrorType && correctErrorMessage;
+					},
+					`Should not be able to retrieve a tombstoned datastore.`,
+				);
+			},
+		);
+	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -43,1286 +43,1043 @@ import { getGCStateFromSummary, getGCTombstoneStateFromSummary } from "./gcTestS
  * to the summary and changing them (sending / receiving ops, loading, etc.) is not allowed.
  */
 describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
-	const remainingTimeUntilSweepMs = 100;
-	const sweepTimeoutMs = 200;
-	assert(
-		remainingTimeUntilSweepMs < sweepTimeoutMs,
-		"remainingTimeUntilSweepMs should be < sweepTimeoutMs",
-	);
-	const settings = {};
-
-	const gcOptions: IGCRuntimeOptions = { inactiveTimeoutMs: 0 };
-	const testContainerConfig: ITestContainerConfig = {
-		runtimeOptions: {
-			summaryOptions: {
-				summaryConfigOverrides: {
-					state: "disabled",
-				},
-			},
-			gcOptions,
-		},
-		loaderProps: { configProvider: mockConfigProvider(settings) },
-	};
-
-	let provider: ITestObjectProvider;
-
-	beforeEach(async function () {
-		provider = getTestObjectProvider({ syncSummarizer: true });
-		if (provider.driver.type !== "local") {
-			this.skip();
-		}
-		settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
-	});
-
-	async function loadContainer(summaryVersion: string) {
-		return provider.loadTestContainer(testContainerConfig, {
-			[LoaderHeader.version]: summaryVersion,
-		});
-	}
-
-	let documentAbsoluteUrl: string | undefined;
-
-	const makeContainer = async () => {
-		const container = await provider.makeTestContainer(testContainerConfig);
-		documentAbsoluteUrl = await container.getAbsoluteUrl("");
-		return container;
-	};
-
-	const loadSummarizerAndContainer = async (summaryVersion?: string) => {
-		return createSummarizerWithContainer(
-			provider,
-			documentAbsoluteUrl,
-			summaryVersion,
-			gcOptions,
-			mockConfigProvider(settings),
-		);
-	};
-	const summarize = async (summarizer: ISummarizer) => {
-		await provider.ensureSynchronized();
-		return summarizeNow(summarizer);
-	};
-
-	// This function creates an unreferenced datastore and returns the datastore's id and the summary version that
-	// datastore was unreferenced in.
-	const summarizationWithUnreferencedDataStoreAfterTime = async (
-		approximateUnreferenceTimestampMs: number,
-	) => {
-		const container = await makeContainer();
-		const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
-		await waitForContainerConnection(container);
-
-		const handleKey = "handle";
-		const dataStore = await defaultDataObject._context.containerRuntime.createDataStore(
-			TestDataObjectType,
-		);
-		const testDataObject = (await dataStore.entryPoint?.get()) as ITestDataObject | undefined;
-		assert(
-			testDataObject !== undefined,
-			"Should have been able to retrieve testDataObject from entryPoint",
-		);
-		const unreferencedId = testDataObject._context.id;
-
-		// Reference a datastore - important for making it live
-		defaultDataObject._root.set(handleKey, testDataObject.handle);
-		// Unreference a datastore
-		defaultDataObject._root.delete(handleKey);
-
-		// Summarize
-		const { container: summarizingContainer1, summarizer: summarizer1 } =
-			await loadSummarizerAndContainer();
-		const summaryVersion = (await summarize(summarizer1)).summaryVersion;
-
-		// TODO: trailing op test - note because of the way gc is currently structured, the error isn't logged,
-		// but it is detected - it's stored in the pending queue and the container closes before the error is sent.
-		testDataObject._root.set("send while unreferenced", "op");
-		await provider.ensureSynchronized();
-
-		// Close the containers as these containers would be closed by session expiry before sweep ready ever occurs
-		container.close();
-		summarizingContainer1.close();
-
-		// Wait some time, the datastore can be in many different unreference states
-		await delay(approximateUnreferenceTimestampMs);
-
-		// Load a new container and summarizer based on the latest summary, summarize
-		const { container: summarizingContainer2, summarizer: summarizer2 } =
-			await loadSummarizerAndContainer(summaryVersion);
-
-		return {
-			unreferencedId,
-			summarizingContainer: summarizingContainer2,
-			summarizer: summarizer2,
-			summaryVersion,
-		};
-	};
-
-	let opCount = 0;
-	// Sends a unique op that's guaranteed to change the DDS for this specific container.
-	// This can also be used to transition a client to write mode.
-	const sendOpToUpdateSummaryTimestampToNow = async (container: IContainer) => {
-		const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
-		defaultDataObject._root.set("send a", `op ${opCount++}`);
-	};
-
-	const getTombstonedDataObjectFromSummary = async (summaryVersion: string, id: string) => {
-		// Load a container with the data store tombstoned
-		const container = await loadContainer(summaryVersion);
-
-		// Transition container to write mode
-		const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
-		defaultDataObject._root.set("send a", "op");
-
-		// Get dataObject
-		const containerRuntime = defaultDataObject._context.containerRuntime as any;
-		const dataStoreContext = containerRuntime.dataStores.contexts.get(id);
-		const dataStoreRuntime: IFluidDataStoreChannel = await dataStoreContext.realize();
-		return (await dataStoreRuntime.entryPoint?.get()) as ITestDataObject;
-	};
-
-	const setupContainerCloseErrorValidation = (container: IContainer, expectedCall: string) => {
-		container.on("closed", (error) => {
-			assert(error !== undefined, `Expecting an error!`);
-			assert(error.errorType === "dataCorruptionError");
-			assert(error.message === `Context is tombstoned! Call site [${expectedCall}]`);
-		});
-	};
-
-	describe("Using tombstone data stores not allowed (per config)", () => {
-		beforeEach(() => {
-			// Allow Loading but not Usage
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
-		});
-
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-		itExpects(
-			"Send ops fails for tombstoned datastores in summarizing container loaded after sweep timeout",
-			[{ eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" }],
-			async () => {
-				const { unreferencedId, summarizer } =
-					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-
-				// The datastore should be tombstoned now
-				const { summaryVersion } = await summarize(summarizer);
-
-				const dataObject = await getTombstonedDataObjectFromSummary(
-					summaryVersion,
-					unreferencedId,
-				);
-
-				// Modifying a testDataObject substantiated from the request pattern should fail!
-				assert.throws(
-					() => dataObject._root.set("send", "op"),
-					(error) => {
-						const correctErrorType = error.errorType === "dataCorruptionError";
-						const correctErrorMessage =
-							error.message?.startsWith(`Context is tombstoned`) === true;
-						return correctErrorType && correctErrorMessage;
-					},
-					`Should not be able to send ops for a tombstoned datastore.`,
-				);
-			},
-		);
-
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-		itExpects(
-			"Send ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
-			[{ eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" }],
-			async () => {
-				const { unreferencedId, summarizingContainer, summarizer } =
-					await summarizationWithUnreferencedDataStoreAfterTime(
-						sweepTimeoutMs - remainingTimeUntilSweepMs,
-					);
-				// Wait enough time so that the datastore is sweep ready
-				await delay(remainingTimeUntilSweepMs);
-
-				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-				// The datastore should be tombstoned now
-				const { summaryVersion } = await summarize(summarizer);
-				const dataObject = await getTombstonedDataObjectFromSummary(
-					summaryVersion,
-					unreferencedId,
-				);
-
-				// Sending an op from a datastore substantiated from the request pattern should fail!
-				assert.throws(
-					() => dataObject._root.set("send", "op"),
-					(error) => {
-						const correctErrorType = error.errorType === "dataCorruptionError";
-						const correctErrorMessage =
-							error.message?.startsWith(`Context is tombstoned`) === true;
-						return correctErrorType && correctErrorMessage;
-					},
-					`Should not be able to send ops for a tombstoned datastore.`,
-				);
-			},
-		);
-
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-		itExpects(
-			"Receive ops fails for tombstoned datastores in summarizing container loaded after sweep time",
-			[
-				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
-				},
-				{
-					eventName:
-						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-					error: "Context is tombstoned! Call site [process]",
-				},
-				{
-					eventName:
-						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-					error: "Context is tombstoned! Call site [process]",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
-					error: "Context is tombstoned! Call site [process]",
-					errorType: "dataCorruptionError",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerDispose",
-					error: "Context is tombstoned! Call site [process]",
-					errorType: "dataCorruptionError",
-				},
-			],
-			async () => {
-				const { unreferencedId, summarizer, summaryVersion, summarizingContainer } =
-					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-				// Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
-				const container = await loadContainer(summaryVersion);
-				// Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-				// production application
-				// This does not cause a sweep ready changed error as the container has loaded from a summary before sweep
-				// ready was set
-				const senderObject = await requestFluidObject<ITestDataObject>(
-					container,
-					unreferencedId,
-				);
-
-				// The datastore should be tombstoned now
-				const { summaryVersion: tombstoneVersion } = await summarize(summarizer);
-
-				// Load a client from the tombstone summary
-				const receivingContainer = await loadContainer(tombstoneVersion);
-				await sendOpToUpdateSummaryTimestampToNow(receivingContainer);
-
-				setupContainerCloseErrorValidation(receivingContainer, "process");
-
-				// Receive an op - both the summarizer and the receiving client log a process error, only the receiving
-				// client closes
-				senderObject._root.set("send an op to be received", "op");
-				await provider.ensureSynchronized();
-				assert(receivingContainer.closed === true, `Reading container should close.`);
-				assert(
-					summarizingContainer.closed !== true,
-					`Summarizing container should not close.`,
-				);
-			},
-		);
-
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-		itExpects(
-			"Receive ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
-			[
-				{
-					eventName:
-						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-					error: "Context is tombstoned! Call site [process]",
-				},
-				{
-					eventName:
-						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-					error: "Context is tombstoned! Call site [process]",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
-					error: "Context is tombstoned! Call site [process]",
-					errorType: "dataCorruptionError",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerDispose",
-					error: "Context is tombstoned! Call site [process]",
-					errorType: "dataCorruptionError",
-				},
-			],
-			async () => {
-				const { unreferencedId, summarizingContainer, summarizer, summaryVersion } =
-					await summarizationWithUnreferencedDataStoreAfterTime(
-						sweepTimeoutMs - remainingTimeUntilSweepMs,
-					);
-				// Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
-				const sendingContainer = await loadContainer(summaryVersion);
-				// Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-				// production application. Causes an inactiveObject loaded error
-				const dataObject = await requestFluidObject<ITestDataObject>(
-					sendingContainer,
-					unreferencedId,
-				);
-
-				// Wait enough time so that the datastore is sweep ready
-				await delay(remainingTimeUntilSweepMs);
-
-				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-				// The datastore should be tombstoned now
-				const { summaryVersion: tombstoneVersion } = await summarize(summarizer);
-
-				// Load a client from the tombstone summary
-				const receivingContainer = await loadContainer(tombstoneVersion);
-				await sendOpToUpdateSummaryTimestampToNow(receivingContainer);
-
-				setupContainerCloseErrorValidation(receivingContainer, "process");
-
-				// Send an op to be received - no sweep changed or loaded - the summarizing container does not log sweep
-				// ready errors as it closes before the op is processed and the datastore is realized
-				dataObject._root.set("send an op to be received", "op");
-				await provider.ensureSynchronized();
-				assert(
-					receivingContainer.closed === true,
-					`Container receiving messages to a tombstoned datastore should close.`,
-				);
-				assert(
-					summarizingContainer.closed !== true,
-					`Summarizing container should not close.`,
-				);
-			},
-		);
-
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-		itExpects(
-			"Send signals fails for tombstoned datastores in summarizing container loaded after sweep timeout",
-			[{ eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" }],
-			async () => {
-				const { unreferencedId, summarizer } =
-					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-				// The datastore should be tombstoned now
-				const { summaryVersion } = await summarize(summarizer);
-
-				const dataObject = await getTombstonedDataObjectFromSummary(
-					summaryVersion,
-					unreferencedId,
-				);
-
-				// Sending a signal from a testDataObject substantiated from the request pattern should fail!
-				assert.throws(
-					() => dataObject._runtime.submitSignal("send", "signal"),
-					(error) => {
-						const correctErrorType = error.errorType === "dataCorruptionError";
-						const correctErrorMessage =
-							error.message?.startsWith(`Context is tombstoned`) === true;
-						return correctErrorType && correctErrorMessage;
-					},
-					`Should not be able to send signals for a tombstoned datastore.`,
-				);
-			},
-		);
-
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-		itExpects(
-			"Receive signals fails for tombstoned datastores in summarizing container loaded after sweep timeout",
-			[
-				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
-				},
-				{
-					eventName:
-						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-					error: "Context is tombstoned! Call site [processSignal]",
-				},
-				{
-					eventName:
-						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-					error: "Context is tombstoned! Call site [processSignal]",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
-					error: "Context is tombstoned! Call site [processSignal]",
-					errorType: "dataCorruptionError",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerDispose",
-					error: "Context is tombstoned! Call site [processSignal]",
-					errorType: "dataCorruptionError",
-				},
-			],
-			async () => {
-				const { unreferencedId, summarizer, summaryVersion } =
-					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-				// The datastore should be tombstoned now
-				await summarize(summarizer);
-
-				// Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
-				const container = await loadContainer(summaryVersion);
-				// Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
-				// production application
-				// This does not cause a sweep ready changed error as the container has loaded from a summary before sweep
-				// ready was set
-				const senderObject = await requestFluidObject<ITestDataObject>(
-					container,
-					unreferencedId,
-				);
-
-				// The datastore should be tombstoned now
-				const { summaryVersion: tombstoneVersion } = await summarize(summarizer);
-
-				// Load a client from the tombstone summary
-				const receivingContainer = await loadContainer(tombstoneVersion);
-				await sendOpToUpdateSummaryTimestampToNow(receivingContainer);
-
-				setupContainerCloseErrorValidation(receivingContainer, "processSignal");
-
-				// Receive a signal by sending it from another container
-				senderObject._runtime.submitSignal("send a signal to be received", "signal");
-				await provider.ensureSynchronized();
-				assert(
-					receivingContainer.closed === true,
-					`Container receiving messages to a tombstoned datastore should close.`,
-				);
-			},
-		);
-	});
-
-	describe("Loading tombstone data stores not allowed (per config)", () => {
-		const expectedHeadersLogged = {
-			request: "{}",
-			handleGet: JSON.stringify({ viaHandle: true }),
-			request_allowTombstone: JSON.stringify({ allowTombstone: true }),
-		};
-
-		beforeEach(() => {
-			// Allow Usage but not Loading
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
-		});
-
-		/**
-		 * Our partners use ContainerRuntime.resolveHandle to issue requests. We can't easily call it directly,
-		 * but the test containers are wired up to route requests to this function.
-		 * (See the innerRequestHandler used in LocalCodeLoader for how it works)
-		 */
-		async function containerRuntime_resolveHandle(
-			container: IContainer,
-			request: IRequest,
-		): Promise<IResponse> {
-			return container.request(request);
-		}
-
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-		itExpects(
-			"Requesting tombstoned datastores fails in interactive client loaded after sweep timeout",
-			[
-				// Interactive client's request
-				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
-					headers: expectedHeadersLogged.request,
-				},
-				// Interactive client's request w/ allowTombstone
-				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
-					category: "generic",
-					headers: expectedHeadersLogged.request_allowTombstone,
-				},
-				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
-				},
-				// Summarizer client's request
-				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
-					category: "generic",
-					headers: expectedHeadersLogged.request,
-					isSummarizerClient: true,
-				},
-			],
-			async () => {
-				const { unreferencedId, summarizingContainer, summarizer } =
-					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-				// The datastore should be tombstoned now
-				const { summaryVersion } = await summarize(summarizer);
-				const container = await loadContainer(summaryVersion);
-				await sendOpToUpdateSummaryTimestampToNow(container);
-
-				// This request fails since the datastore is tombstoned
-				const tombstoneErrorResponse = await containerRuntime_resolveHandle(container, {
-					url: unreferencedId,
-				});
-				assert.equal(
-					tombstoneErrorResponse.status,
-					404,
-					"Should not be able to retrieve a tombstoned datastore in non-summarizer clients",
-				);
-				assert.equal(
-					tombstoneErrorResponse.value,
-					`DataStore was deleted: ${unreferencedId}`,
-					"Expected the Tombstone error message",
-				);
-				assert.equal(
-					tombstoneErrorResponse.headers?.[TombstoneResponseHeaderKey],
-					true,
-					"Expected the Tombstone header",
-				);
-
-				// This request succeeds because the "allowTombstone" header is set to true
-				const tombstoneSuccessResponse = await containerRuntime_resolveHandle(container, {
-					url: unreferencedId,
-					headers: { [AllowTombstoneRequestHeaderKey]: true },
-				});
-				assert.equal(
-					tombstoneSuccessResponse.status,
-					200,
-					"Should be able to retrieve a tombstoned datastore given the allowTombstone header",
-				);
-				assert.notEqual(
-					tombstoneSuccessResponse.headers?.[TombstoneResponseHeaderKey],
-					true,
-					"DID NOT Expect tombstone header to be set on the response",
-				);
-
-				// This request succeeds because the summarizer never fails for tombstones
-				const summarizerResponse = await containerRuntime_resolveHandle(
-					summarizingContainer,
-					{ url: unreferencedId },
-				);
-				assert.equal(
-					summarizerResponse.status,
-					200,
-					"Should be able to retrieve a tombstoned datastore in summarizer clients",
-				);
-				assert.notEqual(
-					summarizerResponse.headers?.[TombstoneResponseHeaderKey],
-					true,
-					"DID NOT Expect tombstone header to be set on the response",
-				);
-			},
-		);
-
-		// SKIPPED: This test is redundant with the previous one; SweepReady calculation/timers has coverage elsewhere
-		itExpects.skip(
-			"Requesting tombstoned datastores fails in summarizing container loaded before sweep timeout",
-			[
-				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
-					viaHandle: false,
-				},
-			],
-			async () => {
-				const { unreferencedId, summarizingContainer, summarizer } =
-					await summarizationWithUnreferencedDataStoreAfterTime(
-						sweepTimeoutMs - remainingTimeUntilSweepMs,
-					);
-				// Wait enough time so that the datastore is sweep ready
-				await delay(remainingTimeUntilSweepMs);
-
-				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-				// The datastore should be tombstoned now
-				await summarize(summarizer);
-				const { summaryVersion } = await summarize(summarizer);
-				const container = await loadContainer(summaryVersion);
-				await sendOpToUpdateSummaryTimestampToNow(container);
-
-				// Requesting a tombstoned datastore should fail!
-				await assert.rejects(
-					async () => requestFluidObject<ITestDataObject>(container, unreferencedId),
-					(error) => {
-						const correctErrorType = error.code === 404;
-						const correctErrorMessage =
-							error.message === `DataStore was deleted: ${unreferencedId}`;
-						return correctErrorType && correctErrorMessage;
-					},
-					`Should not be able to retrieve a tombstoned datastore.`,
-				);
-			},
-		);
-
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-		itExpects(
-			"Handle request for tombstoned datastores fails in summarizing container loaded after sweep timeout",
-			[
-				// Interactive client's handle.get
-				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
-					headers: expectedHeadersLogged.handleGet,
-				},
-				// Interactive client's request w/ allowTombstone
-				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
-					category: "generic",
-					headers: expectedHeadersLogged.request_allowTombstone,
-				},
-				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
-				},
-			],
-			async () => {
-				const { unreferencedId, summarizingContainer, summarizer } =
-					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-				// The datastore should be tombstoned now
-				const { summaryVersion } = await summarize(summarizer);
-				const dataObject = await getTombstonedDataObjectFromSummary(
-					summaryVersion,
-					unreferencedId,
-				);
-
-				const serializer = new FluidSerializer(
-					dataObject._context.IFluidHandleContext,
-					() => {},
-				);
-				const handle: IFluidHandle = parseHandles(
-					{ type: "__fluid_handle__", url: unreferencedId },
-					serializer,
-				);
-
-				// This fails because the DataStore is tombstoned
-				let tombstoneError:
-					| (Error & {
-							code: number;
-							underlyingResponseHeaders?: { [TombstoneResponseHeaderKey]: boolean };
-					  })
-					| undefined;
-				try {
-					await handle.get();
-				} catch (error: any) {
-					tombstoneError = error;
-				}
-				assert.equal(
-					tombstoneError?.code,
-					404,
-					"Tombstone error from handle.get should have 404 status code",
-				);
-				assert.equal(
-					tombstoneError?.message,
-					`DataStore was deleted: ${unreferencedId}`,
-					"Incorrect message for Tombstone error from handle.get",
-				);
-				assert.equal(
-					tombstoneError?.underlyingResponseHeaders?.[TombstoneResponseHeaderKey],
-					true,
-					"Tombstone error from handle.get should include the tombstone flag",
-				);
-
-				// This demonstrates how a consumer could then fetch the tombstoned object to facilitate recovery (actual revival is covered in another test below)
-				const tombstoneSuccessResponse = await (
-					dataObject._context.containerRuntime as ContainerRuntime
-				).resolveHandle({
-					url: unreferencedId,
-					headers: { [AllowTombstoneRequestHeaderKey]: true },
-				});
-				assert.equal(
-					tombstoneSuccessResponse.status,
-					200,
-					"Should be able to retrieve a tombstoned datastore given the allowTombstone header",
-				);
-				assert.notEqual(
-					tombstoneSuccessResponse.headers?.[TombstoneResponseHeaderKey],
-					true,
-					"DID NOT Expect tombstone header to be set on the response",
-				);
-			},
-		);
-
-		// SKIPPED: This test is redundant with the previous one; SweepReady calculation/timers has coverage elsewhere
-		itExpects.skip(
-			"Handle request for tombstoned datastores fails in summarizing container loaded before sweep timeout",
-			[
-				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
-					viaHandle: true,
-				},
-			],
-			async () => {
-				const { unreferencedId, summarizingContainer, summarizer } =
-					await summarizationWithUnreferencedDataStoreAfterTime(
-						sweepTimeoutMs - remainingTimeUntilSweepMs,
-					);
-				// Wait enough time so that the datastore is sweep ready
-				await delay(remainingTimeUntilSweepMs);
-
-				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-				// The datastore should be tombstoned now
-				const { summaryVersion } = await summarize(summarizer);
-				const dataObject = await getTombstonedDataObjectFromSummary(
-					summaryVersion,
-					unreferencedId,
-				);
-
-				// Note: if a user makes a request that looks like this, we will also think that the request is via handle
-				const request: IRequest = {
-					url: unreferencedId,
-					headers: { [RuntimeHeaders.viaHandle]: true },
-				};
-				const response = await dataObject._context.IFluidHandleContext.resolveHandle(
-					request,
-				);
-
-				assert(response !== undefined, `Expecting a response!`);
-				assert(response.status === 404);
-				assert(response.value === `DataStore was deleted: ${unreferencedId}`);
-			},
-		);
-
-		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-		itExpects(
-			"Can un-tombstone datastores by storing a handle",
-			[
-				// When confirming it's tombstoned
-				{ eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested" },
-				// When reviving it
-				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
-					category: "generic",
-				},
-				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
-				},
-				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived",
-					category: "generic",
-				},
-				{ eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived" },
-			],
-			async () => {
-				const { unreferencedId, summarizingContainer, summarizer } =
-					await summarizationWithUnreferencedDataStoreAfterTime(
-						sweepTimeoutMs - remainingTimeUntilSweepMs,
-					);
-				// Wait enough time so that the datastore is sweep ready
-				await delay(remainingTimeUntilSweepMs);
-
-				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-				// The datastore should be tombstoned now
-				const { summaryVersion } = await summarize(summarizer);
-				const tombstoneContainer = await loadContainer(summaryVersion);
-
-				// Datastore should be tombstoned, requesting should error
-				const tombstoneResponse = await containerRuntime_resolveHandle(tombstoneContainer, {
-					url: unreferencedId,
-				});
-				assert.equal(tombstoneResponse.status, 404, "Expected 404 tombstone response");
-				assert.equal(
-					tombstoneResponse.headers?.[TombstoneResponseHeaderKey],
-					true,
-					"Expected tombstone response with flag",
-				);
-
-				const requestAllowingTombstone: IRequest = {
-					url: unreferencedId,
-					headers: { [AllowTombstoneRequestHeaderKey]: true },
-				};
-				const tombstonedObject = await requestFluidObject<ITestDataObject>(
-					tombstoneContainer,
-					requestAllowingTombstone,
-				);
-				const defaultDataObject = await requestFluidObject<ITestDataObject>(
-					tombstoneContainer,
-					"default",
-				);
-				defaultDataObject._root.set("store", tombstonedObject.handle);
-
-				// The datastore should be un-tombstoned now
-				const { summaryVersion: revivalVersion } = await summarize(summarizer);
-				const revivalContainer = await loadContainer(revivalVersion);
-				const revivedObject = await requestFluidObject<ITestDataObject>(
-					revivalContainer,
-					unreferencedId,
-				);
-				revivedObject._root.set("can send", "op");
-				// This signal call closes the tombstoneContainer.
-				// The op above doesn't because the signal reaches the tombstone container faster
-				revivedObject._runtime.submitSignal("can submit", "signal");
-
-				const sendingContainer = await loadContainer(revivalVersion);
-				const sendDataObject = await requestFluidObject<ITestDataObject>(
-					sendingContainer,
-					unreferencedId,
-				);
-				sendDataObject._root.set("can receive", "an op");
-				sendDataObject._runtime.submitSignal("can receive", "a signal");
-				await provider.ensureSynchronized();
-				assert(
-					tombstoneContainer.closed !== true,
-					`Tombstone usage allowed, so container should not close.`,
-				);
-				assert(
-					revivalContainer.closed !== true,
-					`Revived datastore should not close a container when requested, sending/receiving signals/ops.`,
-				);
-				assert(
-					sendingContainer.closed !== true,
-					`Revived datastore should not close a container when sending signals and ops.`,
-				);
-			},
-		);
-	});
-
-	itExpects(
-		"Loading/Using tombstone allowed when configured",
-		[
-			{ eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested" },
-			{
-				eventName:
-					"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
-			},
-			{
-				eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-				callSite: "submitMessage",
-			},
-			{
-				eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-				callSite: "process",
-				clientType: "noninteractive/summarizer",
-			},
-			{
-				eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-				callSite: "process",
-				clientType: "interactive",
-			},
-		],
-		async () => {
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
-			const { unreferencedId, summarizingContainer, summarizer } =
-				await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-			await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
-
-			// The datastore should be tombstoned now
-			const { summaryVersion } = await summarize(summarizer);
-			const container = await loadContainer(summaryVersion);
-			// Requesting the tombstoned data store should succeed since ThrowOnTombstoneLoad is not enabled.
-			// Logs a tombstone and sweep ready error
-			let dataObject: ITestDataObject;
-			await assert.doesNotReject(async () => {
-				dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
-			}, `Should be able to request a tombstoned datastore.`);
-			// Modifying the tombstoned datastore should not fail since ThrowOnTombstoneUsage is not enabled.
-			// Logs a submitMessage error
-			assert.doesNotThrow(
-				() => dataObject._root.set("send", "op"),
-				`Should be able to send ops for a tombstoned datastore.`,
-			);
-
-			// Wait for the above op to be process. That will result in another error logged during process.
-			// Both the summarizing container and the submitting container log a process error
-			await provider.ensureSynchronized();
-		},
-	);
-
-	describe("Tombstone information in summary", () => {
-		/**
-		 * Validates that the give summary tree contains correct information in the tombstone blob in GC tree.
-		 * @param summaryTree - The summary tree that may contain the tombstone blob.
-		 * @param tombstones - A list of ids that should be present in the tombstone blob.
-		 * @param notTombstones - A list of ids that should not be present in the tombstone blob.
-		 */
-		function validateTombstoneState(
-			summaryTree: ISummaryTree,
-			tombstones: string[] | undefined,
-			notTombstones: string[],
-		) {
-			const actualTombstones = getGCTombstoneStateFromSummary(summaryTree);
-			if (tombstones === undefined) {
-				assert(
-					actualTombstones === undefined,
-					"GC tree should not have tombstones in summary",
-				);
-				return;
-			}
-			assert(actualTombstones !== undefined, "GC tree should have tombstones in summary");
-			for (const url of tombstones) {
-				assert(actualTombstones.includes(url), `${url} should be in tombstone blob`);
-			}
-			for (const url of notTombstones) {
-				assert(!actualTombstones.includes(url), `${url} should not be in tombstone blob`);
-			}
-		}
-
-		beforeEach(() => {
-			// This is not the typical configuration we expect (usage may be allowed), but keeping it more strict for the tests
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
-			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
-		});
-
-		it("adds tombstone data stores information to tombstone blob in summary", async () => {
-			const mainContainer = await provider.makeTestContainer(testContainerConfig);
-			const mainDataStore = await requestFluidObject<ITestDataObject>(
-				mainContainer,
-				"default",
-			);
-			const mainDataStoreUrl = `/${mainDataStore._context.id}`;
-			await waitForContainerConnection(mainContainer);
-
-			const summarizer = await createSummarizer(
-				provider,
-				mainContainer,
-				undefined /* summaryVersion */,
-				gcOptions,
-				mockConfigProvider(settings),
-			);
-
-			// Create couple of data stores.
-			const newDataStore = await requestFluidObject<ITestDataObject>(
-				await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType),
-				"",
-			);
-			const newDataStore2 = await requestFluidObject<ITestDataObject>(
-				await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType),
-				"",
-			);
-			const newDataStoreUrl = `/${newDataStore._context.id}`;
-			const newDataStore2Url = `/${newDataStore2._context.id}`;
-
-			// Add the data stores' handle so that they are live and referenced.
-			mainDataStore._root.set("newDataStore", newDataStore.handle);
-			mainDataStore._root.set("newDataStore2", newDataStore2.handle);
-
-			// Remove the data stores' handle to make them unreferenced.
-			mainDataStore._root.delete("newDataStore");
-			mainDataStore._root.delete("newDataStore2");
-
-			// Summarize so that the above data stores are marked unreferenced.
-			await provider.ensureSynchronized();
-			const summary = await summarizeNow(summarizer);
-			validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
-
-			// Wait for sweep timeout so that the data stores are tombstoned.
-			await delay(sweepTimeoutMs + 10);
-			// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
-			mainDataStore._root.set("key", "value");
-			await provider.ensureSynchronized();
-
-			// Summarize. The tombstoned data stores should now be part of the summary.
-			const summary2 = await summarizeNow(summarizer);
-			validateTombstoneState(
-				summary2.summaryTree,
-				[newDataStoreUrl, newDataStore2Url],
-				[mainDataStoreUrl],
-			);
-		});
-
-		it("adds tombstone attachment blob information to tombstone blob in summary", async () => {
-			const mainContainer = await provider.makeTestContainer(testContainerConfig);
-			const mainDataStore = await requestFluidObject<ITestDataObject>(
-				mainContainer,
-				"default",
-			);
-			const mainDataStoreUrl = `/${mainDataStore._context.id}`;
-			await waitForContainerConnection(mainContainer);
-
-			const summarizer = await createSummarizer(
-				provider,
-				mainContainer,
-				undefined /* summaryVersion */,
-				gcOptions,
-				mockConfigProvider(settings),
-			);
-
-			// Upload an attachment blobs and mark it referenced.
-			const blobContents = "Blob contents";
-			const blobHandle = await mainDataStore._context.uploadBlob(
-				stringToBuffer(blobContents, "utf-8"),
-			);
-			mainDataStore._root.set("blob", blobHandle);
-
-			// Remove the blob's handle to make it unreferenced.
-			mainDataStore._root.delete("blob");
-
-			// Summarize so that the above attachment blob is marked unreferenced.
-			await provider.ensureSynchronized();
-			const summary = await summarizeNow(summarizer);
-			validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
-
-			// Wait for sweep timeout so that the blob is tombstoned.
-			await delay(sweepTimeoutMs + 10);
-			// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
-			mainDataStore._root.set("key", "value");
-			await provider.ensureSynchronized();
-
-			// Summarize. The tombstoned attachment blob should now be part of the tombstone blob.
-			const summary2 = await summarizeNow(summarizer);
-			validateTombstoneState(
-				summary2.summaryTree,
-				[blobHandle.absolutePath],
-				[mainDataStoreUrl],
-			);
-		});
-
-		itExpects(
-			"removes un-tombstoned data store and attachment blob from tombstone blob in summary",
-			[
-				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived",
-					category: "generic",
-				},
-				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived",
-					category: "generic",
-				},
-				{
-					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived",
-					type: "DataStore",
-				},
-				{
-					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived",
-					type: "Blob",
-				},
-			],
-			async () => {
-				const mainContainer = await provider.makeTestContainer(testContainerConfig);
-				const mainDataStore = await requestFluidObject<ITestDataObject>(
-					mainContainer,
-					"default",
-				);
-				const mainDataStoreUrl = `/${mainDataStore._context.id}`;
-				await waitForContainerConnection(mainContainer);
-
-				const mockLogger = new MockLogger();
-
-				const summarizer = await createSummarizer(
-					provider,
-					mainContainer,
-					undefined /* summaryVersion */,
-					gcOptions,
-					mockConfigProvider(settings),
-					mockLogger,
-				);
-
-				// Create couple of data stores.
-				const newDataStore = await requestFluidObject<ITestDataObject>(
-					await mainDataStore._context.containerRuntime.createDataStore(
-						TestDataObjectType,
-					),
-					"",
-				);
-				const newDataStore2 = await requestFluidObject<ITestDataObject>(
-					await mainDataStore._context.containerRuntime.createDataStore(
-						TestDataObjectType,
-					),
-					"",
-				);
-				const newDataStoreUrl = `/${newDataStore._context.id}`;
-				const newDataStore2Url = `/${newDataStore2._context.id}`;
-
-				// Add the data stores' handles so that they are live and referenced.
-				mainDataStore._root.set("newDataStore", newDataStore.handle);
-				mainDataStore._root.set("newDataStore2", newDataStore2.handle);
-
-				// Remove the data stores' handles to make them unreferenced.
-				mainDataStore._root.delete("newDataStore");
-				mainDataStore._root.delete("newDataStore2");
-
-				// Upload an attachment blob and mark it referenced.
-				const blobContents = "Blob contents";
-				const blobHandle = await mainDataStore._context.uploadBlob(
-					stringToBuffer(blobContents, "utf-8"),
-				);
-				mainDataStore._root.set("blob", blobHandle);
-
-				// Remove the blob's handle to make it unreferenced.
-				mainDataStore._root.delete("blob");
-
-				// Summarize so that the above data stores and blobs are marked unreferenced.
-				await provider.ensureSynchronized();
-				const summary = await summarizeNow(summarizer);
-				validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
-
-				// Wait for sweep timeout so that the data stores are tombstoned.
-				await delay(sweepTimeoutMs + 10);
-				// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
-				mainDataStore._root.set("key", "value");
-				await provider.ensureSynchronized();
-
-				// Summarize. The tombstoned data stores should now be part of the tombstone blob.
-				const summary2 = await summarizeNow(summarizer);
-				validateTombstoneState(
-					summary2.summaryTree,
-					[newDataStoreUrl, newDataStore2Url, blobHandle.absolutePath],
-					[mainDataStoreUrl],
-				);
-
-				mockLogger.assertMatchNone([
-					{
-						eventName:
-							"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived",
-					},
-					{
-						eventName:
-							"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived",
-					},
-				]);
-
-				// Mark one of the data stores and attachment blob as referenced so that they are not tombstones anymore.
-				// Note that sweepTimeout was shrunk below sessionExpiry, otherwise we'd need to load a new container and
-				// use the allowTombstone header to even get the handle and revive these.
-				mainDataStore._root.set("newDataStore", newDataStore.handle);
-				mainDataStore._root.set("blob", blobHandle);
-				await provider.ensureSynchronized();
-				mockLogger.assertMatch([
-					{
-						eventName:
-							"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived",
-					},
-					{
-						eventName:
-							"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived",
-					},
-				]);
-
-				// Summarize. The un-tombstoned data store and attachment blob should not be part of the tombstone blob.
-				const summary3 = await summarizeNow(summarizer);
-				validateTombstoneState(
-					summary3.summaryTree,
-					[newDataStore2Url],
-					[mainDataStoreUrl, newDataStoreUrl, blobHandle.absolutePath],
-				);
-			},
-		);
-
-		it("does not re-summarize GC state on only tombstone state changed", async () => {
-			const mainContainer = await provider.makeTestContainer(testContainerConfig);
-			const mainDataStore = await requestFluidObject<ITestDataObject>(
-				mainContainer,
-				"default",
-			);
-			await waitForContainerConnection(mainContainer);
-
-			const summarizer = await createSummarizer(
-				provider,
-				mainContainer,
-				undefined /* summaryVersion */,
-				gcOptions,
-				mockConfigProvider(settings),
-			);
-
-			// Create a data store.
-			const newDataStore = await requestFluidObject<ITestDataObject>(
-				await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType),
-				"",
-			);
-
-			// Add the data store's handle so that it is live and referenced.
-			mainDataStore._root.set("newDataStore", newDataStore.handle);
-
-			// Remove the data store's handle to make it unreferenced.
-			mainDataStore._root.delete("newDataStore");
-
-			// Summarize so that the above data stores are marked unreferenced.
-			await provider.ensureSynchronized();
-			const summary = await summarizeNow(summarizer);
-			const gcState = getGCStateFromSummary(summary.summaryTree);
-			assert(
-				gcState !== undefined,
-				"GC state should be available and should not be a handle",
-			);
-
-			// Wait for sweep timeout so that the data stores are tombstoned.
-			await delay(sweepTimeoutMs + 10);
-			// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
-			mainDataStore._root.set("key", "value");
-			await provider.ensureSynchronized();
-
-			// Summarize. The tombstoned data stores should now be part of the summary.
-			const summary2 = await summarizeNow(summarizer);
-			assert.throws(
-				() => getGCStateFromSummary(summary2.summaryTree),
-				(e) => validateAssertionError(e, "GC state is not a blob"),
-			);
-			const tombstoneState = getGCTombstoneStateFromSummary(summary2.summaryTree);
-			assert(
-				tombstoneState !== undefined,
-				"Tombstone state should be available and should be a blob",
-			);
-
-			// Summarize. The tombstoned state should be a handle.
-			const summary3 = await summarizeNow(summarizer);
-			assert.throws(
-				() => getGCTombstoneStateFromSummary(summary3.summaryTree),
-				(e) => validateAssertionError(e, "GC data should be a tree"),
-			);
-		});
-
-		itExpects(
-			"can mark data store from tombstone information in summary in non-summarizer container",
-			[
-				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
-				},
-			],
-			async () => {
-				const mainContainer = await provider.makeTestContainer(testContainerConfig);
-				const mainDataStore = await requestFluidObject<ITestDataObject>(
-					mainContainer,
-					"default",
-				);
-				const mainDataStoreUrl = `/${mainDataStore._context.id}`;
-				await waitForContainerConnection(mainContainer);
-
-				const summarizer = await createSummarizer(
-					provider,
-					mainContainer,
-					undefined /* summaryVersion */,
-					gcOptions,
-					mockConfigProvider(settings),
-				);
-
-				// Create a data store and mark it referenced.
-				const newDataStore = await requestFluidObject<ITestDataObject>(
-					await mainDataStore._context.containerRuntime.createDataStore(
-						TestDataObjectType,
-					),
-					"",
-				);
-				const newDataStoreUrl = `/${newDataStore._context.id}`;
-				mainDataStore._root.set("newDataStore", newDataStore.handle);
-
-				// Remove the data store's handle to make it unreferenced.
-				mainDataStore._root.delete("newDataStore");
-
-				// Summarize so that the above data stores are marked unreferenced.
-				await provider.ensureSynchronized();
-				const summary = await summarizeNow(summarizer);
-				validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
-
-				// Wait for sweep timeout so that the data stores are tombstoned.
-				await delay(sweepTimeoutMs + 10);
-				// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
-				mainDataStore._root.set("key", "value");
-				await provider.ensureSynchronized();
-
-				// Summarize. The tombstoned data stores should now be part of the summary.
-				const summary2 = await summarizeNow(summarizer);
-				validateTombstoneState(summary2.summaryTree, [newDataStoreUrl], [mainDataStoreUrl]);
-
-				// Load a container from the above summary. The tombstoned data store should be correctly marked.
-				const container2 = await loadContainer(summary2.summaryVersion);
-
-				// Requesting the tombstoned data store should result in an error.
-				const unreferencedId = newDataStore._context.id;
-				await assert.rejects(
-					async () => requestFluidObject<ITestDataObject>(container2, unreferencedId),
-					(error) => {
-						const correctErrorType = error.code === 404;
-						const correctErrorMessage =
-							error.message === `DataStore was deleted: ${unreferencedId}`;
-						return correctErrorType && correctErrorMessage;
-					},
-					`Should not be able to retrieve a tombstoned datastore.`,
-				);
-			},
-		);
-	});
+    const remainingTimeUntilSweepMs = 100;
+    const sweepTimeoutMs = 200;
+    assert(remainingTimeUntilSweepMs < sweepTimeoutMs, "remainingTimeUntilSweepMs should be < sweepTimeoutMs");
+    const settings = {};
+
+    const gcOptions: IGCRuntimeOptions = { inactiveTimeoutMs: 0, gcContainerGeneration: 2 };
+    const testContainerConfig: ITestContainerConfig = {
+        runtimeOptions: {
+            summaryOptions: {
+                summaryConfigOverrides: {
+                    state: "disabled",
+                },
+            },
+            gcOptions,
+        },
+        loaderProps: { configProvider: mockConfigProvider(settings) },
+    };
+    const oldContainerConfig: ITestContainerConfig = {
+        runtimeOptions: {
+            summaryOptions: {
+                summaryConfigOverrides: {
+                    state: "disabled",
+                },
+            },
+            gcOptions: { ...gcOptions, gcContainerGeneration: 1 },
+        },
+        loaderProps: { configProvider: mockConfigProvider(settings) },
+    };
+
+    let provider: ITestObjectProvider;
+
+    beforeEach(async function() {
+        provider = getTestObjectProvider({ syncSummarizer: true });
+        if (provider.driver.type !== "local") {
+            this.skip();
+        }
+        settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = sweepTimeoutMs;
+    });
+
+    async function loadContainer(summaryVersion: string) {
+        return provider.loadTestContainer(
+            testContainerConfig,
+            { [LoaderHeader.version]: summaryVersion },
+        );
+    }
+
+    let documentAbsoluteUrl: string | undefined;
+
+    const makeContainer = async () => {
+        const container = await provider.makeTestContainer(testContainerConfig);
+        documentAbsoluteUrl = await container.getAbsoluteUrl("");
+        return container;
+    };
+
+    const makeOldContainer = async () => {
+        const container = await provider.makeTestContainer(oldContainerConfig);
+        documentAbsoluteUrl = await container.getAbsoluteUrl("");
+        return container;
+    };
+
+    const loadSummarizerAndContainer = async (summaryVersion?: string) => {
+        return createSummarizerWithContainer(
+            provider,
+            documentAbsoluteUrl,
+            summaryVersion,
+            gcOptions,
+            mockConfigProvider(settings),
+        );
+    };
+    const summarize = async (summarizer: ISummarizer) => {
+        await provider.ensureSynchronized();
+        return summarizeNow(summarizer);
+    };
+
+    // This function creates an unreferenced datastore and returns the datastore's id and the summary version that
+    // datastore was unreferenced in.
+    const summarizationWithUnreferencedDataStoreAfterTime =
+        async (approximateUnreferenceTimestampMs: number, useOldGeneration: boolean = false) => {
+            const container = useOldGeneration ? await makeOldContainer() : await makeContainer();
+            const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
+            await waitForContainerConnection(container);
+
+            const handleKey = "handle";
+            const dataStore = await defaultDataObject._context.containerRuntime.createDataStore(TestDataObjectType);
+            const testDataObject = await dataStore.entryPoint?.get() as ITestDataObject | undefined;
+            assert(testDataObject !== undefined, "Should have been able to retrieve testDataObject from entryPoint");
+            const unreferencedId = testDataObject._context.id;
+
+            // Reference a datastore - important for making it live
+            defaultDataObject._root.set(handleKey, testDataObject.handle);
+            // Unreference a datastore
+            defaultDataObject._root.delete(handleKey);
+
+            // Summarize
+            const {
+                container: summarizingContainer1,
+                summarizer: summarizer1,
+            } = await loadSummarizerAndContainer();
+            const summaryVersion = (await summarize(summarizer1)).summaryVersion;
+
+            // TODO: trailing op test - note because of the way gc is currently structured, the error isn't logged,
+            // but it is detected - it's stored in the pending queue and the container closes before the error is sent.
+            testDataObject._root.set("send while unreferenced", "op");
+            await provider.ensureSynchronized();
+
+            // Close the containers as these containers would be closed by session expiry before sweep ready ever occurs
+            container.close();
+            summarizingContainer1.close();
+
+            // Wait some time, the datastore can be in many different unreference states
+            await delay(approximateUnreferenceTimestampMs);
+
+            // Load a new container and summarizer based on the latest summary, summarize
+            const {
+                container: summarizingContainer2,
+                summarizer: summarizer2,
+            } = await loadSummarizerAndContainer(summaryVersion);
+
+            return {
+                unreferencedId,
+                summarizingContainer: summarizingContainer2,
+                summarizer: summarizer2,
+                summaryVersion,
+            };
+        };
+
+    let opCount = 0;
+    // Sends a unique op that's guaranteed to change the DDS for this specific container.
+    // This can also be used to transition a client to write mode.
+    const sendOpToUpdateSummaryTimestampToNow = async (container: IContainer) => {
+        const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
+        defaultDataObject._root.set("send a", `op ${opCount++}`);
+    };
+
+    const getTombstonedDataObjectFromSummary = async (summaryVersion: string, id: string) => {
+        // Load a container with the data store tombstoned
+        const container = await loadContainer(summaryVersion);
+
+        // Transition container to write mode
+        const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
+        defaultDataObject._root.set("send a", "op");
+
+        // Get dataObject
+        const containerRuntime = defaultDataObject._context.containerRuntime as any;
+        const dataStoreContext = containerRuntime.dataStores.contexts.get(id);
+        const dataStoreRuntime: IFluidDataStoreChannel = await dataStoreContext.realize();
+        return await dataStoreRuntime.entryPoint?.get() as ITestDataObject;
+    };
+
+    const setupContainerCloseErrorValidation = (container: IContainer, expectedCall: string) => {
+        container.on("closed", (error) => {
+            assert(error !== undefined, `Expecting an error!`);
+            assert(error.errorType === "dataCorruptionError");
+            assert(error.message === `Context is tombstoned! Call site [${expectedCall}]`);
+        });
+    };
+
+    describe("Using tombstone data stores not allowed (per config)", () => {
+        beforeEach(() => {
+            // Allow Loading but not Usage
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Send ops fails for tombstoned datastores in summarizing container loaded after sweep timeout",
+        [
+            { eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+
+            // The datastore should be tombstoned now
+            const { summaryVersion } = await summarize(summarizer);
+
+            const dataObject = await getTombstonedDataObjectFromSummary(summaryVersion, unreferencedId);
+
+            // Modifying a testDataObject substantiated from the request pattern should fail!
+            assert.throws(() => dataObject._root.set("send", "op"),
+                (error) => {
+                    const correctErrorType = error.errorType === "dataCorruptionError";
+                    const correctErrorMessage = error.message?.startsWith(`Context is tombstoned`) === true;
+                    return correctErrorType && correctErrorMessage;
+                },
+                `Should not be able to send ops for a tombstoned datastore.`,
+            );
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Send ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
+        [
+            { eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
+            // Wait enough time so that the datastore is sweep ready
+            await delay(remainingTimeUntilSweepMs);
+
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+            // The datastore should be tombstoned now
+            const { summaryVersion } = await summarize(summarizer);
+            const dataObject = await getTombstonedDataObjectFromSummary(summaryVersion, unreferencedId);
+
+            // Sending an op from a datastore substantiated from the request pattern should fail!
+            assert.throws(() => dataObject._root.set("send", "op"),
+                (error) => {
+                    const correctErrorType = error.errorType === "dataCorruptionError";
+                    const correctErrorMessage = error.message?.startsWith(`Context is tombstoned`) === true;
+                    return correctErrorType && correctErrorMessage;
+                },
+                `Should not be able to send ops for a tombstoned datastore.`,
+            );
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Receive ops fails for tombstoned datastores in summarizing container loaded after sweep time",
+        [
+            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
+            {
+                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+                error: "Context is tombstoned! Call site [process]",
+            },
+            {
+                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+                error: "Context is tombstoned! Call site [process]",
+            },
+            {
+                eventName: "fluid:telemetry:Container:ContainerClose",
+                error: "Context is tombstoned! Call site [process]",
+                errorType: "dataCorruptionError",
+            },
+            {
+                eventName: "fluid:telemetry:Container:ContainerDispose",
+                error: "Context is tombstoned! Call site [process]",
+                errorType: "dataCorruptionError",
+            },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizer,
+                summaryVersion,
+                summarizingContainer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+            // Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
+            const container = await loadContainer(summaryVersion);
+            // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
+            // production application
+            // This does not cause a sweep ready changed error as the container has loaded from a summary before sweep
+            // ready was set
+            const senderObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
+
+            // The datastore should be tombstoned now
+            const { summaryVersion: tombstoneVersion } = await summarize(summarizer);
+
+            // Load a client from the tombstone summary
+            const receivingContainer = await loadContainer(tombstoneVersion);
+            await sendOpToUpdateSummaryTimestampToNow(receivingContainer);
+
+            setupContainerCloseErrorValidation(receivingContainer, "process");
+
+            // Receive an op - both the summarizer and the receiving client log a process error, only the receiving
+            // client closes
+            senderObject._root.set("send an op to be received", "op");
+            await provider.ensureSynchronized();
+            assert(receivingContainer.closed === true, `Reading container should close.`);
+            assert(summarizingContainer.closed !== true, `Summarizing container should not close.`);
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Receive ops fails for tombstoned datastores in summarizing container loaded before sweep timeout",
+        [
+            {
+                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+                error: "Context is tombstoned! Call site [process]",
+            },
+            {
+                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+                error: "Context is tombstoned! Call site [process]",
+            },
+            {
+                eventName: "fluid:telemetry:Container:ContainerClose",
+                error: "Context is tombstoned! Call site [process]",
+                errorType: "dataCorruptionError",
+            },
+            {
+                eventName: "fluid:telemetry:Container:ContainerDispose",
+                error: "Context is tombstoned! Call site [process]",
+                errorType: "dataCorruptionError",
+            },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+                summaryVersion,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
+            // Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
+            const sendingContainer = await loadContainer(summaryVersion);
+            // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
+            // production application. Causes an inactiveObject loaded error
+            const dataObject = await requestFluidObject<ITestDataObject>(sendingContainer, unreferencedId);
+
+            // Wait enough time so that the datastore is sweep ready
+            await delay(remainingTimeUntilSweepMs);
+
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+            // The datastore should be tombstoned now
+            const { summaryVersion: tombstoneVersion } = await summarize(summarizer);
+
+            // Load a client from the tombstone summary
+            const receivingContainer = await loadContainer(tombstoneVersion);
+            await sendOpToUpdateSummaryTimestampToNow(receivingContainer);
+
+            setupContainerCloseErrorValidation(receivingContainer, "process");
+
+            // Send an op to be received - no sweep changed or loaded - the summarizing container does not log sweep
+            // ready errors as it closes before the op is processed and the datastore is realized
+            dataObject._root.set("send an op to be received", "op");
+            await provider.ensureSynchronized();
+            assert(receivingContainer.closed === true, `Container receiving messages to a tombstoned datastore should close.`);
+            assert(summarizingContainer.closed !== true, `Summarizing container should not close.`);
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Send signals fails for tombstoned datastores in summarizing container loaded after sweep timeout",
+        [
+            { eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed" },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+            // The datastore should be tombstoned now
+            const { summaryVersion } = await summarize(summarizer);
+
+            const dataObject = await getTombstonedDataObjectFromSummary(summaryVersion, unreferencedId);
+
+            // Sending a signal from a testDataObject substantiated from the request pattern should fail!
+            assert.throws(() => dataObject._runtime.submitSignal("send", "signal"),
+                (error) => {
+                    const correctErrorType = error.errorType === "dataCorruptionError";
+                    const correctErrorMessage = error.message?.startsWith(`Context is tombstoned`) === true;
+                    return correctErrorType && correctErrorMessage;
+                },
+                `Should not be able to send signals for a tombstoned datastore.`,
+            );
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Receive signals fails for tombstoned datastores in summarizing container loaded after sweep timeout",
+        [
+            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
+            {
+                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+                error: "Context is tombstoned! Call site [processSignal]",
+            },
+            {
+                eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+                error: "Context is tombstoned! Call site [processSignal]",
+            },
+            {
+                eventName: "fluid:telemetry:Container:ContainerClose",
+                error: "Context is tombstoned! Call site [processSignal]",
+                errorType: "dataCorruptionError",
+            },
+            {
+                eventName: "fluid:telemetry:Container:ContainerDispose",
+                error: "Context is tombstoned! Call site [processSignal]",
+                errorType: "dataCorruptionError",
+            },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizer,
+                summaryVersion,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+            // The datastore should be tombstoned now
+            await summarize(summarizer);
+
+            // Load this container from a summary that had not yet tombstoned the datastore so that the datastore loads.
+            const container = await loadContainer(summaryVersion);
+            // Use the request pattern to get the testDataObject - this is unsafe and no one should do this in their
+            // production application
+            // This does not cause a sweep ready changed error as the container has loaded from a summary before sweep
+            // ready was set
+            const senderObject = await requestFluidObject<ITestDataObject>(container, unreferencedId);
+
+            // The datastore should be tombstoned now
+            const { summaryVersion: tombstoneVersion } = await summarize(summarizer);
+
+            // Load a client from the tombstone summary
+            const receivingContainer = await loadContainer(tombstoneVersion);
+            await sendOpToUpdateSummaryTimestampToNow(receivingContainer);
+
+            setupContainerCloseErrorValidation(receivingContainer, "processSignal");
+
+            // Receive a signal by sending it from another container
+            senderObject._runtime.submitSignal("send a signal to be received", "signal");
+            await provider.ensureSynchronized();
+            assert(receivingContainer.closed === true, `Container receiving messages to a tombstoned datastore should close.`);
+        });
+
+    });
+
+    describe("Loading tombstone data stores not allowed (per config)", () => {
+        const expectedHeadersLogged = {
+            request: "{}",
+            handleGet: JSON.stringify({ viaHandle: true }),
+            request_allowTombstone: JSON.stringify({ allowTombstone: true }),
+        };
+
+        beforeEach(() => {
+            // Allow Usage but not Loading
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
+        });
+
+        /**
+         * Our partners use ContainerRuntime.resolveHandle to issue requests. We can't easily call it directly,
+         * but the test containers are wired up to route requests to this function.
+         * (See the innerRequestHandler used in LocalCodeLoader for how it works)
+         */
+        async function containerRuntime_resolveHandle(container: IContainer, request: IRequest): Promise<IResponse> {
+            return container.request(request);
+        }
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Requesting tombstoned datastores fails in interactive client loaded after sweep timeout",
+        [
+            // Interactive client's request
+            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested", headers: expectedHeadersLogged.request },
+            // Interactive client's request w/ allowTombstone
+            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested", category: "generic", headers: expectedHeadersLogged.request_allowTombstone },
+            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
+            // Summarizer client's request
+            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested", category: "generic", headers: expectedHeadersLogged.request, isSummarizerClient: true },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+            // The datastore should be tombstoned now
+            const { summaryVersion } = await summarize(summarizer);
+            const container = await loadContainer(summaryVersion);
+            await sendOpToUpdateSummaryTimestampToNow(container);
+
+            // This request fails since the datastore is tombstoned
+            const tombstoneErrorResponse = await containerRuntime_resolveHandle(container, { url: unreferencedId });
+            assert.equal(tombstoneErrorResponse.status, 404, "Should not be able to retrieve a tombstoned datastore in non-summarizer clients");
+            assert.equal(tombstoneErrorResponse.value, `DataStore was deleted: ${unreferencedId}`, "Expected the Tombstone error message");
+            assert.equal(tombstoneErrorResponse.headers?.[TombstoneResponseHeaderKey], true, "Expected the Tombstone header");
+
+            // This request succeeds because the "allowTombstone" header is set to true
+            const tombstoneSuccessResponse = await containerRuntime_resolveHandle(container, { url: unreferencedId, headers: { [AllowTombstoneRequestHeaderKey]: true }});
+            assert.equal(tombstoneSuccessResponse.status, 200, "Should be able to retrieve a tombstoned datastore given the allowTombstone header");
+            assert.notEqual(tombstoneSuccessResponse.headers?.[TombstoneResponseHeaderKey], true, "DID NOT Expect tombstone header to be set on the response");
+
+            // This request succeeds because the summarizer never fails for tombstones
+            const summarizerResponse = await containerRuntime_resolveHandle(summarizingContainer, { url: unreferencedId });
+            assert.equal(summarizerResponse.status, 200, "Should be able to retrieve a tombstoned datastore in summarizer clients");
+            assert.notEqual(summarizerResponse.headers?.[TombstoneResponseHeaderKey], true, "DID NOT Expect tombstone header to be set on the response");
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Requesting tombstoned datastores succeeds if gcContainerGeneration doesn't match",
+        [
+            // Interactive client's request that succeeds
+            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested", category: "generic", headers: expectedHeadersLogged.request_allowTombstone },
+            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs, true /* useOldGeneration */);
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+            // The datastore should be tombstoned now
+            const { summaryVersion } = await summarize(summarizer);
+            const container = await loadContainer(summaryVersion);
+            await sendOpToUpdateSummaryTimestampToNow(container);
+
+            // This request succeeds even though the datastore is tombstoned, on account of the mismatched gcContainerGeneration
+            const tombstoneSuccessResponse = await containerRuntime_resolveHandle(container, { url: unreferencedId });
+            assert.equal(tombstoneSuccessResponse.status, 200, "Should be able to retrieve a tombstoned datastore given the allowTombstone header");
+            assert.notEqual(tombstoneSuccessResponse.headers?.[TombstoneResponseHeaderKey], true, "DID NOT Expect tombstone header to be set on the response");
+        });
+
+        // SKIPPED: This test is redundant with the previous one; SweepReady calculation/timers has coverage elsewhere
+        itExpects.skip("Requesting tombstoned datastores fails in summarizing container loaded before sweep timeout",
+        [
+            {
+                eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+                viaHandle: false,
+            },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
+            // Wait enough time so that the datastore is sweep ready
+            await delay(remainingTimeUntilSweepMs);
+
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+            // The datastore should be tombstoned now
+            await summarize(summarizer);
+            const { summaryVersion } = await summarize(summarizer);
+            const container = await loadContainer(summaryVersion);
+            await sendOpToUpdateSummaryTimestampToNow(container);
+
+            // Requesting a tombstoned datastore should fail!
+            await assert.rejects(async () => requestFluidObject<ITestDataObject>(container, unreferencedId),
+                (error) => {
+                    const correctErrorType = error.code === 404;
+                    const correctErrorMessage = error.message === `DataStore was deleted: ${unreferencedId}`;
+                    return correctErrorType && correctErrorMessage;
+                },
+                `Should not be able to retrieve a tombstoned datastore.`,
+            );
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Handle request for tombstoned datastores fails in summarizing container loaded after sweep timeout",
+        [
+            // Interactive client's handle.get
+            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested", headers: expectedHeadersLogged.handleGet },
+            // Interactive client's request w/ allowTombstone
+            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested", category: "generic", headers: expectedHeadersLogged.request_allowTombstone },
+            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+            // The datastore should be tombstoned now
+            const { summaryVersion } = await summarize(summarizer);
+            const dataObject = await getTombstonedDataObjectFromSummary(summaryVersion, unreferencedId);
+
+            const serializer = new FluidSerializer(dataObject._context.IFluidHandleContext, () => {});
+            const handle: IFluidHandle = parseHandles({ type: "__fluid_handle__", url: unreferencedId }, serializer);
+
+            // This fails because the DataStore is tombstoned
+            let tombstoneError: Error & { code: number; underlyingResponseHeaders?: { [TombstoneResponseHeaderKey]: boolean; }; } | undefined;
+            try {
+                await handle.get();
+            } catch (error: any) {
+                tombstoneError = error
+            }
+            assert.equal(tombstoneError?.code, 404, "Tombstone error from handle.get should have 404 status code");
+            assert.equal(tombstoneError?.message, `DataStore was deleted: ${unreferencedId}`, "Incorrect message for Tombstone error from handle.get");
+            assert.equal(tombstoneError?.underlyingResponseHeaders?.[TombstoneResponseHeaderKey], true, "Tombstone error from handle.get should include the tombstone flag");
+
+            // This demonstrates how a consumer could then fetch the tombstoned object to facilitate recovery (actual revival is covered in another test below)
+            const tombstoneSuccessResponse = await (dataObject._context.containerRuntime as ContainerRuntime).resolveHandle({ url: unreferencedId, headers: { [AllowTombstoneRequestHeaderKey]: true }});
+            assert.equal(tombstoneSuccessResponse.status, 200, "Should be able to retrieve a tombstoned datastore given the allowTombstone header");
+            assert.notEqual(tombstoneSuccessResponse.headers?.[TombstoneResponseHeaderKey], true, "DID NOT Expect tombstone header to be set on the response");
+        });
+
+        // SKIPPED: This test is redundant with the previous one; SweepReady calculation/timers has coverage elsewhere
+        itExpects.skip("Handle request for tombstoned datastores fails in summarizing container loaded before sweep timeout",
+        [
+            {
+                eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+                viaHandle: true,
+            },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
+            // Wait enough time so that the datastore is sweep ready
+            await delay(remainingTimeUntilSweepMs);
+
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+            // The datastore should be tombstoned now
+            const { summaryVersion } = await summarize(summarizer);
+            const dataObject = await getTombstonedDataObjectFromSummary(summaryVersion, unreferencedId);
+
+            // Note: if a user makes a request that looks like this, we will also think that the request is via handle
+            const request: IRequest = { url: unreferencedId, headers: { [RuntimeHeaders.viaHandle]: true } };
+            const response = await dataObject._context.IFluidHandleContext.resolveHandle(request);
+
+            assert(response !== undefined, `Expecting a response!`);
+            assert(response.status === 404);
+            assert(response.value === `DataStore was deleted: ${unreferencedId}`);
+        });
+
+        // If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
+        itExpects("Can un-tombstone datastores by storing a handle",
+        [
+            // When confirming it's tombstoned
+            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested" },
+            // When reviving it
+            { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested", category: "generic" },
+            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
+            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived", category: "generic" },
+            { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived" },
+        ],
+        async () => {
+            const {
+                unreferencedId,
+                summarizingContainer,
+                summarizer,
+            } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs - remainingTimeUntilSweepMs);
+            // Wait enough time so that the datastore is sweep ready
+            await delay(remainingTimeUntilSweepMs);
+
+            await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+            // The datastore should be tombstoned now
+            const { summaryVersion } = await summarize(summarizer);
+            const tombstoneContainer = await loadContainer(summaryVersion);
+
+            // Datastore should be tombstoned, requesting should error
+            const tombstoneResponse = await containerRuntime_resolveHandle(tombstoneContainer, { url: unreferencedId });
+            assert.equal(tombstoneResponse.status, 404, "Expected 404 tombstone response")
+            assert.equal(tombstoneResponse.headers?.[TombstoneResponseHeaderKey], true, "Expected tombstone response with flag")
+
+            const requestAllowingTombstone: IRequest = {
+                url: unreferencedId,
+                headers: { [AllowTombstoneRequestHeaderKey]: true },
+            };
+            const tombstonedObject = await requestFluidObject<ITestDataObject>(tombstoneContainer, requestAllowingTombstone);
+            const defaultDataObject = await requestFluidObject<ITestDataObject>(tombstoneContainer, "default");
+            defaultDataObject._root.set("store", tombstonedObject.handle);
+
+            // The datastore should be un-tombstoned now
+            const { summaryVersion: revivalVersion } = await summarize(summarizer);
+            const revivalContainer = await loadContainer(revivalVersion);
+            const revivedObject = await requestFluidObject<ITestDataObject>(revivalContainer, unreferencedId);
+            revivedObject._root.set("can send", "op");
+            // This signal call closes the tombstoneContainer.
+            // The op above doesn't because the signal reaches the tombstone container faster
+            revivedObject._runtime.submitSignal("can submit", "signal");
+
+            const sendingContainer = await loadContainer(revivalVersion);
+            const sendDataObject = await requestFluidObject<ITestDataObject>(sendingContainer, unreferencedId);
+            sendDataObject._root.set("can receive", "an op");
+            sendDataObject._runtime.submitSignal("can receive", "a signal");
+            await provider.ensureSynchronized();
+            assert(tombstoneContainer.closed !== true, `Tombstone usage allowed, so container should not close.`);
+            assert(revivalContainer.closed !== true,
+                `Revived datastore should not close a container when requested, sending/receiving signals/ops.`);
+            assert(sendingContainer.closed !== true,
+                `Revived datastore should not close a container when sending signals and ops.`);
+        });
+    });
+
+    itExpects("Loading/Using tombstone allowed when configured",
+    [
+        { eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested" },
+        { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded" },
+        {
+            eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+            callSite: "submitMessage",
+        },
+        {
+            eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+            callSite: "process",
+            clientType: "noninteractive/summarizer",
+        },
+        {
+            eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
+            callSite: "process",
+            clientType: "interactive",
+        },
+    ],
+    async () => {
+        settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = false;
+        settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
+        const {
+            unreferencedId,
+            summarizingContainer,
+            summarizer,
+        } = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+        await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+
+        // The datastore should be tombstoned now
+        const { summaryVersion } = await summarize(summarizer);
+        const container = await loadContainer(summaryVersion);
+        // Requesting the tombstoned data store should succeed since ThrowOnTombstoneLoad is not enabled.
+        // Logs a tombstone and sweep ready error
+        let dataObject: ITestDataObject;
+        await assert.doesNotReject(
+            async () => { dataObject = await requestFluidObject<ITestDataObject>(container, unreferencedId); },
+            `Should be able to request a tombstoned datastore.`,
+        );
+        // Modifying the tombstoned datastore should not fail since ThrowOnTombstoneUsage is not enabled.
+        // Logs a submitMessage error
+        assert.doesNotThrow(() => dataObject._root.set("send", "op"),
+            `Should be able to send ops for a tombstoned datastore.`,
+        );
+
+        // Wait for the above op to be process. That will result in another error logged during process.
+        // Both the summarizing container and the submitting container log a process error
+        await provider.ensureSynchronized();
+    });
+
+    describe("Tombstone information in summary", () => {
+        /**
+         * Validates that the give summary tree contains correct information in the tombstone blob in GC tree.
+         * @param summaryTree - The summary tree that may contain the tombstone blob.
+         * @param tombstones - A list of ids that should be present in the tombstone blob.
+         * @param notTombstones - A list of ids that should not be present in the tombstone blob.
+         */
+        function validateTombstoneState(
+            summaryTree: ISummaryTree,
+            tombstones: string [] | undefined,
+            notTombstones: string[],
+        ) {
+            const actualTombstones = getGCTombstoneStateFromSummary(summaryTree);
+            if (tombstones === undefined) {
+                assert(actualTombstones === undefined, "GC tree should not have tombstones in summary");
+                return;
+            }
+            assert(actualTombstones !== undefined, "GC tree should have tombstones in summary");
+            for (const url of tombstones) {
+                assert(actualTombstones.includes(url), `${url} should be in tombstone blob`);
+            }
+            for (const url of notTombstones) {
+                assert(!actualTombstones.includes(url), `${url} should not be in tombstone blob`);
+            }
+        }
+
+        beforeEach(() => {
+            // This is not the typical configuration we expect (usage may be allowed), but keeping it more strict for the tests
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneLoad"] = true;
+            settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
+        });
+
+        it("adds tombstone data stores information to tombstone blob in summary", async () => {
+            const mainContainer = await provider.makeTestContainer(testContainerConfig);
+            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
+            const mainDataStoreUrl = `/${mainDataStore._context.id}`;
+            await waitForContainerConnection(mainContainer);
+
+            const summarizer = await createSummarizer(
+                provider,
+                mainContainer,
+                undefined /* summaryVersion */,
+                gcOptions,
+                mockConfigProvider(settings),
+            );
+
+            // Create couple of data stores.
+            const newDataStore = await requestFluidObject<ITestDataObject>(
+                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
+            const newDataStore2 = await requestFluidObject<ITestDataObject>(
+                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
+            const newDataStoreUrl = `/${newDataStore._context.id}`;
+            const newDataStore2Url = `/${newDataStore2._context.id}`;
+
+            // Add the data stores' handle so that they are live and referenced.
+            mainDataStore._root.set("newDataStore", newDataStore.handle);
+            mainDataStore._root.set("newDataStore2", newDataStore2.handle);
+
+            // Remove the data stores' handle to make them unreferenced.
+            mainDataStore._root.delete("newDataStore");
+            mainDataStore._root.delete("newDataStore2");
+
+            // Summarize so that the above data stores are marked unreferenced.
+            await provider.ensureSynchronized();
+            const summary = await summarizeNow(summarizer);
+            validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
+
+            // Wait for sweep timeout so that the data stores are tombstoned.
+            await delay(sweepTimeoutMs + 10);
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize. The tombstoned data stores should now be part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+            validateTombstoneState(summary2.summaryTree, [newDataStoreUrl, newDataStore2Url], [mainDataStoreUrl]);
+        });
+
+        it("adds tombstone attachment blob information to tombstone blob in summary", async () => {
+            const mainContainer = await provider.makeTestContainer(testContainerConfig);
+            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
+            const mainDataStoreUrl = `/${mainDataStore._context.id}`;
+            await waitForContainerConnection(mainContainer);
+
+            const summarizer = await createSummarizer(
+                provider,
+                mainContainer,
+                undefined /* summaryVersion */,
+                gcOptions,
+                mockConfigProvider(settings),
+            );
+
+            // Upload an attachment blobs and mark it referenced.
+            const blobContents = "Blob contents";
+            const blobHandle = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            mainDataStore._root.set("blob", blobHandle);
+
+            // Remove the blob's handle to make it unreferenced.
+            mainDataStore._root.delete("blob");
+
+            // Summarize so that the above attachment blob is marked unreferenced.
+            await provider.ensureSynchronized();
+            const summary = await summarizeNow(summarizer);
+            validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
+
+            // Wait for sweep timeout so that the blob is tombstoned.
+            await delay(sweepTimeoutMs + 10);
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize. The tombstoned attachment blob should now be part of the tombstone blob.
+            const summary2 = await summarizeNow(summarizer);
+            validateTombstoneState(summary2.summaryTree, [blobHandle.absolutePath], [mainDataStoreUrl]);
+        });
+
+        itExpects("removes un-tombstoned data store and attachment blob from tombstone blob in summary",
+        [
+            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived", category: "generic" },
+            { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived", category: "generic" },
+            { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived", type: "DataStore" },
+            { eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived", type: "Blob" },
+        ],
+        async () => {
+            const mainContainer = await provider.makeTestContainer(testContainerConfig);
+            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
+            const mainDataStoreUrl = `/${mainDataStore._context.id}`;
+            await waitForContainerConnection(mainContainer);
+
+            const mockLogger = new MockLogger();
+
+            const summarizer = await createSummarizer(
+                provider,
+                mainContainer,
+                undefined /* summaryVersion */,
+                gcOptions,
+                mockConfigProvider(settings),
+                mockLogger,
+            );
+
+            // Create couple of data stores.
+            const newDataStore = await requestFluidObject<ITestDataObject>(
+                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
+            const newDataStore2 = await requestFluidObject<ITestDataObject>(
+                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
+            const newDataStoreUrl = `/${newDataStore._context.id}`;
+            const newDataStore2Url = `/${newDataStore2._context.id}`;
+
+            // Add the data stores' handles so that they are live and referenced.
+            mainDataStore._root.set("newDataStore", newDataStore.handle);
+            mainDataStore._root.set("newDataStore2", newDataStore2.handle);
+
+            // Remove the data stores' handles to make them unreferenced.
+            mainDataStore._root.delete("newDataStore");
+            mainDataStore._root.delete("newDataStore2");
+
+            // Upload an attachment blob and mark it referenced.
+            const blobContents = "Blob contents";
+            const blobHandle = await mainDataStore._context.uploadBlob(stringToBuffer(blobContents, "utf-8"));
+            mainDataStore._root.set("blob", blobHandle);
+
+            // Remove the blob's handle to make it unreferenced.
+            mainDataStore._root.delete("blob");
+
+            // Summarize so that the above data stores and blobs are marked unreferenced.
+            await provider.ensureSynchronized();
+            const summary = await summarizeNow(summarizer);
+            validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
+
+            // Wait for sweep timeout so that the data stores are tombstoned.
+            await delay(sweepTimeoutMs + 10);
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize. The tombstoned data stores should now be part of the tombstone blob.
+            const summary2 = await summarizeNow(summarizer);
+            validateTombstoneState(
+                summary2.summaryTree, [newDataStoreUrl, newDataStore2Url, blobHandle.absolutePath], [mainDataStoreUrl]);
+
+            mockLogger.assertMatchNone([
+                { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived" },
+                { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived" },
+            ]);
+
+            // Mark one of the data stores and attachment blob as referenced so that they are not tombstones anymore.
+            // Note that sweepTimeout was shrunk below sessionExpiry, otherwise we'd need to load a new container and
+            // use the allowTombstone header to even get the handle and revive these.
+            mainDataStore._root.set("newDataStore", newDataStore.handle);
+            mainDataStore._root.set("blob", blobHandle);
+            await provider.ensureSynchronized();
+            mockLogger.assertMatch([
+                { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived" },
+                { eventName: "fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived" },
+            ]);
+
+            // Summarize. The un-tombstoned data store and attachment blob should not be part of the tombstone blob.
+            const summary3 = await summarizeNow(summarizer);
+            validateTombstoneState(
+                summary3.summaryTree, [newDataStore2Url], [mainDataStoreUrl, newDataStoreUrl, blobHandle.absolutePath]);
+        });
+
+        it("does not re-summarize GC state on only tombstone state changed", async () => {
+            const mainContainer = await provider.makeTestContainer(testContainerConfig);
+            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
+            await waitForContainerConnection(mainContainer);
+
+            const summarizer = await createSummarizer(
+                provider,
+                mainContainer,
+                undefined /* summaryVersion */,
+                gcOptions,
+                mockConfigProvider(settings),
+            );
+
+            // Create a data store.
+            const newDataStore = await requestFluidObject<ITestDataObject>(
+                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
+
+            // Add the data store's handle so that it is live and referenced.
+            mainDataStore._root.set("newDataStore", newDataStore.handle);
+
+            // Remove the data store's handle to make it unreferenced.
+            mainDataStore._root.delete("newDataStore");
+
+            // Summarize so that the above data stores are marked unreferenced.
+            await provider.ensureSynchronized();
+            const summary = await summarizeNow(summarizer);
+            const gcState = getGCStateFromSummary(summary.summaryTree);
+            assert(gcState !== undefined, "GC state should be available and should not be a handle");
+
+            // Wait for sweep timeout so that the data stores are tombstoned.
+            await delay(sweepTimeoutMs + 10);
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize. The tombstoned data stores should now be part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+            assert.throws(
+                () => getGCStateFromSummary(summary2.summaryTree),
+                (e) => validateAssertionError(e, "GC state is not a blob"),
+            );
+            const tombstoneState = getGCTombstoneStateFromSummary(summary2.summaryTree);
+            assert(tombstoneState !== undefined, "Tombstone state should be available and should be a blob");
+
+            // Summarize. The tombstoned state should be a handle.
+            const summary3 = await summarizeNow(summarizer);
+            assert.throws(
+                () => getGCTombstoneStateFromSummary(summary3.summaryTree),
+                (e) => validateAssertionError(e, "GC data should be a tree"),
+            );
+        });
+
+        itExpects("can mark data store from tombstone information in summary in non-summarizer container",
+        [
+            {
+                eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+            },
+        ],
+        async () => {
+            const mainContainer = await provider.makeTestContainer(testContainerConfig);
+            const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
+            const mainDataStoreUrl = `/${mainDataStore._context.id}`;
+            await waitForContainerConnection(mainContainer);
+
+            const summarizer = await createSummarizer(
+                provider,
+                mainContainer,
+                undefined /* summaryVersion */,
+                gcOptions,
+                mockConfigProvider(settings),
+            );
+
+            // Create a data store and mark it referenced.
+            const newDataStore = await requestFluidObject<ITestDataObject>(
+                await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType), "");
+            const newDataStoreUrl = `/${newDataStore._context.id}`;
+            mainDataStore._root.set("newDataStore", newDataStore.handle);
+
+            // Remove the data store's handle to make it unreferenced.
+            mainDataStore._root.delete("newDataStore");
+
+            // Summarize so that the above data stores are marked unreferenced.
+            await provider.ensureSynchronized();
+            const summary = await summarizeNow(summarizer);
+            validateTombstoneState(summary.summaryTree, undefined /* tombstones */, []);
+
+            // Wait for sweep timeout so that the data stores are tombstoned.
+            await delay(sweepTimeoutMs + 10);
+            // Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+            mainDataStore._root.set("key", "value");
+            await provider.ensureSynchronized();
+
+            // Summarize. The tombstoned data stores should now be part of the summary.
+            const summary2 = await summarizeNow(summarizer);
+            validateTombstoneState(summary2.summaryTree, [newDataStoreUrl], [mainDataStoreUrl]);
+
+            // Load a container from the above summary. The tombstoned data store should be correctly marked.
+            const container2 = await loadContainer(summary2.summaryVersion);
+
+            // Requesting the tombstoned data store should result in an error.
+            const unreferencedId = newDataStore._context.id;
+            await assert.rejects(async () => requestFluidObject<ITestDataObject>(container2, unreferencedId),
+                (error) => {
+                    const correctErrorType = error.code === 404;
+                    const correctErrorMessage = error.message === `DataStore was deleted: ${unreferencedId}`;
+                    return correctErrorType && correctErrorMessage;
+                },
+                `Should not be able to retrieve a tombstoned datastore.`,
+            );
+        });
+    });
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -78,7 +78,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			gcOptions: {
 				...gcOptions,
 				// Simulate these test containers being loaded at a future time with a higher min version for GC enforcement
-				gcEnforcementMinCreateContainerRuntimeVersion: "3.0.0",
+				gcEnforcementMinCreateContainerRuntimeVersion: "999.999.999",
 			},
 		},
 		loaderProps: { configProvider: mockConfigProvider(settings) },
@@ -126,9 +126,9 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 	// datastore was unreferenced in.
 	const summarizationWithUnreferencedDataStoreAfterTime = async (
 		approximateUnreferenceTimestampMs: number,
-		disableGcFailureViaOption: boolean = false,
+		disableTombstoneFailureViaOption: boolean = false,
 	) => {
-		const container = disableGcFailureViaOption ? await makeContainer(testContainerConfigWithFutureMinGcOption) : await makeContainer();
+		const container = disableTombstoneFailureViaOption ? await makeContainer(testContainerConfigWithFutureMinGcOption) : await makeContainer();
 		const defaultDataObject = await requestFluidObject<ITestDataObject>(container, "default");
 		await waitForContainerConnection(container);
 
@@ -642,7 +642,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 				const { unreferencedId, summarizingContainer, summarizer } =
 					await summarizationWithUnreferencedDataStoreAfterTime(
 						sweepTimeoutMs,
-						true /* disableGcFailureViaOption */,
+						true /* disableTombstoneFailureViaOption */,
 					);
 				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -55,7 +55,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 	const gcOptions: IGCRuntimeOptions = {
 		inactiveTimeoutMs: 0,
 		// Default to the current version to match createContainerRuntimeVersion metadata in test containers created here
-		gcFailureMinCreateContainerRuntimeVersion: pkgVersion,
+		gcEnforcementMinCreateContainerRuntimeVersion: pkgVersion,
 	};
 	const testContainerConfig: ITestContainerConfig = {
 		runtimeOptions: {
@@ -77,8 +77,8 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			},
 			gcOptions: {
 				...gcOptions,
-				// Simulate these test containers being loaded at a future time with a higher min version for GC Failures
-				gcFailureMinCreateContainerRuntimeVersion: "3.0.0",
+				// Simulate these test containers being loaded at a future time with a higher min version for GC enforcement
+				gcEnforcementMinCreateContainerRuntimeVersion: "3.0.0",
 			},
 		},
 		loaderProps: { configProvider: mockConfigProvider(settings) },
@@ -625,7 +625,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 
 		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
-			"Requesting tombstoned datastores succeeds with future gcFailureMinCreateContainerRuntimeVersion",
+			"Requesting tombstoned datastores succeeds with future gcEnforcementMinCreateContainerRuntimeVersion",
 			[
 				// Interactive client's request that succeeds
 				{
@@ -651,7 +651,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 				const container = await loadContainer(summaryVersion);
 				await sendOpToUpdateSummaryTimestampToNow(container);
 
-				// This request succeeds even though the datastore is tombstoned, on account of the later gcFailureMinCreateContainerRuntimeVersion passed in
+				// This request succeeds even though the datastore is tombstoned, on account of the later gcEnforcementMinCreateContainerRuntimeVersion passed in
 				const tombstoneSuccessResponse = await containerRuntime_resolveHandle(container, {
 					url: unreferencedId,
 				});


### PR DESCRIPTION
## Description

In discussions with our internal partner teams, as they consider rolling out GC via the Tombstone feature, they want a way to cut off old documents from exposure to failure due to GC (Tombstones failing to load, or GC Sweep deleting objects).  This is because some GC-impacting bugs in partner code were forward-fixed only, without leaving repair code in place - so documents created before such a bug was fixed would be subject to being corrupted by GC (e.g. due to invalid internal document structure), if they were opened after GC was enabled.

This PR adds an otherwise undocumented ContainerRuntime Option `gcEnforcementMinCreateContainerRuntimeVersion`, which is to be compared with the value of the persisted metadata property `createContainerRuntimeVersion` to determine whether a document was created recently enough to be subjected to enforcement of GC.

Some clarifications:

* If `gcEnforcementMinCreateContainerRuntimeVersion` is omitted (the default case since it's undocumented) or malformed, GC enforcement is determined based on the existing configuration parameters.  Only if it's present and strictly `>` the file's `createContainerRuntimeVersion` will GC enforcement be disabled.
* If `createContainerRuntimeVersion` is missing from a file, it's considered older than any valid value of `gcEnforcementMinCreateContainerRuntimeVersion` such that if the option is set, GC enforcement will be disabled.

## Reviewer Guidance

There are a few todos (`//*` comments) but the basic structure is there.

I'd love special attention given to the gcHelper tests that cover the version comparison stuff.  What other test cases should I put in there?
