### PR TITLE
Improve Logging Error Message Formats to Better Aggregate

### DIFF
--- a/api-report/container-utils.api.md
+++ b/api-report/container-utils.api.md
@@ -72,7 +72,7 @@ export class ThrottlingWarning extends LoggingError implements IThrottlingWarnin
 
 // @public
 export class UsageError extends LoggingError implements IUsageError, IFluidErrorBase {
-    constructor(message: string);
+    constructor(message: string, props?: ITelemetryProperties);
     // (undocumented)
     readonly errorType = ContainerErrorType.usageError;
 }

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1669,13 +1669,11 @@ export class MergeTree {
 				});
 
 				if (newSegment.parent === undefined) {
-					throw new Error(
-						`MergeTree insert failed: ${JSON.stringify({
-							currentSeq: this.collabWindow.currentSeq,
-							minSeq: this.collabWindow.minSeq,
-							segSeq: newSegment.seq,
-						})}`,
-					);
+					throw new UsageError("MergeTree insert failed", {
+						currentSeq: this.collabWindow.currentSeq,
+						minSeq: this.collabWindow.minSeq,
+						segSeq: newSegment.seq,
+					});
 				}
 
 				this.updateRoot(splitNode);

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -57,6 +57,7 @@
 		"@fluidframework/common-definitions": "^0.20.1",
 		"@fluidframework/common-utils": "^1.0.0",
 		"@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+		"@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
@@ -64,6 +65,7 @@
 		"@fluidframework/register-collection": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+		"@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
 		"uuid": "^8.3.1"
 	},
 	"devDependencies": {

--- a/packages/loader/container-utils/src/error.ts
+++ b/packages/loader/container-utils/src/error.ts
@@ -72,8 +72,8 @@ export class ThrottlingWarning extends LoggingError implements IThrottlingWarnin
 export class UsageError extends LoggingError implements IUsageError, IFluidErrorBase {
 	readonly errorType = ContainerErrorType.usageError;
 
-	constructor(message: string) {
-		super(message, { usageError: true });
+	constructor(message: string, props?: ITelemetryProperties) {
+		super(message, { ...props, usageError: true });
 	}
 }
 

--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -414,12 +414,13 @@ export class SummaryGenerator {
 				// Check for retryDelay in summaryNack response.
 				assert(ackNackOp.type === MessageType.SummaryNack, 0x274 /* "type check" */);
 				const summaryNack = ackNackOp.contents;
-				const message = summaryNack?.message;
+				const errorMessage = summaryNack?.message;
 				const retryAfterSeconds = summaryNack?.retryAfter;
 
 				// pre-0.58 error message prefix: summaryNack
-				const error = new LoggingError(`Received summaryNack: ${message}`, {
+				const error = new LoggingError(`Received summaryNack`, {
 					retryAfterSeconds,
+					errorMessage,
 				});
 
 				assert(

--- a/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -80,14 +80,14 @@ describeFullCompat("AgentScheduler", (getTestObjectProvider) => {
 			await scheduler
 				.pick("task1", async () => {})
 				.catch((err) => {
-					assert.deepStrictEqual(err.message, "task1 is already attempted");
+					assert.deepStrictEqual(err.message, "Task is already attempted");
 				});
 		});
 
 		it("Unpicked task release should fail", async () => {
 			await scheduler.pick("task1", async () => {});
 			await scheduler.release("task2").catch((err) => {
-				assert.deepStrictEqual(err.message, "task2 was never registered");
+				assert.deepStrictEqual(err.message, "Task was never registered");
 			});
 		});
 
@@ -186,13 +186,13 @@ describeFullCompat("AgentScheduler", (getTestObjectProvider) => {
 
 			await provider.ensureSynchronized();
 			await scheduler1.release("task4").catch((err) => {
-				assert.deepStrictEqual(err.message, "task4 was never picked");
+				assert.deepStrictEqual(err.message, "Task was never picked");
 			});
 			await scheduler2.release("task1").catch((err) => {
-				assert.deepStrictEqual(err.message, "task1 was never picked");
+				assert.deepStrictEqual(err.message, "Task was never picked");
 			});
 			await scheduler2.release("task2").catch((err) => {
-				assert.deepStrictEqual(err.message, "task2 was never picked");
+				assert.deepStrictEqual(err.message, "Task was never picked");
 			});
 		});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6760,6 +6760,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.0.0
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
+      '@fluidframework/container-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
@@ -6783,6 +6784,7 @@ importers:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.0.0
       '@fluidframework/container-definitions': link:../../common/container-definitions
+      '@fluidframework/container-utils': link:../../loader/container-utils
       '@fluidframework/core-interfaces': link:../../common/core-interfaces
       '@fluidframework/datastore': link:../../runtime/datastore
       '@fluidframework/datastore-definitions': link:../../runtime/datastore-definitions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6769,6 +6769,7 @@ importers:
       '@fluidframework/register-collection': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
+      '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0'
       '@rushstack/eslint-config': ^2.5.1
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.36
@@ -6792,6 +6793,7 @@ importers:
       '@fluidframework/register-collection': link:../../dds/register-collection
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
+      '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       uuid: 8.3.2
     devDependencies:
       '@fluid-tools/build-cli': 0.8.0


### PR DESCRIPTION
Seeing logs around which include variable in the error. this makes aggregation hard. This change normalizes the error, and moves the variables to a properly tagged property of the error.

Example of existing logs, which this will improve:

Data_error
--
c7d24b4b-02b2-4e75-afd7-3f1681525a9e was never picked
c7d24b4b-02b2-4e75-afd7-3f1681525a9e was never picked
c37785c2-ff3b-4aab-a7b3-1358d5e991dc was never registered
c2bbd6d7-0969-4852-8d40-2be8375c0588 was never picked
MergeTree insert failed: {"currentSeq":2116,"minSeq":2105,"segSeq":2117}
Received summaryNack: Proposed parent summary "0564fc42e39c0736eafb8cade371788bd1e5bdbc" does not match actual parent summary "534d8d40524dce4c09c6c4808c1e6e36ec589950".
Received summaryNack: Proposed parent summary "51e9e9bb2717f80f1e53c1ed666e58122c4ac9db" does not match actual parent summary "d1fa05c353264bb40c35ab61b338702fecb283be".
Received summaryNack: Proposed parent summary "7def3e334d9bfcc094d37f71cf3ffdcd13cebd8e" does not match actual parent summary "afc13e1621be810891fca4b074a8688f3d73862d".
Received summaryNack: Proposed parent summary "9d6fbbd63845cbb6136fc2286be964802ffc46c4" does not match actual parent summary "9b84bd6b0cdd34cf2433499e116937f25124129e".


<!--EndFragment--></BODY></HTML>

