### PR TITLE
refactor(external-data): Remove webhook registration from customer service in external-data example app

### DIFF
--- a/examples/hosts/app-integration/external-data/src/mock-customer-service/index.ts
+++ b/examples/hosts/app-integration/external-data/src/mock-customer-service/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export { initializeCustomerService } from "./service";
+export { initializeCustomerService, fluidServicePort } from "./service";

--- a/examples/hosts/app-integration/external-data/src/mock-customer-service/index.ts
+++ b/examples/hosts/app-integration/external-data/src/mock-customer-service/index.ts
@@ -3,4 +3,4 @@
  * Licensed under the MIT License.
  */
 
-export { initializeCustomerService, fluidServicePort } from "./service";
+export { initializeCustomerService } from "./service";

--- a/examples/hosts/app-integration/external-data/src/mock-customer-service/service.ts
+++ b/examples/hosts/app-integration/external-data/src/mock-customer-service/service.ts
@@ -11,7 +11,6 @@ import fetch from "node-fetch";
 
 import { assertValidTaskData, TaskData } from "../model-interface";
 
-export const fluidServicePort = 7070;
 /**
  * Submits notifications of changes to Fluid Service.
  */

--- a/examples/hosts/app-integration/external-data/src/mock-customer-service/service.ts
+++ b/examples/hosts/app-integration/external-data/src/mock-customer-service/service.ts
@@ -15,7 +15,7 @@ export const fluidServicePort = 7070;
 /**
  * Submits notifications of changes to Fluid Service.
  */
-function echoTaskWebhookToFluid(data: TaskData, fluidServiceUrl: string): void {
+function echoExternalDataWebhookToFluid(data: TaskData, fluidServiceUrl: string): void {
 	console.log(
 		`WEBHOOK: External data has been updated. Notifying Fluid Service at ${fluidServiceUrl}`,
 	);
@@ -89,7 +89,7 @@ export async function initializeCustomerService(props: ServiceProps): Promise<Se
 			},
 			body: JSON.stringify({
 				// External data service will call our webhook echoer to notify our subscribers of the data changes.
-				url: `http://localhost:${port}/echo-external-data-webhook`,
+				url: `http://localhost:${port}/external-data-webhook`,
 			}),
 		});
 	} catch (error) {
@@ -131,7 +131,7 @@ export async function initializeCustomerService(props: ServiceProps): Promise<Se
 	 *
 	 * This data will be forwarded to our own subscribers.
 	 */
-	expressApp.post("/echo-external-data-webhook", (request, result) => {
+	expressApp.post("/external-data-webhook", (request, result) => {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 		const messageData = request.body?.data as unknown;
 		if (messageData === undefined) {
@@ -155,7 +155,7 @@ export async function initializeCustomerService(props: ServiceProps): Promise<Se
 					`Data update received from external data service. Notifying webhook subscribers.`,
 				),
 			);
-			echoTaskWebhookToFluid(taskData, fluidServiceUrl);
+			echoExternalDataWebhookToFluid(taskData, fluidServiceUrl);
 			result.send();
 		}
 	});

--- a/examples/hosts/app-integration/external-data/src/mock-customer-service/service.ts
+++ b/examples/hosts/app-integration/external-data/src/mock-customer-service/service.ts
@@ -34,6 +34,7 @@ function echoExternalDataWebhookToFluid(data: TaskData, fluidServiceUrl: string)
 		console.error("WEBHOOK: Encountered an error while notifying Fluid Service:", error);
 	});
 }
+
 /**
  * {@link initializeCustomerService} input properties.
  */

