### PR TITLE
[Port to v2int/2.4] Fixed bug - RefreshLatestSummaryAck can end up updating wrong latest reference sequence number

### DIFF
--- a/api-report/runtime-utils.api.md
+++ b/api-report/runtime-utils.api.md
@@ -95,6 +95,14 @@ export function getBlobSize(content: ISummaryBlob["content"]): number;
 // @public (undocumented)
 export function getNormalizedObjectStoragePathParts(path: string): string[];
 
+// @public
+export interface IFetchSnapshotResult {
+    // (undocumented)
+    snapshotRefSeq: number;
+    // (undocumented)
+    snapshotTree: ISnapshotTree;
+}
+
 // @public (undocumented)
 export interface IRootSummarizerNode extends ISummarizerNode, ISummarizerNodeRootContract {
 }
@@ -110,7 +118,7 @@ export interface ISummarizerNodeRootContract {
     // (undocumented)
     completeSummary(proposalHandle: string): void;
     // (undocumented)
-    refreshLatestSummary(proposalHandle: string | undefined, summaryRefSeq: number, getSnapshot: () => Promise<ISnapshotTree>, readAndParseBlob: ReadAndParseBlob, correlatedSummaryLogger: ITelemetryLogger): Promise<RefreshSummaryResult>;
+    refreshLatestSummary(proposalHandle: string | undefined, summaryRefSeq: number, fetchLatestSnapshot: () => Promise<IFetchSnapshotResult>, readAndParseBlob: ReadAndParseBlob, correlatedSummaryLogger: ITelemetryLogger): Promise<RefreshSummaryResult>;
     // (undocumented)
     startSummary(referenceSequenceNumber: number, summaryLogger: ITelemetryLogger): void;
 }
@@ -144,10 +152,12 @@ export type RefreshSummaryResult = {
 } | {
     latestSummaryUpdated: true;
     wasSummaryTracked: true;
+    summaryRefSeq: number;
 } | {
     latestSummaryUpdated: true;
     wasSummaryTracked: false;
-    snapshot: ISnapshotTree;
+    snapshotTree: ISnapshotTree;
+    summaryRefSeq: number;
 };
 
 // @public (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -94,6 +94,7 @@ import {
     addSummarizeResultToSummary,
     addTreeToSummary,
     createRootSummarizerNodeWithGC,
+    IFetchSnapshotResult,
     IRootSummarizerNodeWithGC,
     RequestParser,
     create404Response,
@@ -103,6 +104,7 @@ import {
     seqFromTree,
     calculateStats,
     TelemetryContext,
+    ReadAndParseBlob,
 } from "@fluidframework/runtime-utils";
 import { GCDataBuilder, trimLeadingAndTrailingSlashes } from "@fluidframework/garbage-collector";
 import { v4 as uuid } from "uuid";
@@ -2802,18 +2804,17 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         // The call to fetch the snapshot is very expensive and not always needed.
         // It should only be done by the summarizerNode, if required.
         // When fetching from storage we will always get the latest version and do not use the ackHandle.
