### PR TITLE
Fire event listeners on FluidContainer when registering event handlers

### DIFF
--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -245,7 +245,7 @@ export class FluidContainer
 							}
 							break;
 						case "disconnected":
-							if (this.connectionState !== ConnectionStateEnum.Disconnected) {
+							if (this.connectionState === ConnectionStateEnum.Disconnected) {
 								listener();
 							}
 							break;


### PR DESCRIPTION
## Description

This PR ports over the logic from `Container` where the event listener is fired if an event handler is registered and the corresponding state for the event is true.

You can find the original implementation [here](https://github.com/microsoft/FluidFramework/blob/d79849fcf17733e62390561d24e63aa6e3ddaa22/packages/loader/container-loader/src/container.ts#L772).

## Reviewer Guidance

I would appreciate feedback on:
- The error message thrown in the `catch` block.
- Importing the enum version of `ConnectionState` as `ConnectionStateEnum` to avoid collision with the namespace version.
- If we should try to unit tests for this, and if so, where?

## Misc
[AB#2007](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2007)