### PR TITLE
build(build-tools): Bump 0.8.0 => 0.9.0 (minor)

### DIFF
--- a/build-tools/lerna.json
+++ b/build-tools/lerna.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"npmClient": "pnpm",
 	"useWorkspaces": true
 }

--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -20,7 +20,7 @@ $ npm install -g @fluid-tools/build-cli
 $ flub COMMAND
 running command...
 $ flub (--version|-V)
-@fluid-tools/build-cli/0.8.0
+@fluid-tools/build-cli/0.9.0
 $ flub --help [COMMAND]
 USAGE
   $ flub COMMAND

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/build-cli",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"description": "Build tools for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {
@@ -70,9 +70,9 @@
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"dependencies": {
-		"@fluid-tools/version-tools": "^0.8.0",
-		"@fluidframework/build-tools": "^0.8.0",
-		"@fluidframework/bundle-size-tools": "^0.8.0",
+		"@fluid-tools/version-tools": "^0.9.0",
+		"@fluidframework/build-tools": "^0.9.0",
+		"@fluidframework/bundle-size-tools": "^0.9.0",
 		"@oclif/core": "^1.9.5",
 		"@oclif/plugin-autocomplete": "^1.3.5",
 		"@oclif/plugin-commands": "^2.2.0",

--- a/build-tools/packages/build-cli/src/packageVersion.ts
+++ b/build-tools/packages/build-cli/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-tools/build-cli";
-export const pkgVersion = "0.8.0";
+export const pkgVersion = "0.9.0";

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/build-tools",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"description": "Fluid Build tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {
@@ -52,8 +52,8 @@
 		"tsc": "tsc"
 	},
 	"dependencies": {
-		"@fluid-tools/version-tools": "^0.8.0",
-		"@fluidframework/bundle-size-tools": "^0.8.0",
+		"@fluid-tools/version-tools": "^0.9.0",
+		"@fluidframework/bundle-size-tools": "^0.9.0",
 		"@octokit/core": "^4.0.5",
 		"@rushstack/node-core-library": "^3.51.1",
 		"async": "^3.2.2",

--- a/build-tools/packages/build-tools/src/packageVersion.ts
+++ b/build-tools/packages/build-tools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/build-tools";
-export const pkgVersion = "0.8.0";
+export const pkgVersion = "0.9.0";

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/bundle-size-tools",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"description": "Utility for analyzing bundle size regressions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/bundle-size-tools/src/packageVersion.ts
+++ b/build-tools/packages/bundle-size-tools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/bundle-size-tools";
-export const pkgVersion = "0.8.0";
+export const pkgVersion = "0.9.0";

--- a/build-tools/packages/version-tools/README.md
+++ b/build-tools/packages/version-tools/README.md
@@ -77,7 +77,7 @@ $ npm install -g @fluid-tools/version-tools
 $ fluv COMMAND
 running command...
 $ fluv (--version|-V)
-@fluid-tools/version-tools/0.8.0
+@fluid-tools/version-tools/0.9.0
 $ fluv --help [COMMAND]
 USAGE
   $ fluv COMMAND

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/version-tools",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"description": "Versioning tools for Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/version-tools/src/packageVersion.ts
+++ b/build-tools/packages/version-tools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-tools/version-tools";
-export const pkgVersion = "0.8.0";
+export const pkgVersion = "0.9.0";

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -50,10 +50,10 @@ importers:
 
   packages/build-cli:
     specifiers:
-      '@fluid-tools/version-tools': ^0.8.0
+      '@fluid-tools/version-tools': ^0.9.0
       '@fluidframework/build-common': ^1.1.0
-      '@fluidframework/build-tools': ^0.8.0
-      '@fluidframework/bundle-size-tools': ^0.8.0
+      '@fluidframework/build-tools': ^0.9.0
+      '@fluidframework/bundle-size-tools': ^0.9.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@microsoft/api-extractor': ^7.22.2
       '@oclif/core': ^1.9.5
@@ -181,9 +181,9 @@ importers:
 
   packages/build-tools:
     specifiers:
-      '@fluid-tools/version-tools': ^0.8.0
+      '@fluid-tools/version-tools': ^0.9.0
       '@fluidframework/build-common': ^1.1.0
-      '@fluidframework/bundle-size-tools': ^0.8.0
+      '@fluidframework/bundle-size-tools': ^0.9.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@octokit/core': ^4.0.5
       '@rushstack/node-core-library': ^3.51.1


### PR DESCRIPTION
Bumps build-tools to 0.9.0 since 0.8.0 has been released.

Command used:

```shell
flub bump build-tools -t minor
```