### PR TITLE
Deprecate Container and Relative Loader

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -23,6 +23,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 -   [Deprecated PendingStateManager interfaces](#Deprecated-PendingStateManager-interfaces)
 -   [Deprecated IFluidHTMLView and HTMLViewAdapter](#Deprecated-IFluidHTMLView-and-HTMLViewAdapter)
 -   [test-drivers and test-pairwise-generator packages will no longer be published](test-drivers-and-test-pairwise-generator-packages-will-no-longer-be-published)
+-   [Container and RelativeLoader Deprecated](#Container-and-RelativeLoader-Deprecated)
 
 ### For Driver Authors: Document Storage Service policy may become required
 
@@ -49,6 +50,13 @@ The following interfaces used by the `PendingStateManager` have been deprecated 
 ### test-drivers and test-pairwise-generator packages will no longer be published
 
 These packages are currently published as `@fluidframework/test-drivers` and `@fluidframework/test-pairwise-generator`. These will be moved to the `@fluid-internal` scope and will no longer be published.
+
+### Container and RelativeLoader Deprecated
+
+The Container and RelativeLoader classes in `@fluidframework/container-loader` have been deprecated and will be removed in the next major release.
+
+-   Container usage should be replaced with usage of the interface IContainer from `@fluidframework/container-definitions`.
+-   RelativeLoader is an internal class and should not be used directly.
 
 ## 2.0.0-internal.3.0.0 Breaking changes
 

--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -53,7 +53,7 @@ export enum ConnectionState {
     EstablishingConnection = 3
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class Container extends EventEmitterWithErrorHandling<IContainerEvents> implements IContainer {
     constructor(loader: Loader, config: IContainerConfig, protocolHandlerBuilder?: ProtocolHandlerBuilder | undefined);
     // (undocumented)
@@ -231,7 +231,7 @@ export class Loader implements IHostLoader {
 // @public
 export type ProtocolHandlerBuilder = (attributes: IDocumentAttributes, snapshot: IQuorumSnapshot, sendProposal: (key: string, value: any) => number) => IProtocolHandler;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class RelativeLoader implements ILoader {
     constructor(container: Container, loader: ILoader | undefined);
     // (undocumented)

--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { ConfigTypes } from '@fluidframework/telemetry-utils';
-import { Container } from '@fluidframework/container-loader';
 import { ContainerRuntime } from '@fluidframework/container-runtime';
 import { ContainerRuntimeFactoryWithDefaultDataStore } from '@fluidframework/aqueduct';
 import { FluidDataStoreRuntime } from '@fluidframework/datastore';
@@ -108,7 +107,7 @@ export enum DataObjectFactoryType {
 export const defaultTimeoutDurationMs = 250;
 
 // @public @deprecated
-export function ensureContainerConnected(container: Container): Promise<void>;
+export function ensureContainerConnected(container: IContainer): Promise<void>;
 
 // @public
 export class EventAndErrorTrackingLogger extends TelemetryLogger {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -277,6 +277,9 @@ export interface IPendingContainerState {
 
 const summarizerClientType = "summarizer";
 
+/**
+ * @deprecated - In the next release Container will no longer be exported, IContainer should be used in its place.
+ */
 export class Container
 	extends EventEmitterWithErrorHandling<IContainerEvents>
 	implements IContainer

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -58,6 +58,9 @@ function canUseCache(request: IRequest): boolean {
 	return request.headers[LoaderHeader.cache] !== false;
 }
 
+/**
+ * @deprecated - In the next release RelativeLoader will no longer be exported. It is an internal class that should not be used directly.
+ */
 export class RelativeLoader implements ILoader {
 	constructor(
 		private readonly container: Container,

--- a/packages/test/test-utils/src/containerUtils.ts
+++ b/packages/test/test-utils/src/containerUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { IContainer } from "@fluidframework/container-definitions";
-import { ConnectionState, Container } from "@fluidframework/container-loader";
+import { ConnectionState } from "@fluidframework/container-loader";
 import { PromiseExecutor, timeoutPromise, TimeoutWithError } from "./timeoutUtils";
 
 /**
@@ -15,8 +15,8 @@ import { PromiseExecutor, timeoutPromise, TimeoutWithError } from "./timeoutUtil
  * - failOnContainerClose = true
  * - timeoutOptions.durationMs = 1s
  */
-export async function ensureContainerConnected(container: Container): Promise<void> {
-	if (!container.connected) {
+export async function ensureContainerConnected(container: IContainer): Promise<void> {
+	if (container.connectionState !== ConnectionState.Connected) {
 		return timeoutPromise((resolve) => container.once("connected", () => resolve()));
 	}
 }


### PR DESCRIPTION
The Container and RelativeLoader classes in `@fluidframework/container-loader` have been deprecated and will be removed in the next major release.

-   Container usage should be replaced with usage of the interface IContainer from `@fluidframework/container-definitions`.
-   RelativeLoader is an internal class and should not be used directly.

Removal in #14100 

[AB#3437](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3437)

