### PR TITLE
Rename TelemetryContext::SetAll to SetMultiple

### DIFF
--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -432,7 +432,7 @@ export interface ITelemetryContext {
     get(prefix: string, property: string): TelemetryEventPropertyType;
     serialize(): string;
     set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
-    setAll(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
+    setMultiple(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
 }
 
 // @public

--- a/api-report/runtime-utils.api.md
+++ b/api-report/runtime-utils.api.md
@@ -230,7 +230,7 @@ export class TelemetryContext implements ITelemetryContext {
     // (undocumented)
     set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
     // (undocumented)
-    setAll(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
+    setMultiple(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
 }
 
 // @public (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2305,7 +2305,7 @@ export class ContainerRuntime
 
 		const telemetryContext = new TelemetryContext();
 		// Add the options that are used to generate this summary to the telemetry context.
-		telemetryContext.setAll("fluid_Summarize", "Options", {
+		telemetryContext.setMultiple("fluid_Summarize", "Options", {
 			fullTree,
 			trackState,
 			runGC,

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -1042,7 +1042,10 @@ export class GarbageCollector implements IGarbageCollector {
 		}
 
 		// Add the options that are used to run GC to the telemetry context.
-		telemetryContext?.setAll("fluid_GC", "Options", { fullGC, runSweep: options.runSweep });
+		telemetryContext?.setMultiple("fluid_GC", "Options", {
+			fullGC,
+			runSweep: options.runSweep,
+		});
 
 		return PerformanceEvent.timedExecAsync(
 			logger,

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -329,12 +329,12 @@ export interface ITelemetryContext {
 	set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
 
 	/**
-	 * Sets a set of values for telemetry data being tracked.
+	 * Sets multiple values for telemetry data being tracked.
 	 * @param prefix - unique prefix to tag this data with (ex: "fluid:summarize:")
 	 * @param property - property name of the telemetry data being tracked (ex: "Options")
 	 * @param values - A set of values to attribute to this summary telemetry data.
 	 */
-	setAll(
+	setMultiple(
 		prefix: string,
 		property: string,
 		values: Record<string, TelemetryEventPropertyType>,

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -357,9 +357,9 @@ export class TelemetryContext implements ITelemetryContext {
 	}
 
 	/**
-	 * {@inheritDoc @fluidframework/runtime-definitions#ITelemetryContext.setAll}
+	 * {@inheritDoc @fluidframework/runtime-definitions#ITelemetryContext.setMultiple}
 	 */
-	setAll(
+	setMultiple(
 		prefix: string,
 		property: string,
 		values: Record<string, TelemetryEventPropertyType>,

--- a/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
@@ -327,7 +327,7 @@ describe("Summary Utils", () => {
 			telemetryContext.set("pre2_", "prop1", "10");
 			telemetryContext.set("pre2_", "prop2", true);
 			telemetryContext.set("pre1_", "prop2", undefined);
-			telemetryContext.setAll("pre3_", "obj1", { prop1: "1", prop2: 2, prop3: true });
+			telemetryContext.setMultiple("pre3_", "obj1", { prop1: "1", prop2: 2, prop3: true });
 
 			const serialized = telemetryContext.serialize();
 


### PR DESCRIPTION
#14070 added a setAll method to TelemetryContext that can be used to set mutliple values to the telemety context. As per https://github.com/microsoft/FluidFramework/pull/14153#discussion_r1105039108, renaming the method to setMultiple since its more inline with what it does.