### PR TITLE
Add support for removing NoClient ops

### DIFF
--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -48,6 +48,12 @@ export interface IDeliServerConfiguration {
 
     // Enable to make deli not add additionalContent to summarize messages that are for the single commit flow
     skipSummarizeAugmentationForSingleCommmit: boolean;
+
+    // disable sequencing NoClient messages
+    disableNoClientMessage: boolean;
+
+    // enables marking leave ops with a flag when they were the last client
+    enableLeaveOpNoClientServerMetadata: boolean;
 }
 
 export interface ICheckpointHeuristicsServerConfiguration {
@@ -206,6 +212,8 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
             },
         },
         skipSummarizeAugmentationForSingleCommmit: false,
+        disableNoClientMessage: false,
+        enableLeaveOpNoClientServerMetadata: false,
     },
     broadcaster: {
         includeEventInMessageBatchName: false,


### PR DESCRIPTION
Deli sequences NoClient ops when the last client leaves the session. There will always be a "leave" op followed by a "noClient" op in these cases.
The NoClient op is only used by the server, never by clients. We can remove NoClient ops by marking a server metadata flag in leave ops to indicate the last client left.
This makes it so the last client leaving will only cause 1 op to be sequenced (their leave op).

Adding this change behind configs because the usage will vary by service and it requires thinking about mix-mode support during rollouts.