### PR TITLE
Deprecate IFluidTokenProvider

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -26,6 +26,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 -   [Container and RelativeLoader deprecated](#container-and-relativeloader-deprecated)
 -   [BlobAggregationStorage and SnapshotExtractor deprecated](#blobaggregationstorage-and-snapshotextractor-deprecated)
 -   [Summarizer node and related items deprecated](#Summarizer-node-and-related-items-deprecated)
+-   [ContainerRuntime IFluidTokenProvider member deprecated](#ContainerRuntime-IFluidTokenProvider-member-deprecated)
 
 ### For Driver Authors: Document Storage Service policy may become required
 
@@ -82,6 +83,10 @@ The following functions, interfaces, and types currently available in `@fluidfra
 -   `IRootSummarizerNodeWithGC`
 -   `ISummarizerNodeRootContract`
 -   `RefreshSummaryResult`
+
+### ContainerRuntime IFluidTokenProvider member deprecated
+
+`ContainerRuntime.IFluidTokenProvider` has been deprecated and will be removed in an upcoming release. Token providers should be accessed using normal provider patterns.
 
 ## 2.0.0-internal.3.0.0 Breaking changes
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -26,7 +26,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 -   [Container and RelativeLoader deprecated](#container-and-relativeloader-deprecated)
 -   [BlobAggregationStorage and SnapshotExtractor deprecated](#blobaggregationstorage-and-snapshotextractor-deprecated)
 -   [Summarizer node and related items deprecated](#Summarizer-node-and-related-items-deprecated)
--   [ContainerRuntime IFluidTokenProvider member deprecated](#ContainerRuntime-IFluidTokenProvider-member-deprecated)
+-   [IFluidTokenProvider deprecated](#IFluidTokenProvider-deprecated)
 
 ### For Driver Authors: Document Storage Service policy may become required
 
@@ -84,9 +84,11 @@ The following functions, interfaces, and types currently available in `@fluidfra
 -   `ISummarizerNodeRootContract`
 -   `RefreshSummaryResult`
 
-### ContainerRuntime IFluidTokenProvider member deprecated
+### IFluidTokenProvider deprecated
 
-`ContainerRuntime.IFluidTokenProvider` has been deprecated and will be removed in an upcoming release. Token providers should be accessed using normal provider patterns.
+The IFluidTokenProvider interface has been deprecated and will be removed in an upcoming release. Fluid Framework does not prescribe a particular approach to token providers.
+
+`ContainerRuntime.IFluidTokenProvider` has also been deprecated and will be removed in an upcoming release. Token providers, like any dependency, should be accessed using normal provider patterns.
 
 ## 2.0.0-internal.3.0.0 Breaking changes
 

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -383,10 +383,10 @@ export interface IFluidPackageEnvironment {
     };
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const IFluidTokenProvider: keyof IProvideFluidTokenProvider;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IFluidTokenProvider extends IProvideFluidTokenProvider {
     // (undocumented)
     intelligence: {
@@ -452,7 +452,7 @@ export interface IProvideFluidCodeDetailsComparer {
     readonly IFluidCodeDetailsComparer: IFluidCodeDetailsComparer;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IProvideFluidTokenProvider {
     // (undocumented)
     readonly IFluidTokenProvider: IFluidTokenProvider;

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -155,7 +155,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     get IFluidHandleContext(): IFluidHandleContext;
     // (undocumented)
     get IFluidRouter(): this;
-    // (undocumented)
+    // @deprecated (undocumented)
     get IFluidTokenProvider(): IFluidTokenProvider | undefined;
     get isDirty(): boolean;
     // @deprecated (undocumented)

--- a/packages/common/container-definitions/src/tokenProvider.ts
+++ b/packages/common/container-definitions/src/tokenProvider.ts
@@ -3,12 +3,21 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * @deprecated Fluid Framework does not prescribe a particular approach to token providers.
+ */
 export const IFluidTokenProvider: keyof IProvideFluidTokenProvider = "IFluidTokenProvider";
 
+/**
+ * @deprecated Fluid Framework does not prescribe a particular approach to token providers.
+ */
 export interface IProvideFluidTokenProvider {
 	readonly IFluidTokenProvider: IFluidTokenProvider;
 }
 
+/**
+ * @deprecated Fluid Framework does not prescribe a particular approach to token providers.
+ */
 export interface IFluidTokenProvider extends IProvideFluidTokenProvider {
 	intelligence: { [service: string]: any };
 }

--- a/packages/common/container-definitions/src/tokenProvider.ts
+++ b/packages/common/container-definitions/src/tokenProvider.ts
@@ -4,19 +4,19 @@
  */
 
 /**
- * @deprecated Fluid Framework does not prescribe a particular approach to token providers.
+ * @deprecated 2.0.0-internal.3.2.0 Fluid Framework does not prescribe a particular approach to token providers.
  */
 export const IFluidTokenProvider: keyof IProvideFluidTokenProvider = "IFluidTokenProvider";
 
 /**
- * @deprecated Fluid Framework does not prescribe a particular approach to token providers.
+ * @deprecated 2.0.0-internal.3.2.0 Fluid Framework does not prescribe a particular approach to token providers.
  */
 export interface IProvideFluidTokenProvider {
 	readonly IFluidTokenProvider: IFluidTokenProvider;
 }
 
 /**
- * @deprecated Fluid Framework does not prescribe a particular approach to token providers.
+ * @deprecated 2.0.0-internal.3.2.0 Fluid Framework does not prescribe a particular approach to token providers.
  */
 export interface IFluidTokenProvider extends IProvideFluidTokenProvider {
 	intelligence: { [service: string]: any };

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1468,6 +1468,9 @@ export class ContainerRuntime
 		this.removeAllListeners();
 	}
 
+	/**
+	 * @deprecated ContainerRuntime is not an IFluidTokenProvider.  Token providers should be accessed using normal provider patterns.
+	 */
 	public get IFluidTokenProvider() {
 		if (this.options?.intelligence) {
 			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1469,7 +1469,7 @@ export class ContainerRuntime
 	}
 
 	/**
-	 * @deprecated ContainerRuntime is not an IFluidTokenProvider.  Token providers should be accessed using normal provider patterns.
+	 * @deprecated 2.0.0-internal.3.2.0 ContainerRuntime is not an IFluidTokenProvider.  Token providers should be accessed using normal provider patterns.
 	 */
 	public get IFluidTokenProvider() {
 		if (this.options?.intelligence) {


### PR DESCRIPTION
It doesn't seem that we need to prescribe any particular token provider pattern, and this interface seems generally unused at this point.  To be removed in `next`.

Also, there should be no built-in expectation that ContainerRuntime is an IFluidTokenProvider - dependencies like this are better injected through other means.  Also to be removed in `next`.