### PR TITLE
Added telemetry that will help identify issues during summarization

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -105,7 +105,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         logger?: ITelemetryLogger;
         runSweep?: boolean;
         fullGC?: boolean;
-    }): Promise<IGCStats | undefined>;
+    }, telemetryContext?: ITelemetryContext): Promise<IGCStats | undefined>;
     // (undocumented)
     get connected(): boolean;
     // (undocumented)

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -427,6 +427,7 @@ export interface ITelemetryContext {
     get(prefix: string, property: string): TelemetryEventPropertyType;
     serialize(): string;
     set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
+    setAll(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
 }
 
 // @public

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -367,6 +367,7 @@ export interface ISummarizerNode {
     // (undocumented)
     getChild(id: string): ISummarizerNode | undefined;
     invalidate(sequenceNumber: number): void;
+    isSummaryInProgress?(): boolean;
     recordChange(op: ISequencedDocumentMessage): void;
     readonly referenceSequenceNumber: number;
     summarize(fullTree: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummarizeResult>;

--- a/api-report/runtime-utils.api.md
+++ b/api-report/runtime-utils.api.md
@@ -229,6 +229,8 @@ export class TelemetryContext implements ITelemetryContext {
     serialize(): string;
     // (undocumented)
     set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
+    // (undocumented)
+    setAll(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
 }
 
 // @public (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2303,11 +2303,13 @@ export class ContainerRuntime
 
 		const telemetryContext = new TelemetryContext();
 		// Add the options that are used to generate this summary to the telemetry context.
-		telemetryContext.set(
-			"fluid_Summarize",
-			"Options",
-			JSON.stringify({ fullTree, trackState, runGC, fullGC, runSweep }),
-		);
+		telemetryContext.setAll("fluid_Summarize", "Options", {
+			fullTree,
+			trackState,
+			runGC,
+			fullGC,
+			runSweep,
+		});
 
 		let gcStats: IGCStats | undefined;
 		if (runGC) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2301,12 +2301,22 @@ export class ContainerRuntime
 			fullGC,
 		} = options;
 
+		const telemetryContext = new TelemetryContext();
+		// Add the options that are used to generate this summary to the telemetry context.
+		telemetryContext.set(
+			"fluid_Summarize",
+			"Options",
+			JSON.stringify({ fullTree, trackState, runGC, fullGC, runSweep }),
+		);
+
 		let gcStats: IGCStats | undefined;
 		if (runGC) {
-			gcStats = await this.collectGarbage({ logger: summaryLogger, runSweep, fullGC });
+			gcStats = await this.collectGarbage(
+				{ logger: summaryLogger, runSweep, fullGC },
+				telemetryContext,
+			);
 		}
 
-		const telemetryContext = new TelemetryContext();
 		const { stats, summary } = await this.summarizerNode.summarize(
 			fullTree,
 			trackState,
@@ -2477,15 +2487,18 @@ export class ContainerRuntime
 	 * Runs garbage collection and updates the reference / used state of the nodes in the container.
 	 * @returns the statistics of the garbage collection run; undefined if GC did not run.
 	 */
-	public async collectGarbage(options: {
-		/** Logger to use for logging GC events */
-		logger?: ITelemetryLogger;
-		/** True to run GC sweep phase after the mark phase */
-		runSweep?: boolean;
-		/** True to generate full GC data */
-		fullGC?: boolean;
-	}): Promise<IGCStats | undefined> {
-		return this.garbageCollector.collectGarbage(options);
+	public async collectGarbage(
+		options: {
+			/** Logger to use for logging GC events */
+			logger?: ITelemetryLogger;
+			/** True to run GC sweep phase after the mark phase */
+			runSweep?: boolean;
+			/** True to generate full GC data */
+			fullGC?: boolean;
+		},
+		telemetryContext?: ITelemetryContext,
+	): Promise<IGCStats | undefined> {
+		return this.garbageCollector.collectGarbage(options, telemetryContext);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -397,7 +397,6 @@ export abstract class FluidDataStoreContext
 						value: JSON.stringify(this.pkg),
 						tag: TelemetryDataTag.CodeArtifact,
 					},
-					stack: generateStack(),
 				});
 				this.channelDeferred?.reject(errorWrapped);
 				this.logger.sendErrorEvent({ eventName: "RealizeError" }, errorWrapped);

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -50,7 +50,11 @@ import {
 	SummarizeInternalFn,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions";
-import { addBlobToSummary, convertSummaryTreeToITree } from "@fluidframework/runtime-utils";
+import {
+	addBlobToSummary,
+	convertSummaryTreeToITree,
+	packagePathToTelemetryProperty,
+} from "@fluidframework/runtime-utils";
 import {
 	ChildLogger,
 	generateStack,
@@ -372,10 +376,7 @@ export abstract class FluidDataStoreContext
 	): never {
 		throw new LoggingError(reason, {
 			failedPkgPath: { value: failedPkgPath, tag: TelemetryDataTag.CodeArtifact },
-			packageName: {
-				value: JSON.stringify(fullPackageName),
-				tag: TelemetryDataTag.CodeArtifact,
-			},
+			fullPackageName: packagePathToTelemetryProperty(fullPackageName),
 		});
 	}
 
@@ -393,10 +394,7 @@ export abstract class FluidDataStoreContext
 						value: this.id,
 						tag: TelemetryDataTag.CodeArtifact,
 					},
-					packageName: {
-						value: JSON.stringify(this.pkg),
-						tag: TelemetryDataTag.CodeArtifact,
-					},
+					packageName: packagePathToTelemetryProperty(this.pkg),
 				});
 				this.channelDeferred?.reject(errorWrapped);
 				this.logger.sendErrorEvent({ eventName: "RealizeError" }, errorWrapped);
@@ -903,10 +901,7 @@ export abstract class FluidDataStoreContext
 					value: this.id,
 					tag: TelemetryDataTag.CodeArtifact,
 				},
