### PR TITLE
feat: tree: export stack cursor

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -146,6 +146,18 @@ export enum CrossFieldTarget {
     Source = 0
 }
 
+// @alpha
+export interface CursorAdapter<TNode> {
+    // (undocumented)
+    getFieldFromNode(node: TNode, key: FieldKey): readonly TNode[];
+    // (undocumented)
+    keysFromNode(node: TNode): readonly FieldKey[];
+    // (undocumented)
+    type(node: TNode): TreeType;
+    // (undocumented)
+    value(node: TNode): Value;
+}
+
 // @alpha (undocumented)
 export const enum CursorLocationType {
     Fields = 1,
@@ -154,6 +166,12 @@ export const enum CursorLocationType {
 
 // @alpha
 export function cursorToJsonObject(reader: ITreeCursor): JsonCompatible;
+
+// @alpha
+export interface CursorWithNode<TNode> extends ITreeCursorSynchronous {
+    fork(): CursorWithNode<TNode>;
+    getNode(): TNode;
+}
 
 // @alpha
 export const defaultSchemaPolicy: FullSchemaPolicy;

--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -1019,6 +1019,9 @@ export class SimpleDependee implements Dependee {
 export function singleJsonCursor(root: JsonCompatible): ITreeCursorSynchronous;
 
 // @alpha (undocumented)
+export function singleStackTreeCursor<TNode>(root: TNode, adapter: CursorAdapter<TNode>): CursorWithNode<TNode>;
+
+// @alpha (undocumented)
 export function singleTextCursor(root: JsonableTree): ITreeCursorSynchronous;
 
 // @alpha

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -49,6 +49,7 @@ export {
 	CursorAdapter,
 	prefixPath,
 	prefixFieldPath,
+	CursorWithNode,
 } from "./treeCursorUtils";
 export { singleTextCursor, jsonableTreeFromCursor } from "./treeTextCursor";
 

--- a/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
@@ -18,6 +18,7 @@ import { fail } from "../util";
 
 /**
  * {@link ITreeCursorSynchronous} that can return the underlying node objects.
+ * @alpha
  */
 export interface CursorWithNode<TNode> extends ITreeCursorSynchronous {
 	/**
@@ -40,6 +41,7 @@ export interface CursorWithNode<TNode> extends ITreeCursorSynchronous {
 
 /**
  * @returns an {@link ITreeCursorSynchronous} for a single root.
+ * @alpha
  */
 export function singleStackTreeCursor<TNode>(
 	root: TNode,
@@ -50,6 +52,7 @@ export function singleStackTreeCursor<TNode>(
 
 /**
  * Provides functionality to allow a {@link singleStackTreeCursor} to implement a cursor.
+ * @alpha
  */
 export interface CursorAdapter<TNode> {
 	/**

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -187,6 +187,9 @@ export {
 	prefixFieldPath,
 	singleTextCursor,
 	namedTreeSchema,
+	singleStackTreeCursor,
+	CursorAdapter,
+	CursorWithNode,
 } from "./feature-libraries";
 
 // Export subset of FieldKinds in an API-Extractor compatible way:


### PR DESCRIPTION
## Description

StackCursor is a useful tool for writing data importers for interop with external systems, so export it at the package level.

