### PR TITLE
build: Remove editorconfig vscode extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,6 @@
     // Add the IDs of extensions you want installed when the container is created.
     "extensions": [
         "dbaeumer.vscode-eslint",
-        "editorconfig.editorconfig",
         "ms-azuretools.vscode-docker",
         "mutantdino.resourcemonitor"
     ],

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
     // List of extensions which should be recommended for users of this workspace.
     "recommendations": [
         "dbaeumer.vscode-eslint",
-        "editorconfig.editorconfig",
         "esbenp.prettier-vscode"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.


### PR DESCRIPTION
We no longer use editorconfig, so I've removed the recommendation and pre-installation in our devcontainer.