### PR TITLE
Tree: Move composition fix

### DIFF
--- a/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
@@ -20,7 +20,7 @@ import {
 import { GapTracker, IndexTracker } from "./tracker";
 import { MarkListFactory } from "./markListFactory";
 import { MarkQueue } from "./markQueue";
-import { getOrAddEffect, MoveEffectTable } from "./moveEffectTable";
+import { getMoveEffect, getOrAddEffect, MoveEffectTable } from "./moveEffectTable";
 import {
 	getInputLength,
 	getOutputLength,
@@ -35,6 +35,7 @@ import {
 	dequeueRelatedReattaches,
 	isBlockedReattach,
 	getOffsetAtRevision,
+	isObjMark,
 } from "./utils";
 
 /**
@@ -524,7 +525,38 @@ function amendComposeI<TNodeChange>(
 	);
 
 	while (!queue.isEmpty()) {
-		factory.push(queue.dequeue());
+		let mark = queue.dequeue();
+		if (isObjMark(mark)) {
+			switch (mark.type) {
+				case "MoveOut":
+				case "ReturnFrom": {
+					const effect = getMoveEffect(
+						moveEffects,
+						CrossFieldTarget.Source,
+						mark.revision,
+						mark.id,
+					);
+					mark = effect.mark ?? mark;
+					delete effect.mark;
+					break;
+				}
+				case "MoveIn":
+				case "ReturnTo": {
+					const effect = getMoveEffect(
+						moveEffects,
+						CrossFieldTarget.Destination,
+						mark.revision,
+						mark.id,
+					);
+					mark = effect.mark ?? mark;
+					delete effect.mark;
+					break;
+				}
+				default:
+					break;
+			}
+		}
+		factory.push(mark);
 	}
 
 	return factory.list;
@@ -542,7 +574,7 @@ export class ComposeQueue<T> {
 		private readonly newRevision: RevisionTag | undefined,
 		newMarks: Changeset<T>,
 		genId: IdAllocator,
-		moveEffects: MoveEffectTable<T>,
+		private readonly moveEffects: MoveEffectTable<T>,
 		composeChanges?: (a: T | undefined, b: T | undefined) => T | undefined,
 	) {
 		this.baseIndex = new IndexTracker();
@@ -586,16 +618,10 @@ export class ComposeQueue<T> {
 		} else if (baseMark === undefined) {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			const length = getInputLength(newMark!);
-			return {
-				baseMark: length > 0 ? length : undefined,
-				newMark: this.newMarks.tryDequeue(),
-			};
+			return this.dequeueNew(length);
 		} else if (newMark === undefined) {
 			const length = getOutputLength(baseMark);
-			return {
-				baseMark: this.baseMarks.tryDequeue(),
-				newMark: length > 0 ? length : undefined,
-			};
+			return this.dequeueBase(length);
 		} else if (isAttach(newMark)) {
 			if (isActiveReattach(newMark) && isDetachMark(baseMark)) {
 				const newRev = newMark.revision ?? this.newRevision;
@@ -665,9 +691,7 @@ export class ComposeQueue<T> {
 						// out with (or ordered it with respect to) newMark.
 						// This later detach must therefore be present in the base changeset, and further to the right.
 						// We'll keep returning all the base marks before that.
-						return {
-							baseMark: this.baseMarks.dequeue(),
-						};
+						return this.dequeueBase();
 					} else {
 						// The reattach is for a detach that occurred chronologically before the baseMark detach.
 						// We rely on the lineage information to tell us where in relation to baseMark this earlier
@@ -676,7 +700,7 @@ export class ComposeQueue<T> {
 						const remainingOffset = targetOffset - currentOffset;
 						assert(remainingOffset >= 0, 0x4e0 /* Overshot the target gap */);
 						if (remainingOffset === 0) {
-							return { newMark: this.newMarks.dequeue() };
+							return this.dequeueNew();
 						}
 						return {
 							baseMark:
@@ -693,11 +717,11 @@ export class ComposeQueue<T> {
 			) {
 				return dequeueRelatedReattaches(this.newMarks, this.baseMarks);
 			}
-			return { newMark: this.newMarks.dequeue() };
+			return this.dequeueNew();
 		} else if (isDetachMark(baseMark) || isBlockedReattach(baseMark)) {
-			return { baseMark: this.baseMarks.dequeue() };
+			return this.dequeueBase();
 		} else if (isConflictedDetach(newMark)) {
-			return { newMark: this.newMarks.dequeue() };
+			return this.dequeueNew();
 		} else {
 			// If we've reached this branch then `baseMark` and `newMark` start at the same location
 			// in the document field at the revision after the base changes and before the new changes.
@@ -721,6 +745,69 @@ export class ComposeQueue<T> {
 			// They therefore refer to the same range for that revision.
 			return { baseMark, newMark };
 		}
+	}
+
+	private dequeueBase(length: number = 0): ComposeMarks<T> {
+		const baseMark = this.baseMarks.dequeue();
+
+		if (baseMark !== undefined && isObjMark(baseMark)) {
+			switch (baseMark.type) {
+				case "MoveOut":
+				case "ReturnFrom":
+					{
+						const effect = getMoveEffect(
+							this.moveEffects,
+							CrossFieldTarget.Source,
+							baseMark.revision,
+							baseMark.id,
+						);
+
+						const newMark = effect.mark;
+						delete effect.mark;
+						if (newMark !== undefined) {
+							return { newMark };
+						}
+					}
+					break;
+				default:
+					break;
+			}
+		}
+
+		return { baseMark, newMark: length > 0 ? length : undefined };
+	}
+
+	private dequeueNew(length: number = 0): ComposeMarks<T> {
+		const newMark = this.newMarks.dequeue();
+
+		if (newMark !== undefined && isObjMark(newMark)) {
+			switch (newMark.type) {
+				case "MoveIn":
+				case "ReturnTo":
+					{
+						const effect = getMoveEffect(
+							this.moveEffects,
+							CrossFieldTarget.Destination,
+							newMark.revision ?? this.newRevision,
+							newMark.id,
+						);
+
+						const baseMark = effect.mark;
+						delete effect.mark;
+						if (baseMark !== undefined) {
+							return { baseMark };
+						}
+					}
+					break;
+				default:
+					break;
+			}
+		}
+
+		return {
+			baseMark: length > 0 ? length : undefined,
+			newMark,
+		};
 	}
 }
 

