### PR TITLE
Deprecated getGCDetailsBase and removed its usage

### DIFF
--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -215,6 +215,7 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     ensureNoDataModelChanges<T>(callback: () => T): T;
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
     getAudience(): IAudience;
+    // @deprecated (undocumented)
     getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
     // (undocumented)
     getCreateChildSummarizerNodeFn(

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -75,7 +75,6 @@ import {
 	IFluidDataStoreRegistry,
 	IFluidDataStoreChannel,
 	IGarbageCollectionData,
-	IGarbageCollectionDetailsBase,
 	IEnvelope,
 	IInboundSignalMessage,
 	ISignalEnvelope,
@@ -1202,7 +1201,6 @@ export class ContainerRuntime
 				(
 					summarizeInternal: SummarizeInternalFn,
 					getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-					getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>,
 				) =>
 					this.summarizerNode.createChild(
 						summarizeInternal,
@@ -1210,11 +1208,9 @@ export class ContainerRuntime
 						createParam,
 						undefined,
 						getGCDataFn,
-						getBaseGCDetailsFn,
 					),
 			(id: string) => this.summarizerNode.deleteChild(id),
 			this.mc.logger,
-			async () => this.garbageCollector.getBaseGCDetails(),
 			(path: string, timestampMs: number, packagePath?: readonly string[]) =>
 				this.garbageCollector.nodeUpdated(path, "Changed", timestampMs, packagePath),
 			(path: string) => this.garbageCollector.isNodeDeleted(path),

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -135,7 +135,6 @@ export interface ILocalFluidDataStoreContextProps extends IFluidDataStoreContext
 /** Properties necessary for creating a remote FluidDataStoreContext */
 export interface IRemoteFluidDataStoreContextProps extends IFluidDataStoreContextProps {
 	readonly snapshotTree: ISnapshotTree | undefined;
-	readonly getBaseGCDetails: () => Promise<IGarbageCollectionDetailsBase | undefined>;
 }
 
 /**
@@ -323,7 +322,6 @@ export abstract class FluidDataStoreContext
 		this.summarizerNode = props.createSummarizerNodeFn(
 			thisSummarizeInternal,
 			async (fullGC?: boolean) => this.getGCDataInternal(fullGC),
-			async () => this.getBaseGCDetails(),
 		);
 
 		this.mc = loggerToMonitoringContext(
@@ -821,7 +819,12 @@ export abstract class FluidDataStoreContext
 		this._isInMemoryRoot = true;
 	}
 
-	public abstract getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
+	/**
+	 * @deprecated - The functionality to get base GC details has been moved to summarizer node.
+	 */
+	public async getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase> {
+		return {};
+	}
 
 	public reSubmit(contents: any, localOpMetadata: unknown) {
 		assert(!!this.channel, 0x14b /* "Channel must exist when resubmitting ops" */);
@@ -928,7 +931,6 @@ export abstract class FluidDataStoreContext
 		return (
 			summarizeInternal: SummarizeInternalFn,
 			getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-			getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>,
 		) =>
 			this.summarizerNode.createChild(
 				summarizeInternal,
@@ -937,7 +939,6 @@ export abstract class FluidDataStoreContext
 				// DDS will not create failure summaries
 				{ throwOnFailure: true },
 				getGCDataFn,
-				getBaseGCDetailsFn,
 			);
 	}
 
@@ -948,7 +949,6 @@ export abstract class FluidDataStoreContext
 
 export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 	private readonly initSnapshotValue: ISnapshotTree | undefined;
-	private readonly baseGCDetailsP: Promise<IGarbageCollectionDetailsBase>;
 
 	constructor(props: IRemoteFluidDataStoreContextProps) {
 		super(props, true /* existing */, BindState.Bound, false /* isLocalDataStore */, () => {
@@ -956,9 +956,6 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 		});
 
 		this.initSnapshotValue = props.snapshotTree;
-		this.baseGCDetailsP = new LazyPromise<IGarbageCollectionDetailsBase>(async () => {
-			return (await props.getBaseGCDetails()) ?? {};
-		});
 
 		if (props.snapshotTree !== undefined) {
 			this.summarizerNode.updateBaseSummaryState(props.snapshotTree);
@@ -1016,10 +1013,6 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 
 	public async getInitialSnapshotDetails(): Promise<ISnapshotDetails> {
 		return this.initialSnapshotDetailsP;
-	}
-
-	public async getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase> {
-		return this.baseGCDetailsP;
 	}
 
 	public generateAttachMessage(): IAttachMessage {
@@ -1138,11 +1131,6 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
 			isRootDataStore,
 			snapshot,
 		};
-	}
-
-	public async getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase> {
-		// Local data store does not have initial summary.
-		return {};
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -21,7 +21,6 @@ import {
 	IEnvelope,
 	IFluidDataStoreContextDetached,
 	IGarbageCollectionData,
-	IGarbageCollectionDetailsBase,
 	IInboundSignalMessage,
 	InboundAttachMessage,
 	ISummarizeResult,
@@ -45,13 +44,9 @@ import {
 } from "@fluidframework/telemetry-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { BlobCacheStorageService, buildSnapshotTree } from "@fluidframework/driver-utils";
-import { assert, Lazy, LazyPromise } from "@fluidframework/common-utils";
+import { assert, Lazy } from "@fluidframework/common-utils";
 import { v4 as uuid } from "uuid";
-import {
-	GCDataBuilder,
-	unpackChildNodesGCDetails,
-	unpackChildNodesUsedRoutes,
-} from "@fluidframework/garbage-collector";
+import { GCDataBuilder, unpackChildNodesUsedRoutes } from "@fluidframework/garbage-collector";
 import { DataStoreContexts } from "./dataStoreContexts";
 import {
 	ContainerRuntime,
@@ -126,7 +121,6 @@ export class DataStores implements IDisposable {
 		) => CreateChildSummarizerNodeFn,
 		private readonly deleteChildSummarizerNodeFn: (id: string) => void,
 		baseLogger: ITelemetryBaseLogger,
-		getBaseGCDetails: () => Promise<IGarbageCollectionDetailsBase>,
 		private readonly gcNodeUpdated: (
 			nodePath: string,
 			timestampMs: number,
@@ -143,15 +137,6 @@ export class DataStores implements IDisposable {
 			this.runtime.IFluidHandleContext,
 		);
 
-		const baseGCDetailsP = new LazyPromise(async () => {
-			const baseGCDetails = await getBaseGCDetails();
-			return unpackChildNodesGCDetails(baseGCDetails);
-		});
-		// Returns the base GC details for the data store with the given id.
-		const dataStoreBaseGCDetails = async (dataStoreId: string) => {
-			const baseGCDetails = await baseGCDetailsP;
-			return baseGCDetails.get(dataStoreId);
-		};
 		// Tombstone should only throw when the feature flag is enabled and the client isn't a summarizer
 		this.throwOnTombstoneLoad =
 			this.mc.config.getBoolean(throwOnTombstoneLoadKey) === true &&
@@ -180,7 +165,6 @@ export class DataStores implements IDisposable {
 				dataStoreContext = new RemoteFluidDataStoreContext({
 					id: key,
 					snapshotTree: value,
-					getBaseGCDetails: async () => dataStoreBaseGCDetails(key),
 					runtime: this.runtime,
 					storage: this.runtime.storage,
 					scope: this.runtime.scope,
@@ -273,10 +257,6 @@ export class DataStores implements IDisposable {
 		const remoteFluidDataStoreContext = new RemoteFluidDataStoreContext({
 			id: attachMessage.id,
 			snapshotTree,
-			// New data stores begin with empty GC details since GC hasn't run on them yet.
-			getBaseGCDetails: async () => {
-				return {};
-			},
 			runtime: this.runtime,
 			storage: new BlobCacheStorageService(this.runtime.storage, flatBlobs),
 			scope: this.runtime.scope,

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -655,7 +655,6 @@ describe("Data Store Context Tests", () => {
 					remoteDataStoreContext = new RemoteFluidDataStoreContext({
 						id: dataStoreId,
 						snapshotTree,
-						getBaseGCDetails: async () => undefined,
 						runtime: containerRuntime,
 						storage: new BlobCacheStorageService(
 							storage as IDocumentStorageService,
@@ -710,8 +709,6 @@ describe("Data Store Context Tests", () => {
 						scope,
 						createSummarizerNodeFn,
 						snapshotTree: undefined,
-						getBaseGCDetails: async () =>
-							undefined as unknown as IGarbageCollectionDetailsBase,
 					});
 
 				assert.throws(codeBlock, (e: Error) =>
@@ -786,7 +783,6 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					getBaseGCDetails: async () => undefined,
 					runtime: containerRuntime,
 					storage: new BlobCacheStorageService(
 						storage as IDocumentStorageService,
@@ -839,7 +835,6 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					getBaseGCDetails: async () => undefined,
 					runtime: containerRuntime,
 					storage: new BlobCacheStorageService(
 						storage as IDocumentStorageService,
@@ -892,7 +887,6 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					getBaseGCDetails: async () => undefined,
 					runtime: containerRuntime,
 					storage: new BlobCacheStorageService(
 						storage as IDocumentStorageService,
@@ -947,7 +941,6 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					getBaseGCDetails: async () => undefined,
 					runtime: containerRuntime,
 					storage: new BlobCacheStorageService(
 						storage as IDocumentStorageService,
@@ -1023,7 +1016,6 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					getBaseGCDetails: async () => undefined,
 					runtime: containerRuntime,
 					storage: new BlobCacheStorageService(
 						storage as IDocumentStorageService,

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -52,7 +52,6 @@ import {
 	IFluidDataStoreContext,
 	IFluidDataStoreChannel,
 	IGarbageCollectionData,
-	IGarbageCollectionDetailsBase,
 	IInboundSignalMessage,
 	ISummaryTreeWithStats,
 	VisibilityState,
@@ -76,12 +75,7 @@ import {
 	IFluidDataStoreRuntimeEvents,
 	IChannelFactory,
 } from "@fluidframework/datastore-definitions";
-import {
-	GCDataBuilder,
-	removeRouteFromAllNodes,
-	unpackChildNodesGCDetails,
-	unpackChildNodesUsedRoutes,
-} from "@fluidframework/garbage-collector";
+import { GCDataBuilder, unpackChildNodesUsedRoutes } from "@fluidframework/garbage-collector";
 import { v4 as uuid } from "uuid";
 import { IChannelContext, summarizeChannel } from "./channelContext";
 import {
@@ -212,10 +206,6 @@ export class FluidDataStoreRuntime
 		return this.mc.logger;
 	}
 
-	// A map of child channel context ids to the their base GC details. This is used to initialize the GC state of the
-	// channel contexts.
-	private readonly channelsBaseGCDetails: LazyPromise<Map<string, IGarbageCollectionDetailsBase>>;
-
 	/**
 	 * If the summarizer makes local changes, a telemetry event is logged. This has the potential to be very noisy.
 	 * So, adding a count of how many telemetry events are logged per data store context. This can be
@@ -276,11 +266,6 @@ export class FluidDataStoreRuntime
 
 		const tree = dataStoreContext.baseSnapshot;
 
-		this.channelsBaseGCDetails = new LazyPromise(async () => {
-			const baseGCDetails = await this.dataStoreContext.getBaseGCDetails();
-			return unpackChildNodesGCDetails(baseGCDetails);
-		});
-
 		// Must always receive the data store type inside of the attributes
 		if (tree?.trees !== undefined) {
 			Object.keys(tree.trees).forEach((path) => {
@@ -337,7 +322,6 @@ export class FluidDataStoreRuntime
 						this.dataStoreContext.getCreateChildSummarizerNodeFn(path, {
 							type: CreateSummarizerNodeSource.FromSummary,
 						}),
-						async () => this.getChannelBaseGCDetails(path),
 					);
 				}
 				const deferred = new Deferred<IChannelContext>();
@@ -657,7 +641,6 @@ export class FluidDataStoreRuntime
 								sequenceNumber: message.sequenceNumber,
 								snapshot: attachMessage.snapshot,
 							}),
-							async () => this.getChannelBaseGCDetails(id),
 							attachMessage.type,
 						);
 
@@ -804,34 +787,6 @@ export class FluidDataStoreRuntime
 	 */
 	private addedGCOutboundReference(srcHandle: IFluidHandle, outboundHandle: IFluidHandle) {
 		this.dataStoreContext.addedGCOutboundReference?.(srcHandle, outboundHandle);
-	}
-
-	/**
-	 * Returns the base GC details for the channel with the given id. This is used to initialize its GC state.
-	 * @param channelId - The id of the channel context that is asked for the initial GC details.
-	 * @returns the requested channel's base GC details.
-	 */
-	private async getChannelBaseGCDetails(
-		channelId: string,
-	): Promise<IGarbageCollectionDetailsBase> {
-		let channelBaseGCDetails = (await this.channelsBaseGCDetails).get(channelId);
-		if (channelBaseGCDetails === undefined) {
-			channelBaseGCDetails = {};
-		} else if (channelBaseGCDetails.gcData?.gcNodes !== undefined) {
-			// Note: if the child channel has an explicit handle route to its parent, it will be removed here and
-			// expected to be added back by the parent when getGCData is called.
-			removeRouteFromAllNodes(channelBaseGCDetails.gcData.gcNodes, this.absolutePath);
-		}
-
-		// Currently, channel context's are always considered used. So, it there are no used routes for it, we still
-		// need to mark it as used. Add self-route (empty string) to the channel context's used routes.
-		if (
-			channelBaseGCDetails.usedRoutes === undefined ||
-			channelBaseGCDetails.usedRoutes.length === 0
-		) {
-			channelBaseGCDetails.usedRoutes = [""];
-		}
-		return channelBaseGCDetails;
 	}
 
 	/**

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -20,7 +20,6 @@ import {
 	CreateChildSummarizerNodeFn,
 	IFluidDataStoreContext,
 	IGarbageCollectionData,
-	IGarbageCollectionDetailsBase,
 	ISummarizeInternalResult,
 	ISummarizeResult,
 	ISummarizerNodeWithGC,
@@ -63,7 +62,6 @@ export class RemoteChannelContext implements IChannelContext {
 		private readonly registry: ISharedObjectRegistry,
 		extraBlobs: Map<string, ArrayBufferLike> | undefined,
 		createSummarizerNode: CreateChildSummarizerNodeFn,
-		getBaseGCDetails: () => Promise<IGarbageCollectionDetailsBase>,
 		private readonly attachMessageType?: string,
 	) {
 		assert(!this.id.includes("/"), 0x310 /* Channel context ID cannot contain slashes */);
@@ -91,7 +89,6 @@ export class RemoteChannelContext implements IChannelContext {
 		this.summarizerNode = createSummarizerNode(
 			thisSummarizeInternal,
 			async (fullGC?: boolean) => this.getGCDataInternal(fullGC),
-			async () => getBaseGCDetails(),
 		);
 
 		this.thresholdOpsCounter = new ThresholdCounter(

--- a/packages/runtime/datastore/src/test/remoteChannelContext.spec.ts
+++ b/packages/runtime/datastore/src/test/remoteChannelContext.spec.ts
@@ -8,7 +8,6 @@ import {
 	CreateChildSummarizerNodeFn,
 	IContainerRuntimeBase,
 	IFluidDataStoreContext,
-	IGarbageCollectionDetailsBase,
 } from "@fluidframework/runtime-definitions";
 import {
 	MockFluidDataStoreContext,
@@ -52,7 +51,6 @@ describe("RemoteChannelContext Tests", () => {
 				sharedObjectRegistry,
 				undefined,
 				undefined as unknown as CreateChildSummarizerNodeFn,
-				async () => undefined as unknown as IGarbageCollectionDetailsBase,
 				"SomeAttachMessageType",
 			);
 		assert.throws(

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -479,6 +479,8 @@ export interface IFluidDataStoreContext
 	uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
 
 	/**
+	 * @deprecated - The functionality to get base GC details has been moved to summarizer node.
+	 *
 	 * Returns the GC details in the initial summary of this data store. This is used to initialize the data store
 	 * and its children with the GC details from the previous summary.
 	 */


### PR DESCRIPTION
The logic to initialize the base GC details of data stores / DDS was moved to summarizer node with GC in this PR -https://github.com/microsoft/FluidFramework/pull/13455.
Deprecated the getBaseDetails() function from IFluidDataStoreRuntime and CreateChildSummarizerNodeFn and removed all usages in container-runtime and datastore-runtime layers. The function is still present in FluidDataStoreContext for back-compat but returns an empty object.