### PR TITLE
fix: Make detached attribution e2e case work with odsp-driver

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
@@ -131,10 +131,6 @@ describeNoCompat("Attributor", (getTestObjectProvider) => {
 	});
 
 	it("attributes content created in a detached state", async () => {
-		if (provider.driver.type === "odsp") {
-			// TODO:#3451: Investigate why this test fails against odsp and re-enable.
-			return;
-		}
 		const attributor = createRuntimeAttributor();
 		const loader = provider.makeTestLoader(getTestConfig(attributor));
 		const defaultCodeDetails: IFluidCodeDetails = {
@@ -150,7 +146,10 @@ describeNoCompat("Attributor", (getTestObjectProvider) => {
 		await provider.ensureSynchronized();
 
 		provider.updateDocumentId(container1.resolvedUrl);
-		const container2 = await provider.loadTestContainer(getTestConfig());
+		const url = await container1.getAbsoluteUrl("");
+		assert(url !== undefined);
+		const container2 = await loader.resolve({ url });
+
 		const sharedString2 = await sharedStringFromContainer(container2);
 		sharedString2.insertText(0, "client 2, ");
 

--- a/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
@@ -130,7 +130,7 @@ describeNoCompat("Attributor", (getTestObjectProvider) => {
 		});
 	});
 
-	it.only("attributes content created in a detached state", async () => {
+	it("attributes content created in a detached state", async () => {
 		const attributor = createRuntimeAttributor();
 		const loader = provider.makeTestLoader(getTestConfig(attributor));
 		const defaultCodeDetails: IFluidCodeDetails = {

--- a/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
@@ -130,7 +130,7 @@ describeNoCompat("Attributor", (getTestObjectProvider) => {
 		});
 	});
 
-	it("attributes content created in a detached state", async () => {
+	it.only("attributes content created in a detached state", async () => {
 		const attributor = createRuntimeAttributor();
 		const loader = provider.makeTestLoader(getTestConfig(attributor));
 		const defaultCodeDetails: IFluidCodeDetails = {
@@ -145,10 +145,10 @@ describeNoCompat("Attributor", (getTestObjectProvider) => {
 		await container1.attach(provider.driver.createCreateNewRequest("doc id"));
 		await provider.ensureSynchronized();
 
-		provider.updateDocumentId(container1.resolvedUrl);
 		const url = await container1.getAbsoluteUrl("");
 		assert(url !== undefined);
-		const container2 = await loader.resolve({ url });
+		const loader2 = provider.makeTestLoader(getTestConfig());
+		const container2 = await loader2.resolve({ url });
 
 		const sharedString2 = await sharedStringFromContainer(container2);
 		sharedString2.insertText(0, "client 2, ");


### PR DESCRIPTION
## Description

The `updateDocumentId` function on `TestObjectProvider` behaves differently for odsp vs. local/tinylicious. This adjusts the logic to load the second container so that it works with all drivers.
