### PR TITLE
Removing cached url resolver

### DIFF
--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -36,7 +36,6 @@ import {
 	IDocumentServiceFactory,
 	IDocumentStorageService,
 	IFluidResolvedUrl,
-	IResolvedUrl,
 	IUrlResolver,
 } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
@@ -110,22 +109,6 @@ export class RelativeLoader implements ILoader {
 		}
 		return this.loader.request(request);
 	}
-}
-
-function createCachedResolver(resolver: IUrlResolver) {
-	const cacheResolver = Object.create(resolver) as IUrlResolver;
-	const resolveCache = new Map<string, Promise<IResolvedUrl | undefined>>();
-	cacheResolver.resolve = async (request: IRequest): Promise<IResolvedUrl | undefined> => {
-		if (!canUseCache(request)) {
-			return resolver.resolve(request);
-		}
-		if (!resolveCache.has(request.url)) {
-			resolveCache.set(request.url, resolver.resolve(request));
-		}
-
-		return resolveCache.get(request.url);
-	};
-	return cacheResolver;
 }
 
 export interface ILoaderOptions extends ILoaderOptions1 {
@@ -306,7 +289,7 @@ export class Loader implements IHostLoader {
 		);
 
 		this.services = {
-			urlResolver: createCachedResolver(MultiUrlResolver.create(loaderProps.urlResolver)),
+			urlResolver: MultiUrlResolver.create(loaderProps.urlResolver),
 			documentServiceFactory: MultiDocumentServiceFactory.create(
 				loaderProps.documentServiceFactory,
 			),


### PR DESCRIPTION
## Description

Remove cacheUrlResolver as it does not provide much benefit as resolver resolve is not expensive since network calls are not made. Plus, we can't just look at the URL to be resolved as key because the resolved URL could differ based on different headers in the request, so it causes bugs and confusion for our partner apps.