--- a/examples/hosts/app-integration/external-data/src/mock-customer-service/start.ts
+++ b/examples/hosts/app-integration/external-data/src/mock-customer-service/start.ts
@@ -13,7 +13,7 @@ import { initializeCustomerService, fluidServicePort } from "./service";
 initializeCustomerService({
 	port: customerServicePort,
 	externalDataServiceWebhookRegistrationUrl: `http://localhost:${externalDataServicePort}/register-for-webhook`,
-	fluidServiceUrl: `http://localhost:${fluidServicePort}/task-list-hook`,
+	fluidServiceUrl: `http://localhost:${fluidServicePort}/broadcast-signal`,
 }).catch((error) => {
 	console.error(`There was an error initializing the mock customer service:\n${error}`);
 

--- a/examples/hosts/app-integration/external-data/src/mock-customer-service/start.ts
+++ b/examples/hosts/app-integration/external-data/src/mock-customer-service/start.ts
@@ -5,7 +5,8 @@
 
 import { customerServicePort } from "../mock-customer-service-interface";
 import { externalDataServicePort } from "../mock-external-data-service-interface";
-import { initializeCustomerService, fluidServicePort } from "./service";
+import { fluidServicePort } from "../utilities";
+import { initializeCustomerService } from "./service";
 
 /**
  * Initializes the mock customer service on its {@link customerServicePort | default port}.

--- a/examples/hosts/app-integration/external-data/src/mock-customer-service/start.ts
+++ b/examples/hosts/app-integration/external-data/src/mock-customer-service/start.ts
@@ -5,7 +5,7 @@
 
 import { customerServicePort } from "../mock-customer-service-interface";
 import { externalDataServicePort } from "../mock-external-data-service-interface";
-import { initializeCustomerService } from "./service";
+import { initializeCustomerService, fluidServicePort } from "./service";
 
 /**
  * Initializes the mock customer service on its {@link customerServicePort | default port}.
@@ -13,6 +13,7 @@ import { initializeCustomerService } from "./service";
 initializeCustomerService({
 	port: customerServicePort,
 	externalDataServiceWebhookRegistrationUrl: `http://localhost:${externalDataServicePort}/register-for-webhook`,
+	fluidServiceUrl: `http://localhost:${fluidServicePort}/task-list-hook`,
 }).catch((error) => {
 	console.error(`There was an error initializing the mock customer service:\n${error}`);
 

--- a/examples/hosts/app-integration/external-data/src/utilities/fluidService.ts
+++ b/examples/hosts/app-integration/external-data/src/utilities/fluidService.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * The port used by the fluid service.
+ */
+export const fluidServicePort = process.env.FLUID_SERVICE_PORT ?? 7070;

--- a/examples/hosts/app-integration/external-data/src/utilities/fluidService.ts
+++ b/examples/hosts/app-integration/external-data/src/utilities/fluidService.ts
@@ -4,6 +4,6 @@
  */
 
 /**
- * The port used by the fluid service.
+ * The port used by the Fluid Service.
  */
 export const fluidServicePort = process.env.FLUID_SERVICE_PORT ?? 7070;

--- a/examples/hosts/app-integration/external-data/src/utilities/index.ts
+++ b/examples/hosts/app-integration/external-data/src/utilities/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { MockWebhook, SubscriberUrl } from "./webhook";
+export { fluidServicePort } from "./fluidService";

--- a/examples/hosts/app-integration/external-data/tests/customerService.test.ts
+++ b/examples/hosts/app-integration/external-data/tests/customerService.test.ts
@@ -42,7 +42,7 @@ describe("mock-customer-service", () => {
 		customerService = await initializeCustomerService({
 			port: customerServicePort,
 			externalDataServiceWebhookRegistrationUrl: `http://localhost:${externalDataServicePort}/register-for-webhook`,
-			fluidServiceUrl: `http://localhost:${localServicePort}/task-list-hook`,
+			fluidServiceUrl: `http://localhost:${localServicePort}/broadcast-signal`,
 		});
 	});
 
@@ -69,7 +69,7 @@ describe("mock-customer-service", () => {
 
 		// Bind listener
 		let wasHookNotifiedForChange = false;
-		localServiceApp.post("/task-list-hook", (_, result) => {
+		localServiceApp.post("/broadcast-signal", (_, result) => {
 			wasHookNotifiedForChange = true;
 			result.send();
 		});

--- a/examples/hosts/app-integration/external-data/tests/customerService.test.ts
+++ b/examples/hosts/app-integration/external-data/tests/customerService.test.ts
@@ -68,9 +68,9 @@ describe("mock-customer-service", () => {
 		localServiceApp.use(cors());
 
 		// Bind listener
-		let wasHookNotifiedForChange = false;
+		let wasFluidNotifiedForChange = false;
 		localServiceApp.post("/broadcast-signal", (_, result) => {
-			wasHookNotifiedForChange = true;
+			wasFluidNotifiedForChange = true;
 			result.send();
 		});
 
@@ -105,7 +105,7 @@ describe("mock-customer-service", () => {
 			await delay(1000);
 
 			// Verify our listener was notified of data change.
-			expect(wasHookNotifiedForChange).toBe(true);
+			expect(wasFluidNotifiedForChange).toBe(true);
 		} catch (error) {
 			fail(error);
 		} finally {

--- a/examples/hosts/app-integration/external-data/tests/customerService.test.ts
+++ b/examples/hosts/app-integration/external-data/tests/customerService.test.ts
@@ -8,7 +8,6 @@ import type { Server } from "http";
 import cors from "cors";
 import express from "express";
 import fetch from "node-fetch";
-import request from "supertest";
 
 import { delay } from "@fluidframework/common-utils";
 
@@ -18,6 +17,7 @@ import { initializeExternalDataService } from "../src/mock-external-data-service
 import { externalDataServicePort } from "../src/mock-external-data-service-interface";
 import { closeServer } from "./utilities";
 
+const localServicePort = 5002;
 /**
  * @remarks
  *
@@ -42,6 +42,7 @@ describe("mock-customer-service", () => {
 		customerService = await initializeCustomerService({
 			port: customerServicePort,
 			externalDataServiceWebhookRegistrationUrl: `http://localhost:${externalDataServicePort}/register-for-webhook`,
+			fluidServiceUrl: `http://localhost:${localServicePort}/task-list-hook`,
 		});
 	});
 
@@ -60,25 +61,8 @@ describe("mock-customer-service", () => {
 
 	// We have omitted `@types/supertest` due to cross-package build issue.
 	// So for these tests we have to live with `any`.
-	/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
-
-	it("register-for-webhook: Registering valid URI succeeds", async () => {
-		await request(customerService!)
-			.post("/register-for-webhook")
-			.send({ url: "https://www.fluidframework.com" })
-			.expect(200);
-	});
-
-	it("register-for-webhook: Registering invalid URI fails", async () => {
-		await request(customerService!)
-			.post("/register-for-webhook")
-			.send({ url: "I am not a URI" })
-			.expect(400);
-	});
-
 	it("register-for-webhook: Complete data flow", async () => {
 		// Set up mock local service, which will be registered as webhook listener
-		const localServicePort = 5002;
 		const localServiceApp = express();
 		localServiceApp.use(express.json());
 		localServiceApp.use(cors());
@@ -93,25 +77,6 @@ describe("mock-customer-service", () => {
 		const localService: Server = localServiceApp.listen(localServicePort);
 
 		try {
-			// Register with the customer service for notifications
-			const webhookRegistrationResponse = await fetch(
-				`http://localhost:${customerServicePort}/register-for-webhook`,
-				{
-					method: "POST",
-					headers: {
-						"Access-Control-Allow-Origin": "*",
-						"Content-Type": "application/json",
-					},
-					body: JSON.stringify({
-						url: `http://localhost:${localServicePort}/task-list-hook`,
-					}),
-				},
-			);
-
-			if (!webhookRegistrationResponse.ok) {
-				fail(`Webhook registration failed. Code: ${webhookRegistrationResponse.status}.`);
-			}
-
 			// Update external data
 			const dataUpdateResponse = await fetch(
 				`http://localhost:${externalDataServicePort}/set-tasks`,
@@ -147,7 +112,5 @@ describe("mock-customer-service", () => {
 			await closeServer(localService);
 		}
 	});
-
-	/* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 	/* eslint-enable @typescript-eslint/no-non-null-assertion */
 });

--- a/examples/hosts/app-integration/external-data/tests/externalDataService.test.ts
+++ b/examples/hosts/app-integration/external-data/tests/externalDataService.test.ts
@@ -156,7 +156,7 @@ describe("mock-external-data-service: webhook", () => {
 
 		// Bind listener
 		let wasHookNotifiedForChange = false;
-		localServiceApp.post("/task-list-hook", (_, result) => {
+		localServiceApp.post("/broadcast-signal", (_, result) => {
 			wasHookNotifiedForChange = true;
 			result.send();
 		});
@@ -174,7 +174,7 @@ describe("mock-external-data-service: webhook", () => {
 						"Content-Type": "application/json",
 					},
 					body: JSON.stringify({
-						url: `http://localhost:${localServicePort}/task-list-hook`,
+						url: `http://localhost:${localServicePort}/broadcast-signal`,
 					}),
 				},
 			);


### PR DESCRIPTION
Port https://github.com/microsoft/FluidFramework/pull/14046 from dev branch to main branch.