### PR TITLE
docs: Expand loader layer readme

### DIFF
--- a/packages/loader/README.md
+++ b/packages/loader/README.md
@@ -1,3 +1,12 @@
 # Fluid Loader
 
-For an overview of the Fluid Loader, please refer to the [@FluidFramework/container-loader package README](container-loader/README.md).
+This is about the "loader layer" of the FLuid Framework, not to be confused with the `Loader` class (which is part of this layer).
+
+The `loader` layer contains code which gets directly included into fluid applications.
+This this layer is kept minimal to reduce the the need to update the application when the Fluid Framework changes,
+as well as keep the size application small.
+Instead most of the code is placed in either the `runtime` or `driver` layers and dynamically loaded by the `loader`.
+
+The loading is initiated by loading a container, which involves the appropriate drivers and runtime for the container.
+See [@FluidFramework/container-loader package README](container-loader/README.md) for details.
+Once the container is loaded, code from the loader layer (but not Loader class) is still involved since it handles passing the ops between the runtime and the driver in both directions.

--- a/packages/loader/README.md
+++ b/packages/loader/README.md
@@ -2,7 +2,7 @@
 
 This is about the "loader layer" of the Fluid Framework, not to be confused with the `Loader` class (which is part of this layer).
 
-The `loader` layer contains code which gets directly included into fluid applications.
+The `loader` layer contains code which gets directly included into Fluid applications.
 This layer is kept minimal to reduce the need to update the application when the Fluid Framework changes,
 as well as keep the size application small.
 Instead most of the code is placed in either the `runtime` or `driver` layers and dynamically loaded by the `loader`.

--- a/packages/loader/README.md
+++ b/packages/loader/README.md
@@ -1,9 +1,9 @@
 # Fluid Loader
 
-This is about the "loader layer" of the FLuid Framework, not to be confused with the `Loader` class (which is part of this layer).
+This is about the "loader layer" of the Fluid Framework, not to be confused with the `Loader` class (which is part of this layer).
 
 The `loader` layer contains code which gets directly included into fluid applications.
-This this layer is kept minimal to reduce the the need to update the application when the Fluid Framework changes,
+This layer is kept minimal to reduce the need to update the application when the Fluid Framework changes,
 as well as keep the size application small.
 Instead most of the code is placed in either the `runtime` or `driver` layers and dynamically loaded by the `loader`.
 


### PR DESCRIPTION
## Description

Add more details clarifying the Loader class vs the loader layer.

Since the first think the linked document talks about includes "access to
Fluid storage as well as consensus over a quorum of clients" it was pretty unclear how this relates to loading.