### PR TITLE
refactor(container-definitions): Add LoaderHeader enum value to override logger

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -23,7 +23,7 @@ _None yet._
 
 ## 2.0.0-internal.4.0.0 Breaking changes
 
-- [container-runtime: LoaderHeader enum changes](#containerruntime-loaderheader-enum-changes)
+-   [container-runtime: LoaderHeader enum changes](#containerruntime-loaderheader-enum-changes)
 
 ### container-runtime: LoaderHeader enum changes
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -27,9 +27,7 @@ _None yet._
 
 ### container-runtime: LoaderHeader enum changes
 
-The LoaderHeader enum in the container-runtime library has a new enum value, `baseLogger`, which is a header that can be
-used to override the base logger used by a Fluid Container on load. This is a breaking change because TypeScript enums
-are not compatible when new enum values are added.
+The LoaderHeader enum in the container-runtime library has a new enum value, `baseLogger`, which is a header that can be used to override the base logger used by a Fluid Container on load. This is a breaking change because TypeScript enums are not compatible when new enum values are added.
 
 This change was originally made in 2.0.0-internal.3.0.1 as a backwards-compatible change using a hard-coded header
 value.

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -15,6 +15,25 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 -   Avoid using code formatting in the title (it's fine to use in the body).
 -   To explain the benefit of your change, use the [What's New](https://fluidframework.com/docs/updates/v1.0.0/) section on FluidFramework.com.
 
+# 2.0.0-internal.4.0.0
+
+## 2.0.0-internal.4.0.0 Upcoming changes
+
+_None yet._
+
+## 2.0.0-internal.4.0.0 Breaking changes
+
+- [container-runtime: LoaderHeader enum changes](#containerruntime-loaderheader-enum-changes)
+
+### container-runtime: LoaderHeader enum changes
+
+The LoaderHeader enum in the container-runtime library has a new enum value, `baseLogger`, which is a header that can be
+used to override the base logger used by a Fluid Container on load. This is a breaking change because TypeScript enums
+are not compatible when new enum values are added.
+
+This change was originally made in 2.0.0-internal.3.0.1 as a backwards-compatible change using a hard-coded header
+value.
+
 # 2.0.0-internal.3.0.0
 
 ## 2.0.0-internal.3.0.0 Upcoming changes

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -535,6 +535,7 @@ export interface IUsageError extends IErrorBase {
 
 // @public
 export enum LoaderHeader {
+    baseLogger = "fluid-base-logger",
     cache = "fluid-cache",
     // (undocumented)
     clientDetails = "fluid-client-details",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -71,6 +71,9 @@
 		"broken": {
 			"InterfaceDeclaration_IConnectionDetails": {
 				"backCompat": false
+			},
+			"EnumDeclaration_LoaderHeader": {
+				"backCompat": false
 			}
 		}
 	}

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -545,8 +545,10 @@ export enum LoaderHeader {
 	 */
 	version = "version",
 
-	// TODO #AB3350: This is a breaking change; it will be enabled in the "next" branch
-	// baseLogger = "fluid-base-logger"
+	/**
+	 * Header used to pass a logger for containers to use on load.
+	 */
+	baseLogger = "fluid-base-logger",
 }
 
 export interface IContainerLoadMode {

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
@@ -1452,6 +1452,7 @@ declare function get_current_EnumDeclaration_LoaderHeader():
 declare function use_old_EnumDeclaration_LoaderHeader(
     use: TypeOnly<old.LoaderHeader>);
 use_old_EnumDeclaration_LoaderHeader(
+    // @ts-expect-error compatibility expected to be broken
     get_current_EnumDeclaration_LoaderHeader());
 
 /*

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -495,7 +495,7 @@ export class Loader implements IHostLoader {
 				resolvedUrl: resolved,
 				version: request.headers?.[LoaderHeader.version] ?? undefined,
 				loadMode: request.headers?.[LoaderHeader.loadMode],
-				baseLogger: request.headers?.["fluid-base-logger"],
+				baseLogger: request.headers?.[LoaderHeader.baseLogger],
 			},
 			pendingLocalState,
 			this.protocolHandlerBuilder,


### PR DESCRIPTION
The LoaderHeader enum in the container-runtime library has a new enum value, `baseLogger`, which is a header that can be used to override the base logger used by a Fluid Container on load. This is a breaking change because TypeScript enums are not compatible when new enum values are added.

BREAKING CHANGE: This is a breaking change because TypeScript enums are not compatible when new enum values are added.

Fixes [AB#3350](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3350)