### PR TITLE
Add UsageError when attempting AgentScheduler.release() on a non-picked task

### DIFF
--- a/packages/framework/agent-scheduler/src/scheduler.ts
+++ b/packages/framework/agent-scheduler/src/scheduler.ts
@@ -181,8 +181,14 @@ export class AgentScheduler
 					taskUrl: { tag: TelemetryDataTag.CodeArtifact, value: taskUrl },
 				});
 			}
-			// Note - the assumption is - we are connected.
-			// If not - all tasks should have been dropped already on disconnect / attachment
+			if (!this.runningTasks.has(taskUrl)) {
+				// If we got disconnected (and are attached), tasks that we WERE picked for at the time of disconnect will still show us as holding the task according to getTaskClientId (the CRC is stale), but we should not try to release because our disconnect will already result in either someone else or ourselves clearing the task upon reconnect.
+				// This UsageError is to enforce that the caller should check AgentScheduler.pickedTasks before trying to release a task.
+				throw new UsageError(`Task is not currently picked`, {
+					taskUrl: { tag: TelemetryDataTag.CodeArtifact, value: taskUrl },
+				});
+			}
+			// We may only release tasks that we KNOW we hold (detached state or connected and own the CRC).  If we're attached+disconnected then we'll lose the task automatically, and so may not release manually (someone else might hold it by the time we reconnect)
 			assert(active, 0x119 /* "This agent became inactive while releasing" */);
 			if (this.getTaskClientId(taskUrl) !== this.clientId) {
 				throw new UsageError(`Task was never picked`, {

--- a/packages/framework/agent-scheduler/src/scheduler.ts
+++ b/packages/framework/agent-scheduler/src/scheduler.ts
@@ -182,13 +182,19 @@ export class AgentScheduler
 				});
 			}
 			if (!this.runningTasks.has(taskUrl)) {
-				// If we got disconnected (and are attached), tasks that we WERE picked for at the time of disconnect will still show us as holding the task according to getTaskClientId (the CRC is stale), but we should not try to release because our disconnect will already result in either someone else or ourselves clearing the task upon reconnect.
-				// This UsageError is to enforce that the caller should check AgentScheduler.pickedTasks before trying to release a task.
+				// If we got disconnected (and are attached), tasks that we WERE picked for at the time of disconnect
+				// will still show us as holding the task according to getTaskClientId (the CRC is stale), but we
+				// should not try to release because our disconnect will already result in either someone else or
+				// ourselves clearing the task upon reconnect.
+				// This UsageError is to enforce that the caller should check AgentScheduler.pickedTasks before trying
+				// to release a task.
 				throw new UsageError(`Task is not currently picked`, {
 					taskUrl: { tag: TelemetryDataTag.CodeArtifact, value: taskUrl },
 				});
 			}
-			// We may only release tasks that we KNOW we hold (detached state or connected and own the CRC).  If we're attached+disconnected then we'll lose the task automatically, and so may not release manually (someone else might hold it by the time we reconnect)
+			// We may only release tasks that we KNOW we hold (detached state or connected and own the CRC).  If we're
+			// attached+disconnected then we'll lose the task automatically, and so may not release manually (someone
+			// else might hold it by the time we reconnect)
 			assert(active, 0x119 /* "This agent became inactive while releasing" */);
 			if (this.getTaskClientId(taskUrl) !== this.clientId) {
 				throw new UsageError(`Task was never picked`, {

--- a/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/agentScheduler.spec.ts
@@ -186,13 +186,13 @@ describeFullCompat("AgentScheduler", (getTestObjectProvider) => {
 
 			await provider.ensureSynchronized();
 			await scheduler1.release("task4").catch((err) => {
-				assert.deepStrictEqual(err.message, "Task was never picked");
+				assert.deepStrictEqual(err.message, "Task is not currently picked");
 			});
 			await scheduler2.release("task1").catch((err) => {
-				assert.deepStrictEqual(err.message, "Task was never picked");
+				assert.deepStrictEqual(err.message, "Task is not currently picked");
 			});
 			await scheduler2.release("task2").catch((err) => {
-				assert.deepStrictEqual(err.message, "Task was never picked");
+				assert.deepStrictEqual(err.message, "Task is not currently picked");
 			});
 		});
 


### PR DESCRIPTION
When connected, attempting to release an unpicked task will throw a UsageError already.  This seems reasonable, to prevent "surprising" another client who currently holds the task (we only have the authority to release the tasks we currently hold).  To avoid hitting this UsageError, a caller should check that their task is in AgentScheduler.pickedTasks before attempting to release it.

This change doubles down on this usage requirement by throwing a similar UsageError in disconnected scenarios (where the caller would again be able to observe that AgentScheduler.pickedTasks is empty).  In the disconnect case checking the CRC is insufficient (it will still reflect the last state of task ownership prior to the disconnect) - whereas this.runningTasks is immediately updated upon disconnect in anticipation that we'll lose the task while offline or immediately upon reconnect.

I leave the assert 0x119 just in case we have some other state screwing up.

[AB#2374](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2374)