### PR TITLE
build(build-tools): Remove postinstall step

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -32,7 +32,6 @@
 		"commit": "git-cz",
 		"format": "npm run prettier:fix",
 		"preinstall": "node ../scripts/only-pnpm.cjs",
-		"postinstall": "npm run build:compile",
 		"install:commitlint": "npm install --global @commitlint/config-conventional",
 		"lint": "lerna run lint --no-sort --stream",
 		"lint:fix": "lerna run lint:fix --no-sort --stream",

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -47,6 +47,7 @@ steps:
         npm i -g pnpm
         pnpm config set store-dir $(pnpmStorePath)
         pnpm i
+        pnpm build:compile
         popd
 
 - ${{ if ne(parameters.buildToolsVersionToInstall, 'repo') }}:


### PR DESCRIPTION
Doing a build in a postinstall step is atypical and increases install times. If a build is needed after install, it should be done manually or in a script.

BREAKING CHANGE: Any jobs that require build-tools be built will need to do so before running.