### PR TITLE
Stress: Improve Logger Consistency

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -18,8 +18,8 @@ import random from "random-js";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { delay, assert } from "@fluidframework/common-utils";
-import { TelemetryLogger } from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ILoadTestConfig } from "./testConfigFile";
 import { LeaderElection } from "./leaderElection";
 
@@ -29,14 +29,12 @@ export interface IRunConfig {
 	testConfig: ILoadTestConfig;
 	verbose: boolean;
 	randEng: random.Engine;
+	logger: ITelemetryLogger;
 }
 
 export interface ILoadTest {
-	run(config: IRunConfig, reset: boolean, logger): Promise<boolean>;
-	detached(
-		config: Omit<IRunConfig, "runId" | "profileName">,
-		logger,
-	): Promise<LoadTestDataStoreModel>;
+	run(config: IRunConfig, reset: boolean): Promise<boolean>;
+	detached(config: Omit<IRunConfig, "runId" | "profileName">): Promise<LoadTestDataStoreModel>;
 	getRuntime(): Promise<IFluidDataStoreRuntime>;
 }
 
@@ -146,7 +144,6 @@ export class LoadTestDataStoreModel {
 		root: ISharedDirectory,
 		runtime: IFluidDataStoreRuntime,
 		containerRuntime: IContainerRuntimeBase,
-		logger: TelemetryLogger,
 	) {
 		await LoadTestDataStoreModel.waitForCatchup(runtime);
 
@@ -192,7 +189,6 @@ export class LoadTestDataStoreModel {
 			sharedmap,
 			runDir,
 			gcDataStore.handle,
-			logger,
 		);
 
 		if (reset) {
@@ -226,7 +222,6 @@ export class LoadTestDataStoreModel {
 		public readonly sharedmap: ISharedMap,
 		private readonly runDir: IDirectory,
 		private readonly gcDataStoreHandle: IFluidHandle,
-		private readonly logger: TelemetryLogger,
 	) {
 		const halfClients = Math.floor(this.config.testConfig.numClients / 2);
 		// The runners are paired up and each pair shares a single taskId
@@ -241,7 +236,10 @@ export class LoadTestDataStoreModel {
 					}
 				},
 				(error) =>
-					this.logger.sendErrorEvent({ eventName: "TaskManager_OnValueChanged" }, error),
+					this.config.logger.sendErrorEvent(
+						{ eventName: "TaskManager_OnValueChanged" },
+						error,
+					),
 			);
 		};
 		this.taskManager.on("lost", changed);
@@ -288,7 +286,8 @@ export class LoadTestDataStoreModel {
 							);
 						}
 					},
-					(error) => this.logger.sendErrorEvent({ eventName: "Counter_OnOp" }, error),
+					(error) =>
+						this.config.logger.sendErrorEvent({ eventName: "Counter_OnOp" }, error),
 				),
 			);
 		}
