### PR TITLE
Patch - Fix op compression when using an older loader

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
@@ -6,6 +6,8 @@
 import { decompress } from "lz4js";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { assert, IsoBuffer, Uint8ArrayToString } from "@fluidframework/common-utils";
+import { ChildLogger } from "@fluidframework/telemetry-utils";
+import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { CompressionAlgorithms } from "../containerRuntime";
 import { IMessageProcessingResult } from "./definitions";
 
@@ -21,13 +23,18 @@ export class OpDecompressor {
     private activeBatch = false;
     private rootMessageContents: any | undefined;
     private processedCount = 0;
+    private readonly logger;
+
+    constructor(logger: ITelemetryLogger) {
+        this.logger = ChildLogger.create(logger, "OpDecompressor");
+    }
 
     public processMessage(message: ISequencedDocumentMessage): IMessageProcessingResult {
         assert(
             message.compression === undefined || message.compression === CompressionAlgorithms.lz4,
             0x511 /* Only lz4 compression is supported */);
 
-        if (message.metadata?.batch === true && message.compression === CompressionAlgorithms.lz4) {
+        if (message.metadata?.batch === true && this.isCompressed(message)) {
             // Beginning of a compressed batch
             assert(this.activeBatch === false, 0x4b8 /* shouldn't have multiple active batches */);
             if (message.compression) {
@@ -74,7 +81,7 @@ export class OpDecompressor {
             };
         }
 
-        if (message.metadata?.batch === undefined && message.compression === CompressionAlgorithms.lz4) {
+        if (message.metadata?.batch === undefined && this.isCompressed(message)) {
             // Single compressed message
             assert(this.activeBatch === false, 0x4ba /* shouldn't receive compressed message in middle of a batch */);
 
@@ -93,6 +100,46 @@ export class OpDecompressor {
             message,
             state: "Skipped",
         };
+    }
+
+    private isCompressed(message: ISequencedDocumentMessage) {
+        if (message.compression === CompressionAlgorithms.lz4) {
+            return true;
+        }
+
+        /**
+         * Back-compat self healing mechanism for ADO:3538, as loaders from
+         * version client_v2.0.0-internal.1.2.0 to client_v2.0.0-internal.2.2.0 do not
+         * support adding the proper compression metadata to compressed messages submitted
+         * by the runtime. Should be removed after the loader reaches sufficient saturation
+         * for a version greater or equal than client_v2.0.0-internal.2.2.0.
+         *
+         * The condition holds true for compressed messages, regardless of metadata. We are ultimately
+         * looking for a message with a single property `packedContents` inside `contents`, of type 'string'
+         * with a base64 encoded value.
+         */
+        try {
+            if (
+                typeof message.contents === "object" &&
+                Object.keys(message.contents).length === 1 &&
+                message.contents?.packedContents !== undefined &&
+                typeof message.contents?.packedContents === "string" &&
+                message.contents.packedContents.length > 0 &&
+                IsoBuffer.from(message.contents.packedContents, "base64").toString("base64") ===
+                message.contents.packedContents
+            ) {
+                this.logger.sendTelemetryEvent({
+                    eventName: "LegacyCompression",
+                    type: message.type,
+                    batch: message.metadata?.batch,
+                });
+                return true;
+            }
+        } catch (err) {
+            return false;
+        }
+
+        return false;
     }
 }
 

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -114,8 +114,9 @@ export class Outbox {
     private compressBatch(batch: IBatch): IBatch {
         if (batch.content.length === 0
             || this.params.config.compressionOptions === undefined
-            || this.params.config.compressionOptions.minimumBatchSizeInBytes > batch.contentSizeInBytes) {
-            // Nothing to do if the batch is empty or if compression is disabled or if we don't need to compress
+            || this.params.config.compressionOptions.minimumBatchSizeInBytes > batch.contentSizeInBytes
+            || this.params.containerContext.submitBatchFn === undefined) {
+            // Nothing to do if the batch is empty or if compression is disabled or not supported, or if we don't need to compress
             return batch;
         }
 

--- a/packages/runtime/container-runtime/src/test/opLifecycle/opDecompressor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opDecompressor.spec.ts
@@ -7,6 +7,7 @@ import { strict as assert } from "assert";
 import { compress } from "lz4js";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { IsoBuffer } from "@fluidframework/common-utils";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { ContainerRuntimeMessage, ContainerMessageType } from "../..";
 import { OpDecompressor } from "../../opLifecycle";
 
@@ -72,9 +73,11 @@ const endBatchEmptyMessage: ISequencedDocumentMessage = {
 };
 
 describe("OpDecompressor", () => {
+    const mockLogger = new MockLogger();
     let decompressor: OpDecompressor;
     beforeEach(() => {
-        decompressor = new OpDecompressor();
+        mockLogger.clear();
+        decompressor = new OpDecompressor(mockLogger);
     });
 
     it("Processes single compressed op", () => {
@@ -83,6 +86,25 @@ describe("OpDecompressor", () => {
         assert.strictEqual(result.message.contents.contents, "value0");
         assert.strictEqual(result.message.metadata?.compressed, undefined);
         assert.strictEqual(result.message.compression, undefined);
+    });
+
+    // Back-compat self healing mechanism for ADO:3538
+    it("Processes single compressed op without compression markers", () => {
+        const result = decompressor.processMessage({
+            ...generateCompressedBatchMessage(1),
+            compression: undefined,
+        });
+        assert.equal(result.state, "Processed");
+        assert.strictEqual(result.message.contents.contents, "value0");
+        assert.strictEqual(result.message.metadata?.compressed, undefined);
+        assert.strictEqual(result.message.compression, undefined);
+
+        mockLogger.assertMatch([
+            {
+                eventName: "OpDecompressor:LegacyCompression",
+                category: "generic",
+            },
+        ]);
     });
 
     it("Expecting only lz4 compression", () => {
@@ -158,10 +180,67 @@ describe("OpDecompressor", () => {
     });
 
     it("Ignores ops without compression", () => {
-        const rootMessage = { ...generateCompressedBatchMessage(5), metadata: undefined, compression: undefined };
-        const firstMessageResult = decompressor.processMessage(rootMessage);
+        const rootMessages = [
+            {
+                // Back-compat self healing mechanism for ADO:3538,
+                // the message should have a `packedContents` property.
+                contents: { some: "contents" },
+                metadata: { meta: "data" },
+                clientId: "clientId",
+                sequenceNumber: 1,
+                term: 1,
+                minimumSequenceNumber: 1,
+                clientSequenceNumber: 1,
+                referenceSequenceNumber: 1,
+                type: "type",
+                timestamp: 1,
+            },
+            {
+                // Back-compat self healing mechanism for ADO:3538,
+                contents: { packedContents: "packedContents is not base64 encoded" },
+                metadata: { meta: "data" },
+                clientId: "clientId",
+                sequenceNumber: 1,
+                term: 1,
+                minimumSequenceNumber: 1,
+                clientSequenceNumber: 1,
+                referenceSequenceNumber: 1,
+                type: "type",
+                timestamp: 1,
+            },
+            {
+                // Back-compat self healing mechanism for ADO:3538,
+                contents: { packedContents: "YmFzZTY0IGNvbnRlbnQ=", some: "contents" },
+                metadata: { meta: "data" },
+                clientId: "clientId",
+                sequenceNumber: 1,
+                term: 1,
+                minimumSequenceNumber: 1,
+                clientSequenceNumber: 1,
+                referenceSequenceNumber: 1,
+                type: "type",
+                timestamp: 1,
+            },
+            {
+                metadata: { meta: "data" },
+                clientId: "clientId",
+                sequenceNumber: 1,
+                term: 1,
+                minimumSequenceNumber: 1,
+                clientSequenceNumber: 1,
+                referenceSequenceNumber: 1,
+                type: "type",
+                timestamp: 1,
+            },
+        ];
 
-        assert.equal(firstMessageResult.state, "Skipped");
-        assert.deepStrictEqual(firstMessageResult.message, rootMessage);
+        for (const rootMessage of rootMessages) {
+            const firstMessageResult = decompressor.processMessage(
+                rootMessage as ISequencedDocumentMessage,
+            );
+
+            assert.equal(firstMessageResult.state, "Skipped");
+            assert.deepStrictEqual(firstMessageResult.message, rootMessage);
+        }
     });
 });

--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -3,9 +3,10 @@
  * Licensed under the MIT License.
  */
 
+// eslint-disable-next-line import/no-nodejs-modules
+import * as crypto from "crypto";
 import { strict as assert } from "assert";
-import { Container } from "@fluidframework/container-loader";
-import { SharedMap } from "@fluidframework/map";
+import { ISharedMap, SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
     DataObjectFactoryType,
@@ -13,53 +14,106 @@ import {
     ITestFluidObject,
     ITestObjectProvider,
 } from "@fluidframework/test-utils";
-import { describeNoCompat } from "@fluidframework/test-version-utils";
+import {
+    describeFullCompat,
+    describeInstallVersions,
+    getVersionedTestObjectProvider,
+} from "@fluidframework/test-version-utils";
 import { CompressionAlgorithms } from "@fluidframework/container-runtime";
+import { pkgVersion } from "../packageVersion";
 
-const testContainerConfig: ITestContainerConfig = {
-    registry: [["mapKey", SharedMap.getFactory()]],
-    runtimeOptions: {
-        compressionOptions: { minimumBatchSizeInBytes: 1, compressionAlgorithm: CompressionAlgorithms.lz4 },
-    },
-    fluidDataObjectType: DataObjectFactoryType.Test,
+const compressionSuite = (getProvider) => {
+    describe("Compression", () => {
+        let provider: ITestObjectProvider;
+        let localMap: ISharedMap;
+        let remoteMap: ISharedMap;
+        const testContainerConfig: ITestContainerConfig = {
+            registry: [["mapKey", SharedMap.getFactory()]],
+            runtimeOptions: {
+                compressionOptions: {
+                    minimumBatchSizeInBytes: 10,
+                    compressionAlgorithm: CompressionAlgorithms.lz4,
+                },
+            },
+            fluidDataObjectType: DataObjectFactoryType.Test,
+        };
+
+        beforeEach(async () => {
+            provider = await getProvider();
+
+            const localContainer = await provider.makeTestContainer(testContainerConfig);
+            const localDataObject = await requestFluidObject<ITestFluidObject>(
+                localContainer,
+                "default",
+            );
+            localMap = await localDataObject.getSharedObject<SharedMap>("mapKey");
+
+            const remoteContainer = await provider.loadTestContainer(testContainerConfig);
+            const remoteDataObject = await requestFluidObject<ITestFluidObject>(
+                remoteContainer,
+                "default",
+            );
+            remoteMap = await remoteDataObject.getSharedObject<SharedMap>("mapKey");
+        });
+
+        afterEach(() => {
+            provider.reset();
+        });
+
+        it("Can compress and process compressed op", async () => {
+            const values = [
+                generateRandomStringOfSize(100),
+                generateRandomStringOfSize(100),
+                generateRandomStringOfSize(100),
+            ];
+
+            for (let i = 0; i < values.length; i++) {
+                localMap.set(`${i}`, values[i]);
+            }
+
+            await provider.ensureSynchronized();
+            for (let i = 0; i < values.length; i++) {
+                assert.equal(localMap.get(`${i}`), values[i]);
+                assert.equal(remoteMap.get(`${i}`), values[i]);
+            }
+        });
+
+        it("Processes ops that weren't worth compressing", async () => {
+            const value = generateRandomStringOfSize(5);
+            localMap.set("testKey", value);
+
+            await provider.ensureSynchronized();
+            assert.strictEqual(localMap.get("testKey"), value);
+            assert.strictEqual(remoteMap.get("testKey"), value);
+        });
+    });
 };
 
-// Reenable full compat ADO:2942
-describeNoCompat("Op Compression", (getTestObjectProvider) => {
-    let provider: ITestObjectProvider;
-    let container: Container;
-    let dataObject: ITestFluidObject;
-    let map: SharedMap;
+describeFullCompat("Op Compression", (getTestObjectProvider) =>
+    compressionSuite(async () => getTestObjectProvider()),
+);
 
-    beforeEach(async () => {
-        provider = getTestObjectProvider();
-
-        container = (await provider.makeTestContainer(
-            testContainerConfig,
-        )) as Container;
-        dataObject = await requestFluidObject<ITestFluidObject>(
-            container,
-            "default",
+const loaderWithoutCompressionField = "2.0.0-internal.1.4.6";
+describeInstallVersions(
+    {
+        requestAbsoluteVersions: [loaderWithoutCompressionField],
+    },
+	/* timeoutMs */ 50000,
+)("Op Compression self-healing with old loader", (getProvider) =>
+    compressionSuite(async () => {
+        const provider = getProvider();
+        return getVersionedTestObjectProvider(
+            pkgVersion, // base version
+            loaderWithoutCompressionField, // loader version
+            {
+                type: provider.driver.type,
+                version: pkgVersion,
+            }, // driver version
+            pkgVersion, // runtime version
+            pkgVersion, // datastore runtime version
         );
-        map = await dataObject.getSharedObject<SharedMap>("mapKey");
-    });
+    }),
+);
 
-    afterEach(() => {
-        provider.reset();
-    });
-
-    it("Can compress and process compressed op", async () => {
-        // The value is such that the compressed value is longer than the uncompressed value
-        // If it wasn't, it wouldn't get compressed
-        map.set("testKey", "///////////////////////////////////");
-        await provider.ensureSynchronized();
-        const value = map.get("testKey");
-        assert.strictEqual(value, "///////////////////////////////////");
-    });
-
-    it("Processes ops that weren't worth compressing", async () => {
-        map.set("testKey", "testValue");
-        await provider.ensureSynchronized();
-        assert.strictEqual(map.get("testKey"), "testValue");
-    });
-});
+const generateRandomStringOfSize = (sizeInBytes: number): string =>
+    crypto.randomBytes(sizeInBytes / 2).toString("hex");


### PR DESCRIPTION
## Description

Porting https://github.com/microsoft/FluidFramework/pull/14337 to the release branch


# NOTE TO REVIEWERS

**As [release/v2int/3.0](https://github.com/microsoft/FluidFramework/tree/release/v2int/3.0) was cut before we moved to tabs, this PR was not done using `cherry-pick`. It was done manually on a fresh branch off the review branch. Please spot check this and be extra careful about the diff between this and https://github.com/microsoft/FluidFramework/pull/14337**