### PR TITLE
[bump] tinylicious: 0.6.0 => 0.7.0 (minor)

### DIFF
--- a/server/tinylicious/package-lock.json
+++ b/server/tinylicious/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tinylicious",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tinylicious",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"description": "Tiny, test implementation of the routerlicious reference service",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Bumped tinylicious from 0.6.0 to 0.7.0 to prepare release for 0.6.0.

Changes done manually as previous 0.6.0 bump was missed (flub does not support this use case even with --no-policy-check)