### PR TITLE
[Port to v2int/3.0] Fixed bug - RefreshLatestSummaryAck can end up updating wrong latest reference sequence number

### DIFF
--- a/api-report/runtime-utils.api.md
+++ b/api-report/runtime-utils.api.md
@@ -95,6 +95,14 @@ export function getBlobSize(content: ISummaryBlob["content"]): number;
 // @public (undocumented)
 export function getNormalizedObjectStoragePathParts(path: string): string[];
 
+// @public
+export interface IFetchSnapshotResult {
+    // (undocumented)
+    snapshotRefSeq: number;
+    // (undocumented)
+    snapshotTree: ISnapshotTree;
+}
+
 // @public (undocumented)
 export interface IRootSummarizerNode extends ISummarizerNode, ISummarizerNodeRootContract {
 }
@@ -110,7 +118,7 @@ export interface ISummarizerNodeRootContract {
     // (undocumented)
     completeSummary(proposalHandle: string): void;
     // (undocumented)
-    refreshLatestSummary(proposalHandle: string | undefined, summaryRefSeq: number, getSnapshot: () => Promise<ISnapshotTree>, readAndParseBlob: ReadAndParseBlob, correlatedSummaryLogger: ITelemetryLogger): Promise<RefreshSummaryResult>;
+    refreshLatestSummary(proposalHandle: string | undefined, summaryRefSeq: number, fetchLatestSnapshot: () => Promise<IFetchSnapshotResult>, readAndParseBlob: ReadAndParseBlob, correlatedSummaryLogger: ITelemetryLogger): Promise<RefreshSummaryResult>;
     // (undocumented)
     startSummary(referenceSequenceNumber: number, summaryLogger: ITelemetryLogger): void;
 }
@@ -144,10 +152,12 @@ export type RefreshSummaryResult = {
 } | {
     latestSummaryUpdated: true;
     wasSummaryTracked: true;
+    summaryRefSeq: number;
 } | {
     latestSummaryUpdated: true;
     wasSummaryTracked: false;
-    snapshot: ISnapshotTree;
+    snapshotTree: ISnapshotTree;
+    summaryRefSeq: number;
 };
 
 // @public (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -94,6 +94,7 @@ import {
     addSummarizeResultToSummary,
     addTreeToSummary,
     createRootSummarizerNodeWithGC,
+    IFetchSnapshotResult,
     IRootSummarizerNodeWithGC,
     RequestParser,
     create404Response,
@@ -103,6 +104,7 @@ import {
     seqFromTree,
     calculateStats,
     TelemetryContext,
+    ReadAndParseBlob,
 } from "@fluidframework/runtime-utils";
 import { GCDataBuilder, trimLeadingAndTrailingSlashes } from "@fluidframework/garbage-collector";
 import { v4 as uuid } from "uuid";

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2828,149 +2828,157 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
         }
     }
 
