### PR TITLE
Replicate serializedNodes into Summary nodes added to pendingSummaries when GC is enabled.

### DIFF
--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNode.ts
@@ -547,7 +547,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 		// There may be additional state that has to be updated in this child. For example, if a summary is being
 		// tracked, the child's summary tracking state needs to be updated too. Same goes for pendingSummaries we might
 		// have outstanding on the parent in case we realize nodes in between Summary Op and Summary Ack.
-		this.maybeUpdateChildState(child);
+		this.maybeUpdateChildState(child, id);
 
 		this.children.set(id, child);
 		return child;
@@ -663,8 +663,10 @@ export class SummarizerNode implements IRootSummarizerNode {
 	 * Also, in case a child node gets realized in between Summary Op and Summary Ack, let's initialize the child's
 	 * pending summary as well.
 	 * @param child - The child node whose state is to be updated.
+	 * @param id - Initial id or path part of this node
+	 *
 	 */
-	protected maybeUpdateChildState(child: SummarizerNode) {
+	protected maybeUpdateChildState(child: SummarizerNode, id: string) {
 		// If a summary is in progress, this child was created after the summary started. So, we need to update the
 		// child's summary state as well.
 		if (this.isSummaryInProgress()) {

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -518,13 +518,13 @@ class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNode
 					const childNodeUsedRoutes = unpackChildNodesUsedRoutes(
 						JSON.parse(summaryNodeWithGC.serializedUsedRoutes),
 					);
-					const newSerializedRoutes = childNodeUsedRoutes.get(id);
+					const newSerializedRoutes = childNodeUsedRoutes.get(id) ?? [""];
 					const newLatestSummaryNode = new SummaryNodeWithGC(
-						JSON.stringify(newSerializedRoutes ?? [""]),
+						JSON.stringify(newSerializedRoutes),
 						{
 							referenceSequenceNumber: value.referenceSequenceNumber,
-							basePath: child.latestSummary.basePath,
-							localPath: child.latestSummary.localPath,
+							basePath: value.basePath,
+							localPath: value.localPath,
 						},
 					);
 					child.addPendingSummary(key, newLatestSummaryNode);

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -43,7 +43,7 @@ import {
  */
 export interface IRootSummarizerNodeWithGC
 	extends ISummarizerNodeWithGC,
-	ISummarizerNodeRootContract { }
+		ISummarizerNodeRootContract {}
 
 // Extend SummaryNode to add used routes tracking to it.
 class SummaryNodeWithGC extends SummaryNode {
@@ -513,7 +513,6 @@ class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNode
 		// In case we have pending summaries on the parent, let's initialize it on the child.
 		if (child.latestSummary !== undefined) {
 			for (const [key, value] of this.pendingSummaries.entries()) {
-
 				const summaryNodeWithGC = value as SummaryNodeWithGC;
 				if (summaryNodeWithGC.serializedUsedRoutes !== undefined) {
 					const childNodeUsedRoutes = unpackChildNodesUsedRoutes(

--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -482,7 +482,8 @@ class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNode
 	 * Updates the state of the child if required. For example, if a summary is currently being  tracked, the child's
 	 * summary tracking state needs to be updated too.
 	 * Also, in case a child node gets realized in between Summary Op and Summary Ack, let's initialize the child's
-	 * pending summary as well.
+	 * pending summary as well. Finally, if the pendingSummaries entries have serializedRoutes, replicate them to the
+	 * pendingSummaries from the child nodes.
 	 * @param child - The child node whose state is to be updated.
 	 */
 	protected maybeUpdateChildState(child: SummarizerNodeWithGC) {

--- a/packages/runtime/runtime-utils/src/test/summarizerNodeWithGc.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summarizerNodeWithGc.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { cloneGCData, GCDataBuilder } from "@fluidframework/garbage-collector";
-import { SummaryType } from "@fluidframework/protocol-definitions";
+import { ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
 import {
 	CreateChildSummarizerNodeParam,
 	CreateSummarizerNodeSource,
@@ -23,6 +23,7 @@ import {
 	// eslint-disable-next-line import/no-internal-modules
 } from "../summarizerNode/summarizerNodeWithGc";
 import { mergeStats } from "../summaryUtils";
+import { IFetchSnapshotResult } from "../summarizerNode";
 
 describe("SummarizerNodeWithGC Tests", () => {
 	const summarizerNodeId = "testNode";
@@ -339,6 +340,128 @@ describe("SummarizerNodeWithGC Tests", () => {
 				},
 				"Complete summary should have failed at the leaf node",
 			);
+		});
+
+		let summaryRefSeq = 123;
+		const blobs = {
+			protocolAttributes: { sequenceNumber: summaryRefSeq },
+		} as const;
+		const readAndParseBlob = async <T>(id: string) => blobs[id] as T;
+
+		const emptySnapshot: ISnapshotTree = { blobs: {}, trees: {} };
+		const protocolTree: ISnapshotTree = {
+			blobs: { attributes: "protocolAttributes" },
+			trees: {},
+		};
+		const coreSnapshot: ISnapshotTree = {
+			blobs: {},
+			trees: {
+				[ids[1]]: {
+					blobs: {},
+					trees: {
+						[ids[2]]: emptySnapshot,
+					},
+				},
+			},
+		};
+		const simpleSnapshot: ISnapshotTree = {
+			blobs: {},
+			trees: {
+				...coreSnapshot.trees,
+				".protocol": protocolTree,
+			},
+		};
+		const fetchLatestSnapshot: () => Promise<IFetchSnapshotResult> = async () => {
+			return {
+				snapshotTree: simpleSnapshot,
+				snapshotRefSeq: summaryRefSeq,
+			};
+		};
+
+		it("Should add GC pending summary node created after parent node was summarized with non-empty used routes", async () => {
+			createRoot();
+			createMid({ type: CreateSummarizerNodeSource.Local });
+			rootNode.startSummary(summaryRefSeq++, logger);
+			rootNode.updateUsedRoutes([""]);
+			midNode?.updateUsedRoutes([""]);
+
+			await rootNode.summarize(false);
+			await midNode?.summarize(false);
+			rootNode.completeSummary("test-handle1");
+
+			let result = await rootNode.refreshLatestSummary(
+				"test-handle1",
+				summaryRefSeq,
+				fetchLatestSnapshot,
+				readAndParseBlob,
+				logger,
+			);
+			assert(result.latestSummaryUpdated === true, "should update");
+			assert(result.wasSummaryTracked === true, "should be tracked");
+
+			rootNode.startSummary(summaryRefSeq++, logger);
+			rootNode.updateUsedRoutes([`/`, `/${ids[1]}`, `/${ids[1]}/${ids[2]}`]);
+			midNode?.updateUsedRoutes([`/`, `/${ids[2]}`]);
+
+			await rootNode.summarize(false);
+			await midNode?.summarize(false);
+			rootNode.completeSummary("test-handle2");
+
+			// Create a new child node for which we will need to create a pending summary for.
+			createLeaf({ type: CreateSummarizerNodeSource.Local });
+
+			result = await rootNode.refreshLatestSummary(
+				"test-handle2",
+				summaryRefSeq,
+				fetchLatestSnapshot,
+				readAndParseBlob,
+				logger,
+			);
+			assert(result.latestSummaryUpdated === true, "should update");
+			assert(result.wasSummaryTracked === true, "should be tracked");
+		});
+
+		it("Should add GC pending summary node created after parent node was summarized with empty used routes", async () => {
+			createRoot();
+			createMid({ type: CreateSummarizerNodeSource.Local });
+			rootNode.startSummary(summaryRefSeq++, logger);
+			rootNode.updateUsedRoutes([""]);
+			midNode?.updateUsedRoutes([""]);
+
+			await rootNode.summarize(false);
+			await midNode?.summarize(false);
+			rootNode.completeSummary("test-handle1");
+
+			let result = await rootNode.refreshLatestSummary(
+				"test-handle1",
+				summaryRefSeq,
+				fetchLatestSnapshot,
+				readAndParseBlob,
+				logger,
+			);
+			assert(result.latestSummaryUpdated === true, "should update");
+			assert(result.wasSummaryTracked === true, "should be tracked");
+
+			rootNode.startSummary(summaryRefSeq++, logger);
+			rootNode.updateUsedRoutes([""]);
+			midNode?.updateUsedRoutes([""]);
+
+			await rootNode.summarize(false);
+			await midNode?.summarize(false);
+			rootNode.completeSummary("test-handle2");
+
+			// Create a new child node for which we will need to create a pending summary for.
+			createLeaf({ type: CreateSummarizerNodeSource.Local });
+
+			result = await rootNode.refreshLatestSummary(
+				"test-handle2",
+				summaryRefSeq,
+				fetchLatestSnapshot,
+				readAndParseBlob,
+				logger,
+			);
+			assert(result.latestSummaryUpdated === true, "should update");
+			assert(result.wasSummaryTracked === true, "should be tracked");
 		});
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
@@ -31,14 +31,15 @@ import {
 	ISummaryTree,
 	MessageType,
 } from "@fluidframework/protocol-definitions";
-import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { IContainerRuntimeBase, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
 import {
-	ITestFluidObject,
 	ITestObjectProvider,
 	wrapDocumentServiceFactory,
 	waitForContainerConnection,
+	summarizeNow,
+	createSummarizerFromFactory,
 } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
 import { UndoRedoStackManager } from "@fluidframework/undo-redo";
@@ -114,12 +115,12 @@ async function loadSummarizer(
 		);
 	});
 
-	const defaultDataStore = await requestFluidObject<ITestFluidObject>(
+	const defaultDataStore = await requestFluidObject<TestDataObject1>(
 		summarizerContainer,
 		"default",
 	);
 	return {
-		containerRuntime: defaultDataStore.context.containerRuntime as ContainerRuntime,
+		containerRuntime: defaultDataStore._context.containerRuntime as ContainerRuntime,
 		summaryCollection,
 	};
 }
@@ -252,12 +253,13 @@ describeNoCompat("Prepare for Summary with Search Blobs", (getTestObjectProvider
 	};
 	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
 		runtime.IFluidHandleContext.resolveHandle(request);
+	const registryStoreEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
+		[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],
+		[dataStoreFactory2.type, Promise.resolve(dataStoreFactory2)],
+	]);
 	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
 		dataStoreFactory1,
-		[
-			[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],
-			[dataStoreFactory2.type, Promise.resolve(dataStoreFactory2)],
-		],
+		registryStoreEntries,
 		undefined,
 		[innerRequestHandler],
 		runtimeOptions,
@@ -273,6 +275,7 @@ describeNoCompat("Prepare for Summary with Search Blobs", (getTestObjectProvider
 
 	let mainContainer: IContainer;
 	let mainDataStore: TestDataObject1;
+	let mainContainerRuntime: ContainerRuntime;
 
 	const createContainer = async (): Promise<IContainer> => {
 		return provider.createContainer(runtimeFactory);
@@ -356,6 +359,7 @@ describeNoCompat("Prepare for Summary with Search Blobs", (getTestObjectProvider
 			// re-sent. Do it here so that the extra events don't mess with rest of the test.
 			mainDataStore = await requestFluidObject<TestDataObject1>(mainContainer, "default");
 			mainDataStore._root.set("anytest", "anyvalue");
+			mainContainerRuntime = mainDataStore._context.containerRuntime as ContainerRuntime;
 			await waitForContainerConnection(mainContainer);
 		});
 
@@ -431,6 +435,73 @@ describeNoCompat("Prepare for Summary with Search Blobs", (getTestObjectProvider
 
 			// The assert 0x1a6 should be hit now.
 			await summarizerClient2.containerRuntime.refreshLatestSummaryAck({
+				proposalHandle: ackedSummary.summaryOp.contents.handle,
+				ackHandle: ackedSummary.summaryAck.contents.handle,
+				summaryRefSeq: ackedSummary.summaryOp.referenceSequenceNumber,
+				summaryLogger: logger,
+			});
+		});
+
+		it("Data store with GC data realized after summarize", async () => {
+			// Create a summarizer client.
+			const { summarizer: summarizer1 } = await createSummarizerFromFactory(
+				provider,
+				mainContainer,
+				dataStoreFactory1,
+				undefined,
+				undefined,
+				registryStoreEntries,
+			);
+
+			// Create a second data store.
+			const ds2 = await requestFluidObject<TestDataObject2>(
+				await mainContainerRuntime.createDataStore(TestDataObjectType2),
+				"",
+			);
+			mainDataStore._root.set("dataStore2", ds2.handle);
+
+			await provider.ensureSynchronized();
+
+			// Summarize with the above data store.
+			const summary1 = await summarizeNow(summarizer1);
+			summarizer1.close();
+
+			// Create a new summarizer from the above summary.
+			const summarizer2 = await getNewSummarizer(summary1.summaryVersion);
+
+			const summarySequenceNumber =
+				summarizer2.containerRuntime.deltaManager.lastSequenceNumber;
+			// Submit a summary and wait for the summary op.
+			const result = await summarizer2.containerRuntime.submitSummary({
+				fullTree: false,
+				refreshLatestAck: false,
+				summaryLogger: logger,
+				cancellationToken: neverCancelledSummaryToken,
+			});
+			assert(result.stage === "submit", "The summary was not submitted");
+			await waitForSummaryOp(summarizer2.containerRuntime);
+
+			// Before refresh is called, request the second data store in the summarizer. This will create summarizer
+			// nodes for its child DDSes. The data store's summarizer node should update the pending used routes
+			// of the child's summarizer node.
+			const ds2MainDataStore = await requestFluidObject<TestDataObject1>(
+				summarizer2.containerRuntime,
+				"default",
+			);
+			const ds2MainDataStoreHandle =
+				ds2MainDataStore._root.get<IFluidHandle<TestDataObject2>>("dataStore2");
+			assert(
+				ds2MainDataStoreHandle !== undefined,
+				"Data store2 handle not present in summarizer",
+			);
+			await ds2MainDataStoreHandle.get();
+
+			// Wait for the above summary to be ack'd.
+			const ackedSummary = await summarizer2.summaryCollection.waitSummaryAck(
+				summarySequenceNumber,
+			);
+			// Refresh the summary. This should not result in any errors.
+			await summarizer2.containerRuntime.refreshLatestSummaryAck({
 				proposalHandle: ackedSummary.summaryOp.contents.handle,
 				ackHandle: ackedSummary.summaryAck.contents.handle,
 				summaryRefSeq: ackedSummary.summaryOp.referenceSequenceNumber,

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
@@ -248,7 +248,7 @@ describeNoCompat("Prepare for Summary with Search Blobs", (getTestObjectProvider
 		summaryOptions: {
 			summaryConfigOverrides: { state: "disabled" },
 		},
-		gcOptions: { gcAllowed: false },
+		gcOptions: { gcAllowed: true },
 	};
 	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
 		runtime.IFluidHandleContext.resolveHandle(request);


### PR DESCRIPTION

## Description

If a data store is realized after a summary has been submitted and before the ack is received, its child summarizer node inherits its pending summaries. This works fine for regular summarizer nodes but the GC summary nodes end up not having the serializedUsedRoutes field set. That eventually leads to an error [Summarization error: '"undefined" is not valid JSON' - 10k hits in the last 28 days by NicholasCouri · Pull Request #13283 · microsoft/FluidFramework (github.com)](https://github.com/microsoft/FluidFramework/pull/13283) which is basically an error parsing the json during a call to refreshLatestSummaryFromPending: 

at JSON.parse ()
at A.refreshLatestSummaryFromPending

The proposed fix is to have a different implementation for maybeUpdateChildState in which we replicate the serializedNodes into each newly added pending summary node. It is basically a replication of the work done by [Fix 0x1a6 by NicholasCouri · Pull Request #11144 · microsoft/FluidFramework (github.](https://github.com/microsoft/FluidFramework/pull/11144)  - only directed to the SummaryNodeWIthGC implementation. 