### PR TITLE
Add a new API (empty implementation) in Alfred for token revocation

### DIFF
--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -33,6 +33,9 @@ export const buildTreePath: (...nodeNames: string[]) => string;
 export const canRead: (scopes: string[]) => boolean;
 
 // @public (undocumented)
+export const canRevokeToken: (scopes: string[]) => boolean;
+
+// @public (undocumented)
 export const canSummarize: (scopes: string[]) => boolean;
 
 // @public (undocumented)

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -18,7 +18,6 @@ import {
     throttle,
     IThrottleMiddlewareOptions,
     getParam,
-    getTokenFromRequest,
     validateTokenRevocationClaims,
 } from "@fluidframework/server-services-utils";
 import { validateRequestParams, handleResponse } from "@fluidframework/server-services";
@@ -181,7 +180,6 @@ export function create(
     router.post(
         "/:tenantId/document/:id/revokeToken",
         validateRequestParams("tenantId", "id"),
-        getTokenFromRequest(),
         validateTokenRevocationClaims(),
         verifyStorageToken(tenantManager, config),
         throttle(tenantThrottler, winston, tenantThrottleOptions),
@@ -193,7 +191,7 @@ export function create(
                 `Received token revocation request.`,
                 lumberjackProperties);
             // TODO: add implementation here.
-            response.status(503).json("Token revocation is not supported for now");
+            response.status(501).json("Token revocation is not supported for now");
         });
     return router;
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -183,11 +183,7 @@ export function create(
         validateRequestParams("tenantId", "id"),
         getTokenFromRequest(),
         validateTokenRevocationClaims(),
-        verifyStorageToken(tenantManager, config, {
-            requireDocumentId: false,
-            ensureSingleUseToken: true,
-            singleUseTokenCache,
-        }),
+        verifyStorageToken(tenantManager, config),
         throttle(tenantThrottler, winston, tenantThrottleOptions),
         async (request, response, next) => {
             const documentId = getParam(request.params, "id");

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -18,6 +18,7 @@ import {
     throttle,
     IThrottleMiddlewareOptions,
     getParam,
+    getTokenFromRequest,
 } from "@fluidframework/server-services-utils";
 import { validateRequestParams, handleResponse } from "@fluidframework/server-services";
 import { Router } from "express";
@@ -170,6 +171,23 @@ export function create(
                 sessionStickinessDurationMs,
             );
             handleResponse(session, response, false);
+        });
+
+    /**
+     * Revoke an access token
+     */
+    router.post(
+        "/:tenantId/document/:id/revokeToken",
+        validateRequestParams("tenantId", "id"),
+        getTokenFromRequest(),
+        verifyStorageToken(tenantManager, config, {
+            requireDocumentId: false,
+            ensureSingleUseToken: true,
+            singleUseTokenCache,
+        }),
+        throttle(throttler, winston, commonThrottleOptions),
+        async (request, response, next) => {
+
         });
     return router;
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -188,7 +188,7 @@ export function create(
             ensureSingleUseToken: true,
             singleUseTokenCache,
         }),
-        throttle(throttler, winston, commonThrottleOptions),
+        throttle(tenantThrottler, winston, tenantThrottleOptions),
         async (request, response, next) => {
             console.log(`Received token revocation request: ${JSON.stringify(request.body)}`);
             const documentId = getParam(request.params, "id");

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -196,6 +196,7 @@ export function create(
             Lumberjack.info(
                 `Received token revocation request.`,
                 lumberjackProperties);
+            // TODO: add implementation here.
             response.status(503).json("Token revocation is not supported for now");
         });
     return router;

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -190,14 +190,13 @@ export function create(
         }),
         throttle(tenantThrottler, winston, tenantThrottleOptions),
         async (request, response, next) => {
-            console.log(`Received token revocation request: ${JSON.stringify(request.body)}`);
             const documentId = getParam(request.params, "id");
             const tenantId = getParam(request.params, "tenantId");
             const lumberjackProperties = getLumberBaseProperties(documentId, tenantId);
             Lumberjack.info(
-                `Received and start processing request: ${JSON.stringify(request.body)}`,
+                `Received token revocation request.`,
                 lumberjackProperties);
-            response.status(200).json("Request received!");
+            response.status(503).json("Token revocation is not supported for now");
         });
     return router;
 }

--- a/server/routerlicious/packages/services-client/src/index.ts
+++ b/server/routerlicious/packages/services-client/src/index.ts
@@ -21,7 +21,7 @@ export { promiseTimeout } from "./promiseTimeout";
 export { RestLessClient, RestLessFieldNames } from "./restLessClient";
 export { BasicRestWrapper, RestWrapper } from "./restWrapper";
 export { defaultHash, getNextHash } from "./rollingHash";
