### PR TITLE
Add telemetry in scriptorium lambda

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -101,20 +101,13 @@ export class ScriptoriumLambda implements IPartitionLambda {
                 this.current.clear();
                 status = "ProcessingComplete";
 
-                // checkpoint batch offset
-                try {
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    this.context.checkpoint(batchOffset!);
-                    status = "CheckpointComplete";
-                    metric?.setProperty("status", status);
-                    metric?.success(`Scriptorium completed processing and checkpointing of batch with offset ${batchOffset?.offset}`);
-                } catch (error) {
-                    const errorMessage = `Scriptorium failed to checkpoint batch with offset ${batchOffset?.offset}`;
-                    this.logErrorTelemetry(errorMessage, error, status, batchOffset?.offset, metric);
-                }
-
-                // continue with next batch
-                this.sendPending();
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                this.context.checkpoint(batchOffset!);
+                status = "CheckpointComplete";
+                
+                metric?.setProperty("status", status);
+                metric?.success(`Scriptorium completed processing and checkpointing of batch with offset ${batchOffset?.offset}`);
+                this.sendPending(); // continue with next batch
             },
             (error) => {
                 const errorMessage = `Scriptorium failed to process batch with offset ${batchOffset?.offset}, going to restart`;

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -106,13 +106,12 @@ export class ScriptoriumLambda implements IPartitionLambda {
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     this.context.checkpoint(batchOffset!);
                     status = "CheckpointComplete";
+                    metric?.setProperty("status", status);
+                    metric?.success(`Scriptorium completed processing and checkpointing of batch with offset ${batchOffset?.offset}`);
                 } catch (error) {
                     const errorMessage = `Scriptorium failed to checkpoint batch with offset ${batchOffset?.offset}`;
                     this.logErrorTelemetry(errorMessage, error, status, batchOffset?.offset, metric);
                 }
-
-                metric?.setProperty("status", status);
-                metric?.success(`Scriptorium completed processing and checkpointing of batch with offset ${batchOffset?.offset}`);
 
                 // continue with next batch
                 this.sendPending();

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -101,13 +101,20 @@ export class ScriptoriumLambda implements IPartitionLambda {
                 this.current.clear();
                 status = "ProcessingComplete";
 
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                this.context.checkpoint(batchOffset!);
-                status = "CheckpointComplete";
-                
-                metric?.setProperty("status", status);
-                metric?.success(`Scriptorium completed processing and checkpointing of batch with offset ${batchOffset?.offset}`);
-                this.sendPending(); // continue with next batch
+                // checkpoint batch offset
+                try {
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    this.context.checkpoint(batchOffset!);
+                    status = "CheckpointComplete";
+                    metric?.setProperty("status", status);
+                    metric?.success(`Scriptorium completed processing and checkpointing of batch with offset ${batchOffset?.offset}`);
+                } catch (error) {
+                    const errorMessage = `Scriptorium failed to checkpoint batch with offset ${batchOffset?.offset}`;
+                    this.logErrorTelemetry(errorMessage, error, status, batchOffset?.offset, metric);
+                }
+
+                // continue with next batch
+                this.sendPending();
             },
             (error) => {
                 const errorMessage = `Scriptorium failed to process batch with offset ${batchOffset?.offset}, going to restart`;

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -161,13 +161,14 @@ export class ScriptoriumLambda implements IPartitionLambda {
 
         const sequenceNumbers = messages.map((message) => message.operation.sequenceNumber);
         const sequenceNumberRanges = convertSortedNumberArrayToRanges(sequenceNumbers);
+        const insertBatchSize = dbOps.length;
 
         return runWithRetry(
             async () => this.opCollection.insertMany(dbOps, false),
             "insertOpScriptorium",
             3 /* maxRetries */,
             1000 /* retryAfterMs */,
-            { ...getLumberBaseProperties(documentId, tenantId), ...{ sequenceNumberRanges } },
+            { ...getLumberBaseProperties(documentId, tenantId), ...{ sequenceNumberRanges, insertBatchSize } },
             (error) => error.code === 11000,
             (error) => !this.clientFacadeRetryEnabled /* shouldRetry */,
             undefined /* calculateIntervalMs */,

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -139,8 +139,8 @@ export class ScriptoriumLambda implements IPartitionLambda {
 
     private logErrorTelemetry(errorMessage: string, error: any, status: string, batchOffset: number | undefined, metric: Lumber<LumberEventName.ScriptoriumProcessBatch> | undefined) {
         if (this.telemetryEnabled && metric) {
-            metric?.setProperty("status", status);
-            metric?.error(errorMessage, error);
+            metric.setProperty("status", status);
+            metric.error(errorMessage, error);
         } else {
             Lumberjack.error(errorMessage, {batchOffset, status}, error);
         }

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -231,8 +231,7 @@
         "groupId": "scriptorium",
         "checkpointBatchSize": 1,
         "checkpointTimeIntervalMsec": 1000,
-        "enableRunWithRetryMetricTelemetry": true,
-        "enableHandlerTelemetry": true
+        "enableTelemetry": true
     },
     "copier": {
         "topic": "rawdeltas",

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -231,7 +231,8 @@
         "groupId": "scriptorium",
         "checkpointBatchSize": 1,
         "checkpointTimeIntervalMsec": 1000,
-        "enableRunWithRetryMetricTelemetry": true
+        "enableRunWithRetryMetricTelemetry": true,
+        "enableHandlerTelemetry": true
     },
     "copier": {
         "topic": "rawdeltas",

--- a/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
@@ -23,6 +23,7 @@ export async function create(config: Provider): Promise<IPartitionLambdaFactory>
     const deletionIntervalMs = config.get("mongo:deletionIntervalMs") as number;
 
     const enableRunWithRetryMetricTelemetry = config.get("scriptorium:enableRunWithRetryMetricTelemetry") as boolean ?? false;
+    const enableHandlerTelemetry = config.get("scriptorium:enableHandlerTelemetry") as boolean ?? false;
 
     // Database connection for global db if enabled
     const factory = await services.getDbFactory(config);
@@ -80,5 +81,5 @@ export async function create(config: Provider): Promise<IPartitionLambdaFactory>
         (error) => { return error.code === FluidServiceErrorCode.FeatureDisabled; },
     );
 
-    return new ScriptoriumLambdaFactory(operationsDbManager, opCollection, { enableRunWithRetryMetricTelemetry });
+    return new ScriptoriumLambdaFactory(operationsDbManager, opCollection, { enableRunWithRetryMetricTelemetry, enableHandlerTelemetry });
 }

--- a/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
@@ -22,8 +22,7 @@ export async function create(config: Provider): Promise<IPartitionLambdaFactory>
     const permanentDeletionEnabled = config.get("mongo:permanentDeletionEnabled") as boolean;
     const deletionIntervalMs = config.get("mongo:deletionIntervalMs") as number;
 
-    const enableRunWithRetryMetricTelemetry = config.get("scriptorium:enableRunWithRetryMetricTelemetry") as boolean ?? false;
-    const enableHandlerTelemetry = config.get("scriptorium:enableHandlerTelemetry") as boolean ?? false;
+    const enableTelemetry = config.get("scriptorium:enableTelemetry") as boolean ?? false;
 
     // Database connection for global db if enabled
     const factory = await services.getDbFactory(config);
@@ -81,5 +80,5 @@ export async function create(config: Provider): Promise<IPartitionLambdaFactory>
         (error) => { return error.code === FluidServiceErrorCode.FeatureDisabled; },
     );
 
-    return new ScriptoriumLambdaFactory(operationsDbManager, opCollection, { enableRunWithRetryMetricTelemetry, enableHandlerTelemetry });
+    return new ScriptoriumLambdaFactory(operationsDbManager, opCollection, { enableTelemetry });
 }

--- a/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
@@ -23,7 +23,7 @@ export enum LumberEventName {
     ScribeHandler = "ScribeHandler",
     ServiceSummary = "ServiceSummary",
     SummaryReader = "SummaryReader",
-    ScriptoriumHandler = "ScriptoriumHandler",
+    ScriptoriumProcessBatch = "ScriptoriumProcessBatch",
 
     // Retries
     RunWithRetry = "RunWithRetry",

--- a/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
@@ -23,6 +23,7 @@ export enum LumberEventName {
     ScribeHandler = "ScribeHandler",
     ServiceSummary = "ServiceSummary",
     SummaryReader = "SummaryReader",
+    ScriptoriumHandler = "ScriptoriumHandler",
 
     // Retries
     RunWithRetry = "RunWithRetry",


### PR DESCRIPTION
## Description

Adding ScriptoriumHandler metric in the scriptorium lambda to help investigating any issues related to scriptorium data loss, and analyze its latency/reliability. It is configurable by flag `scriptorium.enableHandlerTelemetry`.

