### PR TITLE
Try using PAT token for creating PRs

### DIFF
--- a/.github/workflows/merge-commits.yml
+++ b/.github/workflows/merge-commits.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Create PR using octokit
         uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # ratchet:actions/github-script@v6
         with:
-          token: ${{ secrets.BOT_MAIN_NEXT_WORKFLOW_PAT }}
+          token: ${{ secrets.FLUIDBOTPAT }}
           script: |
             const { Octokit } = require("@octokit/core");
             const token = `${{ secrets.GITHUB_TOKEN }}`;


### PR DESCRIPTION
With the [new security announcement made by GitHub](https://docs.opensource.microsoft.com/releasing/securing-content/github-actions-security-announcement) on Feb 19th, the pull request task for the main-next automation workflow seems to be failing. 

Replacing the pull request token with PAT to test if the pull request can be generated.