### PR TITLE
Refactored createSummarizer functions in testSummaryUtils.ts

### DIFF
--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -68,13 +68,13 @@ export const createDocumentId: () => string;
 export function createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>, documentServiceFactory: IDocumentServiceFactory, urlResolver: IUrlResolver, logger?: ITelemetryBaseLogger, options?: ILoaderOptions): IHostLoader;
 
 // @public (undocumented)
-export function createSummarizer(provider: ITestObjectProvider, container: IContainer, summaryVersion?: string, gcOptions?: IGCRuntimeOptions, configProvider?: IConfigProviderBase, logger?: ITelemetryBaseLogger): Promise<ISummarizer>;
+export function createSummarizer(provider: ITestObjectProvider, container: IContainer, summaryVersion?: string, gcOptions?: IGCRuntimeOptions, configProvider?: IConfigProviderBase, logger?: ITelemetryBaseLogger): Promise<{
+    container: IContainer;
+    summarizer: ISummarizer;
+}>;
 
 // @public (undocumented)
-export function createSummarizerFromFactory(provider: ITestObjectProvider, container: IContainer, dataStoreFactory: IFluidDataStoreFactory, summaryVersion?: string, containerRuntimeFactoryType?: typeof ContainerRuntimeFactoryWithDefaultDataStore, registryEntries?: NamedFluidDataStoreRegistryEntries): Promise<ISummarizer>;
-
-// @public (undocumented)
-export function createSummarizerWithContainer(provider: ITestObjectProvider, absoluteUrl: string | undefined, summaryVersion?: string, gcOptions?: IGCRuntimeOptions, configProvider?: IConfigProviderBase, logger?: ITelemetryBaseLogger): Promise<{
+export function createSummarizerFromFactory(provider: ITestObjectProvider, container: IContainer, dataStoreFactory: IFluidDataStoreFactory, summaryVersion?: string, containerRuntimeFactoryType?: typeof ContainerRuntimeFactoryWithDefaultDataStore, registryEntries?: NamedFluidDataStoreRegistryEntries): Promise<{
     container: IContainer;
     summarizer: ISummarizer;
 }>;

--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -67,13 +67,13 @@ export const createDocumentId: () => string;
 // @public
 export function createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>, documentServiceFactory: IDocumentServiceFactory, urlResolver: IUrlResolver, logger?: ITelemetryBaseLogger, options?: ILoaderOptions): IHostLoader;
 
-// @public (undocumented)
+// @public
 export function createSummarizer(provider: ITestObjectProvider, container: IContainer, summaryVersion?: string, gcOptions?: IGCRuntimeOptions, configProvider?: IConfigProviderBase, logger?: ITelemetryBaseLogger): Promise<{
     container: IContainer;
     summarizer: ISummarizer;
 }>;
 
