### PR TITLE
Add assert and handling in documentdeltaConnection

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -92,7 +92,7 @@ export class DocumentDeltaConnection
 				0x244 /* "Socket is closed, but connection is not!" */,
 			);
 		} catch (error) {
-			normalizeError(error, {
+			const normalizedError = normalizeError(error, {
 				props: {
 					details: JSON.stringify({
 						disposed: this._disposed,
@@ -102,7 +102,7 @@ export class DocumentDeltaConnection
 					}),
 				},
 			});
-			throw error;
+			throw normalizedError;
 		} finally {
 			(Error as any).stackTraceLimit = originalStackTraceLimit;
 		}
@@ -252,7 +252,7 @@ export class DocumentDeltaConnection
 			(Error as any).stackTraceLimit = 50;
 			assert(!this.disposed, 0x20c /* "connection disposed" */);
 		} catch (error) {
-			normalizeError(error, {
+			const normalizedError = normalizeError(error, {
 				props: {
 					details: JSON.stringify({
 						disposed: this._disposed,
@@ -262,7 +262,7 @@ export class DocumentDeltaConnection
 					}),
 				},
 			});
-			throw error;
+			throw normalizedError;
 		} finally {
 			(Error as any).stackTraceLimit = originalStackTraceLimit;
 		}

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -30,6 +30,7 @@ import {
 	loggerToMonitoringContext,
 	MonitoringContext,
 	EventEmitterWithErrorHandling,
+	normalizeError,
 } from "@fluidframework/telemetry-utils";
 import type { Socket } from "socket.io-client";
 // For now, this package is versioned and released in unison with the specific drivers
@@ -91,9 +92,8 @@ export class DocumentDeltaConnection
 				0x244 /* "Socket is closed, but connection is not!" */,
 			);
 		} catch (error) {
-			this.logger.sendErrorEvent(
-				{
-					eventName: "ConnectionDisposedAnomaly",
+			normalizeError(error, {
+				props: {
 					details: JSON.stringify({
 						disposed: this._disposed,
 						socketConnected: this.socket?.connected,
@@ -101,8 +101,7 @@ export class DocumentDeltaConnection
 						conenctionId: this.connectionId,
 					}),
 				},
-				error,
-			);
+			});
 			throw error;
 		} finally {
 			(Error as any).stackTraceLimit = originalStackTraceLimit;
@@ -253,9 +252,8 @@ export class DocumentDeltaConnection
 			(Error as any).stackTraceLimit = 50;
 			assert(!this.disposed, 0x20c /* "connection disposed" */);
 		} catch (error) {
-			this.logger.sendErrorEvent(
-				{
-					eventName: "ConnectionDisposed",
+			normalizeError(error, {
+				props: {
 					details: JSON.stringify({
 						disposed: this._disposed,
 						socketConnected: this.socket?.connected,
@@ -263,8 +261,7 @@ export class DocumentDeltaConnection
 						conenctionId: this.connectionId,
 					}),
 				},
-				error,
-			);
+			});
 			throw error;
 		} finally {
 			(Error as any).stackTraceLimit = originalStackTraceLimit;


### PR DESCRIPTION
## Description

Need to add the assert back which were removed in this PR: https://github.com/microsoft/FluidFramework/pull/14327
We should not let the state continue in the broken state and sendingError event does not by itself log the error.