### PR TITLE
Unprivate test-version-utils for end-to-end test runs

### DIFF
--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@fluid-internal/test-version-utils",
 	"version": "2.0.0-internal.4.0.0",
-	"private": true,
 	"description": "End to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
In #14127 I moved test-version-utils to fluid-internal scope and made it private.  However, this is a dependency of the end-to-end tests, which the Real Service end to end tests pipeline expects to be able to install from internal feeds.  This change marks the packages as unprivate to fix that pipeline.