### PR TITLE
Fixed bug - RefreshLatestSummaryAck can end up updating wrong latest reference sequence number

### DIFF
--- a/api-report/runtime-utils.api.md
+++ b/api-report/runtime-utils.api.md
@@ -109,8 +109,10 @@ export interface ISummarizerNodeRootContract {
     clearSummary(): void;
     // (undocumented)
     completeSummary(proposalHandle: string): void;
+    // Warning: (ae-forgotten-export) The symbol "IFetchSnapshotResult" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    refreshLatestSummary(proposalHandle: string | undefined, summaryRefSeq: number, getSnapshot: () => Promise<ISnapshotTree>, readAndParseBlob: ReadAndParseBlob, correlatedSummaryLogger: ITelemetryLogger): Promise<RefreshSummaryResult>;
+    refreshLatestSummary(proposalHandle: string | undefined, summaryRefSeq: number, getSnapshot: () => Promise<IFetchSnapshotResult>, readAndParseBlob: ReadAndParseBlob, correlatedSummaryLogger: ITelemetryLogger): Promise<RefreshSummaryResult>;
     // (undocumented)
     startSummary(referenceSequenceNumber: number, summaryLogger: ITelemetryLogger): void;
 }
@@ -144,10 +146,12 @@ export type RefreshSummaryResult = {
 } | {
     latestSummaryUpdated: true;
     wasSummaryTracked: true;
+    summaryRefSeq: number;
 } | {
     latestSummaryUpdated: true;
     wasSummaryTracked: false;
-    snapshot: ISnapshotTree;
+    snapshotTree: ISnapshotTree;
+    summaryRefSeq: number;
 };
 
 // @public (undocumented)

--- a/api-report/runtime-utils.api.md
+++ b/api-report/runtime-utils.api.md
@@ -95,6 +95,14 @@ export function getBlobSize(content: ISummaryBlob["content"]): number;
 // @public (undocumented)
 export function getNormalizedObjectStoragePathParts(path: string): string[];
 
+// @public
+export interface IFetchSnapshotResult {
+    // (undocumented)
+    snapshotRefSeq: number;
+    // (undocumented)
+    snapshotTree: ISnapshotTree;
+}
+
 // @public (undocumented)
 export interface IRootSummarizerNode extends ISummarizerNode, ISummarizerNodeRootContract {
 }
@@ -109,10 +117,8 @@ export interface ISummarizerNodeRootContract {
     clearSummary(): void;
     // (undocumented)
     completeSummary(proposalHandle: string): void;
-    // Warning: (ae-forgotten-export) The symbol "IFetchSnapshotResult" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
-    refreshLatestSummary(proposalHandle: string | undefined, summaryRefSeq: number, getSnapshot: () => Promise<IFetchSnapshotResult>, readAndParseBlob: ReadAndParseBlob, correlatedSummaryLogger: ITelemetryLogger): Promise<RefreshSummaryResult>;
+    refreshLatestSummary(proposalHandle: string | undefined, summaryRefSeq: number, fetchLatestSnapshot: () => Promise<IFetchSnapshotResult>, readAndParseBlob: ReadAndParseBlob, correlatedSummaryLogger: ITelemetryLogger): Promise<RefreshSummaryResult>;
     // (undocumented)
     startSummary(referenceSequenceNumber: number, summaryLogger: ITelemetryLogger): void;
 }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -102,6 +102,7 @@ import {
 	seqFromTree,
 	calculateStats,
 	TelemetryContext,
+	ReadAndParseBlob,
 } from "@fluidframework/runtime-utils";
 import { GCDataBuilder, trimLeadingAndTrailingSlashes } from "@fluidframework/garbage-collector";
 import { v4 as uuid } from "uuid";
