### PR TITLE
[fluid-runner] Change scope object property to a getter

### DIFF
--- a/packages/tools/fluid-runner/src/codeLoaderBundle.ts
+++ b/packages/tools/fluid-runner/src/codeLoaderBundle.ts
@@ -29,9 +29,10 @@ export interface IFluidFileConverter {
 	getCodeLoader(logger: ITelemetryBaseLogger): Promise<ICodeDetailsLoader>;
 
 	/**
-	 * Scope object to provide at Loader creation
+	 * Get scope object to provide at Loader creation
+	 * @param logger - created logger object to pass to scope object
 	 */
-	scope?: FluidObject;
+	getScope?(logger: ITelemetryBaseLogger): Promise<FluidObject>;
 
 	/**
 	 * Executes code on container and returns the result

--- a/packages/tools/fluid-runner/src/exportFile.ts
+++ b/packages/tools/fluid-runner/src/exportFile.ts
@@ -99,7 +99,7 @@ export async function createContainerAndExecute(
 		urlResolver: new FakeUrlResolver(),
 		documentServiceFactory: createLocalOdspDocumentServiceFactory(localOdspSnapshot),
 		codeLoader: await fluidFileConverter.getCodeLoader(logger),
-		scope: fluidFileConverter.scope,
+		scope: await fluidFileConverter.getScope?.(logger),
 		logger,
 	});
 


### PR DESCRIPTION
# [AB#3134](https://dev.azure.com/fluidframework/internal/_workitems/edit/3134)

[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

Provide logger created by fluid-runner to `IFluidFileConverter.getScope(...)` method that will return scope object.
`IFluidFileConverter.getScope(...)` method implementation will be responsible for setting up scope object properly such that the logger propagates.