### PR TITLE
Introduce a repro for rebase bug in maps + fix

### DIFF
--- a/experimental/PropertyDDS/packages/property-changeset/src/changeset.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/changeset.ts
@@ -618,6 +618,7 @@ export class ChangeSet {
 
 			// Check, whether we have a collision in a path update
 			for (let j = 0; j < paths.length; j++) {
+				io_rebasePropertyChangeSet[typeid] = io_rebasePropertyChangeSet[typeid] ?? {};
 				if (io_rebasePropertyChangeSet[typeid][paths[j]] !== undefined) {
 					in_ownPropertyChangeSet[typeid] = in_ownPropertyChangeSet[typeid] || {};
 

--- a/experimental/PropertyDDS/packages/property-changeset/src/changeset.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/changeset.ts
@@ -618,7 +618,6 @@ export class ChangeSet {
 
 			// Check, whether we have a collision in a path update
 			for (let j = 0; j < paths.length; j++) {
-				io_rebasePropertyChangeSet[typeid] = io_rebasePropertyChangeSet[typeid] ?? {};
 				if (io_rebasePropertyChangeSet[typeid][paths[j]] !== undefined) {
 					in_ownPropertyChangeSet[typeid] = in_ownPropertyChangeSet[typeid] || {};
 
@@ -646,12 +645,17 @@ export class ChangeSet {
 							in_ownPropertyChangeSet[typeid][paths[j]],
 						);
 					}
-
-					// Remove the typeid, when it no longer contains any keys
-					if (isEmpty(io_rebasePropertyChangeSet[typeid])) {
-						delete io_rebasePropertyChangeSet[typeid];
-					}
 				}
+
+				// Remove the typeid, when it no longer contains any keys
+				if (isEmpty(io_rebasePropertyChangeSet[typeid][paths[j]])) {
+					delete io_rebasePropertyChangeSet[typeid][paths[j]];
+				}
+			}
+
+			// Remove the typeid, when it no longer contains any keys
+			if (isEmpty(io_rebasePropertyChangeSet[typeid])) {
+				delete io_rebasePropertyChangeSet[typeid];
 			}
 		}
 

--- a/experimental/PropertyDDS/packages/property-changeset/src/test/map.spec.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/test/map.spec.ts
@@ -1,0 +1,11 @@
+import { ChangeSet } from "../changeset";
+
+describe("Map rebase ChangeSets", function () {
+	it("Case 1", () => {
+		const originalCS = JSON.parse('{"modify":{"NodeProperty":{"a":{"NodeProperty":{"b":{"map<Bool>":{"c":{"modify":{"1":{"value":true,"oldValue":true}}}}}}}}}}');
+		const toRebaseCS = JSON.parse('{"modify":{"NodeProperty":{"a":{"NodeProperty":{"b":{"map<Bool>":{"c":{"remove":{"1":true},"modify":{"2":{"value":true,"oldValue":true}}},"d":{"remove":{"1":true}}}}}}}}}');
+
+		const cs = new ChangeSet(toRebaseCS);
+		cs._rebaseChangeSet(originalCS, [], {});
+	});
+});

--- a/experimental/PropertyDDS/packages/property-changeset/src/test/map.spec.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/test/map.spec.ts
@@ -5,6 +5,7 @@
 
 import { expect } from "chai";
 import { ChangeSet } from "../changeset";
+import { isEmptyChangeSet } from "../changeset_operations/isEmptyChangeset";
 
 describe("Map rebase ChangeSets", function () {
 	it("Case 1", () => {
@@ -17,8 +18,6 @@ describe("Map rebase ChangeSets", function () {
 
 		const cs = new ChangeSet(toRebaseCS);
 		const changes = cs._rebaseChangeSet(originalCS, [], {});
-		cs.applyChangeSet(changes);
-		// Applying the changes from rebase should have the same effect as applying empty changeset.
-		expect(cs.getSerializedChangeSet()).to.equal(toRebaseCS);
+		expect(isEmptyChangeSet(changes)).to.equal(true);
 	});
 });

--- a/experimental/PropertyDDS/packages/property-changeset/src/test/map.spec.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/test/map.spec.ts
@@ -8,8 +8,12 @@ import { ChangeSet } from "../changeset";
 
 describe("Map rebase ChangeSets", function () {
 	it("Case 1", () => {
-		const originalCS = JSON.parse('{"modify":{"NodeProperty":{"a":{"NodeProperty":{"b":{"map<Bool>":{"c":{"modify":{"1":{"value":true,"oldValue":true}}}}}}}}}}');
-		const toRebaseCS = JSON.parse('{"modify":{"NodeProperty":{"a":{"NodeProperty":{"b":{"map<Bool>":{"c":{"remove":{"1":true},"modify":{"2":{"value":true,"oldValue":true}}},"d":{"remove":{"1":true}}}}}}}}}');
+		const originalCS = JSON.parse(
+			'{"modify":{"NodeProperty":{"a":{"NodeProperty":{"b":{"map<Bool>":{"c":{"modify":{"1":{"value":true,"oldValue":true}}}}}}}}}}',
+		);
+		const toRebaseCS = JSON.parse(
+			'{"modify":{"NodeProperty":{"a":{"NodeProperty":{"b":{"map<Bool>":{"c":{"remove":{"1":true},"modify":{"2":{"value":true,"oldValue":true}}},"d":{"remove":{"1":true}}}}}}}}}',
+		);
 
 		const cs = new ChangeSet(toRebaseCS);
 		const changes = cs._rebaseChangeSet(originalCS, [], {});

--- a/experimental/PropertyDDS/packages/property-changeset/src/test/map.spec.ts
+++ b/experimental/PropertyDDS/packages/property-changeset/src/test/map.spec.ts
@@ -1,3 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { expect } from "chai";
 import { ChangeSet } from "../changeset";
 
 describe("Map rebase ChangeSets", function () {
@@ -6,6 +12,9 @@ describe("Map rebase ChangeSets", function () {
 		const toRebaseCS = JSON.parse('{"modify":{"NodeProperty":{"a":{"NodeProperty":{"b":{"map<Bool>":{"c":{"remove":{"1":true},"modify":{"2":{"value":true,"oldValue":true}}},"d":{"remove":{"1":true}}}}}}}}}');
 
 		const cs = new ChangeSet(toRebaseCS);
-		cs._rebaseChangeSet(originalCS, [], {});
+		const changes = cs._rebaseChangeSet(originalCS, [], {});
+		cs.applyChangeSet(changes);
+		// Applying the changes from rebase should have the same effect as applying empty changeset.
+		expect(cs.getSerializedChangeSet()).to.equal(toRebaseCS);
 	});
 });


### PR DESCRIPTION
A bug fix to PropertyDDS rebase logic for maps. 

Rebase function doesn't cleanup correctly changeset post rebase for maps, which results a non empty changeset with no operations in it, this causes `isEmpty(CS)` to be false instead of true and break the rebase logic.