### PR TITLE
tree: use string literals for fail messages

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/view.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/view.ts
@@ -108,7 +108,7 @@ export class ViewSchema extends ViewSchemaData<FullSchemaPolicy> {
 					this.schema.treeSchema.get(adapter.output) ?? this.policy.defaultTreeSchema,
 				)
 			) {
-				fail(`tree adapter for stored ${adapter.output} should not be never`);
+				fail("tree adapter for stored adapter.output should not be never");
 			}
 		}
 		const adapted = {

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/utils.ts
@@ -189,9 +189,7 @@ export function splitMarkOnInput<TMark extends T.SizedMark>(
 	const markLength = getInputLength(mark);
 	const remainder = markLength - length;
 	if (length < 1 || remainder < 1) {
-		fail(
-			`Unable to split mark of length ${markLength} into marks of lengths ${length} and ${remainder}`,
-		);
+		fail("Unable to split mark due to lengths");
 	}
 	if (isSkipMark(mark)) {
 		return [length, remainder] as [TMark, TMark];
@@ -206,7 +204,7 @@ export function splitMarkOnInput<TMark extends T.SizedMark>(
 		case "MMoveOut":
 		case "MReturn":
 		case "MRevive":
-			fail(`Unable to split ${type} mark of length 1`);
+			fail("Unable to split mark of length 1");
 		case "Delete":
 		case "MoveOut":
 		case "Return":
@@ -236,9 +234,7 @@ export function splitMarkOnOutput<TMark extends T.Mark>(
 	const markLength = getOutputLength(mark);
 	const remainder = markLength - length;
 	if (length < 1 || remainder < 1) {
-		fail(
-			`Unable to split mark of length ${markLength} into marks of lengths ${length} and ${remainder}`,
-		);
+		fail("Unable to split mark due to lengths");
 	}
 	if (isSkipMark(mark)) {
 		return [length, remainder] as [TMark, TMark];
@@ -251,14 +247,14 @@ export function splitMarkOnOutput<TMark extends T.Mark>(
 		case "MRevive":
 		case "MInsert":
 		case "MMoveIn":
-			fail(`Unable to split ${type} mark of length 1`);
+			fail("Unable to split mark of length 1");
 		case "MDelete":
 		case "MMoveOut":
 		case "Delete":
 		case "MoveOut":
 		case "Bounce":
 		case "Intake":
-			fail(`Unable to split ${type} mark of length 0`);
+			fail("Unable to split mark of length 0");
 		case "Insert":
 			return [
 				{ ...markObj, content: markObj.content.slice(0, length) },

--- a/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
@@ -201,7 +201,7 @@ function composeMarks<TNodeChange>(
 					return baseMark;
 				}
 				default:
-					fail(`Not implemented: ${newType}`);
+					fail("Not implemented newType");
 			}
 		case "Modify": {
 			switch (newType) {
@@ -223,7 +223,7 @@ function composeMarks<TNodeChange>(
 					);
 				}
 				default:
-					fail(`Not implemented: ${newType}`);
+					fail("Not implemented newType");
 			}
 		}
 		case "MoveIn": {
@@ -291,7 +291,7 @@ function composeMarks<TNodeChange>(
 					}
 				}
 				default:
-					fail(`Not implemented: ${newType}`);
+					fail("Not implemented newType");
 			}
 		}
 		case "ReturnTo": {
@@ -399,11 +399,11 @@ function composeMarks<TNodeChange>(
 					}
 				}
 				default:
-					fail(`Not implemented: ${newType}`);
+					fail("Not implemented newType");
 			}
 		}
 		default:
-			fail(`Composing ${baseType} and ${newType} is not implemented`);
+			fail("Composing this baseType and this newType is not implemented");
 	}
 }
 

--- a/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -397,9 +397,7 @@ export function splitMarkOnInput<T, TMark extends InputSpanningMark<T>>(
 	const markLength = getInputLength(mark);
 	const remainder = markLength - length;
 	if (length < 1 || remainder < 1) {
-		fail(
-			`Unable to split mark of length ${markLength} into marks of lengths ${length} and ${remainder}`,
-		);
+		fail("Unable to split mark due to lengths");
 	}
 	if (isSkipMark(mark)) {
 		return [length, remainder] as [TMark, TMark];
@@ -408,7 +406,7 @@ export function splitMarkOnInput<T, TMark extends InputSpanningMark<T>>(
 	const type = mark.type;
 	switch (type) {
 		case "Modify":
-			fail(`Unable to split ${type} mark of length 1`);
+			fail("Unable to split Modify mark of length 1");
 		case "ReturnTo": {
 			const newId = genId();
 			splitMove(
@@ -506,9 +504,7 @@ export function splitMarkOnOutput<T, TMark extends OutputSpanningMark<T>>(
 	const markLength = getOutputLength(mark, ignorePairing);
 	const remainder = markLength - length;
 	if (length < 1 || remainder < 1) {
-		fail(
-			`Unable to split mark of length ${markLength} into marks of lengths ${length} and ${remainder}`,
-		);
+		fail("Unable to split mark due to lengths");
 	}
 	if (isSkipMark(mark)) {
 		return [length, remainder] as [TMark, TMark];


### PR DESCRIPTION
## Description

Adjust fail messages that used template strings to use string literals to align with #13963.

Once #13963 is in, this will make the error strings not have to be included in the shipped code, allow us to tell apart the different locations, even if they have the same message, and be more compatible with telemetry since it will no longer involve strings which arn't known to be safe from a privacy perspective so would be omitted from most telemetry.