### PR TITLE
[Port v2int 3.2] Fluid Cache: Close DB more consistently, add optional delete DB callbacks (#14315)

### DIFF
--- a/api-report/driver-web-cache.api.md
+++ b/api-report/driver-web-cache.api.md
@@ -4,13 +4,14 @@
 
 ```ts
 
+import { DeleteDBCallbacks } from 'idb';
 import { ICacheEntry } from '@fluidframework/odsp-driver-definitions';
 import { IFileEntry } from '@fluidframework/odsp-driver-definitions';
 import { IPersistedCache } from '@fluidframework/odsp-driver-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 
 // @public (undocumented)
-export function deleteFluidCacheIndexDbInstance(): Promise<void>;
+export function deleteFluidCacheIndexDbInstance(deleteDBCallbacks?: DeleteDBCallbacks): Promise<void>;
 
 // @public
 export class FluidCache implements IPersistedCache {
@@ -29,7 +30,6 @@ export interface FluidCacheConfig {
     maxCacheItemAge: number;
     partitionKey: string | null;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/drivers/driver-web-cache/src/FluidCacheIndexedDb.ts
+++ b/packages/drivers/driver-web-cache/src/FluidCacheIndexedDb.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { openDB, DBSchema, IDBPDatabase, deleteDB } from "idb";
+import { openDB, DBSchema, DeleteDBCallbacks, IDBPDatabase, deleteDB } from "idb";
 import { ICacheEntry } from "@fluidframework/odsp-driver-definitions";
 import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
@@ -73,8 +73,10 @@ export function getFluidCacheIndexedDbInstance(
 
 // Deletes the indexed DB instance.
 // Warning this can throw an error in Firefox incognito, where accessing storage is prohibited.
-export function deleteFluidCacheIndexDbInstance(): Promise<void> {
-	return deleteDB(FluidDriverCacheDBName);
+export function deleteFluidCacheIndexDbInstance(
+	deleteDBCallbacks?: DeleteDBCallbacks,
+): Promise<void> {
+	return deleteDB(FluidDriverCacheDBName, deleteDBCallbacks);
 }
 
 /**


### PR DESCRIPTION
Patch for closing DB more consistently after operations in FluidCache (https://github.com/microsoft/FluidFramework/pull/14315).

