### PR TITLE
[bump] tinylicious: 0.5.0 => 0.6.0 (minor)

### DIFF
--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tinylicious",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tinylicious",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "Tiny, test implementation of the routerlicious reference service",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Bumped tinylicious from 0.5.0 to 0.6.0.

Done using command: `flub release -p tinylicious --no-policyCheck`
