### PR TITLE
Fixing perf benchmark config

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
@@ -13,7 +13,8 @@ import { ITestContainerConfig, ITestObjectProvider } from "@fluidframework/test-
 import { describeNoCompat, ITestDataObject } from "@fluidframework/test-version-utils";
 import { benchmarkMemory, IMemoryTestObject } from "@fluid-tools/benchmark";
 import { ISummaryBlob, SummaryType } from "@fluidframework/protocol-definitions";
-import { bufferToString, TelemetryNullLogger } from "@fluidframework/common-utils";
+import { bufferToString } from "@fluidframework/common-utils";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { createLogger } from "./FileLogger";
 
 const defaultDataStoreId = "default";

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.time.spec.ts
@@ -13,7 +13,8 @@ import { ITestContainerConfig, ITestObjectProvider } from "@fluidframework/test-
 import { describeNoCompat, ITestDataObject } from "@fluidframework/test-version-utils";
 import { benchmark } from "@fluid-tools/benchmark";
 import { ISummaryBlob, SummaryType } from "@fluidframework/protocol-definitions";
-import { bufferToString, TelemetryNullLogger } from "@fluidframework/common-utils";
+import { bufferToString } from "@fluidframework/common-utils";
+import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import { createLogger } from "./FileLogger";
 
 const defaultDataStoreId = "default";

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -13,10 +13,6 @@ parameters:
 - name: artifactPipeline
   type: string
 
-- name: env
-  type: object
-  default:
-
 # Custom steps specified by the "caller" of this template, to actually run perf tests
 - name: customSteps
   type: stepList

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -491,7 +491,7 @@ stages:
               fi
           env:
             FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-            FLUID_BUILD_ID: ${{ variables.artifactBuildId }}
+            FLUID_BUILD_ID: $(Build.BuildId)
 
         - task: Bash@3
           displayName: Write measurements to Aria/Kusto - execution time local
@@ -548,13 +548,26 @@ stages:
             FLUID_ENDPOINTNAME: "local"
 
         - task: Bash@3
+          displayName: Remove Output Folders
+          inputs:
+            targetType: 'inline'
+            workingDirectory: $(toolAbsolutePath)
+            script: |
+              ls -laR ${{ variables.executionTimeTestOutputFolder }};
+              echo "Cleanup  ${{ variables.executionTimeTestOutputFolder }}"
+              rm -rf ${{ variables.executionTimeTestOutputFolder }};
+              ls -laR ${{ variables.memoryUsageTestOutputFolder }};
+              echo "Cleanup  ${{ variables.memoryUsageTestOutputFolder }}"
+              rm -rf ${{ variables.memoryUsageTestOutputFolder }};
+
+        - task: Bash@3
           displayName: Run tests ODSP
           inputs:
             targetType: 'inline'
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}
             script: |
               echo "FLUID_TEST_LOGGER_PKG_PATH= ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger"
-              echo "FLUID_BUILD_ID ${{ variables.artifactBuildId }}"
+              echo "FLUID_BUILD_ID $(Build.BuildId)"
 
               # Run execution time tests
               echo "FLUID_ENDPOINTNAME = odsp"
@@ -582,7 +595,7 @@ stages:
             login__microsoft__secret: $(login-microsoft-secret)
             login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
             FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-            FLUID_BUILD_ID: ${{ variables.artifactBuildId }}
+            FLUID_BUILD_ID: $(Build.BuildId)
             FLUID_ENDPOINTNAME: odsp
 
         - task: Bash@3


### PR DESCRIPTION
## Description

Addressing some outstanding comments from [the perf benchmark change that added ODSP and a telemetry logger](https://github.com/microsoft/FluidFramework/pull/14128): 

- Small fixes to the performance benchmark configuration to use actual build id, 
- clean-up env variable from the config file and 
- reference telemetryNullLogger from telemetry-utils instead of common-utils 