-    /** Implementation of ISummarizerInternalsProvider.refreshLatestSummaryAck */
-    public async refreshLatestSummaryAck(options: IRefreshSummaryAckOptions) {
-        const { proposalHandle, ackHandle, summaryRefSeq, summaryLogger } = options;
-        const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
-        // The call to fetch the snapshot is very expensive and not always needed.
-        // It should only be done by the summarizerNode, if required.
-        // When fetching from storage we will always get the latest version and do not use the ackHandle.
-        const snapshotTreeFetcher = async () => {
-            const fetchResult = await this.fetchLatestSnapshotFromStorage(
-                summaryLogger,
-                {
-                    eventName: "RefreshLatestSummaryGetSnapshot",
-                    ackHandle,
-                    summaryRefSeq,
-                    fetchLatest: true,
-                },
-            );
+	/** Implementation of ISummarizerInternalsProvider.refreshLatestSummaryAck */
+	public async refreshLatestSummaryAck(options: IRefreshSummaryAckOptions) {
+		const { proposalHandle, ackHandle, summaryRefSeq, summaryLogger } = options;
+		const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
+		// The call to fetch the snapshot is very expensive and not always needed.
+		// It should only be done by the summarizerNode, if required.
+		// When fetching from storage we will always get the latest version and do not use the ackHandle.
+		const snapshotTreeFetcher = async () => {
+			const fetchResult = await this.fetchLatestSnapshotFromStorage(summaryLogger, {
+				eventName: "RefreshLatestSummaryGetSnapshot",
+				ackHandle,
+				summaryRefSeq,
+				fetchLatest: true,
+			});
 
-            const latestSnapshotRefSeq = await seqFromTree(fetchResult.snapshotTree, readAndParseBlob);
-            /**
-             * If the fetched snapshot is older than the one for which the ack was received, close the container.
-             * This should never happen because an ack should be sent after the latest summary is updated in the server.
-             * However, there are couple of scenarios where it's possible:
-             * 1. A file was modified externally resulting in modifying the snapshot's sequence number. This can lead to
-             * the document being unusable and we should not proceed.
-             * 2. The server DB failed after the ack was sent which may delete the corresponding snapshot. Ideally, in
-             * such cases, the file will be rolled back along with the ack and we will eventually reach a consistent
-             * state.
-             */
-            if (latestSnapshotRefSeq < summaryRefSeq) {
-                const error = DataProcessingError.create(
-                    "Fetched snapshot is older than the received ack",
-                    "RefreshLatestSummaryAck",
-                    undefined /* sequencedMessage */,
-                    {
-                        ackHandle,
-                        summaryRefSeq,
-                        latestSnapshotRefSeq,
-                    },
-                );
-                this.closeFn(error);
-                throw error;
-            }
+			const latestSnapshotRefSeq = await seqFromTree(
+				fetchResult.snapshotTree,
+				readAndParseBlob,
+			);
+			/**
+			 * If the fetched snapshot is older than the one for which the ack was received, close the container.
+			 * This should never happen because an ack should be sent after the latest summary is updated in the server.
+			 * However, there are couple of scenarios where it's possible:
+			 * 1. A file was modified externally resulting in modifying the snapshot's sequence number. This can lead to
+			 * the document being unusable and we should not proceed.
+			 * 2. The server DB failed after the ack was sent which may delete the corresponding snapshot. Ideally, in
+			 * such cases, the file will be rolled back along with the ack and we will eventually reach a consistent
+			 * state.
+			 */
+			if (latestSnapshotRefSeq < summaryRefSeq) {
+				const error = DataProcessingError.create(
+					"Fetched snapshot is older than the received ack",
+					"RefreshLatestSummaryAck",
+					undefined /* sequencedMessage */,
+					{
+						ackHandle,
+						summaryRefSeq,
+						latestSnapshotRefSeq,
+					},
+				);
+				this.closeFn(error);
+				throw error;
+			}
 
-            summaryLogger.sendTelemetryEvent(
-                {
-                    eventName: "LatestSummaryRetrieved",
-                    ackHandle,
-                    lastSequenceNumber: latestSnapshotRefSeq,
-                    targetSequenceNumber: summaryRefSeq,
-                });
+			summaryLogger.sendTelemetryEvent({
+				eventName: "LatestSummaryRetrieved",
+				ackHandle,
+				lastSequenceNumber: latestSnapshotRefSeq,
+				targetSequenceNumber: summaryRefSeq,
+			});
 
-            // In case we had to retrieve the latest snapshot and it is different than summaryRefSeq,
-            // wait for the delta manager to catch up before refreshing the latest Summary.
-            await this.waitForDeltaManagerToCatchup(latestSnapshotRefSeq,
-                summaryLogger);
+			// In case we had to retrieve the latest snapshot and it is different than summaryRefSeq,
+			// wait for the delta manager to catch up before refreshing the latest Summary.
+			await this.waitForDeltaManagerToCatchup(latestSnapshotRefSeq, summaryLogger);
 
-            return fetchResult.snapshotTree;
-        };
+			return fetchResult.snapshotTree;
+		};
 
-        const result = await this.summarizerNode.refreshLatestSummary(
-            proposalHandle,
-            summaryRefSeq,
-            snapshotTreeFetcher,
-            readAndParseBlob,
-            summaryLogger,
-        );
+		const result = await this.summarizerNode.refreshLatestSummary(
+			proposalHandle,
+			summaryRefSeq,
+			snapshotTreeFetcher,
+			readAndParseBlob,
+			summaryLogger,
+		);
 
-        // Notify the garbage collector so it can update its latest summary state.
-        await this.garbageCollector.refreshLatestSummary(
-            result,
-            proposalHandle,
-            summaryRefSeq,
-            readAndParseBlob,
-        );
-    }
+		// Notify the garbage collector so it can update its latest summary state.
+		await this.garbageCollector.refreshLatestSummary(
+			result,
+			proposalHandle,
+			summaryRefSeq,
+			readAndParseBlob,
+		);
+	}
 
-    /**
-     * Fetches the latest snapshot from storage and uses it to refresh SummarizerNode's
-     * internal state as it should be considered the latest summary ack.
-     * @param summaryLogger - logger to use when fetching snapshot from storage
-     * @returns downloaded snapshot's reference sequence number
-     */
-    private async refreshLatestSummaryAckFromServer(
-        summaryLogger: ITelemetryLogger,
-    ): Promise<{ latestSnapshotRefSeq: number; latestSnapshotVersionId: string | undefined; }> {
-        const { snapshotTree, versionId } = await this.fetchLatestSnapshotFromStorage(
-            summaryLogger,
-            {
-                eventName: "RefreshLatestSummaryGetSnapshot",
-                fetchLatest: true,
-            },
-        );
+	/**
+	 * Fetches the latest snapshot from storage and uses it to refresh SummarizerNode's
+	 * internal state as it should be considered the latest summary ack.
+	 * @param summaryLogger - logger to use when fetching snapshot from storage
+	 * @returns downloaded snapshot's reference sequence number
+	 */
+	private async refreshLatestSummaryAckFromServer(
+		summaryLogger: ITelemetryLogger,
+	): Promise<{ latestSnapshotRefSeq: number; latestSnapshotVersionId: string | undefined }> {
+		const { snapshotTree, versionId } = await this.fetchLatestSnapshotFromStorage(
+			summaryLogger,
+			{
+				eventName: "RefreshLatestSummaryGetSnapshot",
+				fetchLatest: true,
+			},
+		);
 
-        const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
-        const latestSnapshotRefSeq = await seqFromTree(snapshotTree, readAndParseBlob);
+		const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
+		const latestSnapshotRefSeq = await seqFromTree(snapshotTree, readAndParseBlob);
 
-        const result = await this.summarizerNode.refreshLatestSummary(
-            undefined,
-            latestSnapshotRefSeq,
-            async () => snapshotTree,
-            readAndParseBlob,
-            summaryLogger,
-        );
+		const result = await this.summarizerNode.refreshLatestSummary(
+			undefined,
+			latestSnapshotRefSeq,
+			async () => snapshotTree,
+			readAndParseBlob,
+			summaryLogger,
+		);
 
-        // Notify the garbage collector so it can update its latest summary state.
-        await this.garbageCollector.refreshLatestSummary(
-            result,
-            undefined,
-            latestSnapshotRefSeq,
-            readAndParseBlob,
-        )
+		// Notify the garbage collector so it can update its latest summary state.
+		await this.garbageCollector.refreshLatestSummary(
+			result,
+			undefined,
+			latestSnapshotRefSeq,
+			readAndParseBlob,
+		);
 
-        return { latestSnapshotRefSeq, latestSnapshotVersionId: versionId };
-    }
+		return { latestSnapshotRefSeq, latestSnapshotVersionId: versionId };
+	}
 
