### PR TITLE
feat(generate:typetests): Move typetest config to external file

### DIFF
--- a/build-tools/packages/build-tools/src/common/fluidRepo.ts
+++ b/build-tools/packages/build-tools/src/common/fluidRepo.ts
@@ -55,7 +55,7 @@ export interface IFluidBuildConfig {
 		[name: string]: VersionBumpType | PreviousVersionStyle;
 	};
 
-	typeTests?: ITypeValidation;
+	typeTests?: ITypeValidationConfig;
 }
 
 /**
@@ -81,7 +81,7 @@ export interface BrokenCompatSettings {
  */
 export type BrokenCompatTypes = Partial<Record<string, BrokenCompatSettings>>;
 
-export interface ITypeValidation {
+export interface ITypeValidationConfig {
 	/**
 	 * The version of the package. Should match the version field in package.json.
 	 */

--- a/build-tools/packages/build-tools/src/common/fluidRepo.ts
+++ b/build-tools/packages/build-tools/src/common/fluidRepo.ts
@@ -55,7 +55,7 @@ export interface IFluidBuildConfig {
 		[name: string]: VersionBumpType | PreviousVersionStyle;
 	};
 
-	typeValidation?: ITypeValidation;
+	typeTests?: ITypeValidation;
 }
 
 /**

--- a/build-tools/packages/build-tools/src/common/fluidRepo.ts
+++ b/build-tools/packages/build-tools/src/common/fluidRepo.ts
@@ -54,6 +54,8 @@ export interface IFluidBuildConfig {
 	branchReleaseTypes?: {
 		[name: string]: VersionBumpType | PreviousVersionStyle;
 	};
+
+	typeValidation?: ITypeValidation;
 }
 
 /**
@@ -64,6 +66,54 @@ export interface PolicyConfig {
 	dependencies?: {
 		requireTilde?: string[];
 	};
+}
+
+/**
+ * Metadata about known-broken types.
+ */
+export interface BrokenCompatSettings {
+	backCompat?: false;
+	forwardCompat?: false;
+}
+
+/**
+ * A mapping of a type name to its {@link BrokenCompatSettings}.
+ */
+export type BrokenCompatTypes = Partial<Record<string, BrokenCompatSettings>>;
+
+export interface ITypeValidation {
+	/**
+	 * The version of the package. Should match the version field in package.json.
+	 */
+	version: string;
+
+	/**
+	 * An object containing types that are known to be broken.
+	 */
+	broken: BrokenCompatTypes;
+
+	/**
+	 * If true, disables type test preparation and generation for the package.
+	 */
+	disabled?: boolean;
+
+	/**
+	 * The previous version style that was used when the prepare phase was run. This value is cached so that
+	 * generation can work even on branches without the correct config.
+	 */
+	previousVersionStyle?: PreviousVersionStyle;
+
+	/**
+	 * The version range used as the "previous" version to compare against when generating type tests. This may be
+	 * an exact version or a range string.
+	 */
+	baselineRange?: string;
+
+	/**
+	 * The exact version used as the "previous" version to compare against when generating type tests. This should
+	 * always be an exact version.
+	 */
+	baselineVersion?: string;
 }
 
 /**

--- a/build-tools/packages/build-tools/src/common/fluidRepo.ts
+++ b/build-tools/packages/build-tools/src/common/fluidRepo.ts
@@ -54,8 +54,6 @@ export interface IFluidBuildConfig {
 	branchReleaseTypes?: {
 		[name: string]: VersionBumpType | PreviousVersionStyle;
 	};
-
-	typeTests?: ITypeValidationConfig;
 }
 
 /**

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -66,17 +66,18 @@ export interface PackageJson {
 	engines: { node: string; npm: string };
 	os: string[];
 	cpu: string[];
-	[key: string]: any;
-
 	/**
 	 * type compatibility test configuration. This only takes effect when set in the package.json of a package. Setting
 	 * it at the root of the repo or release group has no effect.
 	 */
 	typeValidation?: ITypeValidation;
+
 	/**
 	 * fluid-build config. Some properties only apply when set in the root or release group root package.json.
 	 */
 	fluidBuild?: IFluidBuildConfig;
+
+	[key: string]: any;
 }
 
 export class Package {

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -10,7 +10,7 @@ import * as path from "path";
 import sortPackageJson from "sort-package-json";
 
 import { options } from "../fluidBuild/options";
-import { type IFluidBuildConfig, type ITypeValidation } from "./fluidRepo";
+import { type IFluidBuildConfig, type ITypeValidationConfig } from "./fluidRepo";
 import { defaultLogger } from "./logging";
 import { MonoRepo, MonoRepoKind, PackageManager } from "./monoRepo";
 import {
@@ -70,7 +70,7 @@ export interface PackageJson {
 	 * type compatibility test configuration. This only takes effect when set in the package.json of a package. Setting
 	 * it at the root of the repo or release group has no effect.
 	 */
-	typeValidation?: ITypeValidation;
+	typeValidation?: ITypeValidationConfig;
 
 	/**
 	 * fluid-build config. Some properties only apply when set in the root or release group root package.json.

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -10,8 +10,7 @@ import * as path from "path";
 import sortPackageJson from "sort-package-json";
 
 import { options } from "../fluidBuild/options";
-import type { PreviousVersionStyle } from "../typeValidator/packageJson";
-import { IFluidBuildConfig } from "./fluidRepo";
+import { type IFluidBuildConfig, type ITypeValidation } from "./fluidRepo";
 import { defaultLogger } from "./logging";
 import { MonoRepo, MonoRepoKind, PackageManager } from "./monoRepo";
 import {
@@ -70,62 +69,15 @@ export interface PackageJson {
 	[key: string]: any;
 
 	/**
-	 * fluid-build config. Some properties only apply when set in the root or release group root package.json.
-	 */
-	fluidBuild?: IFluidBuildConfig;
-
-	/**
 	 * type compatibility test configuration. This only takes effect when set in the package.json of a package. Setting
 	 * it at the root of the repo or release group has no effect.
 	 */
-	typeValidation?: {
-		/**
-		 * The version of the package. Should match the version field in package.json.
-		 */
-		version: string;
-
-		/**
-		 * An object containing types that are known to be broken.
-		 */
-		broken: BrokenCompatTypes;
-
-		/**
-		 * If true, disables type test preparation and generation for the package.
-		 */
-		disabled?: boolean;
-
-		/**
-		 * The previous version style that was used when the prepare phase was run. This value is cached so that
-		 * generation can work even on branches without the correct config.
-		 */
-		previousVersionStyle?: PreviousVersionStyle;
-
-		/**
-		 * The version range used as the "previous" version to compare against when generating type tests. This may be
-		 * an exact version or a range string.
-		 */
-		baselineRange?: string;
-
-		/**
-		 * The exact version used as the "previous" version to compare against when generating type tests. This should
-		 * always be an exact version.
-		 */
-		baselineVersion?: string;
-	};
+	typeValidation?: ITypeValidation;
+	/**
+	 * fluid-build config. Some properties only apply when set in the root or release group root package.json.
+	 */
+	fluidBuild?: IFluidBuildConfig;
 }
-
-/**
- * Metadata about known-broken types.
- */
-export interface BrokenCompatSettings {
-	backCompat?: false;
-	forwardCompat?: false;
-}
-
-/**
- * A mapping of a type name to its {@link BrokenCompatSettings}.
- */
-export type BrokenCompatTypes = Partial<Record<string, BrokenCompatSettings>>;
 
 export class Package {
 	private static packageCount: number = 0;

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -24,7 +24,7 @@ import { BuildPackage, BuildResult, summarizeBuildResult } from "../../buildGrap
 import { options } from "../../options";
 import { Task, TaskExec } from "../task";
 
-const { info, verbose } = defaultLogger;
+const { info, verbose, warning } = defaultLogger;
 const traceTaskTrigger = registerDebug("fluid-build:task:trigger");
 const traceTaskDep = registerDebug("fluid-build:task:dep");
 interface TaskExecResult extends ExecAsyncResult {
@@ -417,9 +417,9 @@ export abstract class LeafWithDoneFileTask extends LeafTask {
 					`${this.node.pkg.nameColored}: warning: unable to generate content for ${doneFileFullPath}`,
 				);
 			}
-		} catch {
+		} catch (error) {
 			console.warn(
-				`${this.node.pkg.nameColored}: warning: unable to write ${doneFileFullPath}`,
+				`${this.node.pkg.nameColored}: warning: unable to write ${doneFileFullPath}\n error: ${error}`,
 			);
 		}
 	}

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/miscTasks.ts
@@ -9,6 +9,7 @@ import * as path from "path";
 import { defaultLogger } from "../../../common/logging";
 import { ScriptDependencies } from "../../../common/npmPackage";
 import { globFn, readFileAsync, statAsync, toPosixPath, unquote } from "../../../common/utils";
+import { getPackageDetails } from "../../../typeValidator/packageJson";
 import { BuildPackage } from "../../buildGraph";
 import { LeafTask, LeafWithDoneFileTask } from "./leafTask";
 
@@ -195,12 +196,13 @@ export class GenVerTask extends LeafTask {
 	}
 }
 
