### PR TITLE
Add breaking change warning for test-drivers and test-pairwise-generator

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -48,7 +48,7 @@ The following interfaces used by the `PendingStateManager` have been deprecated 
 
 ### test-drivers and test-pairwise-generator packages will no longer be published
 
-These packages are currently published as `@fluidframework/test-drivers` and `@fluidframework/test-pairwise-generator`. These will be moved to the `@fluid-internal` scope will no longer be published.
+These packages are currently published as `@fluidframework/test-drivers` and `@fluidframework/test-pairwise-generator`. These will be moved to the `@fluid-internal` scope and will no longer be published.
 
 ## 2.0.0-internal.3.0.0 Breaking changes
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -22,6 +22,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 -   [For Driver Authors: Document Storage Service policy may become required](#for-driver-authors-document-storage-service-policy-may-become-required)
 -   [Deprecated PendingStateManager interfaces](#Deprecated-PendingStateManager-interfaces)
 -   [Deprecated IFluidHTMLView and HTMLViewAdapter](#Deprecated-IFluidHTMLView-and-HTMLViewAdapter)
+-   [test-drivers and test-pairwise-generator packages will no longer be published](test-drivers-and-test-pairwise-generator-packages-will-no-longer-be-published)
 
 ### For Driver Authors: Document Storage Service policy may become required
 
@@ -44,6 +45,10 @@ The following interfaces used by the `PendingStateManager` have been deprecated 
 ### Deprecated IFluidHTMLView and HTMLViewAdapter
 
 `IFluidHTMLView` and `HTMLViewAdapter` have been deprecated. It is recommended not to bundle view code with Fluid data, and instead apply the views from outside the container (see https://github.com/microsoft/FluidFramework/tree/main/examples/hosts/app-integration/external-views for an example of this approach). For those views, a dedicated view framework is recommended (see view sampler demo https://github.com/microsoft/FluidFramework/tree/main/examples/apps/view-framework-sampler)
+
+### test-drivers and test-pairwise-generator packages will no longer be published
+
+These packages are currently published as `@fluidframework/test-drivers` and `@fluidframework/test-pairwise-generator`. These will be moved to the `@fluid-internal` scope will no longer be published.
 
 ## 2.0.0-internal.3.0.0 Breaking changes
 


### PR DESCRIPTION
Warning for the change in #14086 that is targeting `next`.