### PR TITLE
Fix incorrect compare to {}

### DIFF
--- a/packages/loader/driver-utils/src/blobAggregationStorage.ts
+++ b/packages/loader/driver-utils/src/blobAggregationStorage.ts
@@ -345,7 +345,7 @@ export class BlobAggregationStorage extends SnapshotExtractor implements IDocume
 				case SummaryType.Tree:
 					// If client created empty tree, keep it as is
 					// Also do not package search blobs - they are part of storage contract
-					if (obj.tree !== {} && key !== "__search") {
+					if (Object.keys(obj).length !== 0 && key !== "__search") {
 						const tree = await this.compressSmallBlobs(
 							obj,
 							newPath,
@@ -353,7 +353,7 @@ export class BlobAggregationStorage extends SnapshotExtractor implements IDocume
 							aggregator,
 						);
 						newSummary.tree[key] = tree;
-						if (tree.tree === {}) {
+						if (Object.keys(obj).length === 0) {
 							// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
 							delete newSummary.tree[key];
 						}


### PR DESCRIPTION
## Description

```
error TS2839: This condition will always return 'false' since JavaScript compares objects by reference, not value.
```

I think this bug might lead to creating search blobs for empty trees.

## Reviewer Guidance

People might expect summaries to not have such empty trees sometime in the future (not know that this bug happened), but such documents do exist, so I think maybe we need some extra testing and/or docs to make sure both cases are kept working long term? I'm not sure who should do that or how to do it.