-export abstract class PackageJsonChangedTask extends LeafWithDoneFileTask {
+export class TypeValidationTask extends LeafWithDoneFileTask {
 	protected async getDoneFileContent(): Promise<string | undefined> {
-		return JSON.stringify(this.package.packageJson);
+		const details = await getPackageDetails(this.package.directory);
+		const content =
+			JSON.stringify(this.package.packageJson) + JSON.stringify(details.typeValidation);
+		return content;
 	}
-}
 
-export class TypeValidationTask extends PackageJsonChangedTask {
 	protected addDependentTasks(dependentTasks: LeafTask[]): void {}
 }

--- a/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
@@ -67,7 +67,7 @@ export async function getPackageDetails(packageDir: string): Promise<PackageDeta
 
 	// use load instead of search because we don't want to recurse up the directory tree looking for configs
 	const result =
-		configExplorer.load("package.json") ?? configExplorer.load("typeValidation.config.json");
+		configExplorer.load("typeValidation.config.json") ?? configExplorer.load("package.json");
 	const config = result?.config;
 	console.log(`loaded from: ${result?.filepath}`);
 

--- a/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
@@ -69,8 +69,6 @@ export async function getPackageDetails(packageDir: string): Promise<PackageDeta
 	const result =
 		configExplorer.load("typeValidation.config.json") ?? configExplorer.load("package.json");
 	const config = result?.config;
-	console.log(`loaded from: ${result?.filepath}`);
-
 	const pkgJson: PackageJson = await readJson(packagePath);
 	const oldVersions: string[] = Object.keys(pkgJson.devDependencies ?? {}).filter((k) =>
 		k.startsWith(pkgJson.name),

--- a/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
@@ -23,7 +23,7 @@ import {
 import { Context } from "../bumpVersion/context";
 import { Logger, defaultLogger } from "../common/logging";
 import { PackageJson } from "../common/npmPackage";
-import { BrokenCompatTypes, ITypeValidation } from "../common/fluidRepo";
+import { BrokenCompatTypes, ITypeValidationConfig } from "../common/fluidRepo";
 import { existsSync, readJson, writeJson } from "fs-extra";
 import { resolve } from "path";
 
@@ -32,7 +32,7 @@ export type PackageDetails = {
 	readonly oldVersions: readonly string[];
 	readonly broken: BrokenCompatTypes;
 	readonly json: PackageJson;
-	typeValidation: ITypeValidation;
+	typeValidation: ITypeValidationConfig;
 };
 
 function createSortedObject<T>(obj: Record<string, T>): Record<string, T> {

--- a/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/packageJson.ts
@@ -21,7 +21,8 @@ import {
 
 import { Context } from "../bumpVersion/context";
 import { Logger, defaultLogger } from "../common/logging";
-import { BrokenCompatTypes, PackageJson } from "../common/npmPackage";
+import { PackageJson } from "../common/npmPackage";
+import { BrokenCompatTypes } from "../common/fluidRepo";
 
 export type PackageDetails = {
 	readonly packageDir: string;

--- a/build-tools/packages/build-tools/src/typeValidator/typeData.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/typeData.ts
@@ -7,6 +7,16 @@ import { Node, Project, ts } from "ts-morph";
 
 import { PackageDetails, getPackageDetails } from "./packageJson";
 
+/**
+ * The name of the config file that is used to store type validation config.
+ */
+export const typeValidationConfigFile = "type-validation.config.json";
+
+/**
+ * The name of the property in package.json that holds type validation config.
+ */
+export const typeValidationPropertyName = "typeValidation";
+
 export interface PackageAndTypeData {
 	packageDetails: PackageDetails;
 	typeData: TypeData[];


### PR DESCRIPTION
Typetest config is stored in package.json today, but this causes a lot of churn in package.json when we release and typetests are updated. This PR tries to load the type test config from a type-validation.config.json file so it's separate from package.json. Config will fall back to loading from package.json if that file is missing.

This should help main/next integrations be a little simpler. When merging from main to next, for the typetest files either side can be accepted, because re-running generation with the `--branch` argument will always write the correct values for next.

BREAKING CHANGE: We now prefer external files for the typetest config, so when running, it will always output to the external config file, and will remove the package.json typeValidation node.