### PR TITLE
style(build-tools): Prettier ignore generated README

### DIFF
--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -4,15 +4,19 @@ flub is a build and release tool for the Fluid Framework GitHub repositories. fl
 fluid build-tools, primarily by reusing existing build-tools functionality and wrapping it in a more consistent,
 maintainable CLI using [oclif](https://oclif.io).
 
+<!-- prettier-ignore-start -->
 <!-- toc -->
 
 -   [@fluid-tools/build-cli](#fluid-toolsbuild-cli)
 -   [Usage](#usage)
 -   [Command Topics](#command-topics)
+
 <!-- tocstop -->
+<!-- prettier-ignore-stop -->
 
 # Usage
 
+<!-- prettier-ignore-start -->
 <!-- usage -->
 
 ```sh-session
@@ -28,7 +32,9 @@ USAGE
 ```
 
 <!-- usagestop -->
+<!-- prettier-ignore-stop -->
 
+<!-- prettier-ignore-start -->
 <!-- commands -->
 
 # Command Topics
@@ -45,6 +51,7 @@ USAGE
 -   [`flub run`](docs/run.md) - Generate a report from input bundle stats collected through the collect bundleStats command.
 
 <!-- commandsstop -->
+<!-- prettier-ignore-stop -->
 
 ## Developer notes
 

--- a/build-tools/packages/version-tools/README.md
+++ b/build-tools/packages/version-tools/README.md
@@ -3,6 +3,7 @@
 The version-tools package provides APIs and a CLI to parse and transform version numbers and ranges that are used by the
 Fluid Framework.
 
+<!-- prettier-ignore-start -->
 <!-- toc -->
 
 -   [@fluid-tools/version-tools](#fluid-toolsversion-tools)
@@ -10,7 +11,9 @@ Fluid Framework.
 -   [General API](#general-api)
 -   [CLI Usage](#cli-usage)
 -   [Commands](#commands)
+
 <!-- tocstop -->
+<!-- prettier-ignore-stop -->
 
 # Version schemes
 
@@ -70,6 +73,7 @@ version-tools provides a command-line interface (`fluv`) when installed directly
 also available in the Fluid build and release tool (`flub`). This is accomplished using
 [oclif's plugin system](https://oclif.io/docs/plugins).
 
+<!-- prettier-ignore-start -->
 <!-- usage -->
 
 ```sh-session
@@ -85,9 +89,11 @@ USAGE
 ```
 
 <!-- usagestop -->
+<!-- prettier-ignore-stop -->
 
 # Commands
 
+<!-- prettier-ignore-start -->
 <!-- commands -->
 
 -   [`fluv autocomplete [SHELL]`](#fluv-autocomplete-shell)
@@ -221,6 +227,7 @@ EXAMPLES
 ```
 
 <!-- commandsstop -->
+<!-- prettier-ignore-stop -->
 
 ## Developer notes
 


### PR DESCRIPTION
Some of the build-tools readme content is autogenerated by oclif. This PR ignores the generated content with prettierignore comments so that formatting doesn't touch the generated content.