@@ -2983,17 +2984,16 @@ export class ContainerRuntime
 		// It should only be done by the summarizerNode, if required.
 		// When fetching from storage we will always get the latest version and do not use the ackHandle.
 		const snapshotTreeFetcher = async () => {
-			const fetchResult = await this.fetchLatestSnapshotFromStorage(summaryLogger, {
-				eventName: "RefreshLatestSummaryGetSnapshot",
-				ackHandle,
-				summaryRefSeq,
-				fetchLatest: true,
-			});
-
-			const latestSnapshotRefSeq = await seqFromTree(
-				fetchResult.snapshotTree,
+			const fetchResult = await this.fetchLatestSnapshotFromStorage(
+				summaryLogger,
+				{
+					eventName: "RefreshLatestSummaryAckFetch",
+					ackHandle,
+					targetSequenceNumber: summaryRefSeq,
+				},
 				readAndParseBlob,
 			);
+
 			/**
 			 * If the fetched snapshot is older than the one for which the ack was received, close the container.
 			 * This should never happen because an ack should be sent after the latest summary is updated in the server.
@@ -3004,7 +3004,7 @@ export class ContainerRuntime
 			 * such cases, the file will be rolled back along with the ack and we will eventually reach a consistent
 			 * state.
 			 */
-			if (latestSnapshotRefSeq < summaryRefSeq) {
+			if (fetchResult.latestSnapshotRefSeq < summaryRefSeq) {
 				const error = DataProcessingError.create(
 					"Fetched snapshot is older than the received ack",
 					"RefreshLatestSummaryAck",
@@ -3012,25 +3012,24 @@ export class ContainerRuntime
 					{
 						ackHandle,
 						summaryRefSeq,
-						latestSnapshotRefSeq,
+						latestSnapshotRefSeq: fetchResult.latestSnapshotRefSeq,
 					},
 				);
 				this.closeFn(error);
 				throw error;
 			}
 
-			summaryLogger.sendTelemetryEvent({
-				eventName: "LatestSummaryRetrieved",
-				ackHandle,
-				lastSequenceNumber: latestSnapshotRefSeq,
-				targetSequenceNumber: summaryRefSeq,
-			});
-
 			// In case we had to retrieve the latest snapshot and it is different than summaryRefSeq,
 			// wait for the delta manager to catch up before refreshing the latest Summary.
-			await this.waitForDeltaManagerToCatchup(latestSnapshotRefSeq, summaryLogger);
+			await this.waitForDeltaManagerToCatchup(
+				fetchResult.latestSnapshotRefSeq,
+				summaryLogger,
+			);
 
-			return fetchResult.snapshotTree;
+			return {
+				snapshotTree: fetchResult.snapshotTree,
+				snapshotRefSeq: fetchResult.latestSnapshotRefSeq,
+			};
 		};
 
 		const result = await this.summarizerNode.refreshLatestSummary(
@@ -3042,12 +3041,7 @@ export class ContainerRuntime
 		);
 
 		// Notify the garbage collector so it can update its latest summary state.
-		await this.garbageCollector.refreshLatestSummary(
-			result,
-			proposalHandle,
-			summaryRefSeq,
-			readAndParseBlob,
-		);
+		await this.garbageCollector.refreshLatestSummary(proposalHandle, result, readAndParseBlob);
 	}
 
 	/**
@@ -3059,30 +3053,29 @@ export class ContainerRuntime
 	private async refreshLatestSummaryAckFromServer(
 		summaryLogger: ITelemetryLogger,
 	): Promise<{ latestSnapshotRefSeq: number; latestSnapshotVersionId: string | undefined }> {
-		const { snapshotTree, versionId } = await this.fetchLatestSnapshotFromStorage(
-			summaryLogger,
-			{
-				eventName: "RefreshLatestSummaryGetSnapshot",
-				fetchLatest: true,
-			},
-		);
-
 		const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
-		const latestSnapshotRefSeq = await seqFromTree(snapshotTree, readAndParseBlob);
-
+		const { snapshotTree, versionId, latestSnapshotRefSeq } =
+			await this.fetchLatestSnapshotFromStorage(
+				summaryLogger,
+				{
+					eventName: "RefreshLatestSummaryFromServerFetch",
+				},
+				readAndParseBlob,
+			);
 		const result = await this.summarizerNode.refreshLatestSummary(
-			undefined,
+			undefined /* proposalHandle */,
 			latestSnapshotRefSeq,
-			async () => snapshotTree,
+			async () => {
+				return { snapshotTree, snapshotRefSeq: latestSnapshotRefSeq };
+			},
 			readAndParseBlob,
 			summaryLogger,
 		);
 
 		// Notify the garbage collector so it can update its latest summary state.
 		await this.garbageCollector.refreshLatestSummary(
+			undefined /* proposalHandle */,
 			result,
-			undefined,
-			latestSnapshotRefSeq,
 			readAndParseBlob,
 		);
 
