### PR TITLE
Trailing messages in compressed batches should be empty.

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
@@ -44,8 +44,17 @@ export class OpCompressor {
 			compression: CompressionAlgorithms.lz4,
 		});
 
+		// Add empty placeholder messages to reserve the sequence numbers
 		for (const message of batch.content.slice(1)) {
-			messages.push({ ...message, contents: undefined });
+			messages.push({
+				deserializedContent: {
+					contents: undefined,
+					type: message.deserializedContent.type,
+				},
+				localOpMetadata: message.localOpMetadata,
+				metadata: message.metadata,
+				referenceSequenceNumber: message.referenceSequenceNumber,
+			});
 		}
 
 		const compressedBatch: IBatch = {

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -233,12 +233,12 @@ export class Outbox {
 		if (this.params.containerContext.submitBatchFn === undefined) {
 			// Legacy path - supporting old loader versions. Can be removed only when LTS moves above
 			// version that has support for batches (submitBatchFn)
-			for (const message of batch.content) {
-				// Legacy path doesn't support compressed payloads and will submit uncompressed payload anyways
-				if (message.metadata?.compressed) {
-					delete message.metadata.compressed;
-				}
+			assert(
+				batch.content[0].compression === undefined,
+				"Compression should not have happened if the loader does not support it",
+			);
 
+			for (const message of batch.content) {
 				this.params.containerContext.submitFn(
 					MessageType.Operation,
 					message.deserializedContent,

--- a/packages/runtime/container-runtime/src/test/opLifecycle/opCompressor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opCompressor.spec.ts
@@ -59,6 +59,10 @@ describe("OpCompressor", () => {
 				if (compressedBatch.content.length > 1) {
 					assert.strictEqual(compressedBatch.content[1].contents, undefined);
 					assert.strictEqual(compressedBatch.content[1].compression, undefined);
+					assert.strictEqual(
+						compressedBatch.content[1].deserializedContent.contents,
+						undefined,
+					);
 				}
 			});
 		}));

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -182,7 +182,7 @@ describeFullCompat("blobs", (getTestObjectProvider) => {
 		]);
 	});
 
-	it("attach sends an op with compression enabled", async function () {
+	it("attach sends ops with compression enabled", async function () {
 		const container = await provider.makeTestContainer({
 			...testContainerConfig,
 			runtimeOptions: {
@@ -204,10 +204,14 @@ describeFullCompat("blobs", (getTestObjectProvider) => {
 			}),
 		);
 
-		const blob = await dataStore._runtime.uploadBlob(
-			stringToBuffer("some random text", "utf-8"),
-		);
-		dataStore._root.set("my blob", blob);
+		for (let i = 0; i < 5; i++) {
+			const blob = await dataStore._runtime.uploadBlob(
+				stringToBuffer("some random text", "utf-8"),
+			);
+
+			dataStore._root.set(`Blob #${i}`, blob);
+		}
+
 		await blobOpP;
 	});
 });


### PR DESCRIPTION
## Description

This is resubmitting https://github.com/microsoft/FluidFramework/pull/14261 which was reverted with https://github.com/microsoft/FluidFramework/pull/14370 as it was stripping all metadata from the batch.

The issue was not caught in testing as the change removed the metadata only for the trailing ops, which broke the stress tests. Adjusted the end-to-end tests to catch similar issues in the future.