### PR TITLE
Fix op compression when using an older loader

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1843,7 +1843,23 @@ export class ContainerRuntime
 				case ContainerMessageType.Rejoin:
 					break;
 				default:
-					assert(!runtimeMessage, 0x3ce /* Runtime message of unknown type */);
+					if (runtimeMessage) {
+						const error = DataProcessingError.create(
+							// Former assert 0x3ce
+							"Runtime message of unknown type",
+							"OpProcessing",
+							message,
+							{
+								local,
+								type: message.type,
+								contentType: typeof message.contents,
+								batch: message.metadata?.batch,
+								compression: message.compression,
+							},
+						);
+						this.closeFn(error);
+						throw error;
+					}
 			}
 
 			// For back-compat, notify only about runtime messages for now.

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1066,7 +1066,10 @@ export class ContainerRuntime
 			runtimeOptions.maxBatchSizeInBytes,
 			this.mc.logger,
 		);
-		this.remoteMessageProcessor = new RemoteMessageProcessor(opSplitter, new OpDecompressor());
+		this.remoteMessageProcessor = new RemoteMessageProcessor(
+			opSplitter,
+			new OpDecompressor(this.mc.logger),
+		);
 
 		this.handleContext = new ContainerFluidHandleContext("", this);
 

--- a/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
@@ -130,7 +130,7 @@ const isCompressed = (message: ISequencedDocumentMessage): boolean => {
 	// version client_v2.0.0-internal.1.2.0 to client_v2.0.0-internal.2.2.0 do not
 	// support adding the proper compression metadata to compressed messages submitted
 	// by the runtime.
-	if (message.contents?.packedContents !== undefined) {
+	if (typeof message.contents === "object" && message.contents?.packedContents !== undefined) {
 		return (
 			Object.keys(message.contents).length === 1 &&
 			typeof message.contents?.packedContents === "string" &&

--- a/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
@@ -129,8 +129,8 @@ export class OpDecompressor {
 		try {
 			if (
 				typeof message.contents === "object" &&
-				message.contents?.packedContents !== undefined &&
 				Object.keys(message.contents).length === 1 &&
+				message.contents?.packedContents !== undefined &&
 				typeof message.contents?.packedContents === "string" &&
 				message.contents.packedContents.length > 0 &&
 				btoa(atob(message.contents.packedContents)) === message.contents.packedContents

--- a/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
@@ -126,10 +126,11 @@ const isCompressed = (message: ISequencedDocumentMessage): boolean => {
 	}
 
 	// This condition holds true for compressed messages, regardless of metadata.
-	// Back-compat self healing mechanism for ADO:, as loaders from
+	// Back-compat self healing mechanism for ADO:3538, as loaders from
 	// version client_v2.0.0-internal.1.2.0 to client_v2.0.0-internal.2.2.0 do not
 	// support adding the proper compression metadata to compressed messages submitted
-	// by the runtime.
+	// by the runtime. Should be removed after the loader reaches sufficient saturation
+	// for a version greater or equal than client_v2.0.0-internal.2.2.0.
 	if (typeof message.contents === "object" && message.contents?.packedContents !== undefined) {
 		return (
 			Object.keys(message.contents).length === 1 &&

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -175,9 +175,11 @@ export class Outbox {
 		if (
 			batch.content.length === 0 ||
 			this.params.config.compressionOptions === undefined ||
-			this.params.config.compressionOptions.minimumBatchSizeInBytes > batch.contentSizeInBytes
+			this.params.config.compressionOptions.minimumBatchSizeInBytes >
+				batch.contentSizeInBytes ||
+			this.params.containerContext.submitBatchFn === undefined
 		) {
-			// Nothing to do if the batch is empty or if compression is disabled or if we don't need to compress
+			// Nothing to do if the batch is empty or if compression is disabled or not supported, or if we don't need to compress
 			return batch;
 		}
 

--- a/packages/runtime/container-runtime/src/test/opLifecycle/opDecompressor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opDecompressor.spec.ts
@@ -88,7 +88,7 @@ describe("OpDecompressor", () => {
 	});
 
 	// Back-compat self healing mechanism for ADO:3538
-	it("Processes single compressed op without compression markers", () => {
+	it.skip("Processes single compressed op without compression markers", () => {
 		const result = decompressor.processMessage({
 			...generateCompressedBatchMessage(1),
 			compression: undefined,

--- a/packages/runtime/container-runtime/src/test/opLifecycle/opDecompressor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opDecompressor.spec.ts
@@ -84,6 +84,18 @@ describe("OpDecompressor", () => {
 		assert.strictEqual(result.message.compression, undefined);
 	});
 
+	// Back-compat self healing mechanism for ADO:
+	it("Processes single compressed op without compression markers", () => {
+		const result = decompressor.processMessage({
+			...generateCompressedBatchMessage(1),
+			compression: undefined,
+		});
+		assert.equal(result.state, "Processed");
+		assert.strictEqual(result.message.contents.contents, "value0");
+		assert.strictEqual(result.message.metadata?.compressed, undefined);
+		assert.strictEqual(result.message.compression, undefined);
+	});
+
 	it("Expecting only lz4 compression", () => {
 		assert.throws(() =>
 			decompressor.processMessage({
@@ -160,9 +172,16 @@ describe("OpDecompressor", () => {
 
 	it("Ignores ops without compression", () => {
 		const rootMessage = {
-			...generateCompressedBatchMessage(5),
-			metadata: undefined,
-			compression: undefined,
+			contents: { some: "contents" },
+			metadata: { meta: "data" },
+			clientId: "clientId",
+			sequenceNumber: 1,
+			term: 1,
+			minimumSequenceNumber: 1,
+			clientSequenceNumber: 1,
+			referenceSequenceNumber: 1,
+			type: "type",
+			timestamp: 1,
 		};
 		const firstMessageResult = decompressor.processMessage(rootMessage);
 

--- a/packages/runtime/container-runtime/src/test/opLifecycle/opDecompressor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opDecompressor.spec.ts
@@ -88,7 +88,7 @@ describe("OpDecompressor", () => {
 	});
 
 	// Back-compat self healing mechanism for ADO:3538
-	it.skip("Processes single compressed op without compression markers", () => {
+	it("Processes single compressed op without compression markers", () => {
 		const result = decompressor.processMessage({
 			...generateCompressedBatchMessage(1),
 			compression: undefined,
@@ -181,23 +181,67 @@ describe("OpDecompressor", () => {
 	});
 
 	it("Ignores ops without compression", () => {
-		const rootMessage = {
-			// Back-compat self healing mechanism for ADO:3538,
-			// the message should have a `packedContents` property.
-			contents: { some: "contents" },
-			metadata: { meta: "data" },
-			clientId: "clientId",
-			sequenceNumber: 1,
-			term: 1,
-			minimumSequenceNumber: 1,
-			clientSequenceNumber: 1,
-			referenceSequenceNumber: 1,
-			type: "type",
-			timestamp: 1,
-		};
-		const firstMessageResult = decompressor.processMessage(rootMessage);
+		const rootMessages = [
+			{
+				// Back-compat self healing mechanism for ADO:3538,
+				// the message should have a `packedContents` property.
+				contents: { some: "contents" },
+				metadata: { meta: "data" },
+				clientId: "clientId",
+				sequenceNumber: 1,
+				term: 1,
+				minimumSequenceNumber: 1,
+				clientSequenceNumber: 1,
+				referenceSequenceNumber: 1,
+				type: "type",
+				timestamp: 1,
+			},
+			{
+				// Back-compat self healing mechanism for ADO:3538,
+				contents: { packedContents: "packedContents is not base64 encoded" },
+				metadata: { meta: "data" },
+				clientId: "clientId",
+				sequenceNumber: 1,
+				term: 1,
+				minimumSequenceNumber: 1,
+				clientSequenceNumber: 1,
+				referenceSequenceNumber: 1,
+				type: "type",
+				timestamp: 1,
+			},
+			{
+				// Back-compat self healing mechanism for ADO:3538,
+				contents: { packedContents: "YmFzZTY0IGNvbnRlbnQ=", some: "contents" },
+				metadata: { meta: "data" },
+				clientId: "clientId",
+				sequenceNumber: 1,
+				term: 1,
+				minimumSequenceNumber: 1,
+				clientSequenceNumber: 1,
+				referenceSequenceNumber: 1,
+				type: "type",
+				timestamp: 1,
+			},
+			{
+				metadata: { meta: "data" },
+				clientId: "clientId",
+				sequenceNumber: 1,
+				term: 1,
+				minimumSequenceNumber: 1,
+				clientSequenceNumber: 1,
+				referenceSequenceNumber: 1,
+				type: "type",
+				timestamp: 1,
+			},
+		];
 
-		assert.equal(firstMessageResult.state, "Skipped");
-		assert.deepStrictEqual(firstMessageResult.message, rootMessage);
+		for (const rootMessage of rootMessages) {
+			const firstMessageResult = decompressor.processMessage(
+				rootMessage as ISequencedDocumentMessage,
+			);
+
+			assert.equal(firstMessageResult.state, "Skipped");
+			assert.deepStrictEqual(firstMessageResult.message, rootMessage);
+		}
 	});
 });

--- a/packages/runtime/container-runtime/src/test/opLifecycle/opDecompressor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opDecompressor.spec.ts
@@ -84,7 +84,7 @@ describe("OpDecompressor", () => {
 		assert.strictEqual(result.message.compression, undefined);
 	});
 
-	// Back-compat self healing mechanism for ADO:
+	// Back-compat self healing mechanism for ADO:3538
 	it("Processes single compressed op without compression markers", () => {
 		const result = decompressor.processMessage({
 			...generateCompressedBatchMessage(1),
@@ -172,6 +172,8 @@ describe("OpDecompressor", () => {
 
 	it("Ignores ops without compression", () => {
 		const rootMessage = {
+			// Back-compat self healing mechanism for ADO:3538,
+			// the message should have a `packedContents` property.
 			contents: { some: "contents" },
 			metadata: { meta: "data" },
 			clientId: "clientId",

--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -3,9 +3,10 @@
  * Licensed under the MIT License.
  */
 
+// eslint-disable-next-line import/no-nodejs-modules
+import * as crypto from "crypto";
 import { strict as assert } from "assert";
-import { Container } from "@fluidframework/container-loader";
-import { SharedMap } from "@fluidframework/map";
+import { ISharedMap, SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
 	DataObjectFactoryType,
@@ -13,50 +14,106 @@ import {
 	ITestFluidObject,
 	ITestObjectProvider,
 } from "@fluidframework/test-utils";
-import { describeFullCompat } from "@fluidframework/test-version-utils";
+import {
+	describeFullCompat,
+	describeInstallVersions,
+	getVersionedTestObjectProvider,
+} from "@fluidframework/test-version-utils";
 import { CompressionAlgorithms } from "@fluidframework/container-runtime";
+import { pkgVersion } from "../packageVersion";
 
-const testContainerConfig: ITestContainerConfig = {
-	registry: [["mapKey", SharedMap.getFactory()]],
-	runtimeOptions: {
-		compressionOptions: {
-			minimumBatchSizeInBytes: 1,
-			compressionAlgorithm: CompressionAlgorithms.lz4,
-		},
-	},
-	fluidDataObjectType: DataObjectFactoryType.Test,
+const compressionSuite = (getProvider) => {
+	describe("Compression", () => {
+		let provider: ITestObjectProvider;
+		let localMap: ISharedMap;
+		let remoteMap: ISharedMap;
+		const testContainerConfig: ITestContainerConfig = {
+			registry: [["mapKey", SharedMap.getFactory()]],
+			runtimeOptions: {
+				compressionOptions: {
+					minimumBatchSizeInBytes: 10,
+					compressionAlgorithm: CompressionAlgorithms.lz4,
+				},
+			},
+			fluidDataObjectType: DataObjectFactoryType.Test,
+		};
+
+		beforeEach(async () => {
+			provider = await getProvider();
+
+			const localContainer = await provider.makeTestContainer(testContainerConfig);
+			const localDataObject = await requestFluidObject<ITestFluidObject>(
+				localContainer,
+				"default",
+			);
+			localMap = await localDataObject.getSharedObject<SharedMap>("mapKey");
+
+			const remoteContainer = await provider.loadTestContainer(testContainerConfig);
+			const remoteDataObject = await requestFluidObject<ITestFluidObject>(
+				remoteContainer,
+				"default",
+			);
+			remoteMap = await remoteDataObject.getSharedObject<SharedMap>("mapKey");
+		});
+
+		afterEach(() => {
+			provider.reset();
+		});
+
+		it("Can compress and process compressed op", async () => {
+			const values = [
+				generateRandomStringOfSize(100),
+				generateRandomStringOfSize(100),
+				generateRandomStringOfSize(100),
+			];
+
+			for (let i = 0; i < values.length; i++) {
+				localMap.set(`${i}`, values[i]);
+			}
+
+			await provider.ensureSynchronized();
+			for (let i = 0; i < values.length; i++) {
+				assert.equal(localMap.get(`${i}`), values[i]);
+				assert.equal(remoteMap.get(`${i}`), values[i]);
+			}
+		});
+
+		it("Processes ops that weren't worth compressing", async () => {
+			const value = generateRandomStringOfSize(5);
+			localMap.set("testKey", value);
+
+			await provider.ensureSynchronized();
+			assert.strictEqual(localMap.get("testKey"), value);
+			assert.strictEqual(remoteMap.get("testKey"), value);
+		});
+	});
 };
 
-describeFullCompat("Op Compression", (getTestObjectProvider) => {
-	let provider: ITestObjectProvider;
-	let container: Container;
-	let dataObject: ITestFluidObject;
-	let map: SharedMap;
+describeFullCompat("Op Compression", (getTestObjectProvider) =>
+	compressionSuite(async () => getTestObjectProvider()),
+);
 
-	beforeEach(async () => {
-		provider = getTestObjectProvider();
+const loaderWithoutCompressionField = "2.0.0-internal.1.4.6";
+describeInstallVersions(
+	{
+		requestAbsoluteVersions: [loaderWithoutCompressionField],
+	},
+	/* timeoutMs */ 50000,
+)("Op Compression self-healing with old loader", (getProvider) =>
+	compressionSuite(async () => {
+		const provider = getProvider();
+		return getVersionedTestObjectProvider(
+			pkgVersion, // base version
+			loaderWithoutCompressionField, // loader version
+			{
+				type: provider.driver.type,
+				version: pkgVersion,
+			}, // driver version
+			pkgVersion, // runtime version
+			pkgVersion, // datastore runtime version
+		);
+	}),
+);
 
-		container = (await provider.makeTestContainer(testContainerConfig)) as Container;
-		dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
-		map = await dataObject.getSharedObject<SharedMap>("mapKey");
-	});
-
-	afterEach(() => {
-		provider.reset();
-	});
-
-	it("Can compress and process compressed op", async () => {
-		// The value is such that the compressed value is longer than the uncompressed value
-		// If it wasn't, it wouldn't get compressed
-		map.set("testKey", "///////////////////////////////////");
-		await provider.ensureSynchronized();
-		const value = map.get("testKey");
-		assert.strictEqual(value, "///////////////////////////////////");
-	});
-
-	it("Processes ops that weren't worth compressing", async () => {
-		map.set("testKey", "testValue");
-		await provider.ensureSynchronized();
-		assert.strictEqual(map.get("testKey"), "testValue");
-	});
-});
+const generateRandomStringOfSize = (sizeInBytes: number): string =>
+	crypto.randomBytes(sizeInBytes / 2).toString("hex");

--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -3,10 +3,9 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-nodejs-modules
-import * as crypto from "crypto";
 import { strict as assert } from "assert";
-import { ISharedMap, SharedMap } from "@fluidframework/map";
+import { Container } from "@fluidframework/container-loader";
+import { SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
 	DataObjectFactoryType,
@@ -14,106 +13,50 @@ import {
 	ITestFluidObject,
 	ITestObjectProvider,
 } from "@fluidframework/test-utils";
-import {
-	describeFullCompat,
-	describeInstallVersions,
-	getVersionedTestObjectProvider,
-} from "@fluidframework/test-version-utils";
+import { describeFullCompat } from "@fluidframework/test-version-utils";
 import { CompressionAlgorithms } from "@fluidframework/container-runtime";
-import { pkgVersion } from "../packageVersion";
 
-const compressionSuite = (getProvider) => {
-	describe("Compression", () => {
-		let provider: ITestObjectProvider;
-		let localMap: ISharedMap;
-		let remoteMap: ISharedMap;
-		const testContainerConfig: ITestContainerConfig = {
-			registry: [["mapKey", SharedMap.getFactory()]],
-			runtimeOptions: {
-				compressionOptions: {
-					minimumBatchSizeInBytes: 10,
-					compressionAlgorithm: CompressionAlgorithms.lz4,
-				},
-			},
-			fluidDataObjectType: DataObjectFactoryType.Test,
-		};
-
-		beforeEach(async () => {
-			provider = await getProvider();
-
-			const localContainer = await provider.makeTestContainer(testContainerConfig);
-			const localDataObject = await requestFluidObject<ITestFluidObject>(
-				localContainer,
-				"default",
-			);
-			localMap = await localDataObject.getSharedObject<SharedMap>("mapKey");
-
-			const remoteContainer = await provider.loadTestContainer(testContainerConfig);
-			const remoteDataObject = await requestFluidObject<ITestFluidObject>(
-				remoteContainer,
-				"default",
-			);
-			remoteMap = await remoteDataObject.getSharedObject<SharedMap>("mapKey");
-		});
-
-		afterEach(() => {
-			provider.reset();
-		});
-
-		it("Can compress and process compressed op", async () => {
-			const values = [
-				generateRandomStringOfSize(100),
-				generateRandomStringOfSize(100),
-				generateRandomStringOfSize(100),
-			];
-
-			for (let i = 0; i < values.length; i++) {
-				localMap.set(`${i}`, values[i]);
-			}
-
-			await provider.ensureSynchronized();
-			for (let i = 0; i < values.length; i++) {
-				assert.equal(localMap.get(`${i}`), values[i]);
-				assert.equal(remoteMap.get(`${i}`), values[i]);
-			}
-		});
-
-		it("Processes ops that weren't worth compressing", async () => {
-			const value = generateRandomStringOfSize(5);
-			localMap.set("testKey", value);
-
-			await provider.ensureSynchronized();
-			assert.strictEqual(localMap.get("testKey"), value);
-			assert.strictEqual(remoteMap.get("testKey"), value);
-		});
-	});
+const testContainerConfig: ITestContainerConfig = {
+	registry: [["mapKey", SharedMap.getFactory()]],
+	runtimeOptions: {
+		compressionOptions: {
+			minimumBatchSizeInBytes: 1,
+			compressionAlgorithm: CompressionAlgorithms.lz4,
+		},
+	},
+	fluidDataObjectType: DataObjectFactoryType.Test,
 };
 
-describeFullCompat("Op Compression", (getTestObjectProvider) =>
-	compressionSuite(async () => getTestObjectProvider()),
-);
+describeFullCompat("Op Compression", (getTestObjectProvider) => {
+	let provider: ITestObjectProvider;
+	let container: Container;
+	let dataObject: ITestFluidObject;
+	let map: SharedMap;
 
-const loaderWithoutCompressionField = "2.0.0-internal.1.4.6";
-describeInstallVersions(
-	{
-		requestAbsoluteVersions: [loaderWithoutCompressionField],
-	},
-	/* timeoutMs */ 50000,
-)("Op Compression self-healing with old loader", (getProvider) =>
-	compressionSuite(async () => {
-		const provider = getProvider();
-		return getVersionedTestObjectProvider(
-			pkgVersion, // base version
-			loaderWithoutCompressionField, // loader version
-			{
-				type: provider.driver.type,
-				version: pkgVersion,
-			}, // driver version
-			pkgVersion, // runtime version
-			pkgVersion, // datastore runtime version
-		);
-	}),
-);
+	beforeEach(async () => {
+		provider = getTestObjectProvider();
 
-const generateRandomStringOfSize = (sizeInBytes: number): string =>
-	crypto.randomBytes(sizeInBytes / 2).toString("hex");
+		container = (await provider.makeTestContainer(testContainerConfig)) as Container;
+		dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
+		map = await dataObject.getSharedObject<SharedMap>("mapKey");
+	});
+
+	afterEach(() => {
+		provider.reset();
+	});
+
+	it("Can compress and process compressed op", async () => {
+		// The value is such that the compressed value is longer than the uncompressed value
+		// If it wasn't, it wouldn't get compressed
+		map.set("testKey", "///////////////////////////////////");
+		await provider.ensureSynchronized();
+		const value = map.get("testKey");
+		assert.strictEqual(value, "///////////////////////////////////");
+	});
+
+	it("Processes ops that weren't worth compressing", async () => {
+		map.set("testKey", "testValue");
+		await provider.ensureSynchronized();
+		assert.strictEqual(map.get("testKey"), "testValue");
+	});
+});

--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -99,16 +99,20 @@ describeInstallVersions(
 		requestAbsoluteVersions: [loaderWithoutCompressionField],
 	},
 	/* timeoutMs */ 50000,
-)("Op Compression self-healing with old loader", () =>
-	compressionSuite(async () =>
-		getVersionedTestObjectProvider(
+)("Op Compression self-healing with old loader", (getProvider) =>
+	compressionSuite(async () => {
+		const provider = getProvider();
+		return getVersionedTestObjectProvider(
 			pkgVersion, // base version
 			loaderWithoutCompressionField, // loader version
-			undefined, // driver
+			{
+				type: provider.driver.type,
+				version: pkgVersion,
+			}, // driver version
 			pkgVersion, // runtime version
 			pkgVersion, // datastore runtime version
-		),
-	),
+		);
+	}),
 );
 
 const generateRandomStringOfSize = (sizeInBytes: number): string =>

--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -3,9 +3,10 @@
  * Licensed under the MIT License.
  */
 
+// eslint-disable-next-line import/no-nodejs-modules
+import * as crypto from "crypto";
 import { strict as assert } from "assert";
-import { Container } from "@fluidframework/container-loader";
-import { SharedMap } from "@fluidframework/map";
+import { ISharedMap, SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
 	DataObjectFactoryType,
@@ -13,50 +14,102 @@ import {
 	ITestFluidObject,
 	ITestObjectProvider,
 } from "@fluidframework/test-utils";
-import { describeFullCompat } from "@fluidframework/test-version-utils";
+import {
+	describeFullCompat,
+	describeInstallVersions,
+	getVersionedTestObjectProvider,
+} from "@fluidframework/test-version-utils";
 import { CompressionAlgorithms } from "@fluidframework/container-runtime";
+import { pkgVersion } from "../packageVersion";
 
-const testContainerConfig: ITestContainerConfig = {
-	registry: [["mapKey", SharedMap.getFactory()]],
-	runtimeOptions: {
-		compressionOptions: {
-			minimumBatchSizeInBytes: 1,
-			compressionAlgorithm: CompressionAlgorithms.lz4,
-		},
-	},
-	fluidDataObjectType: DataObjectFactoryType.Test,
+const compressionSuite = (getProvider) => {
+	describe("Compression", () => {
+		let provider: ITestObjectProvider;
+		let localMap: ISharedMap;
+		let remoteMap: ISharedMap;
+		const testContainerConfig: ITestContainerConfig = {
+			registry: [["mapKey", SharedMap.getFactory()]],
+			runtimeOptions: {
+				compressionOptions: {
+					minimumBatchSizeInBytes: 10,
+					compressionAlgorithm: CompressionAlgorithms.lz4,
+				},
+			},
+			fluidDataObjectType: DataObjectFactoryType.Test,
+		};
+
+		beforeEach(async () => {
+			provider = await getProvider();
+
+			const localContainer = await provider.makeTestContainer(testContainerConfig);
+			const localDataObject = await requestFluidObject<ITestFluidObject>(
+				localContainer,
+				"default",
+			);
+			localMap = await localDataObject.getSharedObject<SharedMap>("mapKey");
+
+			const remoteContainer = await provider.loadTestContainer(testContainerConfig);
+			const remoteDataObject = await requestFluidObject<ITestFluidObject>(
+				remoteContainer,
+				"default",
+			);
+			remoteMap = await remoteDataObject.getSharedObject<SharedMap>("mapKey");
+		});
+
+		afterEach(() => {
+			provider.reset();
+		});
+
+		it("Can compress and process compressed op", async () => {
+			const values = [
+				generateRandomStringOfSize(100),
+				generateRandomStringOfSize(100),
+				generateRandomStringOfSize(100),
+			];
+
+			for (let i = 0; i < values.length; i++) {
+				localMap.set(`${i}`, values[i]);
+			}
+
+			await provider.ensureSynchronized();
+			for (let i = 0; i < values.length; i++) {
+				assert.equal(localMap.get(`${i}`), values[i]);
+				assert.equal(remoteMap.get(`${i}`), values[i]);
+			}
+		});
+
+		it("Processes ops that weren't worth compressing", async () => {
+			const value = generateRandomStringOfSize(5);
+			localMap.set("testKey", value);
+
+			await provider.ensureSynchronized();
+			assert.strictEqual(localMap.get("testKey"), value);
+			assert.strictEqual(remoteMap.get("testKey"), value);
+		});
+	});
 };
 
-describeFullCompat("Op Compression", (getTestObjectProvider) => {
-	let provider: ITestObjectProvider;
-	let container: Container;
-	let dataObject: ITestFluidObject;
-	let map: SharedMap;
+describeFullCompat("Op Compression", (getTestObjectProvider) =>
+	compressionSuite(async () => getTestObjectProvider()),
+);
 
-	beforeEach(async () => {
-		provider = getTestObjectProvider();
+const loaderWithoutCompressionField = "2.0.0-internal.1.4.6";
+describeInstallVersions(
+	{
+		requestAbsoluteVersions: [loaderWithoutCompressionField],
+	},
+	/* timeoutMs */ 50000,
+)("Op Compression self-healing with old loader", () =>
+	compressionSuite(async () =>
+		getVersionedTestObjectProvider(
+			pkgVersion, // base version
+			loaderWithoutCompressionField, // loader version
+			undefined, // driver
+			pkgVersion, // runtime version
+			pkgVersion, // datastore runtime version
+		),
+	),
+);
 
-		container = (await provider.makeTestContainer(testContainerConfig)) as Container;
-		dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
-		map = await dataObject.getSharedObject<SharedMap>("mapKey");
-	});
-
-	afterEach(() => {
-		provider.reset();
-	});
-
-	it("Can compress and process compressed op", async () => {
-		// The value is such that the compressed value is longer than the uncompressed value
-		// If it wasn't, it wouldn't get compressed
-		map.set("testKey", "///////////////////////////////////");
-		await provider.ensureSynchronized();
-		const value = map.get("testKey");
-		assert.strictEqual(value, "///////////////////////////////////");
-	});
-
-	it("Processes ops that weren't worth compressing", async () => {
-		map.set("testKey", "testValue");
-		await provider.ensureSynchronized();
-		assert.strictEqual(map.get("testKey"), "testValue");
-	});
-});
+const generateRandomStringOfSize = (sizeInBytes: number): string =>
+	crypto.randomBytes(sizeInBytes / 2).toString("hex");


### PR DESCRIPTION
## Description

[AB#3538](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3538)

For loaders older than client_v2.0.0-internal.1.2.0 (exclusive), compression gracefully does not work (it does happen, but the messages are eventually sent uncompressed over the wire)

However, for loaders between client_v2.0.0-internal.1.2.0 (inclusive) and client_v2.0.0-internal.2.2.0 (exclusive), the runtime will provide the loader with the compression field as such:

```
this.params.containerContext.submitBatchFn(
                batch.content.map((message) => ({
                    contents: message.contents,
                    metadata: message.metadata,
                    compression: message.compression, // <-- compression marker
                    referenceSequenceNumber: message.referenceSequenceNumber,
                })),
                batch.referenceSequenceNumber,
            );
```

but the delta manager, on the loader side will ignore that field. Therefore, the message is sent over the wire without any compression markers. This means that no client is able to process this compressed message as it has no compression marker, and the container will close with assert `0x3ce` (`Runtime message of unknown type`).

**To work around this, the runtime must figure out if the message is compressed based on its 'shape'**

This change also replaces the assert with an explicit data processing error.