### PR TITLE
ci: Simplify label workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,3 +8,7 @@ labels:
   base-branch: "next"
 - label: "base: release"
   base-branch: "^release/.*"
+
+  # PRs from contributors without write access to the repo should be labeled
+- label: "community-contribution"
+  author-can-merge: False

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,4 +11,5 @@ labels:
 
   # PRs from contributors without write access to the repo should be labeled
 - label: "community-contribution"
-  author-can-merge: False
+  author-can-merge: True
+  negate: True

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,5 +11,4 @@ labels:
 
   # PRs from contributors without write access to the repo should be labeled
 - label: "community-contribution"
-  author-can-merge: True
-  negate: True
+  author-can-merge: False

--- a/.github/labelmaker.yml
+++ b/.github/labelmaker.yml
@@ -1,0 +1,7 @@
+teams:
+  internal: ['FluidFramework-Admin', 'FluidFramework-Contributors', 'FRS-Contributors' ]
+
+labels:
+  externalPRs: ['community-contribution']
+
+sync: true

--- a/.github/labelmaker.yml
+++ b/.github/labelmaker.yml
@@ -1,7 +1,0 @@
-teams:
-  internal: ['FluidFramework-Admin', 'FluidFramework-Contributors', 'FRS-Contributors' ]
-
-labels:
-  externalPRs: ['community-contribution']
-
-sync: true

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -20,3 +20,11 @@ jobs:
       - uses: srvaroa/labeler@953347905ec8e4884e85c9957d24508e24119fc3 # ratchet:srvaroa/labeler@v1.3
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  external_label:
+    runs-on: ubuntu-latest
+    name: Label external PRs
+    steps:
+      - uses: tylerbutler/labelmaker-action@49487085eebc5be6b766198e231f0688e4b4a7c2 # ratchet:tylerbutler/labelmaker-action@main
+        with:
+          token: "${{ secrets.ORG_TOKEN }}"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Label base branches and external contributors
     steps:
-      - uses: srvaroa/labeler@v1.3
+      - uses: srvaroa/labeler@953347905ec8e4884e85c9957d24508e24119fc3 # ratchet:srvaroa/labeler@v1.3
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -15,15 +15,8 @@ jobs:
           sync-labels: true # add/remove labels as modified paths in the PR change
   branches_label:
     runs-on: ubuntu-latest
-    name: Label base branches
+    name: Label base branches and external contributors
     steps:
-      - uses: srvaroa/labeler@97fabbad5804e8a22d5f027aa94c98614facb571 # ratchet:srvaroa/labeler@master
+      - uses: srvaroa/labeler@v1.3
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-  external_label:
-    runs-on: ubuntu-latest
-    name: Label external PRs
-    steps:
-      - uses: tylerbutler/labelmaker-action@49487085eebc5be6b766198e231f0688e4b4a7c2 # ratchet:tylerbutler/labelmaker-action@main
-        with:
-          token: "${{ secrets.ORG_TOKEN }}"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -20,11 +20,3 @@ jobs:
       - uses: srvaroa/labeler@953347905ec8e4884e85c9957d24508e24119fc3 # ratchet:srvaroa/labeler@v1.3
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-  external_label:
-    runs-on: ubuntu-latest
-    name: Label external PRs
-    steps:
-      - uses: tylerbutler/labelmaker-action@49487085eebc5be6b766198e231f0688e4b4a7c2 # ratchet:tylerbutler/labelmaker-action@main
-        with:
-          token: "${{ secrets.ORG_TOKEN }}"


### PR DESCRIPTION
https://github.com/srvaroa/labeler/issues/41 has been resolved, so I've removed the custom action we were using and switched our config to use https://github.com/srvaroa/labeler for labeling external PRs as well as based on branch.