### PR TITLE
feat(build-cli): Allow ssh git remotes

### DIFF
--- a/build-tools/packages/build-cli/src/base.ts
+++ b/build-tools/packages/build-cli/src/base.ts
@@ -137,12 +137,7 @@ export abstract class BaseCommand<T extends typeof BaseCommand.flags>
 			this.verbose(`Repo: ${resolvedRoot}`);
 			this.verbose(`Branch: ${branch}`);
 
-			this._context = new Context(
-				gitRepo,
-				"microsoft/FluidFramework",
-				branch,
-				this.logger,
-			);
+			this._context = new Context(gitRepo, "microsoft/FluidFramework", branch, this.logger);
 		}
 
 		return this._context;

--- a/build-tools/packages/build-cli/src/base.ts
+++ b/build-tools/packages/build-cli/src/base.ts
@@ -139,7 +139,7 @@ export abstract class BaseCommand<T extends typeof BaseCommand.flags>
 
 			this._context = new Context(
 				gitRepo,
-				"github.com/microsoft/FluidFramework",
+				"microsoft/FluidFramework",
 				branch,
 				this.logger,
 			);


### PR DESCRIPTION
## Description

Currently flub can error with the message:
```
$ ./node_modules/@fluid-tools/build-cli/bin/flub release -g client
ERROR: Unable to find remote for 'github.com/microsoft/FluidFramework'
    Error: Failed when signaling success from state: CheckHasRemote
```

This happens if the remote is `git@github.com:microsoft/FluidFramework.git` instead of `https://github.com/microsoft/FluidFramework.git`.

Since I prefer to use ssh keys with github, this is an issue for me.

Because the is used with a partial string match, this can be fixed by truncating it as done in this change.

I suspect people are more likely to have a remote using an ssh key than an unrelated remove containing "microsoft/FluidFramework" listed before this upstream in their remotes list thus I think this improves the change of it working correctly.

There are probably better ways to fix this (like support multiple urls) but this looks good enough, and very easy.

## Breaking Changes

users of flub that have a remote containing the string "microsoft/FluidFramework" (but not "github.com/microsoft/FluidFramework") that does not point to this repo (or a mirror of it) and its listed before the entry pointing to this repo will have flub git confused where it used to work.

I think this is a small enough breaking case not to require a major version rev.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
