### PR TITLE
build(azure,build-tools): Remove @trivago/prettier-plugin-sort-imports

### DIFF
--- a/azure/lerna-package-lock.json
+++ b/azure/lerna-package-lock.json
@@ -8270,109 +8270,6 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
     },
-    "@trivago/prettier-plugin-sort-imports": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.3.0.tgz",
-      "integrity": "sha512-1y44bVZuIN0RsS3oIiGd5k8Vm3IZXYZnp4VsP2Z/S5L9WAOw43HE2clso66M2S/dDeJ+8sKPqnHsEfh39Vjs3w==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "7.17.8",
-        "@babel/generator": "7.17.7",
-        "@babel/parser": "7.17.8",
-        "@babel/traverse": "7.17.3",
-        "@babel/types": "7.17.0",
-        "javascript-natural-sort": "0.7.1",
-        "lodash": "4.17.21"
-      },
-      "dependencies": {
-        "@babel/core": {
-          "version": "7.17.8",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
-          "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
-          "dev": true,
-          "requires": {
-            "@ampproject/remapping": "^2.1.0",
-            "@babel/code-frame": "^7.16.7",
-            "@babel/generator": "^7.17.7",
-            "@babel/helper-compilation-targets": "^7.17.7",
-            "@babel/helper-module-transforms": "^7.17.7",
-            "@babel/helpers": "^7.17.8",
-            "@babel/parser": "^7.17.8",
-            "@babel/template": "^7.16.7",
-            "@babel/traverse": "^7.17.3",
-            "@babel/types": "^7.17.0",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.2",
-            "json5": "^2.1.2",
-            "semver": "^6.3.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.17.7",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
-          "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.17.0",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.17.8",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-          "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
-          "dev": true
-        },
-        "@babel/traverse": {
-          "version": "7.17.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
-          "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.16.7",
-            "@babel/generator": "^7.17.3",
-            "@babel/helper-environment-visitor": "^7.16.7",
-            "@babel/helper-function-name": "^7.16.7",
-            "@babel/helper-hoist-variables": "^7.16.7",
-            "@babel/helper-split-export-declaration": "^7.16.7",
-            "@babel/parser": "^7.17.3",
-            "@babel/types": "^7.17.0",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.17.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.16.7",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "globals": {
-          "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-          "dev": true
-        }
-      }
-    },
     "@ts-morph/common": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.5.2.tgz",
@@ -17254,12 +17151,6 @@
           }
         }
       }
