### PR TITLE
Remove noisy summarizer event

### DIFF
--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -577,9 +577,6 @@ export class RunningSummarizer implements IDisposable {
 			// lockedSummaryAction() will retry heuristic-based summary at the end of current attempt
 			// if it's still needed
 			this.tryWhileSummarizing = true;
-			this.mc.logger.sendTelemetryEvent({
-				eventName: "SummarizeAttemptWithRefreshSummaryAckRunning",
-			});
 			return;
 		}
 


### PR DESCRIPTION

## Description

During the last iteration to unify the lock under RefreshSummaryAck and the Summarizer, we left a telemetry event that is too verbose.  Removing it with this PR.