### PR TITLE
build(docs): Add script to check for broken reference links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -346,8 +346,12 @@ The following npm scripts are supported in this directory:
 | `download` | Download and extract the API JSON and Playground files locally. |
 | `download:api` | Download and extract the API JSON files locally. |
 | `hugo` | Run the local copy of Hugo. |
-| `linkcheck` | `npm run linkcheck:fast -- --external` |
-| `linkcheck:fast` | `linkcheck http://localhost:1313 --skip-file skipped-urls.txt` |
+| `linkcheck` | Starts a local webserver and runs `linkcheck:full` against it. |
+| `linkcheck:fast` | Checks all internal site links and reports the results to the terminal. |
+| `linkcheck:full` | Checks all internal _and external_ site links and reports the results to the terminal. |
+| `linkcheck:reflinks` | Checks the `public` folder for HTML files with broken MarkDown reference links. |
+| `linkcheck:reflinks:default` | --- |
+| `linkcheck:reflinks:win32` | --- |
 | `lint` | `markdownlint-cli2` |
 | `lint:fix` | `markdownlint-cli2-fix` |
 | `start` | Start a local webserver to preview the built site on <http://localhost:1313> |

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -518,6 +518,15 @@
       "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.28.tgz",
       "integrity": "sha512-p8zph8Tflh6KUirDCVOti8tr/BhngQx9Z6QXSKBJgPTZMxiKmP6eF75AKDopUeffp7X80Vdo48nv4kdW9d73Dg=="
     },
+    "@vscode/ripgrep": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.14.2.tgz",
+      "integrity": "sha512-KDaehS8Jfdg1dqStaIPDKYh66jzKd5jy5aYEPzIv0JYFLADPsCSQPBUdsJVXnr0t72OlDcj96W05xt/rSnNFFQ==",
+      "requires": {
+        "https-proxy-agent": "^5.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "@zeit/schemas": {
       "version": "2.21.0",
       "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.21.0.tgz",
@@ -555,7 +564,15 @@
     "addressparser": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
-      "integrity": "sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y="
+      "integrity": "sha512-aQX7AISOMM7HFE0iZ3+YnD07oIeJqWGVnJ+ZIKaBZAk03ftmVYVqsGas/rbXKR21n4D/hKCSHypvcyOkds/xzg=="
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -2933,6 +2950,15 @@
         "resolve-alpn": "^1.0.0"
       }
     },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
     "hugo-extended": {
       "version": "0.93.1",
       "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.93.1.tgz",
@@ -4825,6 +4851,11 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -5210,6 +5241,11 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
+    },
+    "run-script-os": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.6.tgz",
+      "integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw=="
     },
     "rxjs": {
       "version": "6.6.7",

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,6 +28,10 @@
     "hugo": "hugo",
     "linkcheck": "npm run linkcheck:fast -- --external",
     "linkcheck:fast": "linkcheck http://localhost:1313 --skip-file skipped-urls.txt",
+    "linkcheck:full": "npm run linkcheck:fast -- --external",
+    "linkcheck:reflinks": "run-script-os",
+    "linkcheck:reflinks:default": "./node_modules/@vscode/ripgrep/bin/rg '\\[[\\w\\s]+\\]\\[.*?\\]' public --type=html",
+    "linkcheck:reflinks:win32": "./node_modules/@vscode/ripgrep/bin/rg.exe '\\[[\\w\\s]+\\]\\[.*?\\]' public --type=html",
     "lint": "markdownlint-cli2",
     "lint:fix": "markdownlint-cli2-fix",
     "start": "hugo server"
@@ -38,6 +42,7 @@
     "@tylerbu/dl-cli": "1.1.2-tylerbu-0",
     "@tylerbu/markdown-magic": "^2.4.0-tylerbu-1",
     "@vscode/codicons": "0.0.28",
+    "@vscode/ripgrep": "^1.14.2",
     "broken-link-checker": "^0.7.8",
     "chalk": "^2.4.2",
     "concurrently": "^6.2.0",
@@ -58,6 +63,7 @@
     "node-fetch": "^2.6.7",
     "replace-in-file": "^6.2.0",
     "rimraf": "^2.6.2",
+    "run-script-os": "^1.1.6",
     "serve": "^14.1.2",
     "shelljs": "^0.8.5"
   }


### PR DESCRIPTION
Reference links in Markdown can be broken if their reference is missing. For example, consider this Markdown:

```md
A [reference link][].

[reference link]: http://example.com
```

If the last line is missing in the markdown, then the text will be rendered as-is. That is, the rendered HTML will have `A [reference link][]` in it. This is called a broken reference link, and it's not caught by our broken link checker because it looks like text to the link checker (because it _is_ text :)).

This PR uses ripgrep to search the rendered HTML for signs of a broken reflink. It's not run in CI or anything yet, because there may be false positives. For now it's just a script you can run manually.