### PR TITLE
fix: Fix scope for moved packages

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/.mocharc.memory.js
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/.mocharc.memory.js
@@ -6,7 +6,7 @@
 /**
  * Mocha configuration file for memory profiling tests
  */
-const getFluidTestMochaConfig = require("@fluidframework/test-version-utils/mocharc-common.js");
+const getFluidTestMochaConfig = require("@fluid-internal/test-version-utils/mocharc-common.js");
 const packageDir = `${__dirname}/../../..`;
 
 const config = getFluidTestMochaConfig(packageDir);

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/.mocharc.time.js
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/.mocharc.time.js
@@ -6,7 +6,7 @@
 /**
  * Mocha configuration file for runtime profiling tests
  */
-const getFluidTestMochaConfig = require("@fluidframework/test-version-utils/mocharc-common.js");
+const getFluidTestMochaConfig = require("@fluid-internal/test-version-utils/mocharc-common.js");
 const packageDir = `${__dirname}/../../..`;
 
 const config = getFluidTestMochaConfig(packageDir);


### PR DESCRIPTION
## Description

We recently [moved the `test-version-utils` package from the `@fluidframework` scope to `@fluid-internal`](https://github.com/microsoft/FluidFramework/pull/14127) in the `next` branch. A couple of uses of that package in code files weren't updated at the time and are resulting in errors in the Performance benchmarks pipeline, so fixing them in this PR.

@ChumpChief FYI.