### PR TITLE
Tree: Fix move invalidation

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -134,8 +134,12 @@ export const createField: unique symbol;
 
 // @alpha
 export interface CrossFieldManager<T = unknown> {
+    // (undocumented)
+    addDependency(target: CrossFieldTarget, revision: RevisionTag | undefined, id: ChangesetLocalId): void;
     get(target: CrossFieldTarget, revision: RevisionTag | undefined, id: ChangesetLocalId): T | undefined;
     getOrCreate(target: CrossFieldTarget, revision: RevisionTag | undefined, id: ChangesetLocalId, newValue: T): T;
+    // (undocumented)
+    invalidate(target: CrossFieldTarget, revision: RevisionTag | undefined, id: ChangesetLocalId): void;
 }
 
 // @alpha (undocumented)

--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -134,12 +134,8 @@ export const createField: unique symbol;
 
 // @alpha
 export interface CrossFieldManager<T = unknown> {
-    // (undocumented)
-    addDependency(target: CrossFieldTarget, revision: RevisionTag | undefined, id: ChangesetLocalId): void;
-    get(target: CrossFieldTarget, revision: RevisionTag | undefined, id: ChangesetLocalId): T | undefined;
-    getOrCreate(target: CrossFieldTarget, revision: RevisionTag | undefined, id: ChangesetLocalId, newValue: T): T;
-    // (undocumented)
-    invalidate(target: CrossFieldTarget, revision: RevisionTag | undefined, id: ChangesetLocalId): void;
+    get(target: CrossFieldTarget, revision: RevisionTag | undefined, id: ChangesetLocalId, addDependency: boolean): T | undefined;
+    getOrCreate(target: CrossFieldTarget, revision: RevisionTag | undefined, id: ChangesetLocalId, newValue: T, invalidateDependents: boolean): T;
 }
 
 // @alpha (undocumented)

--- a/packages/dds/tree/src/feature-libraries/modular-schema/crossFieldQueries.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/crossFieldQueries.ts
@@ -45,6 +45,18 @@ export interface CrossFieldManager<T = unknown> {
 		id: ChangesetLocalId,
 		newValue: T,
 	): T;
+
+	addDependency(
+		target: CrossFieldTarget,
+		revision: RevisionTag | undefined,
+		id: ChangesetLocalId,
+	): void;
+
+	invalidate(
+		target: CrossFieldTarget,
+		revision: RevisionTag | undefined,
+		id: ChangesetLocalId,
+	): void;
 }
 
 /**

--- a/packages/dds/tree/src/feature-libraries/modular-schema/crossFieldQueries.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/crossFieldQueries.ts
@@ -24,18 +24,19 @@ export enum CrossFieldTarget {
 export interface CrossFieldManager<T = unknown> {
 	/**
 	 * Returns the data associated with triplet key of `target`, `revision`, and `id`.
-	 * Calling this records a dependency for the current field on this key.
+	 * Calling this records a dependency for the current field on this key if `addDepdency` is true.
 	 */
 	get(
 		target: CrossFieldTarget,
 		revision: RevisionTag | undefined,
 		id: ChangesetLocalId,
+		addDependency: boolean,
 	): T | undefined;
 
 	/**
 	 * If there is no data for this key, sets the value to `newValue`.
 	 * Then returns the data for this key.
-	 * All fields which took a dependency on this key will be considered invalidated
+	 * If `invalidateDependents` is true, all fields which took a dependency on this key will be considered invalidated
 	 * and will be given a chance to address the new data in `amendRebase`, `amendInvert`, or `amendCompose`,
 	 * as appropriate.
 	 */
@@ -44,19 +45,8 @@ export interface CrossFieldManager<T = unknown> {
 		revision: RevisionTag | undefined,
 		id: ChangesetLocalId,
 		newValue: T,
+		invalidateDependents: boolean,
 	): T;
