### PR TITLE
Don't proceed to close socket if connection is already disposed in odsp

### DIFF
--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -29,7 +29,8 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     checkpointSequenceNumber: number | undefined;
     get claims(): ITokenClaims;
     get clientId(): string;
-    protected closeSocket(error: IAnyDriverError): void;
+    // (undocumented)
+    protected closeSocketCore(error: IAnyDriverError): void;
     protected createErrorObject(handler: string, error?: any, canRetry?: boolean): IAnyDriverError;
     // (undocumented)
     get details(): IConnected;

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -318,7 +318,24 @@ export class DocumentDeltaConnection
 	/**
 	 * Disconnect from the websocket and close the websocket too.
 	 */
-	protected closeSocket(error: IAnyDriverError) {
+	private closeSocket(error: IAnyDriverError) {
+		if (this._disposed) {
+			// This would be rare situation due to complexity around socket emitting events.
+			this.logger.sendTelemetryEvent({
+				eventName: "SocketCloseOnDisposedConnection",
+				driverVersion,
+				details: JSON.stringify({
+					disposed: this._disposed,
+					socketConnected: this.socket.connected,
+				})},
+				error,
+			);
+			return;
+		}
+		this.closeSocketCore(error);
+	}
+
+	protected closeSocketCore(error: IAnyDriverError) {
 		this.disconnect(error);
 	}
 

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -327,7 +327,7 @@ export class DocumentDeltaConnection
 					driverVersion,
 					details: JSON.stringify({
 						disposed: this._disposed,
-						socketConnected: this.socket.connected,
+						socketConnected: this.socket?.connected,
 						trackedListenerCount: this.trackedListeners.size,
 					}),
 				},

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -321,14 +321,16 @@ export class DocumentDeltaConnection
 	private closeSocket(error: IAnyDriverError) {
 		if (this._disposed) {
 			// This would be rare situation due to complexity around socket emitting events.
-			this.logger.sendTelemetryEvent({
-				eventName: "SocketCloseOnDisposedConnection",
-				driverVersion,
-				details: JSON.stringify({
-					disposed: this._disposed,
-					socketConnected: this.socket.connected,
-					trackedListenerCount: this.trackedListeners.size,
-				})},
+			this.logger.sendTelemetryEvent(
+				{
+					eventName: "SocketCloseOnDisposedConnection",
+					driverVersion,
+					details: JSON.stringify({
+						disposed: this._disposed,
+						socketConnected: this.socket.connected,
+						trackedListenerCount: this.trackedListeners.size,
+					}),
+				},
 				error,
 			);
 			return;

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -327,6 +327,7 @@ export class DocumentDeltaConnection
 				details: JSON.stringify({
 					disposed: this._disposed,
 					socketConnected: this.socket.connected,
+					trackedListenerCount: this.trackedListeners.size,
 				})},
 				error,
 			);

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -652,7 +652,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 	 * Critical path where we need to also close the socket for an error.
 	 * @param error - Error causing the socket to close.
 	 */
-	protected closeSocket(error: IAnyDriverError) {
+	protected closeSocketCore(error: IAnyDriverError) {
 		const socket = this.socketReference;
 		assert(socket !== undefined, 0x416 /* reentrancy not supported in close socket */);
 		socket.closeSocket(error);


### PR DESCRIPTION
## Description

Don't proceed to close socket if connection is already disposed in odsp. This is rare conditions only due to complexity around socket events/tasks scheduling.
I see that the connection has been disposed and then sometimes, socket goes through socket close flow due to socket disconnection even though we have removed the disconnect listener. So, this tells me the processing was already scheduled and there was some race condition. So, I am also adding the telemetry event, so as to gauge the frequency.