### PR TITLE
test(client-debugger-view): Update test app to label its container views and to utilize debugger nicknames

### DIFF
--- a/packages/tools/client-debugger/client-debugger-view/src/test/ClientUtilities.ts
+++ b/packages/tools/client-debugger/client-debugger-view/src/test/ClientUtilities.ts
@@ -5,7 +5,6 @@
 import { ConnectionState } from "@fluidframework/container-loader";
 import { ContainerSchema, FluidContainer, IFluidContainer } from "@fluidframework/fluid-static";
 import {
-	ITinyliciousAudience,
 	TinyliciousClient,
 	TinyliciousContainerServices,
 } from "@fluidframework/tinylicious-client";
@@ -28,9 +27,20 @@ export interface ContainerLoadResult {
  * Basic information about the container, as well as the associated audience.
  */
 export interface ContainerInfo {
+	/**
+	 * {@link ContainerInfo.container}'s unique ID.
+	 */
 	containerId: string;
+
+	/**
+	 * The initialized Fluid Container.
+	 */
 	container: IFluidContainer;
-	audience: ITinyliciousAudience;
+
+	/**
+	 * Optional nickname for the Container to be used in the debugger and associated UI.
+	 */
+	containerNickname?: string;
 }
 
 function initializeTinyliciousClient(): TinyliciousClient {
@@ -44,12 +54,14 @@ function initializeTinyliciousClient(): TinyliciousClient {
  * @param containerSchema - Schema with which to create the container.
  * @param setContentsPreAttach - Optional callback for setting initial content state on the
  * container *before* it is attached.
+ * @param containerNickname - See {@link ContainerInfo.containerNickname}.
  *
  * @throws If container creation or attaching fails for any reason.
  */
 export async function createFluidContainer(
 	containerSchema: ContainerSchema,
 	setContentsPreAttach?: (container: IFluidContainer) => Promise<void>,
+	containerNickname?: string,
 ): Promise<ContainerInfo> {
 	// Initialize Tinylicious client
 	const client = initializeTinyliciousClient();
@@ -65,7 +77,7 @@ export async function createFluidContainer(
 	}
 	console.log("Container created!");
 
-	const { container, services } = createContainerResult;
+	const { container } = createContainerResult;
 
 	// Populate the container with initial app contents (*before* attaching)
 	if (setContentsPreAttach !== undefined) {
@@ -88,33 +100,38 @@ export async function createFluidContainer(
 	return {
 		container,
 		containerId,
-		audience: services.audience,
+		containerNickname,
 	};
 }
 
 /**
  * Loads an existing Container for the given ID.
  *
+ * @param containerId - The unique ID of the existing Fluid Container being loaded.
+ * @param containerSchema - Schema with which to load the Container.
+ * @param containerNickname - See {@link ContainerInfo.containerNickname}.
+ *
  * @throws If no container exists with the specified ID, or if loading / connecting fails for any reason.
  */
 export async function loadExistingFluidContainer(
 	containerId: string,
 	containerSchema: ContainerSchema,
+	containerNickname?: string,
 ): Promise<ContainerInfo> {
 	// Initialize Tinylicious client
 	const client = initializeTinyliciousClient();
 
 	console.log("Loading existing container...");
-	let getContainerResult: ContainerLoadResult;
+	let loadContainerResult: ContainerLoadResult;
 	try {
-		getContainerResult = await client.getContainer(containerId, containerSchema);
+		loadContainerResult = await client.getContainer(containerId, containerSchema);
 	} catch (error) {
 		console.error(`Encountered error loading Fluid container: "${error}".`);
 		throw error;
 	}
 	console.log("Container loaded!");
 
-	const { container, services } = getContainerResult;
+	const { container } = loadContainerResult;
 
 	if (container.connectionState !== ConnectionState.Connected) {
 		console.log("Connecting to container...");
@@ -129,7 +146,7 @@ export async function loadExistingFluidContainer(
 	return {
 		container,
 		containerId,
-		audience: services.audience,
+		containerNickname,
 	};
 }
 

--- a/packages/tools/client-debugger/client-debugger-view/src/test/ClientUtilities.ts
+++ b/packages/tools/client-debugger/client-debugger-view/src/test/ClientUtilities.ts
@@ -159,7 +159,7 @@ export function initializeFluidClientDebugger(containerInfo: ContainerInfo): voi
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		container: (containerInfo.container as FluidContainer).INTERNAL_CONTAINER_DO_NOT_USE!(),
 		containerData: containerInfo.container.initialObjects,
-		containerNickname: containerInfo.containerNickname
+		containerNickname: containerInfo.containerNickname,
 	});
 }
 

--- a/packages/tools/client-debugger/client-debugger-view/src/test/ClientUtilities.ts
+++ b/packages/tools/client-debugger/client-debugger-view/src/test/ClientUtilities.ts
@@ -159,6 +159,7 @@ export function initializeFluidClientDebugger(containerInfo: ContainerInfo): voi
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		container: (containerInfo.container as FluidContainer).INTERNAL_CONTAINER_DO_NOT_USE!(),
 		containerData: containerInfo.container.initialObjects,
+		containerNickname: containerInfo.containerNickname
 	});
 }
 

--- a/packages/tools/client-debugger/client-debugger-view/src/test/app/App.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/test/app/App.tsx
@@ -17,7 +17,6 @@ import { SharedCounter } from "@fluidframework/counter";
 import { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map";
 import { SharedString } from "@fluidframework/sequence";
-import { ITinyliciousAudience } from "@fluidframework/tinylicious-client";
 
 import { CollaborativeTextArea, SharedStringHelper } from "@fluid-experimental/react-inputs";
 import { closeFluidClientDebugger } from "@fluid-tools/client-debugger";
@@ -91,7 +90,10 @@ async function populateRootMap(container: IFluidContainer): Promise<void> {
  * React hook for asynchronously creating / loading two Fluid Containers: a shared container whose ID is put in
  * the URL to enable collaboration, and a private container that is only exposed to the local user.
  */
-function useContainerInfo(): (ContainerInfo | undefined)[] {
+function useContainerInfo(): {
+	privateContainer: ContainerInfo | undefined;
+	sharedContainer: ContainerInfo | undefined;
+} {
 	const [sharedContainerInfo, setSharedContainerInfo] = React.useState<
 		ContainerInfo | undefined
 	>();
@@ -102,26 +104,16 @@ function useContainerInfo(): (ContainerInfo | undefined)[] {
 	// Get the Fluid Data data on app startup and store in the state
 	React.useEffect(
 		() => {
-			async function getFluidData(): Promise<ContainerInfo> {
-				let container: IFluidContainer;
-				let audience: ITinyliciousAudience;
-				let containerId = getContainerIdFromLocation(window.location);
-				if (containerId.length === 0) {
-					({ container, audience, containerId } = await createFluidContainer(
-						containerSchema,
-						populateRootMap,
-					));
-				} else {
-					({ container, audience } = await loadExistingFluidContainer(
-						containerId,
-						containerSchema,
-					));
-				}
+			async function getSharedFluidData(): Promise<ContainerInfo> {
+				const containerNickname = "Shared Container";
 
-				return { container, audience, containerId };
+				const containerId = getContainerIdFromLocation(window.location);
+				return containerId.length === 0
+					? createFluidContainer(containerSchema, populateRootMap, containerNickname)
+					: loadExistingFluidContainer(containerId, containerSchema, containerNickname);
 			}
 
-			getFluidData().then(
+			getSharedFluidData().then(
 				(data) => {
 					if (getContainerIdFromLocation(window.location) !== data.containerId) {
 						window.location.hash = data.containerId;
@@ -138,7 +130,7 @@ function useContainerInfo(): (ContainerInfo | undefined)[] {
 			async function getPrivateContainerData(): Promise<ContainerInfo> {
 				// Always create a new container for the private view.
 				// This isn't shared with other collaborators.
-				return createFluidContainer(containerSchema, populateRootMap);
+				return createFluidContainer(containerSchema, populateRootMap, "Private Container");
 			}
 
 			getPrivateContainerData().then(
@@ -165,7 +157,7 @@ function useContainerInfo(): (ContainerInfo | undefined)[] {
 		[],
 	);
 
-	return [sharedContainerInfo, privateContainerInfo];
+	return { sharedContainer: sharedContainerInfo, privateContainer: privateContainerInfo };
 }
 
 const appTheme = createTheme({
@@ -212,34 +204,28 @@ const appViewPaneStackStyles = mergeStyles({
  */
 export function App(): React.ReactElement {
 	// Load the collaborative SharedString object
-	const containers = useContainerInfo();
-
-	if (containers.length !== 2) {
-		console.error(
-			`Initialization created an unexpected number of containers: ${containers.length}`,
-		);
-	}
+	const { privateContainer, sharedContainer } = useContainerInfo();
 
 	const view = (
 		<Stack horizontal>
 			<StackItem>
-				{containers[0] === undefined ? (
+				{sharedContainer === undefined ? (
 					<Stack horizontalAlign="center" tokens={{ childrenGap: 10 }}>
 						<Spinner />
-						<div>Loading Fluid container...</div>
+						<div>Loading Shared container...</div>
 					</Stack>
 				) : (
-					<AppView containerInfo={containers[0]} />
+					<AppView containerInfo={sharedContainer} />
 				)}
 			</StackItem>
 			<StackItem>
-				{containers[1] === undefined ? (
+				{privateContainer === undefined ? (
 					<Stack horizontalAlign="center" tokens={{ childrenGap: 10 }}>
 						<Spinner />
-						<div>Loading Fluid container...</div>
+						<div>Loading Private container...</div>
 					</Stack>
 				) : (
-					<AppView containerInfo={containers[1]} />
+					<AppView containerInfo={privateContainer} />
 				)}
 			</StackItem>
 		</Stack>
@@ -262,7 +248,7 @@ interface AppViewProps {
  */
 function AppView(props: AppViewProps): React.ReactElement {
 	const { containerInfo } = props;
-	const { container } = containerInfo;
+	const { container, containerId, containerNickname } = containerInfo;
 
 	const rootMap = container.initialObjects.rootMap as SharedMap;
 	if (rootMap === undefined) {
@@ -282,6 +268,17 @@ function AppView(props: AppViewProps): React.ReactElement {
 	return (
 		<Stack horizontal className={rootStackStyles}>
 			<StackItem className={appViewPaneStackStyles}>
+				<h4>
+					{containerNickname === undefined ? (
+						<></>
+					) : (
+						<>
+							{containerNickname}
+							<br />
+						</>
+					)}
+					{containerId}
+				</h4>
 				<Stack>
 					<StackItem>
 						<CounterView sharedCounterHandle={sharedCounterHandle} />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/54606601/218221418-f85ecf63-3b34-4a3e-b204-7adaa2bdf8cb.png)

The labels + nicknames should hopefully make it a bit easier to reason about which container is being analyzed while using the sample app with the debugger.

Also does a bit of related cleanup (adds docs and removes unneeded property from ContainerInfo interface).