### PR TITLE
ci(azure): fix component governance step in pipeline

### DIFF
--- a/tools/pipelines/build-azure.yml
+++ b/tools/pipelines/build-azure.yml
@@ -100,27 +100,3 @@ extends:
     cgSubDirectory: packages
     checkoutSubmodules: true
     taskBundleAnalysis: false
-
-    preCG:
-    - task: UseNode@1
-      displayName: Use Node 14.x
-      inputs:
-        version: 14.x
-    - task: Npm@1
-      displayName: npm ci
-      inputs:
-        command: 'custom'
-        workingDir: azure
-        customCommand: 'ci --ignore-scripts'
-        customRegistry: 'useNpmrc'
-    - task: Bash@3
-      displayName: 'Generate Mono repo package json'
-      inputs:
-        targetType: 'inline'
-        # Must run in the root but creates files relative to the release group root
-        workingDirectory: $(Build.SourcesDirectory)
-        script: |
-          # Generate the package/package lock for the lerna project so we would scan it.
-          node azure/node_modules/@fluidframework/build-tools/dist/genMonoRepoPackageJson/genMonoRepoPackageJson.js --azure
-          cp azure/repo-package.json azure/packages/package.json
-          cp azure/repo-package-lock.json azure/packages/package-lock.json

--- a/tools/pipelines/build-azure.yml
+++ b/tools/pipelines/build-azure.yml
@@ -97,6 +97,5 @@ extends:
     buildDirectory: azure
     tagName: azure
     poolBuild: Large
-    cgSubDirectory: packages
     checkoutSubmodules: true
     taskBundleAnalysis: false


### PR DESCRIPTION
Now that azure is using pnpm, we can remove the prep steps for component governance. Nothing special is required now -- comp governance automatically detects pnpm's lockfile and reads deps from it.