-export { canRead, canSummarize, canWrite } from "./scopes";
+export { canRead, canSummarize, canWrite, canRevokeToken } from "./scopes";
 export {
 	ICreateRefParamsExternal,
 	IGetRefParamsExternal,

--- a/server/routerlicious/packages/services-client/src/scopes.ts
+++ b/server/routerlicious/packages/services-client/src/scopes.ts
@@ -5,6 +5,12 @@
 
 import { ScopeType } from "@fluidframework/protocol-definitions";
 
+/**
+* C1 can revoke an access token of a client
+*/
+const TokenRevokeScopeType = "token:revoke";
+
 export const canRead = (scopes: string[]) => scopes.includes(ScopeType.DocRead);
 export const canWrite = (scopes: string[]) => scopes.includes(ScopeType.DocWrite);
 export const canSummarize = (scopes: string[]) => scopes.includes(ScopeType.SummaryWrite);
+export const canRevokeToken = (scopes: string[]) => scopes.includes(TokenRevokeScopeType);

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -16,7 +16,7 @@ import {
     canRevokeToken,
 } from "@fluidframework/server-services-client";
 import type { ICache, ITenantManager } from "@fluidframework/server-services-core";
-import type { RequestHandler, Response } from "express";
+import type { RequestHandler, Request, Response } from "express";
 import type { Provider } from "nconf";
 import { getLumberBaseProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
 
@@ -119,6 +119,19 @@ export function respondWithNetworkError(
     return response.status(error.code).json(error.details);
 }
 
+function getTokenFromRequest(request: Request): string {
+    const authorizationHeader = request.header("Authorization");
+    if (!authorizationHeader) {
+        throw new NetworkError(403, "Missing Authorization header.");
+    }
+    const tokenRegex = /Basic (.+)/;
+    const tokenMatch = tokenRegex.exec(authorizationHeader);
+    if (!tokenMatch || !tokenMatch[1]) {
+        throw new NetworkError(403, "Missing access token.");
+    }
+    return tokenMatch[1];
+}
+
 /**
  * Verifies the storage token claims and calls riddler to validate the token.
  */
@@ -133,16 +146,6 @@ export function verifyStorageToken(
     return async (request, res, next) => {
         const maxTokenLifetimeSec = config.get("auth:maxTokenLifetimeSec") as number;
         const isTokenExpiryEnabled = config.get("auth:enableTokenExpiration") as boolean;
-        const authorizationHeader = request.header("Authorization");
-        if (!authorizationHeader) {
-            return respondWithNetworkError(res, new NetworkError(403, "Missing Authorization header."));
-        }
-        const tokenRegex = /Basic (.+)/;
-        const tokenMatch = tokenRegex.exec(authorizationHeader);
-        if (!tokenMatch || !tokenMatch[1]) {
-            return respondWithNetworkError(res, new NetworkError(403, "Missing access token."));
-        }
-        const token = tokenMatch[1];
         const tenantId = getParam(request.params, "tenantId");
         if (!tenantId) {
             return respondWithNetworkError(res, new NetworkError(403, "Missing tenantId in request."));
@@ -153,7 +156,9 @@ export function verifyStorageToken(
         }
         let claims: ITokenClaims | undefined;
         let tokenLifetimeMs: number | undefined;
+        let token: string = "";
         try {
+            token = getTokenFromRequest(request);
             claims = validateTokenClaims(token, documentId, tenantId, options.requireDocumentId);
             if (isTokenExpiryEnabled) {
                 tokenLifetimeMs = validateTokenClaimsExpiration(claims, maxTokenLifetimeSec);
@@ -204,28 +209,17 @@ export function verifyStorageToken(
     };
 }
 
-export function getTokenFromRequest(): RequestHandler {
-    return async (request, response, next) => {
-        const authorizationHeader = request.header("Authorization");
-        if (!authorizationHeader) {
-            return respondWithNetworkError(response, new NetworkError(403, "Missing Authorization header."));
-        }
-        const tokenRegex = /Basic (.+)/;
-        const tokenMatch = tokenRegex.exec(authorizationHeader);
-        if (!tokenMatch || !tokenMatch[1]) {
-            return respondWithNetworkError(response, new NetworkError(403, "Missing access token."));
-        }
-        const token = tokenMatch[1];
-        response.locals.token = token;
-        next();
-    };
-}
-
 export function validateTokenRevocationClaims(): RequestHandler {
     return async (request, response, next) => {
-        const token: string = response.locals.token;
-        if (!token) {
-            return respondWithNetworkError(response, new NetworkError(403, "Missing access token."));
+        let token: string = "";
+        try {
+            token = getTokenFromRequest(request);
+        }
+        catch(error: unknown) {
+            if (error instanceof NetworkError) {
+                return respondWithNetworkError(response, error);
+            }
+            return respondWithNetworkError(response, new NetworkError(403, "Missing access token.")); 
         }
 
         const claims = decode(token) as ITokenClaims;

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -143,14 +143,6 @@ export function verifyStorageToken(
             return respondWithNetworkError(res, new NetworkError(403, "Missing access token."));
         }
         const token = tokenMatch[1];
-
-       /*
-        const token = res.locals.token;
-        if (!token) {
-            return respondWithNetworkError(res, new NetworkError(403, "Missing access token."));
-        }
-        */
-
         const tenantId = getParam(request.params, "tenantId");
         if (!tenantId) {
             return respondWithNetworkError(res, new NetworkError(403, "Missing tenantId in request."));

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -12,6 +12,8 @@ export {
 	respondWithNetworkError,
 	validateTokenClaims,
 	verifyStorageToken,
+	getTokenFromRequest,
+	validateTokenRevocationClaims,
 } from "./auth";
 export { parseBoolean } from "./conversion";
 export { deleteSummarizedOps } from "./deleteSummarizedOps";

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -12,7 +12,6 @@ export {
 	respondWithNetworkError,
 	validateTokenClaims,
 	verifyStorageToken,
-	getTokenFromRequest,
 	validateTokenRevocationClaims,
 } from "./auth";
 export { parseBoolean } from "./conversion";


### PR DESCRIPTION
This PR add a new API in Alfred for token revocation feature. Currently it is an empty implementation and only return 503.
It also adds a new scope (permission) for this new API: token:revoke
This new scope is not in the same place as other scopes because scopes are usually defined in protocol package, which is out of server package. Not sure if it should be moved there. Or we can move it later in the future.

The API url is like this: ${alfred_url}/documents/${tenantId}/document/${documentId}/revokeToken

This API can be invoked only if the token include the new scope: token:revoke.


