### PR TITLE
Document @fluidframework/attributor status in README

### DIFF
--- a/packages/framework/attributor/README.md
+++ b/packages/framework/attributor/README.md
@@ -2,6 +2,12 @@
 
 This package contains definitions and implementations for framework-provided attribution functionality.
 
+## Status
+
+All attribution APIs (both in this package and elsewhere in `@fluidframework` packages) are marked as [alpha](https://api-extractor.com/pages/tsdoc/tag_alpha/) to enable fast iteration (as third-party use is not officially supported, breaking API changes can be made in minor versions).
+
+Despite this, the APIs are generally ready for early adoption--feel free to play around with them in local setups and provide feedback on their shape, usability, or other factors!
+
 ## Quickstart
 
 To turn on op-stream based attribution in your container, use `mixinAttributor` to create a `ContainerRuntime` class which supports querying for attribution information.


### PR DESCRIPTION
Adds a simple note mentioning testing & early feedback is welcome despite the alpha tags.