### PR TITLE
feat(external-data): Implemented external fetch during lonely client scenario

### DIFF
--- a/examples/hosts/app-integration/external-data/src/model/taskList.ts
+++ b/examples/hosts/app-integration/external-data/src/model/taskList.ts
@@ -384,17 +384,39 @@ export class TaskList extends DataObject implements ITaskList {
 	 * DataObject, by registering an event listener for changes to the task list.
 	 */
 	protected async hasInitialized(): Promise<void> {
-		const saved = this.root.get<IFluidHandle<SharedMap>>("savedData");
+		const [saved, draft] = await Promise.all([
+			this.root.get<IFluidHandle<SharedMap>>("savedData"),
+			this.root.get<IFluidHandle<SharedMap>>("draftData"),
+		]);
 		if (saved === undefined) {
 			throw new Error("savedData was not initialized");
 		}
 		this._savedData = await saved.get();
 
-		const draft = this.root.get<IFluidHandle<SharedMap>>("draftData");
 		if (draft === undefined) {
 			throw new Error("draftData was not initialized");
 		}
 		this._draftData = await draft.get();
+
+		// Check for other connected clients each time a new runtime is initialized
+		const connected = this.runtime.getAudience();
+		let clientSize = 0;
+		let loneClient: boolean = true;
+
+		// Increase the count of all non-summarizer clients
+		for (const [_, value] of connected.getMembers()) {
+			if (!value.scopes.includes("summary:write")) {
+				clientSize++;
+				if (clientSize > 1) {
+					loneClient = false;
+					break;
+				}
+			}
+		}
+		// Manually fetch data if client is alone in container.
+		if (loneClient) {
+			await this.importExternalData();
+		}
 
 		this._draftData.on("valueChanged", (changed) => {
 			if (changed.previousValue === undefined) {


### PR DESCRIPTION
[AB#2928](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2928)

 ## Description
This PR adds functionality for the scenario in which a client connects to the container and happens to be the only one connected. The import of external data only takes place on the initialization of the container, **NOT** _the container runtime_. As a result, it's possible that  modifications were performed in the external server won't saved in Fluid data if there are no connected clients. 

In this scenario, the lonely client manually fetches and updates the local savedData and draftData.

## Questions
This PR uses getAudience to verify that the current client is alone. When using getQuorum, the function consistently returns 0 members. What is the difference between using these methods? 