### PR TITLE
Alternate implementation for waitForConnectedState

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -28,6 +28,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 -   [Summarizer node and related items deprecated](#Summarizer-node-and-related-items-deprecated)
 -   [IFluidTokenProvider deprecated](#IFluidTokenProvider-deprecated)
 -   [web-code-loader and ICodeAllowList deprecated](#web-code-loader-and-ICodeAllowList-deprecated)
+-   [driver-utils members deprecated](#driver-utils-members-deprecated)
 
 ### For Driver Authors: Document Storage Service policy may become required
 
@@ -95,6 +96,12 @@ The IFluidTokenProvider interface has been deprecated and will be removed in an 
 ### web-code-loader and ICodeAllowList deprecated
 
 The `@fluidframework/web-code-loader` and the `ICodeAllowList` interface from the `@fluidframework/container-definitions` package have been deprecated and will be removed in an upcoming release. Fluid does not prescribe a particular code loader implementation, rather the code loader should be paired with your code details format.
+
+### driver-utils members deprecated
+
+The following members of the `@fluidframework/driver-utils` package have been deprecated and will be removed in an upcoming release:
+
+-   `waitForConnectedState`
 
 ## 2.0.0-internal.3.0.0 Breaking changes
 

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -484,7 +484,7 @@ export class UsageError extends LoggingError implements IDriverErrorBase, IFluid
     readonly errorType = DriverErrorType.usageError;
 }
 
-// @public
+// @public @deprecated
 export function waitForConnectedState(minDelay: number): Promise<void>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -135,6 +135,7 @@ class NoDeltaStream
 }
 
 const waitForOnline = async (): Promise<void> => {
+	// Only wait if we have a strong signal that we're offline - otherwise assume we're online.
 	if (navigator?.onLine === false && window?.addEventListener !== undefined) {
 		return new Promise<void>((resolve) => {
 			const resolveAndRemoveListener = () => {

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -136,13 +136,13 @@ class NoDeltaStream
 
 const waitForOnline = async (): Promise<void> => {
 	// Only wait if we have a strong signal that we're offline - otherwise assume we're online.
-	if (navigator?.onLine === false && window?.addEventListener !== undefined) {
+	if (globalThis.navigator?.onLine === false && globalThis.addEventListener !== undefined) {
 		return new Promise<void>((resolve) => {
 			const resolveAndRemoveListener = () => {
 				resolve();
-				window.removeEventListener("online", resolveAndRemoveListener);
+				globalThis.removeEventListener("online", resolveAndRemoveListener);
 			};
-			window.addEventListener("online", resolveAndRemoveListener);
+			globalThis.addEventListener("online", resolveAndRemoveListener);
 		});
 	}
 };

--- a/packages/loader/driver-utils/src/networkUtils.ts
+++ b/packages/loader/driver-utils/src/networkUtils.ts
@@ -39,7 +39,7 @@ export function logNetworkFailure(
  * But there should be no false negatives.
  * The only exception - Opera returns false when user enters "Work Offline" mode, regardless of actual connectivity.
  *
- * @deprecated - @deprecated 2.0.0-internal.3.2.0 Not recommended for general purpose use.
+ * @deprecated - 2.0.0-internal.3.2.0 Not recommended for general purpose use.
  */
 // eslint-disable-next-line @typescript-eslint/promise-function-async
 export function waitForConnectedState(minDelay: number): Promise<void> {

--- a/packages/loader/driver-utils/src/networkUtils.ts
+++ b/packages/loader/driver-utils/src/networkUtils.ts
@@ -38,6 +38,8 @@ export function logNetworkFailure(
  * or machine connected to router that is not connected to internet)
  * But there should be no false negatives.
  * The only exception - Opera returns false when user enters "Work Offline" mode, regardless of actual connectivity.
+ *
+ * @deprecated - @deprecated 2.0.0-internal.3.2.0 Not recommended for general purpose use.
  */
 // eslint-disable-next-line @typescript-eslint/promise-function-async
 export function waitForConnectedState(minDelay: number): Promise<void> {

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -416,7 +416,6 @@ async function getSingleOpBatch(
 	let lastSuccessTime: number | undefined;
 
 	let retry: number = 0;
-	const deltas: ISequencedDocumentMessage[] = [];
 	const nothing = { partial: false, cancel: true, payload: [] };
 
 	while (signal?.aborted !== true) {
@@ -425,23 +424,20 @@ async function getSingleOpBatch(
 		const startTime = performance.now();
 
 		try {
-			// Issue async request for deltas - limit the number fetched to MaxBatchDeltas
-			const deltasP = get({ ...props, retry } /* telemetry props */);
+			// Issue async request for deltas
+			const { messages, partialResult } = await get({ ...props, retry } /* telemetry props */);;
 
-			const { messages, partialResult } = await deltasP;
-			deltas.push(...messages);
-
-			const deltasRetrievedLast = messages.length;
-
-			if (deltasRetrievedLast !== 0 || !strongTo) {
-				return { payload: deltas, cancel: false, partial: partialResult };
+			// If we got messages back, return them.  Return regardless of whether we got messages back if we didn't
+			// specify a "to", since we don't have an expectation of how many to receive.
+			if (messages.length !== 0 || !strongTo) {
+				return { payload: messages, cancel: false, partial: partialResult };
 			}
 
-			// Storage does not have ops we need.
-			// Attempt to fetch more deltas. If we didn't receive any in the previous call we up our retry
-			// count since something prevented us from seeing those deltas
+			// Otherwise, the storage gave us back an empty set of ops but we were expecting a non-empty set.
 
 			if (lastSuccessTime === undefined) {
+				// Take timestamp of the first time server responded successfully, even though it wasn't with the ops we asked for.
+				// If we keep getting empty responses we'll eventually fail out below.
 				lastSuccessTime = performance.now();
 			} else if (performance.now() - lastSuccessTime > 30000) {
 				// If we are connected and receiving proper responses from server, but can't get any ops back,
@@ -461,8 +457,6 @@ async function getSingleOpBatch(
 			}
 		} catch (error) {
 			const canRetry = canRetryOnError(error);
-
-			lastSuccessTime = undefined;
 
 			const retryAfter = getRetryDelayFromError(error);
 
@@ -485,17 +479,19 @@ async function getSingleOpBatch(
 				throw error;
 			}
 
-			if (retryAfter !== undefined && retryAfter >= 0) {
+			if (retryAfter !== undefined) {
+				// If the error told us to wait, then we will wait for that specific amount rather than the default.
 				delay = retryAfter;
 			}
 		}
 
-		// First, wait for the amount of time we think is appropriate.
+		// If we get here something has gone wrong - either got an unexpected empty set of messages back or a real error.
+		// Either way we will wait a little bit before retrying.
 		await new Promise<void>((resolve) => {
 			setTimeout(resolve, delay);
 		});
 
-		// Then, if we believe we're offline, we assume there's no point in trying until we at least think we're online.
+		// If we believe we're offline, we assume there's no point in trying until we at least think we're online.
 		// NOTE: This isn't strictly true for drivers that don't require network (e.g. local driver).  Really this logic
 		// should probably live in the driver.
 		await waitForOnline();

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -425,7 +425,9 @@ async function getSingleOpBatch(
 
 		try {
 			// Issue async request for deltas
-			const { messages, partialResult } = await get({ ...props, retry } /* telemetry props */);;
+			const { messages, partialResult } = await get(
+				{ ...props, retry } /* telemetry props */,
+			);
 
 			// If we got messages back, return them.  Return regardless of whether we got messages back if we didn't
 			// specify a "to", since we don't have an expectation of how many to receive.

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -380,6 +380,7 @@ export class Queue<T> implements IStream<T> {
 }
 
 const waitForOnline = async (): Promise<void> => {
+	// Only wait if we have a strong signal that we're offline - otherwise assume we're online.
 	if (navigator?.onLine === false && window?.addEventListener !== undefined) {
 		return new Promise<void>((resolve) => {
 			const resolveAndRemoveListener = () => {

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -381,13 +381,13 @@ export class Queue<T> implements IStream<T> {
 
 const waitForOnline = async (): Promise<void> => {
 	// Only wait if we have a strong signal that we're offline - otherwise assume we're online.
-	if (navigator?.onLine === false && window?.addEventListener !== undefined) {
+	if (globalThis.navigator?.onLine === false && globalThis.addEventListener !== undefined) {
 		return new Promise<void>((resolve) => {
 			const resolveAndRemoveListener = () => {
 				resolve();
-				window.removeEventListener("online", resolveAndRemoveListener);
+				globalThis.removeEventListener("online", resolveAndRemoveListener);
 			};
-			window.addEventListener("online", resolveAndRemoveListener);
+			globalThis.addEventListener("online", resolveAndRemoveListener);
 		});
 	}
 };


### PR DESCRIPTION
Splitting this from #14265 since it involves behavior change.  If folks aren't comfortable with this behavior change, then I'll instead close this PR and just hide the API in #14265.

Currently, waitForConnectedState mixes two waiting policies:
1. Wait for a certain amount of time
2. Wait for the browser's "online" state

However, the way it mixes these two is unintuitive and likely to surprise the caller.  For instance:
* If called while offline, will resolve immediately upon the browser going online (the "minDelay" is bypassed)
* `navigator.onLine` can easily be `false` when it resolves

Looking at the call sites, side effects like these don't seem to be intended.  This change has 3 goals:
1. Make the policies explicit: Someone reading the call site should have high confidence in the actual wait time and online/offline state before/during/after.
2. Correctness: If we really intend to have a minimum delay in these places, we should adhere to it and not violate it when online/offline status changes.
3. Reduce API surface area: This API isn't meant for general public use (especially since it has these surprising policy behaviors).  Hiding it reduces noise and risk for customers who might consider using it.

Really, any heuristic about connections/network state should live in the driver (as the driver is the layer that knows whether the network should be relevant in these activities).  For instance, the local driver shouldn't care about network in any of these flows.  But at least for this change, the logic stays in the loader layer.