### PR TITLE
Added telemetry that will help identify issues caused by local changes in summarizer

### DIFF
--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -33,7 +33,6 @@ import {
 	convertToSummaryTree,
 	create404Response,
 	createResponseError,
-	packagePathToTelemetryProperty,
 	responseToException,
 	SummaryTreeBuilder,
 } from "@fluidframework/runtime-utils";
@@ -624,24 +623,10 @@ export class DataStores implements IDisposable {
 				.filter(([_, context]) => {
 					// Summarizer works only with clients with no local changes. A data store in attaching
 					// state indicates an op was sent to attach a local data store.
-					if (context.attachState === AttachState.Attaching) {
-						const error = new LoggingError("Local data store during summarize", {
-							fluidDataStoreId: {
-								value: context.id,
-								tag: TelemetryDataTag.CodeArtifact,
-							},
-							packageName: context.isLoaded
-								? packagePathToTelemetryProperty(context.packagePath)
-								: undefined,
-						});
-						this.mc.logger.sendErrorEvent(
-							{
-								eventName: "LocalDataStoreDuringSummarize",
-							},
-							error,
-						);
-						throw error;
-					}
+					assert(
+						context.attachState !== AttachState.Attaching,
+						"Local data store detected in attaching state during summarize",
+					);
 					return context.attachState === AttachState.Attached;
 				})
 				.map(async ([contextId, context]) => {
@@ -740,24 +725,10 @@ export class DataStores implements IDisposable {
 				.filter(([_, context]) => {
 					// Summarizer client and hence GC works only with clients with no local changes. A data store in
 					// attaching state indicates an op was sent to attach a local data store.
-					if (context.attachState === AttachState.Attaching) {
-						const error = new LoggingError("Local data store during GC", {
-							fluidDataStoreId: {
-								value: context.id,
-								tag: TelemetryDataTag.CodeArtifact,
-							},
-							packageName: context.isLoaded
-								? packagePathToTelemetryProperty(context.packagePath)
-								: undefined,
-						});
-						this.mc.logger.sendErrorEvent(
-							{
-								eventName: "LocalDataStoreDuringGC",
-							},
-							error,
-						);
-						throw error;
-					}
+					assert(
+						context.attachState !== AttachState.Attaching,
+						"Local data store detected in attaching state while running GC",
+					);
 					return context.attachState === AttachState.Attached;
 				})
 				.map(async ([contextId, context]) => {

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
@@ -282,19 +282,6 @@ export class SummarizerNode implements IRootSummarizerNode {
 		readAndParseBlob: ReadAndParseBlob,
 		correlatedSummaryLogger: ITelemetryLogger,
 	): Promise<RefreshSummaryResult> {
-		/**
-		 * Refresh latest summary should never happen while a summary is in progress. If it does, log an error
-		 * so that we can gather data around it and take appropriate action.
-		 */
-		if (this.isSummaryInProgress()) {
-			this.logger.sendErrorEvent({
-				eventName: "UnexpectedRefreshDuringSummarize",
-				proposalHandle,
-				summaryRefSeq,
-				inProgressSummaryRefSeq: this.wipReferenceSequenceNumber,
-			});
-		}
-
 		const eventProps: {
 			proposalHandle: string | undefined;
 			summaryRefSeq: number;

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryLogger } from "@fluidframework/common-definitions";
+import { ITelemetryBaseEvent, ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ISnapshotTree, ISummaryTree, SummaryObject } from "@fluidframework/protocol-definitions";
 import { channelsTreeName, ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 import { ReadAndParseBlob } from "../utils";
@@ -180,7 +180,7 @@ export interface ICreateChildDetails {
 	/** Sequence number of latest known change to the node */
 	changeSequenceNumber: number;
 	/** A unique id of this child to be logged when sending telemetry. */
-	telemetryId: string;
+	telemetryNodeId: string;
 }
 
 export interface ISubtreeInfo<T extends ISnapshotTree | SummaryObject> {
@@ -229,3 +229,5 @@ export function parseSummaryTreeForSubtrees(summary: ISummaryTree): ISubtreeInfo
 		childrenPathPart: undefined,
 	};
 }
+
+export function logUnexpectedError(event: ITelemetryBaseEvent) {}

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeUtils.ts
@@ -179,6 +179,8 @@ export interface ICreateChildDetails {
 	latestSummary: SummaryNode | undefined;
 	/** Sequence number of latest known change to the node */
 	changeSequenceNumber: number;
+	/** A unique id of this child to be logged when sending telemetry. */
+	telemetryId: string;
 }
 
 export interface ISubtreeInfo<T extends ISnapshotTree | SummaryObject> {

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -24,6 +24,7 @@ import {
 	SummarizeInternalFn,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions";
+import { LoggingError, TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { ReadAndParseBlob } from "../utils";
 import { SummarizerNode } from "./summarizerNode";
 import {
@@ -109,6 +110,8 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 		wipSummaryLogger?: ITelemetryLogger,
 		private readonly getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
 		getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>,
+		/** A unique id of this node to be logged when sending telemetry. */
+		telemetryId?: string,
 	) {
 		super(
 			logger,
@@ -119,6 +122,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 			latestSummary,
 			initialSummary,
 			wipSummaryLogger,
+			telemetryId,
 		);
 
 		this.gcDisabled = config.gcDisabled === true;
@@ -239,10 +243,32 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 		// If GC is disabled, don't set wip used routes.
 		if (!this.gcDisabled) {
 			wipSerializedUsedRoutes = this.wipSerializedUsedRoutes;
-			assert(
-				wipSerializedUsedRoutes !== undefined,
-				0x1b5 /* "We should have been tracking used routes" */,
-			);
+			/**
+			 * The absence of wip used routes indicates that GC was not run on this node. This can happen if:
+			 * 1. A child node was created after GC was already run on the parent. For example, a data store
+			 * is realized (loaded) after GC was run on it creating summarizer nodes for its DDSes. In this
+			 * case, the used routes of the parent should be passed on the child nodes and it should be fine.
+			 * 2. A new node was created but GC was never run on it. This can mean that the GC data generated
+			 * during summarize is complete . We should not continue, log and throw an error. This will help us
+			 * identify these cases and take appropriate action.
+			 */
+			if (wipSerializedUsedRoutes === undefined) {
+				const error = new LoggingError("NodeDidNotRunGC", {
+					proposalHandle,
+					referenceSequenceNumber: this.wipReferenceSequenceNumber,
+					id: {
+						tag: TelemetryDataTag.CodeArtifact,
+						value: this.telemetryId,
+					},
+				});
+				this.logger.sendErrorEvent(
+					{
+						eventName: "NodeDidNotRunGC",
+					},
+					error,
+				);
+				throw error;
+			}
 		}
 
 		super.completeSummaryCore(proposalHandle, parentPath, parentSkipRecursion);
@@ -436,7 +462,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 
 		const createDetails: ICreateChildDetails = this.getCreateDetailsForChild(id, createParam);
 		const child = new SummarizerNodeWithGC(
-			this.defaultLogger,
+			this.logger,
 			summarizeInternalFn,
 			{
 				...config,
@@ -449,6 +475,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 			this.wipSummaryLogger,
 			getGCDataFn,
 			async () => getChildBaseGCDetailsP,
+			createDetails.telemetryId,
 		);
 
 		// There may be additional state that has to be updated in this child. For example, if a summary is being
@@ -553,4 +580,5 @@ export const createRootSummarizerNodeWithGC = (
 		undefined /* wipSummaryLogger */,
 		getGCDataFn,
 		getBaseGCDetailsFn,
+		"" /* telemetryId */,
 	);

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -24,7 +24,6 @@ import {
 	SummarizeInternalFn,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions";
-import { LoggingError, TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { ReadAndParseBlob } from "../utils";
 import { SummarizerNode } from "./summarizerNode";
 import {
@@ -253,21 +252,10 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 			 * identify these cases and take appropriate action.
 			 */
 			if (wipSerializedUsedRoutes === undefined) {
-				const error = new LoggingError("NodeDidNotRunGC", {
+				this.throwUnexpectedError({
+					eventName: "NodeDidNotRunGC",
 					proposalHandle,
-					referenceSequenceNumber: this.wipReferenceSequenceNumber,
-					id: {
-						tag: TelemetryDataTag.CodeArtifact,
-						value: this.telemetryId,
-					},
 				});
-				this.logger.sendErrorEvent(
-					{
-						eventName: "NodeDidNotRunGC",
-					},
-					error,
-				);
-				throw error;
 			}
 		}
 
@@ -475,7 +463,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 			this.wipSummaryLogger,
 			getGCDataFn,
 			async () => getChildBaseGCDetailsP,
-			createDetails.telemetryId,
+			createDetails.telemetryNodeId,
 		);
 
 		// There may be additional state that has to be updated in this child. For example, if a summary is being

--- a/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
@@ -460,6 +460,33 @@ describe("Runtime", () => {
 					assert(result.latestSummaryUpdated === true, "should update");
 					assert(result.wasSummaryTracked === true, "should be tracked");
 				});
+
+				it("should fail refresh when summary is in progress", async () => {
+					createRoot();
+					const proposalHandle = "test-handle";
+
+					const referenceSeqNum = 10;
+					rootNode.startSummary(referenceSeqNum, logger);
+					await rootNode.summarize(false);
+					await assert.rejects(
+						async () =>
+							rootNode.refreshLatestSummary(
+								proposalHandle,
+								summaryRefSeq,
+								fetchLatestSnapshot,
+								readAndParseBlob,
+								logger,
+							),
+						(error) => {
+							const correctErrorMessage =
+								error.message === "UnexpectedRefreshDuringSummarize";
+							const correctInProgressRefSeq =
+								error.inProgressSummaryRefSeq === referenceSeqNum;
+							return correctErrorMessage && correctInProgressRefSeq;
+						},
+						"Refresh should fail if called when summary is in progress",
+					);
+				});
 			});
 		});
 	});

--- a/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summarizerNode.spec.ts
@@ -271,14 +271,17 @@ describe("Runtime", () => {
 			});
 
 			describe("Complete Summary", () => {
-				it("Should fail completeSummary if summarize not called", () => {
+				it("Should fail completeSummary if summarize not called on root node", () => {
 					createRoot();
 					rootNode.startSummary(11, logger);
-					expectThrow(
+					assert.throws(
 						() => rootNode.completeSummary("test-handle"),
-						"complete summary",
-						"tracked local paths not set",
-						"0x1a5",
+						(error) => {
+							const correctErrorMessage = error.message === "NodeNotSummarized";
+							const correctErrorId = error.id.value === "";
+							return correctErrorMessage && correctErrorId;
+						},
+						"Complete summary should have failed at the root node",
 					);
 				});
 
@@ -289,11 +292,34 @@ describe("Runtime", () => {
 					rootNode.startSummary(11, logger);
 					await rootNode.summarize(false);
 					await leafNode?.summarize(false);
-					expectThrow(
+					const midNodeId = `/${ids[1]}`;
+					assert.throws(
 						() => rootNode.completeSummary("test-handle"),
-						"complete summary",
-						"tracked local paths not set",
-						"0x1a5",
+						(error) => {
+							const correctErrorMessage = error.message === "NodeNotSummarized";
+							const correctErrorId = error.id.value === midNodeId;
+							return correctErrorMessage && correctErrorId;
+						},
+						"Complete summary should have failed at the mid node",
+					);
+				});
+
+				it("Should fail completeSummary if summarize not called on leaf node", async () => {
+					createRoot();
+					createMid({ type: CreateSummarizerNodeSource.Local });
+					createLeaf({ type: CreateSummarizerNodeSource.Local });
+					rootNode.startSummary(11, logger);
+					await rootNode.summarize(false);
+					await midNode?.summarize(false);
+					const leafNodeId = `/${ids[1]}/${ids[2]}`;
+					assert.throws(
+						() => rootNode.completeSummary("test-handle"),
+						(error) => {
+							const correctErrorMessage = error.message === "NodeNotSummarized";
+							const correctErrorId = error.id.value === leafNodeId;
+							return correctErrorMessage && correctErrorId;
+						},
+						"Complete summary should have failed at the leaf node",
 					);
 				});
 			});


### PR DESCRIPTION
Local changes in the summarizer (local data stores, ops) are breaking invariants in the summarizer / GC flow mainly in the summarizer node code. This is manifesting in various forms by hitting asserts (0x167, 0x1a5, 0x1b5) which makes it harder to tell what the underlying issue is.
This change converts some of these asserts into errors for 2 reasons:
1. These asserts are not valid anymore in the presence of local changes in the summarizer. There is a plan to disallow local changes in summarizer and then these asserts make sense but for now, these should not be asserts.
2. With errors, we can log additional details that can help identify the problem. For example, if these asserts are getting hit for reasons other than local changes, we want to know about them and fix them.

Changes in this PR;
1. Add id to summarizer nodes that is used for logging. This id is the same as data store / DDS id and can help correlate which summarizer node failes.
2. Changed asserts 0x1a5 and 0x1b5 to errors and logged a telemetrry. Added additional details in the log that can help identify where / what the issues are.
3. Added a log at the end of RefreshLatestSummary that tells what the result of refresh was. This can help in debugging issues where refresh was called and there are some errors later but we aren't sure if refresh is actually causing these issues.

[AB#2375](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2375), [AB#2767](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2767), [AB#3392](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3392)