### PR TITLE
Enable typetests for attributor

### DIFF
--- a/packages/framework/attributor/package.json
+++ b/packages/framework/attributor/package.json
@@ -77,6 +77,7 @@
 	"devDependencies": {
 		"@fluid-internal/stochastic-test-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluid-tools/build-cli": "^0.10.0",
+		"@fluidframework/attributor-previous": "npm:@fluidframework/attributor@2.0.0-internal.3.1.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.10.0",
 		"@fluidframework/driver-definitions": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
@@ -100,8 +101,10 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"disabled": true,
-		"version": "2.1.0",
+		"version": "2.0.0-internal.3.2.0",
+		"previousVersionStyle": "~previousMinor",
+		"baselineRange": ">=2.0.0-internal.3.1.0 <2.0.0-internal.3.2.0",
+		"baselineVersion": "2.0.0-internal.3.1.0",
 		"broken": {}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6835,6 +6835,7 @@ importers:
     specifiers:
       '@fluid-internal/stochastic-test-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluid-tools/build-cli': ^0.10.0
+      '@fluidframework/attributor-previous': npm:@fluidframework/attributor@2.0.0-internal.3.1.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.10.0
       '@fluidframework/common-utils': ^1.1.1
@@ -6884,6 +6885,7 @@ importers:
     devDependencies:
       '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-tools/build-cli': 0.10.0
+      '@fluidframework/attributor-previous': /@fluidframework/attributor/2.0.0-internal.3.1.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.10.0
       '@fluidframework/driver-definitions': link:../../common/driver-definitions


### PR DESCRIPTION
## Description

Turns on typetests for `@fluidframework/attributor`. These APIs are still in alpha/beta, but it's useful to know when we do break things (might as well do it intentionally) and the package has had a couple levels of iteration at this point.