### PR TITLE
tree: revert Delta refactor from #13905

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -89,12 +89,6 @@ export type ChangesetLocalId = Brand<number, "ChangesetLocalId">;
 // @alpha
 export type ChildCollection = FieldKey | RootField;
 
-// @alpha (undocumented)
-interface ChildIndex {
-    // (undocumented)
-    readonly index: number;
-}
-
 // @alpha
 export interface ChildLocation {
     // (undocumented)
@@ -191,17 +185,18 @@ declare namespace Delta {
         Mark,
         MarkList,
         Skip,
-        NodeChanges,
+        Modify,
         Delete,
+        ModifyAndDelete,
         MoveOut,
+        ModifyAndMoveOut,
         MoveIn,
+        MoveInAndModify,
         Insert,
+        InsertAndModify,
         MoveId,
         FieldMap,
-        FieldChangeMap_2 as FieldChangeMap,
-        FieldChanges,
-        ChildIndex,
-        NestedChange,
+        FieldMarks,
         MarkType
     }
 }
@@ -329,7 +324,7 @@ export interface FieldChangeHandler<TChangeset, TEditor extends FieldEditor<TCha
     // (undocumented)
     encoder: FieldChangeEncoder<TChangeset>;
     // (undocumented)
-    intoDelta(change: TChangeset, deltaFromChild: ToDelta, reviver: NodeReviver): Delta.FieldChanges;
+    intoDelta(change: TChangeset, deltaFromChild: ToDelta, reviver: NodeReviver): Delta.MarkList;
     // (undocumented)
     rebaser: FieldChangeRebaser<TChangeset>;
     // (undocumented)
@@ -340,9 +335,6 @@ export interface FieldChangeHandler<TChangeset, TEditor extends FieldEditor<TCha
 export type FieldChangeMap = Map<FieldKey, FieldChange>;
 
 // @alpha (undocumented)
