### PR TITLE
disable mutex sync when using iso-git

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -373,7 +373,8 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
             fileSystemManagerFactory,
             externalStorageManager,
             repoPerDocEnabled,
-            enableRepositoryManagerMetrics);
+            enableRepositoryManagerMetrics,
+            false /* enforceSynchronous */);
     }
 
     protected async initGitRepo(fs: IFileSystemManager, gitdir: string): Promise<void> {
@@ -411,9 +412,9 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
     /**
      * A trimmed down version of iso-git's init function
      * https://github.com/isomorphic-git/isomorphic-git/blob/c09dfa20ffe0ab9e6602e0fa172d72ba8994e443/src/commands/init.js#L15
-     * 
+     *
      * Removes checking existence, writing a config file, writing a hooks and info folders, and /HEAD file.
-     * 
+     *
      * This brings file reads from 1 to 0, and writes from 10 to 3.
      */
     private async slimInit(fs: IFileSystemManager, gitdir: string): Promise<void> {

--- a/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/nodegitManager.ts
@@ -363,7 +363,8 @@ export class NodegitRepositoryManagerFactory extends RepositoryManagerFactoryBas
             fileSystemManagerFactory,
             externalStorageManager,
             repoPerDocEnabled,
-            enableRepositoryManagerMetrics);
+            enableRepositoryManagerMetrics,
+            true /* enforceSynchronous */);
     }
 
     protected async initGitRepo(fs: IFileSystemManager, gitdir: string): Promise<nodegit.Repository> {

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
@@ -54,6 +54,7 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
         private readonly externalStorageManager: IExternalStorageManager,
         repoPerDocEnabled: boolean,
         private readonly enableRepositoryManagerMetrics: boolean = false,
+        private readonly enforceSynchronous: boolean = true,
     ) {
         this.internalHandler = repoPerDocEnabled
             ? this.repoPerDocInternalHandler.bind(this)
@@ -203,7 +204,7 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
                 // case there is an ongoing "create repo" operation, in order for the "open repo" to succeed.
                 // The conditional below makes sure we only proceed with the "open repo" operation if there
                 // is no ongoing "create repo".
-                if (repoOperationType === "open" && this.mutexes.get(repoName)?.isLocked()) {
+                if (this.enforceSynchronous && repoOperationType === "open" && this.mutexes.get(repoName)?.isLocked()) {
                     await this.mutexes.get(repoName).waitForUnlock();
                 }
                 if (!this.repositoryCache.has(repoPath)) {
@@ -241,7 +242,7 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
         // to the filesystem, context switching can cause those "create repo" operations to actually happen
         // asynchronously. Therefore, we use a mutex per repository to control concurrent "create repo" requests
         // and make sure only one of them happens atomically.
-        if (repoOperationType === "create") {
+        if (this.enforceSynchronous && repoOperationType === "create") {
             if (!this.mutexes.has(repoName)) {
                 this.mutexes.set(repoName, withTimeout(new Mutex(), 100000));
             }


### PR DESCRIPTION
## Description

Disable use of Mutexes when using Isomorphic Git because the are only needed for NodeGit when using shredded summary format.
