### PR TITLE
Improve benchmark hook documentation

### DIFF
--- a/tools/benchmark/src/Configuration.ts
+++ b/tools/benchmark/src/Configuration.ts
@@ -183,15 +183,122 @@ export interface MochaExclusiveOptions {
 export type HookFunction = () => void | Promise<unknown>;
 
 /**
- * Arguments that can be passed to `benchmark` for optional test setup/teardown. Hooks execute once per test body
- * (*not* on each cycle or iteration). Hooks--along with the benchmarked function--are run without additional error
- * validation. This means any exception thrown from either a hook or the benchmarked function will cause test
- * failure, and subsequent operations won't be run.
+ * Arguments that can be passed to `benchmark` for optional test setup/teardown.
+ * Hooks--along with the benchmarked function--are run without additional error validation.
+ * This means any exception thrown from either a hook or the benchmarked function will cause test failure,
+ * and subsequent operations won't be run.
+ * @remarks
+ *
+ * Be careful when writing non-pure benchmark functions!
+ * Benchmark.js is written with the assumption that each cycle it runs is an independent sample.
+ * This can typically be achieved by using the `onCycle` hook to reset state, with some caveats.
+ * For more details, read below.
+ *
+ * Benchmark.js runs the benchmark function in two hierarchical groups: cycles and iterations.
+ * One iteration consists of a single execution of `benchmarkFn`.
+ * Since the time taken by a single iteration might be significantly smaller than the clock resolution, benchmark
+ * dynamically decides to run a number of iterations per cycle.
+ * After a warmup period, this number is fixed across cycles (i.e. if Benchmark.js decides to run 10,000 iterations
+ * per cycle, all statistical analysis will be performed on cycles which consist of 10,000 iterations)
+ * This strategy also helps minimize noise from JITting code.
+ *
+ * Statistical analysis is performed at the cycle level: Benchmark.js treats each cycle's timing information as a data
+ * point taken from a normal distribution, and runs cycles until the root-mean error is below a threshhold or its max
+ * time has been reached.
+ * The statistical analysis it uses is invalid if cycles aren't independent trials: consider the test
+ * ```typescript
+ * const myList = [];
+ * benchmark({
+ *     title: "insert at start of a list",
+ *     benchmarkFn: () => {
+ *         myList.unshift(0);
+ *     }
+ * });
+ * ```
+ *
+ * If each cycle has 10k iterations, the first cycle will time how long it takes to repeatedly insert elements 0 through 10k
+ * into the start `myList`.
+ * The second cycle will time how long it takes to repeatedly insert elements 10k through 20k at the start, and so on.
+ * As inserting an element at the start of the list is O(list size), it's clear that cycles will take longer and longer.
+ * We can use the `onCycle` hook to alleviate this problem:
+ * ```typescript
+ * let myList = [];
+ * benchmark({
+ *     title: "insert at start of a list",
+ *     onCycle: () => {
+ *         myList = [];
+ *     }
+ *     benchmarkFn: () => {
+ *         myList.unshift(0);
+ *     }
+ * });
+ * ```
+ *
+ * With this change, it's more reasonable to model each cycle as an independent event.
+ *
+ * Note that this approach is slightly misleading in the data it measures: if Benchmark.js chooses a cycle size of 10k,
+ * the time reported per iteration is really an average of the time taken to insert 10k elements at the start, and not
+ * the average time to insert an element to the start of the empty list as the test body might suggest at a glance.
+ * @example
+ *
+ * ```typescript
+ * let iterations = 0;
+ * let cycles = 0;
+ * benchmark({
+ *     title: "my sample performance test"
+ *     before: () => {
+ *         console.log("setup goes here")
+ *     },
+ *     onCycle: () => {
+ *         cycles++;
+ *     },
+ *     after: () => {
+ *         console.log("iterations", iterations);
+ *         console.log("cycles", cycles);
+ *         console.log("teardown goes here")
+ *     }
+ *     benchmarkFn: () => {
+ *         iterations++;
+ *     }
+ * });
+ *
+ * // Sample console output in correctness mode:
+ * //
+ * // setup goes here
+ * // iterations 1
+ * // cycles 1
+ * // teardown goes here
+ * //
+ * // Sample console output in perf mode, if benchmark dynamically chose to run 40 cycles of 14k iterations each:
+ * //
+ * // setup goes here
+ * // iterations 560,000
+ * // cycles 40
+ * // teardown goes here
+ * ```
  * @public
  */
 export interface HookArguments {
+	/**
+	 * Executes once, before the test body it's declared for.
+	 *
+	 * @remarks This does *not* execute on each iteration or cycle.
+	 */
 	before?: HookFunction;
+	/**
+	 * Executes once, after the test body it's declared for.
+	 *
+	 * @remarks This does *not* execute on each iteration or cycle.
+	 */
 	after?: HookFunction;
+	/**
+	 * Executes before the start of each cycle. This has the same semantics as benchmarkjs's `onCycle`:
+	 * https://benchmarkjs.com/docs/#options_onCycle
+	 *
+	 * @remarks
+	 * Beware that cycles run `benchmarkFn` more than once: a typical microbenchmark might involve 10k
+	 * iterations per cycle.
+	 */
 	onCycle?: HookFunction;
 }
 


### PR DESCRIPTION
## Description

Improves documentation on benchmark hooks, with some brain-dump-y remarks on subtle issues with non-pure functions in perf tests.

We'll probably want to move these to somewhere more public facing eventually, but I figured having some of this documented somewhere was better than nothing.