-type FieldChangeMap_2<TTree = ProtoNode> = FieldMap<FieldChanges<TTree>>;
-
-// @alpha (undocumented)
 export interface FieldChangeRebaser<TChangeset> {
     amendCompose(composedChange: TChangeset, composeChild: NodeChangeComposer, genId: IdAllocator, crossFieldManager: CrossFieldManager): TChangeset;
     amendInvert(invertedChange: TChangeset, originalRevision: RevisionTag | undefined, genId: IdAllocator, crossFieldManager: CrossFieldManager): TChangeset;
@@ -351,13 +343,6 @@ export interface FieldChangeRebaser<TChangeset> {
     // (undocumented)
     invert(change: TaggedChange<TChangeset>, invertChild: NodeChangeInverter, genId: IdAllocator, crossFieldManager: CrossFieldManager): TChangeset;
     rebase(change: TChangeset, over: TaggedChange<TChangeset>, rebaseChild: NodeChangeRebaser, genId: IdAllocator, crossFieldManager: CrossFieldManager): TChangeset;
-}
-
-// @alpha (undocumented)
-interface FieldChanges<TTree = ProtoNode> {
-    readonly afterShallow?: readonly NestedChange<TTree>[];
-    readonly beforeShallow?: readonly NestedChange<TTree>[];
-    readonly shallow?: MarkList<TTree>;
 }
 
 // @alpha (undocumented)
@@ -418,6 +403,9 @@ export interface FieldMapObject<TChild> {
     // (undocumented)
     [key: string]: TChild[];
 }
+
+// @alpha (undocumented)
+type FieldMarks<TTree = ProtoNode> = FieldMap<MarkList<TTree>>;
 
 // @alpha (undocumented)
 export interface FieldSchema {
@@ -539,6 +527,18 @@ interface Insert<TTree = ProtoNode> {
     readonly content: readonly TTree[];
     // (undocumented)
     readonly type: typeof MarkType.Insert;
+}
+
+// @alpha
+interface InsertAndModify<TTree = ProtoNode> {
+    // (undocumented)
+    readonly content: TTree;
+    // (undocumented)
+    readonly fields?: FieldMarks<TTree>;
+    // (undocumented)
+    readonly setValue?: Value;
+    // (undocumented)
+    readonly type: typeof MarkType.InsertAndModify;
 }
 
 // @alpha
@@ -702,7 +702,7 @@ export interface MakeNominal {
 }
 
 // @alpha
-type Mark<TTree = ProtoNode> = Skip | Delete | MoveOut | MoveIn | Insert<TTree>;
+type Mark<TTree = ProtoNode> = Skip | Modify<TTree> | Delete | MoveOut | MoveIn | Insert<TTree> | ModifyAndDelete<TTree> | ModifyAndMoveOut<TTree> | MoveInAndModify<TTree> | InsertAndModify<TTree>;
 
 // @alpha
 export interface MarkedArrayLike<T> extends ArrayLike<T> {
@@ -718,11 +718,45 @@ type MarkList<TTree = ProtoNode> = readonly Mark<TTree>[];
 
 // @alpha (undocumented)
 const MarkType: {
-    readonly Insert: 0;
-    readonly MoveIn: 1;
-    readonly Delete: 2;
-    readonly MoveOut: 3;
+    readonly Modify: 0;
+    readonly Insert: 1;
+    readonly InsertAndModify: 2;
+    readonly MoveIn: 3;
+    readonly MoveInAndModify: 4;
+    readonly Delete: 5;
+    readonly ModifyAndDelete: 6;
+    readonly MoveOut: 7;
+    readonly ModifyAndMoveOut: 8;
 };
+
+// @alpha
+interface Modify<TTree = ProtoNode> {
+    // (undocumented)
+    readonly fields?: FieldMarks<TTree>;
+    // (undocumented)
+    readonly setValue?: Value;
+    // (undocumented)
+    readonly type: typeof MarkType.Modify;
+}
+
+// @alpha
+interface ModifyAndDelete<TTree = ProtoNode> {
+    // (undocumented)
+    readonly fields: FieldMarks<TTree>;
+    // (undocumented)
+    readonly type: typeof MarkType.ModifyAndDelete;
+}
+
+// @alpha
+interface ModifyAndMoveOut<TTree = ProtoNode> {
+    // (undocumented)
+    readonly fields?: FieldMarks<TTree>;
+    readonly moveId: MoveId;
+    // (undocumented)
+    readonly setValue?: Value;
+    // (undocumented)
+    readonly type: typeof MarkType.ModifyAndMoveOut;
+}
 
 // @alpha @sealed
 export class ModularChangeFamily implements ChangeFamily<ModularEditBuilder, ModularChangeset>, ChangeRebaser<ModularChangeset> {
@@ -780,6 +814,15 @@ interface MoveIn {
 }
 
 // @alpha
+interface MoveInAndModify<TTree = ProtoNode> {
+    // (undocumented)
+    readonly fields: FieldMarks<TTree>;
+    readonly moveId: MoveId;
+    // (undocumented)
+    readonly type: typeof MarkType.MoveInAndModify;
+}
+
+// @alpha
 interface MoveOut {
     // (undocumented)
     readonly count: number;
@@ -818,9 +861,6 @@ export function namedTreeSchema(data: Partial<TreeSchemaBuilder> & Named<TreeSch
 // @alpha
 export type NameFromBranded<T extends BrandedType<any, string>> = T extends BrandedType<any, infer Name> ? Name : never;
 
-// @alpha (undocumented)
-type NestedChange<TTree = ProtoNode> = ChildIndex & NodeChanges<TTree>;
-
 // @alpha
 export type NestedMap<Key1, Key2, Value> = Map<Key1, Map<Key2, Value>>;
 
@@ -841,14 +881,6 @@ export type NodeChangeInverter = (change: NodeChangeset) => NodeChangeset;
 
 // @alpha (undocumented)
 export type NodeChangeRebaser = (change: NodeChangeset, baseChange: NodeChangeset) => NodeChangeset;
-
-// @alpha
-interface NodeChanges<TTree = ProtoNode> {
-    // (undocumented)
-    readonly fields?: FieldChangeMap_2<TTree>;
-    // (undocumented)
-    readonly setValue?: Value;
-}
 
 // @alpha
 export interface NodeChangeset {
@@ -949,7 +981,7 @@ export const replaceField: unique symbol;
 export type RevisionTag = StableId;
 
 // @alpha
-type Root<TTree = ProtoNode> = FieldChangeMap_2<TTree>;
+type Root<TTree = ProtoNode> = FieldMarks<TTree>;
 
 // @alpha
 export interface RootField {
@@ -1063,7 +1095,7 @@ export interface TaggedChange<TChangeset> {
 }
 
 // @alpha
-export type ToDelta = (child: NodeChangeset, index: number | undefined) => Delta.NodeChanges | undefined;
+export type ToDelta = (child: NodeChangeset, index: number | undefined) => Delta.Modify;
 
 // @alpha (undocumented)
 export enum TransactionResult {

--- a/packages/dds/tree/src/core/forest/editableForest.ts
+++ b/packages/dds/tree/src/core/forest/editableForest.ts
@@ -39,7 +39,7 @@ export interface IEditableForest extends IForestSubscription {
 export function initializeForest(forest: IEditableForest, content: ITreeCursorSynchronous[]): void {
 	// TODO: maybe assert forest is empty?
 	const insert: Delta.Insert = { type: Delta.MarkType.Insert, content };
-	forest.applyDelta(new Map([[rootFieldKeySymbol, { shallow: [insert] }]]));
+	forest.applyDelta(new Map([[rootFieldKeySymbol, [insert]]]));
 }
 
 // TODO: Types below here may be useful for input into edit building APIs, but are no longer used here directly.

--- a/packages/dds/tree/src/core/tree/delta.ts
+++ b/packages/dds/tree/src/core/tree/delta.ts
@@ -130,7 +130,7 @@ import { FieldKey, Value } from "./types";
  * Immutable, therefore safe to retain for async processing.
  * @alpha
  */
-export type Root<TTree = ProtoNode> = FieldChangeMap<TTree>;
+export type Root<TTree = ProtoNode> = FieldMarks<TTree>;
 
 /**
  * The default representation for inserted content.
@@ -142,7 +142,17 @@ export type ProtoNode = ITreeCursorSynchronous;
  * Represents a change being made to a part of the tree.
  * @alpha
  */
-export type Mark<TTree = ProtoNode> = Skip | Delete | MoveOut | MoveIn | Insert<TTree>;
+export type Mark<TTree = ProtoNode> =
+	| Skip
+	| Modify<TTree>
+	| Delete
+	| MoveOut
+	| MoveIn
+	| Insert<TTree>
+	| ModifyAndDelete<TTree>
+	| ModifyAndMoveOut<TTree>
+	| MoveInAndModify<TTree>
+	| InsertAndModify<TTree>;
 
 /**
  * Represents a list of changes to some range of nodes. The index of each mark within the range of nodes, before
@@ -163,9 +173,10 @@ export type Skip = number;
  * Describes modifications made to a subtree.
  * @alpha
  */
-export interface NodeChanges<TTree = ProtoNode> {
+export interface Modify<TTree = ProtoNode> {
+	readonly type: typeof MarkType.Modify;
 	readonly setValue?: Value;
-	readonly fields?: FieldChangeMap<TTree>;
+	readonly fields?: FieldMarks<TTree>;
 }
 
 /**
@@ -175,6 +186,16 @@ export interface NodeChanges<TTree = ProtoNode> {
 export interface Delete {
 	readonly type: typeof MarkType.Delete;
 	readonly count: number;
+}
+
+/**
+ * Describes the deletion of a single node.
+ * Includes descriptions of the modifications the node.
+ * @alpha
+ */
+export interface ModifyAndDelete<TTree = ProtoNode> {
+	readonly type: typeof MarkType.ModifyAndDelete;
+	readonly fields: FieldMarks<TTree>;
 }
 
 /**
@@ -191,6 +212,21 @@ export interface MoveOut {
 }
 
 /**
+ * Describes the moving out of a single node.
+ * Includes descriptions of the modifications made to the node.
+ * @alpha
+ */
+export interface ModifyAndMoveOut<TTree = ProtoNode> {
+	readonly type: typeof MarkType.ModifyAndMoveOut;
+	/**
+	 * The delta should carry exactly one `MoveIn` mark with the same move ID.
+	 */
+	readonly moveId: MoveId;
+	readonly setValue?: Value;
+	readonly fields?: FieldMarks<TTree>;
+}
+
+/**
  * Describes the moving in of a contiguous range of node.
  * @alpha
  */
@@ -204,6 +240,20 @@ export interface MoveIn {
 }
 
 /**
+ * Describes the moving in of a single node.
+ * Includes descriptions of the modifications made to the node.
+ * @alpha
+ */
+export interface MoveInAndModify<TTree = ProtoNode> {
+	readonly type: typeof MarkType.MoveInAndModify;
+	/**
+	 * The delta should carry exactly one `MoveOut` mark with the same move ID.
+	 */
+	readonly moveId: MoveId;
+	readonly fields: FieldMarks<TTree>;
+}
+
+/**
  * Describes the insertion of a contiguous range of node.
  * @alpha
  */
@@ -211,6 +261,18 @@ export interface Insert<TTree = ProtoNode> {
 	readonly type: typeof MarkType.Insert;
 	// TODO: use a single cursor with multiple nodes instead of array of cursors.
 	readonly content: readonly TTree[];
+}
+
+/**
+ * Describes the insertion of a single node.
+ * Includes descriptions of the modifications made to the nodes.
+ * @alpha
+ */
+export interface InsertAndModify<TTree = ProtoNode> {
+	readonly type: typeof MarkType.InsertAndModify;
+	readonly content: TTree;
+	readonly setValue?: Value;
+	readonly fields?: FieldMarks<TTree>;
 }
 
 /**
@@ -227,48 +289,19 @@ export type FieldMap<T> = ReadonlyMap<FieldKey, T>;
 /**
  * @alpha
  */
-export type FieldChangeMap<TTree = ProtoNode> = FieldMap<FieldChanges<TTree>>;
-
-/**
- * @alpha
- */
-export interface FieldChanges<TTree = ProtoNode> {
-	/**
-	 * Changes to the subtrees contained in the field before any of the shallow changes are applied.
-	 * Ordered by ascending index.
-	 */
-	readonly beforeShallow?: readonly NestedChange<TTree>[];
-
-	/**
-	 * Changes to apply to the contents of the field.
-	 */
-	readonly shallow?: MarkList<TTree>;
-
-	/**
-	 * Changes to the subtrees contained in the field after all the shallow changes are applied.
-	 * Ordered by ascending index.
-	 */
-	readonly afterShallow?: readonly NestedChange<TTree>[];
-}
-
-/**
- * @alpha
- */
-export interface ChildIndex {
-	readonly index: number;
-}
-
-/**
- * @alpha
- */
-export type NestedChange<TTree = ProtoNode> = ChildIndex & NodeChanges<TTree>;
+export type FieldMarks<TTree = ProtoNode> = FieldMap<MarkList<TTree>>;
 
 /**
  * @alpha
  */
 export const MarkType = {
-	Insert: 0,
-	MoveIn: 1,
-	Delete: 2,
-	MoveOut: 3,
+	Modify: 0,
+	Insert: 1,
+	InsertAndModify: 2,
+	MoveIn: 3,
+	MoveInAndModify: 4,
+	Delete: 5,
+	ModifyAndDelete: 6,
+	MoveOut: 7,
+	ModifyAndMoveOut: 8,
 } as const;

--- a/packages/dds/tree/src/core/tree/deltaUtil.ts
+++ b/packages/dds/tree/src/core/tree/deltaUtil.ts
@@ -21,8 +21,14 @@ export function inputLength(mark: Mark<unknown>): number {
 		case MarkType.Delete:
 		case MarkType.MoveOut:
 			return mark.count;
+		case MarkType.Modify:
+		case MarkType.ModifyAndDelete:
+		case MarkType.ModifyAndMoveOut:
+			return 1;
 		case MarkType.Insert:
+		case MarkType.InsertAndModify:
 		case MarkType.MoveIn:
+		case MarkType.MoveInAndModify:
 			return 0;
 		default:
 			unreachableCase(type);

--- a/packages/dds/tree/src/core/tree/visitDelta.ts
+++ b/packages/dds/tree/src/core/tree/visitDelta.ts
@@ -88,14 +88,14 @@ export interface DeltaVisitor {
 	exitField(key: FieldKey): void;
 }
 
-type Pass = (delta: Delta.FieldChanges, visitor: DeltaVisitor) => boolean;
+type Pass = (delta: Delta.MarkList, visitor: DeltaVisitor) => boolean;
 
 interface ModifyLike {
 	setValue?: Value;
-	fields?: Delta.FieldChangeMap;
+	fields?: Delta.FieldMarks;
 }
 
-function visitFieldMarks(fields: Delta.FieldChangeMap, visitor: DeltaVisitor, func: Pass): boolean {
+function visitFieldMarks(fields: Delta.FieldMarks, visitor: DeltaVisitor, func: Pass): boolean {
 	let containsMoves = false;
 	for (const [key, field] of fields) {
 		visitor.enterField(key);
@@ -128,125 +128,102 @@ function visitModify(
 	return containsMoves;
 }
 
-function firstPass(delta: Delta.FieldChanges, visitor: DeltaVisitor): boolean {
+function firstPass(delta: Delta.MarkList, visitor: DeltaVisitor): boolean {
 	let containsMoves = false;
-
-	for (const nodeChange of delta.beforeShallow ?? []) {
-		const result = visitModify(nodeChange.index, nodeChange, visitor, firstPass);
-		containsMoves ||= result;
-	}
-
-	const moveInGaps: { readonly index: number; readonly cumulCount: number }[] = [];
-	const shallow = delta.shallow ?? [];
 	let index = 0;
-	for (const mark of shallow) {
+	for (const mark of delta) {
 		if (typeof mark === "number") {
 			// Untouched nodes
 			index += mark;
 		} else {
+			let result = false;
 			// Inline into `switch(mark.type)` once we upgrade to TS 4.7
 			const type = mark.type;
 			switch (type) {
+				case Delta.MarkType.ModifyAndDelete:
+					result = visitModify(index, mark, visitor, firstPass);
+					visitor.onDelete(index, 1);
+					break;
 				case Delta.MarkType.Delete:
 					visitor.onDelete(index, mark.count);
 					break;
+				case Delta.MarkType.ModifyAndMoveOut: {
+					result = visitModify(index, mark, visitor, firstPass);
+					visitor.onMoveOut(index, 1, mark.moveId);
+					break;
+				}
 				case Delta.MarkType.MoveOut:
 					visitor.onMoveOut(index, mark.count, mark.moveId);
+					break;
+				case Delta.MarkType.Modify:
+					result = visitModify(index, mark, visitor, firstPass);
+					index += 1;
 					break;
 				case Delta.MarkType.Insert:
 					visitor.onInsert(index, mark.content);
 					index += mark.content.length;
 					break;
-				case Delta.MarkType.MoveIn: {
-					// Handled in the second pass
-					containsMoves = true;
-					const prevCount =
-						moveInGaps.length === 0 ? 0 : moveInGaps[moveInGaps.length - 1].cumulCount;
-					moveInGaps.push({
-						index: index + prevCount,
-						cumulCount: prevCount + mark.count,
-					});
+				case Delta.MarkType.InsertAndModify:
+					visitor.onInsert(index, [mark.content]);
+					result = visitModify(index, mark, visitor, firstPass);
+					index += 1;
 					break;
-				}
+				case Delta.MarkType.MoveIn:
+				case Delta.MarkType.MoveInAndModify:
+					// Handled in the second pass
+					result = true;
+					break;
 				default:
 					unreachableCase(type);
 			}
+			containsMoves ||= result;
 		}
-	}
-
-	// While processing the `afterShallow` we have to translate each `NestedChange.index` into the corresponding
-	// index for the visitor. Those are not the same because the first pass doesn't apply move-in shallow changes.
-	// While processing the shallow changes, the `moveInGaps` array gets populated with the relevant offsets for us
-	// to make this index adjustment below.
-	let iMoveInGap = 0;
-	let missingMoveIns = 0;
-	for (const nodeChange of delta.afterShallow ?? []) {
-		while (iMoveInGap < moveInGaps.length && nodeChange.index > moveInGaps[iMoveInGap].index) {
-			missingMoveIns = moveInGaps[iMoveInGap].cumulCount;
-			iMoveInGap += 1;
-		}
-		const result = visitModify(
-			nodeChange.index - missingMoveIns,
-			nodeChange,
-			visitor,
-			firstPass,
-		);
-		containsMoves ||= result;
 	}
 	return containsMoves;
 }
 
-function secondPass(delta: Delta.FieldChanges, visitor: DeltaVisitor): boolean {
-	const processBeforeChanges = (() => {
-		const before: readonly Delta.NestedChange[] = delta.beforeShallow ?? [];
-		let iNested = 0;
-		return (visit: boolean, maxIndex: number): void => {
-			while (iNested < before.length && before[iNested].index < maxIndex) {
-				if (visit) {
-					const adjustedIndex = index - (inputContextIndex - before[iNested].index);
-					visitModify(adjustedIndex, before[iNested], visitor, secondPass);
-				}
-				iNested += 1;
-			}
-		};
-	})();
-	const after: readonly Delta.NestedChange[] = delta.afterShallow ?? [];
-	let inputContextIndex = 0;
+function secondPass(delta: Delta.MarkList, visitor: DeltaVisitor): boolean {
 	let index = 0;
-	const shallow = delta.shallow ?? [];
-	for (const mark of shallow) {
+	for (const mark of delta) {
 		if (typeof mark === "number") {
 			// Untouched nodes
 			index += mark;
-			inputContextIndex += mark;
-			processBeforeChanges(true, inputContextIndex);
 		} else {
 			// Inline into the `switch(...)` once we upgrade to TS 4.7
 			const type = mark.type;
 			switch (type) {
+				case Delta.MarkType.ModifyAndDelete:
+				case Delta.MarkType.ModifyAndMoveOut:
 				case Delta.MarkType.Delete:
 				case Delta.MarkType.MoveOut:
 					// Handled in the first pass
-					inputContextIndex += mark.count;
-					processBeforeChanges(false, inputContextIndex);
+					break;
+				case Delta.MarkType.Modify:
+					visitModify(index, mark, visitor, secondPass);
+					index += 1;
 					break;
 				case Delta.MarkType.Insert:
 					// Handled in the first pass
 					index += mark.content.length;
+					break;
+				case Delta.MarkType.InsertAndModify:
+					// Handled in the first pass
+					index += 1;
 					break;
 				case Delta.MarkType.MoveIn: {
 					visitor.onMoveIn(index, mark.count, mark.moveId);
 					index += mark.count;
 					break;
 				}
+				case Delta.MarkType.MoveInAndModify:
+					visitor.onMoveIn(index, 1, mark.moveId);
+					visitModify(index, mark, visitor, secondPass);
+					index += 1;
+					break;
 				default:
 					unreachableCase(type);
 			}
 		}
-	}
-	processBeforeChanges(true, Number.POSITIVE_INFINITY);
-	for (const nodeChange of after) {
-		visitModify(nodeChange.index, nodeChange, visitor, secondPass);
 	}
 	return false;
 }

--- a/packages/dds/tree/src/feature-libraries/deltaUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/deltaUtils.ts
@@ -9,7 +9,7 @@ import { Mutable } from "../util";
 
 /**
  * Converts a `Delta.FieldMarks` whose tree content is represented with by `TIn` instances
- * into a `Delta.FieldMarks` whose tree content is represented with by `TOut` instances.
+ * into a `Delta.FieldMarks`whose tree content is represented with by `TOut` instances.
  *
  * This function is useful for converting `Delta`s that represent tree content with cursors
  * into `Delta`s that represent tree content with a deep-comparable representation of the content.
@@ -18,70 +18,19 @@ import { Mutable } from "../util";
  * @param func - The functions used to map tree content.
  */
 export function mapFieldMarks<TIn, TOut>(
-	fields: Delta.FieldChangeMap<TIn>,
+	fields: Delta.FieldMarks<TIn>,
 	func: (tree: TIn) => TOut,
-): Delta.FieldChangeMap<TOut> {
-	const out: Map<FieldKey, Delta.FieldChanges<TOut>> = new Map();
+): Delta.FieldMarks<TOut> {
+	const out: Map<FieldKey, Delta.MarkList<TOut>> = new Map();
 	for (const [k, v] of fields) {
-		out.set(k, mapFieldChanges<TIn, TOut>(v, func));
-	}
-	return out;
-}
-
-/**
- * Converts a `Delta.FieldChanges` whose tree content is represented with by `TIn` instances
- * into a `Delta.FieldChanges` whose tree content is represented with by `TOut` instances.
- *
- * This function is useful for converting `Delta`s that represent tree content with cursors
- * into `Delta`s that represent tree content with a deep-comparable representation of the content.
- * See {@link assertDeltaEqual}.
- * @param changes - The FieldChanges to convert. Not mutated.
- * @param func - The functions used to map tree content.
- */
-export function mapFieldChanges<TIn, TOut>(
-	changes: Delta.FieldChanges<TIn>,
-	func: (tree: TIn) => TOut,
-): Delta.FieldChanges<TOut> {
-	const field: Mutable<Delta.FieldChanges<TOut>> = {};
-	if (changes.beforeShallow) {
-		field.beforeShallow = changes.beforeShallow.map((nested) => mapNodeChanges(nested, func));
-	}
-	if (changes.shallow) {
-		field.shallow = mapMarkList(changes.shallow, func);
-	}
-	if (changes.afterShallow) {
-		field.afterShallow = changes.afterShallow.map((nested) => mapNodeChanges(nested, func));
-	}
-	return field;
-}
-
-/**
- * Converts a `Delta.NodeChanges` whose tree content is represented with by `TIn` instances
- * into a `Delta.NodeChanges` whose tree content is represented with by `TOut` instances.
- *
- * This function is useful for converting `Delta`s that represent tree content with cursors
- * into `Delta`s that represent tree content with a deep-comparable representation of the content.
- * See {@link assertDeltaEqual}.
- * @param changes - The node changes to convert. Not mutated.
- * @param func - The functions used to map tree content.
- */
-export function mapNodeChanges<TIn, TOut>(
-	changes: Delta.NestedChange<TIn>,
-	func: (tree: TIn) => TOut,
-): Delta.NestedChange<TOut> {
-	const out: Mutable<Delta.NestedChange<TOut>> = { index: changes.index };
-	if (changes.fields !== undefined) {
-		out.fields = mapFieldMarks(changes.fields, func);
-	}
-	if (changes.setValue !== undefined) {
-		out.setValue = changes.setValue;
+		out.set(k, mapMarkList(v, func));
 	}
 	return out;
 }
 
 /**
  * Converts a `Delta.MarkList` whose tree content is represented with by `TIn` instances
- * into a `Delta.MarkList` whose tree content is represented with by `TOut` instances.
+ * into a `Delta.MarkList`whose tree content is represented with by `TOut` instances.
  *
  * This function is useful for converting `Delta`s that represent tree content with cursors
  * into `Delta`s that represent tree content with a deep-comparable representation of the content.
@@ -98,7 +47,7 @@ export function mapMarkList<TIn, TOut>(
 
 /**
  * Converts a `Delta.Mark` whose tree content is represented with by `TIn` instances
- * into a `Delta.Mark` whose tree content is represented with by `TOut` instances.
+ * into a `Delta.Mark`whose tree content is represented with by `TOut` instances.
  *
  * This function is useful for converting `Delta`s that represent tree content with cursors
  * into `Delta`s that represent tree content with a deep-comparable representation of the content.
@@ -115,11 +64,63 @@ export function mapMark<TIn, TOut>(
 	}
 	const type = mark.type;
 	switch (type) {
+		case Delta.MarkType.Modify: {
+			if (mark.fields === undefined && mark.setValue === undefined) {
+				return { type: Delta.MarkType.Modify };
+			}
+			return mark.fields === undefined
+				? {
+						type: Delta.MarkType.Modify,
+						setValue: mark.setValue,
+				  }
+				: {
+						...mark,
+						fields: mapFieldMarks(mark.fields, func),
+				  };
+		}
+		case Delta.MarkType.ModifyAndMoveOut: {
+			if (mark.fields === undefined && mark.setValue === undefined) {
+				return {
+					type: Delta.MarkType.ModifyAndMoveOut,
+					moveId: mark.moveId,
+				};
+			}
+			return mark.fields === undefined
+				? {
+						type: Delta.MarkType.ModifyAndMoveOut,
+						moveId: mark.moveId,
+						setValue: mark.setValue,
+				  }
+				: {
+						...mark,
+						fields: mapFieldMarks(mark.fields, func),
+				  };
+		}
+		case Delta.MarkType.MoveInAndModify:
+		case Delta.MarkType.ModifyAndDelete: {
+			return {
+				...mark,
+				fields: mapFieldMarks(mark.fields, func),
+			};
+		}
 		case Delta.MarkType.Insert: {
 			return {
 				type: Delta.MarkType.Insert,
 				content: mark.content.map(func),
 			};
+		}
+		case Delta.MarkType.InsertAndModify: {
+			const out: Mutable<Delta.InsertAndModify<TOut>> = {
+				type: Delta.MarkType.InsertAndModify,
+				content: func(mark.content),
+			};
+			if (mark.fields !== undefined) {
+				out.fields = mapFieldMarks(mark.fields, func);
+			}
+			if (Object.prototype.hasOwnProperty.call(mark, "setValue")) {
+				out.setValue = mark.setValue;
+			}
+			return out;
 		}
 		case Delta.MarkType.Delete:
 		case Delta.MarkType.MoveIn:

--- a/packages/dds/tree/src/feature-libraries/forestRepairDataStore.ts
+++ b/packages/dds/tree/src/feature-libraries/forestRepairDataStore.ts
@@ -44,7 +44,7 @@ export class ForestRepairDataStore implements RepairDataStore {
 		const forest = this.forestProvider(revision);
 		const cursor = forest.allocateCursor();
 
-		const visitFields = (fields: Delta.FieldChangeMap, parent: RepairDataNode): void => {
+		const visitFieldMarks = (fields: Delta.FieldMarks, parent: RepairDataNode): void => {
 			for (const [key, field] of fields) {
 				if (parent !== this.root) {
 					cursor.enterField(key);
@@ -58,31 +58,7 @@ export class ForestRepairDataStore implements RepairDataStore {
 			}
 		};
 
-		function visitField(
-			delta: Delta.FieldChanges,
-			parent: RepairDataNode,
-			key: FieldKey,
-		): void {
-			if (delta.shallow !== undefined) {
-				visitFieldMarks(delta.shallow, parent, key);
-			}
-			// TODO: support storage of deleted content from inserted trees
-			if (delta.beforeShallow !== undefined) {
-				for (const nested of delta.beforeShallow) {
-					const index = nested.index;
-					cursor.enterNode(index);
-					const child = parent.getOrCreateChild(key, index, undefinedFactory);
-					visitModify(nested, child);
-					cursor.exitNode();
-				}
-			}
-		}
-
-		function visitFieldMarks(
-			delta: Delta.MarkList,
-			parent: RepairDataNode,
-			key: FieldKey,
-		): void {
+		function visitField(delta: Delta.MarkList, parent: RepairDataNode, key: FieldKey): void {
 			let index = 0;
 			for (const mark of delta) {
 				if (typeof mark === "number") {
@@ -92,14 +68,32 @@ export class ForestRepairDataStore implements RepairDataStore {
 					// Inline into `switch(mark.type)` once we upgrade to TS 4.7
 					const type = mark.type;
 					switch (type) {
+						case Delta.MarkType.ModifyAndMoveOut:
+						case Delta.MarkType.ModifyAndDelete: {
+							const child = parent.getOrCreateChild(key, index, repairDataFactory);
+							visitModify(mark, child);
+							onDelete(parent, key, index, 1);
+							index += 1;
+							break;
+						}
 						case Delta.MarkType.MoveOut:
 						case Delta.MarkType.Delete: {
 							onDelete(parent, key, index, mark.count);
 							index += mark.count;
 							break;
 						}
+						case Delta.MarkType.Modify: {
+							cursor.enterNode(index);
+							const child = parent.getOrCreateChild(key, index, undefinedFactory);
+							visitModify(mark, child);
+							cursor.exitNode();
+							index += 1;
+							break;
+						}
 						case Delta.MarkType.Insert:
+						case Delta.MarkType.InsertAndModify:
 						case Delta.MarkType.MoveIn:
+						case Delta.MarkType.MoveInAndModify:
 							break;
 						default:
 							unreachableCase(type);
@@ -123,7 +117,7 @@ export class ForestRepairDataStore implements RepairDataStore {
 				node.data.value.set(revision, value);
 			}
 			if (modify.fields !== undefined) {
-				visitFields(modify.fields, node);
+				visitFieldMarks(modify.fields, node);
 			}
 		}
 
@@ -150,7 +144,7 @@ export class ForestRepairDataStore implements RepairDataStore {
 			}
 		}
 
-		visitFields(change, this.root);
+		visitFieldMarks(change, this.root);
 		cursor.free();
 	}
 
@@ -195,5 +189,5 @@ export class ForestRepairDataStore implements RepairDataStore {
 
 interface ModifyLike {
 	setValue?: Value;
-	fields?: Delta.FieldChangeMap;
+	fields?: Delta.FieldMarks;
 }

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -106,7 +106,7 @@ export {
 import * as FieldKinds from "./defaultFieldKinds";
 export { FieldKinds };
 
-export { mapFieldMarks, mapFieldChanges, mapMark, mapMarkList } from "./deltaUtils";
+export { mapFieldMarks, mapMark, mapMarkList } from "./deltaUtils";
 
 export {
 	EditManagerIndex,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -20,11 +20,7 @@ export interface FieldChangeHandler<
 	rebaser: FieldChangeRebaser<TChangeset>;
 	encoder: FieldChangeEncoder<TChangeset>;
 	editor: TEditor;
-	intoDelta(
-		change: TChangeset,
-		deltaFromChild: ToDelta,
-		reviver: NodeReviver,
-	): Delta.FieldChanges;
+	intoDelta(change: TChangeset, deltaFromChild: ToDelta, reviver: NodeReviver): Delta.MarkList;
 }
 
 /**
@@ -165,13 +161,9 @@ export interface FieldEditor<TChangeset> {
 /**
  * The `index` represents the index of the child node in the input context.
  * The `index` should be `undefined` iff the child node does not exist in the input context (e.g., an inserted node).
- * Returns `undefined` iff the child changes amount to nothing.
  * @alpha
  */
-export type ToDelta = (
-	child: NodeChangeset,
-	index: number | undefined,
-) => Delta.NodeChanges | undefined;
+export type ToDelta = (child: NodeChangeset, index: number | undefined) => Delta.Modify;
 
 /**
  * @alpha

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -167,15 +167,19 @@ export const genericChangeHandler: FieldChangeHandler<GenericChangeset> = {
 			return [{ index, nodeChange: change }];
 		},
 	},
-	intoDelta: (change: GenericChangeset, deltaFromChild: ToDelta): Delta.FieldChanges => {
-		const beforeShallow: Delta.NestedChange[] = [];
+	intoDelta: (change: GenericChangeset, deltaFromChild: ToDelta): Delta.MarkList => {
+		let nodeIndex = 0;
+		const delta: Delta.Mark[] = [];
 		for (const { index, nodeChange } of change) {
-			const childDelta = deltaFromChild(nodeChange, index);
-			if (childDelta) {
-				beforeShallow.push({ index, ...childDelta });
+			if (nodeIndex < index) {
+				const offset = index - nodeIndex;
+				delta.push(offset);
+				nodeIndex = index;
 			}
+			delta.push(deltaFromChild(nodeChange, index));
+			nodeIndex += 1;
 		}
-		return { beforeShallow };
+		return delta;
 	},
 };
 

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
@@ -6,15 +6,7 @@
 import { unreachableCase } from "@fluidframework/common-utils";
 import { singleTextCursor } from "../../treeTextCursor";
 import { TreeSchemaIdentifier, FieldKey, Value, Delta } from "../../../core";
-import {
-	brand,
-	brandOpaque,
-	clone,
-	fail,
-	makeArray,
-	Mutable,
-	OffsetListFactory,
-} from "../../../util";
+import { brand, brandOpaque, clone, fail, makeArray, OffsetListFactory } from "../../../util";
 import { Transposed as T } from "./format";
 import { isSkipMark } from "./utils";
 
@@ -30,17 +22,11 @@ export function toDelta(changeset: T.LocalChangeset): Delta.Root {
 	return out;
 }
 
-function convertMarkList(marks: T.MarkList): Delta.FieldChanges {
-	const markList = new OffsetListFactory<Delta.Mark>();
-	const beforeShallow: Delta.NestedChange[] = [];
-	const afterShallow: Delta.NestedChange[] = [];
-	let inputIndex = 0;
-	let outputIndex = 0;
+function convertMarkList(marks: T.MarkList): Delta.MarkList {
+	const out = new OffsetListFactory<Delta.Mark>();
 	for (const mark of marks) {
 		if (isSkipMark(mark)) {
-			markList.pushOffset(mark);
-			inputIndex += mark;
-			outputIndex += mark;
+			out.pushOffset(mark);
 		} else {
 			// Inline into `switch(mark.type)` once we upgrade to TS 4.7
 			const type = mark.type;
@@ -51,18 +37,16 @@ function convertMarkList(marks: T.MarkList): Delta.FieldChanges {
 						// TODO: can we skip this clone?
 						content: clone(mark.content).map(singleTextCursor),
 					};
-					markList.pushContent(insertMark);
-					outputIndex += mark.content.length;
+					out.pushContent(insertMark);
 					break;
 				}
 				case "MInsert": {
-					const insertMark: Delta.Insert = {
-						type: Delta.MarkType.Insert,
-						content: [singleTextCursor(mark.content)],
+					const insertMark: Delta.InsertAndModify = {
+						...convertModify(mark),
+						type: Delta.MarkType.InsertAndModify,
+						content: singleTextCursor(mark.content),
 					};
-					markList.pushContent(insertMark);
-					afterShallow.push({ index: outputIndex, ...convertModify(mark) });
-					outputIndex += 1;
+					out.pushContent(insertMark);
 					break;
 				}
 				case "MoveIn": {
@@ -71,8 +55,7 @@ function convertMarkList(marks: T.MarkList): Delta.FieldChanges {
 						count: mark.count,
 						moveId: brandOpaque<Delta.MoveId>(mark.id),
 					};
-					markList.pushContent(moveMark);
-					outputIndex += mark.count;
+					out.pushContent(moveMark);
 					break;
 				}
 				case "MMoveIn":
@@ -82,9 +65,12 @@ function convertMarkList(marks: T.MarkList): Delta.FieldChanges {
 					// These have no impacts on the document state.
 					break;
 				case "Modify": {
-					beforeShallow.push({ index: inputIndex, ...convertModify(mark) });
-					inputIndex += 1;
-					outputIndex += 1;
+					if (mark.tomb === undefined) {
+						out.pushContent({
+							type: Delta.MarkType.Modify,
+							...convertModify(mark),
+						});
+					}
 					break;
 				}
 				case "Delete": {
@@ -92,21 +78,24 @@ function convertMarkList(marks: T.MarkList): Delta.FieldChanges {
 						type: Delta.MarkType.Delete,
 						count: mark.count,
 					};
-					markList.pushContent(deleteMark);
-					inputIndex += mark.count;
+					out.pushContent(deleteMark);
 					break;
 				}
 				case "MDelete": {
 					const fields = convertModify(mark).fields;
 					if (fields !== undefined) {
-						beforeShallow.push({ index: inputIndex, ...convertModify(mark) });
+						const deleteMark: Delta.ModifyAndDelete = {
+							type: Delta.MarkType.ModifyAndDelete,
+							fields,
+						};
+						out.pushContent(deleteMark);
+					} else {
+						const deleteMark: Delta.Delete = {
+							type: Delta.MarkType.Delete,
+							count: 1,
+						};
+						out.pushContent(deleteMark);
 					}
-					const deleteMark: Delta.Delete = {
-						type: Delta.MarkType.Delete,
-						count: 1,
-					};
-					markList.pushContent(deleteMark);
-					inputIndex += 1;
 					break;
 				}
 				case "MoveOut": {
@@ -115,8 +104,7 @@ function convertMarkList(marks: T.MarkList): Delta.FieldChanges {
 						moveId: brandOpaque<Delta.MoveId>(mark.id),
 						count: mark.count,
 					};
-					markList.pushContent(moveMark);
-					inputIndex += mark.count;
+					out.pushContent(moveMark);
 					break;
 				}
 				case "Revive": {
@@ -127,8 +115,7 @@ function convertMarkList(marks: T.MarkList): Delta.FieldChanges {
 							singleTextCursor({ type: DUMMY_REVIVED_NODE_TYPE }),
 						),
 					};
-					markList.pushContent(insertMark);
-					outputIndex += mark.count;
+					out.pushContent(insertMark);
 					break;
 				}
 				case "MRevive": {
@@ -137,8 +124,7 @@ function convertMarkList(marks: T.MarkList): Delta.FieldChanges {
 						// TODO: Restore the actual node
 						content: [singleTextCursor({ type: DUMMY_REVIVED_NODE_TYPE })],
 					};
-					markList.pushContent(insertMark);
-					outputIndex += 1;
+					out.pushContent(insertMark);
 					break;
 				}
 				case "MMoveOut":
@@ -156,17 +142,7 @@ function convertMarkList(marks: T.MarkList): Delta.FieldChanges {
 			}
 		}
 	}
-	const fieldChanges: Mutable<Delta.FieldChanges> = {};
-	if (beforeShallow.length > 0) {
-		fieldChanges.beforeShallow = beforeShallow;
-	}
-	if (markList.list.length > 0) {
-		fieldChanges.shallow = markList.list;
-	}
-	if (afterShallow.length > 0) {
-		fieldChanges.afterShallow = afterShallow;
-	}
-	return fieldChanges;
+	return out.list;
 }
 
 const DUMMY_REVIVED_NODE_TYPE: TreeSchemaIdentifier = brand("RevivedNode");
@@ -183,7 +159,7 @@ interface ChangesetMods {
  * Modifications to a subtree as described by a Delta.
  */
 interface DeltaMods {
-	fields?: Delta.FieldChangeMap;
+	fields?: Delta.FieldMarks;
 	setValue?: Value;
 }
 
@@ -202,12 +178,12 @@ function convertModify(modify: ChangesetMods): DeltaMods {
 	return out;
 }
 
-function convertFieldMarks(fields: T.FieldMarks): Delta.FieldChangeMap {
-	const outFields: Map<FieldKey, Delta.FieldChanges> = new Map();
+function convertFieldMarks(fields: T.FieldMarks): Delta.FieldMarks {
+	const outFields: Map<FieldKey, Delta.MarkList> = new Map();
 	for (const key of Object.keys(fields)) {
-		const changes = convertMarkList(fields[key]);
+		const marks = convertMarkList(fields[key]);
 		const brandedKey: FieldKey = brand(key);
-		outFields.set(brandedKey, changes);
+		outFields.set(brandedKey, marks);
 	}
 	return outFields;
 }

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -4,37 +4,36 @@
  */
 
 import { unreachableCase } from "@fluidframework/common-utils";
-import { brandOpaque, fail, Mutable, OffsetListFactory } from "../../util";
+import { brandOpaque, fail, OffsetListFactory } from "../../util";
 import { Delta } from "../../core";
 import { singleTextCursor } from "../treeTextCursor";
 import { NodeReviver } from "../modular-schema";
-import { MarkList } from "./format";
-import { getInputLength, getOutputLength, isSkipMark } from "./utils";
+import { MarkList, ProtoNode } from "./format";
+import { getInputLength, isSkipMark } from "./utils";
 
-export type ToDelta<TNodeChange> = (
-	child: TNodeChange,
-	index: number | undefined,
-) => Delta.NodeChanges | undefined;
+export type ToDelta<TNodeChange> = (child: TNodeChange, index: number | undefined) => Delta.Modify;
 
 export function sequenceFieldToDelta<TNodeChange>(
 	marks: MarkList<TNodeChange>,
 	deltaFromChild: ToDelta<TNodeChange>,
 	reviver: NodeReviver,
-): Delta.FieldChanges {
-	const markList = new OffsetListFactory<Delta.Mark>();
+): Delta.MarkList {
+	const out = new OffsetListFactory<Delta.Mark>();
+	let inputIndex = 0;
 	for (const mark of marks) {
 		if (isSkipMark(mark)) {
-			markList.pushOffset(mark);
+			out.pushOffset(mark);
 		} else {
 			// Inline into `switch(mark.type)` once we upgrade to TS 4.7
 			const type = mark.type;
 			switch (type) {
 				case "Insert": {
-					const insertMark: Delta.Mark = {
-						type: Delta.MarkType.Insert,
-						content: mark.content.map(singleTextCursor),
-					};
-					markList.pushContent(insertMark);
+					const insertMark: Delta.Mark = makeDeltaInsert(
+						mark.content,
+						mark.changes,
+						deltaFromChild,
+					);
+					out.pushContent(insertMark);
 					break;
 				}
 				case "MoveIn":
@@ -44,10 +43,16 @@ export function sequenceFieldToDelta<TNodeChange>(
 						count: mark.count,
 						moveId: brandOpaque<Delta.MoveId>(mark.id),
 					};
-					markList.pushContent(moveMark);
+					out.pushContent(moveMark);
 					break;
 				}
 				case "Modify": {
+					const modify = deltaFromChild(mark.changes, inputIndex);
+					if (modify.setValue !== undefined || modify.fields !== undefined) {
+						out.pushContent(modify);
+					} else {
+						out.pushOffset(1);
+					}
 					break;
 				}
 				case "Delete": {
@@ -55,7 +60,7 @@ export function sequenceFieldToDelta<TNodeChange>(
 						type: Delta.MarkType.Delete,
 						count: mark.count,
 					};
-					markList.pushContent(deleteMark);
+					out.pushContent(deleteMark);
 					break;
 				}
 				case "MoveOut":
@@ -65,7 +70,7 @@ export function sequenceFieldToDelta<TNodeChange>(
 						moveId: brandOpaque<Delta.MoveId>(mark.id),
 						count: mark.count,
 					};
-					markList.pushContent(moveMark);
+					out.pushContent(moveMark);
 					break;
 				}
 				case "Revive": {
@@ -82,9 +87,9 @@ export function sequenceFieldToDelta<TNodeChange>(
 								mark.count,
 							),
 						};
-						markList.pushContent(insertMark);
+						out.pushContent(insertMark);
 					} else if (mark.lastDetachedBy === undefined) {
-						markList.pushOffset(mark.count);
+						out.pushOffset(mark.count);
 					}
 					break;
 				}
@@ -92,59 +97,32 @@ export function sequenceFieldToDelta<TNodeChange>(
 					unreachableCase(type);
 			}
 		}
-	}
-
-	const beforeShallow: Delta.NestedChange[] = [];
-	const afterShallow: Delta.NestedChange[] = [];
-	let inputIndex = 0;
-	let outputIndex = 0;
-	for (const mark of marks) {
-		if (!isSkipMark(mark)) {
-			// Inline into `switch(mark.type)` once we upgrade to TS 4.7
-			const type = mark.type;
-			switch (type) {
-				case "Modify":
-				case "Delete":
-				case "MoveOut":
-				case "ReturnFrom": {
-					if (mark.changes !== undefined) {
-						const childDelta = deltaFromChild(mark.changes, inputIndex);
-						if (childDelta !== undefined) {
-							beforeShallow.push({ index: inputIndex, ...childDelta });
-						}
-					}
-					break;
-				}
-				case "Revive":
-				case "Insert": {
-					if (mark.changes !== undefined) {
-						const childDelta = deltaFromChild(mark.changes, undefined);
-						if (childDelta !== undefined) {
-							afterShallow.push({ index: outputIndex, ...childDelta });
-						}
-					}
-					break;
-				}
-				case "MoveIn":
-				case "ReturnTo":
-					break;
-				default:
-					unreachableCase(type);
-			}
-		}
-		outputIndex += getOutputLength(mark);
 		inputIndex += getInputLength(mark);
 	}
+	return out.list;
+}
 
-	const fieldChanges: Mutable<Delta.FieldChanges> = {};
-	if (beforeShallow.length > 0) {
-		fieldChanges.beforeShallow = beforeShallow;
+/**
+ * Converts inserted content into the format expected in Delta instances.
+ * This involves applying all except MoveIn changes.
+ *
+ * The returned `fields` map may be empty if all modifications are applied by the function.
+ */
+function makeDeltaInsert<TNodeChange>(
+	content: ProtoNode[],
+	changes: TNodeChange | undefined,
+	deltaFromChild: ToDelta<TNodeChange>,
+): Delta.Insert | Delta.InsertAndModify {
+	// TODO: consider processing modifications at the same time as cloning to avoid unnecessary cloning
+	const cursors = content.map(singleTextCursor);
+	if (changes !== undefined) {
+		const outModifications = deltaFromChild(changes, undefined);
+		return {
+			...outModifications,
+			type: Delta.MarkType.InsertAndModify,
+			content: cursors[0],
+		};
+	} else {
+		return { type: Delta.MarkType.Insert, content: cursors };
 	}
-	if (markList.list.length > 0) {
-		fieldChanges.shallow = markList.list;
-	}
-	if (afterShallow.length > 0) {
-		fieldChanges.afterShallow = afterShallow;
-	}
-	return fieldChanges;
 }

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -41,7 +41,7 @@ type TestEditManager = EditManager<TestChange, TestChangeFamily>;
  * `ChangeFamily.intoDelta` with the expected change.
  */
 function asDelta(intentions: number[]): Delta.Root {
-	return intentions.length === 0 ? emptyDelta : new Map([[rootKey, { shallow: intentions }]]);
+	return intentions.length === 0 ? emptyDelta : new Map([[rootKey, intentions]]);
 }
 
 function changeFamilyFactory(
@@ -304,7 +304,7 @@ describe("EditManager", () => {
 				brand(1),
 			);
 			// TODO: This is probably not the best way to assert that the change was rebased properly
-			assert.equal(delta.get("root" as FieldKey)?.shallow?.length, 1);
+			assert.equal(delta.get("root" as FieldKey)?.length, 1);
 		});
 	});
 

--- a/packages/dds/tree/src/test/feature-libraries/defaultFieldKinds.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/defaultFieldKinds.spec.ts
@@ -21,7 +21,7 @@ import {
 	mintRevisionTag,
 } from "../../core";
 import { brand, JsonCompatibleReadOnly } from "../../util";
-import { assertFieldChangesEqual, noRepair } from "../utils";
+import { assertMarkListEqual, noRepair } from "../utils";
 
 const nodeType: TreeSchemaIdentifier = brand("Node");
 const tree1 = { type: nodeType, value: "value1" };
@@ -40,14 +40,14 @@ const crossFieldManager = {
 	consume: unexpectedDelegate,
 };
 
-const deltaFromChild1 = (child: NodeChangeset): Delta.NodeChanges => {
+const deltaFromChild1 = (child: NodeChangeset): Delta.Modify => {
 	assert.deepEqual(child, nodeChange1);
-	return { setValue: "value3" };
+	return { type: Delta.MarkType.Modify, setValue: "value3" };
 };
 
-const deltaFromChild2 = (child: NodeChangeset): Delta.NodeChanges => {
+const deltaFromChild2 = (child: NodeChangeset): Delta.Modify => {
 	assert.deepEqual(child, nodeChange2);
-	return { setValue: "value4" };
+	return { type: Delta.MarkType.Modify, setValue: "value4" };
 };
 
 const encodedChild = "encoded child";
@@ -205,25 +205,24 @@ describe("Value field changesets", () => {
 	});
 
 	it("can be converted to a delta when overwriting content", () => {
-		const expected: Delta.FieldChanges = {
-			shallow: [
-				{ type: Delta.MarkType.Delete, count: 1 },
-				{ type: Delta.MarkType.Insert, content: [singleTextCursor(tree1)] },
-			],
-			afterShallow: [{ index: 0, setValue: "value3" }],
-		};
+		const expected: Delta.MarkList = [
+			{ type: Delta.MarkType.Delete, count: 1 },
+			{
+				type: Delta.MarkType.InsertAndModify,
+				content: singleTextCursor(tree1),
+				setValue: "value3",
+			},
+		];
 
 		const delta = fieldHandler.intoDelta(change1WithChildChange, deltaFromChild1, noRepair);
-		assertFieldChangesEqual(delta, expected);
+		assertMarkListEqual(delta, expected);
 	});
 
 	it("can be converted to a delta when restoring content", () => {
-		const expected: Delta.FieldChanges = {
-			shallow: [
-				{ type: Delta.MarkType.Delete, count: 1 },
-				{ type: Delta.MarkType.Insert, content: [singleTextCursor(tree1)] },
-			],
-		};
+		const expected: Delta.MarkList = [
+			{ type: Delta.MarkType.Delete, count: 1 },
+			{ type: Delta.MarkType.Insert, content: [singleTextCursor(tree1)] },
+		];
 
 		const repair: NodeReviver = (revision: RevisionTag, index: number, count: number) => {
 			assert.equal(revision, detachedBy);
@@ -232,7 +231,7 @@ describe("Value field changesets", () => {
 			return [singleTextCursor(tree1)];
 		};
 		const actual = fieldHandler.intoDelta(revertChange2, deltaFromChild1, repair);
-		assertFieldChangesEqual(actual, expected);
+		assertMarkListEqual(actual, expected);
 	});
 
 	it("can be encoded in JSON", () => {
@@ -370,43 +369,31 @@ describe("Optional field changesets", () => {
 	});
 
 	it("can be converted to a delta when field was empty", () => {
-		const expected: Delta.FieldChanges = {
-			shallow: [
-				{
-					type: Delta.MarkType.Insert,
-					content: [singleTextCursor(tree1)],
-				},
-			],
-			afterShallow: [{ index: 0, setValue: "value3" }],
-		};
+		const expected: Delta.MarkList = [
+			{
+				type: Delta.MarkType.InsertAndModify,
+				content: singleTextCursor(tree1),
+				setValue: "value3",
+			},
+		];
 
-		assertFieldChangesEqual(
-			fieldHandler.intoDelta(change1, deltaFromChild1, noRepair),
-			expected,
-		);
+		assertMarkListEqual(fieldHandler.intoDelta(change1, deltaFromChild1, noRepair), expected);
 	});
 
 	it("can be converted to a delta when replacing content", () => {
-		const expected: Delta.FieldChanges = {
-			shallow: [
-				{ type: Delta.MarkType.Delete, count: 1 },
-				{ type: Delta.MarkType.Insert, content: [singleTextCursor(tree2)] },
-			],
-		};
+		const expected: Delta.MarkList = [
+			{ type: Delta.MarkType.Delete, count: 1 },
+			{ type: Delta.MarkType.Insert, content: [singleTextCursor(tree2)] },
+		];
 
-		assertFieldChangesEqual(
-			fieldHandler.intoDelta(change2, deltaFromChild1, noRepair),
-			expected,
-		);
+		assertMarkListEqual(fieldHandler.intoDelta(change2, deltaFromChild1, noRepair), expected);
 	});
 
 	it("can be converted to a delta when restoring content", () => {
-		const expected: Delta.FieldChanges = {
-			shallow: [
-				{ type: Delta.MarkType.Delete, count: 1 },
-				{ type: Delta.MarkType.Insert, content: [singleTextCursor(tree1)] },
-			],
-		};
+		const expected: Delta.MarkList = [
+			{ type: Delta.MarkType.Delete, count: 1 },
+			{ type: Delta.MarkType.Insert, content: [singleTextCursor(tree1)] },
+		];
 
 		const repair: NodeReviver = (revision: RevisionTag, index: number, count: number) => {
 			assert.equal(revision, detachedBy);
@@ -415,18 +402,13 @@ describe("Optional field changesets", () => {
 			return [singleTextCursor(tree1)];
 		};
 		const actual = fieldHandler.intoDelta(revertChange2, deltaFromChild1, repair);
-		assertFieldChangesEqual(actual, expected);
+		assertMarkListEqual(actual, expected);
 	});
 
 	it("can be converted to a delta with only child changes", () => {
-		const expected: Delta.FieldChanges = {
-			beforeShallow: [{ index: 0, setValue: "value4" }],
-		};
+		const expected: Delta.MarkList = [{ type: Delta.MarkType.Modify, setValue: "value4" }];
 
-		assertFieldChangesEqual(
-			fieldHandler.intoDelta(change4, deltaFromChild2, noRepair),
-			expected,
-		);
+		assertMarkListEqual(fieldHandler.intoDelta(change4, deltaFromChild2, noRepair), expected);
 	});
 
 	it("can be encoded in JSON", () => {

--- a/packages/dds/tree/src/test/feature-libraries/deltaUtils.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/deltaUtils.spec.ts
@@ -19,140 +19,140 @@ const moveId = brandOpaque<Delta.MoveId>(42);
 describe("DeltaUtils", () => {
 	describe("mapFieldMarks", () => {
 		it("maps delta content", () => {
-			const nestedCursorInsert: Delta.Root = new Map([
+			const nestedCursorInsert = new Map([
 				[
 					fooField,
-					{
-						shallow: [
-							42,
-							{
-								type: Delta.MarkType.Insert,
-								content: [nodeXCursor],
-							},
-						],
-						afterShallow: [{ index: 0, setValue: 45 }],
-					},
+					[
+						42,
+						{
+							type: Delta.MarkType.Insert,
+							content: [nodeXCursor],
+						},
+					],
 				],
 			]);
 			const input: Delta.Root = new Map([
 				[
 					fooField,
-					{
-						beforeShallow: [
-							{ index: 0, setValue: 1 },
-							{ index: 1, setValue: 1, fields: nestedCursorInsert },
-							{ index: 2, setValue: 1, fields: nestedCursorInsert },
-							{ index: 3, fields: nestedCursorInsert },
-						],
-						shallow: [
-							2,
-							{
-								type: Delta.MarkType.MoveOut,
-								moveId,
-								count: 1,
-							},
-							{
-								type: Delta.MarkType.MoveIn,
-								moveId,
-								count: 1,
-							},
-							{
-								type: Delta.MarkType.Delete,
-								count: 1,
-							},
-							{
-								type: Delta.MarkType.Insert,
-								content: [nodeXCursor],
-							},
-							{
-								type: Delta.MarkType.Insert,
-								content: [nodeXCursor],
-							},
-							{
-								type: Delta.MarkType.Delete,
-								count: 1,
-							},
-							{
-								type: Delta.MarkType.MoveIn,
-								moveId,
-								count: 1,
-							},
-							{
-								type: Delta.MarkType.MoveOut,
-								moveId,
-								count: 1,
-							},
-						],
-					},
+					[
+						{
+							type: Delta.MarkType.Modify,
+							setValue: 1,
+						},
+						{
+							type: Delta.MarkType.Modify,
+							setValue: 1,
+							fields: nestedCursorInsert,
+						},
+						{
+							type: Delta.MarkType.ModifyAndMoveOut,
+							moveId,
+							setValue: 1,
+							fields: nestedCursorInsert,
+						},
+						{
+							type: Delta.MarkType.MoveInAndModify,
+							moveId,
+							fields: nestedCursorInsert,
+						},
+						{
+							type: Delta.MarkType.ModifyAndDelete,
+							moveId,
+							fields: nestedCursorInsert,
+						},
+						{
+							type: Delta.MarkType.Insert,
+							content: [nodeXCursor],
+						},
+						{
+							type: Delta.MarkType.InsertAndModify,
+							content: nodeXCursor,
+							fields: nestedCursorInsert,
+						},
+						{
+							type: Delta.MarkType.Delete,
+							count: 1,
+						},
+						{
+							type: Delta.MarkType.MoveIn,
+							moveId,
+							count: 1,
+						},
+						{
+							type: Delta.MarkType.MoveOut,
+							moveId,
+							count: 1,
+						},
+					],
 				],
 			]);
 			deepFreeze(input);
 			const actual = mapFieldMarks(input, mapTreeFromCursor);
-			const nestedMapTreeInsert: Delta.Root<MapTree> = new Map([
+			const nestedMapTreeInsert = new Map([
 				[
 					fooField,
-					{
-						shallow: [
-							42,
-							{
-								type: Delta.MarkType.Insert,
-								content: [nodeX],
-							},
-						],
-						afterShallow: [{ index: 0, setValue: 45 }],
-					},
+					[
+						42,
+						{
+							type: Delta.MarkType.Insert,
+							content: [nodeX],
+						},
+					],
 				],
 			]);
 			const expected: Delta.Root<MapTree> = new Map([
 				[
 					fooField,
-					{
-						beforeShallow: [
-							{ index: 0, setValue: 1 },
-							{ index: 1, setValue: 1, fields: nestedMapTreeInsert },
-							{ index: 2, setValue: 1, fields: nestedMapTreeInsert },
-							{ index: 3, fields: nestedMapTreeInsert },
-						],
-						shallow: [
-							2,
-							{
-								type: Delta.MarkType.MoveOut,
-								moveId,
-								count: 1,
-							},
-							{
-								type: Delta.MarkType.MoveIn,
-								moveId,
-								count: 1,
-							},
-							{
-								type: Delta.MarkType.Delete,
-								count: 1,
-							},
-							{
-								type: Delta.MarkType.Insert,
-								content: [nodeX],
-							},
-							{
-								type: Delta.MarkType.Insert,
-								content: [nodeX],
-							},
-							{
-								type: Delta.MarkType.Delete,
-								count: 1,
-							},
-							{
-								type: Delta.MarkType.MoveIn,
-								moveId,
-								count: 1,
-							},
-							{
-								type: Delta.MarkType.MoveOut,
-								moveId,
-								count: 1,
-							},
-						],
-					},
+					[
+						{
+							type: Delta.MarkType.Modify,
+							setValue: 1,
+						},
+						{
+							type: Delta.MarkType.Modify,
+							setValue: 1,
+							fields: nestedMapTreeInsert,
+						},
+						{
+							type: Delta.MarkType.ModifyAndMoveOut,
+							moveId,
+							setValue: 1,
+							fields: nestedMapTreeInsert,
+						},
+						{
+							type: Delta.MarkType.MoveInAndModify,
+							moveId,
+							fields: nestedMapTreeInsert,
+						},
+						{
+							type: Delta.MarkType.ModifyAndDelete,
+							moveId,
+							fields: nestedMapTreeInsert,
+						},
+						{
+							type: Delta.MarkType.Insert,
+							content: [nodeX],
+						},
+						{
+							type: Delta.MarkType.InsertAndModify,
+							content: nodeX,
+							fields: nestedMapTreeInsert,
+						},
+						{
+							type: Delta.MarkType.Delete,
+							count: 1,
+						},
+						{
+							type: Delta.MarkType.MoveIn,
+							moveId,
+							count: 1,
+						},
+						{
+							type: Delta.MarkType.MoveOut,
+							moveId,
+							count: 1,
+						},
+					],
 				],
 			]);
 			deepFreeze(expected);

--- a/packages/dds/tree/src/test/feature-libraries/forestRepairDataStore.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forestRepairDataStore.spec.ts
@@ -64,57 +64,49 @@ describe("ForestRepairDataStore", () => {
 			},
 		};
 		initializeForest(forest, [singleTextCursor(data)]);
-		const delta1: Delta.Root = new Map([
+		const delta1 = new Map([
 			[
 				rootFieldKeySymbol,
-				{
-					beforeShallow: [
-						{
-							index: 0,
-							fields: new Map([
+				[
+					{
+						type: Delta.MarkType.Modify,
+						fields: new Map([
+							[
+								fooKey,
 								[
-									fooKey,
+									1,
 									{
-										shallow: [
-											1,
-											{
-												type: Delta.MarkType.Delete,
-												count: 2,
-											},
-										],
+										type: Delta.MarkType.Delete,
+										count: 2,
 									},
 								],
-							]),
-						},
-					],
-				},
+							],
+						]),
+					},
+				],
 			],
 		]);
 		store.capture(delta1, revision1);
 		forest.applyDelta(delta1);
-		const delta2: Delta.Root = new Map([
+		const delta2 = new Map([
 			[
 				rootFieldKeySymbol,
-				{
-					beforeShallow: [
-						{
-							index: 0,
-							fields: new Map([
+				[
+					{
+						type: Delta.MarkType.Modify,
+						fields: new Map([
+							[
+								fooKey,
 								[
-									fooKey,
 									{
-										shallow: [
-											{
-												type: Delta.MarkType.Delete,
-												count: 2,
-											},
-										],
+										type: Delta.MarkType.Delete,
+										count: 2,
 									},
 								],
-							]),
-						},
-					],
-				},
+							],
+						]),
+					},
+				],
 			],
 		]);
 		store.capture(delta2, revision2);
@@ -145,31 +137,39 @@ describe("ForestRepairDataStore", () => {
 			},
 		};
 		initializeForest(forest, [singleTextCursor(data)]);
-		const delta: Delta.Root = new Map([
-			[
-				rootFieldKeySymbol,
-				{
-					beforeShallow: [
+		store.capture(
+			new Map([
+				[
+					rootFieldKeySymbol,
+					[
 						{
-							index: 0,
+							type: Delta.MarkType.Modify,
 							fields: new Map([
 								[
 									fooKey,
-									{
-										beforeShallow: [
-											{ index: 0, setValue: 40 },
-											{ index: 2, setValue: 42 },
-											{ index: 3, setValue: undefined },
-										],
-									},
+									[
+										{
+											type: Delta.MarkType.Modify,
+											setValue: 40,
+										},
+										1,
+										{
+											type: Delta.MarkType.Modify,
+											setValue: 42,
+										},
+										{
+											type: Delta.MarkType.Modify,
+											setValue: undefined,
+										},
+									],
 								],
 							]),
 						},
 					],
-				},
-			],
-		]);
-		store.capture(delta, revision1);
+				],
+			]),
+			revision1,
+		);
 		const value0 = store.getValue(revision1, {
 			parent: root,
 			parentField: fooKey,

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -24,8 +24,8 @@ const valueHandler: FieldChangeHandler<ValueChangeset> = {
 	rebaser: FieldKinds.replaceRebaser(),
 	encoder: new FieldKinds.ValueEncoder<ValueChangeset & JsonCompatibleReadOnly>(),
 	editor: { buildChildChange: () => fail("Child changes not supported") },
-	intoDelta: (change): Delta.FieldChanges =>
-		change === 0 ? {} : { beforeShallow: [{ index: 0, setValue: change.new }] },
+	intoDelta: (change) =>
+		change === 0 ? [] : [{ type: Delta.MarkType.Modify, setValue: change.new }],
 };
 
 const valueField = new FieldKind(
@@ -110,12 +110,14 @@ const childRebaser = (nodeChangeA: NodeChangeset, nodeChangeB: NodeChangeset): N
 	return nodeChangeFromValueChange(rebased);
 };
 
-const childToDelta = (nodeChange: NodeChangeset): Delta.NodeChanges => {
+const childToDelta = (nodeChange: NodeChangeset): Delta.Modify => {
 	const valueChange = valueChangeFromNodeChange(nodeChange);
 	assert(typeof valueChange !== "number");
-	return {
+	const nodeDelta: Delta.Modify = {
+		type: Delta.MarkType.Modify,
 		setValue: valueChange.new,
 	};
+	return nodeDelta;
 };
 
 const childEncoder = (nodeChange: NodeChangeset): JsonCompatibleReadOnly => {
@@ -361,12 +363,17 @@ describe("Generic FieldKind", () => {
 			},
 		];
 
-		const expected: Delta.FieldChanges = {
-			beforeShallow: [
-				{ index: 0, setValue: 1 },
-				{ index: 2, setValue: 2 },
-			],
+		const valueDelta1: Delta.Mark = {
+			type: Delta.MarkType.Modify,
+			setValue: 1,
 		};
+
+		const valueDelta2: Delta.Mark = {
+			type: Delta.MarkType.Modify,
+			setValue: 2,
+		};
+
+		const expected: Delta.MarkList = [valueDelta1, 1, valueDelta2];
 
 		const actual = genericFieldKind.changeHandler.intoDelta(input, childToDelta, noRepair);
 		assert.deepEqual(actual, expected);

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -42,8 +42,8 @@ const valueHandler: FieldChangeHandler<ValueChangeset> = {
 	encoder: new FieldKinds.ValueEncoder<ValueChangeset & JsonCompatibleReadOnly>(),
 	editor: { buildChildChange: (index, change) => fail("Child changes not supported") },
 
-	intoDelta: (change, deltaFromChild): Delta.FieldChanges =>
-		change === 0 ? {} : { beforeShallow: [{ index: 0, setValue: change.new }] },
+	intoDelta: (change, deltaFromChild) =>
+		change === 0 ? [] : [{ type: Delta.MarkType.Modify, setValue: change.new }],
 };
 
 const valueField = new FieldKind(
@@ -79,10 +79,7 @@ const singleNodeHandler: FieldChangeHandler<NodeChangeset> = {
 	rebaser: singleNodeRebaser,
 	encoder: singleNodeEncoder,
 	editor: singleNodeEditor,
-	intoDelta: (change, deltaFromChild): Delta.FieldChanges => {
-		const childDelta = deltaFromChild(change, 0);
-		return childDelta !== undefined ? { beforeShallow: [{ index: 0, ...childDelta }] } : {};
-	},
+	intoDelta: (change, deltaFromChild) => [deltaFromChild(change, 0)],
 };
 
 const singleNodeField = new FieldKind(
@@ -108,7 +105,7 @@ const idFieldHandler: FieldChangeHandler<IdChangeset> = {
 	rebaser: idFieldRebaser,
 	encoder: new FieldKinds.ValueEncoder<IdChangeset & JsonCompatibleReadOnly>(),
 	editor: { buildChildChange: (index, change) => fail("Child changes not supported") },
-	intoDelta: (change, deltaFromChild) => ({}),
+	intoDelta: (change, deltaFromChild) => [],
 };
 
 /**
@@ -702,36 +699,54 @@ describe("ModularChangeFamily", () => {
 
 	describe("intoDelta", () => {
 		it("fieldChanges", () => {
-			const innerFieldADelta: Delta.FieldChanges = {
-				beforeShallow: [{ index: 0, setValue: 1 }],
-			};
-			const outerFieldADelta: Delta.FieldChanges = {
-				beforeShallow: [{ index: 0, fields: new Map([[fieldA, innerFieldADelta]]) }],
-			};
-			const fieldBDelta: Delta.FieldChanges = {
-				beforeShallow: [{ index: 0, setValue: 2 }],
-			};
+			const valueDelta1: Delta.MarkList = [
+				{
+					type: Delta.MarkType.Modify,
+					setValue: 1,
+				},
+			];
+
+			const valueDelta2: Delta.MarkList = [
+				{
+					type: Delta.MarkType.Modify,
+					setValue: 2,
+				},
+			];
+
+			const nodeDelta: Delta.MarkList = [
+				{
+					type: Delta.MarkType.Modify,
+					fields: new Map([[fieldA, valueDelta1]]),
+				},
+			];
+
 			const expectedDelta: Delta.Root = new Map([
-				[fieldA, outerFieldADelta],
-				[fieldB, fieldBDelta],
+				[fieldA, nodeDelta],
+				[fieldB, valueDelta2],
 			]);
 
 			assertDeltaEqual(family.intoDelta(rootChange1a), expectedDelta);
 		});
 
 		it("value overwrite", () => {
-			const fieldADelta: Delta.FieldChanges = {
-				beforeShallow: [{ index: 0, setValue: testValue }],
-			};
-			const expectedDelta: Delta.Root = new Map([[fieldA, fieldADelta]]);
+			const nodeDelta: Delta.MarkList = [
+				{
+					type: Delta.MarkType.Modify,
+					setValue: testValue,
+				},
+			];
+			const expectedDelta: Delta.Root = new Map([[fieldA, nodeDelta]]);
 			assertDeltaEqual(family.intoDelta(nodeValueOverwrite), expectedDelta);
 		});
 
 		it("value revert", () => {
-			const fieldADelta: Delta.FieldChanges = {
-				beforeShallow: [{ index: 0, setValue: testValue }],
-			};
-			const expectedDelta: Delta.Root = new Map([[fieldA, fieldADelta]]);
+			const nodeDelta: Delta.MarkList = [
+				{
+					type: Delta.MarkType.Modify,
+					setValue: testValue,
+				},
+			];
+			const expectedDelta: Delta.Root = new Map([[fieldA, nodeDelta]]);
 			const repair: RepairDataStore = {
 				capture: (TreeDestruction) => assert.fail(),
 				getNodes: () => assert.fail(),

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
@@ -202,7 +202,7 @@ describe("SequenceField - Rebaser Axioms", () => {
 				const changes = [taggedChange, tagInverse(inv, taggedChange.revision)];
 				const actual = compose(changes);
 				const delta = toDelta(actual);
-				assert.deepEqual(delta, {});
+				assert.deepEqual(delta, []);
 			});
 		}
 	});
@@ -228,7 +228,7 @@ describe("SequenceField - Rebaser Axioms", () => {
 					const changes = [inv, updatedChange];
 					const actual = compose(changes);
 					const delta = toDelta(actual);
-					assert.deepEqual(delta, {});
+					assert.deepEqual(delta, []);
 				});
 			}
 		}
@@ -269,7 +269,7 @@ describe("SequenceField - Sandwich Rebasing", () => {
 		const revABC4 = rebaseTagged(revABC3, delABC2);
 		const actual = compose([delABC2, revABC4]);
 		const delta = toDelta(actual);
-		assert.deepEqual(delta, {});
+		assert.deepEqual(delta, []);
 	});
 
 	it.skip("[Move ABC, Return ABC] ↷ Delete B", () => {
@@ -293,7 +293,7 @@ describe("SequenceField - Sandwich Rebasing", () => {
 		const retABC4 = rebaseTagged(retABC3, movABC2);
 		const actual = compose([movABC2, retABC4]);
 		const delta = toDelta(actual);
-		assert.deepEqual(delta, {});
+		assert.deepEqual(delta, []);
 	});
 
 	it("[Delete AC, Revive AC] ↷ Insert B", () => {
@@ -308,6 +308,6 @@ describe("SequenceField - Sandwich Rebasing", () => {
 		const revAC4 = rebaseTagged(revAC3, delAC2);
 		const actual = compose([delAC2, revAC4]);
 		const delta = toDelta(actual);
-		assert.deepEqual(delta, {});
+		assert.deepEqual(delta, []);
 	});
 });

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
@@ -7,12 +7,15 @@ import { fail, strict as assert } from "assert";
 import {
 	RevisionTag,
 	Delta,
+	FieldKey,
 	ITreeCursorSynchronous,
 	TreeSchemaIdentifier,
 	mintRevisionTag,
 } from "../../../core";
 import {
 	ChangesetLocalId,
+	FieldChange,
+	FieldKinds,
 	NodeChangeset,
 	NodeReviver,
 	SequenceField as SF,
@@ -20,7 +23,7 @@ import {
 } from "../../../feature-libraries";
 import { brand, brandOpaque, makeArray } from "../../../util";
 import { TestChange } from "../../testChange";
-import { assertFieldChangesEqual, deepFreeze } from "../../utils";
+import { assertMarkListEqual, deepFreeze, noRepair } from "../../utils";
 import { ChangeMaker as Change, TestChangeset } from "./testEdits";
 import { composeAnonChanges } from "./utils";
 
@@ -33,6 +36,7 @@ const tag: RevisionTag = mintRevisionTag();
 const tag2: RevisionTag = mintRevisionTag();
 const tag3: RevisionTag = mintRevisionTag();
 const deltaMoveId = brandOpaque<Delta.MoveId>(moveId);
+const fooField = brand<FieldKey>("foo");
 
 const DUMMY_REVIVED_NODE_TYPE: TreeSchemaIdentifier = brand("DummyRevivedNode");
 
@@ -40,12 +44,12 @@ function fakeRepairData(_revision: RevisionTag, _index: number, count: number): 
 	return makeArray(count, () => singleTextCursor({ type: DUMMY_REVIVED_NODE_TYPE }));
 }
 
-function toDelta(change: TestChangeset, reviver: NodeReviver = fakeRepairData): Delta.FieldChanges {
+function toDelta(change: TestChangeset, reviver: NodeReviver = fakeRepairData): Delta.MarkList {
 	deepFreeze(change);
 	return SF.sequenceFieldToDelta(change, TestChange.toDelta, reviver);
 }
 
-function toDeltaShallow(change: TestChangeset): Delta.FieldChanges {
+function toDeltaShallow(change: TestChangeset): Delta.MarkList {
 	deepFreeze(change);
 	return SF.sequenceFieldToDelta(
 		change,
@@ -55,26 +59,23 @@ function toDeltaShallow(change: TestChangeset): Delta.FieldChanges {
 }
 
 const childChange1 = TestChange.mint([0], 1);
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const childChange1Delta = TestChange.toDelta(childChange1)!;
+const childChange1Delta = TestChange.toDelta(childChange1);
 
 describe("SequenceField - toDelta", () => {
 	it("empty mark list", () => {
 		const actual = toDeltaShallow([]);
-		assert.deepEqual(actual, {});
+		assert.deepEqual(actual, []);
 	});
 
 	it("child change", () => {
 		const actual = toDelta(Change.modify(0, childChange1));
-		const expected: Delta.FieldChanges = {
-			beforeShallow: [{ index: 0, ...childChange1Delta }],
-		};
+		const expected: Delta.MarkList = [childChange1Delta];
 		assert.deepEqual(actual, expected);
 	});
 
 	it("empty child change", () => {
 		const actual = toDelta(Change.modify(0, TestChange.emptyChange));
-		const expected: Delta.FieldChanges = {};
+		const expected: Delta.MarkList = [];
 		assert.deepEqual(actual, expected);
 	});
 
@@ -84,9 +85,7 @@ describe("SequenceField - toDelta", () => {
 			type: Delta.MarkType.Insert,
 			content: contentCursor,
 		};
-		const expected: Delta.FieldChanges = {
-			shallow: [mark],
-		};
+		const expected: Delta.MarkList = [mark];
 		const actual = toDelta(changeset);
 		assert.deepStrictEqual(actual, expected);
 	});
@@ -100,50 +99,50 @@ describe("SequenceField - toDelta", () => {
 			return contentCursor;
 		}
 		const actual = toDelta(changeset, reviver);
-		const expected: Delta.FieldChanges = {
-			shallow: [
-				{
-					type: Delta.MarkType.Insert,
-					content: contentCursor,
-				},
-			],
-		};
-		assertFieldChangesEqual(actual, expected);
+		const expected: Delta.MarkList = [
+			{
+				type: Delta.MarkType.Insert,
+				content: contentCursor,
+			},
+		];
+		assertMarkListEqual(actual, expected);
 	});
 
 	it("conflicted revive => skip", () => {
 		const changeset: TestChangeset = composeAnonChanges([
 			Change.revive(0, 1, tag, 0, tag2),
-			Change.delete(1, 1),
+			Change.modify(1, childChange1),
 		]);
 		const actual = toDelta(changeset);
-		const expected: Delta.FieldChanges = {
-			shallow: [1, { type: Delta.MarkType.Delete, count: 1 }],
-		};
-		assertFieldChangesEqual(actual, expected);
+		const expected: Delta.MarkList = [1, childChange1Delta];
+		assertMarkListEqual(actual, expected);
 	});
 
 	it("blocked revive => nil", () => {
 		const changeset: TestChangeset = composeAnonChanges([
 			Change.revive(0, 1, tag, 0, tag2, undefined, tag3),
-			Change.delete(1, 1),
+			Change.modify(1, childChange1),
 		]);
 		const actual = toDelta(changeset);
-		const expected: Delta.FieldChanges = {
-			shallow: [1, { type: Delta.MarkType.Delete, count: 1 }],
-		};
-		assertFieldChangesEqual(actual, expected);
+		const expected: Delta.MarkList = [1, childChange1Delta];
+		assertMarkListEqual(actual, expected);
 	});
 
 	it("revive and modify => insert", () => {
-		const dummyNodeChange = "Dummy Child Change" as NodeChangeset;
-		const dummyNodeDelta = "Dummy Child Delta" as Delta.NodeChanges;
+		const nestedChange: FieldChange = {
+			fieldKind: FieldKinds.sequence.identifier,
+			change: brand("Dummy Child Change"),
+		};
+		const nodeChange = {
+			fieldChanges: new Map([[fooField, nestedChange]]),
+		};
 		const changeset: SF.Changeset = [
-			{ type: "Revive", count: 1, detachedBy: tag, detachIndex: 0, changes: dummyNodeChange },
+			{ type: "Revive", count: 1, detachedBy: tag, detachIndex: 0, changes: nodeChange },
 		];
-		const deltaFromChild = (child: NodeChangeset): Delta.NodeChanges => {
-			assert.deepEqual(child, dummyNodeChange);
-			return dummyNodeDelta;
+		const fieldChanges = new Map([[fooField, [{ type: Delta.MarkType.Insert, content: [] }]]]);
+		const deltaFromChild = (child: NodeChangeset): Delta.Modify => {
+			assert.deepEqual(child, nodeChange);
+			return { type: Delta.MarkType.Modify, fields: fieldChanges };
 		};
 		function reviver(revision: RevisionTag, index: number, count: number): Delta.ProtoNode[] {
 			assert.equal(revision, tag);
@@ -152,16 +151,13 @@ describe("SequenceField - toDelta", () => {
 			return contentCursor;
 		}
 		const actual = SF.sequenceFieldToDelta(changeset, deltaFromChild, reviver);
-		const expected: Delta.FieldChanges = {
-			shallow: [
-				{
-					type: Delta.MarkType.Insert,
-					content: contentCursor,
-				},
-			],
-			afterShallow: [{ index: 0, ...dummyNodeDelta }],
-		};
-		assertFieldChangesEqual(actual, expected);
+		const expected: Delta.MarkList = [
+			{
+				type: Delta.MarkType.Insert,
+				content: contentCursor,
+			},
+		];
+		assertMarkListEqual(actual, expected);
 	});
 
 	it("delete", () => {
@@ -170,9 +166,7 @@ describe("SequenceField - toDelta", () => {
 			type: Delta.MarkType.Delete,
 			count: 10,
 		};
-		const expected: Delta.FieldChanges = {
-			shallow: [mark],
-		};
+		const expected: Delta.MarkList = [mark];
 		const actual = toDelta(changeset);
 		assert.deepStrictEqual(actual, expected);
 	});
@@ -202,9 +196,7 @@ describe("SequenceField - toDelta", () => {
 			moveId: deltaMoveId,
 			count: 10,
 		};
-		const expected: Delta.FieldChanges = {
-			shallow: [42, moveOut, 8, moveIn],
-		};
+		const expected: Delta.MarkList = [42, moveOut, 8, moveIn];
 		const actual = toDelta(changeset);
 		assert.deepStrictEqual(actual, expected);
 	});
@@ -223,31 +215,28 @@ describe("SequenceField - toDelta", () => {
 			type: Delta.MarkType.Insert,
 			content: contentCursor,
 		};
-		const expected: Delta.FieldChanges = {
-			shallow: [del, 3, ins],
-			beforeShallow: [{ index: 14, setValue: "1" }],
+		const set: Delta.Modify = {
+			type: Delta.MarkType.Modify,
+			setValue: "1",
 		};
+		const expected: Delta.MarkList = [del, 3, ins, 1, set];
 		const actual = toDelta(changeset);
 		assert.deepStrictEqual(actual, expected);
 	});
 
-	it("insert and modify => insert and nested change", () => {
+	it("insert and modify => InsertAndModify", () => {
 		const changeset = composeAnonChanges([Change.insert(0, 1), Change.modify(0, childChange1)]);
-		const mark: Delta.Insert = {
-			type: Delta.MarkType.Insert,
-			content: [
-				singleTextCursor({
-					type,
-					value: 0,
-				}),
-			],
+		const mark: Delta.InsertAndModify = {
+			type: Delta.MarkType.InsertAndModify,
+			content: singleTextCursor({
+				type,
+				value: 0,
+			}),
+			setValue: "1",
 		};
-		const expected: Delta.FieldChanges = {
-			shallow: [mark],
-			afterShallow: [{ index: 0, setValue: "1" }],
-		};
+		const expected: Delta.MarkList = [mark];
 		const actual = toDelta(changeset);
-		assertFieldChangesEqual(actual, expected);
+		assertMarkListEqual(actual, expected);
 	});
 
 	it("modify and delete => delete", () => {
@@ -256,10 +245,45 @@ describe("SequenceField - toDelta", () => {
 			type: Delta.MarkType.Delete,
 			count: 1,
 		};
-		const expected: Delta.FieldChanges = {
-			shallow: [mark],
-		};
+		const expected: Delta.MarkList = [mark];
 		const actual = toDelta(changeset);
-		assertFieldChangesEqual(actual, expected);
+		assertMarkListEqual(actual, expected);
+	});
+
+	// This test requires more support for MoveIn
+	it.skip("Insert and modify w/ move-in => Insert and modify", () => {
+		const nestedChange: FieldChange = {
+			fieldKind: FieldKinds.sequence.identifier,
+			change: brand({
+				type: "MoveIn",
+				id: moveId,
+				count: 42,
+			}),
+		};
+		const nodeChange = {
+			fieldChanges: new Map([[fooField, nestedChange]]),
+		};
+		const changeset: SF.Changeset = [
+			{
+				type: "Insert",
+				content,
+				changes: nodeChange,
+			},
+		];
+		const nestedMoveDelta = new Map([
+			[fooField, [{ type: Delta.MarkType.MoveIn, moveId: deltaMoveId, count: 42 }]],
+		]);
+		const mark: Delta.InsertAndModify = {
+			type: Delta.MarkType.InsertAndModify,
+			content: contentCursor[0],
+			fields: nestedMoveDelta,
+		};
+		const expected: Delta.MarkList = [mark];
+		const deltaFromChild = (child: NodeChangeset): Delta.Modify => {
+			assert.deepEqual(child, nodeChange);
+			return { type: Delta.MarkType.Modify, fields: nestedMoveDelta };
+		};
+		const actual = SF.sequenceFieldToDelta(changeset, deltaFromChild, noRepair);
+		assertMarkListEqual(actual, expected);
 	});
 });

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -7,7 +7,7 @@ import { assert } from "@fluidframework/common-utils";
 import { ChangesetLocalId, IdAllocator, SequenceField as SF } from "../../../feature-libraries";
 import { Delta, TaggedChange, makeAnonChange, tagChange } from "../../../core";
 import { TestChange } from "../../testChange";
-import { assertFieldChangesEqual, deepFreeze, fakeRepair } from "../../utils";
+import { assertMarkListEqual, deepFreeze, fakeRepair } from "../../utils";
 import { brand, fail } from "../../../util";
 import { TestChangeset } from "./testEdits";
 
@@ -109,10 +109,10 @@ export function invert(change: TaggedChange<TestChangeset>): TestChangeset {
 }
 
 export function checkDeltaEquality(actual: TestChangeset, expected: TestChangeset) {
-	assertFieldChangesEqual(toDelta(actual), toDelta(expected));
+	assertMarkListEqual(toDelta(actual), toDelta(expected));
 }
 
-export function toDelta(change: TestChangeset): Delta.FieldChanges {
+export function toDelta(change: TestChangeset): Delta.MarkList {
 	return SF.sequenceFieldToDelta(change, TestChange.toDelta, fakeRepair);
 }
 

--- a/packages/dds/tree/src/test/forestTestSuite.ts
+++ b/packages/dds/tree/src/test/forestTestSuite.ts
@@ -281,7 +281,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			cursor.clear();
 
 			const mark: Delta.Delete = { type: Delta.MarkType.Delete, count: 1 };
-			const delta: Delta.Root = new Map([[rootFieldKeySymbol, { shallow: [mark] }]]);
+			const delta: Delta.Root = new Map([[rootFieldKeySymbol, [mark]]]);
 			forest.applyDelta(delta);
 			forest.anchors.applyDelta(delta);
 
@@ -369,9 +369,8 @@ export function testForest(config: ForestTestConfiguration): void {
 			initializeForest(forest, content.map(singleTextCursor));
 
 			const clone = forest.clone(forest.schema, forest.anchors);
-			const delta: Delta.Root = new Map([
-				[rootFieldKeySymbol, { beforeShallow: [{ index: 0, setValue: 2 }] }],
-			]);
+			const setValue: Delta.Modify = { type: Delta.MarkType.Modify, setValue: 2 };
+			const delta: Delta.Root = new Map([[rootFieldKeySymbol, [setValue]]]);
 			clone.applyDelta(delta);
 
 			// Check the clone has the new value
@@ -396,9 +395,8 @@ export function testForest(config: ForestTestConfiguration): void {
 					const cursor = forest.allocateCursor();
 					moveToDetachedField(forest, cursor);
 
-					const delta: Delta.Root = new Map([
-						[rootFieldKeySymbol, { beforeShallow: [{ index: 0, setValue: 2 }] }],
-					]);
+					const setValue: Delta.Modify = { type: Delta.MarkType.Modify, setValue: 2 };
+					const delta: Delta.Root = new Map([[rootFieldKeySymbol, [setValue]]]);
 					assert.throws(() => forest.applyDelta(delta));
 				});
 			}
@@ -408,9 +406,8 @@ export function testForest(config: ForestTestConfiguration): void {
 				const content: JsonableTree = { type: jsonNumber.name, value: 1 };
 				initializeForest(forest, [singleTextCursor(content)]);
 
-				const delta: Delta.Root = new Map([
-					[rootFieldKeySymbol, { beforeShallow: [{ index: 0, setValue: 2 }] }],
-				]);
+				const setValue: Delta.Modify = { type: Delta.MarkType.Modify, setValue: 2 };
+				const delta: Delta.Root = new Map([[rootFieldKeySymbol, [setValue]]]);
 				forest.applyDelta(delta);
 
 				const reader = forest.allocateCursor();
@@ -425,9 +422,8 @@ export function testForest(config: ForestTestConfiguration): void {
 				const content: JsonableTree = { type: jsonNumber.name, value: 1 };
 				initializeForest(forest, [singleTextCursor(content)]);
 
-				const delta: Delta.Root = new Map([
-					[rootFieldKeySymbol, { beforeShallow: [{ index: 0, setValue: undefined }] }],
-				]);
+				const setValue: Delta.Modify = { type: Delta.MarkType.Modify, setValue: undefined };
+				const delta: Delta.Root = new Map([[rootFieldKeySymbol, [setValue]]]);
 				forest.applyDelta(delta);
 
 				const reader = forest.allocateCursor();
@@ -440,30 +436,27 @@ export function testForest(config: ForestTestConfiguration): void {
 				const forest = factory(new InMemoryStoredSchemaRepository(defaultSchemaPolicy));
 				initializeForest(forest, nestedContent.map(singleTextCursor));
 
-				const setField: Delta.NodeChanges = {
+				const setField: Delta.Modify = {
+					type: Delta.MarkType.Modify,
 					fields: new Map([
 						[
 							xField,
-							{
-								shallow: [
-									{ type: Delta.MarkType.Delete, count: 1 },
-									{
-										type: Delta.MarkType.Insert,
-										content: [
-											singleTextCursor({
-												type: jsonBoolean.name,
-												value: true,
-											}),
-										],
-									},
-								],
-							},
+							[
+								{ type: Delta.MarkType.Delete, count: 1 },
+								{
+									type: Delta.MarkType.Insert,
+									content: [
+										singleTextCursor({
+											type: jsonBoolean.name,
+											value: true,
+										}),
+									],
+								},
+							],
 						],
 					]),
 				};
-				const delta: Delta.Root = new Map([
-					[rootFieldKeySymbol, { beforeShallow: [{ index: 0, ...setField }] }],
-				]);
+				const delta: Delta.Root = new Map([[rootFieldKeySymbol, [setField]]]);
 				forest.applyDelta(delta);
 
 				const reader = forest.allocateCursor();
@@ -483,7 +476,7 @@ export function testForest(config: ForestTestConfiguration): void {
 				initializeForest(forest, content.map(singleTextCursor));
 
 				const mark: Delta.Delete = { type: Delta.MarkType.Delete, count: 1 };
-				const delta: Delta.Root = new Map([[rootFieldKeySymbol, { shallow: [mark] }]]);
+				const delta: Delta.Root = new Map([[rootFieldKeySymbol, [0, mark]]]);
 				forest.applyDelta(delta);
 
 				// Inspect resulting tree: should just have `2`.
@@ -509,9 +502,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 				const skip: Delta.Skip = 1;
 				const mark: Delta.Delete = { type: Delta.MarkType.Delete, count: 1 };
-				const delta: Delta.Root = new Map([
-					[rootFieldKeySymbol, { shallow: [skip, mark] }],
-				]);
+				const delta: Delta.Root = new Map([[rootFieldKeySymbol, [skip, mark]]]);
 				forest.applyDelta(delta);
 
 				// Inspect resulting tree: should just have `1`.
@@ -533,7 +524,7 @@ export function testForest(config: ForestTestConfiguration): void {
 					type: Delta.MarkType.Insert,
 					content: [singleTextCursor({ type: jsonNumber.name, value: 3 })],
 				};
-				const delta: Delta.Root = new Map([[rootFieldKeySymbol, { shallow: [mark] }]]);
+				const delta: Delta.Root = new Map([[rootFieldKeySymbol, [mark]]]);
 				forest.applyDelta(delta);
 
 				const reader = forest.allocateCursor();
@@ -562,15 +553,14 @@ export function testForest(config: ForestTestConfiguration): void {
 					count: 1,
 					moveId,
 				};
-				const modify: Delta.NodeChanges = {
+				const modify: Delta.Modify = {
+					type: Delta.MarkType.Modify,
 					fields: new Map([
-						[xField, { shallow: [moveOut] }],
-						[yField, { shallow: [1, moveIn] }],
+						[xField, [moveOut]],
+						[yField, [1, moveIn]],
 					]),
 				};
-				const delta: Delta.Root = new Map([
-					[rootFieldKeySymbol, { beforeShallow: [{ index: 0, ...modify }] }],
-				]);
+				const delta: Delta.Root = new Map([[rootFieldKeySymbol, [modify]]]);
 				forest.applyDelta(delta);
 				const reader = forest.allocateCursor();
 				moveToDetachedField(forest, reader);
@@ -580,10 +570,6 @@ export function testForest(config: ForestTestConfiguration): void {
 				reader.exitField();
 				reader.enterField(yField);
 				assert.equal(reader.getFieldLength(), 2);
-				assert(reader.firstNode());
-				assert.equal(reader.value, 1);
-				assert(reader.nextNode());
-				assert.equal(reader.value, 0);
 			});
 
 			it("insert and modify", () => {
@@ -594,36 +580,24 @@ export function testForest(config: ForestTestConfiguration): void {
 				];
 				initializeForest(forest, content.map(singleTextCursor));
 
-				const mark: Delta.Insert = {
-					type: Delta.MarkType.Insert,
-					content: [singleTextCursor({ type: jsonNumber.name, value: 3 })],
-				};
-				const modify: Delta.NodeChanges = {
+				const mark: Delta.InsertAndModify = {
+					type: Delta.MarkType.InsertAndModify,
+					content: singleTextCursor({ type: jsonNumber.name, value: 3 }),
 					fields: new Map([
 						[
 							brand("newField"),
-							{
-								shallow: [
-									{
-										type: Delta.MarkType.Insert,
-										content: [{ type: jsonNumber.name, value: 4 }].map(
-											singleTextCursor,
-										),
-									},
-								],
-							},
+							[
+								{
+									type: Delta.MarkType.Insert,
+									content: [{ type: jsonNumber.name, value: 4 }].map(
+										singleTextCursor,
+									),
+								},
+							],
 						],
 					]),
 				};
-				const delta: Delta.Root = new Map([
-					[
-						rootFieldKeySymbol,
-						{
-							shallow: [mark],
-							afterShallow: [{ index: 0, ...modify }],
-						},
-					],
-				]);
+				const delta: Delta.Root = new Map([[rootFieldKeySymbol, [mark]]]);
 				forest.applyDelta(delta);
 
 				const reader = forest.allocateCursor();
@@ -647,27 +621,14 @@ export function testForest(config: ForestTestConfiguration): void {
 				initializeForest(forest, nestedContent.map(singleTextCursor));
 
 				const moveId = brandOpaque<Delta.MoveId>(0);
-				const modify: Delta.NodeChanges = {
+				const mark: Delta.ModifyAndDelete = {
+					type: Delta.MarkType.ModifyAndDelete,
 					fields: new Map([
-						[
-							xField,
-							{
-								shallow: [{ type: Delta.MarkType.MoveOut, count: 1, moveId }],
-							},
-						],
+						[xField, [{ type: Delta.MarkType.MoveOut, count: 1, moveId }]],
 					]),
 				};
 				const delta: Delta.Root = new Map([
-					[
-						rootFieldKeySymbol,
-						{
-							shallow: [
-								{ type: Delta.MarkType.Delete, count: 1 },
-								{ type: Delta.MarkType.MoveIn, count: 1, moveId },
-							],
-							beforeShallow: [{ index: 0, ...modify }],
-						},
-					],
+					[rootFieldKeySymbol, [mark, { type: Delta.MarkType.MoveIn, count: 1, moveId }]],
 				]);
 				forest.applyDelta(delta);
 
@@ -683,37 +644,23 @@ export function testForest(config: ForestTestConfiguration): void {
 				initializeForest(forest, nestedContent.map(singleTextCursor));
 
 				const moveId = brandOpaque<Delta.MoveId>(0);
-				const modify: Delta.NodeChanges = {
+				const mark: Delta.Modify = {
+					type: Delta.MarkType.Modify,
 					fields: new Map([
 						[
 							xField,
-							{
-								beforeShallow: [{ index: 0, setValue: 2 }],
-								shallow: [
-									{
-										type: Delta.MarkType.MoveOut,
-										count: 1,
-										moveId,
-									},
-								],
-							},
+							[
+								{
+									type: Delta.MarkType.ModifyAndMoveOut,
+									setValue: 2,
+									moveId,
+								},
+							],
 						],
-						[
-							yField,
-							{
-								shallow: [{ type: Delta.MarkType.MoveIn, count: 1, moveId }],
-							},
-						],
+						[yField, [{ type: Delta.MarkType.MoveIn, count: 1, moveId }]],
 					]),
 				};
-				const delta: Delta.Root = new Map([
-					[
-						rootFieldKeySymbol,
-						{
-							beforeShallow: [{ index: 0, ...modify }],
-						},
-					],
-				]);
+				const delta: Delta.Root = new Map([[rootFieldKeySymbol, [mark]]]);
 				forest.applyDelta(delta);
 
 				const reader = forest.allocateCursor();
@@ -726,6 +673,61 @@ export function testForest(config: ForestTestConfiguration): void {
 				assert(reader.firstNode());
 				assert.equal(reader.value, 2);
 				assert.equal(reader.nextNode(), true);
+			});
+
+			// TODO: Unskip once MoveInAndModify is properly supported.
+			// MoveInAndModify should support inner deltas e.g. Insert, MoveOut, etc.
+			it.skip("move in and modify", () => {
+				const forest = factory(new InMemoryStoredSchemaRepository(defaultSchemaPolicy));
+				initializeForest(forest, nestedContent.map(singleTextCursor));
+
+				const moveId = brandOpaque<Delta.MoveId>(0);
+				const newField: FieldKey = brand("newField");
+				const mark: Delta.Modify = {
+					type: Delta.MarkType.Modify,
+					fields: new Map([
+						[xField, [{ type: Delta.MarkType.MoveOut, count: 1, moveId }]],
+						[
+							yField,
+							[
+								{
+									type: Delta.MarkType.MoveInAndModify,
+									moveId,
+									fields: new Map([
+										[
+											newField,
+											[
+												{
+													type: Delta.MarkType.Insert,
+													content: [
+														{ type: jsonNumber.name, value: 2 },
+													].map(singleTextCursor),
+												},
+											],
+										],
+									]),
+								},
+							],
+						],
+					]),
+				};
+				const delta: Delta.Root = new Map([[rootFieldKeySymbol, [mark]]]);
+				forest.applyDelta(delta);
+
+				const reader = forest.allocateCursor();
+				moveToDetachedField(forest, reader);
+				assert(reader.firstNode());
+				reader.enterField(xField);
+				assert.equal(reader.getFieldLength(), 0);
+				reader.exitField();
+				reader.enterField(yField);
+				assert.equal(reader.getFieldLength(), 2);
+				assert(reader.firstNode());
+				assert.equal(reader.value, 0);
+				reader.enterField(newField);
+				assert.equal(reader.getFieldLength(), 1);
+				assert(reader.firstNode());
+				assert.equal(reader.value, 2);
 			});
 		});
 
@@ -740,7 +742,7 @@ export function testForest(config: ForestTestConfiguration): void {
 					type: Delta.MarkType.Insert,
 					content: content.map(singleTextCursor),
 				};
-				const delta: Delta.Root = new Map([[rootFieldKeySymbol, { shallow: [insert] }]]);
+				const delta: Delta.Root = new Map([[rootFieldKeySymbol, [insert]]]);
 
 				assert.deepEqual(dependent.tokens, []);
 				forest.applyDelta(delta);
@@ -771,26 +773,22 @@ export function testForest(config: ForestTestConfiguration): void {
 				const delta: Delta.Root = new Map([
 					[
 						rootFieldKeySymbol,
-						{
-							beforeShallow: [
-								{
-									index: 0,
-									fields: new Map([
+						[
+							{
+								type: Delta.MarkType.Modify,
+								fields: new Map([
+									[
+										xField,
 										[
-											xField,
 											{
-												shallow: [
-													{
-														type: Delta.MarkType.Delete,
-														count: 1,
-													},
-												],
+												type: Delta.MarkType.Delete,
+												count: 1,
 											},
 										],
-									]),
-								},
-							],
-						},
+									],
+								]),
+							},
+						],
 					],
 				]);
 				const expected: JsonableTree[] = [
@@ -828,15 +826,14 @@ export function testForest(config: ForestTestConfiguration): void {
 					count: 1,
 					moveId,
 				};
-				const modify: Delta.NodeChanges = {
+				const modify: Delta.Modify = {
+					type: Delta.MarkType.Modify,
 					fields: new Map([
-						[xField, { shallow: [moveOut] }],
-						[yField, { shallow: [1, moveIn] }],
+						[xField, [moveOut]],
+						[yField, [1, moveIn]],
 					]),
 				};
-				const delta: Delta.Root = new Map([
-					[rootFieldKeySymbol, { beforeShallow: [{ index: 0, ...modify }] }],
-				]);
+				const delta: Delta.Root = new Map([[rootFieldKeySymbol, [modify]]]);
 				forest.applyDelta(delta);
 				const expected: JsonableTree[] = [
 					{

--- a/packages/dds/tree/src/test/testChange.spec.ts
+++ b/packages/dds/tree/src/test/testChange.spec.ts
@@ -73,12 +73,15 @@ describe("TestChange", () => {
 	it("can be represented as a delta", () => {
 		const change1 = TestChange.mint([0, 1], [2, 3]);
 		const delta = TestChange.toDelta(change1);
-		const expected: Delta.NodeChanges = {
+		const expected = {
+			type: Delta.MarkType.Modify,
 			setValue: "2|3",
 		};
 
 		assert.deepEqual(delta, expected);
-		assert.deepEqual(TestChange.toDelta(TestChange.mint([0, 1], [])), undefined);
+		assert.deepEqual(TestChange.toDelta(TestChange.mint([0, 1], [])), {
+			type: Delta.MarkType.Modify,
+		});
 	});
 
 	it("can be encoded in JSON", () => {

--- a/packages/dds/tree/src/test/testChange.ts
+++ b/packages/dds/tree/src/test/testChange.ts
@@ -166,13 +166,14 @@ function checkChangeList(
 	assert.deepEqual(intentionsSeen, intentions);
 }
 
-function toDelta(change: TestChange): Delta.NodeChanges | undefined {
+function toDelta(change: TestChange): Delta.Modify {
 	if (change.intentions.length > 0) {
 		return {
+			type: Delta.MarkType.Modify,
 			setValue: change.intentions.map(String).join("|"),
 		};
 	}
-	return undefined;
+	return { type: Delta.MarkType.Modify };
 }
 
 export interface AnchorRebaseData {

--- a/packages/dds/tree/src/test/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/tree/anchorSet.spec.ts
@@ -102,21 +102,11 @@ describe("AnchorSet", () => {
 		};
 
 		const modify = {
-			fields: new Map([
-				[
-					fieldBar,
-					{
-						shallow: [3, moveIn],
-					},
-				],
-			]),
+			type: Delta.MarkType.Modify,
+			fields: new Map([[fieldBar, [3, moveIn]]]),
 		};
 
-		const fooChanges: Delta.FieldChanges = {
-			shallow: [3, moveOut],
-			beforeShallow: [{ index: 5, ...modify }],
-		};
-		const delta = new Map([[fieldFoo, fooChanges]]);
+		const delta = new Map([[fieldFoo, [3, moveOut, 1, modify]]]);
 		anchors.applyDelta(delta);
 		checkEquality(anchors.locate(anchor1), makePath([fieldFoo, 4], [fieldBar, 5]));
 		checkEquality(
@@ -155,29 +145,14 @@ function checkEquality(actual: UpPath | undefined, expected: UpPath | undefined)
 }
 
 function makeDelta(mark: Delta.Mark, path: UpPath): Delta.Root {
-	const fields: Delta.FieldChangeMap = new Map([
-		[path.parentField, { shallow: [path.parentIndex, mark] }],
-	]);
-
+	const fields: Delta.Root = new Map([[path.parentField, [path.parentIndex, mark]]]);
 	if (path.parent === undefined) {
 		return fields;
 	}
 
-	return makeDeltaSpine(
-		{
-			fields,
-		},
-		path.parent,
-	);
-}
-
-function makeDeltaSpine(modify: Delta.NodeChanges, path: UpPath): Delta.Root {
-	const fields: Delta.Root = new Map([
-		[path.parentField, { beforeShallow: [{ index: path.parentIndex, ...modify }] }],
-	]);
-	if (path.parent === undefined) {
-		return fields;
-	}
-
-	return makeDeltaSpine({ fields }, path.parent);
+	const modify = {
+		type: Delta.MarkType.Modify,
+		fields,
+	};
+	return makeDelta(modify, path.parent);
 }

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -28,7 +28,6 @@ import { ISharedTree, SharedTreeFactory } from "../shared-tree";
 import {
 	FieldKinds,
 	jsonableTreeFromCursor,
-	mapFieldChanges,
 	mapFieldMarks,
 	mapMarkList,
 	mapTreeFromCursor,
@@ -309,15 +308,6 @@ export function spyOnMethod(
 }
 
 /**
- * Assert two FieldChanges are equal, handling cursors.
- */
-export function assertFieldChangesEqual(a: Delta.FieldChanges, b: Delta.FieldChanges): void {
-	const aTree = mapFieldChanges(a, mapTreeFromCursor);
-	const bTree = mapFieldChanges(b, mapTreeFromCursor);
-	assert.deepStrictEqual(aTree, bTree);
-}
-
-/**
  * Assert two MarkList are equal, handling cursors.
  */
 export function assertMarkListEqual(a: Delta.MarkList, b: Delta.MarkList): void {
@@ -329,7 +319,7 @@ export function assertMarkListEqual(a: Delta.MarkList, b: Delta.MarkList): void 
 /**
  * Assert two Delta are equal, handling cursors.
  */
-export function assertDeltaEqual(a: Delta.FieldChangeMap, b: Delta.FieldChangeMap): void {
+export function assertDeltaEqual(a: Delta.FieldMarks, b: Delta.FieldMarks): void {
 	const aTree = mapFieldMarks(a, mapTreeFromCursor);
 	const bTree = mapFieldMarks(b, mapTreeFromCursor);
 	assert.deepStrictEqual(aTree, bTree);


### PR DESCRIPTION
This PR reverts the changes introduced in PR#13905 with the exception of some added/updated tests.

The changes from PR#13905 were a steppingstone towards a representation of changes where shallow changes and nested changes are decoupled. We have since decided not to invest in such a decoupling at the moment in order to focus on customer-facing features in the lead up to the June deliverables.