### PR TITLE
Patch - Fix op compression when using an older loader - 3.2

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1113,7 +1113,10 @@ export class ContainerRuntime
 			runtimeOptions.maxBatchSizeInBytes,
 			this.mc.logger,
 		);
-		this.remoteMessageProcessor = new RemoteMessageProcessor(opSplitter, new OpDecompressor());
+		this.remoteMessageProcessor = new RemoteMessageProcessor(
+			opSplitter,
+			new OpDecompressor(this.mc.logger),
+		);
 
 		this.handleContext = new ContainerFluidHandleContext("", this);
 
@@ -1890,7 +1893,23 @@ export class ContainerRuntime
 				case ContainerMessageType.Rejoin:
 					break;
 				default:
-					assert(!runtimeMessage, 0x3ce /* Runtime message of unknown type */);
+					if (runtimeMessage) {
+						const error = DataProcessingError.create(
+							// Former assert 0x3ce
+							"Runtime message of unknown type",
+							"OpProcessing",
+							message,
+							{
+								local,
+								type: message.type,
+								contentType: typeof message.contents,
+								batch: message.metadata?.batch,
+								compression: message.compression,
+							},
+						);
+						this.closeFn(error);
+						throw error;
+					}
 			}
 
 			// For back-compat, notify only about runtime messages for now.

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -175,9 +175,11 @@ export class Outbox {
 		if (
 			batch.content.length === 0 ||
 			this.params.config.compressionOptions === undefined ||
-			this.params.config.compressionOptions.minimumBatchSizeInBytes > batch.contentSizeInBytes
+			this.params.config.compressionOptions.minimumBatchSizeInBytes >
+				batch.contentSizeInBytes ||
+			this.params.containerContext.submitBatchFn === undefined
 		) {
-			// Nothing to do if the batch is empty or if compression is disabled or if we don't need to compress
+			// Nothing to do if the batch is empty or if compression is disabled or not supported, or if we don't need to compress
 			return batch;
 		}
 

--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -3,9 +3,10 @@
  * Licensed under the MIT License.
  */
 
+// eslint-disable-next-line import/no-nodejs-modules
+import * as crypto from "crypto";
 import { strict as assert } from "assert";
-import { Container } from "@fluidframework/container-loader";
-import { SharedMap } from "@fluidframework/map";
+import { ISharedMap, SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
 	DataObjectFactoryType,
@@ -13,50 +14,106 @@ import {
 	ITestFluidObject,
 	ITestObjectProvider,
 } from "@fluidframework/test-utils";
-import { describeFullCompat } from "@fluidframework/test-version-utils";
+import {
+	describeFullCompat,
+	describeInstallVersions,
+	getVersionedTestObjectProvider,
+} from "@fluidframework/test-version-utils";
 import { CompressionAlgorithms } from "@fluidframework/container-runtime";
+import { pkgVersion } from "../packageVersion";
 
-const testContainerConfig: ITestContainerConfig = {
-	registry: [["mapKey", SharedMap.getFactory()]],
-	runtimeOptions: {
-		compressionOptions: {
-			minimumBatchSizeInBytes: 1,
-			compressionAlgorithm: CompressionAlgorithms.lz4,
-		},
-	},
-	fluidDataObjectType: DataObjectFactoryType.Test,
+const compressionSuite = (getProvider) => {
+	describe("Compression", () => {
+		let provider: ITestObjectProvider;
+		let localMap: ISharedMap;
+		let remoteMap: ISharedMap;
+		const testContainerConfig: ITestContainerConfig = {
+			registry: [["mapKey", SharedMap.getFactory()]],
+			runtimeOptions: {
+				compressionOptions: {
+					minimumBatchSizeInBytes: 10,
+					compressionAlgorithm: CompressionAlgorithms.lz4,
+				},
+			},
+			fluidDataObjectType: DataObjectFactoryType.Test,
+		};
+
+		beforeEach(async () => {
+			provider = await getProvider();
+
+			const localContainer = await provider.makeTestContainer(testContainerConfig);
+			const localDataObject = await requestFluidObject<ITestFluidObject>(
+				localContainer,
+				"default",
+			);
+			localMap = await localDataObject.getSharedObject<SharedMap>("mapKey");
+
+			const remoteContainer = await provider.loadTestContainer(testContainerConfig);
+			const remoteDataObject = await requestFluidObject<ITestFluidObject>(
+				remoteContainer,
+				"default",
+			);
+			remoteMap = await remoteDataObject.getSharedObject<SharedMap>("mapKey");
+		});
+
+		afterEach(() => {
+			provider.reset();
+		});
+
+		it("Can compress and process compressed op", async () => {
+			const values = [
+				generateRandomStringOfSize(100),
+				generateRandomStringOfSize(100),
+				generateRandomStringOfSize(100),
+			];
+
+			for (let i = 0; i < values.length; i++) {
+				localMap.set(`${i}`, values[i]);
+			}
+
+			await provider.ensureSynchronized();
+			for (let i = 0; i < values.length; i++) {
+				assert.equal(localMap.get(`${i}`), values[i]);
+				assert.equal(remoteMap.get(`${i}`), values[i]);
+			}
+		});
+
+		it("Processes ops that weren't worth compressing", async () => {
+			const value = generateRandomStringOfSize(5);
+			localMap.set("testKey", value);
+
+			await provider.ensureSynchronized();
+			assert.strictEqual(localMap.get("testKey"), value);
+			assert.strictEqual(remoteMap.get("testKey"), value);
+		});
+	});
 };
 
-describeFullCompat("Op Compression", (getTestObjectProvider) => {
-	let provider: ITestObjectProvider;
-	let container: Container;
-	let dataObject: ITestFluidObject;
-	let map: SharedMap;
+describeFullCompat("Op Compression", (getTestObjectProvider) =>
+	compressionSuite(async () => getTestObjectProvider()),
+);
 
-	beforeEach(async () => {
-		provider = getTestObjectProvider();
+const loaderWithoutCompressionField = "2.0.0-internal.1.4.6";
+describeInstallVersions(
+	{
+		requestAbsoluteVersions: [loaderWithoutCompressionField],
+	},
+	/* timeoutMs */ 50000,
+)("Op Compression self-healing with old loader", (getProvider) =>
+	compressionSuite(async () => {
+		const provider = getProvider();
+		return getVersionedTestObjectProvider(
+			pkgVersion, // base version
+			loaderWithoutCompressionField, // loader version
+			{
+				type: provider.driver.type,
+				version: pkgVersion,
+			}, // driver version
+			pkgVersion, // runtime version
+			pkgVersion, // datastore runtime version
+		);
+	}),
+);
 
-		container = (await provider.makeTestContainer(testContainerConfig)) as Container;
-		dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
-		map = await dataObject.getSharedObject<SharedMap>("mapKey");
-	});
-
-	afterEach(() => {
-		provider.reset();
-	});
-
-	it("Can compress and process compressed op", async () => {
-		// The value is such that the compressed value is longer than the uncompressed value
-		// If it wasn't, it wouldn't get compressed
-		map.set("testKey", "///////////////////////////////////");
-		await provider.ensureSynchronized();
-		const value = map.get("testKey");
-		assert.strictEqual(value, "///////////////////////////////////");
-	});
-
-	it("Processes ops that weren't worth compressing", async () => {
-		map.set("testKey", "testValue");
-		await provider.ensureSynchronized();
-		assert.strictEqual(map.get("testKey"), "testValue");
-	});
-});
+const generateRandomStringOfSize = (sizeInBytes: number): string =>
+	crypto.randomBytes(sizeInBytes / 2).toString("hex");


### PR DESCRIPTION
## Description
Preemptively porting https://github.com/microsoft/FluidFramework/pull/14337 to the 3.2 release branch.

As opposed to https://github.com/microsoft/FluidFramework/pull/14345, this was cherry-picked.