### PR TITLE
[GC-stress] Test that failures should up in ADO results

### DIFF
--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -148,7 +148,7 @@ async function main() {
 	} catch (e) {
 		logger.sendErrorEvent({ eventName: "runnerFailed" }, e);
 	} finally {
-		if (testFailed) {
+		if (testFailed || runId === 3) {
 			result = -1;
 		}
 		await safeExit(result, url, runId);

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -32,8 +32,8 @@
 		"gc_ci": {
 			"opRatePerMin": 800,
 			"progressIntervalMs": 5000,
-			"numClients": 10,
-			"totalSendCount": 36000,
+			"numClients": 5,
+			"totalSendCount": 1600,
 			"optionOverrides": {
 				"tinylicious": {
 					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",


### PR DESCRIPTION
Intentionally fail one of the runners and check that the failure shows up in ADO result.