@@ -3092,7 +3085,9 @@ export class ContainerRuntime
 	private async fetchLatestSnapshotFromStorage(
 		logger: ITelemetryLogger,
 		event: ITelemetryGenericEvent,
-	): Promise<{ snapshotTree: ISnapshotTree; versionId: string }> {
+		readAndParseBlob: ReadAndParseBlob,
+		versionId?: string,
+	): Promise<{ snapshotTree: ISnapshotTree; versionId: string; latestSnapshotRefSeq: number }> {
 		return PerformanceEvent.timedExecAsync(
 			logger,
 			event,
@@ -3100,13 +3095,20 @@ export class ContainerRuntime
 				end: (arg0: {
 					getVersionDuration?: number | undefined;
 					getSnapshotDuration?: number | undefined;
+					snapshotRefSeq?: number | undefined;
+					snapshotVersion?: string | undefined;
 				}) => void;
 			}) => {
-				const stats: { getVersionDuration?: number; getSnapshotDuration?: number } = {};
+				const stats: {
+					getVersionDuration?: number;
+					getSnapshotDuration?: number;
+					snapshotRefSeq?: number;
+					snapshotVersion?: string;
+				} = {};
 				const trace = Trace.start();
 
 				const versions = await this.storage.getVersions(
-					null,
+					versionId ?? null,
 					1,
 					"refreshLatestSummaryAckFromServer",
 					FetchSource.noCache,
@@ -3120,9 +3122,16 @@ export class ContainerRuntime
 				const maybeSnapshot = await this.storage.getSnapshotTree(versions[0]);
 				assert(!!maybeSnapshot, 0x138 /* "Failed to get snapshot from storage" */);
 				stats.getSnapshotDuration = trace.trace().duration;
+				const latestSnapshotRefSeq = await seqFromTree(maybeSnapshot, readAndParseBlob);
+				stats.snapshotRefSeq = latestSnapshotRefSeq;
+				stats.snapshotVersion = versions[0].id;
 
 				perfEvent.end(stats);
-				return { snapshotTree: maybeSnapshot, versionId: versions[0].id };
+				return {
+					snapshotTree: maybeSnapshot,
+					versionId: versions[0].id,
+					latestSnapshotRefSeq,
+				};
 			},
 		);
 	}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3089,7 +3089,6 @@ export class ContainerRuntime
 		logger: ITelemetryLogger,
 		event: ITelemetryGenericEvent,
 		readAndParseBlob: ReadAndParseBlob,
