### PR TITLE
Add upcoming breaking notes for bindToContext and getBaseGCDetails deprecation

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -19,6 +19,16 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 
 ## 2.0.0-internal.4.0.0 Upcoming changes
 
+-   [bindToContext deprecated in IFluidDataStoreContext](#bindToContext-deprecated-in-IFluidDataStoreContext)
+-   [getBaseGCDetails deprecated in IFluidDataStoreContext and CreateChildSummarizerNodeFn](#getBaseGCDetails-deprecated-in-IFluidDataStoreContext-and-CreateChildSummarizerNodeFn)
+
+### bindToContext deprecated in IFluidDataStoreContext
+
+`bindToContext` in IFluidDataStoreContext was deprecated in 2.0.0-internal.2.0.0. This is a heads up that it will be removed in 2.0.0-internal.5.0.0. Its usage in FluidDataStoreRuntime was removed in this release.
+
+### getBaseGCDetails deprecated in IFluidDataStoreContext and CreateChildSummarizerNodeFn
+getBaseGCDetails() has been deprecated in IFluidDataStoreContext and CreateChildSummarizerNodeFn. The functionality to update the base GC details of nodes has been moved to summarizer nodes. These will be removed in 2.0.0-internal.5.0.0.
+
 ## 2.0.0-internal.4.0.0 Breaking changes
 
 -   [Container and RelativeLoader no longer exported](#Container-and-RelativeLoader-no-longer-exported)


### PR DESCRIPTION
bindToContext and getBaseGCDetails have been deprecated. See https://github.com/microsoft/FluidFramework/pull/14194 and https://github.com/microsoft/FluidFramework/pull/14196 for details.
This change adds a note in breaking.md for their deprecation and subsequent removal.