### PR TITLE
Deep copy op content on submit

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2840,7 +2840,7 @@ export class ContainerRuntime
 
 		const message: BatchMessage = {
 			contents: serializedContent,
-			deserializedContent: JSON.parse(serializedContent), // Deep copy
+			deserializedContent: JSON.parse(serializedContent), // Deep copy in case caller changes reference object
 			metadata,
 			localOpMetadata,
 			referenceSequenceNumber: this.deltaManager.lastSequenceNumber,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2829,8 +2829,7 @@ export class ContainerRuntime
 			0x132 /* "sending ops in detached container" */,
 		);
 
-		const deserializedContent: ContainerRuntimeMessage = { type, contents };
-		const serializedContent = JSON.stringify(deserializedContent);
+		const serializedContent = JSON.stringify({ type, contents });
 
 		if (this.deltaManager.readOnlyInfo.readonly) {
 			this.logger.sendTelemetryEvent({
@@ -2841,7 +2840,7 @@ export class ContainerRuntime
 
 		const message: BatchMessage = {
 			contents: serializedContent,
-			deserializedContent,
+			deserializedContent: JSON.parse(serializedContent), // Deep copy
 			metadata,
 			localOpMetadata,
 			referenceSequenceNumber: this.deltaManager.lastSequenceNumber,

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -29,7 +29,7 @@ import {
 	ContainerRuntime,
 	IContainerRuntimeOptions,
 } from "../containerRuntime";
-import { PendingStateManager } from "../pendingStateManager";
+import { PendingStateManager, IPendingMessage } from "../pendingStateManager";
 import { DataStores } from "../dataStores";
 
 describe("Runtime", () => {
@@ -914,7 +914,7 @@ describe("Runtime", () => {
 				assert.notStrictEqual(state, undefined, "expect pending local state");
 				assert.strictEqual(state?.pendingStates.length, 1, "expect 1 pending message");
 				assert.deepStrictEqual(
-					(state?.pendingStates[0] as any).content.contents,
+					(state?.pendingStates[0] as IPendingMessage).content.contents,
 					{
 						prop1: 1,
 					},

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -875,5 +875,52 @@ describe("Runtime", () => {
 			);
 			assert.equal((runtime as unknown as { method2: () => any }).method2(), 42);
 		});
+
+		describe("Op content modification", () => {
+			let containerRuntime: ContainerRuntime;
+			let pendingStateManager: PendingStateManager;
+
+			const getMockContext = (): Partial<IContainerContext> => {
+				return {
+					attachState: AttachState.Attached,
+					deltaManager: new MockDeltaManager(),
+					quorum: new MockQuorumClients(),
+					taggedLogger: new MockLogger(),
+					clientDetails: { capabilities: { interactive: true } },
+					closeFn: (_error?: ICriticalContainerError): void => {},
+					updateDirtyContainerState: (_dirty: boolean) => {},
+				};
+			};
+
+			beforeEach(async () => {
+				containerRuntime = await ContainerRuntime.loadRuntime({
+					context: getMockContext() as IContainerContext,
+					registryEntries: [],
+					existing: false,
+					runtimeOptions: {},
+				});
+				pendingStateManager = (containerRuntime as any).pendingStateManager;
+			});
+
+			it("modifying op content after submit does not reflect in PendingStateManager", () => {
+				const content = { prop1: 1 };
+				containerRuntime.submitDataStoreOp("1", content);
+				(containerRuntime as any).flush();
+
+				content.prop1 = 2;
+
+				const state = pendingStateManager.getLocalState();
+
+				assert.notStrictEqual(state, undefined, "expect pending local state");
+				assert.strictEqual(state?.pendingStates.length, 1, "expect 1 pending message");
+				assert.deepStrictEqual(
+					(state?.pendingStates[0] as any).content.contents,
+					{
+						prop1: 1,
+					},
+					"content of pending local message has changed",
+				);
+			});
+		});
 	});
 });


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

There's a bug where the op content can be modified after submitting and those changes are reflected in the PendingStateManager (see https://github.com/microsoft/FluidFramework/pull/13994#issuecomment-1425119969).
We should deep copy the content to ensure that it will remain constant and not be a reference to some external object.