### PR TITLE
feat(container-loader): Allow setting the container's logger at load time

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -127,6 +127,7 @@ export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComp
 
 // @public (undocumented)
 export interface IContainerConfig {
+    baseLogger?: ITelemetryBaseLogger;
     // (undocumented)
     canReconnect?: boolean;
     clientDetailsOverride?: IClientDetails;
@@ -137,6 +138,7 @@ export interface IContainerConfig {
 
 // @public (undocumented)
 export interface IContainerLoadOptions {
+    baseLogger?: ITelemetryBaseLogger;
     canReconnect?: boolean;
     clientDetailsOverride?: IClientDetails;
     loadMode?: IContainerLoadMode;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -7,6 +7,7 @@
 import merge from "lodash/merge";
 import { v4 as uuid } from "uuid";
 import {
+    ITelemetryBaseLogger,
     ITelemetryLogger,
     ITelemetryProperties,
     TelemetryEventCategory,
@@ -133,6 +134,11 @@ export interface IContainerLoadOptions {
      * Loads the Container in paused state if true, unpaused otherwise.
      */
     loadMode?: IContainerLoadMode;
+    /**
+     * A logger that the container will use for logging operations. If not provided, the container will
+     * use the loader's logger, `Loader.services.subLogger`.
+     */
+    baseLogger?: ITelemetryBaseLogger;
 }
 
 export interface IContainerConfig {
@@ -146,6 +152,11 @@ export interface IContainerConfig {
      * Serialized state from a previous instance of this container
      */
     serializedContainerState?: IPendingContainerState;
+    /**
+     * A logger that the container will use for logging operations. If not provided, the container will
+     * use the loader's logger, `Loader.services.subLogger`.
+     */
+    baseLogger?: ITelemetryBaseLogger;
 }
 
 /**

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -477,22 +477,23 @@ export class Loader implements IHostLoader {
         };
     }
 
-    private async loadContainer(
-        request: IRequest,
-        resolved: IFluidResolvedUrl,
-        pendingLocalState?: IPendingContainerState,
-    ): Promise<Container> {
-        return Container.load(
-            this,
-            {
-                canReconnect: request.headers?.[LoaderHeader.reconnect],
-                clientDetailsOverride: request.headers?.[LoaderHeader.clientDetails],
-                resolvedUrl: resolved,
-                version: request.headers?.[LoaderHeader.version] ?? undefined,
-                loadMode: request.headers?.[LoaderHeader.loadMode],
-            },
-            pendingLocalState,
-            this.protocolHandlerBuilder,
-        );
-    }
+	private async loadContainer(
+		request: IRequest,
+		resolved: IFluidResolvedUrl,
+		pendingLocalState?: IPendingContainerState,
+	): Promise<Container> {
+		return Container.load(
+			this,
+			{
+				canReconnect: request.headers?.[LoaderHeader.reconnect],
+				clientDetailsOverride: request.headers?.[LoaderHeader.clientDetails],
+				resolvedUrl: resolved,
+				version: request.headers?.[LoaderHeader.version] ?? undefined,
+				loadMode: request.headers?.[LoaderHeader.loadMode],
+				baseLogger: request.headers?.["fluid-base-logger"],
+			},
+			pendingLocalState,
+			this.protocolHandlerBuilder,
+		);
+	}
 }


### PR DESCRIPTION
Cherry-pick of #13779 to the 3.0 release branch.

Developers can now specify a logger that should be used by a container when it is loaded instead of always using the Loader's logger (`Loader.services.subLogger`).

Today a container's logger is set based on the logger used in the Loader. This is not ideal in nested container scenarios, where a container is loading a data store within another container, which is itself within another container. Apps/hosts often augment the logger from the loader when loading a container, and when loading a nested container, it makes sense to provide an augmented logger to the container directly rather than using the one from the loader.

This PR enables the scenario by adding a `fluid-base-logger` request header to the container load request. If set, then the container's `subLogger` will be set to the header value. If the override isn't set, then the container will use the loader's logger as it does today.