-
-	addDependency(
-		target: CrossFieldTarget,
-		revision: RevisionTag | undefined,
-		id: ChangesetLocalId,
-	): void;
-
-	invalidate(
-		target: CrossFieldTarget,
-		revision: RevisionTag | undefined,
-		id: ChangesetLocalId,
-	): void;
 }
 
 /**

--- a/packages/dds/tree/src/feature-libraries/modular-schema/crossFieldQueries.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/crossFieldQueries.ts
@@ -24,7 +24,7 @@ export enum CrossFieldTarget {
 export interface CrossFieldManager<T = unknown> {
 	/**
 	 * Returns the data associated with triplet key of `target`, `revision`, and `id`.
-	 * Calling this records a dependency for the current field on this key if `addDepdency` is true.
+	 * Calling this records a dependency for the current field on this key if `addDependency` is true.
 	 */
 	get(
 		target: CrossFieldTarget,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -214,6 +214,4 @@ const invalidFunc = () => fail("Should not be called when converting generic cha
 const invalidCrossFieldManager: CrossFieldManager = {
 	getOrCreate: invalidFunc,
 	get: invalidFunc,
-	addDependency: invalidFunc,
-	invalidate: invalidFunc,
 };

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -214,4 +214,6 @@ const invalidFunc = () => fail("Should not be called when converting generic cha
 const invalidCrossFieldManager: CrossFieldManager = {
 	getOrCreate: invalidFunc,
 	get: invalidFunc,
+	addDependency: invalidFunc,
+	invalidate: invalidFunc,
 };

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -605,6 +605,29 @@ function newCrossFieldManager<T>(crossFieldTable: CrossFieldTable<T>): CrossFiel
 			id: ChangesetLocalId,
 			newValue: unknown,
 		) => {
+			return getOrAddInNestedMap(getMap(target), revision, id, newValue);
+		},
+		get: (
+			target: CrossFieldTarget,
+			revision: RevisionTag | undefined,
+			id: ChangesetLocalId,
+		) => {
+			return tryGetFromNestedMap(getMap(target), revision, id);
+		},
+
+		addDependency: (
+			target: CrossFieldTarget,
+			revision: RevisionTag | undefined,
+			id: ChangesetLocalId,
+		) => {
+			addToNestedSet(getQueries(target), revision, id);
+		},
+
+		invalidate: (
+			target: CrossFieldTarget,
+			revision: RevisionTag | undefined,
+			id: ChangesetLocalId,
+		) => {
 			const dependents =
 				target === CrossFieldTarget.Source
 					? crossFieldTable.srcDependents
@@ -617,16 +640,6 @@ function newCrossFieldManager<T>(crossFieldTable: CrossFieldTable<T>): CrossFiel
 			if (nestedSetContains(getQueries(target), revision, id)) {
 				manager.fieldInvalidated = true;
 			}
-
-			return getOrAddInNestedMap(getMap(target), revision, id, newValue);
-		},
-		get: (
-			target: CrossFieldTarget,
-			revision: RevisionTag | undefined,
-			id: ChangesetLocalId,
-		) => {
-			addToNestedSet(getQueries(target), revision, id);
-			return tryGetFromNestedMap(getMap(target), revision, id);
 		},
 	};
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -128,7 +128,7 @@ export class ModularChangeFamily
 			crossFieldTable,
 		);
 
-		while (crossFieldTable.fieldsToUpdate.size > 0) {
+		if (crossFieldTable.fieldsToUpdate.size > 0) {
 			const fieldsToUpdate = crossFieldTable.fieldsToUpdate;
 			crossFieldTable.fieldsToUpdate = new Set();
 			for (const field of fieldsToUpdate) {
@@ -144,6 +144,11 @@ export class ModularChangeFamily
 				field.change = brand(amendedChange);
 			}
 		}
+
+		assert(
+			crossFieldTable.fieldsToUpdate.size === 0,
+			"Should not need more than one amend pass.",
+		);
 		return makeModularChangeset(composedFields, maxId);
 	}
 
@@ -247,7 +252,7 @@ export class ModularChangeFamily
 			crossFieldTable,
 		);
 