-// @public (undocumented)
+// @public
 export function createSummarizerFromFactory(provider: ITestObjectProvider, container: IContainer, dataStoreFactory: IFluidDataStoreFactory, summaryVersion?: string, containerRuntimeFactoryType?: typeof ContainerRuntimeFactoryWithDefaultDataStore, registryEntries?: NamedFluidDataStoreRegistryEntries): Promise<{
     container: IContainer;
     summarizer: ISummarizer;

--- a/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
@@ -80,8 +80,7 @@ describe("PropertyDDS summarizer", () => {
 	};
 
 	const getSummarizer = async (container) => {
-		const summarizer = await createSummarizer(objProvider, container);
-		return summarizer;
+		return createSummarizer(objProvider, container);
 	};
 
 	const createUserNode = (name: string) => {
@@ -182,7 +181,7 @@ describe("PropertyDDS summarizer", () => {
 		});
 
 		// Summarize
-		await summarizeNow(summarizer);
+		await summarizeNow(summarizer.summarizer);
 
 		await objProvider.ensureSynchronized();
 

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -199,7 +199,7 @@ export class TestTreeProvider {
 			const firstTree = await dataObject.getSharedObject<ISharedTree>(
 				TestTreeProvider.treeId,
 			);
-			const summarizer = await createSummarizer(objProvider, container);
+			const { summarizer } = await createSummarizer(objProvider, container);
 			const provider = new TestTreeProvider(objProvider, [
 				container,
 				firstTree,

--- a/packages/test/test-end-to-end-tests/src/test/SummarizeFetchValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizeFetchValidation.spec.ts
@@ -94,7 +94,7 @@ async function createSummarizer(
 	container: IContainer,
 	summaryVersion?: string,
 ): Promise<ISummarizer> {
-	return createSummarizerFromFactory(
+	const createSummarizerResult = await createSummarizerFromFactory(
 		provider,
 		container,
 		dataStoreFactory1,
@@ -102,6 +102,7 @@ async function createSummarizer(
 		containerRuntimeFactoryWithDefaultDataStore,
 		registryStoreEntries,
 	);
+	return createSummarizerResult.summarizer;
 }
 
 /**

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithOutOfOrderDataStoreRealization.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithOutOfOrderDataStoreRealization.spec.ts
@@ -148,7 +148,7 @@ async function createSummarizer(
 	container: IContainer,
 	summaryVersion?: string,
 ): Promise<ISummarizer> {
-	return createSummarizerFromFactory(
+	const createSummarizerResult = await createSummarizerFromFactory(
 		provider,
 		container,
 		dataStoreFactory1,
@@ -156,6 +156,7 @@ async function createSummarizer(
 		containerRuntimeFactoryWithDefaultDataStore,
 		registryStoreEntries,
 	);
+	return createSummarizerResult.summarizer;
 }
 
 function createDataStoreRuntime(factory: typeof FluidDataStoreRuntime = FluidDataStoreRuntime) {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
@@ -68,13 +68,14 @@ describeFullCompat.skip("GC summary compatibility tests", (getTestObjectProvider
 	});
 
 	async function createSummarizer(version: number, summaryVersion?: string) {
-		return createSummarizerFromFactory(
+		const createSummarizerResult = await createSummarizerFromFactory(
 			provider,
 			mainContainer,
 			dataObjectFactory,
 			summaryVersion,
 			getContainerRuntimeApi(pkgVersion, version).ContainerRuntimeFactoryWithDefaultDataStore,
 		);
+		return createSummarizerResult.summarizer;
 	}
 
 	// Set up the tests that will run against the different versions of the container runtime.

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDataStoreRequests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDataStoreRequests.spec.ts
@@ -65,7 +65,7 @@ describeNoCompat("GC Data Store Requests", (getTestObjectProvider) => {
 		mainDataStore._root.set("test", "value");
 		await waitForContainerConnection(mainContainer);
 
-		summarizer = await createSummarizer(provider, mainContainer);
+		summarizer = (await createSummarizer(provider, mainContainer)).summarizer;
 	});
 
 	it("should fail requests with externalRequest flag for unreferenced data stores", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -113,7 +113,7 @@ describeNoCompat("GC Data Store Aliased No Compat", (getTestObjectProvider) => {
 		await aliasedDataStore.trySetAlias(alias);
 
 		// summarize
-		const summarizer = await createSummarizer(provider, container);
+		const { summarizer } = await createSummarizer(provider, container);
 		const { summaryTree } = await summarizeNow(summarizer);
 		const gcState = getGCStateFromSummary(summaryTree);
 		assert(
@@ -149,7 +149,7 @@ describeNoCompat("GC Data Store Aliased No Compat", (getTestObjectProvider) => {
 		mainDatastore._root.delete(handleKey);
 
 		// summarize
-		const summarizer = await createSummarizer(provider, container);
+		const { summarizer } = await createSummarizer(provider, container);
 		const { summaryTree } = await summarizeNow(summarizer);
 		const gcState = getGCStateFromSummary(summaryTree);
 		assert(

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
@@ -52,14 +52,14 @@ describeNoCompat("GC Data Store Duplicates", (getTestObjectProvider) => {
 		const dds = SharedMap.create(mainDataStore._runtime);
 		mainDataStore._root.set("dds", dds.handle);
 
-		const summarizer1 = await createSummarizer(provider, mainContainer);
+		const { summarizer: summarizer1 } = await createSummarizer(provider, mainContainer);
 		let summaryResult = await waitForSummary(summarizer1);
 
 		// Change ds1 but not the root dds
 		dds.set("change", "change1");
 
 		summarizer1.close();
-		const summarizer2 = await createSummarizer(
+		const { summarizer: summarizer2 } = await createSummarizer(
 			provider,
 			mainContainer,
 			summaryResult.summaryVersion,
@@ -75,7 +75,7 @@ describeNoCompat("GC Data Store Duplicates", (getTestObjectProvider) => {
 		const dds = SharedMap.create(mainDataStore._runtime);
 		mainDataStore._root.set("dds", dds.handle);
 
-		const summarizer1 = await createSummarizer(provider, mainContainer);
+		const { summarizer: summarizer1 } = await createSummarizer(provider, mainContainer);
 		let summaryResult = await waitForSummary(summarizer1);
 
 		// Change ds1 but not the root dds so that the root dds routes are pulled by default
@@ -88,7 +88,7 @@ describeNoCompat("GC Data Store Duplicates", (getTestObjectProvider) => {
 		await dataStore.trySetAlias("ARootDataStore");
 
 		summarizer1.close();
-		const summarizer2 = await createSummarizer(
+		const { summarizer: summarizer2 } = await createSummarizer(
 			provider,
 			mainContainer,
 			summaryResult.summaryVersion,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -289,9 +289,14 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
 				};
 
 				// Create a summarizer client that will be used to summarize the container.
-				const summarizer1 = await createSummarizer(provider, mainContainer, undefined, {
-					inactiveTimeoutMs,
-				});
+				const { summarizer: summarizer1 } = await createSummarizer(
+					provider,
+					mainContainer,
+					undefined,
+					{
+						inactiveTimeoutMs,
+					},
+				);
 
 				// Create a data store, mark it as referenced and then unreferenced; summarize;
 				const dataStore = await requestFluidObject<ITestDataObject>(
@@ -353,9 +358,14 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
 					return summaryResult.summaryVersion;
 				};
 
-				const summarizer1 = await createSummarizer(provider, mainContainer, undefined, {
-					inactiveTimeoutMs,
-				});
+				const { summarizer: summarizer1 } = await createSummarizer(
+					provider,
+					mainContainer,
+					undefined,
+					{
+						inactiveTimeoutMs,
+					},
+				);
 
 				const dataStore = await requestFluidObject<ITestDataObject>(
 					await containerRuntime.createDataStore(TestDataObjectType),
@@ -369,7 +379,7 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
 
 				// Load a new summarizer from the above summary such that the second data store is not loaded.
 				summarizer1.close();
-				const summarizer2 = await createSummarizer(
+				const { summarizer: summarizer2 } = await createSummarizer(
 					provider,
 					mainContainer,
 					summaryVersion1,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
@@ -67,7 +67,7 @@ describeNoCompat("GC incremental summaries", (getTestObjectProvider) => {
 
 	it("only summarizes changed data stores", async () => {
 		const dataStoreSummaryTypesMap: Map<string, SummaryType> = new Map();
-		const summarizer1 = await createSummarizer(provider, mainContainer);
+		const { summarizer: summarizer1 } = await createSummarizer(provider, mainContainer);
 
 		// Create data stores B and C, and mark them as referenced.
 		const dataStoreB = await requestFluidObject<ITestDataObject>(
@@ -102,7 +102,7 @@ describeNoCompat("GC incremental summaries", (getTestObjectProvider) => {
 
 	it("only summarizes changed data stores across multiple summarizer clients", async () => {
 		const dataStoreSummaryTypesMap: Map<string, SummaryType> = new Map();
-		const summarizer1 = await createSummarizer(provider, mainContainer);
+		const { summarizer: summarizer1 } = await createSummarizer(provider, mainContainer);
 
 		// Create data stores B and C, and mark them as referenced.
 		const dataStoreB = await requestFluidObject<ITestDataObject>(
@@ -128,7 +128,11 @@ describeNoCompat("GC incremental summaries", (getTestObjectProvider) => {
 
 		// Close existing summarizer and load a new summarizer from the summary generated above.
 		summarizer1.close();
-		const summarizer2 = await createSummarizer(provider, mainContainer, summaryVersion);
+		const { summarizer: summarizer2 } = await createSummarizer(
+			provider,
+			mainContainer,
+			summaryVersion,
+		);
 
 		// Summarize the new client and validate that all data store entries are handles since none of them changed.
 		dataStoreSummaryTypesMap.set(dataStoreA._context.id, SummaryType.Handle);
@@ -141,7 +145,11 @@ describeNoCompat("GC incremental summaries", (getTestObjectProvider) => {
 
 		// Close existing summarizer and load a new summarizer from the summary generated above.
 		summarizer2.close();
-		const summarizer3 = await createSummarizer(provider, mainContainer, summaryVersion);
+		const { summarizer: summarizer3 } = await createSummarizer(
+			provider,
+			mainContainer,
+			summaryVersion,
+		);
 
 		// Summarize the new client and validate that dataStoreA's entry is a tree and rest of the data store
 		// entries are handles.
@@ -151,7 +159,7 @@ describeNoCompat("GC incremental summaries", (getTestObjectProvider) => {
 
 	it("summarizes data stores whose reference state changed across summarizer clients", async () => {
 		const dataStoreSummaryTypesMap: Map<string, SummaryType> = new Map();
-		const summarizer1 = await createSummarizer(provider, mainContainer);
+		const { summarizer: summarizer1 } = await createSummarizer(provider, mainContainer);
 
 		// Create data stores B and C, and mark them as referenced.
 		const dataStoreB = await requestFluidObject<ITestDataObject>(
@@ -184,7 +192,11 @@ describeNoCompat("GC incremental summaries", (getTestObjectProvider) => {
 
 		// Close existing summarizer and load a new summarizer from the summary generated above.
 		summarizer1.close();
-		const summarizer2 = await createSummarizer(provider, mainContainer, summaryVersion);
+		const { summarizer: summarizer2 } = await createSummarizer(
+			provider,
+			mainContainer,
+			summaryVersion,
+		);
 
 		// Add back the reference to dataStoreB.
 		dataStoreA._root.set("dataStoreB", dataStoreB.handle);
@@ -195,7 +207,11 @@ describeNoCompat("GC incremental summaries", (getTestObjectProvider) => {
 
 		// Close existing summarizer and load a new summarizer from the summary generated above.
 		summarizer2.close();
-		const summarizer3 = await createSummarizer(provider, mainContainer, summaryVersion);
+		const { summarizer: summarizer3 } = await createSummarizer(
+			provider,
+			mainContainer,
+			summaryVersion,
+		);
 
 		// Validate that all data store entries are handles since none of them changed.
 		dataStoreSummaryTypesMap.set(dataStoreA._context.id, SummaryType.Handle);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
@@ -15,7 +15,7 @@ import { IContainerRuntime } from "@fluidframework/container-runtime-definitions
 import { SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
-	createSummarizerWithContainer,
+	createSummarizer,
 	ITestObjectProvider,
 	summarizeNow,
 	waitForContainerConnection,
@@ -38,14 +38,6 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
 	let mainContainer: IContainer;
 	let containerRuntime: IContainerRuntime;
 	let dataStoreA: ITestDataObject;
-
-	/**
-	 * Creates a summarizer with the given summary version and returns the IContainer along with the ISummarizer.
-	 */
-	async function createSummarizerAndContainer(summaryVersion?: string) {
-		const url = await mainContainer.getAbsoluteUrl("");
-		return createSummarizerWithContainer(provider, url, summaryVersion);
-	}
 
 	/**
 	 * Returns the reference state for all the nodes in the given summary tree.
@@ -130,7 +122,7 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
 	});
 
 	it("updates referenced nodes correctly when loading from an older summary", async () => {
-		const { summarizer: summarizer1 } = await createSummarizerAndContainer();
+		const { summarizer: summarizer1 } = await createSummarizer(provider, mainContainer);
 
 		// Create a data store and mark it unreferenced to begin with.
 		const dataStoreBHandle = (await containerRuntime.createDataStore(TestDataObjectType))
@@ -152,8 +144,11 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
 
 		// Create a second summarizer with summary1. Note that this is done before posting another summary because ODSP
 		// may delete this summary when a new one is posted.
-		const { container: container2, summarizer: summarizer2 } =
-			await createSummarizerAndContainer(summaryResult1.summaryVersion);
+		const { container: container2, summarizer: summarizer2 } = await createSummarizer(
+			provider,
+			mainContainer,
+			summaryResult1.summaryVersion,
+		);
 
 		// Reference dataStoreB now.
 		dataStoreA._root.set("dataStoreB", dataStoreB.handle);
@@ -204,7 +199,7 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
 	});
 
 	it("updates unreferenced nodes correctly when loading from an older summary", async () => {
-		const { summarizer: summarizer1 } = await createSummarizerAndContainer();
+		const { summarizer: summarizer1 } = await createSummarizer(provider, mainContainer);
 
 		// Create a data store and mark it referenced to begin with.
 		const dataStoreBHandle = (await containerRuntime.createDataStore(TestDataObjectType))
@@ -225,8 +220,11 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
 
 		// Create a second summarizer with summary1. Note that this is done before posting another summary because ODSP
 		// may delete this summary when a new one is posted.
-		const { container: container2, summarizer: summarizer2 } =
-			await createSummarizerAndContainer(summaryResult1.summaryVersion);
+		const { container: container2, summarizer: summarizer2 } = await createSummarizer(
+			provider,
+			mainContainer,
+			summaryResult1.summaryVersion,
+		);
 
 		// Unreference dataStoreB now.
 		dataStoreA._root.delete("dataStoreB");
@@ -282,7 +280,7 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
 	 * in older summary is correctly propagated to DDS as well.
 	 */
 	it("updates unreferenced nodes correctly when DDS is unchanged after loading from older summary", async () => {
-		const { summarizer: summarizer1 } = await createSummarizerAndContainer();
+		const { summarizer: summarizer1 } = await createSummarizer(provider, mainContainer);
 
 		// Create a second DDS in dataStoreA. This will be changed after loading from old summary so that the data store
 		// changes but the root DDS containing references is unchanged.
@@ -308,8 +306,11 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
 
 		// Create a second summarizer with summary1. Note that this is done before posting another summary because ODSP
 		// may delete this summary when a new one is posted.
-		const { container: container2, summarizer: summarizer2 } =
-			await createSummarizerAndContainer(summaryResult1.summaryVersion);
+		const { container: container2, summarizer: summarizer2 } = await createSummarizer(
+			provider,
+			mainContainer,
+			summaryResult1.summaryVersion,
+		);
 
 		// Reference dataStoreB now.
 		dataStoreA._root.set("dataStoreB", dataStoreB.handle);
@@ -364,7 +365,7 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
 	});
 
 	it("updates unreferenced timestamps correctly when loading from an older summary", async () => {
-		const { summarizer: summarizer1 } = await createSummarizerAndContainer();
+		const { summarizer: summarizer1 } = await createSummarizer(provider, mainContainer);
 
 		// Create a data store and mark it unreferenced to begin with.
 		const dataStoreBHandle = (await containerRuntime.createDataStore(TestDataObjectType))
@@ -384,8 +385,11 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
 
 		// Create a second summarizer with summary1. Note that this is done before posting another summary because ODSP
 		// may delete this summary when a new one is posted.
-		const { container: container2, summarizer: summarizer2 } =
-			await createSummarizerAndContainer(summaryResult1.summaryVersion);
+		const { container: container2, summarizer: summarizer2 } = await createSummarizer(
+			provider,
+			mainContainer,
+			summaryResult1.summaryVersion,
+		);
 
 		// Reference and unreference dataStoreB.
 		dataStoreA._root.set("dataStoreB", dataStoreB.handle);
@@ -433,7 +437,7 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
 	});
 
 	it("does not log gcUnknownOutboundReferences errors when loading from an older summary", async () => {
-		const { summarizer: summarizer1 } = await createSummarizerAndContainer();
+		const { summarizer: summarizer1 } = await createSummarizer(provider, mainContainer);
 
 		// Create a data store and mark it unreferenced to begin with.
 		const dataStoreBHandle = (await containerRuntime.createDataStore(TestDataObjectType))
@@ -455,8 +459,11 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
 
 		// Create a second summarizer with summary1. Note that this is done before posting another summary because ODSP
 		// may delete this summary when a new one is posted.
-		const { container: container2, summarizer: summarizer2 } =
-			await createSummarizerAndContainer(summaryResult1.summaryVersion);
+		const { container: container2, summarizer: summarizer2 } = await createSummarizer(
+			provider,
+			mainContainer,
+			summaryResult1.summaryVersion,
+		);
 
 		// Reference dataStoreB. This should result in an explicit reference from dataStoreA -> dataStoreB.
 		dataStoreA._root.set("dataStoreB", dataStoreB.handle);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummarizer.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummarizer.spec.ts
@@ -139,7 +139,8 @@ describeNoCompat("GC reference updates in summarizer", (getTestObjectProvider) =
 		mainDataStore._root.set("test", "value");
 		await waitForContainerConnection(mainContainer);
 
-		summarizer = await createSummarizerFromFactory(provider, mainContainer, dataStoreFactory);
+		summarizer = (await createSummarizerFromFactory(provider, mainContainer, dataStoreFactory))
+			.summarizer;
 	});
 
 	describe("SharedMatrix", () => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -14,7 +14,6 @@ import {
 	waitForContainerConnection,
 	mockConfigProvider,
 	ITestContainerConfig,
-	createSummarizerWithContainer,
 } from "@fluidframework/test-utils";
 import { describeNoCompat, ITestDataObject, itExpects } from "@fluidframework/test-version-utils";
 import { delay, stringToBuffer } from "@fluidframework/common-utils";
@@ -59,7 +58,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 			dataStore._root.set("transition to write", "true");
 			await waitForContainerConnection(container, true);
 
-			const summarizer = await createSummarizer(
+			const { summarizer } = await createSummarizer(
 				provider,
 				container,
 				undefined /* summaryVersion */,
@@ -118,8 +117,6 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 				// Summarize so that the tombstoned blobs are now part of the summary.
 				const summary2 = await summarizeNow(summarizer);
 				const container2 = await loadContainer(summary2.summaryVersion);
-				const absoluteUrl = await container2.getAbsoluteUrl("");
-				assert(absoluteUrl !== undefined, "Should be able to retrieve the absolute url");
 
 				// Retrieving the blob should fail. Note that the blob is requested via its url since this container does
 				// not have access to the blob's handle since it loaded after the blob was tombstoned.
@@ -133,9 +130,9 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 				assert(container2.closed !== true, "Container should not have closed");
 
 				// But the summarizing container should succeed (logging and error)
-				const { container: summarizingContainer } = await createSummarizerWithContainer(
+				const { container: summarizingContainer } = await createSummarizer(
 					provider,
-					absoluteUrl,
+					container2,
 					summary2.summaryVersion,
 					gcOptions,
 					mockConfigProvider(settings),
@@ -470,7 +467,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 				mainDataStore._root.set("transition to write", "true");
 				await waitForContainerConnection(mainContainer, true);
 
-				const summarizer = await createSummarizer(
+				const { summarizer } = await createSummarizer(
 					provider,
 					mainContainer,
 					undefined /* summaryVersion */,
@@ -561,7 +558,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 				mainDataStore._root.delete("local1");
 				mainDataStore._root.delete("local2");
 
-				const summarizer = await createSummarizer(
+				const { summarizer } = await createSummarizer(
 					provider,
 					mainContainer,
 					undefined /* summaryVersion */,
@@ -655,7 +652,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 				mainDataStore._root.set("transition to write", "true");
 				await waitForContainerConnection(mainContainer, true);
 
-				const summarizer = await createSummarizer(
+				const { summarizer } = await createSummarizer(
 					provider,
 					mainContainer,
 					undefined /* summaryVersion */,
@@ -763,7 +760,7 @@ describeNoCompat("GC attachment blob tombstone tests", (getTestObjectProvider) =
 		 * GC data to validate references against and ensure that gcUnknownOutboundReferences error is not logged.
 		 */
 		async function createSummarizerWithInitialSummary(container: IContainer) {
-			const summarizer = await createSummarizer(
+			const { summarizer } = await createSummarizer(
 				provider,
 				container,
 				undefined /* summaryVersion */,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -14,7 +14,6 @@ import {
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
 	ITestObjectProvider,
-	createSummarizerWithContainer,
 	summarizeNow,
 	waitForContainerConnection,
 	mockConfigProvider,
@@ -95,18 +94,14 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 		});
 	}
 
-	let documentAbsoluteUrl: string | undefined;
-
 	const makeContainer = async (config: ITestContainerConfig = testContainerConfig) => {
-		const container = await provider.makeTestContainer(config);
-		documentAbsoluteUrl = await container.getAbsoluteUrl("");
-		return container;
+		return provider.makeTestContainer(config);
 	};
 
-	const loadSummarizerAndContainer = async (summaryVersion?: string) => {
-		return createSummarizerWithContainer(
+	const loadSummarizer = async (container: IContainer, summaryVersion?: string) => {
+		return createSummarizer(
 			provider,
-			documentAbsoluteUrl,
+			container,
 			summaryVersion,
 			testContainerConfig.runtimeOptions?.gcOptions,
 			mockConfigProvider(settings),
@@ -143,8 +138,9 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 		defaultDataObject._root.delete(handleKey);
 
 		// Summarize
-		const { container: summarizingContainer1, summarizer: summarizer1 } =
-			await loadSummarizerAndContainer();
+		const { container: summarizingContainer1, summarizer: summarizer1 } = await loadSummarizer(
+			container,
+		);
 		const summaryVersion = (await summarize(summarizer1)).summaryVersion;
 
 		// TODO: trailing op test - note because of the way gc is currently structured, the error isn't logged,
@@ -160,8 +156,10 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 		await delay(approximateUnreferenceTimestampMs);
 
 		// Load a new container and summarizer based on the latest summary, summarize
-		const { container: summarizingContainer2, summarizer: summarizer2 } =
-			await loadSummarizerAndContainer(summaryVersion);
+		const { container: summarizingContainer2, summarizer: summarizer2 } = await loadSummarizer(
+			container,
+			summaryVersion,
+		);
 
 		return {
 			unreferencedId,
@@ -1076,7 +1074,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			const mainDataStoreUrl = `/${mainDataStore._context.id}`;
 			await waitForContainerConnection(mainContainer);
 
-			const summarizer = await createSummarizer(
+			const { summarizer } = await createSummarizer(
 				provider,
 				mainContainer,
 				undefined /* summaryVersion */,
@@ -1133,7 +1131,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			const mainDataStoreUrl = `/${mainDataStore._context.id}`;
 			await waitForContainerConnection(mainContainer);
 
-			const summarizer = await createSummarizer(
+			const { summarizer } = await createSummarizer(
 				provider,
 				mainContainer,
 				undefined /* summaryVersion */,
@@ -1204,7 +1202,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 
 				const mockLogger = new MockLogger();
 
-				const summarizer = await createSummarizer(
+				const { summarizer } = await createSummarizer(
 					provider,
 					mainContainer,
 					undefined /* summaryVersion */,
@@ -1312,7 +1310,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			);
 			await waitForContainerConnection(mainContainer);
 
-			const summarizer = await createSummarizer(
+			const { summarizer } = await createSummarizer(
 				provider,
 				mainContainer,
 				undefined /* summaryVersion */,
@@ -1383,7 +1381,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 				const mainDataStoreUrl = `/${mainDataStore._context.id}`;
 				await waitForContainerConnection(mainContainer);
 
-				const summarizer = await createSummarizer(
+				const { summarizer } = await createSummarizer(
 					provider,
 					mainContainer,
 					undefined /* summaryVersion */,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneUnreferencePhases.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneUnreferencePhases.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
-	createSummarizerWithContainer,
+	createSummarizer,
 	ITestContainerConfig,
 	ITestObjectProvider,
 	mockConfigProvider,
@@ -46,17 +46,6 @@ describeNoCompat("GC unreference phases", (getTestObjectProvider) => {
 	};
 
 	let provider: ITestObjectProvider;
-	let documentAbsoluteUrl: string | undefined;
-
-	const loadSummarizerAndContainer = async (summaryVersion?: string) => {
-		return createSummarizerWithContainer(
-			provider,
-			documentAbsoluteUrl,
-			summaryVersion,
-			gcOptions,
-			mockConfigProvider(settings),
-		);
-	};
 
 	beforeEach(async function () {
 		provider = getTestObjectProvider({ syncSummarizer: true });
@@ -72,11 +61,16 @@ describeNoCompat("GC unreference phases", (getTestObjectProvider) => {
 
 	it("GC nodes go from referenced to unreferenced to inactive to sweep ready to tombstone", async () => {
 		const mainContainer = await provider.makeTestContainer(testContainerConfig);
-		documentAbsoluteUrl = await mainContainer.getAbsoluteUrl("");
 		const mainDataStore = await requestFluidObject<ITestDataObject>(mainContainer, "default");
 		await waitForContainerConnection(mainContainer);
 
-		const { summarizer } = await loadSummarizerAndContainer();
+		const { summarizer } = await createSummarizer(
+			provider,
+			mainContainer,
+			undefined /* summaryVersion */,
+			gcOptions,
+			mockConfigProvider(settings),
+		);
 
 		// create datastore and blob
 		const dataStore = await mainDataStore._context.containerRuntime.createDataStore(

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
@@ -95,7 +95,7 @@ describeNoCompat("GC trailing ops tests", (getTestObjectProvider) => {
 			);
 
 			// Create a summarizer
-			const mainSummarizer = await createSummarizer(
+			const { summarizer: mainSummarizer } = await createSummarizer(
 				provider,
 				mainContainer,
 				undefined,
@@ -127,7 +127,7 @@ describeNoCompat("GC trailing ops tests", (getTestObjectProvider) => {
 			mainSummarizer.close();
 
 			// Load a new container/summarizer from the summary and trailing ops
-			const summarizer = await createSummarizer(
+			const { summarizer } = await createSummarizer(
 				provider,
 				mainContainer,
 				summary1.summaryVersion,
@@ -184,7 +184,7 @@ describeNoCompat("GC trailing ops tests", (getTestObjectProvider) => {
 				);
 
 				// Create a summarizer
-				const mainSummarizer = await createSummarizer(
+				const { summarizer: mainSummarizer } = await createSummarizer(
 					provider,
 					mainContainer,
 					undefined,
@@ -223,7 +223,7 @@ describeNoCompat("GC trailing ops tests", (getTestObjectProvider) => {
 				mainSummarizer.close();
 
 				// Load a new container/summarizer from the summary and trailing ops
-				const summarizer = await createSummarizer(
+				const { summarizer } = await createSummarizer(
 					provider,
 					mainContainer,
 					summary1.summaryVersion,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedFlagInSnapshot.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedFlagInSnapshot.spec.ts
@@ -107,7 +107,7 @@ describeNoCompat("GC unreferenced flag in downloaded snapshot", (getTestObjectPr
 
 	it("should return the unreferenced flag correctly in snapshot for deleted data stores", async () => {
 		const deletedDataStoreIds: string[] = [];
-		const summarizer = await createSummarizer(provider, mainContainer);
+		const { summarizer } = await createSummarizer(provider, mainContainer);
 
 		// Create couple of data stores.
 		const dataStore2 = await requestFluidObject<ITestDataObject>(
@@ -146,7 +146,7 @@ describeNoCompat("GC unreferenced flag in downloaded snapshot", (getTestObjectPr
 
 	it("should return the unreferenced flag correctly in snapshot for revived data stores", async () => {
 		let deletedDataStoreIds: string[] = [];
-		const summarizer = await createSummarizer(provider, mainContainer);
+		const { summarizer } = await createSummarizer(provider, mainContainer);
 
 		// Create couple of data stores.
 		const dataStore2 = await requestFluidObject<ITestDataObject>(

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -68,7 +68,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 
 	describe("unreferenced timestamp in summary", () => {
 		it("adds / removes unreferenced timestamp for data stores correctly", async () => {
-			const summarizer = await createSummarizer(provider, mainContainer);
+			const { summarizer } = await createSummarizer(provider, mainContainer);
 
 			// Create a new data store and mark it as referenced by storing its handle in a referenced DDS.
 			const dataStoreB = await requestFluidObject<ITestDataObject>(
@@ -123,7 +123,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 		});
 
 		it("adds / removes unreferenced timestamp for attachment blobs correctly", async () => {
-			const summarizer = await createSummarizer(provider, mainContainer);
+			const { summarizer } = await createSummarizer(provider, mainContainer);
 
 			// Upload an attachment blob and mark it as referenced by storing its handle in a referenced DDS.
 			const blob1Contents = "Blob contents 1";
@@ -175,7 +175,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 		});
 
 		it("uses unreferenced timestamp from previous summary correctly", async () => {
-			const summarizer1 = await createSummarizer(provider, mainContainer);
+			const { summarizer: summarizer1 } = await createSummarizer(provider, mainContainer);
 
 			// Create a new data store and mark it as referenced by storing its handle in a referenced DDS.
 			const dataStoreB = await requestFluidObject<ITestDataObject>(
@@ -219,7 +219,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 			// Load a new summarizer from the last summary. Validate that the GC state has not changed and we get a
 			// handle for it.
 			summarizer1.close();
-			const summarizer2 = await createSummarizer(
+			const { summarizer: summarizer2 } = await createSummarizer(
 				provider,
 				mainContainer,
 				summaryResult2.summaryVersion,
@@ -257,7 +257,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 			 * Validates that the unreferenced time for B is t2 which is > t1.
 			 */
 			it(`Scenario 1 - Reference added and then removed`, async () => {
-				const summarizer = await createSummarizer(provider, mainContainer);
+				const { summarizer } = await createSummarizer(provider, mainContainer);
 
 				// Create data store B and mark it as referenced by storing its handle in A.
 				const dataStoreB = await requestFluidObject<ITestDataObject>(
@@ -303,7 +303,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 			 * Validates that the unreferenced time for B and C is t2 which is > t1.
 			 */
 			it(`Scenario 2 - Reference transitively added and removed`, async () => {
-				const summarizer = await createSummarizer(provider, mainContainer);
+				const { summarizer } = await createSummarizer(provider, mainContainer);
 
 				// Create data stores B and C and mark them referenced as follows by storing their handles as follows:
 				// dataStoreA -> dataStoreB -> dataStoreC
@@ -364,7 +364,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 			 * Validates that the unreferenced time for B, C and D is t2 which is > t1.
 			 */
 			it(`Scenario 3 - Reference added through chain of references and removed`, async () => {
-				const summarizer = await createSummarizer(provider, mainContainer);
+				const { summarizer } = await createSummarizer(provider, mainContainer);
 
 				// Create data stores B, C and D and mark them referenced as follows by storing their handles as follows:
 				// dataStoreA -> dataStoreB -> dataStoreC -> dataStoreD
@@ -436,7 +436,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 			 * Validates that the unreferenced time for C is t2 which is > t1.
 			 */
 			it(`Scenario 4 - Reference added and removed via new nodes`, async () => {
-				const summarizer = await createSummarizer(provider, mainContainer);
+				const { summarizer } = await createSummarizer(provider, mainContainer);
 
 				// Create data store C and mark it referenced by storing its handle in data store A.
 				const dataStoreC = await requestFluidObject<ITestDataObject>(
@@ -495,7 +495,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 			 * that we can detect new root data stores and outbound references from them.
 			 */
 			it(`Scenario 5 - Reference added via new root nodes and removed`, async () => {
-				const summarizer = await createSummarizer(provider, mainContainer);
+				const { summarizer } = await createSummarizer(provider, mainContainer);
 
 				// Create data store C and mark it referenced by storing its handle in data store A.
 				const dataStoreC = await requestFluidObject<ITestDataObject>(
@@ -551,7 +551,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 			 * observed by summarizer. So, the summarizer does not see this reference directly but only when B is realized.
 			 */
 			it(`Scenario 6 - Reference added via new unreferenced nodes and removed`, async () => {
-				const summarizer = await createSummarizer(provider, mainContainer);
+				const { summarizer } = await createSummarizer(provider, mainContainer);
 
 				// Create data store C and mark it referenced by storing its handle in data store A.
 				const dataStoreC = await requestFluidObject<ITestDataObject>(
@@ -612,7 +612,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 			 * references the node which was unreferenced in previous summary.
 			 */
 			it(`Scenario 7 - Reference added transitively via new nodes and removed`, async () => {
-				const summarizer = await createSummarizer(provider, mainContainer);
+				const { summarizer } = await createSummarizer(provider, mainContainer);
 
 				// Create data store D and mark it referenced by storing its handle in data store A.
 				const dataStoreD = await requestFluidObject<ITestDataObject>(
@@ -672,7 +672,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 			 * 3. Summary 2 at t2. V = [A*, B]. E = []. B is still referenced.
 			 */
 			it(`Scenario 8 - Reference to DDS not added`, async () => {
-				const summarizer = await createSummarizer(provider, mainContainer);
+				const { summarizer } = await createSummarizer(provider, mainContainer);
 
 				// 1. Get summary 1 and validate that A is referenced. E = [].
 				await provider.ensureSynchronized();
@@ -709,7 +709,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 			 * Validates that the unreferenced time for C is t2 which is > t1.
 			 */
 			it(`Scenario 1 - Reference added to unreferenced node`, async () => {
-				const summarizer = await createSummarizer(provider, mainContainer);
+				const { summarizer } = await createSummarizer(provider, mainContainer);
 
 				// Create data stores B and C and mark them referenced as follows by storing their handles as follows:
 				// dataStoreA -> dataStoreB -> dataStoreC.
@@ -764,7 +764,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 			 * Validates that the unreferenced time for C and D is t2 which is > t1.
 			 */
 			it(`Scenario 2 - Reference added to a list of unreferenced nodes`, async () => {
-				const summarizer = await createSummarizer(provider, mainContainer);
+				const { summarizer } = await createSummarizer(provider, mainContainer);
 
 				// Create data stores B, C and D mark them referenced as follows by storing their handles as follows:
 				// dataStoreA -> dataStoreB -> dataStoreC -> dataStoreD.
@@ -833,7 +833,7 @@ describeNoCompat("GC unreferenced timestamp", (getTestObjectProvider) => {
 			 * Validates that the unreferenced time for C and D is t2 which is > t1.
 			 */
 			it(`Scenario 3 - Reference added to a list of unreferenced nodes and a reference is removed`, async () => {
-				const summarizer = await createSummarizer(provider, mainContainer);
+				const { summarizer } = await createSummarizer(provider, mainContainer);
 
 				// Create data stores B, C and D mark them referenced as follows by storing their handles as follows:
 				// dataStoreA -> dataStoreB -> dataStoreC -> dataStoreD.

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpgrade.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpgrade.spec.ts
@@ -128,7 +128,7 @@ describeNoCompat("GC version upgrade", (getTestObjectProvider) => {
 		let dataStoresAsHandles: string[] = [];
 
 		// Create a summarizer client.
-		const summarizer1 = await createSummarizerFromFactory(
+		const { summarizer: summarizer1 } = await createSummarizerFromFactory(
 			provider,
 			mainContainer,
 			dataObjectFactory,
@@ -146,7 +146,7 @@ describeNoCompat("GC version upgrade", (getTestObjectProvider) => {
 
 		// Create a new summarizer with a new GC version and the latest summary that has been generated.
 		summarizer1.close();
-		const summarizer2 = await createSummarizerFromFactory(
+		const { summarizer: summarizer2 } = await createSummarizerFromFactory(
 			provider,
 			mainContainer,
 			dataObjectFactory,

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -118,6 +118,15 @@
 		"previousVersionStyle": "~previousMinor",
 		"baselineRange": ">=2.0.0-internal.3.1.0 <2.0.0-internal.3.2.0",
 		"baselineVersion": "2.0.0-internal.3.1.0",
-		"broken": {}
+		"broken": {
+			"FunctionDeclaration_createSummarizerWithContainer": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"RemovedFunctionDeclaration_createSummarizerWithContainer": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -29,10 +29,11 @@ import { timeoutAwait } from "./timeoutUtils";
 const summarizerClientType = "summarizer";
 
 async function createSummarizerCore(
-	absoluteUrl: string | undefined,
+	container: IContainer,
 	loader: IHostLoader,
 	summaryVersion?: string,
 ) {
+	const absoluteUrl = await container.getAbsoluteUrl("");
 	if (absoluteUrl === undefined) {
 		throw new Error("URL could not be resolved");
 	}
@@ -74,6 +75,11 @@ const defaultSummaryOptions: ISummaryRuntimeOptions = {
 	},
 };
 
+/**
+ * Creates a summarizer client from the given container and data store factory, and returns the summarizer client's
+ * IContainer and ISummarizer.
+ * The ISummarizer can be used to generate on-demand summaries. The IContainer can be used to fetch data stores, etc.
+ */
 export async function createSummarizerFromFactory(
 	provider: ITestObjectProvider,
 	container: IContainer,
@@ -81,7 +87,7 @@ export async function createSummarizerFromFactory(
 	summaryVersion?: string,
 	containerRuntimeFactoryType = ContainerRuntimeFactoryWithDefaultDataStore,
 	registryEntries?: NamedFluidDataStoreRegistryEntries,
-): Promise<ISummarizer> {
+): Promise<{ container: IContainer; summarizer: ISummarizer }> {
 	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
 		runtime.IFluidHandleContext.resolveHandle(request);
 	const runtimeFactory = new containerRuntimeFactoryType(
@@ -95,34 +101,16 @@ export async function createSummarizerFromFactory(
 	const loader = provider.createLoader([[provider.defaultCodeDetails, runtimeFactory]], {
 		configProvider: mockConfigProvider(),
 	});
-	const absoluteUrl = await container.getAbsoluteUrl("");
-	return (await createSummarizerCore(absoluteUrl, loader, summaryVersion)).summarizer;
+	return createSummarizerCore(container, loader, summaryVersion);
 }
 
+/**
+ * Creates a summarizer client from the given container and returns the summarizer client's IContainer and ISummarizer.
+ * The ISummarizer can be used to generate on-demand summaries. The IContainer can be used to fetch data stores, etc.
+ */
 export async function createSummarizer(
 	provider: ITestObjectProvider,
 	container: IContainer,
-	summaryVersion?: string,
-	gcOptions?: IGCRuntimeOptions,
-	configProvider: IConfigProviderBase = mockConfigProvider(),
-	logger?: ITelemetryBaseLogger,
-): Promise<ISummarizer> {
-	const absoluteUrl = await container.getAbsoluteUrl("");
-	return (
-		await createSummarizerWithContainer(
-			provider,
-			absoluteUrl,
-			summaryVersion,
-			gcOptions,
-			configProvider,
-			logger,
-		)
-	).summarizer;
-}
-
-export async function createSummarizerWithContainer(
-	provider: ITestObjectProvider,
-	absoluteUrl: string | undefined,
 	summaryVersion?: string,
 	gcOptions?: IGCRuntimeOptions,
 	configProvider: IConfigProviderBase = mockConfigProvider(),
@@ -136,8 +124,9 @@ export async function createSummarizerWithContainer(
 		loaderProps: { configProvider, logger },
 	};
 	const loader = provider.makeTestLoader(testContainerConfig);
-	return createSummarizerCore(absoluteUrl, loader, summaryVersion);
+	return createSummarizerCore(container, loader, summaryVersion);
 }
+
 /**
  * Summarizes on demand and returns the summary tree, the version number and the reference sequence number of the
  * submitted summary.

--- a/packages/test/test-utils/src/index.ts
+++ b/packages/test/test-utils/src/index.ts
@@ -29,12 +29,7 @@ export {
 	ITestObjectProvider,
 	TestObjectProvider,
 } from "./testObjectProvider";
-export {
-	createSummarizer,
-	createSummarizerFromFactory,
-	createSummarizerWithContainer,
-	summarizeNow,
-} from "./TestSummaryUtils";
+export { createSummarizer, createSummarizerFromFactory, summarizeNow } from "./TestSummaryUtils";
 export {
 	defaultTimeoutDurationMs,
 	timeoutAwait,

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -160,26 +160,14 @@ use_old_FunctionDeclaration_createSummarizerFromFactory(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_createSummarizerWithContainer": {"forwardCompat": false}
+* "RemovedFunctionDeclaration_createSummarizerWithContainer": {"forwardCompat": false}
 */
-declare function get_old_FunctionDeclaration_createSummarizerWithContainer():
-    TypeOnly<typeof old.createSummarizerWithContainer>;
-declare function use_current_FunctionDeclaration_createSummarizerWithContainer(
-    use: TypeOnly<typeof current.createSummarizerWithContainer>);
-use_current_FunctionDeclaration_createSummarizerWithContainer(
-    get_old_FunctionDeclaration_createSummarizerWithContainer());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_createSummarizerWithContainer": {"backCompat": false}
+* "RemovedFunctionDeclaration_createSummarizerWithContainer": {"backCompat": false}
 */
-declare function get_current_FunctionDeclaration_createSummarizerWithContainer():
-    TypeOnly<typeof current.createSummarizerWithContainer>;
-declare function use_old_FunctionDeclaration_createSummarizerWithContainer(
-    use: TypeOnly<typeof old.createSummarizerWithContainer>);
-use_old_FunctionDeclaration_createSummarizerWithContainer(
-    get_current_FunctionDeclaration_createSummarizerWithContainer());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
Merged the createSummarizer and createSummarizerWithContainer methods into one as the only difference was the return type. The create summarizer methods now always return the ISummarizer as well as the IContainer.