-        const snapshotTreeFetcher = async () => {
+        const fetchLatestSnapshot: () => Promise<IFetchSnapshotResult> = async () => {
             const fetchResult = await this.fetchLatestSnapshotFromStorage(
                 summaryLogger,
                 {
-                    eventName: "RefreshLatestSummaryGetSnapshot",
+                    eventName: "RefreshLatestSummaryAckFetch",
                     ackHandle,
-                    summaryRefSeq,
-                    fetchLatest: true,
+                    targetSequenceNumber: summaryRefSeq,
                 },
+                readAndParseBlob,
             );
 
-            const latestSnapshotRefSeq = await seqFromTree(fetchResult.snapshotTree, readAndParseBlob);
             /**
              * If the fetched snapshot is older than the one for which the ack was received, close the container.
              * This should never happen because an ack should be sent after the latest summary is updated in the server.
@@ -2824,7 +2825,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
              * such cases, the file will be rolled back along with the ack and we will eventually reach a consistent
              * state.
              */
-            if (latestSnapshotRefSeq < summaryRefSeq) {
+            if (fetchResult.latestSnapshotRefSeq < summaryRefSeq) {
                 const error = DataProcessingError.create(
                     "Fetched snapshot is older than the received ack",
                     "RefreshLatestSummaryAck",
@@ -2832,44 +2833,36 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                     {
                         ackHandle,
                         summaryRefSeq,
-                        latestSnapshotRefSeq,
+                        latestSnapshotRefSeq: fetchResult.latestSnapshotRefSeq,
                     },
                 );
                 this.closeFn(error);
                 throw error;
             }
 
-            summaryLogger.sendTelemetryEvent(
-                {
-                    eventName: "LatestSummaryRetrieved",
-                    ackHandle,
-                    lastSequenceNumber: latestSnapshotRefSeq,
-                    targetSequenceNumber: summaryRefSeq,
-                });
-
             // In case we had to retrieve the latest snapshot and it is different than summaryRefSeq,
             // wait for the delta manager to catch up before refreshing the latest Summary.
-            await this.waitForDeltaManagerToCatchup(latestSnapshotRefSeq,
-                summaryLogger);
+            await this.waitForDeltaManagerToCatchup(
+                fetchResult.latestSnapshotRefSeq,
+                summaryLogger,
+            );
 
-            return fetchResult.snapshotTree;
+            return {
+                snapshotTree: fetchResult.snapshotTree,
+                snapshotRefSeq: fetchResult.latestSnapshotRefSeq,
+            };
         };
 
         const result = await this.summarizerNode.refreshLatestSummary(
             proposalHandle,
             summaryRefSeq,
-            snapshotTreeFetcher,
+            fetchLatestSnapshot,
             readAndParseBlob,
             summaryLogger,
         );
 
         // Notify the garbage collector so it can update its latest summary state.
-        await this.garbageCollector.refreshLatestSummary(
-            result,
-            proposalHandle,
-            summaryRefSeq,
-            readAndParseBlob,
-        );
+        await this.garbageCollector.refreshLatestSummary(proposalHandle, result, readAndParseBlob);
     }
 
     /**
@@ -2881,30 +2874,31 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     private async refreshLatestSummaryAckFromServer(
         summaryLogger: ITelemetryLogger,
     ): Promise<{ latestSnapshotRefSeq: number; latestSnapshotVersionId: string | undefined; }> {
-        const { snapshotTree, versionId } = await this.fetchLatestSnapshotFromStorage(
-            summaryLogger,
-            {
-                eventName: "RefreshLatestSummaryGetSnapshot",
-                fetchLatest: true,
-            },
-        );
-
         const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
-        const latestSnapshotRefSeq = await seqFromTree(snapshotTree, readAndParseBlob);
-
+        const { snapshotTree, versionId, latestSnapshotRefSeq } =
+            await this.fetchLatestSnapshotFromStorage(
+                summaryLogger,
+                {
+                    eventName: "RefreshLatestSummaryFromServerFetch",
+                },
+                readAndParseBlob,
+            );
+        const fetchLatestSnapshot: IFetchSnapshotResult = {
+            snapshotTree,
+            snapshotRefSeq: latestSnapshotRefSeq,
+        };
         const result = await this.summarizerNode.refreshLatestSummary(
-            undefined,
+            undefined /* proposalHandle */,
             latestSnapshotRefSeq,
-            async () => snapshotTree,
+            async () => fetchLatestSnapshot,
             readAndParseBlob,
             summaryLogger,
         );
 
         // Notify the garbage collector so it can update its latest summary state.
         await this.garbageCollector.refreshLatestSummary(
+            undefined /* proposalHandle */,
             result,
-            undefined,
-            latestSnapshotRefSeq,
             readAndParseBlob,
         )
 
