### PR TITLE
build: Fix type tests on release branch

### DIFF
--- a/packages/framework/test-client-utils/src/test/types/validateTestClientUtilsPrevious.generated.ts
+++ b/packages/framework/test-client-utils/src/test/types/validateTestClientUtilsPrevious.generated.ts
@@ -36,3 +36,27 @@ declare function use_old_VariableDeclaration_generateTestUser(
     use: TypeOnly<typeof old.generateTestUser>);
 use_old_VariableDeclaration_generateTestUser(
     get_current_VariableDeclaration_generateTestUser());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_InsecureTokenProvider": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_InsecureTokenProvider():
+    TypeOnly<old.InsecureTokenProvider>;
+declare function use_current_ClassDeclaration_InsecureTokenProvider(
+    use: TypeOnly<current.InsecureTokenProvider>);
+use_current_ClassDeclaration_InsecureTokenProvider(
+    get_old_ClassDeclaration_InsecureTokenProvider());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_InsecureTokenProvider": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_InsecureTokenProvider():
+    TypeOnly<current.InsecureTokenProvider>;
+declare function use_old_ClassDeclaration_InsecureTokenProvider(
+    use: TypeOnly<old.InsecureTokenProvider>);
+use_old_ClassDeclaration_InsecureTokenProvider(
+    get_current_ClassDeclaration_InsecureTokenProvider());


### PR DESCRIPTION
For reasons we haven't yet figured out, one of the type tests is outdated on the release branch. This change should address it.