### PR TITLE
refactor: tree: Move ReferenceCounted to util

### DIFF
--- a/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
@@ -15,9 +15,9 @@ import {
 	TreeType,
 	PathRootPrefix,
 } from "../../core";
-import { fail } from "../../util";
+import { fail, ReferenceCountedBase } from "../../util";
 import { prefixPath, SynchronousCursor } from "../treeCursorUtils";
-import { ChunkedCursor, cursorChunk, dummyRoot, ReferenceCountedBase, TreeChunk } from "./chunk";
+import { ChunkedCursor, cursorChunk, dummyRoot, TreeChunk } from "./chunk";
 
 /**
  * General purpose one node chunk.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunk.ts
@@ -11,19 +11,7 @@ import {
 	ITreeCursorSynchronous,
 	rootFieldKeySymbol,
 } from "../../core";
-
-export interface ReferenceCounted {
-	referenceAdded(): void;
-
-	referenceRemoved(): void;
-
-	/**
-	 * @returns true if mutating this object may impact other users of it.
-	 *
-	 * Implementations can return true if the refcount is 1 OR the content is logically immutable.
-	 */
-	isShared(): boolean;
-}
+import { ReferenceCounted } from "../../util";
 
 /**
  * Contiguous part of the tree which get stored together in some data format.
@@ -50,34 +38,6 @@ export interface TreeChunk extends ReferenceCounted {
 	 * which would compose better with utilities for processing sequences of nodes.
 	 */
 	cursor(): ChunkedCursor;
-}
-
-/**
- * Base class to assist with implementing ReferenceCounted
- */
-export abstract class ReferenceCountedBase implements ReferenceCounted {
-	private refCount: number = 1;
-
-	public referenceAdded(): void {
-		this.refCount++;
-	}
-
-	public referenceRemoved(): void {
-		this.refCount--;
-		assert(this.refCount >= 0, 0x4c4 /* Negative ref count */);
-		if (this.refCount === 0) {
-			this.dispose();
-		}
-	}
-
-	public isShared(): boolean {
-		return this.refCount > 1;
-	}
-
-	/**
-	 * Called when refcount reaches 0.
-	 */
-	protected abstract dispose(): void;
 }
 
 /**

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/sequenceChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/sequenceChunk.ts
@@ -3,8 +3,9 @@
  * Licensed under the MIT License.
  */
 
+import { ReferenceCountedBase } from "../../util";
 import { BasicChunkCursor } from "./basicChunk";
-import { ChunkedCursor, dummyRoot, ReferenceCountedBase, TreeChunk } from "./chunk";
+import { ChunkedCursor, dummyRoot, TreeChunk } from "./chunk";
 
 /**
  * General purpose multi-node sequence chunk.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
@@ -14,9 +14,9 @@ import {
 	Value,
 	PathRootPrefix,
 } from "../../core";
-import { compareArrays, fail } from "../../util";
+import { compareArrays, fail, ReferenceCountedBase } from "../../util";
 import { prefixFieldPath, prefixPath, SynchronousCursor } from "../treeCursorUtils";
-import { ChunkedCursor, cursorChunk, dummyRoot, ReferenceCountedBase, TreeChunk } from "./chunk";
+import { ChunkedCursor, cursorChunk, dummyRoot, TreeChunk } from "./chunk";
 
 /**
  * Create a tree chunk with ref count 1.

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
@@ -22,7 +22,7 @@ import {
 	chunkTree,
 	TreeChunk,
 } from "../../../feature-libraries";
-import { brand } from "../../../util";
+import { brand, ReferenceCountedBase } from "../../../util";
 // eslint-disable-next-line import/no-internal-modules
 import { uniformChunk } from "../../../feature-libraries/chunked-forest";
 // eslint-disable-next-line import/no-internal-modules
@@ -39,7 +39,6 @@ import { SequenceChunk } from "../../../feature-libraries/chunked-forest/sequenc
 import { jsonNumber } from "../../../domains";
 import {
 	ChunkedCursor,
-	ReferenceCountedBase,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/chunked-forest/chunk";
 import { emptyShape, testData } from "./uniformChunkTestData";

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -62,3 +62,4 @@ export {
 	RecursiveReadonly,
 	zipIterables,
 } from "./utils";
+export { ReferenceCountedBase, ReferenceCounted } from "./referenceCounting";

--- a/packages/dds/tree/src/util/referenceCounting.ts
+++ b/packages/dds/tree/src/util/referenceCounting.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert } from "@fluidframework/common-utils";
+
+export interface ReferenceCounted {
+	referenceAdded(): void;
+
+	referenceRemoved(): void;
+
+	/**
+	 * @returns true if mutating this object may impact other users of it.
+	 *
+	 * Implementations can return true if the refcount is 1 OR the content is logically immutable.
+	 */
+	isShared(): boolean;
+}
+
+/**
+ * Base class to assist with implementing ReferenceCounted.
+ */
+export abstract class ReferenceCountedBase implements ReferenceCounted {
+	protected constructor(private refCount: number = 1) {}
+
+	public referenceAdded(count = 1): void {
+		this.refCount += count;
+	}
+
+	public referenceRemoved(count = 1): void {
+		this.refCount -= count;
+		assert(this.refCount >= 0, 0x4c4 /* Negative ref count */);
+		if (this.refCount === 0) {
+			this.dispose();
+		}
+	}
+
+	public isShared(): boolean {
+		return this.refCount > 1;
+	}
+
+	public isUnreferenced(): boolean {
+		return this.refCount === 0;
+	}
+
+	/**
+	 * Called when refcount reaches 0.
+	 */
+	protected abstract dispose(): void;
+}


### PR DESCRIPTION
## Description

Move ReferenceCounted to util where it can be used by AnchorSet.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