-		versionId?: string,
 	): Promise<{ snapshotTree: ISnapshotTree; versionId: string; latestSnapshotRefSeq: number }> {
 		return PerformanceEvent.timedExecAsync(
 			logger,
@@ -3111,7 +3110,7 @@ export class ContainerRuntime
 				const trace = Trace.start();
 
 				const versions = await this.storage.getVersions(
-					versionId ?? null,
+					null,
 					1,
 					"refreshLatestSummaryAckFromServer",
 					FetchSource.noCache,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -93,6 +93,7 @@ import {
 	addSummarizeResultToSummary,
 	addTreeToSummary,
 	createRootSummarizerNodeWithGC,
+	IFetchSnapshotResult,
 	IRootSummarizerNodeWithGC,
 	RequestParser,
 	create404Response,
@@ -2983,7 +2984,7 @@ export class ContainerRuntime
 		// The call to fetch the snapshot is very expensive and not always needed.
 		// It should only be done by the summarizerNode, if required.
 		// When fetching from storage we will always get the latest version and do not use the ackHandle.
-		const snapshotTreeFetcher = async () => {
+		const fetchLatestSnapshot: () => Promise<IFetchSnapshotResult> = async () => {
 			const fetchResult = await this.fetchLatestSnapshotFromStorage(
 				summaryLogger,
 				{
@@ -3035,7 +3036,7 @@ export class ContainerRuntime
 		const result = await this.summarizerNode.refreshLatestSummary(
 			proposalHandle,
 			summaryRefSeq,
-			snapshotTreeFetcher,
+			fetchLatestSnapshot,
 			readAndParseBlob,
 			summaryLogger,
 		);
@@ -3062,12 +3063,14 @@ export class ContainerRuntime
 				},
 				readAndParseBlob,
 			);
+		const fetchLatestSnapshot: IFetchSnapshotResult = {
+			snapshotTree,
+			snapshotRefSeq: latestSnapshotRefSeq,
+		};
 		const result = await this.summarizerNode.refreshLatestSummary(
 			undefined /* proposalHandle */,
 			latestSnapshotRefSeq,
-			async () => {
-				return { snapshotTree, snapshotRefSeq: latestSnapshotRefSeq };
-			},
+			async () => fetchLatestSnapshot,
 			readAndParseBlob,
 			summaryLogger,
 		);

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -1629,11 +1629,11 @@ describe("Garbage Collection Tests", () => {
 			const refreshSummaryResult: RefreshSummaryResult = {
 				latestSummaryUpdated: true,
 				wasSummaryTracked: true,
+				summaryRefSeq: 0,
 			};
 			await garbageCollector.refreshLatestSummary(
-				refreshSummaryResult,
 				undefined,
-				0,
+				refreshSummaryResult,
 				parseNothing,
 			);
 
@@ -2224,9 +2224,8 @@ describe("Garbage Collection Tests", () => {
 			checkGCSummaryType(tree1, SummaryType.Tree, "first");
 
 			await garbageCollector.refreshLatestSummary(
-				{ wasSummaryTracked: true, latestSummaryUpdated: true },
 				undefined,
-				0,
+				{ wasSummaryTracked: true, latestSummaryUpdated: true, summaryRefSeq: 0 },
 				parseNothing,
 			);
 

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -102,6 +102,11 @@
 		"previousVersionStyle": "~previousMinor",
 		"baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
 		"baselineVersion": "2.0.0-internal.3.0.0",
-		"broken": {}
+		"broken": {
+			"TypeAliasDeclaration_RefreshSummaryResult": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/runtime-utils/src/index.ts
+++ b/packages/runtime/runtime-utils/src/index.ts
@@ -21,6 +21,7 @@ export { RuntimeFactoryHelper } from "./runtimeFactoryHelper";
 export {
 	createRootSummarizerNode,
 	createRootSummarizerNodeWithGC,
+	IFetchSnapshotResult,
 	IRootSummarizerNode,
 	IRootSummarizerNodeWithGC,
 	ISummarizerNodeRootContract,

--- a/packages/runtime/runtime-utils/src/summarizerNode/index.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/index.ts
@@ -3,6 +3,10 @@
  * Licensed under the MIT License.
  */
 
-export { ISummarizerNodeRootContract, RefreshSummaryResult } from "./summarizerNodeUtils";
+export {
+	IFetchSnapshotResult,
+	ISummarizerNodeRootContract,
+	RefreshSummaryResult,
+} from "./summarizerNodeUtils";
 export { IRootSummarizerNode, createRootSummarizerNode } from "./summarizerNode";
 export { IRootSummarizerNodeWithGC, createRootSummarizerNodeWithGC } from "./summarizerNodeWithGc";

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
@@ -26,6 +26,7 @@ import { ReadAndParseBlob } from "../utils";
 import {
 	EscapedPath,
 	ICreateChildDetails,
+	IFetchSnapshotResult,
 	IInitialSummary,
 	ISummarizerNodeRootContract,
 	parseSummaryForSubtrees,
@@ -216,12 +217,11 @@ export class SummarizerNode implements IRootSummarizerNode {
 	/**
 	 * Refreshes the latest summary tracked by this node. If we have a pending summary for the given proposal handle,
 	 * it becomes the latest summary. If the current summary is already ahead (e.g., loaded from a service summary),
-	 * we skip the update. Otherwise, we get the snapshot by calling `getSnapshot` and update latest
-	 * summary based off of that.
+	 * we skip the update. Otherwise, we fetch the latest snapshot and update latest summary based off of that.
 	 *
 	 * @returns A RefreshSummaryResult type which returns information based on the following three scenarios:
 	 *
-	 * 1. The latest summary was not udpated.
+	 * 1. The latest summary was not updated.
 	 *
 	 * 2. The latest summary was updated and the summary corresponding to the params was being tracked.
 	 *
@@ -231,7 +231,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 	public async refreshLatestSummary(
 		proposalHandle: string | undefined,
 		summaryRefSeq: number,
-		getSnapshot: () => Promise<ISnapshotTree>,
+		fetchLatestSnapshot: () => Promise<IFetchSnapshotResult>,
 		readAndParseBlob: ReadAndParseBlob,
 		correlatedSummaryLogger: ITelemetryLogger,
 	): Promise<RefreshSummaryResult> {
@@ -250,7 +250,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 					proposalHandle,
 					maybeSummaryNode.referenceSequenceNumber,
 				);
-				return { latestSummaryUpdated: true, wasSummaryTracked: true };
+				return { latestSummaryUpdated: true, wasSummaryTracked: true, summaryRefSeq };
 			}
 
 			const props = {
@@ -265,21 +265,36 @@ export class SummarizerNode implements IRootSummarizerNode {
 			});
 		}
 
-		// If we have seen a summary same or later as the current one, ignore it.
+		// If the summary for which refresh is called is older than the latest tracked summary, ignore it.
 		if (this.referenceSequenceNumber >= summaryRefSeq) {
 			return { latestSummaryUpdated: false };
 		}
 
-		const snapshotTree = await getSnapshot();
+		// Fetch the latest snapshot and refresh state from it. Note that we need to use the reference sequence number
+		// of the fetched snapshot and not the "summaryRefSeq" that was passed in.
+		const { snapshotTree, snapshotRefSeq: fetchedSnapshotRefSeq } = await fetchLatestSnapshot();
+
+		// Possible re-entrancy. We may have updated latest summary state while fetching the snapshot. If the fetched
+		// snapshot is older than the latest tracked summary, ignore it.
+		if (this.referenceSequenceNumber >= fetchedSnapshotRefSeq) {
+			return { latestSummaryUpdated: false };
+		}
+
 		await this.refreshLatestSummaryFromSnapshot(
-			summaryRefSeq,
+			fetchedSnapshotRefSeq,
 			snapshotTree,
 			undefined,
 			EscapedPath.create(""),
 			correlatedSummaryLogger,
 			readAndParseBlob,
 		);
-		return { latestSummaryUpdated: true, wasSummaryTracked: false, snapshot: snapshotTree };
+
+		return {
+			latestSummaryUpdated: true,
+			wasSummaryTracked: false,
+			snapshotTree,
+			summaryRefSeq: fetchedSnapshotRefSeq,
+		};
 	}
 	/**
 	 * Called when we get an ack from the server for a summary we've just sent. Updates the reference state of this node

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
@@ -9,14 +9,14 @@ import { channelsTreeName, ISummaryTreeWithStats } from "@fluidframework/runtime
 import { ReadAndParseBlob } from "../utils";
 
 /**
- * Return value of refreshSummaryAck function. There can be three different scenarios based on the passed params:
+ * Return type of refreshSummaryAck function. There can be three different scenarios based on the passed params:
  *
- * 1. The latest summary was not udpated.
+ * 1. The latest summary was not updated.
  *
  * 2. The latest summary was updated and the summary corresponding to the params was tracked by this client.
  *
  * 3. The latest summary was updated but the summary corresponding to the params was not tracked. In this case, the
- * latest summary is updated based on the downloaded snapshot which is also returned.
+ * latest snapshot is fetched and the latest summary state is updated based on it.
  */
 export type RefreshSummaryResult =
 	| {
@@ -25,12 +25,22 @@ export type RefreshSummaryResult =
 	| {
 			latestSummaryUpdated: true;
 			wasSummaryTracked: true;
+			summaryRefSeq: number;
 	  }
 	| {
 			latestSummaryUpdated: true;
 			wasSummaryTracked: false;
-			snapshot: ISnapshotTree;
+			snapshotTree: ISnapshotTree;
+			summaryRefSeq: number;
 	  };
+
+/**
+ * Result of snapshot fetch during refreshing latest summary state.
+ */
+export interface IFetchSnapshotResult {
+	snapshotTree: ISnapshotTree;
+	snapshotRefSeq: number;
+}
 
 export interface ISummarizerNodeRootContract {
 	startSummary(referenceSequenceNumber: number, summaryLogger: ITelemetryLogger): void;
@@ -39,7 +49,7 @@ export interface ISummarizerNodeRootContract {
 	refreshLatestSummary(
 		proposalHandle: string | undefined,
 		summaryRefSeq: number,
-		getSnapshot: () => Promise<ISnapshotTree>,
+		getSnapshot: () => Promise<IFetchSnapshotResult>,
 		readAndParseBlob: ReadAndParseBlob,
 		correlatedSummaryLogger: ITelemetryLogger,
 	): Promise<RefreshSummaryResult>;

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
@@ -49,7 +49,7 @@ export interface ISummarizerNodeRootContract {
 	refreshLatestSummary(
 		proposalHandle: string | undefined,
 		summaryRefSeq: number,
-		getSnapshot: () => Promise<IFetchSnapshotResult>,
+		fetchLatestSnapshot: () => Promise<IFetchSnapshotResult>,
 		readAndParseBlob: ReadAndParseBlob,
 		correlatedSummaryLogger: ITelemetryLogger,
 	): Promise<RefreshSummaryResult>;

--- a/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
@@ -19,11 +19,13 @@ import {
 } from "@fluidframework/runtime-definitions";
 import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 
-import { createRootSummarizerNode, IRootSummarizerNode } from "../summarizerNode";
+import {
+	createRootSummarizerNode,
+	IFetchSnapshotResult,
+	IRootSummarizerNode,
+} from "../summarizerNode";
 // eslint-disable-next-line import/no-internal-modules
 import { SummarizerNode } from "../summarizerNode/summarizerNode";
-// eslint-disable-next-line import/no-internal-modules
-import { IFetchSnapshotResult } from "../summarizerNode/summarizerNodeUtils";
 import { mergeStats } from "../summaryUtils";
 
 describe("Runtime", () => {
@@ -175,7 +177,7 @@ describe("Runtime", () => {
 
 			// The reference sequence number of the fetched snapshot.
 			let snapshotRefSeq = summaryRefSeq;
-			const fetchSnapshot: () => Promise<IFetchSnapshotResult> = async () => {
+			const fetchLatestSnapshot: () => Promise<IFetchSnapshotResult> = async () => {
 				return {
 					snapshotTree: simpleSnapshot,
 					snapshotRefSeq,
@@ -352,7 +354,7 @@ describe("Runtime", () => {
 					const result = await rootNode.refreshLatestSummary(
 						undefined,
 						summaryRefSeq,
-						fetchSnapshot,
+						fetchLatestSnapshot,
 						readAndParseBlob,
 						logger,
 					);
@@ -371,7 +373,7 @@ describe("Runtime", () => {
 					const result = await rootNode.refreshLatestSummary(
 						undefined,
 						summaryRefSeq,
-						fetchSnapshot,
+						fetchLatestSnapshot,
 						readAndParseBlob,
 						logger,
 					);
@@ -389,7 +391,7 @@ describe("Runtime", () => {
 					const result = await rootNode.refreshLatestSummary(
 						"test-handle",
 						summaryRefSeq,
-						fetchSnapshot,
+						fetchLatestSnapshot,
 						readAndParseBlob,
 						logger,
 					);
@@ -407,7 +409,7 @@ describe("Runtime", () => {
 					const result = await rootNode.refreshLatestSummary(
 						undefined,
 						summaryRefSeq,
-						fetchSnapshot,
+						fetchLatestSnapshot,
 						readAndParseBlob,
 						logger,
 					);
@@ -425,7 +427,7 @@ describe("Runtime", () => {
 					const result = await rootNode.refreshLatestSummary(
 						proposalHandle,
 						summaryRefSeq,
-						fetchSnapshot,
+						fetchLatestSnapshot,
 						readAndParseBlob,
 						logger,
 					);

--- a/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
@@ -647,6 +647,7 @@ declare function get_old_TypeAliasDeclaration_RefreshSummaryResult():
 declare function use_current_TypeAliasDeclaration_RefreshSummaryResult(
     use: TypeOnly<current.RefreshSummaryResult>);
 use_current_TypeAliasDeclaration_RefreshSummaryResult(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_RefreshSummaryResult());
 
 /*
@@ -659,6 +660,7 @@ declare function get_current_TypeAliasDeclaration_RefreshSummaryResult():
 declare function use_old_TypeAliasDeclaration_RefreshSummaryResult(
     use: TypeOnly<old.RefreshSummaryResult>);
 use_old_TypeAliasDeclaration_RefreshSummaryResult(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_RefreshSummaryResult());
 
 /*


### PR DESCRIPTION
## Bug
When refreshLatestSummaryAck is called, if pending state corresponding to the ack is not found, the latest summary is downloaded. This change was made fairly recently - [Proposal - refreshLatestSummaryAck's fetchSnapshotFromStorage always retrieving the latest summary by NicholasCouri · Pull Request #12313 · microsoft/FluidFramework (github.com)](https://github.com/microsoft/FluidFramework/pull/12313).

This means that the snapshot that is downloaded may have a reference sequence number (fetchedSummaryRefSeq) that is greater than the ack's (summaryRefSeq). However, the latest summary reference sequence number of summarizer nodes and GC is updated to summaryRefSeq which can lead to inconsitent state and future summaries may be incorrect.

## Fix
After the latest snapshot is downloaded, use the reference sequence number of this snapshot to update the state of the summarizer nodes and GC.

## Telemetry Improvements
Made a couple of improvements to the refresh latest summary telemetry:
- Renamed the telemetry to distinguish between refreshLatestSummaryAck and refreshLatestSummaryAckFromServer. This will help in analyzing logs.
- Added the reference sequence number and version of the downloaded summary which was missing when snapshot was downloaded for refreshLatestSummaryAckFromServer.

[AB#3412](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3412)