### PR TITLE
Update type tests to be based on 2.0.0-internal.3.0.0

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -2504,16 +2504,224 @@
       }
     },
     "@fluid-experimental/sequence-deprecated": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-Kf0sLqzdwrYICuAyRY1A8a6g7KQmbgD57mWHUrQ5S7p+8vphF3bHJ3AX8xBbwuDlwNV+PG4cKAhHtz4BpZJdeQ==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-kZ0zg3UBWlWt2gxsGbEzZt2WyXr14Qacn3joBosuRN4lsj07Bh8KaMTcUGIwmPqX/L7rXiMH5faAjtHDgzm4KQ==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/sequence": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/sequence": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluid-experimental/sequence-deprecated-previous": {
@@ -2651,15 +2859,32 @@
       }
     },
     "@fluid-tools/fluidapp-odsp-urlresolver-previous": {
-      "version": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.2.1.1",
-      "resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-2.0.0-internal.2.1.1.tgz",
-      "integrity": "sha512-ydY6VjoGdxEjJEgqI/Eg+BvaXUFkqOA4nQ0rk8wTHqobDskM8PFkJY/e1XRAjrIr/VC2O0n6I8QT7ryobhRw9A==",
+      "version": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluid-tools/fluidapp-odsp-urlresolver/-/fluidapp-odsp-urlresolver-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-MjhERKrorACUG6qdlCu9PC3ObrEOCQuSwL870dEf0t9xBDvMAezFxRyDd2UbTBWOdes/lMleoE+3pgA2I0FZmQ==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@fluid-tools/version-tools": {
@@ -2739,31 +2964,31 @@
       }
     },
     "@fluid-tools/webpack-fluid-loader-previous": {
-      "version": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-8qXfA+nGBqZ+BAxTC10jpoBfhBPhM5uiirwmqU3t+iNWzH8/x1/q9gULem1OcZ/NGfETjCYG6GXSSw8/jb9KeA==",
+      "version": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluid-tools/webpack-fluid-loader/-/webpack-fluid-loader-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-L0BxacIPa1Zmd14Kdfq/KW3RIApApZF3kA9ITHOMTMG3NKjKRm0Xt3xL/6c9VeYlmdpu9nvDpWTainVRfrlvaA==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/local-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/local-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/server-local-server": "^0.1038.2000",
         "@fluidframework/server-services-client": "^0.1038.2000",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/tool-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/view-adapters": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/web-code-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/tool-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/view-adapters": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/view-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/web-code-loader": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "axios": "^0.26.0",
         "buffer": "^6.0.3",
         "express": "^4.16.3",
@@ -2771,70 +2996,942 @@
         "sillyname": "^0.1.0",
         "uuid": "^8.3.1",
         "webpack-dev-server": "~4.6.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/agent-scheduler-previous": {
-      "version": "npm:@fluidframework/agent-scheduler@2.0.0-internal.2.1.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-2.0.0-internal.2.1.1.tgz",
-      "integrity": "sha512-m1t00P4fDpMB7e3zVdjBO0G+TQ2EKAHuiBgNR4+dGr+Sx7Vs2/uc6A5LBeIGtDVRaxqs8LbCfWTaCgQPhXeeGg==",
+      "version": "npm:@fluidframework/agent-scheduler@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-ho0sipdKODk6KS2mPjhqq521yaLoLE4YKL+YnAlnizQpLHCzLBToXAL1saxx/lgOtOi11xAG0wxo5S2uIEw0gQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/map": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/register-collection": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/map": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/register-collection": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/aqueduct": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-qKpN8RtwgH2UDldE/0oYCw+HrgI6MKpo7ArgPAZWGROQ27ULa2UfeIttX8PKJRwL/VNEu6Ku9EJN8zw3RRU45w==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-fW8NHqV9JZVEVDg2o5u99ibfRNhKwTQgi/kFGy9rlLW+5535VUaKeXjdomMVUTMmwmbzNuQX55R+P+UPY3atYw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/map": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/synthesize": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/map": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/request-handler": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/synthesize": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/view-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/aqueduct-previous": {
-      "version": "npm:@fluidframework/aqueduct@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-PAEnL928V5eJH3Z8A2GBMRe5OMQ4gYmlBxJvL5NBX7xKoyEmFPvfMQi8qfGYWQAQRKJN3+r+U+z2QUlQGHkHPA==",
+      "version": "npm:@fluidframework/aqueduct@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-1L60qAOrOLzkn0E7Ho4g8pvh3v4timLupptLq4VokfK4SJoKjW1bIrtWmG3wB9A/n0zMSDqj3vi5yYzi7lRZVA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/synthesize": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/map": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/request-handler": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/synthesize": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/view-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
+      }
+    },
+    "@fluidframework/attributor": {
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/attributor/-/attributor-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-8oGCM8JT/UBar7zu9dOfYHGLVsZVnqf/XlV2n9iqFscx7UBLApfYWtXjAaYBrU78sKT2YTZeBHUOgj0UNgTyVg==",
+      "requires": {
+        "@fluidframework/common-utils": "^1.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/protocol-definitions": "^1.1.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "lz4js": "^0.2.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/build-common": {
@@ -2954,31 +4051,448 @@
       }
     },
     "@fluidframework/cell": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-Zoai3SQ9uRlL2MAK44CA4bB7mV/4ZfxBID2bNmM9RUR8DA7JBXkOhAJaCC4H48aH9FGON2z/dubD2XFNxEh8fA==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-ndhz1eHJlhhjnID0+ScVvdz5rivz+wcZ0wXanKFd992F05avLI+O0tfaijTcrQzU1HKa2kOIDfpUIAEpEkEiiQ==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/cell-previous": {
-      "version": "npm:@fluidframework/cell@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-/UxOkxbM26bpZeqFNGZRDAD7p7foUH84yFC/ZUxLvzSUDVEA59Torefe9hjwWEBuny06qdI4eFkHX47A+zKtNQ==",
+      "version": "npm:@fluidframework/cell@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-3PvCUKL4X1ieBggKCbAYYppTewAUovFctJGqqVYDxYvh6loHj3v5UrrsPMRo0pXD2T5rhn+Mp9qtdyuR6HEmkQ==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/common-definitions": {
@@ -3020,59 +4534,220 @@
       }
     },
     "@fluidframework/container-definitions-previous": {
-      "version": "npm:@fluidframework/container-definitions@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-Y+BXNRQ8cS9X4f0EwdtiLqGICVKV6m4xGqSAfhzVJh/3UrfbzIzp00/MbogCjHZnwb9QHUxPD2CacsrY2V/kSQ==",
+      "version": "npm:@fluidframework/container-definitions@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-QG4M1dNzop3WMxc9v5Dn6+zRyiUbqjeVMVlARq9DNpHaqSOrvKR3lW+zhgoxd9VptVR7onbiSMSDV63uIEHKfw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/protocol-definitions": "^1.1.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/protocol-definitions": "^1.1.0",
+        "events": "^3.1.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@fluidframework/container-loader": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-TQnDixAD4JYWE5rHZHkwNPrhCK8SWDsMTyJH+dFGSjF9MjBzxiodnRE4JaO688aJWeff6IBxZZJ7E0K10NaDeQ==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-Kc5apLtps2CoI9/pPwy3xVBeSCuJe1FxHYPsvA0XQoId5vtEwxxS6Iqap6DflZDWopfRVXIdObTWj5c8v11Vjg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "abort-controller": "^3.0.0",
         "double-ended-queue": "^2.1.0-0",
         "events": "^3.1.0",
         "lodash": "^4.17.21",
         "url": "^0.11.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/container-loader-previous": {
-      "version": "npm:@fluidframework/container-loader@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-rgIl4qBK0R86lvx3nVvPfgvw6onzORkGVbOimuzk9ePoX0Er7KKF3qAcVMfL7+LWwllHF2dFzyMRv7OtKfTxxQ==",
+      "version": "npm:@fluidframework/container-loader@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-RBP4yJHe9xjqK9dMHmlcH9ukbQyKpckvz49j/+O5VovroVzNLrH8l+TAuLtt3DsJBLLzBzv1/CIiNuZ7DVEBTw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "abort-controller": "^3.0.0",
         "double-ended-queue": "^2.1.0-0",
+        "events": "^3.1.0",
         "lodash": "^4.17.21",
         "url": "^0.11.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/container-runtime": {
@@ -3115,42 +4790,246 @@
       }
     },
     "@fluidframework/container-runtime-definitions-previous": {
-      "version": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-aUewKYpnWP2SlZClPd/GXft+he8RBPwb5bL4E/9cJRCbyuaUGyW7zuFVKfiiLSbNYBF4wtJBBU5WqNRw1DV0YQ==",
+      "version": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-tKnQqHdhBXmMCrmFx53B6VQ9QBJUxYx6WbsJGtxSFylNS/YNLtN4/WPr/MvmHgzqSEYu3fL5IHHk9R3kldwrLw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@types/node": "^14.18.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@fluidframework/container-runtime-previous": {
-      "version": "npm:@fluidframework/container-runtime@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-5g3ZwBf2K/D95DXx+kfOKg1gCWYp5aIDtiqg7F4+JJFsdt2Vit42D35WBJBPyZ/P8eHy1fYA/Jm/zAJ7nwZXYQ==",
+      "version": "npm:@fluidframework/container-runtime@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-VgItZM0zbmT6gvN102zuOKjaTwCeJZIiE3ReXZh4CzB3YklsVvZ8Md5Caq9hnEBLmTwdXOat72flKQW+EZV/BQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/garbage-collector": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "double-ended-queue": "^2.1.0-0",
+        "events": "^3.1.0",
         "lz4js": "^0.2.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/container-utils": {
@@ -3166,15 +5045,56 @@
       }
     },
     "@fluidframework/container-utils-previous": {
-      "version": "npm:@fluidframework/container-utils@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-PpT2bBBl8CmQnsgQrNKWzI2GmDG0S3IZt6LTsXu/OLj+OkjXW+xDFzmuaguZn0gCmrvOvr0vSz23/w3F4QaMjg==",
+      "version": "npm:@fluidframework/container-utils@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-qKBvbotMTAZ2bZLUqATbyQyE+fpL2MsX51DEQNW8PF0g+fZixbch/gMakCcz76H0/FLfxCW35F2cQZ0ABytREw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/core-interfaces": {
@@ -3183,54 +5103,678 @@
       "integrity": "sha512-Fnox1Hgk7PbhVCH1lCQe3Cr/204r4vaQBSOYLMfO/ai3xvfy9oirEfFcBYdt3+5gs2f+fY85ip2zvmE0wTXwyw=="
     },
     "@fluidframework/core-interfaces-previous": {
-      "version": "npm:@fluidframework/core-interfaces@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-B7JNJWkR/0y6CJn90Kk8vTMmZDRKR81OEd82a3CUuYbfAJBsVcMeTPFdh9obrLiH7FS9/f1MxQHFXy7zLOAOWw=="
+      "version": "npm:@fluidframework/core-interfaces@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-WuV3EeKNLjVKoF+X09hj9NC7y9Z2V+l7KU9ojO1oRABkatL/XvtkS8ArX9CCOU0zHg7By28hGP7eZXhVyngf8Q=="
     },
     "@fluidframework/counter": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-5eQ1oz5unQ4bZdUIfOd3u1HuJbMck2+YweMdfws99RTyM5SGQK6oDbVhzg4BFYHm9ZcWSF5/Y9XdyD+FfKSSFQ==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-/dvu6kMUOgwbpgRnWmeRvzwmQJUNYX4TDUZ1ZenOxzxeTXDrOTMMrsFsby8+4iJYShbAtAMoFbwDzwQMjWHDXQ==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/counter-previous": {
-      "version": "npm:@fluidframework/counter@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-jUIWY63RZvMrP+o3HcjBtovbji2HTo3W8M8lPD13taoI6XBmzo619mG7PLmGtCMl7eQ6+hJ++nOvenP4uGWOKQ==",
+      "version": "npm:@fluidframework/counter@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-/iLnTo5fYsiMBxIE/gORUPNTzo9G1+K+BNOe2ieQj09YY8Ft/iuO2rLLDCkFDu6B8IY3eVvQo/yzehXiQcJWdw==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/data-object-base-previous": {
-      "version": "npm:@fluidframework/data-object-base@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-n2xAF0KBFxk0B+4WNDO3JYwsXS94fVL7KUkkgAzLU7I1rGTkzJ+HhlVO0r4nkKItKH5ZPmmD2CcFPxzoPSytYA==",
+      "version": "npm:@fluidframework/data-object-base@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/data-object-base/-/data-object-base-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-neFuWndhzffx8zr8J/kiuNWzpHXF4//MhR6R1X7SM884VHoGNF6Ys/KKcTlzyLEdNn25VQau071/WZm7fdkF0A==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/request-handler": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/datastore": {
@@ -3270,91 +5814,454 @@
       }
     },
     "@fluidframework/datastore-definitions-previous": {
-      "version": "npm:@fluidframework/datastore-definitions@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-46x/eiFnbBRdUMmPkHaI/Znar7Uxr5dSdgw6p7Zi1dvr+3l9F0ZZ0d92FdBcyk4EJlRJlqbZLq4I7Wv7k9hJog==",
+      "version": "npm:@fluidframework/datastore-definitions@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-LTAYWtLqf/MXwLYmkM7dhwfAq7FHnRl4A1eghP63+rFFZOhoth26UXP8FTsm4tZUXmGPb0pfE9FdKvi7KvvwVA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@types/node": "^14.18.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@fluidframework/datastore-previous": {
-      "version": "npm:@fluidframework/datastore@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-cbQHCNWoTNVDOOZX5Oq9pni0KgYSN5zAnGoYr5YTON3D+tGKPTIShp75UHyIzsWWFEYZrg/ybvqCMRAfPuoeoQ==",
+      "version": "npm:@fluidframework/datastore@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-OIwHzbylP5kg0Wp57m3JwKsvj7kmg2tcTPm6zS6+AFYeHxZNVXARZOHxTfDx/KQY1BkBidqtHIP8dYs7JESF2Q==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/garbage-collector": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "lodash": "^4.17.21",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/dds-interceptions-previous": {
-      "version": "npm:@fluidframework/dds-interceptions@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-IFIvT/5P8Y6TYm3KbLhNiyCwjIJEMp53QfB7fobchmblHor7/rqoXhAI5BPwwld3+q33BcSBK/bx/x6T3uQXvw==",
+      "version": "npm:@fluidframework/dds-interceptions@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/dds-interceptions/-/dds-interceptions-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-HjZ5wQs3OLln3fhCTSQYatGIPIRPCPvEh6yMkv+9ej9ESKirz1pzfd5uX+i4Om6pR1W2UZtGZnpLfKd7U9OpPw==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/sequence": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/map": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/sequence": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@fluidframework/debugger-previous": {
-      "version": "npm:@fluidframework/debugger@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-YsTjwLMJnSh9q4QbtIUEOsoRV2Heq1ePQUsrKEnu+wR9HGP5r/pSb1sWrirwMsYeSdHjLdBYMhq67WiCF2IKpQ==",
+      "version": "npm:@fluidframework/debugger@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/debugger/-/debugger-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-LRSzjdGWynnb0ec7LMp47y+JthzyKByig2HrJVCfTxaBidW9MMi8b5N1PJZdCqyesyfywfQ+IGyzfm24C7BW3Q==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/replay-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/replay-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "jsonschema": "^1.2.6"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/driver-base": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-o3JJlg17YmlFB4Pm47MUH/6GRc+GdYJ8XQJm4lyP8NG4lonNygj5y6nRMRxh6rsYQq/30/FBMyWE+hyNrYIlgA==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-J8O/UBo2f7k3FLHWInsTW/QZ2pdSvzIXyasUumx2u48lBQArykEouHdQPK8Hct2CbuHNhY0Vq7SO0Rle3Wgqng==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/driver-base-previous": {
-      "version": "npm:@fluidframework/driver-base@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-3bFBZGjtF0saMia4EeLzjpbT3MURCwyLpDN72Bc6DeelmcRXsr+kOriwk/9PV6AyO7Yjyk7y5fCTTQJSjFO3/w==",
+      "version": "npm:@fluidframework/driver-base@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-IVALkemyc9/sy/WkzqGmwLpCE0fJp+M3Fr5haslh4W+rlF4O3hSyzgNm5hDLKV+ZEDqRnBAzRFTcGR74umX2KQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/driver-definitions": {
@@ -3368,13 +6275,20 @@
       }
     },
     "@fluidframework/driver-definitions-previous": {
-      "version": "npm:@fluidframework/driver-definitions@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-XaS/93Quwm8mbRF/cE6O+mE8vr9s4vwv4H4DGqNQiitGfPEu4l/4BrzHWNmlpJTENu5LZfWY1q/7CDw0nRov5Q==",
+      "version": "npm:@fluidframework/driver-definitions@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-TXgFzgADjtpu6iQSBVAdFGcYJ4LNoW995Qfphjqb60rO5Zzk9d5E4UzX9Wedvu5Cra6hRm7ddv+9esbJ2fhp0A==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        }
       }
     },
     "@fluidframework/driver-utils": {
@@ -3396,32 +6310,75 @@
       }
     },
     "@fluidframework/driver-utils-previous": {
-      "version": "npm:@fluidframework/driver-utils@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-x0cIgwWETVttS5BxEYWBRsV6JiFWRnOzuWsBAtuFrhkRZO04d4hobEc/UWgJgcZaBrtqY7ba4fMmAwU5cWPFSA==",
+      "version": "npm:@fluidframework/driver-utils@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-PrDMHppC6a/IgQ2IrP0Xl1IgH+vHBiIKvhRPpkyFsNtT05ReAsXQC4qhr3cE/GhX3xso+qsGOkPBw7I9Fd2FtA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/gitresources": "^0.1038.2000",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "axios": "^0.26.0",
         "url": "^0.11.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/driver-web-cache-previous": {
-      "version": "npm:@fluidframework/driver-web-cache@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-IfzcYzofia5RBI/PqO8orO9TPA7hYY5NIT+izKE9ZV6BQQnh9Y19LaLxpAAZAiOVllpv/iUd8tLUirahsdl5Fw==",
+      "version": "npm:@fluidframework/driver-web-cache@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-web-cache/-/driver-web-cache-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-LnbGT3f9NpVHd5LcaVzDg+yj9DkVxne2uMlooQZm/4HvisJnCEEzruSHP5br5JysztoGljKt/tMP0tHAK153qw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "idb": "^6.1.2"
+      },
+      "dependencies": {
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/eslint-config-fluid": {
@@ -3447,72 +6404,378 @@
       }
     },
     "@fluidframework/file-driver-previous": {
-      "version": "npm:@fluidframework/file-driver@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-nNy7veICX/9RRZPK7wiiotTNEK1KhcVQ+d5cDjplRfOMvEMuDRMnx783Br5mc4O9YLlrbP3YAO+0lI2fd0vrdQ==",
+      "version": "npm:@fluidframework/file-driver@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/file-driver/-/file-driver-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-vOqyv7T/4bclA/Zp6pEgRK4n9PcjfrtRVIcyt/W3Qo9a7EEx5iic8EjbzGoXB7xRPYgZfgHMnL+qnahzC+bEPg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/replay-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/replay-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/fluid-runner-previous": {
-      "version": "npm:@fluidframework/fluid-runner@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-runner/-/fluid-runner-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-Bdunrbr+dyjJzcjrxCXwjo/rDfaUI8j45VhT9N41QKL+vhOF0C5Ri9WQKwJX2Qr5YWBJwfCHYNj8AnuTJyhv+g==",
+      "version": "npm:@fluidframework/fluid-runner@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-runner/-/fluid-runner-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-TDkFR/N1QpD5OBpPHbg5v3b9+UNeSECjp5kDw0gB4fco0SnjYVFkks4XmZWS4M/P8saZB29L84zqbMSHU6q8bQ==",
       "requires": {
-        "@fluidframework/aqueduct": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/aqueduct": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "json2csv": "^5.0.7",
         "yargs": "13.2.2"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/fluid-static": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-wgI+Y2alA/j9jdl1w0d24waDMF+woAwrCt5YBLORd5OPwzUr3CbdSgL8JL3gg1Oo4KYQmzpx8Cgx36L9QPfMfw==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-83Gzt/LVludXzq7RZadJyIR797+rpdg4fo3moJCfl1B00v1IaijycJSUhU5Etb4GlIk8vmfI5l8pPTD9hkWNmg==",
       "requires": {
-        "@fluidframework/aqueduct": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/aqueduct": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/request-handler": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/fluid-static-previous": {
-      "version": "npm:@fluidframework/fluid-static@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-v3//RQ8c+Fjzymz7f8XWx8iolXwLYAwI9KqWYvybfcZIV/gnGrWssJ93K72CUeYOZqGe/XKbJyPl6e43PJjQWA==",
+      "version": "npm:@fluidframework/fluid-static@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-HP9YGv4X+vd7e6dNn9TtX1Q1GSfD0hyXpS2yrIwm7ez/psUHa9j3UOOXGrkm9MQ35msp129wJ6pGZZOHVwloIQ==",
       "requires": {
-        "@fluidframework/aqueduct": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/aqueduct": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/request-handler": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/garbage-collector": {
@@ -3527,13 +6790,56 @@
       }
     },
     "@fluidframework/garbage-collector-previous": {
-      "version": "npm:@fluidframework/garbage-collector@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-6ZHbBEIbljtMqAjnP/R3MP7MyrPfyWut2q84mKeX8XymXHQoq3S8ApHUyso3NEBTfTxn1hkXvqLq86eumCwqxw==",
+      "version": "npm:@fluidframework/garbage-collector@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-ut7kJm/VCsZswI0c5BVGyBXcLLO3o8gDnfe/cIja0EIiz4niBtP7M2EQ5O5uG+5l8+xwWvEEOOJBEhmqXVUsyA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/protocol-definitions": "^1.1.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@fluidframework/gitresources": {
@@ -3542,358 +6848,2829 @@
       "integrity": "sha512-cbxiG5ygZtGHHXqvkaeGzPbE6fKZcuCo5ZgOPstpH7hvZsUdikohx9h2z0q0KwiW8oV/54S++UOaRAmKTPoh8w=="
     },
     "@fluidframework/ink": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-Xyck2LuKqtHbnwM0pyPqlK3SkDBU1p5EHKm5NsS1zrYrQSUjLJYlbsew2Lbc0ka1iEVbRff2T3oiwThTj1zs5Q==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-HZm5IvHJoBDMCS5KbcmmXyQI+i5mvyxXzbBTM6c72La68mUFEvM73Uj+6cEH61TCLgXjX1vUqz9HqM/FAkjxhg==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/ink-previous": {
-      "version": "npm:@fluidframework/ink@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-E+1pBFwK2H+w61wENQG+GyvX9ud/AcsU7wFFvYiJcGSxr9HizEwD03CSK2lhOjyklMc+WG5xNkpMDEOe5PoAtg==",
+      "version": "npm:@fluidframework/ink@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/ink/-/ink-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-RAGPYk6jc4/qHAT6VaFT2snW9PXC6449jlmmdd5ZXuHURBB7e6giinM0CfsYnJwt1YucU6J26qi4YMYuqf/7Sg==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/local-driver": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-nEDHvLQ2w5RlnxJpSIIKCJ5XT6c26tgMeAT3xTZEpfisqPhD1nRyMxpXN8mVkgu5GqnqCytsS+0P2PmDjkbarg==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-ato6fpQhy+AbOZRIcuTjy3PT5940sbsvwm6DrXEIH2eQlxDqov0u6oJygQibnbAq/fMJOIsupASSMWbSdLCNuQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/server-local-server": "^0.1038.2000",
         "@fluidframework/server-services-client": "^0.1038.2000",
         "@fluidframework/server-services-core": "^0.1038.2000",
         "@fluidframework/server-test-utils": "^0.1038.2000",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "events": "^3.1.0",
         "jsrsasign": "^10.5.25",
         "url": "^0.11.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/local-driver-previous": {
-      "version": "npm:@fluidframework/local-driver@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-Y72ZLmFtRxsraymJWhedtE6iJ9lsH02PcsrsqpQcqEYD9I4o3mdVCaJFCGNpgKjYgc3ljPjou4IXHYqTsiJ2NA==",
+      "version": "npm:@fluidframework/local-driver@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-0n9twrel34UX8VwzUwJSqDkawSOpYwO+MS9QEoe+7eUxb57uxB0AS/ctGYIKTNGTGrHHTH1VWKQs8EIgQopz2g==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/server-local-server": "^0.1038.2000",
         "@fluidframework/server-services-client": "^0.1038.2000",
         "@fluidframework/server-services-core": "^0.1038.2000",
         "@fluidframework/server-test-utils": "^0.1038.2000",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "events": "^3.1.0",
         "jsrsasign": "^10.5.25",
         "url": "^0.11.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/location-redirection-utils-previous": {
-      "version": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/location-redirection-utils/-/location-redirection-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-r+/yKBAzOJwOXGfngB/jw8wap/W2TmelCTB88xAiCigasYbDR+alf7ByhlcD6Xn4mhpaV71IIUYqk91r6t8B8g==",
+      "version": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/location-redirection-utils/-/location-redirection-utils-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-1cX+dmULnnJf9iVg5O97rphIX2/075a5Rqe8yo2rmqJM2QmZbalYmCKfcpNaZdtQFitilr0Sea6+ky99ZowIUQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/map": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-PVEwpPx63bW2d/tb1lOEf61/1llm2llBJ9+W7SVLPUPXJtQQQB1QycE6gmx9W5/3Px2KwDlvGDVz7Vz+yctx/g==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-tvdOOshLtCbDBNXVZC5PeLgbUeMUwGWBhqFHQNnrRas+zm9itmV59bVZdW1OCsxc5yMLIrEWbXAL+VMV8Xj3VA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "path-browserify": "^1.0.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/map-previous": {
-      "version": "npm:@fluidframework/map@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-27wFQeJUwwubgUyZMj555q+0LgeNqTI72y8zd5B+RJTBAMDGENY2ZK/vjZkTFBIHFrEpvHFmF+ZmzN6W0P35mQ==",
+      "version": "npm:@fluidframework/map@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-CmUUZCmsC68BwoCv5pMmqSRgQHurCObalqo/h3LPVukNXvb+VaLWLY9wAvTMlRS9TuqHFghkXsH6Y94BCzGIkw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "path-browserify": "^1.0.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/matrix": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-Uli4yAHumjTU6q3IBTwUtatMjQ4BmqlIg8diVMDkF+Izw/hU4XTCEDC4wVvBlrBU7A3QYK74dGBU2O6ORUSk1w==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-8uFxameyPF5O8Sp5z2bDCw7wo/iJ46my45l05YAXTDlJa+qfhphg40jw4ZacSpvRtZZ2DyvXauZ1ys80zg19gQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@tiny-calc/nano": "0.0.0-alpha.5",
         "events": "^3.1.0",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/matrix-previous": {
-      "version": "npm:@fluidframework/matrix@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-dLeh+0Q1SL9c7dwbNTOyfgxsOVB7GdL3dReLqf3Md6eiT1wwMu7wAOgIq7gfc49P3GHRLjMlGseIV3ccrxezBQ==",
+      "version": "npm:@fluidframework/matrix@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-b+NFqqzdWb6GEBNtMi8pfE/F7ZKygaV0kIQrAbhoSUp5NRgje0cb9LX1B1dhBdPhRo+3dfq3imJXrn0iICbxWA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@tiny-calc/nano": "0.0.0-alpha.5",
+        "events": "^3.1.0",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/merge-tree": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-X0QZWGhho2zLfmBYN4KhpyMkb2nG/58g2h211b87L+4hAKkugAEb76bzs6YjSE0BFKEZy18BMdKqYcgT24qMhQ==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-/Hu7Ytke3xJgSde+EY/qnNVIKh9bROeJkHxBXAvThHdGbr+k4dx/HBfn4cgQ0zfqP8zO4FGXc46xJY9D+qCNsg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/merge-tree-previous": {
-      "version": "npm:@fluidframework/merge-tree@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-MRjHrDRQbUY44v1WzJL49pbdivvb+BvB36bWEs8HT0pGJahPrWSCBahf8771rvfd2G7Yvl9uUSueMDSmzOwgkw==",
+      "version": "npm:@fluidframework/merge-tree@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-UXEIClsn+9VYAF7Rbd6AduAv+3TWKoZtRJFGA70ro/ZifvFx9ciQAgDnKfgEhddbjabgqAkeqI9VcWexobCACA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
+      }
+    },
+    "@fluidframework/mocha-test-setup": {
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-EwiY9V2mjN8px6lakrNeD4RYWTi7ERl6W5c8XLcXCoFCIOh7P4yBYondYogghcnyWjs+wivwg9Vz7uQEyr6RVg==",
+      "requires": {
+        "@fluidframework/common-definitions": "^0.20.1",
+        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "mocha": "^10.0.0"
       }
     },
     "@fluidframework/mocha-test-setup-previous": {
-      "version": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-OOZf8cdm3R29cFoBSKWsuQ+/PJpKUxuVzHaeS/Xqkf9HxCOr9Y7XDg5/jVoVLdPcHdNhTwKykSpMOFSCfhTfFQ==",
+      "version": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/mocha-test-setup/-/mocha-test-setup-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-OzOLiGZ5xIxYapJ9NCICpGlH6muvst6IywR6lW8nBIN16TxVebWuNMNltDhFeZ0DMN3UPohWLigLKjlllJ9KkQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "mocha": "^10.0.0"
       }
     },
     "@fluidframework/odsp-doclib-utils": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-5Vdp4k+SUfXf2eZDVbrBpyeul/KOTBdN+VbYNq+Y+/oFKhXUCGPL+S4cQN9wBMOFr5rbq/Npqf2YqVzXaQd5WQ==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-Sv47A4jGSycmBgolM42ir2/OO+BfA2Vj5JGvDdtTm10UQp5xBsVCY6Z0U6/aPZ4j05D8XaahX5+6HJ5fJ0KIuw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "node-fetch": "^2.6.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/odsp-doclib-utils-previous": {
-      "version": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-94eIjEythnG8/OI9PIMaA2Jd3VyUa6m2TOW+KwtHENVqBTa4/ZEDpWkVc39rRv1VKU4GEvx4V1+lRjhzN17j5Q==",
+      "version": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-doclib-utils/-/odsp-doclib-utils-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-xUc4xrnwrDNY8t4BLK0l6ZRhIxRC+m2yqQG37MKtvRE79h1Q2+Xt+sG5VtD/G3TZ33ZP6SY31+4T151grWfEew==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "node-fetch": "^2.6.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/odsp-driver": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-r6r1ha1wt5UF+rzkY04B2VUdHxrq4GhIJxQHsTEP5jeXNFFRHhORsLH188+2WCjh2l/2JrDLrbYFP+LBQzOQng==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-7BoZGHSKxjv9czZBHEGdM/wVrdqLQ2UCEfMBleRAX/aSW/iUoGzsqfwSpI3L9A13+iAfY04Lypfh7Wth0uNewQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/gitresources": "^0.1038.2000",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.1",
         "socket.io-client": "^4.4.1",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/odsp-driver-definitions": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-phnGN6xgYhLhijGS+cHXAMVgNzCMXYBjvnYgFmYjkmuV2XIIQ8RmJX10EoLTGCYDV44VqQU58EhiUuQ0ID+tQw==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-Ky6lRRO2KaSnPJeTsFYJu1geimtQDmN4+/1v547k1ekoBQNg2179a+6nWXGBoyTmwBkfQ5K56JZ0Z6Fl0EcCow==",
       "requires": {
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@fluidframework/odsp-driver-definitions-previous": {
-      "version": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-8O683idVdX+0FCDXuwdoAF50TGKr/SgEgngHjcWOfkSLlXBx8OkbPfypBJ+lsYSE6aVvOjzVxNN6Od72KnCDrQ==",
+      "version": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver-definitions/-/odsp-driver-definitions-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-ggjQBOjwEQD2GSCkpj48az32zecYACeo1hYdYPQ0Uh6wXP36zBV1YlgYnlZWXXq2CuLV51Ks+HxKmSFRYawFmA==",
       "requires": {
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@fluidframework/odsp-driver-previous": {
-      "version": "npm:@fluidframework/odsp-driver@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-zYqiXUcxQYGlobKLPNS2WdpSrK/1PB/cimitqWQ9yh66dY/p0z2qG2xdKfm2FWNew7k9pnJbCkZzxqR3NQ5G/w==",
+      "version": "npm:@fluidframework/odsp-driver@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-driver/-/odsp-driver-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-awbLN3E1j4zwSmL7E8S+ECaZRNIFiGJ7elLTnjx645tBy5JI4drVnFygtuGoaXCCwQ+bwhbQd6Ml1FDQAduxbg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/gitresources": "^0.1038.2000",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.1",
         "socket.io-client": "^4.4.1",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/odsp-urlresolver": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-9rEMGcRxf+11gqdeAfVDtxbPN2xW49Ryq6DxU2Q6KteDrmw0eekFWBW1iK0aqne9YtOpsrrP7yfIa1r62q5K5Q==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-54ejRWu4nBHn1krkI3ArPef7claEN6h5dOeqhnp9WtiJPhUrK1lBqB4FjJRQo9OcFObyVSL104UNGaqY3k3r1w==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@fluidframework/odsp-urlresolver-previous": {
-      "version": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-FBaxclM18yqbPjhXuozqsQCkf6OvPySfxw2tEUDnLS0xxuOHv/g/HiCiDdVVbCosytFVRKTrNIbJGY9HGSFBHg==",
+      "version": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/odsp-urlresolver/-/odsp-urlresolver-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-g1Zi0cIH2S0Z/nPQIKCtLWLlFMSUoGN4dfT327iSbV1xj19nBMaqGXy3Dc/dGOblbKDmSPkuSvj2icVkeNbkfg==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@fluidframework/ordered-collection": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-IDygQ72CLDDmSngm34hFxDStjGCqvr746jcezswQdwIUEVTC4f/cIrr0NYmIeFYXwVtH7TBUomsLeXT6/uirkg==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-gBTJL4G8OYRw1dSe1Xf6YKsz8PCzFwUaHcGzgLGMregdtlbnjyHPvr0igpuggyTIsQxCd+/rMrAnnYQQ5jtWSg==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/ordered-collection-previous": {
-      "version": "npm:@fluidframework/ordered-collection@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-uVwA9R3Zrp1BHU4QKDF91eKYeAq7HpKE7BSGdbAzpdibHknCx6fad5TKW9rgB5/CYRXiTpR77X07cY59KG7GFg==",
+      "version": "npm:@fluidframework/ordered-collection@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-I8X4wVv1yJYROla2RKVpWUVvWFBwiTBXT/Aku6fwqpco8ZsJm+r4N5h9aeixbEhqvoKiFQpBWjlfRJzQbRr5ww==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/protocol-base": {
@@ -3916,140 +9693,979 @@
       }
     },
     "@fluidframework/register-collection": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-KXHJRv7RLkHDv+LbDkWJ0Jt26tp0VIb+ZrZD2szUY1Eh6WBq1wCfqDeAXl6Lq5ORuUregdVdRmeEAvYxcgUvPw==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-pE7++Vp7QOqTq8eGtaxMOAjAf7NTlRUxbkT+Ev5qzN0q7UxC7aWmkjXPs/yQHfXIxY65CT0tuhOZIHqEeIbasQ==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/register-collection-previous": {
-      "version": "npm:@fluidframework/register-collection@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-8gBxZCeO0T+X9Jd9FBIjyvbb38a29jialMewljjp1HmvYY9mq0hczkOsqdDGkX7mEXJjKFh0t3FNL8aXD1SOkA==",
+      "version": "npm:@fluidframework/register-collection@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-vpIG/WQOz5V4mllVT/GwYLUpvBjDQVs1U00KKE2dc/AN5lVN1ckfTAZWtpSKHstRbpKxnOkD6aNJj741m7vyjg==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/replay-driver": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-k3psQD2hfBN6YJfi9t6VLtKScOPa5TA7GA5tneVR7WwaLr9tdULGvPv96d4QDhuABnjxTD8QaX8TT6zzRRNxTw==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-nGgGyMN9FYmSsTSlk0o2gKKdSU0TTd+WIUHCFQqckOn+D+1Lh/kGBRtLE50cDmSMYyMN4SQTZicm4cupErN64g==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/replay-driver-previous": {
-      "version": "npm:@fluidframework/replay-driver@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-9PoxCnCuVvwuB1MI+GP+0bDfBNpdW4Hc/8Q4QDVYLvKsMtzd03W4TmmGJkglzjGj/MgR6WlU2jRATECnqXbc3g==",
+      "version": "npm:@fluidframework/replay-driver@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/replay-driver/-/replay-driver-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-5O65gs0pjzFJ7rZBXz2gzLaBRXjSWeQNZDr9a0qIyiVwPkTtel0coxI+AB1SGgRcH/wOcxxlyqu3fdJdrUODwQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/request-handler": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-b/p5j5EXljtGZb/GSPsLJMP7pqyTSHvBKs+Zzv8ZaW4DDsgMO8VfQnLASXOakhB4GTN10iFu8Me+sdW5KDVIMg==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-cJLxF6bpiwBspO/idJY9ktR5dYWkZ+UJpO7/ENAXQkPlpS0nvxyJ00St5aL7M43+7U+zRnA9vmXD7MzElVnE1Q==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/request-handler-previous": {
-      "version": "npm:@fluidframework/request-handler@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-8fYfd0ZzGhNsXEtXDxKiDQvT1KJzWKt7w7mE8SJQCqJpiZarLfP4m5sCgQ8MflGHokyrdS0HoAff1PUh7Fz/bg==",
+      "version": "npm:@fluidframework/request-handler@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-LzIqECFuKItGh7po5zKw1m4XBs6+BktC2+DsfzdpBwxVDZAPK14eBudwhZqIyKzhWo7NalNXngcmbiZMeXL4Jw==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/routerlicious-driver": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-hHRvDmUGUybAfx5YuTWp90u6X6aU4TOe+2cAKl5gmhyD7W9Z6R//MbMt8KHl5Wc2tS32+8nIg6wZQ36oYxs06g==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-6dk+i2Ac/aybpeS6JnLIFLAwgNb5XF3oLxyL9G+dQ1r1HvoVr/8y3FVZTGjxSUb+MdVv5axytLbNlVy41vlIIQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/gitresources": "^0.1038.2000",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "@fluidframework/server-services-client": "^0.1038.2000",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "cross-fetch": "^3.1.5",
         "json-stringify-safe": "5.0.1",
         "querystring": "^0.2.0",
         "socket.io-client": "^4.4.1",
         "url-parse": "^1.5.8",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/routerlicious-driver-previous": {
-      "version": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-cAHwV48LFAsONXy+8+CD1wMgM7O0qd24DRBclqOleQzmB7f1lojhcxgSAloeI0busMegb0X3bJ71/jZ5U28JCg==",
+      "version": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-9LWlZUXqdVoaPyQRZXp8kHu5Bz52EKAsXpdK5tX5JvUXTK7afACoTAEfNxoKHtvk/or9okg84Ol9nLHp2naVGg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/gitresources": "^0.1038.2000",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "@fluidframework/server-services-client": "^0.1038.2000",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "cross-fetch": "^3.1.5",
         "json-stringify-safe": "5.0.1",
         "querystring": "^0.2.0",
         "socket.io-client": "^4.4.1",
         "url-parse": "^1.5.8",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/routerlicious-urlresolver-previous": {
-      "version": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-kI7YPiyGNcBdWi4U00Xr4/hGVV4eystNxsXO0oDHknksukadSzzbDtPlyWQUgR8vRr2SkvuwgTwlHSi38thqPQ==",
+      "version": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-urlresolver/-/routerlicious-urlresolver-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-MAIVaNPtx1luAy2ie5QRC63fOuSekUAvOaFxpjJikPWmSJaNeClZsGYK6kB1whgi8TY2PXFws5kTxH+ESI4m4Q==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "nconf": "^0.12.0",
         "url": "^0.11.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@fluidframework/runtime-definitions": {
@@ -4066,17 +10682,45 @@
       }
     },
     "@fluidframework/runtime-definitions-previous": {
-      "version": "npm:@fluidframework/runtime-definitions@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-FEdRUE1PKhv6oRciRP9KPZnm6505b7CzKLOudV8rQtEFKqdD9WODPQAOgOtfZWcKs2ZAoavfowmJ5iJovKT6EA==",
+      "version": "npm:@fluidframework/runtime-definitions@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-ATZdgKDf4UuXKZwpE+bXAkvYvQkPQQzeGcBrVKRnkg6zKaQIOzQx0aP2+WycEPz07aTfewo321MX1HzTLrxfdw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/protocol-definitions": "^1.1.0",
-        "@types/node": "^14.18.0"
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/protocol-definitions": "^1.1.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@fluidframework/runtime-utils": {
@@ -4098,60 +10742,568 @@
       }
     },
     "@fluidframework/runtime-utils-previous": {
-      "version": "npm:@fluidframework/runtime-utils@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-U7LyFfd1RrH/Vzy5rn3aNlFPjway16To/T0ZrrmeoPDnCNP6FBUgdLsZqUGwyaWCTPhNyLy3E8lfzcgecKrGDA==",
+      "version": "npm:@fluidframework/runtime-utils@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-ygijs7mVbKDC2wpl3DDkq9bdXRjlMLgVoiIMnKTc5MKwtum3gw7bMmy+VoCCIzjKUjtsWKXt2ZvlkVeH2E8QoA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/garbage-collector": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/garbage-collector": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/sequence": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-amvOAnwb2M1iPeLD1HQdLgdg0aCDyPj4BojBR7LTZb01Xjd3k6P5D/CkPCnBgTSoRCQoLw3jnchCRNvNftkYaQ==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-INsbIn6GmGt7Kwbg+ExEoe4X3BNsNVWhRSgaj9dnWv/gQtySHOiXNF71RslAuNdzZ8ssfQwqjvHimt/Kvvqmzg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/sequence-previous": {
-      "version": "npm:@fluidframework/sequence@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-KZASJO8bo6Ksz9enDc+Jl0RkN2wfxV8vEO0j0Zw53VGzskhDV4ZiwOw4t3WUS2QYV3FNLGHttWZWKy3AESEZyw==",
+      "version": "npm:@fluidframework/sequence@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-QGrwdaS4ub0fp7A25Px9F8VdqR8G3oqRPgpmpENnWI5RxDtlGZ3pXbELSjkER6NgaCnnTS1n681SuZKro3n6gQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/server-lambdas": {
@@ -4470,64 +11622,669 @@
       }
     },
     "@fluidframework/shared-object-base-previous": {
-      "version": "npm:@fluidframework/shared-object-base@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-oZ5S8ZpPHoM0Au0alaXxTD+pqf6MnopDIlQ1ER2dA+MfvGtR3/Rg1jdyOn/dmpx83lXdKA942uQv0zzND0hX7A==",
+      "version": "npm:@fluidframework/shared-object-base@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-oVcw1hJfHH8KLJfiFyFgZeEv18vAoBKLcFoN23KCGTKaIL82Wh5QWeTNax/Aq0AUH7v23/9SUjbNz1CzL15XMA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/shared-summary-block-previous": {
-      "version": "npm:@fluidframework/shared-summary-block@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-Tw2nhgazY/M+Y4dmLffffi+GKgWvMbX66yLnI1HYOsHZGXcGGZKORBi1VWQOz5P8cIuX8k8e5bJ05rAU8G239A==",
+      "version": "npm:@fluidframework/shared-summary-block@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/shared-summary-block/-/shared-summary-block-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-i8r28ofR0TDZQ9LXZbjzRjqtCY2MEfcL+ZjYblD2/MsUSCtw67Swza7dZkAL9LJ+ZooWok9Lx5hiUXOIIG1Wtg==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/synthesize": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-0rm0jwdvkwvGyUVaIjURcdBPOYAhegwtIo8zOuSnryETzRU7uliaDS5gWyMmf/0dHsJd4J0/XzCh/NIh08Ztsg=="
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-/1yPs0z8QJyCryyXSHQE243ey+2OPEzaLhgug3dlwKQ7839L0bnGd2FhYgtdVRx7DiLP5pWWHnAS6+W00mEwbQ=="
     },
     "@fluidframework/synthesize-previous": {
-      "version": "npm:@fluidframework/synthesize@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-Z1PdSOr9PrpcU8tCG+INGzS5RFMoe9sO+IrGgACJ1tFDpja29gs3su9JfIWcgnDIAtL2lbP/i8ezxBGDbJZPxQ=="
+      "version": "npm:@fluidframework/synthesize@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-YXjv2ra75ZsKOr9833BkdoYUHcZ0S/JTPz8195oFIQWcZmYAVW+oep3a38iLGpS9DOKx5JEyUs85QM3v34FYqg=="
     },
     "@fluidframework/task-manager-previous": {
-      "version": "npm:@fluidframework/task-manager@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/task-manager/-/task-manager-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-/Drvtblg00+OH7y8hyFeQKu76UYBG1/07Yf+b7R/hiESplSk/0XIQ2kRxK/vXyelwFUT7PUowgPI3ytLCHFLrQ==",
+      "version": "npm:@fluidframework/task-manager@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/task-manager/-/task-manager-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-pIisKggfDTgfs2cSlVSCrx2jaJSaiHoUITXMUgXKpxG3HdBnrRmWwiPumejZEvwUFcvcHwowjvCBhK4Iuv3hfA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/shared-object-base": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/shared-object-base": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "events": "^3.1.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/shared-object-base": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/telemetry-utils": {
@@ -4543,9 +12300,9 @@
       }
     },
     "@fluidframework/telemetry-utils-previous": {
-      "version": "npm:@fluidframework/telemetry-utils@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-eERa9i4aAS3dwGxTdkGlkY4GCl9BVufvsGQBC67Pv56N6pVO0HNhiYS1x0vszGA3UZRtjn4NO00PIEP6FQB54g==",
+      "version": "npm:@fluidframework/telemetry-utils@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-cYCw+A8x92NOPCQHiOUfIHHxToTLsqCKW4RWvLV7m6hGnH/Q3cwmgQcPESpPGZrdQSCW0HNHf2CjxSmN7rqKQQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
@@ -4555,25 +12312,43 @@
       }
     },
     "@fluidframework/test-client-utils-previous": {
-      "version": "npm:@fluidframework/test-client-utils@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-oxotV13eQhNUpZ4iz9UHESjBJYB/Ca7Y4796IC3kCaX49LMjgEMQXiM8sbnOgDt8RkUHE2ZeDTO+QLshPO5myw==",
+      "version": "npm:@fluidframework/test-client-utils@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-client-utils/-/test-client-utils-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-+3IvBTwbkj3ZClmwpWwSsz2onpWZ3yI2NMzQFLm3O+rrb9NoqFJDopFxxHamjTCD3Q3p7pED3fdIaGqcwBFjBg==",
       "requires": {
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "sillyname": "^0.1.0"
+        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "sillyname": "^0.1.0",
+        "uuid": "^8.3.1"
       }
     },
     "@fluidframework/test-driver-definitions": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-YytMbCV5zubexbJzabj9pyT/1VfBwAAEUHzpMFMpQCJmVpGV1Ujpcs9Gzd7HaLhh0URe6l353LS3U6hXgafSHQ==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-EHhNRZiUJHNYF5QJYoK1sasd22PzmNPuStkgxX9sVZAOoQ/SSjfu1QWLRxS5bN+HRXdRnjBm+ZxjWeDQypxvdg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@fluidframework/test-driver-definitions-previous": {
@@ -4589,132 +12364,528 @@
       }
     },
     "@fluidframework/test-drivers": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-dmvdkf2TF/JHMhDgMc/0Fqa7iSRMhrQFcQtjoy3YFWmuQZNng1fTk9tZmnmPQpWLiimP/NyQ9j3C75dMEYeBmw==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-D4Zy71wSjXTyg509pp92eKtpLuOx3UvTx7rRfH2K/NH7XFruP4TK2Mqonmt8Pb2dUgOiPBLDQUi5l1/gFw0RVg==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/local-driver": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/local-driver": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-urlresolver": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/server-local-server": "^0.1038.2000",
-        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/tool-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/test-pairwise-generator": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/tinylicious-driver": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/tool-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "axios": "^0.26.0",
         "semver": "^7.3.4",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/test-drivers-previous": {
-      "version": "npm:@fluidframework/test-drivers@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-8ISe9b8iwcwJVrDZrEsWa/C/0tbNeSozIz2nHuYelFNhDEJMGVCBqxrHT+OL5YODf+ZVKcSAdZY1afiHZJbgAg==",
+      "version": "npm:@fluidframework/test-drivers@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-drivers/-/test-drivers-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-1k+tjib7A+ZD9UHoih4lrQZLIoHG/JlB2NPcB7ws9vicQSqLuGLxORds+ldCPZ+COxnJRFWNQTPveZ3YO0ki3g==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/local-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/odsp-urlresolver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/local-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/odsp-urlresolver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/server-local-server": "^0.1038.2000",
-        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-pairwise-generator": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/tool-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/test-pairwise-generator": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/tinylicious-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/tool-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "axios": "^0.26.0",
         "semver": "^7.3.4",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/test-loader-utils-previous": {
-      "version": "npm:@fluidframework/test-loader-utils@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-MhkIO3fm3EKqlNFiEufRPL5weKnFApnnRRxg23EiddYo1OhAtqqGccf3pTghEQT8EhmscgJmnNMPo1KQb6xW0g==",
+      "version": "npm:@fluidframework/test-loader-utils@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-loader-utils/-/test-loader-utils-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-1OPRj/HrkUPC3l8N3xwf2HnTWV7QyEmhaaZkahQttZFlWSin2qlR4yVhBXlhiNYXfdyfXiTiD91lA7owNM1qtQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/test-pairwise-generator": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-uHHyHg86pZZCZLAjCvoyCFRpHWqPosiW9A33MKbNg82RKzNRC3U+X4apZzyns4WGjq4k7DhliBZ4n85Ev6aDWA==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-+i6WPEosbBY/E++C8annToPVdWUGpzSjY5STZB1T+L/kFNncpFlfsmq8fuYwM/yA6chgUlcR49j0qRBRcTJObA==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
         "random-js": "^1.0.8"
       }
     },
     "@fluidframework/test-pairwise-generator-previous": {
-      "version": "npm:@fluidframework/test-pairwise-generator@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-z+h0VM12B5HESqdr4jfAS7qxzmCUuueoUnH56yztHT+cbgbQrIunN2tTWpog+PCGVx5vMwd7fAo9UNoZDYI/+w==",
+      "version": "npm:@fluidframework/test-pairwise-generator@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-pairwise-generator/-/test-pairwise-generator-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-Tpnc2nbTzQyj9LzWprQgbqY0yC9sijvHt5YkvMrlnBQADpxYQ4tM0pXg9izyJwSibHK+TKxym/6OrOm1Bl2XiQ==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
         "random-js": "^1.0.8"
       }
     },
     "@fluidframework/test-runtime-utils": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-tsC+0bzVqnY5PTF1KEs6puH5Nqu0IZpgA4pKh1UqAX1Fh5MnfILwuk4a9we69bUR2yB2CVofaKEF4GRScNlpZQ==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-0tZWzxz0lkYvC5IfdizuOnKj6RiSq2q14S5znjcGSx87LQpxrZZWLOV9I/O5PVFgxLW1rPFyzJARnCUfr6ecqw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "axios": "^0.26.0",
         "events": "^3.1.0",
         "jsrsasign": "^10.5.25",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/test-runtime-utils-previous": {
-      "version": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-nBBuFCLqM6RKylZj1aeEl4XhhwuXTj1PXgfMZJfhHV5pPJ434W6KDFtq2OwXagwLLOsuDfDjBlyppy6P5ByKKg==",
+      "version": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-EdDyv13YXAB7krOdPB1xv/dH9cQy3r6QiqTWxK8Ed6Yy6LZjk3f93ff1k4mw6LSGCjBw5Ncw1r6Vft/NWVnyDQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "axios": "^0.26.0",
+        "events": "^3.1.0",
         "jsrsasign": "^10.5.25",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/test-tools": {
@@ -4724,160 +12895,948 @@
       "dev": true
     },
     "@fluidframework/test-utils": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-rFUkq1+apdVrqEl8UN+kjcZzpun48QTE0kssNIohN5OhSmjlFV6M1LWae6MeL39486DQyl/6c25/vupjiC9SnQ==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-hHvFsTi+MQowVCcHzkLiYadAI6aajaIQ2H4WHGs98cpOThX4AEUsMGik3jo0ozWwHU6SD9NTG/FJn9vHDMexag==",
       "requires": {
-        "@fluidframework/aqueduct": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/aqueduct": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/local-driver": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/map": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/local-driver": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/map": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/request-handler": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "best-random": "^1.0.0",
         "debug": "^4.1.1",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/test-utils-previous": {
-      "version": "npm:@fluidframework/test-utils@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-3y0WtePiPqQKGIO1VYfQi8jMyhdH92RG5xUPqpYWtAi8pj3456CuVXAOGY7vxEW/unkLCmF/1BIPFk0fA2jLNw==",
+      "version": "npm:@fluidframework/test-utils@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-31q4d8LBRoc2R0xSiOgDwSmvdZ6gMs2CysrzZqCB7+/5EP5lwyIhYghQIX1WpjkF7iHjHWzvRADwMgwiu/g5PA==",
       "requires": {
-        "@fluidframework/aqueduct": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/aqueduct": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/local-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/local-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/map": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/request-handler": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/telemetry-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/request-handler": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "best-random": "^1.0.0",
         "debug": "^4.1.1",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/test-version-utils-previous": {
-      "version": "npm:@fluidframework/test-version-utils@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-pc6+OdalaX+qmLcTtf+QfZxmqln8xG5yjAsb8goWDnOFk1dsxEtxx9E8m6jj8mmFNa+/vUAQHsNtJJUYOWtd3Q==",
+      "version": "npm:@fluidframework/test-version-utils@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/test-version-utils/-/test-version-utils-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-TNQPRrLIDWGknVJ+ZWUp63e79nUW5RKuIePT+PQidsBDpUGtBmQ1/I1NmhjQ2cwQx7riqGHu0ecA29u2FcSMMg==",
       "requires": {
-        "@fluid-experimental/sequence-deprecated": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/aqueduct": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/cell": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluid-experimental/sequence-deprecated": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/aqueduct": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/attributor": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/cell": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-runtime": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/counter": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/datastore-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/ink": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/matrix": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/ordered-collection": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-runtime": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/counter": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/ink": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/map": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/matrix": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/ordered-collection": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/register-collection": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/sequence": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-drivers": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/test-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/register-collection": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/sequence": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/test-driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/test-drivers": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/test-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "nconf": "^0.12.0",
         "proper-lockfile": "^4.1.2",
         "semver": "^7.3.4"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "double-ended-queue": "^2.1.0-0",
+            "events": "^3.1.0",
+            "lz4js": "^0.2.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/container-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/runtime-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "lodash": "^4.17.21",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/tinylicious-client-previous": {
-      "version": "npm:@fluidframework/tinylicious-client@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-HmtW7Tn2Djpw4ZUjMG89IfJotCKf7EJX20XPnCmO3ED5J40L7VZAtL+If/lxaq/9q37IsiQCEOyEX9Ib6YMf6Q==",
+      "version": "npm:@fluidframework/tinylicious-client@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-j6h6m+0dYKywfT8zFTGAD0nq0SolUqM6KvDqL0YCAQqsSxVHK7HmhG38CUbJBiQdMaW/j/n4naLKXx01oQB+aQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/fluid-static": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/fluid-static": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/map": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/runtime-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/tinylicious-driver": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/tinylicious-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/container-runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/datastore-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/garbage-collector": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/runtime-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/runtime-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/datastore-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/garbage-collector": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/runtime-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/tinylicious-driver": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-vFdaarBcUIPT5EER6HogenVaEnb0U4wQjt2v6hlBHA0R8jGoRfmj+8gzYB2+NeLKRdiBHVBCSSne776kTMSypQ==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-1VghzUTqxCt8GjBpIzHODlW1zJ4xpqD73r1IW/glRP7+rRikqdtTZRdMsmjHs8ui1HcfL3pSK7lZo+2gRlEwPQ==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/server-services-client": "^0.1038.2000",
         "jsrsasign": "^10.5.25",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/tinylicious-driver-previous": {
-      "version": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.2.1.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.2.1.1.tgz",
-      "integrity": "sha512-BDX2wLnyn0UYc2UfzOCGBvtRfTQrVuzhdwZeE3Na5PtH3ypuyItJ21EYiUqHjEKjEV2MDDf0IFeu/FeAkMYzfQ==",
+      "version": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-gkdSaZXhzy+mkT3I6ZUlzW80oZbmzwvwUC/Olk4b4M8dnuxi0qxjHzWBTEK93aYW/lA8rnuFaZR3HFLTn6u0UA==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-utils": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-definitions": "^1.1.0",
-        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/routerlicious-driver": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/server-services-client": "^0.1038.2000",
         "jsrsasign": "^10.5.25",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        },
+        "@fluidframework/driver-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/gitresources": "^0.1038.2000",
+            "@fluidframework/protocol-base": "^0.1038.2000",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "@fluidframework/telemetry-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "axios": "^0.26.0",
+            "url": "^0.11.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/telemetry-utils": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^1.0.0",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uuid": "^8.3.1"
+          }
+        }
       }
     },
     "@fluidframework/tool-utils": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-aJr2DTzdY/wikzGsAyOKQ/uHLtZHToLDLgJ1BaRT5xkRf2RpE62jii/t93FDFfu1WemcPhpMh2eJ5rkJ6Ui/ow==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-2NoJc64YmvYNy5LUdhP+Ng3P7PDX1UgF4IUQjHAUW5Z7plWydxsxsX46pD/cgsOqHyiOG6Oy5cQkLMlzvk2KoQ==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "async-mutex": "^0.3.1",
