### PR TITLE
tree: cleanup JsObject performance testing in tree

### DIFF
--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -15,8 +15,8 @@
 	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
-		"bench": "mocha --timeout 999999 --perfMode --parentProcess --fgrep @Benchmark --reporter \"../../../node_modules/@fluid-tools/benchmark/dist/MochaReporter.js\"",
-		"bench:profile": "mocha --v8-prof --timeout 999999 --perfMode --fgrep @Benchmark --reporter \"../../../node_modules/@fluid-tools/benchmark/dist/MochaReporter.js\" && node --prof-process isolate-0x*-v8.log > profile.txt && rm isolate-0x*-v8.log && cat profile.txt",
+		"bench": "mocha --timeout 999999 --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js",
+		"bench:profile": "mocha --v8-prof --timeout 999999 --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js && node --prof-process isolate-0x*-v8.log > profile.txt && rm isolate-0x*-v8.log && cat profile.txt",
 		"build": "concurrently npm:build:compile npm:lint && npm run build:docs",
 		"build:commonjs": "npm run tsc && npm run typetests:gen && npm run build:test",
 		"build:compile": "concurrently npm:build:commonjs npm:build:esnext",

--- a/packages/dds/tree/src/test/domains/json/jsDirectObject.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsDirectObject.bench.ts
@@ -5,36 +5,10 @@
 
 import { strict as assert } from "assert";
 import { benchmark, BenchmarkType, isInPerformanceTestingMode } from "@fluid-tools/benchmark";
-import { Jsonable } from "@fluidframework/datastore-definitions";
 import { averageTwoValues, sumDirect } from "./benchmarks";
 import { generateTwitterJsonByByteSize, Twitter } from "./twitter";
 import { Canada, generateCanada } from "./canada";
-
-// IIRC, extracting this helper from clone() encourages V8 to inline the terminal case at
-// the leaves, but this should be verified.
-function cloneObject<T, J = Jsonable<T>>(obj: J): J {
-	if (Array.isArray(obj)) {
-		// PERF: 'Array.map()' was ~44% faster than looping over the array. (node 14 x64)
-		return obj.map(clone) as unknown as J;
-	} else {
-		const result: any = {};
-		// PERF: Nested array allocs make 'Object.entries()' ~2.4x slower than reading
-		//       value via 'value[key]', even when destructuring. (node 14 x64)
-		for (const key of Object.keys(obj)) {
-			result[key] = clone((obj as any)[key]);
-		}
-		return result as J;
-	}
-}
-
-// Optimized deep clone implementation for "Jsonable" object trees.  Used as a real-world-ish
-// baseline to measure the overhead of using ITreeCursor in a scenario where we're reifying a
-// domain model for the application.
-function clone<T>(value: Jsonable<T>): Jsonable<T> {
-	// PERF: Separate clone vs. cloneObject yields an ~11% speedup in 'canada.json',
-	//       likely due to inlining short-circuiting recursing at leaves (node 14 x64).
-	return typeof value !== "object" || value === null ? value : cloneObject(value);
-}
+import { clone } from "./jsObjectUtil";
 
 /**
  * Performance test suite that measures a variety of access patterns using the direct JS objects to compare its performance when using ITreeCursor.

--- a/packages/dds/tree/src/test/domains/json/jsObjectUtil.ts
+++ b/packages/dds/tree/src/test/domains/json/jsObjectUtil.ts
@@ -1,0 +1,38 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { JsonCompatible, JsonCompatibleObject } from "../../../util";
+
+function cloneObject(obj: JsonCompatibleObject | JsonCompatible[]): JsonCompatible {
+	if (Array.isArray(obj)) {
+		// PERF: 'Array.map()' was ~44% faster than looping over the array. (node 14 x64)
+		return obj.map(clone);
+	} else {
+		const result: JsonCompatibleObject = {};
+		// PERF: Nested array allocs make 'Object.entries()' ~2.4x slower than reading
+		//       value via 'value[key]', even when destructuring. (node 14 x64)
+		for (const key of Object.keys(obj)) {
+			// Like `result[key] = clone(obj[key]);` but safe for when key == "__proto__"
+			Object.defineProperty(result, key, {
+				enumerable: true,
+				configurable: true,
+				writable: true,
+				value: clone(obj[key]),
+			});
+		}
+		return result;
+	}
+}
+
+/**
+ * Optimized deep clone implementation for "Jsonable" object trees.
+ * Used as a real-world-ish baseline to measure the overhead of using ITreeCursor
+ * in a scenario where we're reifying a domain model for the application.
+ */
+export function clone(value: JsonCompatible): JsonCompatible {
+	// PERF: Separate clone vs. cloneObject yields showed improvements with 'canada.json' in the past,
+	// but for the current code the difference is within noise ( < 3%) (node 14 x64).
+	return typeof value !== "object" || value === null ? value : cloneObject(value);
+}

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -5,7 +5,6 @@
 
 import { strict as assert } from "assert";
 import { benchmark, BenchmarkType, isInPerformanceTestingMode } from "@fluid-tools/benchmark";
