### PR TITLE
Re-expose @fluid-internal/test-drivers for performance pipeline

### DIFF
--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@fluid-internal/test-drivers",
 	"version": "2.0.0-internal.4.0.0",
-	"private": true,
 	"description": "A driver abstraction and implementations for testing against server",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
## Description

#14086 marked this package private, but it's referenced by the internal performance pipeline. See failed run [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=129038&view=logs&j=91a1ed3c-a099-5941-fcb5-88df1e68d5ee&t=0aa85430-bfbe-5702-da3c-71f485853d99). This re-exposes to keep data flowing. Note the package still won't be publicly available (as it is in the @fluid-internal namespace).