-    },
-    "javascript-natural-sort": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
-      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
-      "dev": true
     },
     "jest": {
       "version": "26.6.3",

--- a/azure/package.json
+++ b/azure/package.json
@@ -92,7 +92,6 @@
 		"@fluidframework/test-tools": "^0.2.3074",
 		"@microsoft/api-documenter": "^7.17.9",
 		"@microsoft/api-extractor": "^7.22.2",
-		"@trivago/prettier-plugin-sort-imports": "^3.3.0",
 		"c8": "^7.7.1",
 		"concurrently": "^6.2.0",
 		"copyfiles": "^2.4.1",

--- a/azure/prettier.config.cjs
+++ b/azure/prettier.config.cjs
@@ -5,15 +5,4 @@
 
 module.exports = {
 	...require("@fluidframework/build-common/prettier.config.cjs"),
-	plugins: ["@trivago/prettier-plugin-sort-imports"],
-	importOrder: [
-		"^node:(.*)$", // Special-case `node:` imports
-		"<THIRD_PARTY_MODULES>",
-		"^fluid-framework$", // Special match for `fluid-framework` package
-		"^@fluidframework/(.*)$", // Match all `@fluidframework/` packages
-		"^@fluid-(.*?)/(.*)$", // Match other `@fluid-` scoped packages (`@fluid-experimental/`, `@fluid-tools/`, etc.)
-		"^[./]", // Match package-local file imports
-	],
-	importOrderSeparation: true,
-	importOrderSortSpecifiers: true,
 };

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -85,7 +85,6 @@
 		"@fluidframework/test-tools": "^0.2.3074",
 		"@microsoft/api-documenter": "^7.17.9",
 		"@microsoft/api-extractor": "^7.22.2",
-		"@trivago/prettier-plugin-sort-imports": "^3.3.0",
 		"c8": "^7.7.1",
 		"commitizen": "^4.2.5",
 		"concurrently": "^6.2.0",

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -103,7 +103,6 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
-		"@trivago/prettier-plugin-sort-imports": "^3.3.0",
 		"@types/chai": "^4",
 		"@types/chai-arrays": "^2.0.0",
 		"@types/fs-extra": "^8.1.0",

--- a/build-tools/packages/build-cli/prettier.config.cjs
+++ b/build-tools/packages/build-cli/prettier.config.cjs
@@ -5,15 +5,4 @@
 
 module.exports = {
 	...require("@fluidframework/build-common/prettier.config.cjs"),
-	plugins: [require("@trivago/prettier-plugin-sort-imports")],
-	importOrder: [
-		"^node:(.*)$", // Special-case `node:` imports
-		"<THIRD_PARTY_MODULES>",
-		"^fluid-framework$", // Special match for `fluid-framework` package
-		"^@fluidframework/(.*)$", // Match all `@fluidframework/` packages
-		"^@fluid-(.*?)/(.*)$", // Match other `@fluid-` scoped packages (`@fluid-experimental/`, `@fluid-tools/`, etc.)
-		"^[./]", // Match package-local file imports
-	],
-	importOrderSeparation: true,
-	importOrderSortSpecifiers: true,
 };

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -82,7 +82,6 @@
 	"devDependencies": {
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@trivago/prettier-plugin-sort-imports": "^3.3.0",
 		"@types/async": "^3.2.6",
 		"@types/fs-extra": "^8.1.0",
 		"@types/glob": "^7.1.1",

--- a/build-tools/packages/build-tools/prettier.config.cjs
+++ b/build-tools/packages/build-tools/prettier.config.cjs
@@ -5,15 +5,4 @@
 
 module.exports = {
 	...require("@fluidframework/build-common/prettier.config.cjs"),
-	plugins: [require("@trivago/prettier-plugin-sort-imports")],
-	importOrder: [
-		"^node:(.*)$", // Special-case `node:` imports
-		"<THIRD_PARTY_MODULES>",
-		"^fluid-framework$", // Special match for `fluid-framework` package
-		"^@fluidframework/(.*)$", // Match all `@fluidframework/` packages
-		"^@fluid-(.*?)/(.*)$", // Match other `@fluid-` scoped packages (`@fluid-experimental/`, `@fluid-tools/`, etc.)
-		"^[./]", // Match package-local file imports
-	],
-	importOrderSeparation: true,
-	importOrderSortSpecifiers: true,
 };

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -45,7 +45,6 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
-		"@trivago/prettier-plugin-sort-imports": "^3.3.0",
 		"@types/jszip": "^3.4.1",
 		"@types/msgpack-lite": "^0.1.8",
 		"@types/node": "^14.18.0",

--- a/build-tools/packages/bundle-size-tools/prettier.config.cjs
+++ b/build-tools/packages/bundle-size-tools/prettier.config.cjs
@@ -5,15 +5,4 @@
 
 module.exports = {
 	...require("@fluidframework/build-common/prettier.config.cjs"),
-	plugins: [require("@trivago/prettier-plugin-sort-imports")],
-	importOrder: [
-		"^node:(.*)$", // Special-case `node:` imports
-		"<THIRD_PARTY_MODULES>",
-		"^fluid-framework$", // Special match for `fluid-framework` package
-		"^@fluidframework/(.*)$", // Match all `@fluidframework/` packages
-		"^@fluid-(.*?)/(.*)$", // Match other `@fluid-` scoped packages (`@fluid-experimental/`, `@fluid-tools/`, etc.)
-		"^[./]", // Match package-local file imports
-	],
-	importOrderSeparation: true,
-	importOrderSortSpecifiers: true,
 };

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -84,7 +84,6 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
-		"@trivago/prettier-plugin-sort-imports": "^3.3.0",
 		"@types/chai": "^4",
 		"@types/mocha": "^9.0.0",
 		"@types/node": "^14.18.0",

--- a/build-tools/packages/version-tools/prettier.config.cjs
+++ b/build-tools/packages/version-tools/prettier.config.cjs
@@ -5,15 +5,4 @@
 
 module.exports = {
 	...require("@fluidframework/build-common/prettier.config.cjs"),
-	plugins: [require("@trivago/prettier-plugin-sort-imports")],
-	importOrder: [
-		"^node:(.*)$", // Special-case `node:` imports
-		"<THIRD_PARTY_MODULES>",
-		"^fluid-framework$", // Special match for `fluid-framework` package
-		"^@fluidframework/(.*)$", // Match all `@fluidframework/` packages
-		"^@fluid-(.*?)/(.*)$", // Match other `@fluid-` scoped packages (`@fluid-experimental/`, `@fluid-tools/`, etc.)
-		"^[./]", // Match package-local file imports
-	],
-	importOrderSeparation: true,
-	importOrderSortSpecifiers: true,
 };

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -10,7 +10,6 @@ importers:
       '@fluidframework/test-tools': ^0.2.3074
       '@microsoft/api-documenter': ^7.17.9
       '@microsoft/api-extractor': ^7.22.2
-      '@trivago/prettier-plugin-sort-imports': ^3.3.0
       c8: ^7.7.1
       commitizen: ^4.2.5
       concurrently: ^6.2.0
@@ -32,7 +31,6 @@ importers:
       '@fluidframework/test-tools': 0.2.3074
       '@microsoft/api-documenter': 7.17.24
       '@microsoft/api-extractor': 7.27.1
-      '@trivago/prettier-plugin-sort-imports': 3.3.0_prettier@2.6.2
       c8: 7.11.3
       commitizen: 4.2.5
       concurrently: 6.5.1
@@ -65,7 +63,6 @@ importers:
       '@oclif/test': ^2
       '@octokit/core': ^4.0.5
       '@rushstack/node-core-library': ^3.51.1
-      '@trivago/prettier-plugin-sort-imports': ^3.3.0
       '@types/chai': ^4
       '@types/chai-arrays': ^2.0.0
       '@types/fs-extra': ^8.1.0
@@ -146,7 +143,6 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.27.1
-      '@trivago/prettier-plugin-sort-imports': 3.3.0_prettier@2.6.2
       '@types/chai': 4.3.3
       '@types/chai-arrays': 2.0.0
       '@types/fs-extra': 8.1.2
@@ -187,7 +183,6 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@octokit/core': ^4.0.5
       '@rushstack/node-core-library': ^3.51.1
-      '@trivago/prettier-plugin-sort-imports': ^3.3.0
       '@types/async': ^3.2.6
       '@types/fs-extra': ^8.1.0
       '@types/glob': ^7.1.1
@@ -264,7 +259,6 @@ importers:
     devDependencies:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@trivago/prettier-plugin-sort-imports': 3.3.0_prettier@2.6.2
       '@types/async': 3.2.15
       '@types/fs-extra': 8.1.2
       '@types/glob': 7.2.0
@@ -295,7 +289,6 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@microsoft/api-extractor': ^7.22.2
-      '@trivago/prettier-plugin-sort-imports': ^3.3.0
       '@types/jszip': ^3.4.1
       '@types/msgpack-lite': ^0.1.8
       '@types/node': ^14.18.0
@@ -325,7 +318,6 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.27.1
-      '@trivago/prettier-plugin-sort-imports': 3.3.0_prettier@2.6.2
       '@types/jszip': 3.4.1
       '@types/msgpack-lite': 0.1.8
       '@types/node': 14.18.31
@@ -351,7 +343,6 @@ importers:
       '@oclif/plugin-not-found': ^2.3.1
       '@oclif/plugin-plugins': ^2.0.1
       '@oclif/test': ^2
-      '@trivago/prettier-plugin-sort-imports': ^3.3.0
       '@types/chai': ^4
       '@types/mocha': ^9.0.0
       '@types/node': ^14.18.0
@@ -390,7 +381,6 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.27.1
-      '@trivago/prettier-plugin-sort-imports': 3.3.0_prettier@2.6.2
       '@types/chai': 4.3.3
       '@types/mocha': 9.1.1
       '@types/node': 14.18.31
@@ -433,29 +423,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/core/7.17.8:
-    resolution: {integrity: sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.19.3
-      '@babel/helper-compilation-targets': 7.19.3_@babel+core@7.17.8
-      '@babel/helper-module-transforms': 7.19.0
-      '@babel/helpers': 7.19.0
-      '@babel/parser': 7.19.3
-      '@babel/template': 7.18.10
-      '@babel/traverse': 7.19.3
-      '@babel/types': 7.19.3
-      convert-source-map: 1.8.0
-      debug: 4.3.4
-      gensync: 1.0.0-beta.2
-      json5: 2.2.1
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/core/7.19.3:
     resolution: {integrity: sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==}
     engines: {node: '>=6.9.0'}
@@ -493,15 +460,6 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /@babel/generator/7.17.7:
-    resolution: {integrity: sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.19.3
-      jsesc: 2.5.2
-      source-map: 0.5.7
-    dev: true
-
   /@babel/generator/7.19.3:
     resolution: {integrity: sha512-fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==}
     engines: {node: '>=6.9.0'}
@@ -509,19 +467,6 @@ packages:
       '@babel/types': 7.19.3
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
-    dev: true
-
-  /@babel/helper-compilation-targets/7.19.3_@babel+core@7.17.8:
-    resolution: {integrity: sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.19.3
-      '@babel/core': 7.17.8
-      '@babel/helper-validator-option': 7.18.6
-      browserslist: 4.21.4
-      semver: 6.3.0
     dev: true
 
   /@babel/helper-compilation-targets/7.19.3_@babel+core@7.19.3:
@@ -627,14 +572,6 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
-  /@babel/parser/7.17.8:
-    resolution: {integrity: sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.19.3
-    dev: true
-
   /@babel/parser/7.19.3:
     resolution: {integrity: sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==}
     engines: {node: '>=6.0.0'}
@@ -660,24 +597,6 @@ packages:
       '@babel/types': 7.19.3
     dev: true
 
-  /@babel/traverse/7.17.3:
-    resolution: {integrity: sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.19.3
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.19.3
-      '@babel/types': 7.19.3
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/traverse/7.19.3:
     resolution: {integrity: sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==}
     engines: {node: '>=6.9.0'}
@@ -694,14 +613,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@babel/types/7.17.0:
-    resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
-      to-fast-properties: 2.0.0
     dev: true
 
   /@babel/types/7.19.3:
@@ -2699,23 +2610,6 @@ packages:
   /@tootallnate/once/2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
-
-  /@trivago/prettier-plugin-sort-imports/3.3.0_prettier@2.6.2:
-    resolution: {integrity: sha512-1y44bVZuIN0RsS3oIiGd5k8Vm3IZXYZnp4VsP2Z/S5L9WAOw43HE2clso66M2S/dDeJ+8sKPqnHsEfh39Vjs3w==}
-    peerDependencies:
-      prettier: 2.x
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/generator': 7.17.7
-      '@babel/parser': 7.17.8
-      '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
-      javascript-natural-sort: 0.7.1
-      lodash: 4.17.21
-      prettier: 2.6.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@ts-morph/common/0.5.2:
     resolution: {integrity: sha512-eLmfYV6u6gUgHrB9QV9lpuWg3cD60mhXdv0jvM5exWR/Cor8HG+GziFIj2hPEWHJknqzuU4meZd8DTqIzZfDRQ==}
@@ -7523,10 +7417,6 @@ packages:
       filelist: 1.0.4
       minimatch: 3.1.2
 
-  /javascript-natural-sort/0.7.1:
-    resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
-    dev: true
-
   /jest-worker/27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
@@ -10354,11 +10244,6 @@ packages:
       buffer-from: 1.1.2
       source-map: 0.6.1
     dev: false
-
-  /source-map/0.5.7:
-    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
-    engines: {node: '>=0.10.0'}
-    dev: true
 
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}

--- a/build-tools/prettier.config.cjs
+++ b/build-tools/prettier.config.cjs
@@ -5,15 +5,4 @@
 
 module.exports = {
 	...require("@fluidframework/build-common/prettier.config.cjs"),
-	plugins: ["@trivago/prettier-plugin-sort-imports"],
-	importOrder: [
-		"^node:(.*)$", // Special-case `node:` imports
-		"<THIRD_PARTY_MODULES>",
-		"^fluid-framework$", // Special match for `fluid-framework` package
-		"^@fluidframework/(.*)$", // Match all `@fluidframework/` packages
-		"^@fluid-(.*?)/(.*)$", // Match other `@fluid-` scoped packages (`@fluid-experimental/`, `@fluid-tools/`, etc.)
-		"^[./]", // Match package-local file imports
-	],
-	importOrderSeparation: true,
-	importOrderSortSpecifiers: true,
 };


### PR DESCRIPTION
The @trivago/prettier-plugin-sort-imports prettier plugin is not used across the repo, and due to limitations in prettier, we can't use it for some projects and not others. So I have removed the plugin from azure and build-tools.