### PR TITLE
Increase chunk sizes in stress tests.

### DIFF
--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -96,7 +96,7 @@ export function generateRuntimeOptions(
 		maxBatchSizeInBytes: [716800],
 		enableOpReentryCheck: [true],
 		// Compressed payloads over 1MB will be split into chunked ops of this size
-		chunkSizeInBytes: [1024, 38400, 614400],
+		chunkSizeInBytes: [307200, 614400, 706800],
 	};
 
 	return generatePairwiseOptions<IContainerRuntimeOptions>(


### PR DESCRIPTION
## Description

The chunk sizes are too aggressive. With `1024` bytes, a 1 MB payload will be split into 1000 ops. So, if we have the test sending 250 ops, they will eventually become 250000 ops, will exceed the summarizer limit and the containers will never recover.