### PR TITLE
Made incremental updates for SharedCell Attribution

### DIFF
--- a/api-report/cell.api.md
+++ b/api-report/cell.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AttributionKey } from '@fluidframework/runtime-definitions';
 import { IChannelAttributes } from '@fluidframework/datastore-definitions';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IChannelStorageService } from '@fluidframework/datastore-definitions';
@@ -15,12 +16,6 @@ import { ISharedObjectEvents } from '@fluidframework/shared-object-base';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { Serializable } from '@fluidframework/datastore-definitions';
 import { SharedObject } from '@fluidframework/shared-object-base';
-
-// @alpha
-export interface AttributionKey {
-    seq: number;
-    type: "op";
-}
 
 // @alpha
 export interface ICellAttributionOptions {
@@ -53,7 +48,7 @@ export interface ISharedCellEvents<T> extends ISharedObjectEvents {
 // @public
 export class SharedCell<T = any> extends SharedObject<ISharedCellEvents<T>> implements ISharedCell<T> {
     // @alpha
-    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes, options?: ICellOptions);
+    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
     // @internal (undocumented)
     protected applyStashedOp(content: unknown): unknown;
     static create(runtime: IFluidDataStoreRuntime, id?: string): SharedCell;

--- a/packages/dds/cell/src/cell.ts
+++ b/packages/dds/cell/src/cell.ts
@@ -5,7 +5,6 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
-import { loggerToMonitoringContext } from "@fluidframework/telemetry-utils";
 import {
 	IChannelAttributes,
 	IFluidDataStoreRuntime,
@@ -13,7 +12,7 @@ import {
 	IChannelFactory,
 	Serializable,
 } from "@fluidframework/datastore-definitions";
-import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
+import { AttributionKey, ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 import { readAndParse } from "@fluidframework/driver-utils";
 import {
 	createSingleBlobSummary,
@@ -21,13 +20,7 @@ import {
 	SharedObject,
 } from "@fluidframework/shared-object-base";
 import { CellFactory } from "./cellFactory";
-import {
-	ISharedCell,
-	ISharedCellEvents,
-	ICellLocalOpMetadata,
-	AttributionKey,
-	ICellOptions,
-} from "./interfaces";
+import { ISharedCell, ISharedCellEvents, ICellLocalOpMetadata, ICellOptions } from "./interfaces";
 
 /**
  * Description of a cell delta operation
@@ -120,14 +113,12 @@ export class SharedCell<T = any>
 	 * @param id - Unique identifier for the `SharedCell`.
 	 */
 	// eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
-	constructor(
-		id: string,
-		runtime: IFluidDataStoreRuntime,
-		attributes: IChannelAttributes,
-		options?: ICellOptions,
-	) {
+	constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes) {
 		super(id, runtime, attributes, "fluid_cell_");
 
+		this.options = runtime.options as ICellOptions;
+
+		/*
 		this.options ??= options;
 
 		const configSetAttribution = loggerToMonitoringContext(this.logger).config.getBoolean(
@@ -135,7 +126,7 @@ export class SharedCell<T = any>
 		);
 		if (configSetAttribution !== undefined) {
 			(this.options ?? (this.options = {})).attribution = { track: configSetAttribution };
-		}
+		} */
 	}
 
 	/**

--- a/packages/dds/cell/src/cell.ts
+++ b/packages/dds/cell/src/cell.ts
@@ -117,16 +117,6 @@ export class SharedCell<T = any>
 		super(id, runtime, attributes, "fluid_cell_");
 
 		this.options = runtime.options as ICellOptions;
-
-		/*
-		this.options ??= options;
-
-		const configSetAttribution = loggerToMonitoringContext(this.logger).config.getBoolean(
-			"Fluid.Attribution.EnableOnNewFile",
-		);
-		if (configSetAttribution !== undefined) {
-			(this.options ?? (this.options = {})).attribution = { track: configSetAttribution };
-		} */
 	}
 
 	/**

--- a/packages/dds/cell/src/index.ts
+++ b/packages/dds/cell/src/index.ts
@@ -13,7 +13,6 @@ export { SharedCell } from "./cell";
 export {
 	ISharedCell,
 	ISharedCellEvents,
-	AttributionKey,
 	ICellOptions,
 	ICellAttributionOptions,
 } from "./interfaces";

--- a/packages/dds/cell/src/interfaces.ts
+++ b/packages/dds/cell/src/interfaces.ts
@@ -5,6 +5,7 @@
 
 import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-object-base";
 import { Serializable } from "@fluidframework/datastore-definitions";
+import { AttributionKey } from "@fluidframework/runtime-definitions";
 
 /**
  * Events emitted by {@link ISharedCell}.
@@ -145,28 +146,4 @@ export interface ICellOptions {
  */
 export interface ICellAttributionOptions {
 	track?: boolean;
-}
-
-/**
- * Can be indexed into the ContainerRuntime in order to retrieve attribution info.
- *
- * @alpha
- */
-export interface AttributionKey {
-	/**
-	 * The type of attribution this key corresponds to.
-	 *
-	 * Keys currently all represent op-based attribution, so have the form `{ type: "op", key: sequenceNumber }`.
-	 * Thus, they can be used with an `OpStreamAttributor` to recover timestamp/user information.
-	 *
-	 * @remarks - If we want to support different types of attribution, a reasonable extensibility point is to make
-	 * AttributionKey a discriminated union on the 'type' field. This would empower
-	 * consumers with the ability to implement different attribution policies.
-	 */
-	type: "op";
-
-	/**
-	 * The sequenceNumber of the op this attribution key is for.
-	 */
-	seq: number;
 }

--- a/packages/dds/cell/src/test/cell.spec.ts
+++ b/packages/dds/cell/src/test/cell.spec.ts
@@ -24,24 +24,34 @@ function createConnectedCell(
 ): ISharedCell {
 	// Create and connect a second SharedCell.
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
+	if (options?.attribution?.track ?? false) {
+		dataStoreRuntime.options = {
+			attribution: {
+				track: true,
+			},
+		};
+	}
 	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
 		deltaConnection: containerRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
 
-	const cell = new SharedCell(id, dataStoreRuntime, CellFactory.Attributes, options);
+	const cell = new SharedCell(id, dataStoreRuntime, CellFactory.Attributes);
 	cell.connect(services);
 	return cell;
 }
 
 function createLocalCell(id: string, options?: ICellOptions): ISharedCell {
-	const subCell = new SharedCell(
-		id,
-		new MockFluidDataStoreRuntime(),
-		CellFactory.Attributes,
-		options,
-	);
+	const dataStoreRuntime = new MockFluidDataStoreRuntime();
+	if (options?.attribution?.track ?? false) {
+		dataStoreRuntime.options = {
+			attribution: {
+				track: true,
+			},
+		};
+	}
+	const subCell = new SharedCell(id, dataStoreRuntime, CellFactory.Attributes);
 	return subCell;
 }
 
@@ -307,32 +317,44 @@ describe("Cell", () => {
 
 				containerRuntimeFactory.processSomeMessages(1);
 
-				// Verify the attributon is not undefined
-				assert.notEqual(
-					cell1.getAttribution(),
-					undefined,
-					"the first cell does not have valid attribution",
-				);
-				// Verify the attribution of SharedCell with 1 pending message
-				assert.notEqual(
-					cell1.getAttribution()?.seq,
-					cell2.getAttribution()?.seq,
-					"the attribution key should not be consistent",
-				);
-
-				containerRuntimeFactory.processAllMessages();
-
-				// Verify the attributon is not undefined
-				assert.notEqual(
-					cell2.getAttribution(),
-					undefined,
-					"the second cell does not have valid attribution",
-				);
-				// Verify the attribution of SharedCell with all pending messages processed
 				assert.equal(
 					cell1.getAttribution()?.seq,
+					1,
+					"the first cell does not have valid attribution",
+				);
+
+				assert.equal(
+					cell2.getAttribution(),
+					undefined,
+					"the second cell has attribution with a pending local edit",
+				);
+
+				containerRuntimeFactory.processSomeMessages(1);
+
+				assert.equal(
+					cell1.getAttribution()?.seq,
+					2,
+					"the first cell does not have valid attribution",
+				);
+
+				assert.equal(
 					cell2.getAttribution()?.seq,
-					"the attribution key should be consistent",
+					2,
+					"the second cell does not have valid attribution",
+				);
+
+				containerRuntimeFactory.processSomeMessages(1);
+
+				assert.equal(
+					cell1.getAttribution()?.seq,
+					3,
+					"the first cell does not have valid attribution after clearing",
+				);
+
+				assert.equal(
+					cell2.getAttribution()?.seq,
+					3,
+					"the second cell does not have valid attribution after clearing",
 				);
 			});
 		});

--- a/packages/dds/cell/src/test/cell.spec.ts
+++ b/packages/dds/cell/src/test/cell.spec.ts
@@ -24,13 +24,8 @@ function createConnectedCell(
 ): ISharedCell {
 	// Create and connect a second SharedCell.
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
-	if (options?.attribution?.track ?? false) {
-		dataStoreRuntime.options = {
-			attribution: {
-				track: true,
-			},
-		};
-	}
+	dataStoreRuntime.options = options ?? dataStoreRuntime.options;
+
 	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
 		deltaConnection: containerRuntime.createDeltaConnection(),
@@ -44,13 +39,7 @@ function createConnectedCell(
 
 function createLocalCell(id: string, options?: ICellOptions): ISharedCell {
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
-	if (options?.attribution?.track ?? false) {
-		dataStoreRuntime.options = {
-			attribution: {
-				track: true,
-			},
-		};
-	}
+	dataStoreRuntime.options = options ?? dataStoreRuntime.options;
 	const subCell = new SharedCell(id, dataStoreRuntime, CellFactory.Attributes);
 	return subCell;
 }
@@ -318,7 +307,7 @@ describe("Cell", () => {
 				containerRuntimeFactory.processSomeMessages(1);
 
 				assert.equal(
-					cell1.getAttribution()?.seq,
+					cell1.getAttribution()?.type === "op" && cell1.getAttribution()?.seq,
 					1,
 					"the first cell does not have valid attribution",
 				);
@@ -332,13 +321,13 @@ describe("Cell", () => {
 				containerRuntimeFactory.processSomeMessages(1);
 
 				assert.equal(
-					cell1.getAttribution()?.seq,
+					cell1.getAttribution()?.type === "op" && cell1.getAttribution()?.seq,
 					2,
 					"the first cell does not have valid attribution",
 				);
 
 				assert.equal(
-					cell2.getAttribution()?.seq,
+					cell2.getAttribution()?.type === "op" && cell2.getAttribution()?.seq,
 					2,
 					"the second cell does not have valid attribution",
 				);
@@ -346,13 +335,13 @@ describe("Cell", () => {
 				containerRuntimeFactory.processSomeMessages(1);
 
 				assert.equal(
-					cell1.getAttribution()?.seq,
+					cell1.getAttribution()?.type === "op" && cell1.getAttribution()?.seq,
 					3,
 					"the first cell does not have valid attribution after clearing",
 				);
 
 				assert.equal(
-					cell2.getAttribution()?.seq,
+					cell2.getAttribution()?.type === "op" && cell2.getAttribution()?.seq,
 					3,
 					"the second cell does not have valid attribution after clearing",
 				);

--- a/packages/dds/cell/src/test/cell.spec.ts
+++ b/packages/dds/cell/src/test/cell.spec.ts
@@ -306,42 +306,51 @@ describe("Cell", () => {
 
 				containerRuntimeFactory.processSomeMessages(1);
 
+				let key1 = cell1.getAttribution();
+				let key2 = cell2.getAttribution();
+
 				assert.equal(
-					cell1.getAttribution()?.type === "op" && cell1.getAttribution()?.seq,
+					key1?.type === "op" && key1?.seq,
 					1,
 					"the first cell does not have valid attribution",
 				);
 
 				assert.equal(
-					cell2.getAttribution(),
+					key2,
 					undefined,
 					"the second cell has attribution with a pending local edit",
 				);
 
 				containerRuntimeFactory.processSomeMessages(1);
 
+				key1 = cell1.getAttribution();
+				key2 = cell2.getAttribution();
+
 				assert.equal(
-					cell1.getAttribution()?.type === "op" && cell1.getAttribution()?.seq,
+					key1?.type === "op" && key1?.seq,
 					2,
 					"the first cell does not have valid attribution",
 				);
 
 				assert.equal(
-					cell2.getAttribution()?.type === "op" && cell2.getAttribution()?.seq,
+					key2?.type === "op" && key2?.seq,
 					2,
 					"the second cell does not have valid attribution",
 				);
 
 				containerRuntimeFactory.processSomeMessages(1);
 
+				key1 = cell1.getAttribution();
+				key2 = cell2.getAttribution();
+
 				assert.equal(
-					cell1.getAttribution()?.type === "op" && cell1.getAttribution()?.seq,
+					key1?.type === "op" && key1?.seq,
 					3,
 					"the first cell does not have valid attribution after clearing",
 				);
 
 				assert.equal(
-					cell2.getAttribution()?.type === "op" && cell2.getAttribution()?.seq,
+					key2?.type === "op" && key2?.seq,
 					3,
 					"the second cell does not have valid attribution after clearing",
 				);


### PR DESCRIPTION
[AB#3363](https://dev.azure.com/fluidframework/internal/_workitems/edit/3363)

It resolves some remaining issues for SharedCell Attribution:

1. Refer the `AttributionKey` from `runtime-definition`
2. Use the `DataStoreRuntime.options` in constructor
3. Refactor some test suites to increase test coverage