### PR TITLE
feat(benchmark): add onCycle hook

### DIFF
--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/benchmark",
-	"version": "0.45.1",
+	"version": "0.46.0",
 	"description": "Benchmarking tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/benchmark",
-	"version": "0.45.0",
+	"version": "0.45.1",
 	"description": "Benchmarking tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/tools/benchmark/src/Configuration.ts
+++ b/tools/benchmark/src/Configuration.ts
@@ -184,7 +184,7 @@ export type HookFunction = () => void | Promise<unknown>;
 
 /**
  * Arguments that can be passed to `benchmark` for optional test setup/teardown. Hooks execute once per test body
- * (*not* on each cycle or sample). Hooks--along with the benchmarked function--are run without additional error
+ * (*not* on each cycle or iteration). Hooks--along with the benchmarked function--are run without additional error
  * validation. This means any exception thrown from either a hook or the benchmarked function will cause test
  * failure, and subsequent operations won't be run.
  * @public
@@ -192,6 +192,7 @@ export type HookFunction = () => void | Promise<unknown>;
 export interface HookArguments {
 	before?: HookFunction;
 	after?: HookFunction;
+	onCycle?: HookFunction;
 }
 
 /**

--- a/tools/benchmark/src/Runner.ts
+++ b/tools/benchmark/src/Runner.ts
@@ -54,6 +54,7 @@ export function benchmark(args: BenchmarkArguments): Test {
 		only: args.only ?? false,
 		before: args.before ?? (() => {}),
 		after: args.after ?? (() => {}),
+		onCycle: args.onCycle ?? (() => {}),
 		category: args.category ?? "",
 	};
 	const { isAsync, benchmarkFn: argsBenchmarkFn } = validateBenchmarkArguments(args);
@@ -161,6 +162,7 @@ export function benchmark(args: BenchmarkArguments): Test {
 				// This helps noise from allocations before the test (ex: from previous tests or startup) from
 				// impacting the test.
 				benchmarkInstance.on("start end", () => global?.gc?.());
+				benchmarkInstance.on("cycle", options.onCycle);
 				benchmarkInstance.on("complete", async () => {
 					const stats: BenchmarkData = {
 						aborted: benchmarkInstance.aborted,
@@ -184,6 +186,7 @@ export function benchmark(args: BenchmarkArguments): Test {
 
 		await options.before();
 		await argsBenchmarkFn();
+		await options.onCycle();
 		await options.after();
 		await Promise.resolve();
 	});


### PR DESCRIPTION
Exposes the `onCycle` hook of the [underlying benchmarking library](https://benchmarkjs.com/). This change is necessary for https://github.com/microsoft/FluidFramework/pull/13118

The [`onCycle` documentation](https://benchmarkjs.com/docs/#options_onCycle) is unfortunately quite sparse, but for our purposes we use this hook in order to perform insertion benchmarks with roughly the same behavior on each cycle. One cycle corresponds to many iterations.