-    private async fetchLatestSnapshotFromStorage(
-        logger: ITelemetryLogger,
-        event: ITelemetryGenericEvent,
-    ): Promise<{ snapshotTree: ISnapshotTree; versionId: string; }> {
-        return PerformanceEvent.timedExecAsync(
-            logger, event, async (perfEvent: {
-                end: (arg0: {
-                    getVersionDuration?: number | undefined;
-                    getSnapshotDuration?: number | undefined;
-                }) => void;
-            }) => {
-            const stats: { getVersionDuration?: number; getSnapshotDuration?: number; } = {};
-            const trace = Trace.start();
+	private async fetchLatestSnapshotFromStorage(
+		logger: ITelemetryLogger,
+		event: ITelemetryGenericEvent,
+	): Promise<{ snapshotTree: ISnapshotTree; versionId: string }> {
+		return PerformanceEvent.timedExecAsync(
+			logger,
+			event,
+			async (perfEvent: {
+				end: (arg0: {
+					getVersionDuration?: number | undefined;
+					getSnapshotDuration?: number | undefined;
+				}) => void;
+			}) => {
+				const stats: { getVersionDuration?: number; getSnapshotDuration?: number } = {};
+				const trace = Trace.start();
 
-            const versions = await this.storage.getVersions(
-                null, 1, "refreshLatestSummaryAckFromServer", FetchSource.noCache);
-            assert(!!versions && !!versions[0], 0x137 /* "Failed to get version from storage" */);
-            stats.getVersionDuration = trace.trace().duration;
+				const versions = await this.storage.getVersions(
+					null,
+					1,
+					"refreshLatestSummaryAckFromServer",
+					FetchSource.noCache,
+				);
+				assert(
+					!!versions && !!versions[0],
+					0x137 /* "Failed to get version from storage" */,
+				);
+				stats.getVersionDuration = trace.trace().duration;
 
-            const maybeSnapshot = await this.storage.getSnapshotTree(versions[0]);
-            assert(!!maybeSnapshot, 0x138 /* "Failed to get snapshot from storage" */);
-            stats.getSnapshotDuration = trace.trace().duration;
+				const maybeSnapshot = await this.storage.getSnapshotTree(versions[0]);
+				assert(!!maybeSnapshot, 0x138 /* "Failed to get snapshot from storage" */);
+				stats.getSnapshotDuration = trace.trace().duration;
 
-            perfEvent.end(stats);
-            return { snapshotTree: maybeSnapshot, versionId: versions[0].id };
-        });
-    }
+				perfEvent.end(stats);
+				return { snapshotTree: maybeSnapshot, versionId: versions[0].id };
+			},
+		);
+	}
 
     public notifyAttaching(snapshot: ISnapshotTreeWithBlobContents) {
         if (this.mc.config.getBoolean("enableOfflineLoad") ?? this.runtimeOptions.enableOfflineLoad) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2906,7 +2906,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
      */
     private async refreshLatestSummaryAckFromServer(
         summaryLogger: ITelemetryLogger,
-    ): Promise<{ latestSnapshotRefSeq: number; latestSnapshotVersionId: string | undefined }> {
+    ): Promise<{ latestSnapshotRefSeq: number; latestSnapshotVersionId: string | undefined; }> {
         const readAndParseBlob = async <T>(id: string) => readAndParse<T>(this.storage, id);
         const { snapshotTree, versionId, latestSnapshotRefSeq } =
             await this.fetchLatestSnapshotFromStorage(
@@ -2933,7 +2933,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
             undefined /* proposalHandle */,
             result,
             readAndParseBlob,
-        );
+        )
 
         return { latestSnapshotRefSeq, latestSnapshotVersionId: versionId };
     }
