### PR TITLE
Pause/resume inbound signal along with inbound op queue

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2535,6 +2535,7 @@ export class ContainerRuntime
 
 		try {
 			await this.deltaManager.inbound.pause();
+			await this.deltaManager.inboundSignal.pause();
 
 			const summaryRefSeqNum = this.deltaManager.lastSequenceNumber;
 			const minimumSequenceNumber = this.deltaManager.minimumSequenceNumber;
@@ -2732,6 +2733,7 @@ export class ContainerRuntime
 			this.summarizerNode.clearSummary();
 			// Restart the delta manager
 			this.deltaManager.inbound.resume();
+			this.deltaManager.inboundSignal.resume();
 		}
 	}
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2535,7 +2535,13 @@ export class ContainerRuntime
 
 		try {
 			await this.deltaManager.inbound.pause();
-			await this.deltaManager.inboundSignal.pause();
+			if (
+				this.mc.config.getBoolean(
+					"Fluid.ContainerRuntime.SubmitSummary.disableInboundSignalPause",
+				) !== true
+			) {
+				await this.deltaManager.inboundSignal.pause();
+			}
 
 			const summaryRefSeqNum = this.deltaManager.lastSequenceNumber;
 			const minimumSequenceNumber = this.deltaManager.minimumSequenceNumber;
@@ -2731,9 +2737,16 @@ export class ContainerRuntime
 		} finally {
 			// Cleanup wip summary in case of failure
 			this.summarizerNode.clearSummary();
+
 			// Restart the delta manager
 			this.deltaManager.inbound.resume();
-			this.deltaManager.inboundSignal.resume();
+			if (
+				this.mc.config.getBoolean(
+					"Fluid.ContainerRuntime.SubmitSummary.disableInboundSignalPause",
+				) !== true
+			) {
+				this.deltaManager.inboundSignal.resume();
+			}
 		}
 	}
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2533,11 +2533,13 @@ export class ContainerRuntime
 			await this.waitForDeltaManagerToCatchup(latestSnapshotRefSeq, summaryNumberLogger);
 		}
 
-		const disableInboundSignalPauseKey =
-			"Fluid.ContainerRuntime.SubmitSummary.disableInboundSignalPause";
+		const shouldPauseInboundSignal =
+			this.mc.config.getBoolean(
+				"Fluid.ContainerRuntime.SubmitSummary.disableInboundSignalPause",
+			) !== true;
 		try {
 			await this.deltaManager.inbound.pause();
-			if (this.mc.config.getBoolean(disableInboundSignalPauseKey) !== true) {
+			if (shouldPauseInboundSignal) {
 				await this.deltaManager.inboundSignal.pause();
 			}
 
@@ -2738,7 +2740,7 @@ export class ContainerRuntime
 
 			// Restart the delta manager
 			this.deltaManager.inbound.resume();
-			if (this.mc.config.getBoolean(disableInboundSignalPauseKey) !== true) {
+			if (shouldPauseInboundSignal) {
 				this.deltaManager.inboundSignal.resume();
 			}
 		}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2533,13 +2533,11 @@ export class ContainerRuntime
 			await this.waitForDeltaManagerToCatchup(latestSnapshotRefSeq, summaryNumberLogger);
 		}
 
+		const disableInboundSignalPauseKey =
+			"Fluid.ContainerRuntime.SubmitSummary.disableInboundSignalPause";
 		try {
 			await this.deltaManager.inbound.pause();
-			if (
-				this.mc.config.getBoolean(
-					"Fluid.ContainerRuntime.SubmitSummary.disableInboundSignalPause",
-				) !== true
-			) {
+			if (this.mc.config.getBoolean(disableInboundSignalPauseKey) !== true) {
 				await this.deltaManager.inboundSignal.pause();
 			}
 
@@ -2740,11 +2738,7 @@ export class ContainerRuntime
 
 			// Restart the delta manager
 			this.deltaManager.inbound.resume();
-			if (
-				this.mc.config.getBoolean(
-					"Fluid.ContainerRuntime.SubmitSummary.disableInboundSignalPause",
-				) !== true
-			) {
+			if (this.mc.config.getBoolean(disableInboundSignalPauseKey) !== true) {
 				this.deltaManager.inboundSignal.resume();
 			}
 		}


### PR DESCRIPTION
Here's an example why:  Suppose at the same time the Summarization is happening, another client creates a datastore and starts sending signals.  The attach op for that will be stuck in the paused inbound op queue, but the signal will come through - but there's no datastorecontext to route the signal to!

Fixes [AB#3430](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3430)