### PR TITLE
[GC-stress] Fixed data objects and blobs incorrectly running multiple times

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -4,7 +4,7 @@
 			"opRatePerMin": 600,
 			"progressIntervalMs": 5000,
 			"numClients": 5,
-			"totalSendCount": 2400,
+			"totalSendCount": 1200,
 			"optionOverrides": {
 				"tinylicious": {
 					"comment": "SessionExpiry: 30 seconds. Inactive Timeout: 33 seconds. Sweep Timeout: 35 seconds.",


### PR DESCRIPTION
Data objects and blobs were running multiple times because every clients would run them when loading. However, a data store / blob should only be run by the client that created and referenced it. Otherwise, we will end up with changes in data stores / blob after they have been unreferenced.

## Reviewer Guidance
These changes are in an experimental test branches.