### PR TITLE
fix(client-debug-view): Improve If-statement for string/number data check

### DIFF
--- a/packages/tools/client-debugger/client-debugger-view/src/components/data-object-views/SharedMapView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/data-object-views/SharedMapView.tsx
@@ -78,8 +78,8 @@ function getTableValue(data: unknown, _renderChild: RenderChild): React.ReactNod
 		return "null";
 	}
 
-	if (typeof data === ("string" || "number")) {
-		return <>{data}</>;
+	if (typeof data === "string" || typeof data === "number") {
+		return <> {data}</>;
 	}
 
 	return <>{_renderChild(data)}</>;


### PR DESCRIPTION
#### Description

Fixes if statement in `sharedMapView.tsx` to filter both `string` and `number`

Before 

<img width="611" alt="MicrosoftTeams-image (2)" src="https://user-images.githubusercontent.com/111468570/218228701-016ee5df-cdfe-461a-8b75-0385c6f17f6a.png">

After 

<img width="731" alt="MicrosoftTeams-image" src="https://user-images.githubusercontent.com/111468570/218228692-8b45fc92-42f8-489a-bfdb-e4f654defa96.png">

