### PR TITLE
Add telemetry for 0x244 and 0x20c assert in documentdeltaconnection

### DIFF
--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -23,7 +23,7 @@ import type { Socket } from 'socket.io-client';
 
 // @public
 export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocumentDeltaConnectionEvents> implements IDocumentDeltaConnection, IDisposable {
-    protected constructor(socket: Socket, documentId: string, logger: ITelemetryLogger, enableLongPollingDowngrades?: boolean);
+    protected constructor(socket: Socket, documentId: string, logger: ITelemetryLogger, enableLongPollingDowngrades?: boolean, connectionId?: string | undefined);
     // (undocumented)
     protected addTrackedListener(event: string, listener: (...args: any[]) => void): void;
     checkpointSequenceNumber: number | undefined;
@@ -31,6 +31,8 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     get clientId(): string;
     // (undocumented)
     protected closeSocketCore(error: IAnyDriverError): void;
+    // (undocumented)
+    protected readonly connectionId?: string | undefined;
     protected createErrorObject(handler: string, error?: any, canRetry?: boolean): IAnyDriverError;
     // (undocumented)
     get details(): IConnected;

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -81,10 +81,24 @@ export class DocumentDeltaConnection
 	}
 
 	public get disposed() {
-		assert(
-			this._disposed || this.socket.connected,
-			0x244 /* "Socket is closed, but connection is not!" */,
-		);
+		if (!(this._disposed || this.socket.connected)) {
+			// Increase the stack trace limit temporarily, so as to debug better in case it occurs.
+			// We are seeing this in telemetry and we are unable to figure out why it is happening, so this should help.
+			const originalStackTraceLimit = (Error as any).stackTraceLimit;
+			(Error as any).stackTraceLimit = 50;
+			if (this.disposed) {
+				this.logger.sendErrorEvent({
+					eventName: "ConnectionDisposedAnomaly",
+					details: JSON.stringify({
+						disposed: this._disposed,
+						socketConnected: this.socket?.connected,
+						clientId: this._details?.clientId,
+						conenctionId: this.connectionId,
+					}),
+				});
+			}
+			(Error as any).stackTraceLimit = originalStackTraceLimit;
+		}
 		return this._disposed;
 	}
 
@@ -227,26 +241,20 @@ export class DocumentDeltaConnection
 		// Increase the stack trace limit temporarily, so as to debug better in case it occurs.
 		// We are seeing this in telemetry and we are unable to figure out why it is happening, so this should help.
 		const originalStackTraceLimit = (Error as any).stackTraceLimit;
-		try {
-			(Error as any).stackTraceLimit = 50;
-			assert(!this.disposed, 0x20c /* "connection disposed" */);
-		} catch (error) {
-			this.logger.sendErrorEvent(
-				{
-					eventName: "ConnectionDisposedAnomaly",
-					details: JSON.stringify({
-						disposed: this._disposed,
-						socketConnected: this.socket?.connected,
-						clientId: this._details?.clientId,
-						conenctionId: this.connectionId,
-					}),
-				},
-				error,
-			);
-			throw error;
-		} finally {
-			(Error as any).stackTraceLimit = originalStackTraceLimit;
+		(Error as any).stackTraceLimit = 50;
+		if (this.disposed) {
+			this.logger.sendErrorEvent({
+				eventName: "ConnectionDisposed",
+				details: JSON.stringify({
+					disposed: this._disposed,
+					socketConnected: this.socket?.connected,
+					clientId: this._details?.clientId,
+					conenctionId: this.connectionId,
+				}),
+			});
 		}
+		(Error as any).stackTraceLimit = originalStackTraceLimit;
+		return;
 	}
 
 	/**

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -86,17 +86,15 @@ export class DocumentDeltaConnection
 			// We are seeing this in telemetry and we are unable to figure out why it is happening, so this should help.
 			const originalStackTraceLimit = (Error as any).stackTraceLimit;
 			(Error as any).stackTraceLimit = 50;
-			if (this.disposed) {
-				this.logger.sendErrorEvent({
-					eventName: "ConnectionDisposedAnomaly",
-					details: JSON.stringify({
-						disposed: this._disposed,
-						socketConnected: this.socket?.connected,
-						clientId: this._details?.clientId,
-						conenctionId: this.connectionId,
-					}),
-				});
-			}
+			this.logger.sendErrorEvent({
+				eventName: "ConnectionDisposedAnomaly",
+				details: JSON.stringify({
+					disposed: this._disposed,
+					socketConnected: this.socket?.connected,
+					clientId: this._details?.clientId,
+					conenctionId: this.connectionId,
+				}),
+			});
 			(Error as any).stackTraceLimit = originalStackTraceLimit;
 		}
 		return this._disposed;

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -292,6 +292,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 			socketReference,
 			telemetryLogger,
 			enableMultiplexing,
+			uuid(),
 		);
 
 		try {
@@ -386,8 +387,9 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 		socketReference: SocketReference,
 		logger: ITelemetryLogger,
 		private readonly enableMultiplexing?: boolean,
+		connectionId?: string,
 	) {
-		super(socket, documentId, logger);
+		super(socket, documentId, logger, false, connectionId);
 		this.socketReference = socketReference;
 		this.requestOpsNoncePrefix = `${uuid()}-`;
 	}
@@ -493,6 +495,9 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 				{
 					eventName: "ServerDisconnect",
 					clientId: this.hasDetails ? this.clientId : undefined,
+					details: JSON.stringify({
+						connection: this.connectionId,
+					}),
 				},
 				error,
 			);

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -292,7 +292,6 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 			socketReference,
 			telemetryLogger,
 			enableMultiplexing,
-			uuid(),
 		);
 
 		try {
@@ -387,9 +386,8 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 		socketReference: SocketReference,
 		logger: ITelemetryLogger,
 		private readonly enableMultiplexing?: boolean,
-		connectionId?: string,
 	) {
-		super(socket, documentId, logger, false, connectionId);
+		super(socket, documentId, logger, false, uuid());
 		this.socketReference = socketReference;
 		this.requestOpsNoncePrefix = `${uuid()}-`;
 	}

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -661,9 +661,9 @@ export class ConnectionManager implements IConnectionManager {
 		// eslint-disable-next-line @typescript-eslint/no-floating-promises
 		this._outbound.pause();
 		this._outbound.clear();
-		this.props.disconnectHandler(reason);
-
 		connection.dispose();
+
+		this.props.disconnectHandler(reason);
 
 		this._connectionVerboseProps = {};
 


### PR DESCRIPTION
## Description

Add telemetry for 0x244 and 0x20c assert in documentdeltaconnection. Improve stack trace limit temporarily for this error, so that we can see stack and debug it.