@@ -307,7 +306,7 @@ export class LoadTestDataStoreModel {
 					.get<IFluidHandle>(key)!
 					.get()
 					.catch((error) => {
-						this.logger.sendErrorEvent(
+						this.config.logger.sendErrorEvent(
 							{
 								eventName: "ReadBlobFailed_OnValueChanged",
 								key,
@@ -496,25 +495,23 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 		this.root.set(taskManagerKey, TaskManager.create(this.runtime).handle);
 	}
 
-	public async detached(config: Omit<IRunConfig, "runId">, logger) {
+	public async detached(config: Omit<IRunConfig, "runId">) {
 		return LoadTestDataStoreModel.createRunnerInstance(
 			{ ...config, runId: -1 },
 			false,
 			this.root,
 			this.runtime,
 			this.context.containerRuntime,
-			logger,
 		);
 	}
 
-	public async run(config: IRunConfig, reset: boolean, logger: TelemetryLogger) {
+	public async run(config: IRunConfig, reset: boolean) {
 		const dataModel = await LoadTestDataStoreModel.createRunnerInstance(
 			config,
 			reset,
 			this.root,
 			this.runtime,
 			this.context.containerRuntime,
-			logger,
 		);
 
 		const leaderElection = new LeaderElection(this.runtime);

--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -10,7 +10,7 @@ import commander from "commander";
 import { TestDriverTypes, DriverEndpoint } from "@fluidframework/test-driver-definitions";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ILoadTestConfig } from "./testConfigFile";
-import { createTestDriver, getProfile, initialize, loggerP, safeExit } from "./utils";
+import { createLogger, createTestDriver, getProfile, initialize, safeExit } from "./utils";
 
 interface ITestUserConfig {
 	/* Credentials' key/value description:
@@ -124,7 +124,12 @@ async function orchestratorProcess(
 ) {
 	const seed = args.seed ?? Date.now();
 	const seedArg = `0x${seed.toString(16)}`;
-	const logger = await loggerP;
+	const logger = await createLogger({
+		driverType: driver,
+		driverEndpointName: endpoint,
+		profile: args.profileName,
+		runId: undefined,
+	});
 
 	const testDriver = await createTestDriver(driver, endpoint, seed, undefined, args.browserAuth);
 
@@ -228,9 +233,6 @@ async function orchestratorProcess(
 			}),
 		);
 	} finally {
-		if (logger !== undefined) {
-			await logger.flush();
-		}
 		await safeExit(0, url);
 	}
 }

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -38,11 +38,37 @@ import { ILoadTestConfig, ITestConfig } from "./testConfigFile";
 const packageName = `${pkgName}@${pkgVersion}`;
 
 class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
+	private static readonly loggerP = new LazyPromise<FileLogger>(async () => {
+		if (process.env.FLUID_TEST_LOGGER_PKG_PATH !== undefined) {
+			await import(process.env.FLUID_TEST_LOGGER_PKG_PATH);
+			const logger = getTestLogger?.();
+			assert(logger !== undefined, "Expected getTestLogger to return something");
+			return new FileLogger(logger);
+		} else {
+			return new FileLogger();
+		}
+	});
+
+	public static async createLogger(dimensions: {
+		driverType: string;
+		driverEndpointName: string | undefined;
+		profile: string | undefined;
+		runId: number | undefined;
+	}) {
+		return ChildLogger.create(await this.loggerP, undefined, {
+			all: dimensions,
+		});
+	}
+
+	public static async flushLogger(runInfo?: { url: string; runId?: number }) {
+		await (await this.loggerP).flush(runInfo);
+	}
+
 	private error: boolean = false;
 	private readonly schema = new Map<string, number>();
 	private logs: ITelemetryBaseEvent[] = [];
 
-	public constructor(private readonly baseLogger?: ITelemetryBufferedLogger) {
+	private constructor(private readonly baseLogger?: ITelemetryBufferedLogger) {
 		super(undefined /* namespace */, { all: { testVersion: pkgVersion } });
 	}
 
@@ -94,16 +120,7 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
 	}
 }
 
-export const loggerP = new LazyPromise<FileLogger>(async () => {
-	if (process.env.FLUID_TEST_LOGGER_PKG_PATH !== undefined) {
-		await import(process.env.FLUID_TEST_LOGGER_PKG_PATH);
-		const logger = getTestLogger?.();
-		assert(logger !== undefined, "Expected getTestLogger to return something");
-		return new FileLogger(logger);
-	} else {
-		return new FileLogger();
-	}
-});
+export const createLogger = FileLogger.createLogger.bind(FileLogger);
 
 const codeDetails: IFluidCodeDetails = {
 	package: packageName,
@@ -165,13 +182,13 @@ export async function initialize(
 		),
 	);
 
-	const logger = ChildLogger.create(await loggerP, undefined, {
-		all: {
-			driverType: testDriver.type,
-			driverEndpointName: testDriver.endpointName,
-			profile: profileName,
-		},
+	const logger = await createLogger({
+		driverType: testDriver.type,
+		driverEndpointName: testDriver.endpointName,
+		profile: profileName,
+		runId: undefined,
 	});
+
 	// Construct the loader
 	const loader = new Loader({
 		urlResolver: testDriver.createUrlResolver(),
@@ -199,7 +216,7 @@ export async function initialize(
 			"attachment blobs in detached container not supported on this service",
 		);
 		const ds = await requestFluidObject<ILoadTest>(container, "/");
-		const dsm = await ds.detached({ testConfig, verbose, randEng }, logger);
+		const dsm = await ds.detached({ testConfig, verbose, randEng, logger });
 		await Promise.all(
 			[...Array(testConfig.detachedBlobCount).keys()].map(async (i) => dsm.writeBlob(i)),
 		);
@@ -267,7 +284,7 @@ export async function safeExit(code: number, url: string, runId?: number) {
 		setTimeout(resolve, 1000);
 	});
 	// Flush the logs
-	await loggerP.then(async (l) => l.flush({ url, runId }));
+	await FileLogger.flushLogger({ url, runId });
 
 	process.exit(code);
 }


### PR DESCRIPTION
Seeing log entries in the logs which don't contain all dimensions. This change enforces a consistent set of dimensions by removing global access to the FileLogger singleton which doesn't have default dimensions, and unifies code paths to use share child loggers that require dimension to be instantiated.