### PR TITLE
Removed BindState from data store context and data store runtime

### DIFF
--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -43,16 +43,6 @@ export interface AttributionInfo {
 // @alpha
 export type AttributionKey = OpAttributionKey | DetachedAttributionKey;
 
-// @public @deprecated (undocumented)
-export enum BindState {
-    // (undocumented)
-    Binding = "Binding",
-    // (undocumented)
-    Bound = "Bound",
-    // (undocumented)
-    NotBound = "NotBound"
-}
-
 // @public (undocumented)
 export const blobCountPropertyName = "BlobCount";
 
@@ -189,7 +179,7 @@ export interface IFluidDataStoreChannel extends IFluidRouter, IDisposable {
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
     updateUsedRoutes(usedRoutes: string[]): void;
     // (undocumented)
-    readonly visibilityState?: VisibilityState_2;
+    readonly visibilityState: VisibilityState_2;
 }
 
 // @public

--- a/api-report/test-runtime-utils.api.md
+++ b/api-report/test-runtime-utils.api.md
@@ -54,6 +54,7 @@ import { MessageType } from '@fluidframework/protocol-definitions';
 import { ReadOnlyInfo } from '@fluidframework/container-definitions';
 import { ScopeType } from '@fluidframework/protocol-definitions';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
+import { VisibilityState as VisibilityState_2 } from '@fluidframework/runtime-definitions';
 
 // @public
 export interface IInsecureUser extends IUser {
@@ -464,6 +465,8 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     updateUsedRoutes(usedRoutes: string[]): void;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
+    // (undocumented)
+    get visibilityState(): VisibilityState_2;
     // (undocumented)
     waitAttached(): Promise<void>;
 }

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -64,6 +64,13 @@
 		"broken": {
 			"InterfaceDeclaration_ITelemetryContext": {
 				"forwardCompat": false
+			},
+			"RemovedEnumDeclaration_BindState": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"InterfaceDeclaration_IFluidDataStoreChannel": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -224,15 +224,6 @@ export interface IContainerRuntimeBase
 }
 
 /**
- * @deprecated Used only in deprecated API bindToContext
- */
-export enum BindState {
-	NotBound = "NotBound",
-	Binding = "Binding",
-	Bound = "Bound",
-}
-
-/**
  * Minimal interface a data store runtime needs to provide for IFluidDataStoreContext to bind to control.
  *
  * Functionality include attach, snapshot, op/signal processing, request routes, expose an entryPoint,
@@ -246,7 +237,7 @@ export interface IFluidDataStoreChannel extends IFluidRouter, IDisposable {
 	 */
 	readonly attachState: AttachState;
 
-	readonly visibilityState?: VisibilityState;
+	readonly visibilityState: VisibilityState;
 
 	/**
 	 * Runs through the graph and attaches the bound handles. Then binds this runtime to the container.

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -11,7 +11,6 @@ export {
 } from "./attribution";
 export {
 	AliasResult,
-	BindState,
 	CreateChildSummarizerNodeFn,
 	FlushMode,
 	FlushModeExperimental,

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -88,26 +88,14 @@ use_old_TypeAliasDeclaration_AttributionKey(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "EnumDeclaration_BindState": {"forwardCompat": false}
+* "RemovedEnumDeclaration_BindState": {"forwardCompat": false}
 */
-declare function get_old_EnumDeclaration_BindState():
-    TypeOnly<old.BindState>;
-declare function use_current_EnumDeclaration_BindState(
-    use: TypeOnly<current.BindState>);
-use_current_EnumDeclaration_BindState(
-    get_old_EnumDeclaration_BindState());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "EnumDeclaration_BindState": {"backCompat": false}
+* "RemovedEnumDeclaration_BindState": {"backCompat": false}
 */
-declare function get_current_EnumDeclaration_BindState():
-    TypeOnly<current.BindState>;
-declare function use_old_EnumDeclaration_BindState(
-    use: TypeOnly<old.BindState>);
-use_old_EnumDeclaration_BindState(
-    get_current_EnumDeclaration_BindState());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -527,6 +515,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreChannel():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreChannel(
     use: TypeOnly<current.IFluidDataStoreChannel>);
 use_current_InterfaceDeclaration_IFluidDataStoreChannel(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreChannel());
 
 /*

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -105,6 +105,10 @@
 		"previousVersionStyle": "~previousMinor",
 		"baselineRange": ">=2.0.0-internal.3.1.0 <2.0.0-internal.3.2.0",
 		"baselineVersion": "2.0.0-internal.3.1.0",
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_MockFluidDataStoreRuntime": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -43,6 +43,7 @@ import {
 	IFluidDataStoreChannel,
 	IGarbageCollectionData,
 	ISummaryTreeWithStats,
+	VisibilityState,
 } from "@fluidframework/runtime-definitions";
 import { v4 as uuid } from "uuid";
 import { MockDeltaManager } from "./mockDeltas";
@@ -466,6 +467,10 @@ export class MockFluidDataStoreRuntime
 
 	public get attachState(): AttachState {
 		return this.local ? AttachState.Detached : AttachState.Attached;
+	}
+
+	public get visibilityState(): VisibilityState {
+		return this.local ? VisibilityState.NotVisible : VisibilityState.GloballyVisible;
 	}
 
 	public bindChannel(channel: IChannel): void {

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -311,6 +311,7 @@ declare function get_old_ClassDeclaration_MockFluidDataStoreRuntime():
 declare function use_current_ClassDeclaration_MockFluidDataStoreRuntime(
     use: TypeOnly<current.MockFluidDataStoreRuntime>);
 use_current_ClassDeclaration_MockFluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockFluidDataStoreRuntime());
 
 /*

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -6,7 +6,10 @@
 import { strict as assert } from "assert";
 import { IContainer } from "@fluidframework/container-definitions";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
+import {
+	IContainerRuntime,
+	IDataStoreWithBindToContext_Deprecated,
+} from "@fluidframework/container-runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
 	createSummarizer,
@@ -55,7 +58,9 @@ describeFullCompat("GC Data Store Aliased Full Compat", (getTestObjectProvider) 
 		);
 		const ds1 = await requestFluidObject<ITestDataObject>(aliasableDataStore1, "");
 
-		(aliasableDataStore1 as any).fluidDataStoreChannel.bindToContext();
+		(
+			aliasableDataStore1 as IDataStoreWithBindToContext_Deprecated
+		).fluidDataStoreChannel?.bindToContext?.();
 		await provider.ensureSynchronized();
 
 		// We run the summary so await this.getInitialSnapshotDetails() is called before the datastore is aliased

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -18,7 +18,10 @@ import {
 	SummaryCollection,
 	DefaultSummaryConfiguration,
 } from "@fluidframework/container-runtime";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
+import {
+	IContainerRuntime,
+	IDataStoreWithBindToContext_Deprecated,
+} from "@fluidframework/container-runtime-definitions";
 import { UsageError } from "@fluidframework/container-utils";
 import { IFluidRouter } from "@fluidframework/core-interfaces";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
@@ -442,7 +445,9 @@ describeNoCompat("Named root data stores", (getTestObjectProvider) => {
 			const aliasedDataStore1 = aliasedDataStoreResponse1.value as ITestFluidObject;
 			// Casting any to repro a race condition where bindToContext is called before summarization,
 			// but aliasing happens afterwards
-			(aliasableDataStore1 as any).fluidDataStoreChannel.bindToContext();
+			(
+				aliasableDataStore1 as IDataStoreWithBindToContext_Deprecated
+			).fluidDataStoreChannel?.bindToContext?.();
 			await provider.ensureSynchronized();
 
 			const containerRuntime2 = runtimeOf(dataObject2) as ContainerRuntime;


### PR DESCRIPTION
Removed BindState from data stores. It was deprecated in 2.0.0-internal.1.2.0 by https://github.com/microsoft/FluidFramework/pull/12062.
The bindToContext method in IFluidDataStoreContext can be removed in the next major version (2.0.0-internal.5.0.0).