### PR TITLE
Revert "Empty compression messages"

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
@@ -45,16 +45,7 @@ export class OpCompressor {
 		});
 
 		for (const message of batch.content.slice(1)) {
-			// Add an empty placeholder message to reserve the sequence numbers
-			messages.push({
-				deserializedContent: {
-					contents: undefined,
-					type: message.deserializedContent.type,
-				},
-				localOpMetadata: undefined,
-				metadata: undefined,
-				referenceSequenceNumber: message.referenceSequenceNumber,
-			});
+			messages.push({ ...message, contents: undefined });
 		}
 
 		const compressedBatch: IBatch = {

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -233,12 +233,12 @@ export class Outbox {
 		if (this.params.containerContext.submitBatchFn === undefined) {
 			// Legacy path - supporting old loader versions. Can be removed only when LTS moves above
 			// version that has support for batches (submitBatchFn)
-			assert(
-				batch.content[0].compression === undefined,
-				"Compression should not have happened if the loader does not support it",
-			);
-
 			for (const message of batch.content) {
+				// Legacy path doesn't support compressed payloads and will submit uncompressed payload anyways
+				if (message.metadata?.compressed) {
+					delete message.metadata.compressed;
+				}
+
 				this.params.containerContext.submitFn(
 					MessageType.Operation,
 					message.deserializedContent,

--- a/packages/runtime/container-runtime/src/test/opLifecycle/opCompressor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opCompressor.spec.ts
@@ -59,12 +59,6 @@ describe("OpCompressor", () => {
 				if (compressedBatch.content.length > 1) {
 					assert.strictEqual(compressedBatch.content[1].contents, undefined);
 					assert.strictEqual(compressedBatch.content[1].compression, undefined);
-					assert.strictEqual(compressedBatch.content[1].metadata, undefined);
-					assert.strictEqual(compressedBatch.content[1].localOpMetadata, undefined);
-					assert.strictEqual(
-						compressedBatch.content[1].deserializedContent.contents,
-						undefined,
-					);
 				}
 			});
 		}));


### PR DESCRIPTION
Reverts microsoft/FluidFramework#14261

The change surfaced a bug related to the compressed message metadata and fired an incident in our stress tests.