### PR TITLE
Handle overriding attribution.track in attributor package

### DIFF
--- a/packages/dds/sequence/README.md
+++ b/packages/dds/sequence/README.md
@@ -408,24 +408,23 @@ Using the interval collection API has two main benefits:
 
 SharedString supports storing information attributing each character position to the user who inserted it and the time at which that insertion happened.
 This functionality is off by default.
-Enable it by setting the following options used while initializing the SharedString.
+To enable this functionality, first ensure that all clients are created with an attribution policy factory in the loader settings:
 
 ```typescript
 import { createInsertOnlyAttributionPolicy } from "@fluidframework/merge-tree";
 // Use these options in the IContainerContext used to instantiate your container runtime.
 const options: ILoaderOptions = {
 	attribution: {
-		// Beware: production applications should roll out and saturate code with "track: false"
-		// before enabling it to avoid compatability concerns.
-		track: true,
 		policyFactory: createInsertOnlyAttributionPolicy,
 	},
 };
 ```
 
-If the config flag `"Fluid.Attribution.EnableOnNewFile"` is set, its value will override the value of `track` in these options.
+This ensures that the client is able to load existing documents containing attribution information,
+and specifies which kinds of operations should be attributed at the SharedString level (currently, only insertions).
+The stored attribution information can be found on the `attribution` field of the SharedString's segments.
 
-Attribution information is stored on the `attribution` field of the SharedString's segments.
+Next, enable the `"Fluid.Attribution.EnableOnNewFile"` config flag to start tracking attribution information for new files.
 
 ```typescript
 const { segment, offset } = sharedString.getContainingSegment(5);
@@ -433,6 +432,10 @@ const key = segment.attribution.getAtOffset(offset);
 // `key` can be used with an IAttributor to recover user/timestamp info about the insertion of the character at offset 5.
 // See the @fluidframework/attributor package for more details.
 ```
+
+For further reading on attribution, see the [@fluidframework/attributor README](../../framework/attributor/README.md).
+
+There are plans to make attribution policies more flexible, for example tracking attribution of property changes separately from segment insertion.
 
 ### Examples
 

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { Deferred, bufferToString, assert } from "@fluidframework/common-utils";
-import { ChildLogger, loggerToMonitoringContext } from "@fluidframework/telemetry-utils";
+import { ChildLogger } from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import {
 	IChannelAttributes,
@@ -22,7 +22,6 @@ import {
 	IMergeTreeDeltaOp,
 	IMergeTreeGroupMsg,
 	IMergeTreeOp,
-	IMergeTreeOptions,
 	IMergeTreeRemoveMsg,
 	IRelativePosition,
 	ISegment,

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -197,22 +197,10 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 			this.logger.sendErrorEvent({ eventName: "SequenceLoadFailed" }, error);
 		});
 
-		const mergeTreeOptions = {
-			...(dataStoreRuntime.options as IMergeTreeOptions),
-		};
-
-		const configSetAttribution = loggerToMonitoringContext(this.logger).config.getBoolean(
-			"Fluid.Attribution.EnableOnNewFile",
-		);
-		if (configSetAttribution !== undefined) {
-			mergeTreeOptions.attribution ??= {};
-			mergeTreeOptions.attribution.track = configSetAttribution;
-		}
-
 		this.client = new Client(
 			segmentFromSpec,
 			ChildLogger.create(this.logger, "SharedSegmentSequence.MergeTreeClient"),
-			mergeTreeOptions,
+			dataStoreRuntime.options,
 		);
 
 		this.client.on("delta", (opArgs, deltaArgs) => {

--- a/packages/framework/attributor/src/test/mixinAttributor.spec.ts
+++ b/packages/framework/attributor/src/test/mixinAttributor.spec.ts
@@ -48,13 +48,13 @@ describe("mixinAttributor", () => {
 			quorum: new MockQuorumClients(),
 			taggedLogger: new MockLogger(),
 			clientDetails: { capabilities: { interactive: true } },
-
 			closeFn: (error?: ICriticalContainerError): void => {
 				if (error) {
 					// eslint-disable-next-line @typescript-eslint/no-throw-literal
 					throw error;
 				}
 			},
+			options: {},
 			updateDirtyContainerState: (_dirty: boolean) => {},
 		};
 	};


### PR DESCRIPTION
## Description

This moves concern about this config flag out of DDS's control: they should still respect the loader option, but don't need to care about the config flag anymore.
