### PR TITLE
Fixed telemetry added by #14143 never firing and changed max count to 10 by default

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -262,10 +262,10 @@ export abstract class FluidDataStoreContext
 
 	/**
 	 * If the summarizer makes local changes, a telemetry event is logged. This has the potential to be very noisy.
-	 * So, adding a threshold of how many telemetry events can be logged per data store context. This can be
+	 * So, adding a count of how many telemetry events are logged per data store context. This can be
 	 * controlled via feature flags.
 	 */
-	private localChangesTelemetryThreshold: number;
+	private localChangesTelemetryCount: number;
 
 	// The used routes of this node as per the last GC run. This is used to update the used routes of the channel
 	// if it realizes after GC is run.
@@ -341,9 +341,9 @@ export abstract class FluidDataStoreContext
 			this._containerRuntime.gcTombstoneEnforcementAllowed &&
 			this.clientDetails.type !== summarizerClientType;
 
-		// By default, a data store can log maximum 100 local changes telemetry in summarizer.
-		this.localChangesTelemetryThreshold =
-			this.mc.config.getNumber("Fluid.Telemetry.LocalChangesTelemetryThreshold") ?? 100;
+		// By default, a data store can log maximum 10 local changes telemetry in summarizer.
+		this.localChangesTelemetryCount =
+			this.mc.config.getNumber("Fluid.Telemetry.LocalChangesTelemetryCount") ?? 10;
 	}
 
 	public dispose(): void {
@@ -901,28 +901,28 @@ export abstract class FluidDataStoreContext
 	 * other clients that are up-to-date till seq# 100 may not have them yet.
 	 */
 	protected identifyLocalChangeInSummarizer(eventName: string, type?: string) {
-		if (this.clientDetails.type === summarizerClientType) {
-			// If the count of telemetry logged has crossed the threshold, don't log any more.
-			if (this.localChangesTelemetryThreshold > 0) {
-				return;
-			}
-
-			// Log a telemetry if there are local changes in the summarizer. This will give us data on how often
-			// this is happening and which data stores do this. The eventual goal is to disallow local changes
-			// in the summarizer and the data will help us plan this.
-			this.mc.logger.sendTelemetryEvent({
-				eventName,
-				type,
-				fluidDataStoreId: {
-					value: this.id,
-					tag: TelemetryDataTag.CodeArtifact,
-				},
-				packageName: packagePathToTelemetryProperty(this.pkg),
-				isSummaryInProgress: this.summarizerNode.isSummaryInProgress?.(),
-				stack: generateStack(),
-			});
-			this.localChangesTelemetryThreshold--;
+		if (
+			this.clientDetails.type !== summarizerClientType ||
+			this.localChangesTelemetryCount <= 0
+		) {
+			return;
 		}
+
+		// Log a telemetry if there are local changes in the summarizer. This will give us data on how often
+		// this is happening and which data stores do this. The eventual goal is to disallow local changes
+		// in the summarizer and the data will help us plan this.
+		this.mc.logger.sendTelemetryEvent({
+			eventName,
+			type,
+			fluidDataStoreId: {
+				value: this.id,
+				tag: TelemetryDataTag.CodeArtifact,
+			},
+			packageName: packagePathToTelemetryProperty(this.pkg),
+			isSummaryInProgress: this.summarizerNode.isSummaryInProgress?.(),
+			stack: generateStack(),
+		});
+		this.localChangesTelemetryCount--;
 	}
 
 	public getCreateChildSummarizerNodeFn(id: string, createParam: CreateChildSummarizerNodeParam) {

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -34,13 +34,18 @@ import {
 	IRootSummarizerNodeWithGC,
 	packagePathToTelemetryProperty,
 } from "@fluidframework/runtime-utils";
-import { isFluidError, TelemetryNullLogger } from "@fluidframework/telemetry-utils";
+import {
+	isFluidError,
+	MockLogger,
+	TelemetryDataTag,
+	TelemetryNullLogger,
+} from "@fluidframework/telemetry-utils";
 import {
 	MockFluidDataStoreRuntime,
 	validateAssertionError,
 } from "@fluidframework/test-runtime-utils";
 
-import { FluidObjectHandle } from "@fluidframework/datastore";
+import { DataStoreMessageType, FluidObjectHandle } from "@fluidframework/datastore";
 import {
 	LocalDetachedFluidDataStoreContext,
 	LocalFluidDataStoreContext,
@@ -52,6 +57,7 @@ import {
 	ReadFluidDataStoreAttributes,
 	WriteFluidDataStoreAttributes,
 } from "../summaryFormat";
+import { summarizerClientType } from "../summarizerClientElection";
 
 describe("Data Store Context Tests", () => {
 	const dataStoreId = "Test1";
@@ -65,6 +71,35 @@ describe("Data Store Context Tests", () => {
 		const makeLocallyVisibleFn = () => {};
 		let containerRuntime: ContainerRuntime;
 		let summarizerNode: IRootSummarizerNodeWithGC;
+
+		function createContainerRuntime(
+			logger = new TelemetryNullLogger(),
+			clientDetails = {},
+			submitDataStoreOp = (id: string, contents: any, localOpMetadata: unknown) => {},
+		): ContainerRuntime {
+			const factory: IFluidDataStoreFactory = {
+				type: "store-type",
+				get IFluidDataStoreFactory() {
+					return factory;
+				},
+				instantiateDataStore: async (context: IFluidDataStoreContext) =>
+					new MockFluidDataStoreRuntime(),
+			};
+			const registry: IFluidDataStoreRegistry = {
+				get IFluidDataStoreRegistry() {
+					return registry;
+				},
+				get: async (pkg) => (pkg === "BOGUS" ? undefined : factory),
+			};
+			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+			return {
+				IFluidDataStoreRegistry: registry,
+				on: (event, listener) => {},
+				logger,
+				clientDetails,
+				submitDataStoreOp,
+			} as ContainerRuntime;
+		}
 
 		beforeEach(async () => {
 			summarizerNode = createRootSummarizerNodeWithGC(
@@ -87,28 +122,7 @@ describe("Data Store Context Tests", () => {
 					{ throwOnFailure: true },
 					getGCDataFn,
 				);
-
-			const factory: IFluidDataStoreFactory = {
-				type: "store-type",
-				get IFluidDataStoreFactory() {
-					return factory;
-				},
-				instantiateDataStore: async (context: IFluidDataStoreContext) =>
-					new MockFluidDataStoreRuntime(),
-			};
-			const registry: IFluidDataStoreRegistry = {
-				get IFluidDataStoreRegistry() {
-					return registry;
-				},
-				get: async (pkg) => (pkg === "BOGUS" ? undefined : factory),
-			};
-			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-			containerRuntime = {
-				IFluidDataStoreRegistry: registry,
-				on: (event, listener) => {},
-				logger: new TelemetryNullLogger(),
-				clientDetails: {},
-			} as ContainerRuntime;
+			containerRuntime = createContainerRuntime();
 		});
 
 		describe("Initialization", () => {
@@ -351,6 +365,122 @@ describe("Data Store Context Tests", () => {
 
 				const isRootNode = await localDataStoreContext.isRoot();
 				assert.strictEqual(isRootNode, false, "The data store should not be root.");
+			});
+		});
+
+		describe("Local data stores in summarizer client", () => {
+			let mockLogger: MockLogger;
+			const packageName = ["TestDataStore1"];
+			beforeEach(async () => {
+				// Change the container runtime's logger to MockLogger and its type to be a summarizer client.
+				mockLogger = new MockLogger();
+				const clientDetails = {
+					capabilities: {
+						interactive: false,
+					},
+					type: summarizerClientType,
+				};
+				containerRuntime = createContainerRuntime(mockLogger, clientDetails);
+			});
+
+			it("logs when local data store is created in summarizer", async () => {
+				localDataStoreContext = new LocalFluidDataStoreContext({
+					id: dataStoreId,
+					pkg: packageName,
+					runtime: containerRuntime,
+					storage,
+					scope,
+					createSummarizerNodeFn,
+					makeLocallyVisibleFn,
+					snapshotTree: undefined,
+					isRootDataStore: false,
+				});
+
+				const expectedEvents = [
+					{
+						eventName: "FluidDataStoreContext:DataStoreCreatedInSummarizer",
+						packageName: packagePathToTelemetryProperty(packageName),
+						fluidDataStoreId: {
+							value: dataStoreId,
+							tag: TelemetryDataTag.CodeArtifact,
+						},
+					},
+				];
+				mockLogger.assertMatch(
+					expectedEvents,
+					"data store create event not generated as expected",
+				);
+			});
+
+			it("logs when local data store sends op in summarizer", async () => {
+				localDataStoreContext = new LocalFluidDataStoreContext({
+					id: dataStoreId,
+					pkg: packageName,
+					runtime: containerRuntime,
+					storage,
+					scope,
+					createSummarizerNodeFn,
+					makeLocallyVisibleFn,
+					snapshotTree: undefined,
+					isRootDataStore: false,
+				});
+				await localDataStoreContext.realize();
+
+				localDataStoreContext.submitMessage(
+					DataStoreMessageType.ChannelOp,
+					"summarizer message",
+					{},
+				);
+
+				const expectedEvents = [
+					{
+						eventName: "FluidDataStoreContext:DataStoreMessageSubmittedInSummarizer",
+						packageName: packagePathToTelemetryProperty(packageName),
+						fluidDataStoreId: {
+							value: dataStoreId,
+							tag: TelemetryDataTag.CodeArtifact,
+						},
+						type: DataStoreMessageType.ChannelOp,
+					},
+				];
+				mockLogger.assertMatch(
+					expectedEvents,
+					"data store message submitted event not generated as expected",
+				);
+			});
+
+			it("logs maximum of 10 local summarizer events per data store", async () => {
+				localDataStoreContext = new LocalFluidDataStoreContext({
+					id: dataStoreId,
+					pkg: packageName,
+					runtime: containerRuntime,
+					storage,
+					scope,
+					createSummarizerNodeFn,
+					makeLocallyVisibleFn,
+					snapshotTree: undefined,
+					isRootDataStore: false,
+				});
+				await localDataStoreContext.realize();
+
+				let eventCount = 0;
+				for (let i = 0; i < 15; i++) {
+					localDataStoreContext.submitMessage(
+						DataStoreMessageType.ChannelOp,
+						`summarizer message ${i}`,
+						{},
+					);
+				}
+				for (const event of mockLogger.events) {
+					if (
+						event.eventName ===
+							"FluidDataStoreContext:DataStoreMessageSubmittedInSummarizer" ||
+						event.eventName === "FluidDataStoreContext:DataStoreCreatedInSummarizer"
+					) {
+						eventCount++;
+					}
+				}
+				assert.strictEqual(eventCount, 10, "There should be only 10 events per data store");
 			});
 		});
 

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -218,10 +218,10 @@ export class FluidDataStoreRuntime
 
 	/**
 	 * If the summarizer makes local changes, a telemetry event is logged. This has the potential to be very noisy.
-	 * So, adding a threshold of how many telemetry events can be logged per data store context. This can be
+	 * So, adding a count of how many telemetry events are logged per data store context. This can be
 	 * controlled via feature flags.
 	 */
-	private localChangesTelemetryThreshold: number;
+	private localChangesTelemetryCount: number;
 
 	/**
 	 * Invokes the given callback and expects that no ops are submitted
@@ -386,9 +386,9 @@ export class FluidDataStoreRuntime
 			this.deferredAttached.resolve();
 		}
 
-		// By default, a data store can log maximum 100 local changes telemetry in summarizer.
-		this.localChangesTelemetryThreshold =
-			this.mc.config.getNumber("Fluid.Telemetry.LocalChangesTelemetryThreshold") ?? 100;
+		// By default, a data store can log maximum 10 local changes telemetry in summarizer.
+		this.localChangesTelemetryCount =
+			this.mc.config.getNumber("Fluid.Telemetry.LocalChangesTelemetryCount") ?? 10;
 	}
 
 	public dispose(): void {
@@ -1146,33 +1146,30 @@ export class FluidDataStoreRuntime
 		channelId: string,
 		channelType: string,
 	) {
-		if (this.clientDetails.type === "summarizer") {
-			// If the count of telemetry logged has crossed the threshold, don't log any more.
-			if (this.localChangesTelemetryThreshold > 0) {
-				return;
-			}
-
-			// Log a telemetry if there are local changes in the summarizer. This will give us data on how often
-			// this is happening and which data stores do this. The eventual goal is to disallow local changes
-			// in the summarizer and the data will help us plan this.
-			this.mc.logger.sendTelemetryEvent({
-				eventName,
-				channelType,
-				channelId: {
-					value: channelId,
-					tag: TelemetryDataTag.CodeArtifact,
-				},
-				fluidDataStoreId: {
-					value: this.id,
-					tag: TelemetryDataTag.CodeArtifact,
-				},
-				fluidDataStorePackagePath: packagePathToTelemetryProperty(
-					this.dataStoreContext.packagePath,
-				),
-				stack: generateStack(),
-			});
-			this.localChangesTelemetryThreshold--;
+		if (this.clientDetails.type !== "summarizer" || this.localChangesTelemetryCount <= 0) {
+			return;
 		}
+
+		// Log a telemetry if there are local changes in the summarizer. This will give us data on how often
+		// this is happening and which data stores do this. The eventual goal is to disallow local changes
+		// in the summarizer and the data will help us plan this.
+		this.mc.logger.sendTelemetryEvent({
+			eventName,
+			channelType,
+			channelId: {
+				value: channelId,
+				tag: TelemetryDataTag.CodeArtifact,
+			},
+			fluidDataStoreId: {
+				value: this.id,
+				tag: TelemetryDataTag.CodeArtifact,
+			},
+			fluidDataStorePackagePath: packagePathToTelemetryProperty(
+				this.dataStoreContext.packagePath,
+			),
+			stack: generateStack(),
+		});
+		this.localChangesTelemetryCount--;
 	}
 }
 


### PR DESCRIPTION
The telemetry added by #14143 would never fire because it checked for the following condition incorrectly:
`this.localChangesTelemetryThreshold > 0`

Fixed this, updated max count to 10 by default and added unit tests to validate that the telemetry works as expected.