### PR TITLE
GC Sweep: containers close with proper error message when deleted datastores fail receive ops

### DIFF
--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -448,6 +448,8 @@ export class DataStores implements IDisposable {
 	) {
 		const envelope = message.contents as IEnvelope;
 		const transformed = { ...message, contents: envelope.contents };
+		const request = { url: envelope.address };
+		this.validateNotDeleted(envelope.address, request);
 		const context = this.contexts.get(envelope.address);
 		assert(!!context, 0x162 /* "There should be a store context for the op" */);
 		context.process(transformed, local, localMessageMetadata);
@@ -491,7 +493,7 @@ export class DataStores implements IDisposable {
 	private validateNotDeleted(
 		id: string,
 		request: IRequest,
-		requestHeaderData: RuntimeHeaderData,
+		requestHeaderData?: RuntimeHeaderData,
 	) {
 		const dataStoreNodePath = `/${id}`;
 		if (this.isDataStoreDeleted(dataStoreNodePath)) {

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -564,6 +564,8 @@ export class DataStores implements IDisposable {
 	}
 
 	public processSignal(address: string, message: IInboundSignalMessage, local: boolean) {
+		const request = { url: address };
+		this.validateNotDeleted(address, request);
 		const context = this.contexts.get(address);
 		if (!context) {
 			// Attach message may not have been processed yet

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -159,6 +159,14 @@ describeNoCompat("GC data store sweep tests", (getTestObjectProvider) => {
 		};
 	};
 
+	const setupContainerCloseErrorValidation = (container: IContainer) => {
+		container.on("closed", (error) => {
+			assert(error !== undefined, `Expecting an error!`);
+			assert(error.errorType === "dataProcessingError");
+			assert(error.message.startsWith("DataStore was deleted:"));
+		});
+	};
+
 	describe("Using swept data stores not allowed", () => {
 		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
@@ -244,7 +252,6 @@ describeNoCompat("GC data store sweep tests", (getTestObjectProvider) => {
 				// The datastore should be swept now
 				const { summaryVersion } = await summarize(summarizer);
 				const container = await loadContainer(summaryVersion);
-				await sendOpToUpdateSummaryTimestampToNow(container);
 
 				// This request fails since the datastore is swept
 				const errorResponse = await containerRuntime_resolveHandle(container, {
@@ -285,6 +292,62 @@ describeNoCompat("GC data store sweep tests", (getTestObjectProvider) => {
 					summarizerResponse.headers?.[TombstoneResponseHeaderKey],
 					undefined,
 					"DID NOT Expect tombstone header to be set on the response",
+				);
+			},
+		);
+
+		itExpects(
+			"Receiving ops for swept datastores fails in client after sweep timeout and summarizing container",
+			[
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
+				},
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
+				},
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
+				},
+				{
+					eventName: "fluid:telemetry:Container:ContainerClose",
+				},
+				{
+					eventName: "fluid:telemetry:Container:ContainerClose",
+				},
+			],
+			async () => {
+				const {
+					unreferencedId,
+					summarizingContainer,
+					summarizer,
+					summaryVersion: unreferencedSummaryVersion,
+				} = await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+				const sendingContainer = await loadContainer(unreferencedSummaryVersion);
+				const response = await containerRuntime_resolveHandle(sendingContainer, {
+					url: unreferencedId,
+				});
+				const dataObject = response.value as ITestDataObject;
+
+				// The datastore should be swept now
+				const { summaryVersion } = await summarize(summarizer);
+				const container = await loadContainer(summaryVersion);
+				setupContainerCloseErrorValidation(summarizingContainer);
+				setupContainerCloseErrorValidation(container);
+
+				// Send an op to the swept data store
+				dataObject._root.set("send", "op");
+				await provider.ensureSynchronized();
+
+				// The containers should fail
+				assert(
+					summarizingContainer.closed,
+					"Summarzing container with deleted datastore should close on receiving an op for it",
+				);
+				assert(
+					container.closed,
+					"Container with deleted datastore should close on receiving an op for it",
 				);
 			},
 		);


### PR DESCRIPTION
[AB#2385](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2385)

When a container receives an op/signal for a deleted datastore it closes with the appropriate gc error messaging.