--- a/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -210,23 +210,20 @@ function applyMoveEffectsToDest<T>(
 	const result: Mark<T>[] = [];
 
 	assert(effect.modifyAfter === undefined, 0x566 /* Cannot modify move destination */);
-	if (effect.mark !== undefined) {
-		result.push(effect.mark);
-	} else {
-		if (!effect.shouldRemove) {
-			const newMark: MoveIn | ReturnTo = {
-				...mark,
-				count: effect.count ?? mark.count,
-			};
-			if (effect.pairedMarkStatus !== undefined) {
-				if (effect.pairedMarkStatus === PairedMarkUpdate.Deactivated) {
-					newMark.isSrcConflicted = true;
-				} else {
-					delete newMark.isSrcConflicted;
-				}
+
+	if (!effect.shouldRemove) {
+		const newMark: MoveIn | ReturnTo = {
+			...mark,
+			count: effect.count ?? mark.count,
+		};
+		if (effect.pairedMarkStatus !== undefined) {
+			if (effect.pairedMarkStatus === PairedMarkUpdate.Deactivated) {
+				newMark.isSrcConflicted = true;
+			} else {
+				delete newMark.isSrcConflicted;
 			}
-			result.push(newMark);
 		}
+		result.push(newMark);
 	}
 
 	if (effect.child !== undefined) {
@@ -256,7 +253,6 @@ function applyMoveEffectsToDest<T>(
 	}
 
 	if (consumeEffect) {
-		delete effect.mark;
 		delete effect.count;
 		delete effect.child;
 	}
@@ -277,9 +273,7 @@ function applyMoveEffectsToSource<T>(
 		mark.id,
 	);
 	const result: Mark<T>[] = [];
-	if (effect.mark !== undefined) {
-		result.push(effect.mark);
-	} else if (!effect.shouldRemove) {
+	if (!effect.shouldRemove) {
 		const newMark = clone(mark);
 		newMark.count = effect.count ?? newMark.count;
 		if (effect.modifyAfter !== undefined) {
@@ -334,7 +328,6 @@ function applyMoveEffectsToSource<T>(
 	}
 
 	if (consumeEffect) {
-		delete effect.mark;
 		delete effect.count;
 		delete effect.child;
 		delete effect.modifyAfter;

--- a/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -266,7 +266,7 @@ function applyMoveEffectsToSource<T>(
 	consumeEffect: boolean,
 	composeChildren?: (a: T | undefined, b: T | undefined) => T | undefined,
 ): Mark<T>[] {
-	const effect = getOrAddEffect(
+	const effect = getMoveEffect(
 		effects,
 		CrossFieldTarget.Source,
 		mark.revision ?? revision,

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.spec.ts
@@ -677,6 +677,28 @@ describe("SequenceField - Compose", () => {
 		const actual = shallowCompose([makeAnonChange(move), makeAnonChange(deletion)]);
 		assert.deepEqual(actual, expected);
 	});
+
+	it("move ○ move with no net effect (back and forward)", () => {
+		const move1 = Change.move(1, 1, 0);
+		const move2 = Change.move(0, 1, 1);
+		const expected = shallowCompose([
+			tagChange(Change.move(1, 1, 1), tag2),
+			makeAnonChange([]),
+		]);
+		const actual = shallowCompose([tagChange(move1, tag1), tagChange(move2, tag2)]);
+		assert.deepEqual(actual, expected);
+	});
+
+	it("move ○ move with no net effect (forward and back)", () => {
+		const move1 = Change.move(0, 1, 1);
+		const move2 = Change.move(1, 1, 0);
+		const expected = shallowCompose([
+			tagChange(Change.move(0, 1, 0), tag2),
+			makeAnonChange([]),
+		]);
+		const actual = shallowCompose([tagChange(move1, tag1), tagChange(move2, tag2)]);
+		assert.deepEqual(actual, expected);
+	});
 });
 function tagggedChange(
 	reviveA: SF.Changeset<never>,


### PR DESCRIPTION
Fixed an issue where sequence field's compose implementation would treat moved new marks as if they were base marks.