### PR TITLE
Log errors in TestObjectProvider creation, including token errors

### DIFF
--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -79,6 +79,7 @@
 		"@fluidframework/register-collection": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/runtime-definitions": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/sequence": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
+		"@fluidframework/telemetry-utils": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-driver-definitions": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-drivers": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-utils": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -47,18 +47,11 @@ function createCompatSuite(
 							config.dataRuntime,
 						);
 					} catch (error) {
-						const logger = ChildLogger.create(
-							getTestLogger?.(),
-							"DescribeCompatSetup",
-							{
-								all: {
-									driverType: driver,
-								},
-							},
-						);
+						const logger = ChildLogger.create(getTestLogger?.(), "DescribeCompatSetup");
 						logger.sendErrorEvent(
 							{
 								eventName: "TestObjectProviderLoadFailed",
+								driverType: driver,
 							},
 							error,
 						);

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -55,6 +55,7 @@ function createCompatSuite(
 							},
 							error,
 						);
+						throw error;
 					}
 
 					Object.defineProperty(this, "__fluidTestProvider", { get: () => provider });

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { ChildLogger } from "@fluidframework/telemetry-utils";
 import {
 	getUnexpectedLogErrorException,
 	ITestObjectProvider,
@@ -30,20 +31,38 @@ function createCompatSuite(
 				let provider: TestObjectProvider;
 				let resetAfterEach: boolean;
 				before(async function () {
-					provider = await getVersionedTestObjectProvider(
-						baseVersion,
-						config.loader,
-						{
-							type: driver,
-							version: config.driver,
-							config: {
-								r11s: { r11sEndpointName },
-								odsp: { tenantIndex },
+					try {
+						provider = await getVersionedTestObjectProvider(
+							baseVersion,
+							config.loader,
+							{
+								type: driver,
+								version: config.driver,
+								config: {
+									r11s: { r11sEndpointName },
+									odsp: { tenantIndex },
+								},
 							},
-						},
-						config.containerRuntime,
-						config.dataRuntime,
-					);
+							config.containerRuntime,
+							config.dataRuntime,
+						);
+					} catch (error) {
+						const logger = ChildLogger.create(
+							getTestLogger?.(),
+							"DescribeCompatSetup",
+							{
+								all: {
+									driverType: driver,
+								},
+							},
+						);
+						logger.sendErrorEvent(
+							{
+								eventName: "TestObjectProviderLoadFailed",
+							},
+							error,
+						);
+					}
 
 					Object.defineProperty(this, "__fluidTestProvider", { get: () => provider });
 				});

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -125,7 +125,7 @@ export async function fetchTokens(
 		} catch (error) {
 			if (isFluidError(error) && isAccessTokenError(parsedResponse)) {
 				error.addTelemetryProperties({
-					error: parsedResponse.error,
+					innerError: parsedResponse.error,
 					errorDescription: parsedResponse.error_description,
 					code: JSON.stringify(parsedResponse.error_codes),
 					timestamp: parsedResponse.timestamp,

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -4,6 +4,7 @@
  */
 
 import { assert } from "@fluidframework/common-utils";
+import { isFluidError } from "@fluidframework/telemetry-utils";
 import { getAadTenant, getAadUrl, getSiteUrl } from "./odspDocLibUtils";
 import { throwOdspNetworkError } from "./odspErrorUtils";
 import { unauthPostAsync } from "./odspRequest";
@@ -104,24 +105,55 @@ export async function fetchTokens(
 		client_secret: clientConfig.clientSecret,
 		...credentials,
 	};
-	const result = await unauthPostAsync(
+	const response = await unauthPostAsync(
 		getFetchTokenUrl(server),
 		new URLSearchParams(body), // This formats the body like a query string which is the expected format
 	);
-	const tokens = await result.json();
-	const accessToken = tokens.access_token;
-	const refreshToken = tokens.refresh_token;
+
+	const parsedResponse = await response.json();
+	const accessToken = parsedResponse.access_token;
+	const refreshToken = parsedResponse.refresh_token;
 
 	if (accessToken === undefined || refreshToken === undefined) {
-		// Look up error codes at https://login.microsoftonline.com/error
-		throwOdspNetworkError(
-			// pre-0.58 error message: unableToGetAccessToken
-			`Unable to get access token. Error code: ${JSON.stringify(tokens.code ?? [])}`,
-			tokens.error === "invalid_grant" ? 401 : result.status,
-			result,
-		);
+		try {
+			throwOdspNetworkError(
+				// pre-0.58 error message: unableToGetAccessToken
+				"Unable to get access token.",
+				parsedResponse.error === "invalid_grant" ? 401 : response.status,
+				response,
+			);
+		} catch (error) {
+			if (isFluidError(error) && isAccessTokenError(parsedResponse)) {
+				error.addTelemetryProperties({
+					error: parsedResponse.error,
+					code: JSON.stringify(parsedResponse.error_codes),
+					timestamp: parsedResponse.timestamp,
+					traceId: parsedResponse.trace_id,
+					correlationId: parsedResponse.correlation_id,
+				});
+			}
+			throw error;
+		}
 	}
 	return { accessToken, refreshToken };
+}
+
+/**
+ * See https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#error-response-1
+ * for documentation on these values.
+ *
+ * Error codes can also be looked up using https://login.microsoftonline.com/error
+ */
+interface AadOauth2TokenError {
+	error: string;
+	error_codes: string[];
+	timestamp: string;
+	trace_id: string;
+	correlation_id: string;
+}
+
+function isAccessTokenError(parsedResponse: any): parsedResponse is AadOauth2TokenError {
+	return typeof parsedResponse?.error === "string" && Array.isArray(parsedResponse?.error_codes);
 }
 
 /**

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -126,6 +126,7 @@ export async function fetchTokens(
 			if (isFluidError(error) && isAccessTokenError(parsedResponse)) {
 				error.addTelemetryProperties({
 					error: parsedResponse.error,
+					errorDescription: parsedResponse.error_description,
 					code: JSON.stringify(parsedResponse.error_codes),
 					timestamp: parsedResponse.timestamp,
 					traceId: parsedResponse.trace_id,
@@ -147,6 +148,7 @@ export async function fetchTokens(
 interface AadOauth2TokenError {
 	error: string;
 	error_codes: string[];
+	error_description: string;
 	timestamp: string;
 	trace_id: string;
 	correlation_id: string;

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -113,9 +113,10 @@ export async function fetchTokens(
 	const refreshToken = tokens.refresh_token;
 
 	if (accessToken === undefined || refreshToken === undefined) {
+		// Look up error codes at https://login.microsoftonline.com/error
 		throwOdspNetworkError(
 			// pre-0.58 error message: unableToGetAccessToken
-			"Unable to get access token",
+			`Unable to get access token. Error code: ${JSON.stringify(tokens.code ?? [])}`,
 			tokens.error === "invalid_grant" ? 401 : result.status,
 			result,
 		);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9464,6 +9464,7 @@ importers:
       '@fluidframework/register-collection': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluidframework/sequence': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
+      '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-drivers': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-utils': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
@@ -9513,6 +9514,7 @@ importers:
       '@fluidframework/register-collection': link:../../dds/register-collection
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/sequence': link:../../dds/sequence
+      '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       '@fluidframework/test-driver-definitions': link:../test-driver-definitions
       '@fluidframework/test-drivers': link:../test-drivers
       '@fluidframework/test-utils': link:../test-utils


### PR DESCRIPTION
## Description

e2e tests against odsp-driver were failing due to an expired tenant. This should help narrow down future issues faster.