### PR TITLE
[GC-stress] Enable logging to kusto

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -58,7 +58,7 @@ stages:
           login__microsoft__clientId: $(login-microsoft-clientId)
           login__microsoft__secret: $(login-microsoft-secret)
           login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
-          #FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+          FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
 
   # stress tests tinylicious
   - stage:
@@ -75,4 +75,4 @@ stages:
         testCommand: start:t9s:gc:ci
         env:
           nothing_useful: hello world
-          #FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+          FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject


### PR DESCRIPTION
Now that the alerts from the main stress tests filter out logs from test/ branches, enabling logging the results from gc stress tests to kusto.