### PR TITLE
[GC-stress] Fail test on tombstone failure and update configs

### DIFF
--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -120,7 +120,8 @@ async function main() {
 	fileLogger.observer.on("logEvent", (logEvent: ITelemetryBaseEvent) => {
 		if (
 			logEvent.eventName.includes("InactiveObject") ||
-			logEvent.eventName.includes("SweepReadyObject")
+			logEvent.eventName.includes("SweepReadyObject") ||
+			logEvent.eventName.startsWith("GC_Tombstone")
 		) {
 			testFailed = true;
 			console.error(`xxxxxxxxx ${JSON.stringify(logEvent)}`);

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -7,23 +7,23 @@
 			"totalSendCount": 1200,
 			"optionOverrides": {
 				"tinylicious": {
-					"comment": "SessionExpiry: 30 seconds. Inactive Timeout: 33 seconds. Sweep Timeout: 35 seconds.",
+					"comment": "SessionExpiry: 20 seconds. Inactive Timeout: 40 seconds. Sweep Timeout: 45 seconds.",
 					"configurations": {
 						"Fluid.GarbageCollection.RunSessionExpiry": [true],
-						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [33000],
-						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [35000],
-						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [30000],
+						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [40000],
+						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [45000],
+						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [20000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
 					}
 				},
 				"odsp": {
-					"comment": "SessionExpiry: 30 seconds. Inactive Timeout: 33 seconds. Sweep Timeout: 35 seconds.",
+					"comment": "SessionExpiry: 20 seconds. Inactive Timeout: 40 seconds. Sweep Timeout: 45 seconds.",
 					"configurations": {
 						"Fluid.GarbageCollection.RunSessionExpiry": [true],
 						"Fluid.Driver.Odsp.TestOverride.DisableSnapshotCache": [true],
-						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [33000],
-						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [35000],
-						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [30000],
+						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [40000],
+						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [45000],
+						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [20000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
 					}
 				}
@@ -36,22 +36,22 @@
 			"totalSendCount": 36000,
 			"optionOverrides": {
 				"tinylicious": {
-					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 16 mins. Sweep Timeout: 17 mins.",
+					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 					"configurations": {
 						"Fluid.GarbageCollection.RunSessionExpiry": [true],
-						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [960000],
-						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1020000],
+						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [1200000],
+						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000],
 						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [900000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
 					}
 				},
 				"odsp": {
-					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 16 mins. Sweep Timeout: 17 mins.",
+					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 					"configurations": {
 						"Fluid.GarbageCollection.RunSessionExpiry": [true],
 						"Fluid.Driver.Odsp.TestOverride.DisableSnapshotCache": [true],
-						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [960000],
-						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1020000],
+						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [1200000],
+						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000],
 						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [900000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
 					}


### PR DESCRIPTION
- If tomsbtone errors are seen, fail the test.
- Updated configs to have larger time gap between session expiry and inactive / sweep timeout. This is because after a client revives an object, it may take some time (say sequencingDelay) for the op to be sequenced. If the gap between session expiry and inactive timeout is smaller than sequencingDelay, this will result in a inactiveObject_revived event.
