### PR TITLE
[GC-stress] Added artifactBuildId because the pipeline is failing without it

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -51,6 +51,7 @@ stages:
         poolBuild: Large
         testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
+        artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 150
         testCommand: start:odsp:gc:ci
         env:
@@ -69,6 +70,7 @@ stages:
         poolBuild: Large
         testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
+        artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 150
         testCommand: start:t9s:gc:ci
         env:


### PR DESCRIPTION
Pipelines are failing without artifactBuildId - https://dev.azure.com/fluidframework/internal/_build/results?buildId=130799&view=results