### PR TITLE
Deprecate ReactViewAdapter

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -21,7 +21,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 
 -   [For Driver Authors: Document Storage Service policy may become required](#for-driver-authors-document-storage-service-policy-may-become-required)
 -   [Deprecated PendingStateManager interfaces](#Deprecated-PendingStateManager-interfaces)
--   [Deprecated IFluidHTMLView and HTMLViewAdapter](#Deprecated-IFluidHTMLView-and-HTMLViewAdapter)
+-   [Deprecated IFluidHTMLView, ReactViewAdapter, and HTMLViewAdapter](#Deprecated-IFluidHTMLView-ReactViewAdapter-and-HTMLViewAdapter)
 -   [Some test packages will no longer be published](#some-test-packages-will-no-longer-be-published)
 -   [Container and RelativeLoader deprecated](#container-and-relativeloader-deprecated)
 -   [BlobAggregationStorage and SnapshotExtractor deprecated](#blobaggregationstorage-and-snapshotextractor-deprecated)
@@ -44,9 +44,9 @@ The following interfaces used by the `PendingStateManager` have been deprecated 
 -   `IPendingState`
 -   `IPendingLocalState`
 
-### Deprecated IFluidHTMLView and HTMLViewAdapter
+### Deprecated IFluidHTMLView, ReactViewAdapter, and HTMLViewAdapter
 
-`IFluidHTMLView` and `HTMLViewAdapter` have been deprecated. It is recommended not to bundle view code with Fluid data, and instead apply the views from outside the container (see https://github.com/microsoft/FluidFramework/tree/main/examples/hosts/app-integration/external-views for an example of this approach). For those views, a dedicated view framework is recommended (see view sampler demo https://github.com/microsoft/FluidFramework/tree/main/examples/apps/view-framework-sampler)
+`IFluidHTMLView`, `ReactViewAdapter`, and `HTMLViewAdapter` have been deprecated. It is recommended not to bundle view code with Fluid data, and instead apply the views from outside the container (see https://github.com/microsoft/FluidFramework/tree/main/examples/hosts/app-integration/external-views for an example of this approach). For those views, a dedicated view framework is recommended (see view sampler demo https://github.com/microsoft/FluidFramework/tree/main/examples/apps/view-framework-sampler)
 
 ### Some test packages will no longer be published
 

--- a/api-report/view-adapters.api.md
+++ b/api-report/view-adapters.api.md
@@ -24,7 +24,7 @@ export class HTMLViewAdapter implements IFluidHTMLView {
     render(elm: HTMLElement, options?: IFluidHTMLOptions): void;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IReactViewAdapterProps {
     view: FluidObject;
 }
@@ -42,11 +42,13 @@ export class MountableView implements IFluidMountableView {
     unmount(): void;
 }
 
-// @public
+// @public @deprecated
 export class ReactViewAdapter extends React_2.Component<IReactViewAdapterProps> {
+    // @deprecated
     constructor(props: IReactViewAdapterProps);
+    // @deprecated
     static canAdapt(view: FluidObject): boolean;
-    // (undocumented)
+    // @deprecated
     render(): JSX.Element;
 }
 

--- a/packages/framework/view-adapters/src/react/reactViewAdapter.tsx
+++ b/packages/framework/view-adapters/src/react/reactViewAdapter.tsx
@@ -7,6 +7,9 @@ import { FluidObject } from "@fluidframework/core-interfaces";
 import { IFluidHTMLView } from "@fluidframework/view-interfaces";
 import React from "react";
 
+/**
+ * @deprecated See {@link @fluidframework/view-interfaces#IFluidHTMLView}
+ */
 export interface IReactViewAdapterProps {
 	/**
 	 * The view to adapt into a React component.
@@ -19,11 +22,15 @@ export interface IReactViewAdapterProps {
  * views that implement IFluidHTMLView.
  *
  * If the object is none of these, we render nothing.
+ *
+ * @deprecated See {@link @fluidframework/view-interfaces#IFluidHTMLView}
  */
 export class ReactViewAdapter extends React.Component<IReactViewAdapterProps> {
 	/**
 	 * Test whether the given Fluid object can be successfully adapted by a ReactViewAdapter.
 	 * @param view - the fluid object to test if it is adaptable.
+	 *
+	 * @deprecated See {@link @fluidframework/view-interfaces#IFluidHTMLView}
 	 */
 	public static canAdapt(view: FluidObject): boolean {
 		const maybeView: FluidObject<IFluidHTMLView> = view;
@@ -35,6 +42,9 @@ export class ReactViewAdapter extends React.Component<IReactViewAdapterProps> {
 	 */
 	private readonly element: JSX.Element;
 
+	/**
+	 * @deprecated See {@link @fluidframework/view-interfaces#IFluidHTMLView}
+	 */
 	constructor(props: IReactViewAdapterProps) {
 		super(props);
 
@@ -52,6 +62,10 @@ export class ReactViewAdapter extends React.Component<IReactViewAdapterProps> {
 		this.element = <></>;
 	}
 
+	/**
+	 * React render method
+	 * @deprecated See {@link @fluidframework/view-interfaces#IFluidHTMLView}
+	 */
 	public render(): JSX.Element {
 		return this.element;
 	}


### PR DESCRIPTION
When removing `IFluidHTMLView` I realized this also made the `ReactViewAdapter` useless, since it then became just a React component wrapping a React component.  This change deprecates that adapter as well, and I'll remove it along with the other items in `next`.