-				packageName: {
-					value: JSON.stringify(this.pkg),
-					tag: TelemetryDataTag.CodeArtifact,
-				},
+				packageName: packagePathToTelemetryProperty(this.pkg),
 				isSummaryInProgress: this.summarizerNode.isSummaryInProgress?.(),
 				stack: generateStack(),
 			});

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -1042,11 +1042,7 @@ export class GarbageCollector implements IGarbageCollector {
 		}
 
 		// Add the options that are used to run GC to the telemetry context.
-		telemetryContext?.set(
-			"fluid_GC",
-			"Options",
-			JSON.stringify({ fullGC, runSweep: options.runSweep }),
-		);
+		telemetryContext?.setAll("fluid_GC", "Options", { fullGC, runSweep: options.runSweep });
 
 		return PerformanceEvent.timedExecAsync(
 			logger,

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -156,11 +156,14 @@ export interface IGarbageCollector {
 	/** Initialize the state from the base snapshot after its creation. */
 	initializeBaseState(): Promise<void>;
 	/** Run garbage collection and update the reference / used state of the system. */
-	collectGarbage(options: {
-		logger?: ITelemetryLogger;
-		runSweep?: boolean;
-		fullGC?: boolean;
-	}): Promise<IGCStats | undefined>;
+	collectGarbage(
+		options: {
+			logger?: ITelemetryLogger;
+			runSweep?: boolean;
+			fullGC?: boolean;
+		},
+		telemetryContext?: ITelemetryContext,
+	): Promise<IGCStats | undefined>;
 	/** Summarizes the GC data and returns it as a summary tree. */
 	summarize(
 		fullTree: boolean,
@@ -1001,14 +1004,17 @@ export class GarbageCollector implements IGarbageCollector {
 	 * Runs garbage collection and updates the reference / used state of the nodes in the container.
 	 * @returns stats of the GC run or undefined if GC did not run.
 	 */
-	public async collectGarbage(options: {
-		/** Logger to use for logging GC events */
-		logger?: ITelemetryLogger;
-		/** True to run GC sweep phase after the mark phase */
-		runSweep?: boolean;
-		/** True to generate full GC data */
-		fullGC?: boolean;
-	}): Promise<IGCStats | undefined> {
+	public async collectGarbage(
+		options: {
+			/** Logger to use for logging GC events */
+			logger?: ITelemetryLogger;
+			/** True to run GC sweep phase after the mark phase */
+			runSweep?: boolean;
+			/** True to generate full GC data */
+			fullGC?: boolean;
+		},
+		telemetryContext?: ITelemetryContext,
+	): Promise<IGCStats | undefined> {
 		const fullGC =
 			options.fullGC ?? (this.gcOptions.runFullGC === true || this.summaryStateNeedsReset);
 		const logger = options.logger
@@ -1034,6 +1040,13 @@ export class GarbageCollector implements IGarbageCollector {
 			});
 			return undefined;
 		}
+
+		// Add the options that are used to run GC to the telemetry context.
+		telemetryContext?.set(
+			"fluid_GC",
+			"Options",
+			JSON.stringify({ fullGC, runSweep: options.runSweep }),
+		);
 
 		return PerformanceEvent.timedExecAsync(
 			logger,

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -32,6 +32,7 @@ import {
 import {
 	createRootSummarizerNodeWithGC,
 	IRootSummarizerNodeWithGC,
+	packagePathToTelemetryProperty,
 } from "@fluidframework/runtime-utils";
 import { isFluidError, TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import {
@@ -106,6 +107,7 @@ describe("Data Store Context Tests", () => {
 				IFluidDataStoreRegistry: registry,
 				on: (event, listener) => {},
 				logger: new TelemetryNullLogger(),
+				clientDetails: {},
 			} as ContainerRuntime;
 		});
 
@@ -131,9 +133,10 @@ describe("Data Store Context Tests", () => {
 			});
 
 			it("Errors thrown during realize are wrapped as DataProcessingError", async () => {
+				const fullPackageName = ["BOGUS1", "BOGUS2"];
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
-					pkg: ["BOGUS"], // This will cause an error when calling `realizeCore`
+					pkg: fullPackageName, // This will cause an error when calling `realizeCore`
 					runtime: containerRuntime,
 					storage,
 					scope,
@@ -154,10 +157,15 @@ describe("Data Store Context Tests", () => {
 						"Error should be a DataProcessingError",
 					);
 					const props = e.getTelemetryProperties();
+					assert.strictEqual(
+						(props.fullPackageName as ITaggedTelemetryPropertyType)?.value,
+						packagePathToTelemetryProperty(fullPackageName)?.value,
+						"The error should have the full package name in its telemetry properties",
+					);
 					assert.equal(
-						(props.packageName as ITaggedTelemetryPropertyType)?.value,
-						"BOGUS",
-						"The error should have the packageName in its telemetry properties",
+						(props.failedPkgPath as ITaggedTelemetryPropertyType)?.value,
+						"BOGUS1",
+						"The error should have the failed package path in its telemetry properties",
 					);
 					assert.equal(
 						(props.fluidDataStoreId as ITaggedTelemetryPropertyType)?.value,
@@ -256,6 +264,7 @@ describe("Data Store Context Tests", () => {
 				containerRuntime = {
 					IFluidDataStoreRegistry: registryWithSubRegistries,
 					on: (event, listener) => {},
+					clientDetails: {},
 				} as ContainerRuntime;
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
@@ -450,6 +459,7 @@ describe("Data Store Context Tests", () => {
 			containerRuntime = {
 				IFluidDataStoreRegistry: registry,
 				on: (event, listener) => {},
+				clientDetails: {},
 			} as ContainerRuntime;
 		});
 
@@ -964,6 +974,7 @@ describe("Data Store Context Tests", () => {
 				IFluidDataStoreRegistry: registry,
 				on: (event, listener) => {},
 				logger: new TelemetryNullLogger(),
+				clientDetails: {},
 			} as ContainerRuntime;
 		});
 

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -111,6 +111,7 @@ describe("Data Store Creation Tests", () => {
 				IFluidDataStoreRegistry: globalRegistry,
 				on: (event, listener) => {},
 				logger: new TelemetryNullLogger(),
+				clientDetails: {},
 			} as ContainerRuntime;
 			const summarizerNode = createRootSummarizerNodeWithGC(
 				new TelemetryNullLogger(),

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -61,6 +61,10 @@
 		"previousVersionStyle": "~previousMinor",
 		"baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
 		"baselineVersion": "2.0.0-internal.3.0.0",
-		"broken": {}
+		"broken": {
+			"InterfaceDeclaration_ITelemetryContext": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -329,6 +329,18 @@ export interface ITelemetryContext {
 	set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
 
 	/**
+	 * Sets a set of values for telemetry data being tracked.
+	 * @param prefix - unique prefix to tag this data with (ex: "fluid:summarize:")
+	 * @param property - property name of the telemetry data being tracked (ex: "Options")
+	 * @param values - A set of values to attribute to this summary telemetry data.
+	 */
+	setAll(
+		prefix: string,
+		property: string,
+		values: Record<string, TelemetryEventPropertyType>,
+	): void;
+
+	/**
 	 * Get the telemetry data being tracked
 	 * @param prefix - unique prefix for this data (ex: "fluid:map:")
 	 * @param property - property name of the telemetry data being tracked (ex: "DirectoryCount")

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -229,6 +229,9 @@ export interface ISummarizerNode {
 	): ISummarizerNode;
 
 	getChild(id: string): ISummarizerNode | undefined;
+
+	/** True if a summary is currently in progress */
+	isSummaryInProgress?(): boolean;
 }
 
 /**

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -1103,6 +1103,7 @@ declare function get_old_InterfaceDeclaration_ITelemetryContext():
 declare function use_current_InterfaceDeclaration_ITelemetryContext(
     use: TypeOnly<current.ITelemetryContext>);
 use_current_InterfaceDeclaration_ITelemetryContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ITelemetryContext());
 
 /*

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -106,6 +106,9 @@
 			"TypeAliasDeclaration_RefreshSummaryResult": {
 				"forwardCompat": false,
 				"backCompat": false
+			},
+			"ClassDeclaration_TelemetryContext": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
@@ -89,7 +89,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummarizeResult> {
 		assert(
-			this.isTrackingInProgress(),
+			this.isSummaryInProgress(),
 			0x1a1 /* "summarize should not be called when not tracking the summary" */,
 		);
 		assert(
@@ -589,9 +589,9 @@ export class SummarizerNode implements IRootSummarizerNode {
 	 * @param child - The child node whose state is to be updated.
 	 */
 	protected maybeUpdateChildState(child: SummarizerNode) {
-		// If we are tracking a summary, this child was created after the tracking started. So, we need to update the
-		// child's tracking state as well.
-		if (this.isTrackingInProgress()) {
+		// If a summary is in progress, this child was created after the summary started. So, we need to update the
+		// child's summary state as well.
+		if (this.isSummaryInProgress()) {
 			child.wipReferenceSequenceNumber = this.wipReferenceSequenceNumber;
 		}
 		// In case we have pending summaries on the parent, let's initialize it on the child.
@@ -614,7 +614,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 	/**
 	 * Tells whether summary tracking is in progress. True if "startSummary" API is called before summarize.
 	 */
-	protected isTrackingInProgress(): boolean {
+	public isSummaryInProgress(): boolean {
 		return this.wipReferenceSequenceNumber !== undefined;
 	}
 }

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -164,9 +164,9 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 		trackState: boolean = true,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummarizeResult> {
-		// If GC is not disabled and we are tracking a summary, GC should have run and updated the used routes for this
+		// If GC is not disabled and a summary is in progress, GC should have run and updated the used routes for this
 		// summary by calling updateUsedRoutes which sets wipSerializedUsedRoutes.
-		if (!this.gcDisabled && this.isTrackingInProgress()) {
+		if (!this.gcDisabled && this.isSummaryInProgress()) {
 			assert(
 				this.wipSerializedUsedRoutes !== undefined,
 				0x1b1 /* "wip used routes should be set if tracking a summary" */,
@@ -482,9 +482,9 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 		// are in the same order.
 		this.usedRoutes = usedRoutes.sort();
 
-		// If GC is not disabled and we are tracking a summary, update the work-in-progress used routes so that it can
+		// If GC is not disabled and a summary is in progress, update the work-in-progress used routes so that it can
 		// be tracked for this summary.
-		if (!this.gcDisabled && this.isTrackingInProgress()) {
+		if (!this.gcDisabled && this.isSummaryInProgress()) {
 			this.wipSerializedUsedRoutes = JSON.stringify(this.usedRoutes);
 		}
 	}

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -357,6 +357,20 @@ export class TelemetryContext implements ITelemetryContext {
 	}
 
 	/**
+	 * {@inheritDoc @fluidframework/runtime-definitions#ITelemetryContext.setAll}
+	 */
+	setAll(
+		prefix: string,
+		property: string,
+		values: Record<string, TelemetryEventPropertyType>,
+	): void {
+		// Set the values individually so that they are logged as a flat list along with other properties.
+		for (const key of Object.keys(values)) {
+			this.set(prefix, `${property}_${key}`, values[key]);
+		}
+	}
+
+	/**
 	 * {@inheritDoc @fluidframework/runtime-definitions#ITelemetryContext.get}
 	 */
 	get(prefix: string, property: string): TelemetryEventPropertyType {

--- a/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
@@ -327,13 +327,19 @@ describe("Summary Utils", () => {
 			telemetryContext.set("pre2_", "prop1", "10");
 			telemetryContext.set("pre2_", "prop2", true);
 			telemetryContext.set("pre1_", "prop2", undefined);
+			telemetryContext.setAll("pre3_", "obj1", { prop1: "1", prop2: 2, prop3: true });
 
-			const obj = JSON.parse(telemetryContext.serialize());
+			const serialized = telemetryContext.serialize();
+
+			const obj = JSON.parse(serialized);
 
 			assert.strictEqual(obj.pre1_prop1, 10);
 			assert.strictEqual(obj.pre1_prop2, undefined);
 			assert.strictEqual(obj.pre2_prop1, "10");
 			assert.strictEqual(obj.pre2_prop2, true);
+			assert.strictEqual(obj.pre3_obj1_prop1, "1");
+			assert.strictEqual(obj.pre3_obj1_prop2, 2);
+			assert.strictEqual(obj.pre3_obj1_prop3, true);
 		});
 	});
 });

--- a/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
@@ -817,6 +817,7 @@ declare function get_old_ClassDeclaration_TelemetryContext():
 declare function use_current_ClassDeclaration_TelemetryContext(
     use: TypeOnly<current.TelemetryContext>);
 use_current_ClassDeclaration_TelemetryContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TelemetryContext());
 
 /*


### PR DESCRIPTION
We are seeing a few issues during summarization which are hard to debug with the existing telemetry. This change adds new telemetry or improves existing telemetry to better understand these issues:
1. Added summarize and GC options that are used to run GC / summarize. This will help identify what the expected behavior is based on these options.
2. In the error in DataStoreContext::rejectDeferredRealize, added the full package path. This will help applications understand what packages these errors are seen in and define the next course of actions. For example, if the package path is [A, B, C], the existing error only logs C if say getting C fails. However, this makes it difficult to distinguish from other packages whose paths are something like [B, D, C]. We are seeing this during summarize and it will help us understand what packages are failing.
3. In DataStoreContext::RealizeError added the package path that can help identify which package failed to realize. A lot of times these packages may have been deprecated by apps and the error could indicate that a back-compat fix is missing. This is also happening during summarize.
4. If a local data store context is created or if a data store sends an op in the summarizer client, log a telemetry. This will help us identify how often this is happening and which packages are doing this. The goal is to disallow local changes in summarizer. This telemetry will help us gauge the impact and prepare for this change.