### PR TITLE
Added Summarize_start event to be logged when a summary starts

### DIFF
--- a/packages/runtime/container-runtime/src/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summaryGenerator.ts
@@ -229,11 +229,15 @@ export class SummaryGenerator {
 			timeSinceLastSummary,
 		};
 
-		const summarizeEvent = PerformanceEvent.start(logger, {
-			eventName: "Summarize",
-			refreshLatestAck,
-			...summarizeTelemetryProps,
-		});
+		const summarizeEvent = PerformanceEvent.start(
+			logger,
+			{
+				eventName: "Summarize",
+				refreshLatestAck,
+				...summarizeTelemetryProps,
+			},
+			{ start: true, end: true, cancel: "generic" },
+		);
 
 		// Helper functions to report failures and return.
 		const getFailMessage = (errorCode: keyof typeof summarizeErrors) =>


### PR DESCRIPTION
Summarize is an important process that should not be interleaved with certain other processes such as refreshing latest summary, processing ops, etc. When an issue happens during summarize, its difficult to build a timeline of what happened from the current logs because the summarize start is not logged.
For example, in the following logs, summarize and refresh latest summary are happening in parallel. However, its not possible to tell which one started first and its crucial to understand that in order to fix issues.

Event_Time | Data_eventName
-- | --
2023-02-02 05:54:52.6160000 | fluid:telemetry:Summarizer:RunningSummarizer
2023-02-02 05:54:52.6170000 | fluid:telemetry:SummarizerNode:PendingSummaryNotFound
2023-02-02 05:54:52.6230000 | fluid:telemetry:OdspDriver:TreesLatest_GetToken_end
2023-02-02 05:54:53.1320000 | fluid:telemetry:Summarizer:Running:GarbageCollection_end
2023-02-02 05:54:53.6430000 | fluid:telemetry:SummarizeTelemetry
2023-02-02 05:54:53.8010000 | fluid:telemetry:OdspDriver:TreesLatest_end
2023-02-02 05:54:53.8020000 | fluid:telemetry:OdspDriver:ObtainSnapshot_end
2023-02-02 05:54:53.8020000 | fluid:telemetry:Summarizer:RefreshLatestSummaryGetSnapshot_end
2023-02-02 05:54:53.8030000 | fluid:telemetry:Summarizer:LatestSummaryRetrieved
<!--EndFragment--></BODY></HTML>

This PR adds a Summarize_start event which will increase an event per summarize but I believe it will very helpful in understanding issues during summary process.