### PR TITLE
GC Sweep: Delete sweep ready attachment blobs from BlobManager

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -117,6 +117,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     // (undocumented)
     createDetachedRootDataStore(pkg: Readonly<string[]>, rootDataStoreId: string): IFluidDataStoreContextDetached;
     createSummary(blobRedirectTable?: Map<string, string>, telemetryContext?: ITelemetryContext): ISummaryTree;
+    deleteSweepReadyNodes(sweepReadyRoutes: string[]): string[];
+    // @deprecated (undocumented)
     deleteUnusedNodes(unusedRoutes: string[]): string[];
     // (undocumented)
     get deltaManager(): IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -117,6 +117,9 @@
 		"broken": {
 			"EnumDeclaration_RuntimeHeaders": {
 				"forwardCompat": false
+			},
+			"ClassDeclaration_ContainerRuntime": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -730,7 +730,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 			const pathParts = route.split("/");
 			assert(
 				pathParts.length === 3 && pathParts[1] === BlobManager.basePath,
-				0x2d5 /* "Invalid blob node id in unused routes." */,
+				"Invalid blob node id in deleted routes.",
 			);
 			const blobId = pathParts[2];
 			if (!this.redirectTable.has(blobId)) {

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -41,7 +41,7 @@ import {
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions";
 import { ContainerRuntime, TombstoneResponseHeaderKey } from "./containerRuntime";
-import { sendGCUnexpectedUsageEvent, throwOnTombstoneLoadKey } from "./gc";
+import { sendGCUnexpectedUsageEvent, sweepAttachmentBlobsKey throwOnTombstoneLoadKey } from "./gc";
 import { Throttler, formExponentialFn, IThrottler } from "./throttler";
 import { summarizerClientType } from "./summary";
 
@@ -710,6 +710,38 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 			const blobId = pathParts[2];
 			this.redirectTable.delete(blobId);
 		}
+	}
+
+	/**
+	 * This is called to delete unused blobs and returns that list so that other systems can remove those nodes from
+	 * their states (i.e. garbage collection when sweep is run).
+	 * @param unusedRoutes - The routes of attachment blobs that should be deleted.
+	 * @returns - routes of deleted nodes such that garbage collection can delete those nodes from its state.
+	 */
+	public deleteUnusedRoutes(unusedRoutes: string[]): string[] {
+		// If sweep for attachment blobs is not enabled, return empty list indicating nothing is deleted.
+		if (this.mc.config.getBoolean(sweepAttachmentBlobsKey) !== true) {
+			return [];
+		}
+
+		// The routes or blob node paths are in the same format as returned in getGCData -
+		// `/<BlobManager.basePath>/<blobId>`.
+		for (const route of unusedRoutes) {
+			const pathParts = route.split("/");
+			assert(
+				pathParts.length === 3 && pathParts[1] === BlobManager.basePath,
+				0x2d5 /* "Invalid blob node id in unused routes." */,
+			);
+			const blobId = pathParts[2];
+			if (!this.redirectTable.has(blobId)) {
+				this.mc.logger.sendErrorEvent({
+					eventName: "DeletedAttachmentBlobNotFound",
+					blobId,
+				});
+			}
+			this.redirectTable.delete(blobId);
+		}
+		return Array.from(unusedRoutes);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2365,19 +2365,23 @@ export class ContainerRuntime
 	}
 
 	/**
-	 * This is called to delete objects from the runtime
-	 * @param unusedRoutes - object routes and sub routes that can be deleted
-	 * @returns - routes of objects deleted from the runtime
+	 * @deprecated - Replaced by deleteSweepReadyNodes.
 	 */
 	public deleteUnusedNodes(unusedRoutes: string[]): string[] {
-		const { dataStoreRoutes, blobManagerRoutes } =
-			this.getDataStoreAndBlobManagerRoutes(unusedRoutes);
-		const deletedRoutes: string[] = [];
+		throw new Error("deleteUnusedRoutes should not be called");
+	}
 
-		const deletedDataStoreRoutes = this.dataStores.deleteUnusedNodes(dataStoreRoutes);
-		const deletedBlobManagerRoutes = this.blobManager.deleteUnusedRoutes(blobManagerRoutes);
-		deletedRoutes.push(...deletedDataStoreRoutes, ...deletedBlobManagerRoutes);
-		return deletedRoutes;
+	/**
+	 * After GC has run and identified nodes that are sweep ready, this is called to delete the sweep ready nodes.
+	 * @param sweepReadyRoutes - The routes of nodes that are sweep ready and should be deleted.
+	 * @returns - The routes of nodes that were deleted.
+	 */
+	public deleteSweepReadyNodes(sweepReadyRoutes: string[]): string[] {
+		const { dataStoreRoutes, blobManagerRoutes } =
+			this.getDataStoreAndBlobManagerRoutes(sweepReadyRoutes);
+
+		const deletedRoutes = this.dataStores.deleteSweepReadyNodes(dataStoreRoutes);
+		return deletedRoutes.concat(this.blobManager.deleteSweepReadyNodes(blobManagerRoutes));
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2370,12 +2370,13 @@ export class ContainerRuntime
 	 * @returns - routes of objects deleted from the runtime
 	 */
 	public deleteUnusedNodes(unusedRoutes: string[]): string[] {
-		const { dataStoreRoutes } = this.getDataStoreAndBlobManagerRoutes(unusedRoutes);
+		const { dataStoreRoutes, blobManagerRoutes } =
+			this.getDataStoreAndBlobManagerRoutes(unusedRoutes);
 		const deletedRoutes: string[] = [];
 
 		const deletedDataStoreRoutes = this.dataStores.deleteUnusedNodes(dataStoreRoutes);
-		deletedRoutes.push(...deletedDataStoreRoutes);
-
+		const deletedBlobManagerRoutes = this.blobManager.deleteUnusedRoutes(blobManagerRoutes);
+		deletedRoutes.push(...deletedDataStoreRoutes, ...deletedBlobManagerRoutes);
 		return deletedRoutes;
 	}
 

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -796,29 +796,31 @@ export class DataStores implements IDisposable {
 
 	/**
 	 * This is called to delete unused nodes and returns that list so that other
-	 * systems can remove those nodes from their states (i.e. garbage collection when sweep is run)
-	 * @param unusedRoutes - The routes of data stores and DDSes that should be deleted
-	 * @returns - routes of deleted nodes such that garbage collection can delete those nodes from its reference graph
-	 * and other state
+	 * systems can remove those nodes from their states (i.e. garbage collection when sweep is run).
+	 * @param unusedRoutes - The routes of data stores and DDSes that should be deleted.
+	 * @returns - routes of deleted nodes such that garbage collection can delete those nodes from its state.
 	 */
 	public deleteUnusedNodes(unusedRoutes: string[]): string[] {
+		// If sweep for data stores is not enabled, return empty list indicating nothing is deleted.
 		if (this.mc.config.getBoolean(sweepDatastoresKey) !== true) {
 			return [];
 		}
-		const deletedRoutes = new Set<string>();
-
 		for (const route of unusedRoutes) {
 			const pathParts = route.split("/");
 			const dataStoreId = pathParts[1];
 
 			// TODO: GC:Validation - Skip any routes already deleted
-
-			// Push all deleted DataStore (/datastoreId) and sub DataStore (/datastoreId/...) routes to deleted routes
-			deletedRoutes.add(route);
-
-			// Ignore sub-data store routes because a data store and its sub-routes are deleted together, so, we only need to delete the data store.
+			// Ignore sub-data store routes because a data store and its sub-routes are deleted together, so, we only
+			// need to delete the data store.
 			if (pathParts.length > 2) {
 				continue;
+			}
+
+			if (!this.contexts.has(dataStoreId)) {
+				this.mc.logger.sendErrorEvent({
+					eventName: "DeletedDataStoreNotFound",
+					dataStoreId,
+				});
 			}
 
 			const dataStore = this.contexts.get(dataStoreId);
@@ -830,8 +832,7 @@ export class DataStores implements IDisposable {
 			// Delete the summarizer node of the unused data stores.
 			this.deleteChildSummarizerNodeFn(dataStoreId);
 		}
-
-		return Array.from(deletedRoutes);
+		return Array.from(unusedRoutes);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -795,17 +795,17 @@ export class DataStores implements IDisposable {
 	}
 
 	/**
-	 * This is called to delete unused nodes and returns that list so that other
-	 * systems can remove those nodes from their states (i.e. garbage collection when sweep is run).
-	 * @param unusedRoutes - The routes of data stores and DDSes that should be deleted.
-	 * @returns - routes of deleted nodes such that garbage collection can delete those nodes from its state.
+	 * Delete data stores and its objects that are sweep ready.
+	 * @param sweepReadyDataStoreRoutes - The routes of data stores and its objects that are sweep ready and should
+	 * be deleted.
+	 * @returns - The routes of data stores and its objects that were deleted.
 	 */
-	public deleteUnusedNodes(unusedRoutes: string[]): string[] {
+	public deleteSweepReadyNodes(sweepReadyDataStoreRoutes: string[]): string[] {
 		// If sweep for data stores is not enabled, return empty list indicating nothing is deleted.
 		if (this.mc.config.getBoolean(sweepDatastoresKey) !== true) {
 			return [];
 		}
-		for (const route of unusedRoutes) {
+		for (const route of sweepReadyDataStoreRoutes) {
 			const pathParts = route.split("/");
 			const dataStoreId = pathParts[1];
 
@@ -827,12 +827,12 @@ export class DataStores implements IDisposable {
 			assert(dataStore !== undefined, 0x571 /* Attempting to delete unknown dataStore */);
 			dataStore.delete();
 
-			// Delete the contexts of unused data stores.
+			// Delete the contexts of sweep ready data stores.
 			this.contexts.delete(dataStoreId);
-			// Delete the summarizer node of the unused data stores.
+			// Delete the summarizer node of the sweep ready data stores.
 			this.deleteChildSummarizerNodeFn(dataStoreId);
 		}
-		return Array.from(unusedRoutes);
+		return Array.from(sweepReadyDataStoreRoutes);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -1301,7 +1301,7 @@ export class GarbageCollector implements IGarbageCollector {
 	private runSweepPhase(sweepReadyNodes: string[], gcData: IGarbageCollectionData) {
 		// TODO: GC:Validation - validate that removed routes are not double deleted
 		// TODO: GC:Validation - validate that the child routes of removed routes are deleted as well
-		const sweptRoutes = this.runtime.deleteUnusedNodes(sweepReadyNodes);
+		const sweptRoutes = this.runtime.deleteSweepReadyNodes(sweepReadyNodes);
 		const updatedGCData = this.deleteSweptRoutes(sweptRoutes, gcData);
 
 		for (const nodeId of sweptRoutes) {

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -149,10 +149,11 @@ export interface IGarbageCollectionRuntime {
 	/** After GC has run, called to notify the runtime of routes that are unused in it. */
 	updateUnusedRoutes(unusedRoutes: string[]): void;
 	/**
-	 * After GC has run, called to notify the runtime of deletable routes. The runtime is responsible
-	 * for telling the garbage collector the routes of the objects it has deleted
+	 * After GC has run and identified nodes that are sweep ready, called to delete the sweep ready nodes. The runtime
+	 * should return the routes of nodes that were deleted.
+	 * @param sweepReadyRoutes - The routes of nodes that are sweep ready and should be deleted.
 	 */
-	deleteUnusedNodes(unusedNodes: string[]): string[];
+	deleteSweepReadyNodes(sweepReadyRoutes: string[]): string[];
 	/** Called to notify the runtime of routes that are tombstones. */
 	updateTombstonedRoutes(tombstoneRoutes: string[]): void;
 	/** Returns a referenced timestamp to be used to track unreferenced nodes. */

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -50,6 +50,8 @@ export const gcVersionUpgradeToV2Key = "Fluid.GarbageCollection.GCVersionUpgrade
 // Feature gate to enable GC sweep for datastores.
 // TODO: Remove Test from the flag when we are confident to turn on sweep
 export const sweepDatastoresKey = "Fluid.GarbageCollection.Test.SweepDataStores";
+// Feature gate to enable GC sweep for attachment blobs.
+export const sweepAttachmentBlobsKey = "Fluid.GarbageCollection.Test.SweepAttachmentBlobs";
 
 // One day in milliseconds.
 export const oneDayMs = 1 * 24 * 60 * 60 * 1000;

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -18,6 +18,7 @@ export {
 	defaultInactiveTimeoutMs,
 	gcTestModeKey,
 	disableSweepLogKey,
+	sweepAttachmentBlobsKey,
 	gcVersionUpgradeToV2Key,
 	currentGCVersion,
 	stableGCVersion,

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -126,7 +126,7 @@ describe("Garbage Collection Tests", () => {
 				return { totalNodeCount: 0, unusedNodeCount: 0 };
 			},
 			updateUnusedRoutes: (unusedRoutes: string[]) => {},
-			deleteUnusedNodes: (deletableRoutes: string[]): string[] => {
+			deleteSweepReadyNodes: (sweepReadyRoutes: string[]): string[] => {
 				return [];
 			},
 			updateTombstonedRoutes: (tombstoneRoutes: string[]) => {},

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -119,6 +119,7 @@ declare function get_old_ClassDeclaration_ContainerRuntime():
 declare function use_current_ClassDeclaration_ContainerRuntime(
     use: TypeOnly<current.ContainerRuntime>);
 use_current_ClassDeclaration_ContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_ContainerRuntime());
 
 /*

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -301,8 +301,15 @@ describeNoCompat("GC attachment blob sweep tests", (getTestObjectProvider) => {
 				"default",
 			);
 
+			// Upload the same blob again in container3.
 			const container3BlobHandle = await container3MainDataStore._runtime.uploadBlob(
 				stringToBuffer(blobContents, "utf-8"),
+			);
+
+			// Load the blobs in container2 and container3 and validate that they are still available.
+			await assert.doesNotReject(
+				container2BlobHandle.get(),
+				"Container2 should be able to get the blob",
 			);
 			await assert.doesNotReject(
 				container3BlobHandle.get(),

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -20,6 +20,7 @@ import { delay, stringToBuffer } from "@fluidframework/common-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
 import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
 import { getUrlFromItemId, MockDetachedBlobStorage } from "../mockDetachedBlobStorage";
+import { getGCDeletedStateFromSummary, getGCStateFromSummary } from "./gcTestSummaryUtils";
 
 /**
  * These tests validate that SweepReady attachment blobs are correctly swept. Swept attachment blobs should be
@@ -51,11 +52,11 @@ describeNoCompat("GC attachment blob sweep tests", (getTestObjectProvider) => {
 
 	async function validateBlobRetrievalFails(
 		container: IContainer,
-		blobUrl: string,
+		blobNodePath: string,
 		messagePrefix: string,
 	) {
-		const blobId = blobUrl.split("/")[2];
-		const response = await container.request({ url: blobUrl });
+		const blobId = blobNodePath.split("/")[2];
+		const response = await container.request({ url: blobNodePath });
 		assert.strictEqual(response?.status, 404, `${messagePrefix}: Expecting a 404 response`);
 		assert.equal(
 			response.value,
@@ -311,6 +312,51 @@ describeNoCompat("GC attachment blob sweep tests", (getTestObjectProvider) => {
 			// Wait for the above ops to be processed. They should not result in errors in containers where the blob
 			// is deleted.
 			await provider.ensureSynchronized();
+		});
+
+		it("updates deleted blobs in the GC data in summary", async () => {
+			const { dataStore: mainDataStore, summarizer } = await createDataStoreAndSummarizer();
+
+			// Upload an attachment blob.
+			const blobContents = "Blob contents";
+			const blobHandle = await mainDataStore._runtime.uploadBlob(
+				stringToBuffer(blobContents, "utf-8"),
+			);
+			const blobNodePath = blobHandle.absolutePath;
+
+			// Reference and then unreference the blob so that it's unreferenced in the next summary.
+			mainDataStore._root.set("blob1", blobHandle);
+			mainDataStore._root.delete("blob1");
+
+			// Summarize so that the above attachment blobs are marked unreferenced.
+			await provider.ensureSynchronized();
+			await summarizeNow(summarizer);
+
+			// Wait for sweep timeout so that the blobs are ready to be deleted.
+			await delay(sweepTimeoutMs + 10);
+
+			// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+			mainDataStore._root.set("key", "value");
+			await provider.ensureSynchronized();
+
+			// Summarize so that the sweep ready blobs are deleted.
+			const summary2 = await summarizeNow(summarizer);
+
+			// Validate that the GC state does not contain an entry for the deleted blob.
+			const gcState = getGCStateFromSummary(summary2.summaryTree);
+			assert(gcState !== undefined, "GC tree is not available in the summary");
+			for (const [nodePath] of Object.entries(gcState.gcNodes)) {
+				if (nodePath === blobNodePath) {
+					assert(false, `Blob ${blobNodePath} should have been deleted from GC state`);
+				}
+			}
+
+			// Validate that the deleted nodes in the GC data has the deleted blob node.
+			const deletedNodesState = getGCDeletedStateFromSummary(summary2.summaryTree);
+			assert(
+				deletedNodesState?.includes(blobNodePath),
+				`Blob ${blobNodePath} is missing from deleted nodes`,
+			);
 		});
 	});
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -21,7 +21,7 @@ import { delay, stringToBuffer } from "@fluidframework/common-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
 import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions";
 // eslint-disable-next-line import/no-internal-modules
-import { blobsTreeName } from "@fluidframework/container-runtime/dist/summaryFormat";
+import { blobsTreeName } from "@fluidframework/container-runtime/dist/summary";
 import { getUrlFromItemId, MockDetachedBlobStorage } from "../mockDetachedBlobStorage";
 import { getGCDeletedStateFromSummary, getGCStateFromSummary } from "./gcTestSummaryUtils";
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -342,7 +342,7 @@ describeNoCompat("GC data store sweep tests", (getTestObjectProvider) => {
 				// The containers should fail
 				assert(
 					summarizingContainer.closed,
-					"Summarzing container with deleted datastore should close on receiving an op for it",
+					"Summarizing container with deleted datastore should close on receiving an op for it",
 				);
 				assert(
 					container.closed,
@@ -352,7 +352,7 @@ describeNoCompat("GC data store sweep tests", (getTestObjectProvider) => {
 		);
 
 		itExpects(
-			"Receiving ops for swept datastores fails in client after sweep timeout and summarizing container",
+			"Receiving signals for swept datastores fails in client after sweep timeout and summarizing container",
 			[
 				{
 					eventName:
@@ -398,11 +398,11 @@ describeNoCompat("GC data store sweep tests", (getTestObjectProvider) => {
 				// The containers should fail
 				assert(
 					summarizingContainer.closed,
-					"Summarzing container with deleted datastore should close on receiving an op for it",
+					"Summarizing container with deleted datastore should close on receiving a signal for it",
 				);
 				assert(
 					container.closed,
-					"Container with deleted datastore should close on receiving an op for it",
+					"Container with deleted datastore should close on receiving a signal for it",
 				);
 			},
 		);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -9,6 +9,8 @@ import {
 	ISummarizer,
 	TombstoneResponseHeaderKey,
 } from "@fluidframework/container-runtime";
+import { ISummaryTree } from "@fluidframework/protocol-definitions";
+import { channelsTreeName } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
 	ITestObjectProvider,
@@ -410,7 +412,43 @@ describeNoCompat("GC data store sweep tests", (getTestObjectProvider) => {
 	});
 
 	describe("Deleted data stores in summary", () => {
-		it("updates deleted blobs in the GC data in summary", async () => {
+		/**
+		 * Validates that the given data store state is correct in the summary:
+		 * - It should be deleted from the data store summary tree.
+		 * - It should not be present in the GC state in GC summary tree.
+		 * - It should be present in the deleted nodes in GC summary tree.
+		 */
+		function validateDataStoreStateInSummary(
+			summaryTree: ISummaryTree,
+			dataStoreNodePath: string,
+		) {
+			// Validate that the data store is deleted from the data store summary tree.
+			const deletedDataStoreId = dataStoreNodePath.split("/")[1];
+			const channelsTree = (summaryTree.tree[channelsTreeName] as ISummaryTree).tree;
+			for (const [id] of Object.entries(channelsTree)) {
+				if (id === deletedDataStoreId) {
+					assert(false, `Data store ${id} should have been deleted from the summary`);
+				}
+			}
+
+			// Validate that the GC state does not contain an entry for the deleted data store.
+			const gcState = getGCStateFromSummary(summaryTree);
+			assert(gcState !== undefined, "GC tree is not available in the summary");
+			for (const [nodePath] of Object.entries(gcState.gcNodes)) {
+				if (nodePath === dataStoreNodePath) {
+					assert(false, `Data store ${nodePath} should not present be in GC state`);
+				}
+			}
+
+			// Validate that the deleted nodes in the GC data has the deleted data store.
+			const deletedNodesState = getGCDeletedStateFromSummary(summaryTree);
+			assert(
+				deletedNodesState?.includes(dataStoreNodePath),
+				`Data store ${dataStoreNodePath} should be in deleted nodes`,
+			);
+		}
+
+		it("updates deleted data store state in the summary", async () => {
 			const { unreferencedId, summarizingContainer, summarizer } =
 				await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
 			const deletedDataStoreNodePath = `/${unreferencedId}`;
@@ -419,21 +457,8 @@ describeNoCompat("GC data store sweep tests", (getTestObjectProvider) => {
 			// The datastore should be swept now
 			const summary2 = await summarize(summarizer);
 
-			// Validate that the GC state does not contain an entry for the deleted data store.
-			const gcState = getGCStateFromSummary(summary2.summaryTree);
-			assert(gcState !== undefined, "GC tree is not available in the summary");
-			for (const [nodePath] of Object.entries(gcState.gcNodes)) {
-				if (nodePath.startsWith(deletedDataStoreNodePath)) {
-					assert(false, `${unreferencedId} nodes should have been deleted from GC state`);
-				}
-			}
-
-			// Validate that the deleted nodes in the GC data has the deleted data store node.
-			const deletedNodesState = getGCDeletedStateFromSummary(summary2.summaryTree);
-			assert(
-				deletedNodesState?.includes(deletedDataStoreNodePath),
-				`${deletedDataStoreNodePath} is missing from deleted nodes`,
-			);
+			// Validate that the deleted data store's state is correct in the summary.
+			validateDataStoreStateInSummary(summary2.summaryTree, deletedDataStoreNodePath);
 		});
 	});
 });


### PR DESCRIPTION
Implement sweep for attachment blobs. When sweep is enabled for attachment blobs, any blobs that are sweep ready will be deleted from the redirect table. They will also be removed from the next summary because only blob ids in the redirect table are written into the summary.

[AB#2387](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2387)