@@ -4887,12 +13846,12 @@
       }
     },
     "@fluidframework/tool-utils-previous": {
-      "version": "npm:@fluidframework/tool-utils@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-2VYa5c/OQgLzgK2mQw2alIEoqk190KMo2ybQR8UUSAog/AMH96hD/NR3Oj7Kze9fyU0NWzIcXBMIMkQDEZHZfA==",
+      "version": "npm:@fluidframework/tool-utils@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/tool-utils/-/tool-utils-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-JdypYLgG8gLeotVEnDRKwd1DTMw1Xw5PwP0K+nf6rxmVU/UdVTEpdpCx1Fxu/8S9dwnUXSYY+JXUdy0pt2DCtA==",
       "requires": {
         "@fluidframework/common-utils": "^1.0.0",
-        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/odsp-doclib-utils": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "@fluidframework/protocol-base": "^0.1038.2000",
         "@fluidframework/protocol-definitions": "^1.1.0",
         "async-mutex": "^0.3.1",
@@ -4902,72 +13861,159 @@
       }
     },
     "@fluidframework/undo-redo-previous": {
-      "version": "npm:@fluidframework/undo-redo@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-avQTBoqLIbGRuY41odSzaFXY3OPsp+fpc72jKRhuikRRwyX3SNJsKs2PevEokH1bYqgw7oIPpjL+f3mtG9BMVw==",
+      "version": "npm:@fluidframework/undo-redo@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/undo-redo/-/undo-redo-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-m5Oxz+R/cODHL10umy/UcAwryAa67zpuMxIZISRv9N8tYaJABRodPls99BK/dLW93KypFTW5kPq33PESD4JYpA==",
       "requires": {
-        "@fluidframework/map": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/matrix": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/merge-tree": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/sequence": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/map": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/matrix": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/merge-tree": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/sequence": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "events": "^3.1.0"
       }
     },
     "@fluidframework/view-adapters": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-IqhmxXdx8RgtO50UZmsRIC/UEfdFa8BOjiCDYDSUivjmlbwTgINCS/TZjnEq9I338t8wAaXmObX2nIS4cJvQuQ==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-hPYD0CS/9tx6UGJVxfpZDCxU5BubLF0uGbIPlHOPLYD4Wo81hLBesEkS53lzX0sgB0qrficrGFAjqv5WkJ1I2A==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/view-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "react": "^17.0.1",
         "react-dom": "^17.0.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        }
       }
     },
     "@fluidframework/view-adapters-previous": {
-      "version": "npm:@fluidframework/view-adapters@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-4uJNgrFidEg5310Zy3/ZaHpXMBK13mynQhTnDIQ7PqhnVjy+Jswfz9AcnO1hm/NGdlh2CUC+9GGYGmi8s+QMNA==",
+      "version": "npm:@fluidframework/view-adapters@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/view-adapters/-/view-adapters-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-e3fisAFHB/7z+ca2JDVgGChGoufLKlvCEmPv1IvDpswQG0UuWjqcanIn0d1b/ObrdaYikKhS9NfFv6PLgo0CCA==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/view-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/view-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "react": "^17.0.1",
         "react-dom": "^17.0.1"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        }
       }
     },
     "@fluidframework/view-interfaces": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-07lf/w9zI4Gf5mwjdVNSutWcr9U6xi3KBJ8lFLGXx9xL/X62CUJairUC14nKpkKflQsIQRGIWpSFInY3iIxjMQ==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-R4KOWbPofQRqKeEE45DuQw9DEZqadrZYcy7Lh8SKp9SOMyT+BYkavNuS7q2UjSx/W5/YxIC/wuwfGuX5p5fSLA==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        }
       }
     },
     "@fluidframework/view-interfaces-previous": {
-      "version": "npm:@fluidframework/view-interfaces@2.0.0-internal.2.2.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.2.2.0.tgz",
-      "integrity": "sha512-AvFzO1VmHH/LJOz3u/c4IoctZ6hr7O7NmsrYsxOBQxynb8IOe7PWVYfEvpX45J3W5KHhbxPMvYKhTh8ovKS2Eg==",
+      "version": "npm:@fluidframework/view-interfaces@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-HOvqcf1aLLncc7Vpq5ItiprpiB8RfQj+mVgxet/dgSNbsrwbp/J409ydPBjjJFYQH2Dg80Fo7avM29iditwhhQ==",
       "requires": {
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        }
       }
     },
     "@fluidframework/web-code-loader": {
-      "version": "2.0.0-internal.2.4.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.4.0.tgz",
-      "integrity": "sha512-U8EWrrddAZGOFsmyC+hjU1kXIlx3mtQtB1GrE2LD1AWKCG5jHNzC1d41NYgIo3DCpis0IodKwsv6Me5Bm2cWpA==",
+      "version": "2.0.0-internal.3.1.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.3.1.0.tgz",
+      "integrity": "sha512-7v7cVy/mAT6uXoivGd+gNALMNv0FRVwOOoqmmbYt9fLoky+u5Pqw1FngB/gfvEmj+yZc+fjWZ0+ZErJ1A9y+jQ==",
       "requires": {
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.4.0 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
         "isomorphic-fetch": "^3.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@fluidframework/web-code-loader-previous": {
-      "version": "npm:@fluidframework/web-code-loader@2.0.0-internal.2.1.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.2.1.1.tgz",
-      "integrity": "sha512-I+Whj5q77X82exkZCuRABGV0emuonAn3A9TUdFRSKsWrLR6VQzw+O+ixNun7Dzu4RHEo/tvIOIgJAvBiMfIJKQ==",
+      "version": "npm:@fluidframework/web-code-loader@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/web-code-loader/-/web-code-loader-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-QpgJS+/1iyBWtV2UYAUes8NJHXcRsidrSnoBkqOAjh/q863n0YAByOJuBB92XHbREnn6mN5m3qLMqvLGdfQ0ug==",
       "requires": {
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
-        "@fluidframework/core-interfaces": ">=2.0.0-internal.2.1.1 <2.0.0-internal.3.0.0",
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/core-interfaces": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
         "isomorphic-fetch": "^3.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "@gar/promisify": {
@@ -29903,16 +38949,45 @@
       "integrity": "sha512-OapHwT5Ug1c3iiv8JNrwh/3XGjP45l/2iwfl25chePrvCgl0786ZvsJK+hxCCaUZjPm1lHdh5LHZhmKRxunziA=="
     },
     "fluid-framework-previous": {
-      "version": "npm:fluid-framework@2.0.0-internal.2.1.0",
-      "resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.2.1.0.tgz",
-      "integrity": "sha512-T9IOSods5CJ8xRpnD5JNpimEWLsb5hMFhlv6CMzkOW7Sq9sPzOMnGJqZEGy6gZignR8tLCGtvdhKsHi5JkKLuQ==",
+      "version": "npm:fluid-framework@2.0.0-internal.3.0.0",
+      "resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.0.0-internal.3.0.0.tgz",
+      "integrity": "sha512-oplrZ7ckLN9Ap/4ZBD+XKY4L2LvB6C8+VX0CRSNbYul0mDNG2wxPZVD4kzIwqh5t+aIF436r8HDYNFTDZ3wq2g==",
       "requires": {
-        "@fluidframework/container-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/container-loader": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/driver-definitions": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/fluid-static": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/map": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0",
-        "@fluidframework/sequence": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
+        "@fluidframework/container-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/container-loader": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/driver-definitions": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/fluid-static": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/map": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0",
+        "@fluidframework/sequence": ">=2.0.0-internal.3.0.0 <2.0.0-internal.4.0.0"
+      },
+      "dependencies": {
+        "@fluidframework/container-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/driver-definitions": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0"
+          }
+        },
+        "@fluidframework/core-interfaces": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww=="
+        },
+        "@fluidframework/driver-definitions": {
+          "version": "2.0.0-internal.3.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.3.1.0.tgz",
+          "integrity": "sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/core-interfaces": ">=2.0.0-internal.3.1.0 <2.0.0-internal.4.0.0",
+            "@fluidframework/protocol-definitions": "^1.1.0"
+          }
+        }
       }
     },
     "flush-write-stream": {

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -51,7 +51,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.2.2.0",
+    "@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -64,9 +64,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.2.0",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -44,7 +44,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.2.2.0",
+    "@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -57,18 +57,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "InterfaceDeclaration_IFluidObject": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "RemovedInterfaceDeclaration_IFluidObject": {
-        "forwardCompat": false,
-        "backCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
+++ b/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
@@ -328,18 +328,6 @@ use_old_InterfaceDeclaration_IFluidLoadable(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IFluidObject": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IFluidObject": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IFluidPackage": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IFluidPackage():

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -47,7 +47,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.2.2.0",
+    "@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -59,34 +59,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "TypeAliasDeclaration_DriverError": {
-        "backCompat": false
-      },
-      "EnumDeclaration_DriverErrorType": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IDriverBasicError": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IGenericNetworkError": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IDriverErrorBase": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IThrottlingWarning": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IAuthorizationError": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_ILocationRedirectionError": {
-        "backCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.generated.ts
+++ b/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.generated.ts
@@ -35,7 +35,6 @@ declare function get_current_TypeAliasDeclaration_DriverError():
 declare function use_old_TypeAliasDeclaration_DriverError(
     use: TypeOnly<old.DriverError>);
 use_old_TypeAliasDeclaration_DriverError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_DriverError());
 
 /*
@@ -60,7 +59,6 @@ declare function get_current_EnumDeclaration_DriverErrorType():
 declare function use_old_EnumDeclaration_DriverErrorType(
     use: TypeOnly<old.DriverErrorType>);
 use_old_EnumDeclaration_DriverErrorType(
-    // @ts-expect-error compatibility expected to be broken
     get_current_EnumDeclaration_DriverErrorType());
 
 /*
@@ -205,7 +203,6 @@ declare function get_current_InterfaceDeclaration_IAuthorizationError():
 declare function use_old_InterfaceDeclaration_IAuthorizationError(
     use: TypeOnly<old.IAuthorizationError>);
 use_old_InterfaceDeclaration_IAuthorizationError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IAuthorizationError());
 
 /*
@@ -494,7 +491,6 @@ declare function get_current_InterfaceDeclaration_IDriverBasicError():
 declare function use_old_InterfaceDeclaration_IDriverBasicError(
     use: TypeOnly<old.IDriverBasicError>);
 use_old_InterfaceDeclaration_IDriverBasicError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDriverBasicError());
 
 /*
@@ -519,7 +515,6 @@ declare function get_current_InterfaceDeclaration_IDriverErrorBase():
 declare function use_old_InterfaceDeclaration_IDriverErrorBase(
     use: TypeOnly<old.IDriverErrorBase>);
 use_old_InterfaceDeclaration_IDriverErrorBase(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDriverErrorBase());
 
 /*
@@ -592,7 +587,6 @@ declare function get_current_InterfaceDeclaration_IGenericNetworkError():
 declare function use_old_InterfaceDeclaration_IGenericNetworkError(
     use: TypeOnly<old.IGenericNetworkError>);
 use_old_InterfaceDeclaration_IGenericNetworkError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IGenericNetworkError());
 
 /*
@@ -617,7 +611,6 @@ declare function get_current_InterfaceDeclaration_ILocationRedirectionError():
 declare function use_old_InterfaceDeclaration_ILocationRedirectionError(
     use: TypeOnly<old.ILocationRedirectionError>);
 use_old_InterfaceDeclaration_ILocationRedirectionError(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ILocationRedirectionError());
 
 /*
@@ -762,7 +755,6 @@ declare function get_current_InterfaceDeclaration_IThrottlingWarning():
 declare function use_old_InterfaceDeclaration_IThrottlingWarning(
     use: TypeOnly<old.IThrottlingWarning>);
 use_old_InterfaceDeclaration_IThrottlingWarning(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IThrottlingWarning());
 
 /*

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -75,7 +75,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.2.2.0",
+    "@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
@@ -94,9 +94,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -74,7 +74,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.2.2.0",
+    "@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
@@ -93,9 +93,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -76,7 +76,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.2.2.0",
+    "@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -93,9 +93,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -85,7 +85,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.2.2.0",
+    "@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -104,9 +104,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -86,7 +86,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.2.2.0",
+    "@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -110,9 +110,9 @@
     "uuid": "^8.3.1"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -84,7 +84,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.2.2.0",
+    "@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/test-pairwise-generator": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
@@ -108,25 +108,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "ClassDeclaration_Client": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "InterfaceDeclaration_SegmentGroup": {
-        "forwardCompat": false
-      },
-      "InterfaceDeclaration_MergeTreeStats": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "RemovedInterfaceDeclaration_MergeTreeStats": {
-        "forwardCompat": false,
-        "backCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
+++ b/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
@@ -64,6 +64,30 @@ use_old_FunctionDeclaration_appendToMergeTreeDeltaRevertibles(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_AttributionKey": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_AttributionKey():
+    TypeOnly<old.AttributionKey>;
+declare function use_current_InterfaceDeclaration_AttributionKey(
+    use: TypeOnly<current.AttributionKey>);
+use_current_InterfaceDeclaration_AttributionKey(
+    get_old_InterfaceDeclaration_AttributionKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_AttributionKey": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_AttributionKey():
+    TypeOnly<current.AttributionKey>;
+declare function use_old_InterfaceDeclaration_AttributionKey(
+    use: TypeOnly<old.AttributionKey>);
+use_old_InterfaceDeclaration_AttributionKey(
+    get_current_InterfaceDeclaration_AttributionKey());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_BaseSegment": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_BaseSegment():
@@ -143,7 +167,6 @@ declare function get_old_ClassDeclaration_Client():
 declare function use_current_ClassDeclaration_Client(
     use: TypeOnly<current.Client>);
 use_current_ClassDeclaration_Client(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_Client());
 
 /*
@@ -156,7 +179,6 @@ declare function get_current_ClassDeclaration_Client():
 declare function use_old_ClassDeclaration_Client(
     use: TypeOnly<old.Client>);
 use_old_ClassDeclaration_Client(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_Client());
 
 /*
@@ -666,6 +688,30 @@ use_old_FunctionDeclaration_extendIfUndefined(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IAttributionCollection": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IAttributionCollection():
+    TypeOnly<old.IAttributionCollection<any>>;
+declare function use_current_InterfaceDeclaration_IAttributionCollection(
+    use: TypeOnly<current.IAttributionCollection<any>>);
+use_current_InterfaceDeclaration_IAttributionCollection(
+    get_old_InterfaceDeclaration_IAttributionCollection());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IAttributionCollection": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IAttributionCollection():
+    TypeOnly<current.IAttributionCollection<any>>;
+declare function use_old_InterfaceDeclaration_IAttributionCollection(
+    use: TypeOnly<old.IAttributionCollection<any>>);
+use_old_InterfaceDeclaration_IAttributionCollection(
+    get_current_InterfaceDeclaration_IAttributionCollection());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ICombiningOp": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ICombiningOp():
@@ -1002,6 +1048,30 @@ use_old_InterfaceDeclaration_IMergeTreeAnnotateMsg(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IMergeTreeAttributionOptions": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IMergeTreeAttributionOptions():
+    TypeOnly<old.IMergeTreeAttributionOptions>;
+declare function use_current_InterfaceDeclaration_IMergeTreeAttributionOptions(
+    use: TypeOnly<current.IMergeTreeAttributionOptions>);
+use_current_InterfaceDeclaration_IMergeTreeAttributionOptions(
+    get_old_InterfaceDeclaration_IMergeTreeAttributionOptions());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IMergeTreeAttributionOptions": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IMergeTreeAttributionOptions():
+    TypeOnly<current.IMergeTreeAttributionOptions>;
+declare function use_old_InterfaceDeclaration_IMergeTreeAttributionOptions(
+    use: TypeOnly<old.IMergeTreeAttributionOptions>);
+use_old_InterfaceDeclaration_IMergeTreeAttributionOptions(
+    get_current_InterfaceDeclaration_IMergeTreeAttributionOptions());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IMergeTreeClientSequenceArgs": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IMergeTreeClientSequenceArgs():
@@ -1214,6 +1284,30 @@ declare function use_old_TypeAliasDeclaration_IMergeTreeOp(
     use: TypeOnly<old.IMergeTreeOp>);
 use_old_TypeAliasDeclaration_IMergeTreeOp(
     get_current_TypeAliasDeclaration_IMergeTreeOp());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IMergeTreeOptions": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IMergeTreeOptions():
+    TypeOnly<old.IMergeTreeOptions>;
+declare function use_current_InterfaceDeclaration_IMergeTreeOptions(
+    use: TypeOnly<current.IMergeTreeOptions>);
+use_current_InterfaceDeclaration_IMergeTreeOptions(
+    get_old_InterfaceDeclaration_IMergeTreeOptions());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IMergeTreeOptions": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IMergeTreeOptions():
+    TypeOnly<current.IMergeTreeOptions>;
+declare function use_old_InterfaceDeclaration_IMergeTreeOptions(
+    use: TypeOnly<old.IMergeTreeOptions>);
+use_old_InterfaceDeclaration_IMergeTreeOptions(
+    get_current_InterfaceDeclaration_IMergeTreeOptions());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -2130,18 +2224,6 @@ use_old_InterfaceDeclaration_MergeTreeRevertibleDriver(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_MergeTreeStats": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_MergeTreeStats": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_MinListener": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_MinListener():
@@ -2965,7 +3047,6 @@ declare function get_old_InterfaceDeclaration_SegmentGroup():
 declare function use_current_InterfaceDeclaration_SegmentGroup(
     use: TypeOnly<current.SegmentGroup>);
 use_current_InterfaceDeclaration_SegmentGroup(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_SegmentGroup());
 
 /*

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -78,7 +78,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.2.2.0",
+    "@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -95,9 +95,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -77,7 +77,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.2.2.0",
+    "@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -94,9 +94,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -92,7 +92,7 @@
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/gitresources": "^0.1038.2000",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.2.2.0",
+    "@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.3.0.0",
     "@fluidframework/server-services-client": "^0.1038.2000",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -114,9 +114,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -83,7 +83,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.2.2.0",
+    "@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -103,9 +103,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -77,7 +77,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.2.2.0",
+    "@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -96,9 +96,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -83,7 +83,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.2.2.0",
+    "@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -101,9 +101,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.2.0",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -46,7 +46,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.2.2.0",
+    "@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -61,9 +61,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.2.2.0",
+    "@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -58,9 +58,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.2.0",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -48,7 +48,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.2.2.0",
+    "@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -64,9 +64,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -47,7 +47,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.2.2.0",
+    "@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/node": "^14.18.36",
@@ -59,9 +59,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.8.0",
-    "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.2.1.1",
+    "@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
@@ -64,9 +64,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -80,7 +80,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.2.2.0",
+    "@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
@@ -97,9 +97,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -61,6 +61,8 @@
     "version": "2.0.0-internal.3.0.1",
     "previousVersionStyle": "previousPatch",
     "baselineRange": "2.0.0-internal.3.0.0",
-    "broken": {}
+    "broken": {
+      "TypeAliasDeclaration_OdspError": {"forwardCompat": false}
+    }
   }
 }

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -45,7 +45,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.2.2.0",
+    "@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.3.0.0",
     "@fluidframework/protocol-definitions": "^1.1.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -58,9 +58,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.generated.ts
+++ b/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.generated.ts
@@ -455,6 +455,7 @@ declare function get_old_TypeAliasDeclaration_OdspError():
 declare function use_current_TypeAliasDeclaration_OdspError(
     use: TypeOnly<current.OdspError>);
 use_current_TypeAliasDeclaration_OdspError(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_OdspError());
 
 /*

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -85,7 +85,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.2.2.0",
+    "@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -105,9 +105,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -50,7 +50,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.2.2.0",
+    "@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.36",
@@ -63,9 +63,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -48,7 +48,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.2.2.0",
+    "@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -64,9 +64,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -85,7 +85,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.2.2.0",
+    "@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -108,9 +108,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -52,7 +52,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.2.2.0",
+    "@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/nconf": "^0.10.0",
@@ -67,9 +67,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/test-tools": "^0.2.3074",
-    "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.2.1.1",
+    "@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
     "@types/mocha": "^9.1.1",
@@ -63,9 +63,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.8.0",
-    "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.2.1.1",
+    "@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
@@ -94,9 +94,9 @@
     }
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.8.0",
-    "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.2.2.0",
+    "@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
@@ -105,13 +105,9 @@
   },
   "module:es5": "es5/index.js",
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "InterfaceDeclaration_IDataObjectProps": {
-        "forwardCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
+++ b/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
@@ -335,7 +335,6 @@ declare function get_old_InterfaceDeclaration_IDataObjectProps():
 declare function use_current_InterfaceDeclaration_IDataObjectProps(
     use: TypeOnly<current.IDataObjectProps>);
 use_current_InterfaceDeclaration_IDataObjectProps(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IDataObjectProps());
 
 /*

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
-    "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.2.2.0",
+    "@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -93,9 +93,9 @@
   },
   "module:es5": "es5/index.js",
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -73,7 +73,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.2.2.0",
+    "@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
@@ -96,9 +96,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -67,7 +67,7 @@
     "previousVersionStyle": "previousPatch",
     "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {
-      "EnumDeclaration_DriverErrorType": {"backCompat": false}
+      "EnumDeclaration_DriverErrorType": {"forwardCompat": false}
     }
   }
 }

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -57,15 +57,17 @@
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.2",
     "eslint": "~8.6.0",
-    "fluid-framework-previous": "npm:fluid-framework@2.0.0-internal.2.1.0",
+    "fluid-framework-previous": "npm:fluid-framework@2.0.0-internal.3.0.0",
     "prettier": "~2.6.2",
     "rimraf": "^2.6.2",
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.2.2.0",
-    "baselineRange": ">=2.0.0-internal.2.1.0 <2.0.0-internal.2.2.0",
-    "baselineVersion": "2.0.0-internal.2.1.0",
-    "broken": {}
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
+    "broken": {
+      "EnumDeclaration_DriverErrorType": {"backCompat": false}
+    }
   }
 }

--- a/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.generated.ts
+++ b/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.generated.ts
@@ -251,6 +251,7 @@ declare function get_current_EnumDeclaration_DriverErrorType():
 declare function use_old_EnumDeclaration_DriverErrorType(
     use: TypeOnly<old.DriverErrorType>);
 use_old_EnumDeclaration_DriverErrorType(
+    // @ts-expect-error compatibility expected to be broken
     get_current_EnumDeclaration_DriverErrorType());
 
 /*

--- a/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.generated.ts
+++ b/packages/framework/fluid-framework/src/test/types/validateFluidFrameworkPrevious.generated.ts
@@ -239,6 +239,7 @@ declare function get_old_EnumDeclaration_DriverErrorType():
 declare function use_current_EnumDeclaration_DriverErrorType(
     use: TypeOnly<current.DriverErrorType>);
 use_current_EnumDeclaration_DriverErrorType(
+    // @ts-expect-error compatibility expected to be broken
     get_old_EnumDeclaration_DriverErrorType());
 
 /*
@@ -251,7 +252,6 @@ declare function get_current_EnumDeclaration_DriverErrorType():
 declare function use_old_EnumDeclaration_DriverErrorType(
     use: TypeOnly<old.DriverErrorType>);
 use_old_EnumDeclaration_DriverErrorType(
-    // @ts-expect-error compatibility expected to be broken
     get_current_EnumDeclaration_DriverErrorType());
 
 /*

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -79,7 +79,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.2.2.0",
+    "@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.3.0.0",
     "@fluidframework/map": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/sequence": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
@@ -98,9 +98,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -74,7 +74,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.2.2.0",
+    "@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.3.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -95,9 +95,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -72,7 +72,7 @@
     "@fluidframework/datastore": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.2.2.0",
+    "@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -88,9 +88,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -49,7 +49,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/uuid": "^8.3.0",
@@ -61,9 +61,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -64,7 +64,7 @@
     "@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/test-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.2.2.0",
+    "@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -83,9 +83,9 @@
     "fluid-framework": ">=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.2.2.0",
+    "@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/diff": "^3.5.1",
@@ -96,9 +96,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -42,7 +42,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.2.2.0",
+    "@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^17.0.44",
@@ -55,9 +55,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -39,7 +39,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.2.2.0",
+    "@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/react": "^17.0.44",
@@ -52,9 +52,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -84,7 +84,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.2.2.0",
+    "@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/test-loader-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
@@ -108,9 +108,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -73,7 +73,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
@@ -92,9 +92,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -78,7 +78,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
@@ -99,9 +99,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -102,6 +102,14 @@
     "version": "2.0.0-internal.3.0.1",
     "previousVersionStyle": "previousPatch",
     "baselineRange": "2.0.0-internal.3.0.0",
-    "broken": {}
+    "broken": {
+      "ClassDeclaration_AuthorizationError": {"forwardCompat": false},
+      "ClassDeclaration_DeltaStreamConnectionForbiddenError": {"forwardCompat": false},
+      "ClassDeclaration_FluidInvalidSchemaError": {"forwardCompat": false},
+      "ClassDeclaration_GenericNetworkError": {"forwardCompat": false},
+      "ClassDeclaration_LocationRedirectionError": {"forwardCompat": false},
+      "ClassDeclaration_ThrottlingError": {"forwardCompat": false},
+      "ClassDeclaration_UsageError": {"forwardCompat": false}
+    }
   }
 }

--- a/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.generated.ts
+++ b/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.generated.ts
@@ -832,6 +832,30 @@ use_old_FunctionDeclaration_logNetworkFailure(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_MapWithExpiration": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_MapWithExpiration():
+    TypeOnly<old.MapWithExpiration>;
+declare function use_current_ClassDeclaration_MapWithExpiration(
+    use: TypeOnly<current.MapWithExpiration>);
+use_current_ClassDeclaration_MapWithExpiration(
+    get_old_ClassDeclaration_MapWithExpiration());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_MapWithExpiration": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_MapWithExpiration():
+    TypeOnly<current.MapWithExpiration>;
+declare function use_old_ClassDeclaration_MapWithExpiration(
+    use: TypeOnly<old.MapWithExpiration>);
+use_old_ClassDeclaration_MapWithExpiration(
+    get_current_ClassDeclaration_MapWithExpiration());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "EnumDeclaration_MessageType2": {"forwardCompat": false}
 */
 declare function get_old_EnumDeclaration_MessageType2():

--- a/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.generated.ts
+++ b/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.generated.ts
@@ -23,6 +23,7 @@ declare function get_old_ClassDeclaration_AuthorizationError():
 declare function use_current_ClassDeclaration_AuthorizationError(
     use: TypeOnly<current.AuthorizationError>);
 use_current_ClassDeclaration_AuthorizationError(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_AuthorizationError());
 
 /*
@@ -311,6 +312,7 @@ declare function get_old_ClassDeclaration_DeltaStreamConnectionForbiddenError():
 declare function use_current_ClassDeclaration_DeltaStreamConnectionForbiddenError(
     use: TypeOnly<current.DeltaStreamConnectionForbiddenError>);
 use_current_ClassDeclaration_DeltaStreamConnectionForbiddenError(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_DeltaStreamConnectionForbiddenError());
 
 /*
@@ -455,6 +457,7 @@ declare function get_old_ClassDeclaration_FluidInvalidSchemaError():
 declare function use_current_ClassDeclaration_FluidInvalidSchemaError(
     use: TypeOnly<current.FluidInvalidSchemaError>);
 use_current_ClassDeclaration_FluidInvalidSchemaError(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_FluidInvalidSchemaError());
 
 /*
@@ -479,6 +482,7 @@ declare function get_old_ClassDeclaration_GenericNetworkError():
 declare function use_current_ClassDeclaration_GenericNetworkError(
     use: TypeOnly<current.GenericNetworkError>);
 use_current_ClassDeclaration_GenericNetworkError(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_GenericNetworkError());
 
 /*
@@ -791,6 +795,7 @@ declare function get_old_ClassDeclaration_LocationRedirectionError():
 declare function use_current_ClassDeclaration_LocationRedirectionError(
     use: TypeOnly<current.LocationRedirectionError>);
 use_current_ClassDeclaration_LocationRedirectionError(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_LocationRedirectionError());
 
 /*
@@ -1295,6 +1300,7 @@ declare function get_old_ClassDeclaration_ThrottlingError():
 declare function use_current_ClassDeclaration_ThrottlingError(
     use: TypeOnly<current.ThrottlingError>);
 use_current_ClassDeclaration_ThrottlingError(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_ThrottlingError());
 
 /*
@@ -1319,6 +1325,7 @@ declare function get_old_ClassDeclaration_UsageError():
 declare function use_current_ClassDeclaration_UsageError(
     use: TypeOnly<current.UsageError>);
 use_current_ClassDeclaration_UsageError(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_UsageError());
 
 /*

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -73,7 +73,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
@@ -91,9 +91,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -42,7 +42,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
     "eslint": "~8.6.0",
@@ -51,9 +51,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -43,7 +43,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/protocol-definitions": "^1.1.0",
-    "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@2.0.0-internal.2.1.1",
+    "@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/isomorphic-fetch": "^0.0.35",
@@ -56,9 +56,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -45,7 +45,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.2.2.0",
+    "@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -57,9 +57,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -87,7 +87,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.2.2.0",
+    "@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
@@ -109,43 +109,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.2.0",
-    "broken": {
-      "RemovedVariableDeclaration_gcBlobPrefix": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "RemovedVariableDeclaration_gcTombstoneBlobKey": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "RemovedVariableDeclaration_gcTreeKey": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "VariableDeclaration_DefaultSummaryConfiguration": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_ISummaryBaseConfiguration": {
-        "backCompat": false
-      },
-      "TypeAliasDeclaration_ISummaryConfiguration": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_ISummaryConfigurationDisableHeuristics": {
-        "backCompat": false
-      },
-      "InterfaceDeclaration_ISummaryConfigurationHeuristics": {
-        "backCompat": false
-      },
-      "ClassDeclaration_ContainerRuntime": {
-        "forwardCompat": false
-      },
-      "InterfaceDeclaration_ISummarizerRuntime": {
-        "backCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -40,6 +40,30 @@ use_old_VariableDeclaration_agentSchedulerId(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_AllowTombstoneRequestHeaderKey": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_AllowTombstoneRequestHeaderKey():
+    TypeOnly<typeof old.AllowTombstoneRequestHeaderKey>;
+declare function use_current_VariableDeclaration_AllowTombstoneRequestHeaderKey(
+    use: TypeOnly<typeof current.AllowTombstoneRequestHeaderKey>);
+use_current_VariableDeclaration_AllowTombstoneRequestHeaderKey(
+    get_old_VariableDeclaration_AllowTombstoneRequestHeaderKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_AllowTombstoneRequestHeaderKey": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_AllowTombstoneRequestHeaderKey():
+    TypeOnly<typeof current.AllowTombstoneRequestHeaderKey>;
+declare function use_old_VariableDeclaration_AllowTombstoneRequestHeaderKey(
+    use: TypeOnly<typeof old.AllowTombstoneRequestHeaderKey>);
+use_old_VariableDeclaration_AllowTombstoneRequestHeaderKey(
+    get_current_VariableDeclaration_AllowTombstoneRequestHeaderKey());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "EnumDeclaration_CompressionAlgorithms": {"forwardCompat": false}
 */
 declare function get_old_EnumDeclaration_CompressionAlgorithms():
@@ -95,7 +119,6 @@ declare function get_old_ClassDeclaration_ContainerRuntime():
 declare function use_current_ClassDeclaration_ContainerRuntime(
     use: TypeOnly<current.ContainerRuntime>);
 use_current_ClassDeclaration_ContainerRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_ContainerRuntime());
 
 /*
@@ -156,7 +179,6 @@ declare function get_current_VariableDeclaration_DefaultSummaryConfiguration():
 declare function use_old_VariableDeclaration_DefaultSummaryConfiguration(
     use: TypeOnly<typeof old.DefaultSummaryConfiguration>);
 use_old_VariableDeclaration_DefaultSummaryConfiguration(
-    // @ts-expect-error compatibility expected to be broken
     get_current_VariableDeclaration_DefaultSummaryConfiguration());
 
 /*
@@ -206,42 +228,6 @@ declare function use_old_ClassDeclaration_FluidDataStoreRegistry(
     use: TypeOnly<old.FluidDataStoreRegistry>);
 use_old_ClassDeclaration_FluidDataStoreRegistry(
     get_current_ClassDeclaration_FluidDataStoreRegistry());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcBlobPrefix": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcBlobPrefix": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcTombstoneBlobKey": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcTombstoneBlobKey": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcTreeKey": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcTreeKey": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1081,7 +1067,6 @@ declare function get_current_InterfaceDeclaration_ISummarizerRuntime():
 declare function use_old_InterfaceDeclaration_ISummarizerRuntime(
     use: TypeOnly<old.ISummarizerRuntime>);
 use_old_InterfaceDeclaration_ISummarizerRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISummarizerRuntime());
 
 /*
@@ -1178,7 +1163,6 @@ declare function get_current_InterfaceDeclaration_ISummaryBaseConfiguration():
 declare function use_old_InterfaceDeclaration_ISummaryBaseConfiguration(
     use: TypeOnly<old.ISummaryBaseConfiguration>);
 use_old_InterfaceDeclaration_ISummaryBaseConfiguration(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISummaryBaseConfiguration());
 
 /*
@@ -1251,7 +1235,6 @@ declare function get_current_TypeAliasDeclaration_ISummaryConfiguration():
 declare function use_old_TypeAliasDeclaration_ISummaryConfiguration(
     use: TypeOnly<old.ISummaryConfiguration>);
 use_old_TypeAliasDeclaration_ISummaryConfiguration(
-    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_ISummaryConfiguration());
 
 /*
@@ -1276,7 +1259,6 @@ declare function get_current_InterfaceDeclaration_ISummaryConfigurationDisableHe
 declare function use_old_InterfaceDeclaration_ISummaryConfigurationDisableHeuristics(
     use: TypeOnly<old.ISummaryConfigurationDisableHeuristics>);
 use_old_InterfaceDeclaration_ISummaryConfigurationDisableHeuristics(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISummaryConfigurationDisableHeuristics());
 
 /*
@@ -1325,7 +1307,6 @@ declare function get_current_InterfaceDeclaration_ISummaryConfigurationHeuristic
 declare function use_old_InterfaceDeclaration_ISummaryConfigurationHeuristics(
     use: TypeOnly<old.ISummaryConfigurationHeuristics>);
 use_old_InterfaceDeclaration_ISummaryConfigurationHeuristics(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISummaryConfigurationHeuristics());
 
 /*
@@ -1663,6 +1644,30 @@ declare function use_old_ClassDeclaration_SummaryCollection(
     use: TypeOnly<old.SummaryCollection>);
 use_old_ClassDeclaration_SummaryCollection(
     get_current_ClassDeclaration_SummaryCollection());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_TombstoneResponseHeaderKey": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_TombstoneResponseHeaderKey():
+    TypeOnly<typeof old.TombstoneResponseHeaderKey>;
+declare function use_current_VariableDeclaration_TombstoneResponseHeaderKey(
+    use: TypeOnly<typeof current.TombstoneResponseHeaderKey>);
+use_current_VariableDeclaration_TombstoneResponseHeaderKey(
+    get_old_VariableDeclaration_TombstoneResponseHeaderKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_TombstoneResponseHeaderKey": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_TombstoneResponseHeaderKey():
+    TypeOnly<typeof current.TombstoneResponseHeaderKey>;
+declare function use_old_VariableDeclaration_TombstoneResponseHeaderKey(
+    use: TypeOnly<typeof old.TombstoneResponseHeaderKey>);
+use_old_VariableDeclaration_TombstoneResponseHeaderKey(
+    get_current_VariableDeclaration_TombstoneResponseHeaderKey());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -45,7 +45,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.2.2.0",
+    "@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -57,13 +57,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "InterfaceDeclaration_IFluidDataStoreRuntime": {
-        "forwardCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
@@ -191,7 +191,6 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreRuntime():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreRuntime(
     use: TypeOnly<current.IFluidDataStoreRuntime>);
 use_current_InterfaceDeclaration_IFluidDataStoreRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -84,7 +84,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
-    "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.2.2.0",
+    "@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.3.0.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
@@ -104,13 +104,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "ClassDeclaration_FluidDataStoreRuntime": {
-        "forwardCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
+++ b/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
@@ -47,7 +47,6 @@ declare function get_old_ClassDeclaration_FluidDataStoreRuntime():
 declare function use_current_ClassDeclaration_FluidDataStoreRuntime(
     use: TypeOnly<current.FluidDataStoreRuntime>);
 use_current_ClassDeclaration_FluidDataStoreRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_FluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -78,7 +78,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@2.0.0-internal.2.2.0",
+    "@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
@@ -96,9 +96,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/runtime/garbage-collector/src/test/types/validateGarbageCollectorPrevious.generated.ts
+++ b/packages/runtime/garbage-collector/src/test/types/validateGarbageCollectorPrevious.generated.ts
@@ -112,6 +112,30 @@ use_old_ClassDeclaration_GCDataBuilder(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_getGCDataFromSnapshot": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_getGCDataFromSnapshot():
+    TypeOnly<typeof old.getGCDataFromSnapshot>;
+declare function use_current_FunctionDeclaration_getGCDataFromSnapshot(
+    use: TypeOnly<typeof current.getGCDataFromSnapshot>);
+use_current_FunctionDeclaration_getGCDataFromSnapshot(
+    get_old_FunctionDeclaration_getGCDataFromSnapshot());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_getGCDataFromSnapshot": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_getGCDataFromSnapshot():
+    TypeOnly<typeof current.getGCDataFromSnapshot>;
+declare function use_old_FunctionDeclaration_getGCDataFromSnapshot(
+    use: TypeOnly<typeof old.getGCDataFromSnapshot>);
+use_old_FunctionDeclaration_getGCDataFromSnapshot(
+    get_current_FunctionDeclaration_getGCDataFromSnapshot());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IGCResult": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IGCResult():

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -46,7 +46,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.2.2.0",
+    "@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "concurrently": "^6.2.0",
@@ -57,20 +57,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "RemovedVariableDeclaration_gcBlobKey": {
-        "forwardCompat": false,
-        "backCompat": false
-      },
-      "InterfaceDeclaration_IFluidDataStoreContext": {
-        "forwardCompat": false
-      },
-      "InterfaceDeclaration_IFluidDataStoreContextDetached": {
-        "forwardCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -232,14 +232,98 @@ use_old_EnumDeclaration_FlushMode(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcBlobKey": {"forwardCompat": false}
+* "VariableDeclaration_gcBlobPrefix": {"forwardCompat": false}
 */