-import { Jsonable } from "@fluidframework/datastore-definitions";
 import {
 	ITreeCursor,
 	singleJsonCursor,
@@ -34,38 +33,7 @@ import { Canada, generateCanada } from "./canada";
 import { averageTwoValues, sum, sumMap } from "./benchmarks";
 import { generateTwitterJsonByByteSize, Twitter } from "./twitter";
 import { CitmCatalog, generateCitmJson } from "./citm";
-
-// IIRC, extracting this helper from clone() encourages V8 to inline the terminal case at
-// the leaves, but this should be verified.
-function cloneObject<T, J = Jsonable<T>>(obj: J): J {
-	if (Array.isArray(obj)) {
-		// PERF: 'Array.map()' was ~44% faster than looping over the array. (node 14 x64)
-		return obj.map(clone) as unknown as J;
-	} else {
-		const result: any = {};
-		// PERF: Nested array allocs make 'Object.entries()' ~2.4x slower than reading
-		//       value via 'value[key]', even when destructuring. (node 14 x64)
-		for (const key of Object.keys(obj)) {
-			// Like `result[key] = clone((obj as any)[key]);` but safe for when key == "__proto__"
-			Object.defineProperty(result, key, {
-				enumerable: true,
-				configurable: true,
-				writable: true,
-				value: clone((obj as any)[key]),
-			});
-		}
-		return result as J;
-	}
-}
-
-// Optimized deep clone implementation for "Jsonable" object trees.  Used as a real-world-ish
-// baseline to measure the overhead of using ITreeCursor in a scenario where we're reifying a
-// domain model for the application.
-function clone<T>(value: Jsonable<T>): Jsonable<T> {
-	// PERF: Separate clone vs. cloneObject yields an ~11% speedup in 'canada.json',
-	//       likely due to inlining short-circuiting recursing at leaves (node 14 x64).
-	return typeof value !== "object" || value === null ? value : cloneObject(value);
-}
+import { clone } from "./jsObjectUtil";
 
 /**
  * Performance test suite that measures a variety of access patterns using ITreeCursor.
@@ -91,7 +59,7 @@ function bench(
 				type: BenchmarkType.Measurement,
 				title: "Clone JS Object",
 				before: () => {
-					const cloned = clone<any>(json);
+					const cloned = clone(json);
 					assert.deepEqual(cloned, json, "clone() must return an equivalent tree.");
 					assert.notEqual(
 						cloned,
@@ -100,7 +68,7 @@ function bench(
 					);
 				},
 				benchmarkFn: () => {
-					clone<any>(json);
+					clone(json);
 				},
 			});
 


### PR DESCRIPTION
## Description

This does a few fixes:

1. De-duplicate js object cloning code (fixing that one copy did not handle __proto__ fields correctly)
2. Improve typing for js object cloning code: in newer versions of typescript it did not compile due to the inner cloning function claiming to take non object values and no handling them. The updated version solves this with which much clearer types, and also is able to remove `as` casts from the implementation and `<any>` from the usages.
3. Use normal module resolution for the reporter instead of a direct path. The path no longer worked due to how pnpm does the bootstrapping.
4. Update the perf note about splitting the clone method: testing determined it was no longer accurate.
5. Use a doc comment on the function instead of a `//` comment.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