@@ -2914,29 +2908,54 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     private async fetchLatestSnapshotFromStorage(
         logger: ITelemetryLogger,
         event: ITelemetryGenericEvent,
-    ): Promise<{ snapshotTree: ISnapshotTree; versionId: string; }> {
+        readAndParseBlob: ReadAndParseBlob,
+    ): Promise<{ snapshotTree: ISnapshotTree; versionId: string; latestSnapshotRefSeq: number }> {
         return PerformanceEvent.timedExecAsync(
-            logger, event, async (perfEvent: {
+            logger,
+            event,
+            async (perfEvent: {
                 end: (arg0: {
                     getVersionDuration?: number | undefined;
                     getSnapshotDuration?: number | undefined;
+                    snapshotRefSeq?: number | undefined;
+                    snapshotVersion?: string | undefined;
                 }) => void;
             }) => {
-            const stats: { getVersionDuration?: number; getSnapshotDuration?: number; } = {};
+            const stats: {
+                getVersionDuration?: number;
+                getSnapshotDuration?: number;
+                snapshotRefSeq?: number;
+                snapshotVersion?: string;
+            } = {};
             const trace = Trace.start();
 
             const versions = await this.storage.getVersions(
-                null, 1, "refreshLatestSummaryAckFromServer", FetchSource.noCache);
-            assert(!!versions && !!versions[0], 0x137 /* "Failed to get version from storage" */);
+                null,
+                1,
+                "refreshLatestSummaryAckFromServer",
+                FetchSource.noCache,
+            );
+            assert(
+                !!versions && !!versions[0],
+                0x137 /* "Failed to get version from storage" */,
+            );
             stats.getVersionDuration = trace.trace().duration;
 
             const maybeSnapshot = await this.storage.getSnapshotTree(versions[0]);
             assert(!!maybeSnapshot, 0x138 /* "Failed to get snapshot from storage" */);
             stats.getSnapshotDuration = trace.trace().duration;
+            const latestSnapshotRefSeq = await seqFromTree(maybeSnapshot, readAndParseBlob);
+            stats.snapshotRefSeq = latestSnapshotRefSeq;
+            stats.snapshotVersion = versions[0].id;
 
             perfEvent.end(stats);
-            return { snapshotTree: maybeSnapshot, versionId: versions[0].id };
-        });
+            return {
+                snapshotTree: maybeSnapshot,
+                versionId: versions[0].id,
+                latestSnapshotRefSeq,
+            };
+            },
+        );
     }
 
     public notifyAttaching(snapshot: ISnapshotTreeWithBlobContents) {

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -158,9 +158,8 @@ export interface IGarbageCollector {
     getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
     /** Called when the latest summary of the system has been refreshed. */
     refreshLatestSummary(
-        result: RefreshSummaryResult,
         proposalHandle: string | undefined,
-        summaryRefSeq: number,
+        result: RefreshSummaryResult,
         readAndParseBlob: ReadAndParseBlob,
     ): Promise<void>;
     /** Called when a node is updated. Used to detect and log when an inactive node is changed or loaded. */
@@ -1179,9 +1178,8 @@ export class GarbageCollector implements IGarbageCollector {
      * is downloaded and should be used to update the state.
      */
     public async refreshLatestSummary(
-        result: RefreshSummaryResult,
         proposalHandle: string | undefined,
-        summaryRefSeq: number,
+        result: RefreshSummaryResult,
         readAndParseBlob: ReadAndParseBlob,
     ): Promise<void> {
         // If the latest summary was updated and the summary was tracked, this client is the one that generated this
@@ -1208,8 +1206,8 @@ export class GarbageCollector implements IGarbageCollector {
         }
 
         // If the summary was not tracked by this client, the state should be updated from the downloaded snapshot.
-        const snapshot = result.snapshot;
-        const metadataBlobId = snapshot.blobs[metadataBlobName];
+        const snapshotTree = result.snapshotTree;
+        const metadataBlobId = snapshotTree.blobs[metadataBlobName];
         if (metadataBlobId) {
             const metadata = await readAndParseBlob<IContainerRuntimeMetadata>(metadataBlobId);
             this.latestSummaryGCVersion = getGCVersion(metadata);
@@ -1223,10 +1221,10 @@ export class GarbageCollector implements IGarbageCollector {
                 "No reference timestamp when updating GC state from snapshot",
                 "refreshLatestSummary",
                 undefined,
-                { proposalHandle, summaryRefSeq, details: JSON.stringify(this.configs) },
+                { proposalHandle, summaryRefSeq: result.summaryRefSeq, details: JSON.stringify(this.configs) },
             );
         }
-        const gcSnapshotTree = snapshot.trees[gcTreeKey];
+        const gcSnapshotTree = snapshotTree.trees[gcTreeKey];
         // If GC ran in the container that generated this snapshot, it will have a GC tree.
         this.wasGCRunInLatestSummary = gcSnapshotTree !== undefined;
         let latestGCData: IGarbageCollectionSnapshotData | undefined;

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -1194,8 +1194,12 @@ describe("Garbage Collection Tests", () => {
             const deletedNodesBlob = gcSummary.summary.tree[gcDeletedBlobKey];
             assert(deletedNodesBlob.type === SummaryType.Handle, "Deleted nodes state should be a handle");
 
-            const refreshSummaryResult: RefreshSummaryResult = { latestSummaryUpdated: true, wasSummaryTracked: true};
-            await garbageCollector.refreshLatestSummary(refreshSummaryResult, undefined, 0, parseNothing);
+            const refreshSummaryResult: RefreshSummaryResult = { latestSummaryUpdated: true, wasSummaryTracked: true, summaryRefSeq: 0 };
+			await garbageCollector.refreshLatestSummary(
+				undefined,
+				refreshSummaryResult,
+				parseNothing,
+			);
 
             // Run GC and summarize again. The whole GC summary should now be a summary handle.
             await garbageCollector.collectGarbage({});
@@ -1735,12 +1739,11 @@ describe("Garbage Collection Tests", () => {
 
             checkGCSummaryType(tree1, SummaryType.Tree, "first");
 
-            await garbageCollector.refreshLatestSummary(
-                { wasSummaryTracked: true, latestSummaryUpdated: true },
-                undefined,
-                0,
-                parseNothing,
-            );
+			await garbageCollector.refreshLatestSummary(
+				undefined,
+				{ wasSummaryTracked: true, latestSummaryUpdated: true, summaryRefSeq: 0 },
+				parseNothing,
+			);
 
             await garbageCollector.collectGarbage({});
             const tree2 = garbageCollector.summarize(fullTree, trackState);

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -101,6 +101,11 @@
     "version": "2.0.0-internal.2.4.0",
     "previousVersionStyle": "previousPatch",
     "baselineRange": "2.0.0-internal.2.4.0",
-    "broken": {}
+    "broken": {
+      "TypeAliasDeclaration_RefreshSummaryResult": {
+        "forwardCompat": false,
+        "backCompat": false
+      }
+    }
   }
 }

--- a/packages/runtime/runtime-utils/src/index.ts
+++ b/packages/runtime/runtime-utils/src/index.ts
@@ -21,6 +21,7 @@ export { RuntimeFactoryHelper } from "./runtimeFactoryHelper";
 export {
 	createRootSummarizerNode,
 	createRootSummarizerNodeWithGC,
+    IFetchSnapshotResult,
 	IRootSummarizerNode,
 	IRootSummarizerNodeWithGC,
 	ISummarizerNodeRootContract,

--- a/packages/runtime/runtime-utils/src/summarizerNode/index.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/index.ts
@@ -3,6 +3,10 @@
  * Licensed under the MIT License.
  */
 
-export { ISummarizerNodeRootContract, RefreshSummaryResult } from "./summarizerNodeUtils";
+export {
+	IFetchSnapshotResult,
+	ISummarizerNodeRootContract,
+	RefreshSummaryResult,
+} from "./summarizerNodeUtils";
 export { IRootSummarizerNode, createRootSummarizerNode } from "./summarizerNode";
 export { IRootSummarizerNodeWithGC, createRootSummarizerNodeWithGC } from "./summarizerNodeWithGc";

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
@@ -13,25 +13,35 @@ import { channelsTreeName, ISummaryTreeWithStats } from "@fluidframework/runtime
 import { ReadAndParseBlob } from "../utils";
 
 /**
- * Return value of refreshSummaryAck function. There can be three different scenarios based on the passed params:
+ * Return type of refreshSummaryAck function. There can be three different scenarios based on the passed params:
  *
- * 1. The latest summary was not udpated.
+ * 1. The latest summary was not updated.
  *
  * 2. The latest summary was updated and the summary corresponding to the params was tracked by this client.
  *
  * 3. The latest summary was updated but the summary corresponding to the params was not tracked. In this case, the
- * latest summary is updated based on the downloaded snapshot which is also returned.
+ * latest snapshot is fetched and the latest summary state is updated based on it.
  */
 export type RefreshSummaryResult = {
     latestSummaryUpdated: false;
 } | {
     latestSummaryUpdated: true;
     wasSummaryTracked: true;
+    summaryRefSeq: number;
 } | {
     latestSummaryUpdated: true;
     wasSummaryTracked: false;
-    snapshot: ISnapshotTree;
+    snapshotTree: ISnapshotTree;
+    summaryRefSeq: number;
 };
+
+/**
+ * Result of snapshot fetch during refreshing latest summary state.
+ */
+export interface IFetchSnapshotResult {
+    snapshotTree: ISnapshotTree;
+    snapshotRefSeq: number;
+}
 
 export interface ISummarizerNodeRootContract {
     startSummary(referenceSequenceNumber: number, summaryLogger: ITelemetryLogger): void;
@@ -40,7 +50,7 @@ export interface ISummarizerNodeRootContract {
     refreshLatestSummary(
         proposalHandle: string | undefined,
         summaryRefSeq: number,
-        getSnapshot: () => Promise<ISnapshotTree>,
+        fetchLatestSnapshot: () => Promise<IFetchSnapshotResult>,
         readAndParseBlob: ReadAndParseBlob,
         correlatedSummaryLogger: ITelemetryLogger,
     ): Promise<RefreshSummaryResult>;

--- a/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
@@ -17,6 +17,7 @@ import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 
 import {
     createRootSummarizerNode,
+    IFetchSnapshotResult,
     IRootSummarizerNode,
 } from "../summarizerNode";
 // eslint-disable-next-line import/no-internal-modules
@@ -144,10 +145,19 @@ describe("Runtime", () => {
                 [channelsTreeName]: coreSnapshot,
                 ".protocol": protocolTree,
             } };
-            const getSnapshot = async () => simpleSnapshot;
+
+            // The reference sequence number of the fetched snapshot.
+            let snapshotRefSeq = summaryRefSeq;
+            const fetchLatestSnapshot: () => Promise<IFetchSnapshotResult> = async () => {
+                return {
+                    snapshotTree: simpleSnapshot,
+                    snapshotRefSeq,
+                };
+            };
 
             beforeEach(() => {
                 summarizeCalls = [0, 0, 0];
+                snapshotRefSeq = summaryRefSeq;
             });
 
             describe("Create Child", () => {
@@ -307,13 +317,36 @@ describe("Runtime", () => {
                     const result = await rootNode.refreshLatestSummary(
                         undefined,
                         summaryRefSeq,
-                        getSnapshot,
+                        fetchLatestSnapshot,
                         readAndParseBlob,
                         logger,
                     );
                     assert(result.latestSummaryUpdated === true, "should update");
                     assert(result.wasSummaryTracked === false, "should not be tracked");
-                    assert(result.snapshot !== undefined, "should have tree result");
+                    assert(result.snapshotTree !== undefined, "should have tree result");
+                    assert(
+                        result.summaryRefSeq === summaryRefSeq,
+                        "summary ref seq should be the same as the one passed in",
+                    );
+                });
+
+                it("Should use the ref seq number of the fetched snapshot", async () => {
+                    createRoot();
+                    snapshotRefSeq = summaryRefSeq + 1;
+                    const result = await rootNode.refreshLatestSummary(
+                        undefined,
+                        summaryRefSeq,
+                        fetchLatestSnapshot,
+                        readAndParseBlob,
+                        logger,
+                    );
+                    assert(result.latestSummaryUpdated === true, "should update");
+                    assert(result.wasSummaryTracked === false, "should not be tracked");
+                    assert(result.snapshotTree !== undefined, "should have tree result");
+                    assert(
+                        result.summaryRefSeq === snapshotRefSeq,
+                        "summary ref seq should be the snapshot ref seq",
+                    );
                 });
 
                 it("Should refresh from tree when proposal handle not pending", async () => {
@@ -321,13 +354,17 @@ describe("Runtime", () => {
                     const result = await rootNode.refreshLatestSummary(
                         "test-handle",
                         summaryRefSeq,
-                        getSnapshot,
+                        fetchLatestSnapshot,
                         readAndParseBlob,
                         logger,
                     );
                     assert(result.latestSummaryUpdated === true, "should update");
                     assert(result.wasSummaryTracked === false, "should not be tracked");
-                    assert(result.snapshot !== undefined, "should have tree result");
+                    assert(result.snapshotTree !== undefined, "should have tree result");
+                    assert(
+                        result.summaryRefSeq === summaryRefSeq,
+                        "summary ref seq should be the same as the one passed in",
+                    );
                 });
 
                 it("Should not refresh latest if already passed ref seq number", async () => {
@@ -335,7 +372,7 @@ describe("Runtime", () => {
                     const result = await rootNode.refreshLatestSummary(
                         undefined,
                         summaryRefSeq,
-                        getSnapshot,
+                        fetchLatestSnapshot,
                         readAndParseBlob,
                         logger,
                     );
@@ -353,7 +390,7 @@ describe("Runtime", () => {
                     const result = await rootNode.refreshLatestSummary(
                         proposalHandle,
                         summaryRefSeq,
-                        getSnapshot,
+                        fetchLatestSnapshot,
                         readAndParseBlob,
                         logger,
                     );

--- a/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
@@ -647,6 +647,7 @@ declare function get_old_TypeAliasDeclaration_RefreshSummaryResult():
 declare function use_current_TypeAliasDeclaration_RefreshSummaryResult(
     use: TypeOnly<current.RefreshSummaryResult>);
 use_current_TypeAliasDeclaration_RefreshSummaryResult(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_RefreshSummaryResult());
 
 /*
@@ -659,6 +660,7 @@ declare function get_current_TypeAliasDeclaration_RefreshSummaryResult():
 declare function use_old_TypeAliasDeclaration_RefreshSummaryResult(
     use: TypeOnly<old.RefreshSummaryResult>);
 use_old_TypeAliasDeclaration_RefreshSummaryResult(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_RefreshSummaryResult());
 
 /*


### PR DESCRIPTION
Porting #14052 to 2.0.0-internal.2.4 release branch