### PR TITLE
Use a * export on environment-specific exports in common-utils

### DIFF
--- a/common/lib/common-utils/src/index.ts
+++ b/common/lib/common-utils/src/index.ts
@@ -24,6 +24,7 @@ export { Heap, IComparer, IHeapNode, NumberComparer } from "./heap";
  * In a future breaking change of common-utils, we could use a named export for their intersection if we
  * desired.
  */
+// eslint-disable-next-line no-restricted-syntax
 export * from "./indexNode";
 export { Lazy } from "./lazy";
 export { BaseTelemetryNullLogger, TelemetryNullLogger } from "./logger";

--- a/common/lib/common-utils/src/index.ts
+++ b/common/lib/common-utils/src/index.ts
@@ -19,7 +19,7 @@ export { Heap, IComparer, IHeapNode, NumberComparer } from "./heap";
 /**
  * NOTE: This export is remapped to export from "./indexBrowser" in browser environments via package.json.
  * Because the two files don't have fully isomorphic exports, using named exports for the full API surface
- * is problematic.
+ * is problematic if that named export includes values not in their intersection.
  *
  * In a future breaking change of common-utils, we could use a named export for their intersection if we
  * desired.

--- a/common/lib/common-utils/src/index.ts
+++ b/common/lib/common-utils/src/index.ts
@@ -16,16 +16,15 @@ export { delay } from "./delay";
 export { doIfNotDisposed } from "./disposal";
 export { EventForwarder } from "./eventForwarder";
 export { Heap, IComparer, IHeapNode, NumberComparer } from "./heap";
-export {
-	Buffer,
-	bufferToString,
-	gitHashFile,
-	hashFile,
-	IsoBuffer,
-	performance,
-	stringToBuffer,
-	Uint8ArrayToString,
-} from "./indexNode";
+/**
+ * NOTE: This export is remapped to export from "./indexBrowser" in browser environments via package.json.
+ * Because the two files don't have fully isomorphic exports, using named exports for the full API surface
+ * is problematic.
+ *
+ * In a future breaking change of common-utils, we could use a named export for their intersection if we
+ * desired.
+ */
+export * from "./indexNode";
 export { Lazy } from "./lazy";
 export { BaseTelemetryNullLogger, TelemetryNullLogger } from "./logger";
 export { IsomorphicPerformance } from "./performanceIsomorphic";


### PR DESCRIPTION
## Description

Resolves the introduction of a breaking change by reverting the export style used for environment-specific exports.