-		while (crossFieldTable.fieldsToUpdate.size > 0) {
+		if (crossFieldTable.fieldsToUpdate.size > 0) {
 			const fieldsToUpdate = crossFieldTable.fieldsToUpdate;
 			crossFieldTable.fieldsToUpdate = new Set();
 			for (const { fieldChange, originalRevision } of fieldsToUpdate) {
@@ -263,6 +268,12 @@ export class ModularChangeFamily
 				fieldChange.change = brand(amendedChange);
 			}
 		}
+
+		assert(
+			crossFieldTable.fieldsToUpdate.size === 0,
+			"Should not need more than one amend pass.",
+		);
+
 		return makeModularChangeset(invertedFields, maxId);
 	}
 
@@ -347,7 +358,7 @@ export class ModularChangeFamily
 			crossFieldTable,
 		);
 
-		while (crossFieldTable.fieldsToUpdate.size > 0) {
+		if (crossFieldTable.fieldsToUpdate.size > 0) {
 			const fieldsToUpdate = crossFieldTable.fieldsToUpdate;
 			crossFieldTable.fieldsToUpdate = new Set();
 			for (const { fieldChange, baseChange } of fieldsToUpdate) {
@@ -363,6 +374,11 @@ export class ModularChangeFamily
 				fieldChange.change = brand(amendedChange);
 			}
 		}
+
+		assert(
+			crossFieldTable.fieldsToUpdate.size === 0,
+			"Should not need more than one amend pass.",
+		);
 
 		return makeModularChangeset(rebasedFields, maxId);
 	}

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -154,12 +154,7 @@ function invertMark<TNodeChange>(
 						mark.revision ?? revision,
 						mark.id,
 						invertChild(mark.changes),
-					);
-
-					crossFieldManager.invalidate(
-						CrossFieldTarget.Destination,
-						mark.revision ?? revision,
-						mark.id,
+						true,
 					);
 				}
 				return [
@@ -190,12 +185,7 @@ function invertMark<TNodeChange>(
 						CrossFieldTarget.Destination,
 						mark.revision ?? revision,
 						mark.id,
-					);
-
-					crossFieldManager.addDependency(
-						CrossFieldTarget.Destination,
-						mark.revision ?? revision,
-						mark.id,
+						true,
 					);
 
 					if (movedChanges !== undefined) {
@@ -227,12 +217,7 @@ function transferMovedChanges<TNodeChange>(
 				CrossFieldTarget.Destination,
 				mark.revision ?? revision,
 				mark.id,
-			);
-
-			crossFieldManager.addDependency(
-				CrossFieldTarget.Destination,
-				mark.revision ?? revision,
-				mark.id,
+				true,
 			);
 
 			if (change !== undefined) {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -155,6 +155,12 @@ function invertMark<TNodeChange>(
 						mark.id,
 						invertChild(mark.changes),
 					);
+
+					crossFieldManager.invalidate(
+						CrossFieldTarget.Destination,
+						mark.revision ?? revision,
+						mark.id,
+					);
 				}
 				return [
 					{
@@ -185,6 +191,13 @@ function invertMark<TNodeChange>(
 						mark.revision ?? revision,
 						mark.id,
 					);
+
+					crossFieldManager.addDependency(
+						CrossFieldTarget.Destination,
+						mark.revision ?? revision,
+						mark.id,
+					);
+
 					if (movedChanges !== undefined) {
 						invertedMark.changes = movedChanges;
 					}
@@ -215,6 +228,13 @@ function transferMovedChanges<TNodeChange>(
 				mark.revision ?? revision,
 				mark.id,
 			);
+
+			crossFieldManager.addDependency(
+				CrossFieldTarget.Destination,
+				mark.revision ?? revision,
+				mark.id,
+			);
+
 			if (change !== undefined) {
 				mark.changes = change;
 			}

--- a/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -136,13 +136,10 @@ export function getOrAddEffect<T>(
 	resetMerges: boolean = false,
 	invalidate: boolean = true,
 ): MoveEffect<T> {
-	if (invalidate) {
-		moveEffects.invalidate(target, revision, id);
-	}
 	if (resetMerges) {
 		clearMergeability(moveEffects, target, revision, id);
 	}
-	return moveEffects.getOrCreate(target, revision, id, {});
+	return moveEffects.getOrCreate(target, revision, id, {}, invalidate);
 }
 
 export function getMoveEffect<T>(
@@ -152,10 +149,7 @@ export function getMoveEffect<T>(
 	id: MoveId,
 	addDependency: boolean = true,
 ): MoveEffect<T> {
-	if (addDependency) {
-		moveEffects.addDependency(target, revision, id);
-	}
-	return moveEffects.get(target, revision, id) ?? {};
+	return moveEffects.get(target, revision, id, addDependency) ?? {};
 }
 
 export function clearMergeability<T>(
@@ -166,11 +160,13 @@ export function clearMergeability<T>(
 ): void {
 	const effect = getOrAddEffect(moveEffects, target, revision, id);
 	if (effect.mergeLeft !== undefined) {
-		delete getOrAddEffect(moveEffects, target, revision, effect.mergeLeft).mergeRight;
+		delete getOrAddEffect(moveEffects, target, revision, effect.mergeLeft, false, false)
+			.mergeRight;
 		delete effect.mergeLeft;
 	}
 	if (effect.mergeRight !== undefined) {
-		delete getOrAddEffect(moveEffects, target, revision, effect.mergeRight).mergeLeft;
+		delete getOrAddEffect(moveEffects, target, revision, effect.mergeRight, false, false)
+			.mergeLeft;
 		delete effect.mergeRight;
 	}
 }

--- a/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -55,7 +55,7 @@ export interface MoveEffect<T> {
 	/**
 	 * The ID of a mark which can be merged into this mark from the right.
 	 */
-	mergeRight?: MoveId;
+	mergeRight?: MoveId; // Do we need this?
 
 	/**
 	 * Node changes which should be applied to this mark.
@@ -134,7 +134,11 @@ export function getOrAddEffect<T>(
 	revision: RevisionTag | undefined,
 	id: MoveId,
 	resetMerges: boolean = false,
+	invalidate: boolean = true,
 ): MoveEffect<T> {
+	if (invalidate) {
+		moveEffects.invalidate(target, revision, id);
+	}
 	if (resetMerges) {
 		clearMergeability(moveEffects, target, revision, id);
 	}
@@ -146,7 +150,11 @@ export function getMoveEffect<T>(
 	target: CrossFieldTarget,
 	revision: RevisionTag | undefined,
 	id: MoveId,
+	addDependency: boolean = true,
 ): MoveEffect<T> {
+	if (addDependency) {
+		moveEffects.addDependency(target, revision, id);
+	}
 	return moveEffects.get(target, revision, id) ?? {};
 }
 
@@ -174,8 +182,8 @@ export function makeMergeable<T>(
 	leftId: MoveId,
 	rightId: MoveId,
 ): void {
-	getOrAddEffect(moveEffects, target, revision, leftId).mergeRight = rightId;
-	getOrAddEffect(moveEffects, target, revision, rightId).mergeLeft = leftId;
+	getOrAddEffect(moveEffects, target, revision, leftId, false, false).mergeRight = rightId;
+	getOrAddEffect(moveEffects, target, revision, rightId, false, false).mergeLeft = leftId;
 }
 
 export type MoveMark<T> = MoveOut<T> | MoveIn | ReturnFrom<T> | ReturnTo;

--- a/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -55,7 +55,7 @@ export interface MoveEffect<T> {
 	/**
 	 * The ID of a mark which can be merged into this mark from the right.
 	 */
-	mergeRight?: MoveId; // Do we need this?
+	mergeRight?: MoveId;
 
 	/**
 	 * Node changes which should be applied to this mark.

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -854,7 +854,15 @@ export function newCrossFieldTable<T = unknown>(): CrossFieldTable<T> {
 		mapSrc,
 		mapDst,
 
-		get: (target: CrossFieldTarget, revision: RevisionTag | undefined, id: MoveId) => {
+		get: (
+			target: CrossFieldTarget,
+			revision: RevisionTag | undefined,
+			id: MoveId,
+			addDependency: boolean,
+		) => {
+			if (addDependency) {
+				addToNestedSet(getQueries(target), revision, id);
+			}
 			return tryGetFromNestedMap(getMap(target), revision, id);
 		},
 		getOrCreate: (
@@ -862,27 +870,17 @@ export function newCrossFieldTable<T = unknown>(): CrossFieldTable<T> {
 			revision: RevisionTag | undefined,
 			id: MoveId,
 			defaultValue: T,
+			invalidateDependents: boolean,
 		) => {
+			if (invalidateDependents && nestedSetContains(getQueries(target), revision, id)) {
+				table.isInvalidated = true;
+			}
 			return getOrAddInNestedMap<RevisionTag | undefined, MoveId, T>(
 				getMap(target),
 				revision,
 				id,
 				defaultValue,
 			);
-		},
-
-		addDependency: (
-			target: CrossFieldTarget,
-			revision: RevisionTag | undefined,
-			id: MoveId,
-		) => {
-			addToNestedSet(getQueries(target), revision, id);
-		},
-
-		invalidate: (target: CrossFieldTarget, revision: RevisionTag | undefined, id: MoveId) => {
-			if (nestedSetContains(getQueries(target), revision, id)) {
-				table.isInvalidated = true;
-			}
 		},
 
 		reset: () => {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -8,7 +8,6 @@ import { RevisionTag, TaggedChange } from "../../core";
 import {
 	addToNestedSet,
 	clone,
-	deleteFromNestedMap,
 	fail,
 	getOrAddEmptyToMap,
 	getOrAddInNestedMap,
@@ -55,7 +54,6 @@ import { MarkQueue } from "./markQueue";
 import {
 	applyMoveEffectsToMark,
 	getMoveEffect,
-	getOrAddEffect,
 	makeMergeable,
 	MoveEffectTable,
 	MoveMark,
@@ -484,14 +482,15 @@ function tryMergeMoves<T>(
 	const rev = left.revision ?? revision;
 	const oppEnd =
 		target === CrossFieldTarget.Source ? CrossFieldTarget.Destination : CrossFieldTarget.Source;
-	const prevMergeId = getMoveEffect(moveEffects, oppEnd, rev, left.id).mergeRight;
+
+	const prevMergeId = getMoveEffect(moveEffects, oppEnd, rev, left.id, false).mergeRight;
 	if (prevMergeId !== undefined && prevMergeId !== right.id) {
 		makeMergeable(moveEffects, oppEnd, rev, prevMergeId, right.id);
 	} else {
 		makeMergeable(moveEffects, oppEnd, rev, left.id, right.id);
 	}
 
-	const leftEffect = getOrAddEffect(moveEffects, target, rev, left.id);
+	const leftEffect = getMoveEffect(moveEffects, target, rev, left.id);
 	if (leftEffect.mergeRight === right.id) {
 		const rightEffect = getMoveEffect(moveEffects, target, rev, right.id);
 		assert(rightEffect.mergeLeft === left.id, 0x56d /* Inconsistent merge info */);
@@ -856,9 +855,7 @@ export function newCrossFieldTable<T = unknown>(): CrossFieldTable<T> {
 		mapDst,
 
 		get: (target: CrossFieldTarget, revision: RevisionTag | undefined, id: MoveId) => {
-			const result = tryGetFromNestedMap(getMap(target), revision, id);
-			addToNestedSet(getQueries(target), revision, id);
-			return result;
+			return tryGetFromNestedMap(getMap(target), revision, id);
 		},
 		getOrCreate: (
 			target: CrossFieldTarget,
@@ -866,9 +863,6 @@ export function newCrossFieldTable<T = unknown>(): CrossFieldTable<T> {
 			id: MoveId,
 			defaultValue: T,
 		) => {
-			if (nestedSetContains(getQueries(target), revision, id)) {
-				table.isInvalidated = true;
-			}
 			return getOrAddInNestedMap<RevisionTag | undefined, MoveId, T>(
 				getMap(target),
 				revision,
@@ -876,8 +870,20 @@ export function newCrossFieldTable<T = unknown>(): CrossFieldTable<T> {
 				defaultValue,
 			);
 		},
-		consume: (target: CrossFieldTarget, revision: RevisionTag | undefined, id: MoveId) =>
-			deleteFromNestedMap(getMap(target), revision, id),
+
+		addDependency: (
+			target: CrossFieldTarget,
+			revision: RevisionTag | undefined,
+			id: MoveId,
+		) => {
+			addToNestedSet(getQueries(target), revision, id);
+		},
+
+		invalidate: (target: CrossFieldTarget, revision: RevisionTag | undefined, id: MoveId) => {
+			if (nestedSetContains(getQueries(target), revision, id)) {
+				table.isInvalidated = true;
+			}
+		},
 
 		reset: () => {
 			table.isInvalidated = false;

--- a/packages/dds/tree/src/test/feature-libraries/defaultFieldKinds.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/defaultFieldKinds.spec.ts
@@ -37,7 +37,8 @@ const idAllocator: IdAllocator = unexpectedDelegate;
 const crossFieldManager = {
 	get: unexpectedDelegate,
 	getOrCreate: unexpectedDelegate,
-	consume: unexpectedDelegate,
+	addDependency: unexpectedDelegate,
+	invalidate: unexpectedDelegate,
 };
 
 const deltaFromChild1 = (child: NodeChangeset): Delta.NodeChanges => {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -131,7 +131,8 @@ const childDecoder = (nodeChange: JsonCompatibleReadOnly): NodeChangeset => {
 const crossFieldManager = {
 	get: unexpectedDelegate,
 	getOrCreate: unexpectedDelegate,
-	consume: unexpectedDelegate,
+	addDependency: unexpectedDelegate,
+	invalidate: unexpectedDelegate,
 };
 
 describe("Generic FieldKind", () => {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -13,6 +13,7 @@ import {
 	GenericChangeset,
 	genericFieldKind,
 	IdAllocator,
+	CrossFieldManager,
 } from "../../../feature-libraries";
 import { makeAnonChange, tagChange, TaggedChange, Delta, FieldKey } from "../../../core";
 import { brand, fail, JsonCompatibleReadOnly } from "../../../util";
@@ -128,11 +129,9 @@ const childDecoder = (nodeChange: JsonCompatibleReadOnly): NodeChangeset => {
 	return nodeChangeFromValueChange(valueChange);
 };
 
-const crossFieldManager = {
+const crossFieldManager: CrossFieldManager = {
 	get: unexpectedDelegate,
 	getOrCreate: unexpectedDelegate,
-	addDependency: unexpectedDelegate,
-	invalidate: unexpectedDelegate,
 };
 
 describe("Generic FieldKind", () => {

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -45,7 +45,7 @@ function composeI<T>(
 	if (moveEffects.isInvalidated) {
 		resetCrossFieldTable(moveEffects);
 		SF.amendCompose(composed, composer, idAllocator, moveEffects);
-		// assert(!moveEffects.isInvalidated, "Compose should not need more than one amend pass");
+		assert(!moveEffects.isInvalidated, "Compose should not need more than one amend pass");
 	}
 	return composed;
 }
@@ -60,7 +60,7 @@ export function rebase(change: TestChangeset, base: TaggedChange<TestChangeset>)
 	if (moveEffects.isInvalidated) {
 		moveEffects.reset();
 		rebasedChange = SF.amendRebase(rebasedChange, base, idAllocator, moveEffects);
-		// assert(!moveEffects.isInvalidated, "Rebase should not need more than one amend pass");
+		assert(!moveEffects.isInvalidated, "Rebase should not need more than one amend pass");
 	}
 	return rebasedChange;
 }


### PR DESCRIPTION
Added parameters to the methods on `CrossFieldManager` to control whether a given read should add an invalidation dependency and whether a given write should trigger invalidation. Sequence field no longer causes invalidation when updating information about the adjacency of move marks. There may still be specific cases where invalidation is necessary, but this change resolves a serious issue where composition and rebasing of moves did not always terminate.