### PR TITLE
Fluid Cache: Close DB more consistently, add optional delete DB callbacks

### DIFF
--- a/api-report/driver-web-cache.api.md
+++ b/api-report/driver-web-cache.api.md
@@ -4,13 +4,14 @@
 
 ```ts
 
+import { DeleteDBCallbacks } from 'idb';
 import { ICacheEntry } from '@fluidframework/odsp-driver-definitions';
 import { IFileEntry } from '@fluidframework/odsp-driver-definitions';
 import { IPersistedCache } from '@fluidframework/odsp-driver-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 
 // @public (undocumented)
-export function deleteFluidCacheIndexDbInstance(): Promise<void>;
+export function deleteFluidCacheIndexDbInstance(deleteDBCallbacks?: DeleteDBCallbacks): Promise<void>;
 
 // @public
 export class FluidCache implements IPersistedCache {
@@ -29,7 +30,6 @@ export interface FluidCacheConfig {
     maxCacheItemAge: number;
     partitionKey: string | null;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/drivers/driver-web-cache/src/FluidCacheIndexedDb.ts
+++ b/packages/drivers/driver-web-cache/src/FluidCacheIndexedDb.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { openDB, DBSchema, IDBPDatabase, deleteDB } from "idb";
+import { openDB, DBSchema, DeleteDBCallbacks, IDBPDatabase, deleteDB } from "idb";
 import { ICacheEntry } from "@fluidframework/odsp-driver-definitions";
 import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
@@ -73,8 +73,10 @@ export function getFluidCacheIndexedDbInstance(
 
 // Deletes the indexed DB instance.
 // Warning this can throw an error in Firefox incognito, where accessing storage is prohibited.
-export function deleteFluidCacheIndexDbInstance(): Promise<void> {
-	return deleteDB(FluidDriverCacheDBName);
+export function deleteFluidCacheIndexDbInstance(
+	deleteDBCallbacks?: DeleteDBCallbacks,
+): Promise<void> {
+	return deleteDB(FluidDriverCacheDBName, deleteDBCallbacks);
 }
 
 /**

--- a/packages/framework/test-client-utils/src/test/types/validateTestClientUtilsPrevious.generated.ts
+++ b/packages/framework/test-client-utils/src/test/types/validateTestClientUtilsPrevious.generated.ts
@@ -36,3 +36,27 @@ declare function use_old_VariableDeclaration_generateTestUser(
     use: TypeOnly<typeof old.generateTestUser>);
 use_old_VariableDeclaration_generateTestUser(
     get_current_VariableDeclaration_generateTestUser());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_InsecureTokenProvider": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_InsecureTokenProvider():
+    TypeOnly<old.InsecureTokenProvider>;
+declare function use_current_ClassDeclaration_InsecureTokenProvider(
+    use: TypeOnly<current.InsecureTokenProvider>);
+use_current_ClassDeclaration_InsecureTokenProvider(
+    get_old_ClassDeclaration_InsecureTokenProvider());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_InsecureTokenProvider": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_InsecureTokenProvider():
+    TypeOnly<current.InsecureTokenProvider>;
+declare function use_old_ClassDeclaration_InsecureTokenProvider(
+    use: TypeOnly<old.InsecureTokenProvider>);
+use_old_ClassDeclaration_InsecureTokenProvider(
+    get_current_ClassDeclaration_InsecureTokenProvider());


### PR DESCRIPTION
## Description

Consistently close DB after operations in FluidCache. Allow optional listeners on DB deletion to check for blocked situations as needed.

FluidCache return paths can leave DB open, delaying and potentially blocking DB deletions. Additionally, having delete callbacks can help identify when these situations will occur ahead of time so the delete caller can act appropriately.

I would like to add unit tests to ensure DB closure but also have an urgency to consume this as quickly as possible. I will follow up in another PR if needed.