### PR TITLE
Added local DDS in summarizer telemetry and feature flag to limit  the count of summarizer local changes telemetry

### DIFF
--- a/api-report/datastore.api.md
+++ b/api-report/datastore.api.md
@@ -84,6 +84,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     getQuorum(): IQuorumClients;
     // (undocumented)
     readonly id: string;
+    protected identifyLocalChangeInSummarizer(eventName: string, channelId: string, channelType: string): void;
     // (undocumented)
     get IFluidHandleContext(): this;
     // (undocumented)
@@ -93,7 +94,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     // @deprecated (undocumented)
     static load(context: IFluidDataStoreContext, sharedObjectRegistry: ISharedObjectRegistry, existing: boolean): FluidDataStoreRuntime;
     // (undocumented)
-    readonly logger: ITelemetryLogger;
+    get logger(): ITelemetryLogger;
     makeVisibleAndAttachGraph(): void;
     // (undocumented)
     get objectsRoutingContext(): this;

--- a/api-report/datastore.api.md
+++ b/api-report/datastore.api.md
@@ -84,7 +84,6 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     getQuorum(): IQuorumClients;
     // (undocumented)
     readonly id: string;
-    protected identifyLocalChangeInSummarizer(eventName: string, channelId: string, channelType: string): void;
     // (undocumented)
     get IFluidHandleContext(): this;
     // (undocumented)

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -265,9 +265,7 @@ export abstract class FluidDataStoreContext
 	 * So, adding a threshold of how many telemetry events can be logged per data store context. This can be
 	 * controlled via feature flags.
 	 */
-	private readonly localChangesTelemetryThreshold?: number;
-	// The count of the local changes in summarizer telemetry that has been logged by this data store context.
-	private localChangesTelemetryCount = 0;
+	private localChangesTelemetryThreshold: number;
 
 	// The used routes of this node as per the last GC run. This is used to update the used routes of the channel
 	// if it realizes after GC is run.
@@ -343,9 +341,9 @@ export abstract class FluidDataStoreContext
 			this._containerRuntime.gcTombstoneEnforcementAllowed &&
 			this.clientDetails.type !== summarizerClientType;
 
-		this.localChangesTelemetryThreshold = this.mc.config.getNumber(
-			"Fluid.Telemetry.LocalChangesTelemetryThreshold",
-		);
+		// By default, a data store can log maximum 100 local changes telemetry in summarizer.
+		this.localChangesTelemetryThreshold =
+			this.mc.config.getNumber("Fluid.Telemetry.LocalChangesTelemetryThreshold") ?? 100;
 	}
 
 	public dispose(): void {
@@ -905,13 +903,9 @@ export abstract class FluidDataStoreContext
 	protected identifyLocalChangeInSummarizer(eventName: string, type?: string) {
 		if (this.clientDetails.type === summarizerClientType) {
 			// If the count of telemetry logged has crossed the threshold, don't log any more.
-			if (
-				this.localChangesTelemetryThreshold !== undefined &&
-				this.localChangesTelemetryCount >= this.localChangesTelemetryThreshold
-			) {
+			if (this.localChangesTelemetryThreshold > 0) {
 				return;
 			}
-			this.localChangesTelemetryCount++;
 
 			// Log a telemetry if there are local changes in the summarizer. This will give us data on how often
 			// this is happening and which data stores do this. The eventual goal is to disallow local changes
@@ -927,6 +921,7 @@ export abstract class FluidDataStoreContext
 				isSummaryInProgress: this.summarizerNode.isSummaryInProgress?.(),
 				stack: generateStack(),
 			});
+			this.localChangesTelemetryThreshold--;
 		}
 	}
 

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -425,7 +425,10 @@ export class FluidDataStoreRuntime
 
 					return { mimeType: "fluid/object", status: 200, value: channel };
 				} catch (error) {
-					this.mc.logger.sendErrorEvent({ eventName: "GetChannelFailedInRequest" }, error);
+					this.mc.logger.sendErrorEvent(
+						{ eventName: "GetChannelFailedInRequest" },
+						error,
+					);
 
 					return createResponseError(500, `Failed to get Channel: ${error}`, request);
 				}
@@ -1140,7 +1143,7 @@ export class FluidDataStoreRuntime
 	 * eventual consistency. For example, the next summary (say at ref seq# 100) may contain these changes whereas
 	 * other clients that are up-to-date till seq# 100 may not have them yet.
 	 */
-	protected identifyLocalChangeInSummarizer(
+	private identifyLocalChangeInSummarizer(
 		eventName: string,
 		channelId: string,
 		channelType: string,

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -425,7 +425,7 @@ export class FluidDataStoreRuntime
 
 					return { mimeType: "fluid/object", status: 200, value: channel };
 				} catch (error) {
-					this.logger.sendErrorEvent({ eventName: "GetChannelFailedInRequest" }, error);
+					this.mc.logger.sendErrorEvent({ eventName: "GetChannelFailedInRequest" }, error);
 
 					return createResponseError(500, `Failed to get Channel: ${error}`, request);
 				}


### PR DESCRIPTION
Follow up to https://github.com/microsoft/FluidFramework/pull/14070.
Added telemetry when local DDS is created in summarizer client.
Added a feature flag that can limit the number of these events logged by a data store since this log can become too noisy.