### PR TITLE
build(client): Fix build break due to renamed packages

### DIFF
--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -40,6 +40,7 @@
 	},
 	"dependencies": {
 		"@fluid-example/example-utils": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
+		"@fluid-example/schemas": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluid-experimental/property-binder": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluid-experimental/property-changeset": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluid-experimental/property-common": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
@@ -47,7 +48,6 @@
 		"@fluid-experimental/property-inspector-table": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluid-experimental/property-properties": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluid-experimental/property-proxy": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
-		"@fluid-experimental/schemas": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/aqueduct": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/common-utils": "^1.1.1",
 		"@fluidframework/container-definitions": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",

--- a/experimental/PropertyDDS/examples/partial-checkout/src/demo/squaresApp.ts
+++ b/experimental/PropertyDDS/examples/partial-checkout/src/demo/squaresApp.ts
@@ -8,7 +8,7 @@ import { ContainerProperty, PropertyFactory } from "@fluid-experimental/property
 // import { IPropertyTree } from "../dataObject";
 import { DataBinder } from "@fluid-experimental/property-binder";
 import _ from "lodash";
-import { SQUARES_DEMO_SCHEMAS } from "@fluid-experimental/schemas";
+import { SQUARES_DEMO_SCHEMAS } from "@fluid-example/schemas";
 import { assert } from "@fluidframework/common-utils";
 import { IPropertyTree } from "../dataObject";
 import { renderMoveButton } from "../view";

--- a/experimental/PropertyDDS/examples/property-inspector/README.md
+++ b/experimental/PropertyDDS/examples/property-inspector/README.md
@@ -12,7 +12,7 @@ Go back to the root folder and run:
 pnpm install
 alias fb='clear && node "$(git rev-parse --show-toplevel)/node_modules/.bin/fluid-build"'
 fb --install --symlink:full
-fb --all @fluid-experimental/property-inspector tinylicious
+fb --all @fluid-example/property-inspector tinylicious
 ```
 
 You can then run the example with:

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -40,6 +40,7 @@
 	},
 	"dependencies": {
 		"@fluid-example/example-utils": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
+		"@fluid-example/schemas": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluid-experimental/property-binder": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluid-experimental/property-changeset": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluid-experimental/property-common": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
@@ -47,7 +48,6 @@
 		"@fluid-experimental/property-inspector-table": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluid-experimental/property-properties": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluid-experimental/property-proxy": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
-		"@fluid-experimental/schemas": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/aqueduct": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/common-utils": "^1.1.1",
 		"@fluidframework/container-definitions": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",

--- a/experimental/PropertyDDS/examples/property-inspector/src/app.tsx
+++ b/experimental/PropertyDDS/examples/property-inspector/src/app.tsx
@@ -5,7 +5,7 @@
 
 import { StaticCodeLoader, TinyliciousModelLoader } from "@fluid-example/example-utils";
 import { PropertyFactory } from "@fluid-experimental/property-properties";
-import { registerSchemas } from "@fluid-experimental/schemas";
+import { registerSchemas } from "@fluid-example/schemas";
 
 import { PropertyTreeContainerRuntimeFactory, IPropertyTreeAppModel } from "./containerCode";
 import { renderApp } from "./inspector";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2864,6 +2864,7 @@ importers:
   experimental/PropertyDDS/examples/partial-checkout:
     specifiers:
       '@fluid-example/example-utils': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
+      '@fluid-example/schemas': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluid-experimental/property-binder': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluid-experimental/property-changeset': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluid-experimental/property-common': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
@@ -2871,7 +2872,6 @@ importers:
       '@fluid-experimental/property-inspector-table': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluid-experimental/property-properties': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluid-experimental/property-proxy': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
-      '@fluid-experimental/schemas': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluidframework/aqueduct': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/common-utils': ^1.1.1
@@ -2928,6 +2928,7 @@ importers:
       webpack-dev-server: ~4.6.0
     dependencies:
       '@fluid-example/example-utils': link:../../../../examples/utils/example-utils
+      '@fluid-example/schemas': link:../schemas
       '@fluid-experimental/property-binder': link:../../packages/property-binder
       '@fluid-experimental/property-changeset': link:../../packages/property-changeset
       '@fluid-experimental/property-common': link:../../packages/property-common
@@ -2935,7 +2936,6 @@ importers:
       '@fluid-experimental/property-inspector-table': link:../../packages/property-inspector-table
       '@fluid-experimental/property-properties': link:../../packages/property-properties
       '@fluid-experimental/property-proxy': link:../../packages/property-proxy
-      '@fluid-experimental/schemas': link:../schemas
       '@fluidframework/aqueduct': link:../../../../packages/framework/aqueduct
       '@fluidframework/common-utils': 1.1.1
       '@fluidframework/container-definitions': link:../../../../packages/common/container-definitions
@@ -2995,6 +2995,7 @@ importers:
   experimental/PropertyDDS/examples/property-inspector:
     specifiers:
       '@fluid-example/example-utils': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
+      '@fluid-example/schemas': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluid-experimental/property-binder': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluid-experimental/property-changeset': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluid-experimental/property-common': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
@@ -3002,7 +3003,6 @@ importers:
       '@fluid-experimental/property-inspector-table': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluid-experimental/property-properties': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluid-experimental/property-proxy': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
-      '@fluid-experimental/schemas': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluidframework/aqueduct': '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/common-utils': ^1.1.1
@@ -3063,6 +3063,7 @@ importers:
       webpack-dev-server: ~4.6.0
     dependencies:
       '@fluid-example/example-utils': link:../../../../examples/utils/example-utils
+      '@fluid-example/schemas': link:../schemas
       '@fluid-experimental/property-binder': link:../../packages/property-binder
       '@fluid-experimental/property-changeset': link:../../packages/property-changeset
       '@fluid-experimental/property-common': link:../../packages/property-common
@@ -3070,7 +3071,6 @@ importers:
       '@fluid-experimental/property-inspector-table': link:../../packages/property-inspector-table
       '@fluid-experimental/property-properties': link:../../packages/property-properties
       '@fluid-experimental/property-proxy': link:../../packages/property-proxy
-      '@fluid-experimental/schemas': link:../schemas
       '@fluidframework/aqueduct': link:../../../../packages/framework/aqueduct
       '@fluidframework/common-utils': 1.1.1
       '@fluidframework/container-definitions': link:../../../../packages/common/container-definitions
@@ -23750,7 +23750,7 @@ packages:
       - supports-color
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   /concat-stream/1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -38648,7 +38648,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.15.1
-      webpack: 5.75.0
+      webpack: 5.75.0_webpack-cli@4.10.0
 
   /terser/4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -40721,6 +40721,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /webpack/5.75.0_webpack-cli@4.10.0:
     resolution: {integrity: sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==}


### PR DESCRIPTION
PR #14206 renamed some packages to use the fluid-example scope. However, it didn't update the references to those packages in code/package.json. This PR corrects that.