### PR TITLE
Disable large payloads as it still creates too much traffic.

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -36,12 +36,6 @@
 						"Fluid.Container.summarizeProtocolTree2": [true, false]
 					}
 				}
-			},
-			"content": {
-				"useRandomContent": true,
-				"useVariableOpSize": true,
-				"opSizeinBytes": 2172864,
-				"largeOpRate": 500
 			}
 		},
 		"ci_frs": {
@@ -53,12 +47,6 @@
 			"faultInjectionMs": {
 				"min": 0,
 				"max": 150000
-			},
-			"content": {
-				"useRandomContent": true,
-				"useVariableOpSize": true,
-				"opSizeinBytes": 2172864,
-				"largeOpRate": 500
 			}
 		},
 		"full": {


### PR DESCRIPTION
## Description

Real-life metrics don't match the metrics from the test run for https://github.com/microsoft/FluidFramework/pull/14000

Disabling until I figure out a way to not have all clients send the large payloads all at once.