@@ -2954,39 +2954,39 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                     snapshotVersion?: string | undefined;
                 }) => void;
             }) => {
-                const stats: {
-                    getVersionDuration?: number;
-                    getSnapshotDuration?: number;
-                    snapshotRefSeq?: number;
-                    snapshotVersion?: string;
-                } = {};
-                const trace = Trace.start();
+            const stats: {
+                getVersionDuration?: number;
+                getSnapshotDuration?: number;
+                snapshotRefSeq?: number;
+                snapshotVersion?: string;
+            } = {};
+            const trace = Trace.start();
 
-                const versions = await this.storage.getVersions(
-                    null,
-                    1,
-                    "refreshLatestSummaryAckFromServer",
-                    FetchSource.noCache,
-                );
-                assert(
-                    !!versions && !!versions[0],
-                    0x137 /* "Failed to get version from storage" */,
-                );
-                stats.getVersionDuration = trace.trace().duration;
+            const versions = await this.storage.getVersions(
+                null,
+                1,
+                "refreshLatestSummaryAckFromServer",
+                FetchSource.noCache,
+            );
+            assert(
+                !!versions && !!versions[0],
+                0x137 /* "Failed to get version from storage" */,
+            );
+            stats.getVersionDuration = trace.trace().duration;
 
-                const maybeSnapshot = await this.storage.getSnapshotTree(versions[0]);
-                assert(!!maybeSnapshot, 0x138 /* "Failed to get snapshot from storage" */);
-                stats.getSnapshotDuration = trace.trace().duration;
-                const latestSnapshotRefSeq = await seqFromTree(maybeSnapshot, readAndParseBlob);
-                stats.snapshotRefSeq = latestSnapshotRefSeq;
-                stats.snapshotVersion = versions[0].id;
+            const maybeSnapshot = await this.storage.getSnapshotTree(versions[0]);
+            assert(!!maybeSnapshot, 0x138 /* "Failed to get snapshot from storage" */);
+            stats.getSnapshotDuration = trace.trace().duration;
+            const latestSnapshotRefSeq = await seqFromTree(maybeSnapshot, readAndParseBlob);
+            stats.snapshotRefSeq = latestSnapshotRefSeq;
+            stats.snapshotVersion = versions[0].id;
 
-                perfEvent.end(stats);
-                return {
-                    snapshotTree: maybeSnapshot,
-                    versionId: versions[0].id,
-                    latestSnapshotRefSeq,
-                };
+            perfEvent.end(stats);
+            return {
+                snapshotTree: maybeSnapshot,
+                versionId: versions[0].id,
+                latestSnapshotRefSeq,
+            };
             },
         );
     }

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -157,12 +157,11 @@ export interface IGarbageCollector {
     /** Returns the GC details generated from the base snapshot. */
     getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
     /** Called when the latest summary of the system has been refreshed. */
-    refreshLatestSummary(
-        result: RefreshSummaryResult,
-        proposalHandle: string | undefined,
-        summaryRefSeq: number,
-        readAndParseBlob: ReadAndParseBlob,
-    ): Promise<void>;
+	refreshLatestSummary(
+		proposalHandle: string | undefined,
+		result: RefreshSummaryResult,
+		readAndParseBlob: ReadAndParseBlob,
+	): Promise<void>;
     /** Called when a node is updated. Used to detect and log when an inactive node is changed or loaded. */
     nodeUpdated(
         nodePath: string,
@@ -1178,12 +1177,11 @@ export class GarbageCollector implements IGarbageCollector {
      * Called to refresh the latest summary state. This happens when either a pending summary is acked or a snapshot
      * is downloaded and should be used to update the state.
      */
-    public async refreshLatestSummary(
-        result: RefreshSummaryResult,
-        proposalHandle: string | undefined,
-        summaryRefSeq: number,
-        readAndParseBlob: ReadAndParseBlob,
-    ): Promise<void> {
+	public async refreshLatestSummary(
+		proposalHandle: string | undefined,
+		result: RefreshSummaryResult,
+		readAndParseBlob: ReadAndParseBlob,
+	): Promise<void> {
         // If the latest summary was updated and the summary was tracked, this client is the one that generated this
         // summary. So, update wasGCRunInLatestSummary.
         // Note that this has to be updated if GC did not run too. Otherwise, `gcStateNeedsReset` will always return
@@ -1208,8 +1206,8 @@ export class GarbageCollector implements IGarbageCollector {
         }
 
         // If the summary was not tracked by this client, the state should be updated from the downloaded snapshot.
-        const snapshot = result.snapshot;
-        const metadataBlobId = snapshot.blobs[metadataBlobName];
+		const snapshotTree = result.snapshotTree;
+		const metadataBlobId = snapshotTree.blobs[metadataBlobName];
         if (metadataBlobId) {
             const metadata = await readAndParseBlob<IContainerRuntimeMetadata>(metadataBlobId);
             this.latestSummaryGCVersion = getGCVersion(metadata);
@@ -1223,10 +1221,10 @@ export class GarbageCollector implements IGarbageCollector {
                 "No reference timestamp when updating GC state from snapshot",
                 "refreshLatestSummary",
                 undefined,
-                { proposalHandle, summaryRefSeq, details: JSON.stringify(this.configs) },
+                { proposalHandle, summaryRefSeq: result.summaryRefSeq, details: JSON.stringify(this.configs) },
             );
         }
-        const gcSnapshotTree = snapshot.trees[gcTreeKey];
+        const gcSnapshotTree = snapshotTree.trees[gcTreeKey];
         // If GC ran in the container that generated this snapshot, it will have a GC tree.
         this.wasGCRunInLatestSummary = gcSnapshotTree !== undefined;
         let latestGCData: IGarbageCollectionSnapshotData | undefined;

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -157,11 +157,11 @@ export interface IGarbageCollector {
     /** Returns the GC details generated from the base snapshot. */
     getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
     /** Called when the latest summary of the system has been refreshed. */
-	refreshLatestSummary(
-		proposalHandle: string | undefined,
-		result: RefreshSummaryResult,
-		readAndParseBlob: ReadAndParseBlob,
-	): Promise<void>;
+    refreshLatestSummary(
+        proposalHandle: string | undefined,
+        result: RefreshSummaryResult,
+        readAndParseBlob: ReadAndParseBlob,
+    ): Promise<void>;
     /** Called when a node is updated. Used to detect and log when an inactive node is changed or loaded. */
     nodeUpdated(
         nodePath: string,
@@ -1177,11 +1177,11 @@ export class GarbageCollector implements IGarbageCollector {
      * Called to refresh the latest summary state. This happens when either a pending summary is acked or a snapshot
      * is downloaded and should be used to update the state.
      */
-	public async refreshLatestSummary(
-		proposalHandle: string | undefined,
-		result: RefreshSummaryResult,
-		readAndParseBlob: ReadAndParseBlob,
-	): Promise<void> {
+    public async refreshLatestSummary(
+        proposalHandle: string | undefined,
+        result: RefreshSummaryResult,
+        readAndParseBlob: ReadAndParseBlob,
+    ): Promise<void> {
         // If the latest summary was updated and the summary was tracked, this client is the one that generated this
         // summary. So, update wasGCRunInLatestSummary.
         // Note that this has to be updated if GC did not run too. Otherwise, `gcStateNeedsReset` will always return
@@ -1206,8 +1206,8 @@ export class GarbageCollector implements IGarbageCollector {
         }
 
         // If the summary was not tracked by this client, the state should be updated from the downloaded snapshot.
-		const snapshotTree = result.snapshotTree;
-		const metadataBlobId = snapshotTree.blobs[metadataBlobName];
+        const snapshotTree = result.snapshotTree;
+        const metadataBlobId = snapshotTree.blobs[metadataBlobName];
         if (metadataBlobId) {
             const metadata = await readAndParseBlob<IContainerRuntimeMetadata>(metadataBlobId);
             this.latestSummaryGCVersion = getGCVersion(metadata);

--- a/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/garbageCollection.spec.ts
@@ -1194,8 +1194,12 @@ describe("Garbage Collection Tests", () => {
             const deletedNodesBlob = gcSummary.summary.tree[gcDeletedBlobKey];
             assert(deletedNodesBlob.type === SummaryType.Handle, "Deleted nodes state should be a handle");
 
-            const refreshSummaryResult: RefreshSummaryResult = { latestSummaryUpdated: true, wasSummaryTracked: true};
-            await garbageCollector.refreshLatestSummary(refreshSummaryResult, undefined, 0, parseNothing);
+            const refreshSummaryResult: RefreshSummaryResult = { latestSummaryUpdated: true, wasSummaryTracked: true, summaryRefSeq: 0 };
+			await garbageCollector.refreshLatestSummary(
+				undefined,
+				refreshSummaryResult,
+				parseNothing,
+			);
 
             // Run GC and summarize again. The whole GC summary should now be a summary handle.
             await garbageCollector.collectGarbage({});
@@ -1735,12 +1739,11 @@ describe("Garbage Collection Tests", () => {
 
             checkGCSummaryType(tree1, SummaryType.Tree, "first");
 
-            await garbageCollector.refreshLatestSummary(
-                { wasSummaryTracked: true, latestSummaryUpdated: true },
-                undefined,
-                0,
-                parseNothing,
-            );
+			await garbageCollector.refreshLatestSummary(
+				undefined,
+				{ wasSummaryTracked: true, latestSummaryUpdated: true, summaryRefSeq: 0 },
+				parseNothing,
+			);
 
             await garbageCollector.collectGarbage({});
             const tree2 = garbageCollector.summarize(fullTree, trackState);

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -101,6 +101,11 @@
     "version": "2.0.0-internal.3.0.0",
     "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
     "baselineVersion": "2.0.0-internal.2.2.0",
-    "broken": {}
+		"broken": {
+			"TypeAliasDeclaration_RefreshSummaryResult": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
   }
 }

--- a/packages/runtime/runtime-utils/src/index.ts
+++ b/packages/runtime/runtime-utils/src/index.ts
@@ -21,6 +21,7 @@ export { RuntimeFactoryHelper } from "./runtimeFactoryHelper";
 export {
 	createRootSummarizerNode,
 	createRootSummarizerNodeWithGC,
+    IFetchSnapshotResult,
 	IRootSummarizerNode,
 	IRootSummarizerNodeWithGC,
 	ISummarizerNodeRootContract,

--- a/packages/runtime/runtime-utils/src/summarizerNode/index.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/index.ts
@@ -3,6 +3,10 @@
  * Licensed under the MIT License.
  */
 
-export { ISummarizerNodeRootContract, RefreshSummaryResult } from "./summarizerNodeUtils";
+export {
+	IFetchSnapshotResult,
+	ISummarizerNodeRootContract,
+	RefreshSummaryResult,
+} from "./summarizerNodeUtils";
 export { IRootSummarizerNode, createRootSummarizerNode } from "./summarizerNode";
 export { IRootSummarizerNodeWithGC, createRootSummarizerNodeWithGC } from "./summarizerNodeWithGc";

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
@@ -26,6 +26,7 @@ import { ReadAndParseBlob } from "../utils";
 import {
     EscapedPath,
     ICreateChildDetails,
+    IFetchSnapshotResult,
     IInitialSummary,
     ISummarizerNodeRootContract,
     parseSummaryForSubtrees,
@@ -202,12 +203,11 @@ export class SummarizerNode implements IRootSummarizerNode {
 	/**
 	 * Refreshes the latest summary tracked by this node. If we have a pending summary for the given proposal handle,
 	 * it becomes the latest summary. If the current summary is already ahead (e.g., loaded from a service summary),
-	 * we skip the update. Otherwise, we get the snapshot by calling `getSnapshot` and update latest
-	 * summary based off of that.
+	 * we skip the update. Otherwise, we fetch the latest snapshot and update latest summary based off of that.
 	 *
 	 * @returns A RefreshSummaryResult type which returns information based on the following three scenarios:
 	 *
-	 * 1. The latest summary was not udpated.
+	 * 1. The latest summary was not updated.
 	 *
 	 * 2. The latest summary was updated and the summary corresponding to the params was being tracked.
 	 *
@@ -217,7 +217,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 	public async refreshLatestSummary(
 		proposalHandle: string | undefined,
 		summaryRefSeq: number,
-		getSnapshot: () => Promise<ISnapshotTree>,
+		fetchLatestSnapshot: () => Promise<IFetchSnapshotResult>,
 		readAndParseBlob: ReadAndParseBlob,
 		correlatedSummaryLogger: ITelemetryLogger,
 	): Promise<RefreshSummaryResult> {
@@ -236,7 +236,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 					proposalHandle,
 					maybeSummaryNode.referenceSequenceNumber,
 				);
-				return { latestSummaryUpdated: true, wasSummaryTracked: true };
+				return { latestSummaryUpdated: true, wasSummaryTracked: true, summaryRefSeq };
 			}
 
 			const props = {
@@ -251,21 +251,36 @@ export class SummarizerNode implements IRootSummarizerNode {
 			});
 		}
 
-		// If we have seen a summary same or later as the current one, ignore it.
+		// If the summary for which refresh is called is older than the latest tracked summary, ignore it.
 		if (this.referenceSequenceNumber >= summaryRefSeq) {
 			return { latestSummaryUpdated: false };
 		}
 
-		const snapshotTree = await getSnapshot();
+		// Fetch the latest snapshot and refresh state from it. Note that we need to use the reference sequence number
+		// of the fetched snapshot and not the "summaryRefSeq" that was passed in.
+		const { snapshotTree, snapshotRefSeq: fetchedSnapshotRefSeq } = await fetchLatestSnapshot();
+
+		// Possible re-entrancy. We may have updated latest summary state while fetching the snapshot. If the fetched
+		// snapshot is older than the latest tracked summary, ignore it.
+		if (this.referenceSequenceNumber >= fetchedSnapshotRefSeq) {
+			return { latestSummaryUpdated: false };
+		}
+
 		await this.refreshLatestSummaryFromSnapshot(
-			summaryRefSeq,
+			fetchedSnapshotRefSeq,
 			snapshotTree,
 			undefined,
 			EscapedPath.create(""),
 			correlatedSummaryLogger,
 			readAndParseBlob,
 		);
-		return { latestSummaryUpdated: true, wasSummaryTracked: false, snapshot: snapshotTree };
+
+		return {
+			latestSummaryUpdated: true,
+			wasSummaryTracked: false,
+			snapshotTree,
+			summaryRefSeq: fetchedSnapshotRefSeq,
+		};
 	}
 /**
  * Called when we get an ack from the server for a summary we've just sent. Updates the reference state of this node

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
@@ -13,25 +13,35 @@ import { channelsTreeName, ISummaryTreeWithStats } from "@fluidframework/runtime
 import { ReadAndParseBlob } from "../utils";
 
 /**
- * Return value of refreshSummaryAck function. There can be three different scenarios based on the passed params:
+ * Return type of refreshSummaryAck function. There can be three different scenarios based on the passed params:
  *
- * 1. The latest summary was not udpated.
+ * 1. The latest summary was not updated.
  *
  * 2. The latest summary was updated and the summary corresponding to the params was tracked by this client.
  *
  * 3. The latest summary was updated but the summary corresponding to the params was not tracked. In this case, the
- * latest summary is updated based on the downloaded snapshot which is also returned.
+ * latest snapshot is fetched and the latest summary state is updated based on it.
  */
 export type RefreshSummaryResult = {
     latestSummaryUpdated: false;
 } | {
     latestSummaryUpdated: true;
     wasSummaryTracked: true;
+    summaryRefSeq: number;
 } | {
     latestSummaryUpdated: true;
     wasSummaryTracked: false;
-    snapshot: ISnapshotTree;
+    snapshotTree: ISnapshotTree;
+    summaryRefSeq: number;
 };
+
+/**
+ * Result of snapshot fetch during refreshing latest summary state.
+ */
+export interface IFetchSnapshotResult {
+    snapshotTree: ISnapshotTree;
+    snapshotRefSeq: number;
+}
 
 export interface ISummarizerNodeRootContract {
     startSummary(referenceSequenceNumber: number, summaryLogger: ITelemetryLogger): void;
@@ -40,7 +50,7 @@ export interface ISummarizerNodeRootContract {
     refreshLatestSummary(
         proposalHandle: string | undefined,
         summaryRefSeq: number,
-        getSnapshot: () => Promise<ISnapshotTree>,
+        fetchLatestSnapshot: () => Promise<IFetchSnapshotResult>,
         readAndParseBlob: ReadAndParseBlob,
         correlatedSummaryLogger: ITelemetryLogger,
     ): Promise<RefreshSummaryResult>;

--- a/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
@@ -301,66 +301,66 @@ describe("Runtime", () => {
                 });
             });
 
-            describe("Refresh Latest Summary", () => {
-                it("Should refresh from tree when no proposal handle provided", async () => {
-                    createRoot();
-                    const result = await rootNode.refreshLatestSummary(
-                        undefined,
-                        summaryRefSeq,
-                        getSnapshot,
-                        readAndParseBlob,
-                        logger,
-                    );
-                    assert(result.latestSummaryUpdated === true, "should update");
-                    assert(result.wasSummaryTracked === false, "should not be tracked");
-                    assert(result.snapshot !== undefined, "should have tree result");
-                });
+			describe("Refresh Latest Summary", () => {
+				it("Should refresh from tree when no proposal handle provided", async () => {
+					createRoot();
+					const result = await rootNode.refreshLatestSummary(
+						undefined,
+						summaryRefSeq,
+						getSnapshot,
+						readAndParseBlob,
+						logger,
+					);
+					assert(result.latestSummaryUpdated === true, "should update");
+					assert(result.wasSummaryTracked === false, "should not be tracked");
+					assert(result.snapshot !== undefined, "should have tree result");
+				});
 
-                it("Should refresh from tree when proposal handle not pending", async () => {
-                    createRoot();
-                    const result = await rootNode.refreshLatestSummary(
-                        "test-handle",
-                        summaryRefSeq,
-                        getSnapshot,
-                        readAndParseBlob,
-                        logger,
-                    );
-                    assert(result.latestSummaryUpdated === true, "should update");
-                    assert(result.wasSummaryTracked === false, "should not be tracked");
-                    assert(result.snapshot !== undefined, "should have tree result");
-                });
+				it("Should refresh from tree when proposal handle not pending", async () => {
+					createRoot();
+					const result = await rootNode.refreshLatestSummary(
+						"test-handle",
+						summaryRefSeq,
+						getSnapshot,
+						readAndParseBlob,
+						logger,
+					);
+					assert(result.latestSummaryUpdated === true, "should update");
+					assert(result.wasSummaryTracked === false, "should not be tracked");
+					assert(result.snapshot !== undefined, "should have tree result");
+				});
 
-                it("Should not refresh latest if already passed ref seq number", async () => {
-                    createRoot({ refSeq: summaryRefSeq });
-                    const result = await rootNode.refreshLatestSummary(
-                        undefined,
-                        summaryRefSeq,
-                        getSnapshot,
-                        readAndParseBlob,
-                        logger,
-                    );
-                    assert(result.latestSummaryUpdated === false, "we already got this summary");
-                });
+				it("Should not refresh latest if already passed ref seq number", async () => {
+					createRoot({ refSeq: summaryRefSeq });
+					const result = await rootNode.refreshLatestSummary(
+						undefined,
+						summaryRefSeq,
+						getSnapshot,
+						readAndParseBlob,
+						logger,
+					);
+					assert(result.latestSummaryUpdated === false, "we already got this summary");
+				});
 
-                it("Should refresh from pending", async () => {
-                    createRoot();
-                    const proposalHandle = "test-handle";
+				it("Should refresh from pending", async () => {
+					createRoot();
+					const proposalHandle = "test-handle";
 
-                    rootNode.startSummary(10, logger);
-                    await rootNode.summarize(false);
-                    rootNode.completeSummary(proposalHandle);
+					rootNode.startSummary(10, logger);
+					await rootNode.summarize(false);
+					rootNode.completeSummary(proposalHandle);
 
-                    const result = await rootNode.refreshLatestSummary(
-                        proposalHandle,
-                        summaryRefSeq,
-                        getSnapshot,
-                        readAndParseBlob,
-                        logger,
-                    );
-                    assert(result.latestSummaryUpdated === true, "should update");
-                    assert(result.wasSummaryTracked === true, "should be tracked");
-                });
-            });
+					const result = await rootNode.refreshLatestSummary(
+						proposalHandle,
+						summaryRefSeq,
+						getSnapshot,
+						readAndParseBlob,
+						logger,
+					);
+					assert(result.latestSummaryUpdated === true, "should update");
+					assert(result.wasSummaryTracked === true, "should be tracked");
+				});
+			});
         });
     });
 });

--- a/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
@@ -147,13 +147,13 @@ describe("Runtime", () => {
             } };
 
             // The reference sequence number of the fetched snapshot.
-			let snapshotRefSeq = summaryRefSeq;
-			const fetchLatestSnapshot: () => Promise<IFetchSnapshotResult> = async () => {
-				return {
-					snapshotTree: simpleSnapshot,
-					snapshotRefSeq,
-				};
-			};
+            let snapshotRefSeq = summaryRefSeq;
+            const fetchLatestSnapshot: () => Promise<IFetchSnapshotResult> = async () => {
+                return {
+                    snapshotTree: simpleSnapshot,
+                    snapshotRefSeq,
+                };
+            };
 
             beforeEach(() => {
                 summarizeCalls = [0, 0, 0];
@@ -311,93 +311,93 @@ describe("Runtime", () => {
                 });
             });
 
-			describe("Refresh Latest Summary", () => {
-				it("Should refresh from tree when no proposal handle provided", async () => {
-					createRoot();
-					const result = await rootNode.refreshLatestSummary(
-						undefined,
-						summaryRefSeq,
-						fetchLatestSnapshot,
-						readAndParseBlob,
-						logger,
-					);
-					assert(result.latestSummaryUpdated === true, "should update");
-					assert(result.wasSummaryTracked === false, "should not be tracked");
-					assert(result.snapshotTree !== undefined, "should have tree result");
-					assert(
-						result.summaryRefSeq === summaryRefSeq,
-						"summary ref seq should be the same as the one passed in",
-					);
-				});
+            describe("Refresh Latest Summary", () => {
+                it("Should refresh from tree when no proposal handle provided", async () => {
+                    createRoot();
+                    const result = await rootNode.refreshLatestSummary(
+                        undefined,
+                        summaryRefSeq,
+                        fetchLatestSnapshot,
+                        readAndParseBlob,
+                        logger,
+                    );
+                    assert(result.latestSummaryUpdated === true, "should update");
+                    assert(result.wasSummaryTracked === false, "should not be tracked");
+                    assert(result.snapshotTree !== undefined, "should have tree result");
+                    assert(
+                        result.summaryRefSeq === summaryRefSeq,
+                        "summary ref seq should be the same as the one passed in",
+                    );
+                });
 
-				it("Should use the ref seq number of the fetched snapshot", async () => {
-					createRoot();
-					snapshotRefSeq = summaryRefSeq + 1;
-					const result = await rootNode.refreshLatestSummary(
-						undefined,
-						summaryRefSeq,
-						fetchLatestSnapshot,
-						readAndParseBlob,
-						logger,
-					);
-					assert(result.latestSummaryUpdated === true, "should update");
-					assert(result.wasSummaryTracked === false, "should not be tracked");
-					assert(result.snapshotTree !== undefined, "should have tree result");
-					assert(
-						result.summaryRefSeq === snapshotRefSeq,
-						"summary ref seq should be the snapshot ref seq",
-					);
-				});
+                it("Should use the ref seq number of the fetched snapshot", async () => {
+                    createRoot();
+                    snapshotRefSeq = summaryRefSeq + 1;
+                    const result = await rootNode.refreshLatestSummary(
+                        undefined,
+                        summaryRefSeq,
+                        fetchLatestSnapshot,
+                        readAndParseBlob,
+                        logger,
+                    );
+                    assert(result.latestSummaryUpdated === true, "should update");
+                    assert(result.wasSummaryTracked === false, "should not be tracked");
+                    assert(result.snapshotTree !== undefined, "should have tree result");
+                    assert(
+                        result.summaryRefSeq === snapshotRefSeq,
+                        "summary ref seq should be the snapshot ref seq",
+                    );
+                });
 
-				it("Should refresh from tree when proposal handle not pending", async () => {
-					createRoot();
-					const result = await rootNode.refreshLatestSummary(
-						"test-handle",
-						summaryRefSeq,
-						fetchLatestSnapshot,
-						readAndParseBlob,
-						logger,
-					);
-					assert(result.latestSummaryUpdated === true, "should update");
-					assert(result.wasSummaryTracked === false, "should not be tracked");
-					assert(result.snapshotTree !== undefined, "should have tree result");
-					assert(
-						result.summaryRefSeq === summaryRefSeq,
-						"summary ref seq should be the same as the one passed in",
-					);
-				});
+                it("Should refresh from tree when proposal handle not pending", async () => {
+                    createRoot();
+                    const result = await rootNode.refreshLatestSummary(
+                        "test-handle",
+                        summaryRefSeq,
+                        fetchLatestSnapshot,
+                        readAndParseBlob,
+                        logger,
+                    );
+                    assert(result.latestSummaryUpdated === true, "should update");
+                    assert(result.wasSummaryTracked === false, "should not be tracked");
+                    assert(result.snapshotTree !== undefined, "should have tree result");
+                    assert(
+                        result.summaryRefSeq === summaryRefSeq,
+                        "summary ref seq should be the same as the one passed in",
+                    );
+                });
 
-				it("Should not refresh latest if already passed ref seq number", async () => {
-					createRoot({ refSeq: summaryRefSeq });
-					const result = await rootNode.refreshLatestSummary(
-						undefined,
-						summaryRefSeq,
-						fetchLatestSnapshot,
-						readAndParseBlob,
-						logger,
-					);
-					assert(result.latestSummaryUpdated === false, "we already got this summary");
-				});
+                it("Should not refresh latest if already passed ref seq number", async () => {
+                    createRoot({ refSeq: summaryRefSeq });
+                    const result = await rootNode.refreshLatestSummary(
+                        undefined,
+                        summaryRefSeq,
+                        fetchLatestSnapshot,
+                        readAndParseBlob,
+                        logger,
+                    );
+                    assert(result.latestSummaryUpdated === false, "we already got this summary");
+                });
 
-				it("Should refresh from pending", async () => {
-					createRoot();
-					const proposalHandle = "test-handle";
+                it("Should refresh from pending", async () => {
+                    createRoot();
+                    const proposalHandle = "test-handle";
 
-					rootNode.startSummary(10, logger);
-					await rootNode.summarize(false);
-					rootNode.completeSummary(proposalHandle);
+                    rootNode.startSummary(10, logger);
+                    await rootNode.summarize(false);
+                    rootNode.completeSummary(proposalHandle);
 
-					const result = await rootNode.refreshLatestSummary(
-						proposalHandle,
-						summaryRefSeq,
-						fetchLatestSnapshot,
-						readAndParseBlob,
-						logger,
-					);
-					assert(result.latestSummaryUpdated === true, "should update");
-					assert(result.wasSummaryTracked === true, "should be tracked");
-				});
-			});
+                    const result = await rootNode.refreshLatestSummary(
+                        proposalHandle,
+                        summaryRefSeq,
+                        fetchLatestSnapshot,
+                        readAndParseBlob,
+                        logger,
+                    );
+                    assert(result.latestSummaryUpdated === true, "should update");
+                    assert(result.wasSummaryTracked === true, "should be tracked");
+                });
+            });
         });
     });
 });

--- a/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
@@ -647,6 +647,7 @@ declare function get_old_TypeAliasDeclaration_RefreshSummaryResult():
 declare function use_current_TypeAliasDeclaration_RefreshSummaryResult(
     use: TypeOnly<current.RefreshSummaryResult>);
 use_current_TypeAliasDeclaration_RefreshSummaryResult(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_RefreshSummaryResult());
 
 /*
@@ -659,6 +660,7 @@ declare function get_current_TypeAliasDeclaration_RefreshSummaryResult():
 declare function use_old_TypeAliasDeclaration_RefreshSummaryResult(
     use: TypeOnly<old.RefreshSummaryResult>);
 use_old_TypeAliasDeclaration_RefreshSummaryResult(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_RefreshSummaryResult());
 
 /*


### PR DESCRIPTION
Porting https://github.com/microsoft/FluidFramework/pull/14052 to 2.0.0-internal.3.0 release branch