### PR TITLE
deprecate(driver-utils): blobAggregationStorage classes

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -22,8 +22,9 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 -   [For Driver Authors: Document Storage Service policy may become required](#for-driver-authors-document-storage-service-policy-may-become-required)
 -   [Deprecated PendingStateManager interfaces](#Deprecated-PendingStateManager-interfaces)
 -   [Deprecated IFluidHTMLView and HTMLViewAdapter](#Deprecated-IFluidHTMLView-and-HTMLViewAdapter)
--   [test-drivers and test-pairwise-generator packages will no longer be published](test-drivers-and-test-pairwise-generator-packages-will-no-longer-be-published)
--   [Container and RelativeLoader Deprecated](#Container-and-RelativeLoader-Deprecated)
+-   [test-drivers and test-pairwise-generator packages will no longer be published](#test-drivers-and-test-pairwise-generator-packages-will-no-longer-be-published)
+-   [Container and RelativeLoader deprecated](#container-and-relativeloader-deprecated)
+-   [BlobAggregationStorage and SnapshotExtractor deprecated](#blobaggregationstorage-and-snapshotextractor-deprecated)
 
 ### For Driver Authors: Document Storage Service policy may become required
 
@@ -51,12 +52,17 @@ The following interfaces used by the `PendingStateManager` have been deprecated 
 
 These packages are currently published as `@fluidframework/test-drivers` and `@fluidframework/test-pairwise-generator`. These will be moved to the `@fluid-internal` scope and will no longer be published.
 
-### Container and RelativeLoader Deprecated
+### Container and RelativeLoader deprecated
 
 The Container and RelativeLoader classes in `@fluidframework/container-loader` have been deprecated and will be removed in the next major release.
 
 -   Container usage should be replaced with usage of the interface IContainer from `@fluidframework/container-definitions`.
 -   RelativeLoader is an internal class and should not be used directly.
+
+### BlobAggregationStorage and SnapshotExtractor deprecated
+
+The Container and RelativeLoader classes in `@fluidframework/driver-utils` have been deprecated and will be removed in
+the next major release. These classes were experimental and never widely used. There are no replacements.
 
 ## 2.0.0-internal.3.0.0 Breaking changes
 

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -56,7 +56,7 @@ export class AuthorizationError extends LoggingError implements IAuthorizationEr
     readonly tenantId: string | undefined;
 }
 
-// @public (undocumented)
+// @public @deprecated
 export class BlobAggregationStorage extends SnapshotExtractor implements IDocumentStorageService {
     protected constructor(storage: IDocumentStorageService, logger: ITelemetryLogger, allowPacking: boolean, packingLevel: number, blobCutOffSize?: number | undefined);
     // (undocumented)
@@ -430,7 +430,7 @@ export class RetryableError<T extends string> extends NetworkErrorBasic<T> {
 // @public (undocumented)
 export function runWithRetry<T>(api: (cancel?: AbortSignal) => Promise<T>, fetchCallName: string, logger: ITelemetryLogger, progress: IProgress): Promise<T>;
 
-// @public (undocumented)
+// @public @deprecated
 export abstract class SnapshotExtractor {
     // (undocumented)
     protected readonly aggregatedBlobName = "__big";

--- a/packages/loader/driver-utils/src/blobAggregationStorage.ts
+++ b/packages/loader/driver-utils/src/blobAggregationStorage.ts
@@ -63,9 +63,11 @@ class BlobAggregator {
 	}
 }
 
-/*
+/**
  * Base class that deals with unpacking snapshots (in place) containing aggregated blobs
  * It relies on abstract methods for reads and storing unpacked blobs.
+ *
+ * @deprecated This class was introduced experimentally and is no longer used.
  */
 export abstract class SnapshotExtractor {
 	protected readonly aggregatedBlobName = "__big";
@@ -149,10 +151,12 @@ class SnapshotExtractorInPlace extends SnapshotExtractor {
 	}
 }
 
-/*
+/**
  * Snapshot packer and extractor.
  * When summary is written it will find and aggregate small blobs into bigger blobs
  * When snapshot is read, it will unpack aggregated blobs and provide them transparently to caller.
+ *
+ * @deprecated This class was introduced experimentally and is no longer used.
  */
 export class BlobAggregationStorage extends SnapshotExtractor implements IDocumentStorageService {
 	// Tells data store if it can use incremental summary (i.e. reuse DDSes from previous summary


### PR DESCRIPTION
In #12936, Vlad [commented ](https://github.com/microsoft/FluidFramework/pull/12936#issuecomment-1315922327) that the blobAggregationStorage classes are unused and can be removed. This PR marks them as deprecated. A future PR will remove them completely in the next branch.