### PR TITLE
tree: Inline some fail messages

### DIFF
--- a/packages/dds/tree/src/core/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/core/edit-manager/editManager.ts
@@ -156,7 +156,11 @@ export class EditManager<
 			// `newCommit` should correspond to the oldest change in `localChanges`, so we move it into trunk.
 			// `localChanges` are already rebased to the trunk, so we can use the stored change instead of rebasing the
 			// change in the incoming commit.
-			const change = this.localChanges.shift() ?? fail(UNEXPECTED_SEQUENCED_LOCAL_EDIT);
+			const change =
+				this.localChanges.shift() ??
+				fail(
+					"Received a sequenced change from the local session despite having no local changes",
+				);
 
 			// TODO: The local change may contain references to local revision tags.
 			// When other clients rebase this change, they will instead use the corresponding sequence numbers
@@ -401,9 +405,6 @@ export interface Branch<TChangeset> {
 	localChanges: Commit<TChangeset>[];
 	refSeq: SeqNumber;
 }
-
-const UNEXPECTED_SEQUENCED_LOCAL_EDIT =
-	"Received a sequenced change from the local session despite having no local changes";
 
 /**
  * The in-memory data that summaries contain.

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
@@ -76,7 +76,7 @@ function convertMarkList(marks: T.MarkList): Delta.FieldChanges {
 					break;
 				}
 				case "MMoveIn":
-					fail(ERR_NOT_IMPLEMENTED);
+					fail("MMoveIn not implemented");
 				case "Bounce":
 				case "Intake":
 					// These have no impacts on the document state.
@@ -145,7 +145,7 @@ function convertMarkList(marks: T.MarkList): Delta.FieldChanges {
 				case "Return":
 				case "MReturn":
 				case "Gap":
-					fail(ERR_NOT_IMPLEMENTED);
+					fail("Gap not implemented");
 				case "Tomb": {
 					// These tombs are only used to precisely describe the location of other attaches.
 					// They have no impact on the current state.
@@ -170,8 +170,6 @@ function convertMarkList(marks: T.MarkList): Delta.FieldChanges {
 }
 
 const DUMMY_REVIVED_NODE_TYPE: TreeSchemaIdentifier = brand("RevivedNode");
-
-const ERR_NOT_IMPLEMENTED = "Not implemented";
 
 /**
  * Modifications to a subtree as described by a Changeset.

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceEditBuilder.ts
@@ -151,7 +151,9 @@ export class SequenceEditBuilder extends ProgressiveEditBuilderBase<SequenceChan
 					let indexA = aPath.parentIndex;
 					let indexB = bPath.parentIndex;
 					if (indexA === indexB) {
-						fail(ERR_UP_PATH_NOT_VALID);
+						fail(
+							"If the two paths have the same key and the same index then they should have shared an UpPath earlier",
+						);
 					}
 					let aMarkList = aFieldMarks[keyA];
 					let bMarkList = bFieldMarks[keyB];
@@ -235,6 +237,3 @@ export interface NodePath extends UpPath {}
  * Only valid for a specific revision of that tree.
  */
 export interface PlacePath extends UpPath {}
-
-const ERR_UP_PATH_NOT_VALID =
-	"If the two paths have the same key and the same index then they should have shared an UpPath earlier";

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -16,9 +16,6 @@ export type ToDelta<TNodeChange> = (
 	index: number | undefined,
 ) => Delta.NodeChanges | undefined;
 
-const ERR_NO_REVISION_ON_REVIVE =
-	"Unable to get convert revive mark to delta due to missing revision tag";
-
 export function sequenceFieldToDelta<TNodeChange>(
 	marks: MarkList<TNodeChange>,
 	deltaFromChild: ToDelta<TNodeChange>,
@@ -78,7 +75,9 @@ export function sequenceFieldToDelta<TNodeChange>(
 							content: reviver(
 								mark.detachedBy ??
 									mark.lastDetachedBy ??
-									fail(ERR_NO_REVISION_ON_REVIVE),
+									fail(
+										"Unable to get convert revive mark to delta due to missing revision tag",
+									),
 								mark.detachIndex,
 								mark.count,
 							),


### PR DESCRIPTION
## Description

This inlines some constants that were uses as error messages with tree's `fail` function.

This makes these usages compatible with #13963