### PR TITLE
Enabled session expiry and track GC state by default

### DIFF
--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -202,7 +202,6 @@ export class GarbageCollector implements IGarbageCollector {
 
 		this.summaryStateTracker = new GCSummaryStateTracker(
 			this.shouldRunGC,
-			this.configs.trackGCState,
 			this.configs.tombstoneMode,
 			this.mc,
 			baseSnapshot?.trees[gcTreeKey] !== undefined /* wasGCRunInBaseSnapshot */,

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -19,6 +19,7 @@ import {
 	maxSnapshotCacheExpiryMs,
 	oneDayMs,
 	runGCKey,
+	runSessionExpiryKey,
 	runSweepKey,
 } from "./gcDefinitions";
 import { getGCVersion } from "./gcHelpers";
@@ -82,8 +83,8 @@ export function generateGCConfigs(
 		// The sweep phase has to be explicitly enabled by setting the sweepAllowed flag in GC options to true.
 		sweepEnabled = createParams.gcOptions.sweepAllowed === true;
 
-		// Set the Session Expiry only if GC is enabled.
-		if (gcEnabled) {
+		// Set the Session Expiry if GC is enabled and session expiry flag isn't explicitly set to false.
+		if (gcEnabled && mc.config.getBoolean(runSessionExpiryKey) !== false) {
 			sessionExpiryTimeoutMs =
 				createParams.gcOptions.sessionExpiryTimeoutMs ?? defaultSessionExpiryDurationMs;
 		}

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -32,6 +32,8 @@ export const runGCKey = "Fluid.GarbageCollection.RunGC";
 export const runSweepKey = "Fluid.GarbageCollection.RunSweep";
 // Feature gate key to turn GC test mode on / off.
 export const gcTestModeKey = "Fluid.GarbageCollection.GCTestMode";
+// Feature gate key to expire a session after a set period of time.
+export const runSessionExpiryKey = "Fluid.GarbageCollection.RunSessionExpiry";
 // Feature gate key to turn GC sweep log off.
 export const disableSweepLogKey = "Fluid.GarbageCollection.DisableSweepLog";
 // Feature gate key to disable the tombstone feature, i.e., tombstone information is not read / written into summary.

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -32,10 +32,6 @@ export const runGCKey = "Fluid.GarbageCollection.RunGC";
 export const runSweepKey = "Fluid.GarbageCollection.RunSweep";
 // Feature gate key to turn GC test mode on / off.
 export const gcTestModeKey = "Fluid.GarbageCollection.GCTestMode";
-// Feature gate key to expire a session after a set period of time.
-export const runSessionExpiryKey = "Fluid.GarbageCollection.RunSessionExpiry";
-// Feature gate key to write the gc blob as a handle if the data is the same.
-export const trackGCStateKey = "Fluid.GarbageCollection.TrackGCState";
 // Feature gate key to turn GC sweep log off.
 export const disableSweepLogKey = "Fluid.GarbageCollection.DisableSweepLog";
 // Feature gate key to disable the tombstone feature, i.e., tombstone information is not read / written into summary.
@@ -330,11 +326,6 @@ export interface IGarbageCollectorConfigs {
 	 * step for sweep where accidental sweep ready objects can be recovered.
 	 */
 	readonly tombstoneMode: boolean;
-	/**
-	 * Tracks whether GC state should be tracked. If true, for unchanged GC data across summaries, a summary
-	 * handle is written to summary instead of a summary tree / blob.
-	 */
-	readonly trackGCState: boolean;
 	/** @see GCFeatureMatrix. */
 	readonly persistedGcFeatureMatrix: GCFeatureMatrix | undefined;
 	/** The version of GC in the base snapshot. */

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -23,7 +23,6 @@ export {
 	IGCStats,
 	oneDayMs,
 	runGCKey,
-	runSessionExpiryKey,
 	runSweepKey,
 	stableGCVersion,
 	sweepAttachmentBlobsKey,

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -23,6 +23,7 @@ export {
 	IGCStats,
 	oneDayMs,
 	runGCKey,
+	runSessionExpiryKey,
 	runSweepKey,
 	stableGCVersion,
 	sweepAttachmentBlobsKey,

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -37,7 +37,6 @@ import {
 	IGarbageCollectorConfigs,
 	IGarbageCollectorCreateParams,
 	defaultSessionExpiryDurationMs,
-	runSessionExpiryKey,
 	oneDayMs,
 	disableSweepLogKey,
 	GCVersion,
@@ -167,8 +166,6 @@ describe("Garbage Collection Tests", () => {
 	});
 
 	it("Session expiry closes container", () => {
-		injectedSettings[runSessionExpiryKey] = "true";
-
 		let closeCalled = false;
 		function closeCalledAfterExactTicks(ticks: number) {
 			clock.tick(ticks - 1);
@@ -677,11 +674,6 @@ describe("Garbage Collection Tests", () => {
 		describe("SweepReady events (summarizer container)", () => {
 			const sweepTimeoutMs =
 				defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
-
-			beforeEach(() => {
-				injectedSettings[runSessionExpiryKey] = true;
-			});
-
 			summarizerContainerTests(
 				sweepTimeoutMs,
 				"GarbageCollector:SweepReadyObject_Revived",
@@ -696,7 +688,6 @@ describe("Garbage Collection Tests", () => {
 				defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
 
 			beforeEach(() => {
-				injectedSettings[runSessionExpiryKey] = true;
 				injectedSettings[disableSweepLogKey] = true;
 			});
 
@@ -796,10 +787,6 @@ describe("Garbage Collection Tests", () => {
 				);
 			}
 
-			beforeEach(() => {
-				injectedSettings[runSessionExpiryKey] = true;
-			});
-
 			it("Inactive object used - generates events but does not close container (SweepReadyUsageDetection enabled)", async () => {
 				const inactiveTimeoutMs = 400;
 				injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
@@ -842,7 +829,6 @@ describe("Garbage Collection Tests", () => {
 			const inactiveTimeoutMs = 500;
 			const sweepTimeoutMs =
 				defaultSessionExpiryDurationMs + defaultSnapshotCacheExpiryMs + oneDayMs;
-			injectedSettings[runSessionExpiryKey] = "true";
 			injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
 				inactiveTimeoutMs;
 
@@ -913,10 +899,6 @@ describe("Garbage Collection Tests", () => {
 	});
 
 	describe("Deleted blobs in GC summary tree", () => {
-		beforeEach(() => {
-			injectedSettings["Fluid.GarbageCollection.TrackGCState"] = true;
-		});
-
 		it("correctly reads and write deleted blobs in summary", async () => {
 			// Set up the GC reference graph to have something to work with.
 			defaultGCData.gcNodes["/"] = [nodes[0]];
@@ -1579,7 +1561,6 @@ describe("Garbage Collection Tests", () => {
 		let garbageCollector: IGarbageCollector;
 
 		beforeEach(() => {
-			injectedSettings["Fluid.GarbageCollection.TrackGCState"] = true;
 			// Initialize nodes A & D.
 			defaultGCData.gcNodes = {};
 			defaultGCData.gcNodes["/"] = nodes;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
@@ -30,7 +30,6 @@ import {
 	ITestObjectProvider,
 	TestFluidObjectFactory,
 	wrapDocumentServiceFactory,
-	mockConfigProvider,
 	waitForContainerConnection,
 } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
@@ -218,13 +217,8 @@ describeNoCompat("GC Tree stored as a handle in summaries", (getTestObjectProvid
 	const isTreeHandle = true;
 	const isTree = false;
 
-	const settings = {
-		"Fluid.GarbageCollection.TrackGCState": "true",
-	};
-	const configProvider = mockConfigProvider(settings);
-
 	const createContainer = async (): Promise<IContainer> => {
-		return provider.createContainer(runtimeFactory, { configProvider });
+		return provider.createContainer(runtimeFactory);
 	};
 
 	const getNewSummarizer = async (summaryVersion?: string) => {
@@ -233,7 +227,6 @@ describeNoCompat("GC Tree stored as a handle in summaries", (getTestObjectProvid
 			runtimeFactory,
 			mainContainer.deltaManager.lastSequenceNumber,
 			summaryVersion,
-			{ configProvider },
 		);
 	};
 

--- a/packages/test/test-utils/src/TestConfigs.ts
+++ b/packages/test/test-utils/src/TestConfigs.ts
@@ -8,8 +8,6 @@ import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-util
 export const mockConfigProvider = (
 	settings: Record<string, ConfigTypes> = {},
 ): IConfigProviderBase => {
-	settings["Fluid.GarbageCollection.TrackGCState"] = "true";
-	settings["Fluid.GarbageCollection.WriteDataAtRoot"] = "true";
 	return {
 		getRawConfig: (name: string): ConfigTypes => settings[name],
 	};


### PR DESCRIPTION
Session expiry and trackGCState are disabled by default. They could however be enabled via feature flags / config provider settings to test that they work as expected. We have had them enabled for a while now and they have been working fine.
This change enables them by default.

[AB#3498](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3498)