### PR TITLE
Try using PAT token for creating PRs

### DIFF
--- a/.github/workflows/merge-commits.yml
+++ b/.github/workflows/merge-commits.yml
@@ -116,7 +116,7 @@ jobs:
           token: ${{ secrets.BOT_MAIN_NEXT_WORKFLOW_PAT }}
           script: |
             const { Octokit } = require("@octokit/core");
-            const token = `${{ secrets.GITHUB_TOKEN }}`;
+            const token = `${{ secrets.FLUIDBOTPAT }}`;
             const sha = 'main-next-${{needs.dequeue.outputs.SHA}}';
             const author = '${{needs.dequeue.outputs.AUTHOR}}';
             const description = `


### PR DESCRIPTION
With the [new security announcement made by GitHub](https://docs.opensource.microsoft.com/releasing/securing-content/github-actions-security-announcement) on Feb 19th, the pull request task for the main-next automation workflow seems to be failing. 

Replacing the pull request token with PAT to test if the pull request can be generated.