+declare function get_old_VariableDeclaration_gcBlobPrefix():
+    TypeOnly<typeof old.gcBlobPrefix>;
+declare function use_current_VariableDeclaration_gcBlobPrefix(
+    use: TypeOnly<typeof current.gcBlobPrefix>);
+use_current_VariableDeclaration_gcBlobPrefix(
+    get_old_VariableDeclaration_gcBlobPrefix());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_gcBlobKey": {"backCompat": false}
+* "VariableDeclaration_gcBlobPrefix": {"backCompat": false}
 */
+declare function get_current_VariableDeclaration_gcBlobPrefix():
+    TypeOnly<typeof current.gcBlobPrefix>;
+declare function use_old_VariableDeclaration_gcBlobPrefix(
+    use: TypeOnly<typeof old.gcBlobPrefix>);
+use_old_VariableDeclaration_gcBlobPrefix(
+    get_current_VariableDeclaration_gcBlobPrefix());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_gcDeletedBlobKey": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_gcDeletedBlobKey():
+    TypeOnly<typeof old.gcDeletedBlobKey>;
+declare function use_current_VariableDeclaration_gcDeletedBlobKey(
+    use: TypeOnly<typeof current.gcDeletedBlobKey>);
+use_current_VariableDeclaration_gcDeletedBlobKey(
+    get_old_VariableDeclaration_gcDeletedBlobKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_gcDeletedBlobKey": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_gcDeletedBlobKey():
+    TypeOnly<typeof current.gcDeletedBlobKey>;
+declare function use_old_VariableDeclaration_gcDeletedBlobKey(
+    use: TypeOnly<typeof old.gcDeletedBlobKey>);
+use_old_VariableDeclaration_gcDeletedBlobKey(
+    get_current_VariableDeclaration_gcDeletedBlobKey());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_gcTombstoneBlobKey": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_gcTombstoneBlobKey():
+    TypeOnly<typeof old.gcTombstoneBlobKey>;
+declare function use_current_VariableDeclaration_gcTombstoneBlobKey(
+    use: TypeOnly<typeof current.gcTombstoneBlobKey>);
+use_current_VariableDeclaration_gcTombstoneBlobKey(
+    get_old_VariableDeclaration_gcTombstoneBlobKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_gcTombstoneBlobKey": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_gcTombstoneBlobKey():
+    TypeOnly<typeof current.gcTombstoneBlobKey>;
+declare function use_old_VariableDeclaration_gcTombstoneBlobKey(
+    use: TypeOnly<typeof old.gcTombstoneBlobKey>);
+use_old_VariableDeclaration_gcTombstoneBlobKey(
+    get_current_VariableDeclaration_gcTombstoneBlobKey());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_gcTreeKey": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_gcTreeKey():
+    TypeOnly<typeof old.gcTreeKey>;
+declare function use_current_VariableDeclaration_gcTreeKey(
+    use: TypeOnly<typeof current.gcTreeKey>);
+use_current_VariableDeclaration_gcTreeKey(
+    get_old_VariableDeclaration_gcTreeKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_gcTreeKey": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_gcTreeKey():
+    TypeOnly<typeof current.gcTreeKey>;
+declare function use_old_VariableDeclaration_gcTreeKey(
+    use: TypeOnly<typeof old.gcTreeKey>);
+use_old_VariableDeclaration_gcTreeKey(
+    get_current_VariableDeclaration_gcTreeKey());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -395,7 +479,6 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContext(
     use: TypeOnly<current.IFluidDataStoreContext>);
 use_current_InterfaceDeclaration_IFluidDataStoreContext(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -420,7 +503,6 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContextDetached():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: TypeOnly<current.IFluidDataStoreContextDetached>);
 use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*
@@ -630,6 +712,30 @@ use_old_InterfaceDeclaration_IGarbageCollectionNodeData(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IGarbageCollectionSnapshotData": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IGarbageCollectionSnapshotData():
+    TypeOnly<old.IGarbageCollectionSnapshotData>;
+declare function use_current_InterfaceDeclaration_IGarbageCollectionSnapshotData(
+    use: TypeOnly<current.IGarbageCollectionSnapshotData>);
+use_current_InterfaceDeclaration_IGarbageCollectionSnapshotData(
+    get_old_InterfaceDeclaration_IGarbageCollectionSnapshotData());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IGarbageCollectionSnapshotData": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IGarbageCollectionSnapshotData():
+    TypeOnly<current.IGarbageCollectionSnapshotData>;
+declare function use_old_InterfaceDeclaration_IGarbageCollectionSnapshotData(
+    use: TypeOnly<old.IGarbageCollectionSnapshotData>);
+use_old_InterfaceDeclaration_IGarbageCollectionSnapshotData(
+    get_current_InterfaceDeclaration_IGarbageCollectionSnapshotData());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IGarbageCollectionState": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IGarbageCollectionState():
@@ -650,6 +756,30 @@ declare function use_old_InterfaceDeclaration_IGarbageCollectionState(
     use: TypeOnly<old.IGarbageCollectionState>);
 use_old_InterfaceDeclaration_IGarbageCollectionState(
     get_current_InterfaceDeclaration_IGarbageCollectionState());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy():
+    TypeOnly<old.IGarbageCollectionSummaryDetailsLegacy>;
+declare function use_current_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy(
+    use: TypeOnly<current.IGarbageCollectionSummaryDetailsLegacy>);
+use_current_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy(
+    get_old_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy():
+    TypeOnly<current.IGarbageCollectionSummaryDetailsLegacy>;
+declare function use_old_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy(
+    use: TypeOnly<old.IGarbageCollectionSummaryDetailsLegacy>);
+use_old_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy(
+    get_current_InterfaceDeclaration_IGarbageCollectionSummaryDetailsLegacy());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -80,7 +80,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -98,14 +98,14 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.2.0",
-		"broken": {
-			"TypeAliasDeclaration_RefreshSummaryResult": {
-				"forwardCompat": false,
-				"backCompat": false
-			}
-		}
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
+    "broken": {
+      "TypeAliasDeclaration_RefreshSummaryResult": {
+        "forwardCompat": false,
+        "backCompat": false
+      }
+    }
   }
 }

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -83,7 +83,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/jsrsasign": "^8.0.8",
@@ -101,16 +101,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "ClassDeclaration_MockFluidDataStoreContext": {
-        "forwardCompat": false
-      },
-      "ClassDeclaration_MockFluidDataStoreRuntime": {
-        "forwardCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -16,6 +16,30 @@ type TypeOnly<T> = {
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IInsecureUser": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IInsecureUser():
+    TypeOnly<old.IInsecureUser>;
+declare function use_current_InterfaceDeclaration_IInsecureUser(
+    use: TypeOnly<current.IInsecureUser>);
+use_current_InterfaceDeclaration_IInsecureUser(
+    get_old_InterfaceDeclaration_IInsecureUser());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IInsecureUser": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IInsecureUser():
+    TypeOnly<current.IInsecureUser>;
+declare function use_old_InterfaceDeclaration_IInsecureUser(
+    use: TypeOnly<old.IInsecureUser>);
+use_old_InterfaceDeclaration_IInsecureUser(
+    get_current_InterfaceDeclaration_IInsecureUser());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IMockContainerRuntimePendingMessage": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IMockContainerRuntimePendingMessage():
@@ -263,7 +287,6 @@ declare function get_old_ClassDeclaration_MockFluidDataStoreContext():
 declare function use_current_ClassDeclaration_MockFluidDataStoreContext(
     use: TypeOnly<current.MockFluidDataStoreContext>);
 use_current_ClassDeclaration_MockFluidDataStoreContext(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockFluidDataStoreContext());
 
 /*
@@ -288,7 +311,6 @@ declare function get_old_ClassDeclaration_MockFluidDataStoreRuntime():
 declare function use_current_ClassDeclaration_MockFluidDataStoreRuntime(
     use: TypeOnly<current.MockFluidDataStoreRuntime>);
 use_current_ClassDeclaration_MockFluidDataStoreRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockFluidDataStoreRuntime());
 
 /*

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -63,7 +63,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.2.2.0",
+    "@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -77,9 +77,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -84,7 +84,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@2.0.0-internal.2.2.0",
+    "@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -99,9 +99,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -61,7 +61,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@2.0.0-internal.2.2.0",
+    "@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.36",
@@ -75,9 +75,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -92,7 +92,7 @@
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/diff": "^3.5.1",
@@ -113,9 +113,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -92,7 +92,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/nock": "^9.3.0",
@@ -114,9 +114,9 @@
     "webpack-cli": "^4.9.2"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/test/test-version-utils/src/test/types/validateTestVersionUtilsPrevious.generated.ts
+++ b/packages/test/test-version-utils/src/test/types/validateTestVersionUtilsPrevious.generated.ts
@@ -383,7 +383,6 @@ declare function get_old_InterfaceDeclaration_ITestDataObject():
 declare function use_current_InterfaceDeclaration_ITestDataObject(
     use: TypeOnly<current.ITestDataObject>);
 use_current_InterfaceDeclaration_ITestDataObject(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ITestDataObject());
 
 /*

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -74,7 +74,7 @@
     "@fluid-tools/build-cli": "^0.8.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
-    "@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.2.2.0",
+    "@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.3.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
@@ -90,9 +90,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -95,7 +95,7 @@
   },
   "devDependencies": {
     "@fluid-tools/build-cli": "^0.8.0",
-    "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.2.2.0",
+    "@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.3.0.0",
     "@fluidframework/build-common": "^1.1.0",
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
@@ -120,9 +120,9 @@
     "webpack-cli": "^4.9.2"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -93,6 +93,8 @@
     "version": "2.0.0-internal.3.0.1",
     "previousVersionStyle": "previousPatch",
     "baselineRange": "2.0.0-internal.3.0.0",
-    "broken": {}
+    "broken": {
+      "ClassDeclaration_OdspRedirectError": {"forwardCompat": false}
+    }
   }
 }

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -75,7 +75,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.3.0.0",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.18.36",
@@ -90,9 +90,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }

--- a/packages/utils/odsp-doclib-utils/src/test/types/validateOdspDoclibUtilsPrevious.generated.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/types/validateOdspDoclibUtilsPrevious.generated.ts
@@ -767,6 +767,7 @@ declare function get_old_ClassDeclaration_OdspRedirectError():
 declare function use_current_ClassDeclaration_OdspRedirectError(
     use: TypeOnly<current.OdspRedirectError>);
 use_current_ClassDeclaration_OdspRedirectError(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_OdspRedirectError());
 
 /*

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -80,7 +80,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
@@ -100,13 +100,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
-    "broken": {
-      "ClassDeclaration_MockLogger": {
-        "forwardCompat": false
-      }
-    }
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
+    "broken": {}
   }
 }

--- a/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
+++ b/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
@@ -544,6 +544,126 @@ use_old_FunctionDeclaration_isValidLegacyError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt():
+    TypeOnly<old.ITaggedTelemetryPropertyTypeExt>;
+declare function use_current_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt(
+    use: TypeOnly<current.ITaggedTelemetryPropertyTypeExt>);
+use_current_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt(
+    get_old_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt():
+    TypeOnly<current.ITaggedTelemetryPropertyTypeExt>;
+declare function use_old_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt(
+    use: TypeOnly<old.ITaggedTelemetryPropertyTypeExt>);
+use_old_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt(
+    get_current_InterfaceDeclaration_ITaggedTelemetryPropertyTypeExt());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryErrorEventExt": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITelemetryErrorEventExt():
+    TypeOnly<old.ITelemetryErrorEventExt>;
+declare function use_current_InterfaceDeclaration_ITelemetryErrorEventExt(
+    use: TypeOnly<current.ITelemetryErrorEventExt>);
+use_current_InterfaceDeclaration_ITelemetryErrorEventExt(
+    get_old_InterfaceDeclaration_ITelemetryErrorEventExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryErrorEventExt": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITelemetryErrorEventExt():
+    TypeOnly<current.ITelemetryErrorEventExt>;
+declare function use_old_InterfaceDeclaration_ITelemetryErrorEventExt(
+    use: TypeOnly<old.ITelemetryErrorEventExt>);
+use_old_InterfaceDeclaration_ITelemetryErrorEventExt(
+    get_current_InterfaceDeclaration_ITelemetryErrorEventExt());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryEventExt": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITelemetryEventExt():
+    TypeOnly<old.ITelemetryEventExt>;
+declare function use_current_InterfaceDeclaration_ITelemetryEventExt(
+    use: TypeOnly<current.ITelemetryEventExt>);
+use_current_InterfaceDeclaration_ITelemetryEventExt(
+    get_old_InterfaceDeclaration_ITelemetryEventExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryEventExt": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITelemetryEventExt():
+    TypeOnly<current.ITelemetryEventExt>;
+declare function use_old_InterfaceDeclaration_ITelemetryEventExt(
+    use: TypeOnly<old.ITelemetryEventExt>);
+use_old_InterfaceDeclaration_ITelemetryEventExt(
+    get_current_InterfaceDeclaration_ITelemetryEventExt());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryGenericEventExt": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITelemetryGenericEventExt():
+    TypeOnly<old.ITelemetryGenericEventExt>;
+declare function use_current_InterfaceDeclaration_ITelemetryGenericEventExt(
+    use: TypeOnly<current.ITelemetryGenericEventExt>);
+use_current_InterfaceDeclaration_ITelemetryGenericEventExt(
+    get_old_InterfaceDeclaration_ITelemetryGenericEventExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryGenericEventExt": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITelemetryGenericEventExt():
+    TypeOnly<current.ITelemetryGenericEventExt>;
+declare function use_old_InterfaceDeclaration_ITelemetryGenericEventExt(
+    use: TypeOnly<old.ITelemetryGenericEventExt>);
+use_old_InterfaceDeclaration_ITelemetryGenericEventExt(
+    get_current_InterfaceDeclaration_ITelemetryGenericEventExt());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryLoggerExt": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITelemetryLoggerExt():
+    TypeOnly<old.ITelemetryLoggerExt>;
+declare function use_current_InterfaceDeclaration_ITelemetryLoggerExt(
+    use: TypeOnly<current.ITelemetryLoggerExt>);
+use_current_InterfaceDeclaration_ITelemetryLoggerExt(
+    get_old_InterfaceDeclaration_ITelemetryLoggerExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryLoggerExt": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITelemetryLoggerExt():
+    TypeOnly<current.ITelemetryLoggerExt>;
+declare function use_old_InterfaceDeclaration_ITelemetryLoggerExt(
+    use: TypeOnly<old.ITelemetryLoggerExt>);
+use_old_InterfaceDeclaration_ITelemetryLoggerExt(
+    get_current_InterfaceDeclaration_ITelemetryLoggerExt());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ITelemetryLoggerPropertyBag": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ITelemetryLoggerPropertyBag():
@@ -588,6 +708,54 @@ declare function use_old_InterfaceDeclaration_ITelemetryLoggerPropertyBags(
     use: TypeOnly<old.ITelemetryLoggerPropertyBags>);
 use_old_InterfaceDeclaration_ITelemetryLoggerPropertyBags(
     get_current_InterfaceDeclaration_ITelemetryLoggerPropertyBags());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryPerformanceEventExt": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITelemetryPerformanceEventExt():
+    TypeOnly<old.ITelemetryPerformanceEventExt>;
+declare function use_current_InterfaceDeclaration_ITelemetryPerformanceEventExt(
+    use: TypeOnly<current.ITelemetryPerformanceEventExt>);
+use_current_InterfaceDeclaration_ITelemetryPerformanceEventExt(
+    get_old_InterfaceDeclaration_ITelemetryPerformanceEventExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryPerformanceEventExt": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITelemetryPerformanceEventExt():
+    TypeOnly<current.ITelemetryPerformanceEventExt>;
+declare function use_old_InterfaceDeclaration_ITelemetryPerformanceEventExt(
+    use: TypeOnly<old.ITelemetryPerformanceEventExt>);
+use_old_InterfaceDeclaration_ITelemetryPerformanceEventExt(
+    get_current_InterfaceDeclaration_ITelemetryPerformanceEventExt());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryPropertiesExt": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITelemetryPropertiesExt():
+    TypeOnly<old.ITelemetryPropertiesExt>;
+declare function use_current_InterfaceDeclaration_ITelemetryPropertiesExt(
+    use: TypeOnly<current.ITelemetryPropertiesExt>);
+use_current_InterfaceDeclaration_ITelemetryPropertiesExt(
+    get_old_InterfaceDeclaration_ITelemetryPropertiesExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITelemetryPropertiesExt": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITelemetryPropertiesExt():
+    TypeOnly<current.ITelemetryPropertiesExt>;
+declare function use_old_InterfaceDeclaration_ITelemetryPropertiesExt(
+    use: TypeOnly<old.ITelemetryPropertiesExt>);
+use_old_InterfaceDeclaration_ITelemetryPropertiesExt(
+    get_current_InterfaceDeclaration_ITelemetryPropertiesExt());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -695,7 +863,6 @@ declare function get_old_ClassDeclaration_MockLogger():
 declare function use_current_ClassDeclaration_MockLogger(
     use: TypeOnly<current.MockLogger>);
 use_current_ClassDeclaration_MockLogger(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockLogger());
 
 /*
@@ -973,6 +1140,30 @@ declare function use_old_EnumDeclaration_TelemetryDataTag(
     use: TypeOnly<old.TelemetryDataTag>);
 use_old_EnumDeclaration_TelemetryDataTag(
     get_current_EnumDeclaration_TelemetryDataTag());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_TelemetryEventPropertyTypeExt": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_TelemetryEventPropertyTypeExt():
+    TypeOnly<old.TelemetryEventPropertyTypeExt>;
+declare function use_current_TypeAliasDeclaration_TelemetryEventPropertyTypeExt(
+    use: TypeOnly<current.TelemetryEventPropertyTypeExt>);
+use_current_TypeAliasDeclaration_TelemetryEventPropertyTypeExt(
+    get_old_TypeAliasDeclaration_TelemetryEventPropertyTypeExt());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_TelemetryEventPropertyTypeExt": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_TelemetryEventPropertyTypeExt():
+    TypeOnly<current.TelemetryEventPropertyTypeExt>;
+declare function use_old_TypeAliasDeclaration_TelemetryEventPropertyTypeExt(
+    use: TypeOnly<old.TelemetryEventPropertyTypeExt>);
+use_old_TypeAliasDeclaration_TelemetryEventPropertyTypeExt(
+    get_current_TypeAliasDeclaration_TelemetryEventPropertyTypeExt());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -78,7 +78,7 @@
     "@fluidframework/build-tools": "^0.8.0",
     "@fluidframework/eslint-config-fluid": "^2.0.0",
     "@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.0.1 <2.0.0-internal.4.0.0",
-    "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.2.2.0",
+    "@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.3.0.0",
     "@microsoft/api-extractor": "^7.22.2",
     "@rushstack/eslint-config": "^2.5.1",
     "@types/debug": "^4.1.5",
@@ -96,9 +96,9 @@
     "typescript": "~4.5.5"
   },
   "typeValidation": {
-    "version": "2.0.0-internal.3.0.0",
-    "baselineRange": ">=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0",
-    "baselineVersion": "2.0.0-internal.2.1.1",
+    "version": "2.0.0-internal.3.0.1",
+    "previousVersionStyle": "previousPatch",
+    "baselineRange": "2.0.0-internal.3.0.0",
     "broken": {}
   }
 }


### PR DESCRIPTION
## Description

Due to issues with npm and aliased packages for type tests, this branch needed updates to build cleanly.

Since this is a 2.0.0-internal.3.0.0 branch, it doesn't need to do type tests against 2.0.0-internal.2.0.0, so is updated to 2.0.0-internal.3.0.0.

`npm i && npm run typetests:prepare -- --reset && npm i`

Unfortunately this results in npm actually installing 2.0.0-internal.3.1.0 and thus instead of doing back compat for the previous patch, its doing forward compat with the next minor. This resulted in some errors having to be suppressed:

In `@fluidframework/runtime-utils`:
```
      "TypeAliasDeclaration_RefreshSummaryResult": {
        "forwardCompat": false,
        "backCompat": false
      }
```
And in `fluid-framework`: `"EnumDeclaration_DriverErrorType": {"forwardCompat": false}

More I had to add after doing a clean build:

```
odsp-driver-definitions
"TypeAliasDeclaration_OdspError": {"forwardCompat": false}

@fluidframework/driver-utils

      "ClassDeclaration_AuthorizationError": {"forwardCompat": false},
      "ClassDeclaration_DeltaStreamConnectionForbiddenError": {"forwardCompat": false},
      "ClassDeclaration_FluidInvalidSchemaError": {"forwardCompat": false},
      "ClassDeclaration_GenericNetworkError": {"forwardCompat": false},
      "ClassDeclaration_LocationRedirectionError": {"forwardCompat": false},
      "ClassDeclaration_ThrottlingError": {"forwardCompat": false},
      "ClassDeclaration_UsageError": {"forwardCompat": false}
```

Changes were finished up with `npm run typetests:gen`
