### PR TITLE
Add scopeOverride to enable per-container-resolve customization of runtime initialization

### DIFF
--- a/api-report/container-loader.api.md
+++ b/api-report/container-loader.api.md
@@ -133,6 +133,7 @@ export interface IContainerConfig {
     clientDetailsOverride?: IClientDetails;
     // (undocumented)
     resolvedUrl?: IFluidResolvedUrl;
+    scopeOverride?: FluidObject;
     serializedContainerState?: IPendingContainerState;
 }
 
@@ -144,6 +145,7 @@ export interface IContainerLoadOptions {
     loadMode?: IContainerLoadMode;
     // (undocumented)
     resolvedUrl: IFluidResolvedUrl;
+    scopeOverride?: FluidObject;
     version: string | undefined;
 }
 

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -546,7 +546,10 @@ export enum LoaderHeader {
 	version = "version",
 
 	// TODO #AB3350: This is a breaking change; it will be enabled in the "next" branch
-	// baseLogger = "fluid-base-logger"
+	// baseLogger = "fluid-base-logger",
+
+	// TODO #AB???: This is a breaking change; it will be enabled in the "next" branch
+	// scopeOverride = "fluid-scope-override",
 }
 
 export interface IContainerLoadMode {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -13,7 +13,7 @@ import {
 	TelemetryEventCategory,
 } from "@fluidframework/common-definitions";
 import { assert, performance, unreachableCase } from "@fluidframework/common-utils";
-import { IRequest, IResponse, IFluidRouter } from "@fluidframework/core-interfaces";
+import { IRequest, IResponse, IFluidRouter, FluidObject } from "@fluidframework/core-interfaces";
 import {
 	IAudience,
 	IConnectionDetails,
@@ -129,6 +129,10 @@ export interface IContainerLoadOptions {
 	 * use the loader's logger, `Loader.services.subLogger`.
 	 */
 	baseLogger?: ITelemetryBaseLogger;
+	/**
+	 * A scope object to replace the one provided on the Loader.
+	 */
+	scopeOverride?: FluidObject;
 }
 
 export interface IContainerConfig {
@@ -147,6 +151,10 @@ export interface IContainerConfig {
 	 * use the loader's logger, `Loader.services.subLogger`.
 	 */
 	baseLogger?: ITelemetryBaseLogger;
+	/**
+	 * A scope object to replace the one provided on the Loader.
+	 */
+	scopeOverride?: FluidObject;
 }
 
 /**
@@ -300,6 +308,7 @@ export class Container
 				canReconnect: loadOptions.canReconnect,
 				serializedContainerState: pendingLocalState,
 				baseLogger: loadOptions.baseLogger,
+				scopeOverride: loadOptions.scopeOverride,
 			},
 			protocolHandlerBuilder,
 		);
@@ -452,6 +461,7 @@ export class Container
 	}
 
 	private readonly clientDetailsOverride: IClientDetails | undefined;
+	private readonly _scopeOverride: FluidObject | undefined;
 	private readonly _deltaManager: DeltaManager<ConnectionManager>;
 	private service: IDocumentService | undefined;
 
@@ -602,7 +612,7 @@ export class Container
 	}
 	public readonly options: ILoaderOptions;
 	private get scope() {
-		return this.loader.services.scope;
+		return this._scopeOverride ?? this.loader.services.scope;
 	}
 	private get codeLoader() {
 		return this.loader.services.codeLoader;
@@ -624,6 +634,7 @@ export class Container
 		});
 
 		this.clientDetailsOverride = config.clientDetailsOverride;
+		this._scopeOverride = config.scopeOverride;
 		this._resolvedUrl = config.resolvedUrl;
 		if (config.canReconnect !== undefined) {
 			this._canReconnect = config.canReconnect;

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -496,6 +496,7 @@ export class Loader implements IHostLoader {
 				version: request.headers?.[LoaderHeader.version] ?? undefined,
 				loadMode: request.headers?.[LoaderHeader.loadMode],
 				baseLogger: request.headers?.["fluid-base-logger"],
+				scopeOverride: request.headers?.["fluid-scope-override"],
 			},
 			pendingLocalState,
 			this.protocolHandlerBuilder,

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -457,7 +457,13 @@ export class Loader implements IHostLoader {
 	}
 
 	private canCacheForRequest(headers: IRequestHeader): boolean {
-		return this.cachingEnabled && headers[LoaderHeader.cache] !== false;
+		return (
+			this.cachingEnabled &&
+			headers[LoaderHeader.cache] !== false &&
+			// LoaderHeader.baseLogger and LoaderHeader.scopeOverride must create a new Container to apply the overrides.
+			headers["fluid-base-logger"] === undefined &&
+			headers["fluid-scope-override"] === undefined
+		);
 	}
 
 	private parseHeader(parsed: IParsedUrl, request: IRequest) {


### PR DESCRIPTION
Related: #13779 

Currently, the scope is set once (at Loader creation time).  However, it's possible hosts may want to pass different scope information on a per-resolve basis.  This is particularly true when the load is performed in a different context, e.g. a top-level container vs. loading a "guest" container as a sub-part of an experience.

Normally we recommend against using scope, but it does serve a purpose here of allowing hosts to pass objects to their container runtime at initialization time.  Since the initialization phase (instantiateRuntime) is buried in the Container, this is the best entrypoint we currently make available for host customization of that initialization.