### PR TITLE
feat: tree: Add parent access to EditableTree

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -230,6 +230,7 @@ export interface EditableField extends MarkedArrayLike<UnwrappedEditableTree | C
     readonly fieldSchema: FieldSchema;
     getNode(index: number): EditableTree;
     insertNodes(index: number, newContent: ITreeCursor | ITreeCursor[]): void;
+    readonly parent?: EditableTree;
     readonly primaryType?: TreeSchemaIdentifier;
     replaceNodes(index: number, newContent: ITreeCursor | ITreeCursor[], count?: number): void;
 }
@@ -239,6 +240,10 @@ export interface EditableTree extends Iterable<EditableField>, ContextuallyTyped
     [createField](fieldKey: FieldKey, newContent: ITreeCursor | ITreeCursor[]): void;
     [getField](fieldKey: FieldKey): EditableField;
     readonly [indexSymbol]: number;
+    readonly [parentField]: {
+        readonly parent: EditableField;
+        readonly index: number;
+    };
     readonly [proxyTargetSymbol]: object;
     [replaceField](fieldKey: FieldKey, newContent: ITreeCursor | ITreeCursor[]): void;
     [Symbol.iterator](): IterableIterator<EditableField>;
@@ -876,6 +881,9 @@ export type Opaque<T extends Brand<any, string>> = T extends Brand<infer ValueTy
 export interface OptionalFieldEditBuilder {
     set(newContent: ITreeCursor | undefined, wasEmpty: boolean): void;
 }
+
+// @alpha
+export const parentField: unique symbol;
 
 // @alpha
 export interface PathRootPrefix {

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
@@ -106,7 +106,7 @@ export const createField: unique symbol = Symbol("editable-tree:createField()");
 export const replaceField: unique symbol = Symbol("editable-tree:replaceField()");
 
 /**
- * A symbol to get the function, which access parent information of an {@link EditableTree},
+ * A symbol to get information about where an {@link EditableTree} is parented in contexts where string keys are already in use for fields.
  * in contexts where string keys are already in use for fields.
  * @alpha
  */

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
@@ -106,6 +106,13 @@ export const createField: unique symbol = Symbol("editable-tree:createField()");
 export const replaceField: unique symbol = Symbol("editable-tree:replaceField()");
 
 /**
+ * A symbol to get the function, which access parent information of an {@link EditableTree},
+ * in contexts where string keys are already in use for fields.
+ * @alpha
+ */
+export const parentField: unique symbol = Symbol("editable-tree:parentField()");
+
+/**
  * A tree which can be traversed and edited.
  *
  * When iterating, only visits non-empty fields.
@@ -225,6 +232,11 @@ export interface EditableTree extends Iterable<EditableField>, ContextuallyTyped
 	 * replaced with merge semantics that is more consistent with that of optional and value fields.
 	 */
 	[replaceField](fieldKey: FieldKey, newContent: ITreeCursor | ITreeCursor[]): void;
+
+	/**
+	 * The field this tree is in, and the index within that field.
+	 */
+	readonly [parentField]: { readonly parent: EditableField; readonly index: number };
 }
 
 /**
@@ -288,6 +300,12 @@ export interface EditableField
 	 * The `FieldKey` of this field.
 	 */
 	readonly fieldKey: FieldKey;
+
+	/**
+	 * The node which has this field on it under `fieldKey`.
+	 * `undefined` iff this field is a detached field.
+	 */
+	readonly parent?: EditableTree;
 
 	/**
 	 * The type name of the parent node.
@@ -593,6 +611,25 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 				fail("`Forbidden` fields may not be replaced as they never exist.");
 		}
 	}
+
+	public get parentField(): { readonly parent: EditableField; readonly index: number } {
+		const cursor = this.cursor;
+		const index = cursor.fieldIndex;
+		cursor.exitNode();
+		const key = cursor.getFieldKey();
+		cursor.exitField();
+		const parentType = cursor.type;
+		cursor.enterField(key);
+		const fieldSchema = getFieldSchema(
+			key,
+			this.context.schema,
+			lookupTreeSchema(this.context.schema, parentType),
+		);
+		const proxifiedField = proxifyField(this.context, fieldSchema, this.cursor, false);
+		this.cursor.enterNode(index);
+
+		return { parent: proxifiedField, index };
+	}
 }
 
 /**
@@ -625,6 +662,8 @@ const nodeProxyHandler: AdaptingProxyHandler<NodeProxyTarget, EditableTree> = {
 				return target.createField.bind(target);
 			case replaceField:
 				return target.replaceField.bind(target);
+			case parentField:
+				return target.parentField;
 			default:
 				return undefined;
 		}
@@ -701,6 +740,7 @@ const nodeProxyHandler: AdaptingProxyHandler<NodeProxyTarget, EditableTree> = {
 			case getField:
 			case createField:
 			case replaceField:
+			case parentField:
 				return true;
 			case valueSymbol:
 				// Could do `target.value !== ValueSchema.Nothing`
@@ -791,6 +831,13 @@ const nodeProxyHandler: AdaptingProxyHandler<NodeProxyTarget, EditableTree> = {
 					value: target.replaceField.bind(target),
 					writable: false,
 				};
+			case parentField:
+				return {
+					configurable: true,
+					enumerable: false,
+					value: target.parentField,
+					writable: false,
+				};
 			default:
 				return undefined;
 		}
@@ -823,6 +870,18 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 
 	get [proxyTargetSymbol](): FieldProxyTarget {
 		return this;
+	}
+
+	get parent(): EditableTree | undefined {
+		if (this.getAnchor().parent === undefined) {
+			return undefined;
+		}
+
+		const cursor = this.cursor;
+		cursor.exitField();
+		const target = new NodeProxyTarget(this.context, cursor);
+		cursor.enterField(this.fieldKey);
+		return adaptWithProxy(target, nodeProxyHandler);
 	}
 
 	buildAnchorFromCursor(cursor: ITreeSubscriptionCursor): FieldAnchor {
@@ -949,6 +1008,7 @@ const editableFieldPropertySetWithoutLength = new Set<string>([
 	"fieldKey",
 	"fieldSchema",
 	"primaryType",
+	"parent",
 ]);
 /**
  * The set of `EditableField` properties exposed by `fieldProxyHandler`.

--- a/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
@@ -19,6 +19,7 @@ export {
 	getField,
 	createField,
 	replaceField,
+	parentField,
 } from "./editableTree";
 
 export { EditableTreeContext, getEditableTreeContext } from "./editableTreeContext";

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -39,6 +39,7 @@ export {
 	MarkedArrayLike,
 	isWritableArrayLike,
 	isContextuallyTypedNodeDataObject,
+	parentField,
 } from "./editable-tree";
 export { ForestIndex } from "./forestIndex";
 export { singleMapTreeCursor, mapTreeFromCursor } from "./mapTreeCursor";

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -190,6 +190,7 @@ export {
 	singleStackTreeCursor,
 	CursorAdapter,
 	CursorWithNode,
+	parentField,
 } from "./feature-libraries";
 
 // Export subset of FieldKinds in an API-Extractor compatible way:


### PR DESCRIPTION
## Description

EditableTree objects know what their parents are (they have to, since the editing methods need to know where to edit), but did not expose this information in the API at all.

This change adds a way to access parents of both nodes and fields, making up navigation possible.

This is useful for a user needs to discover the context of an editable tree node, for example find its parent sequence to edit it.
