### PR TITLE
refactor(client-debugger-view): Simplify contract of `renderClientDebuggerView`

### DIFF
--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/OpenDebuggerPanel.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/OpenDebuggerPanel.ts
@@ -8,15 +8,14 @@ import { debuggerPanelId } from "./Constants";
 import { isDebuggerPanelOpen } from "./Utilities";
 
 /**
- * Appends the debugger view panel to the document (as a child under `body`).
- *
- * @returns Whether or not a new debugger view was appended to the document.
+ * Appends the debugger view panel to the document (as a child under `body`) if the debugger panel is not already open.
  *
  * @internal
  */
-export async function openDebuggerPanel(): Promise<boolean> {
+export async function openDebuggerPanel(): Promise<void> {
 	if (isDebuggerPanelOpen()) {
-		return false;
+		console.warn("Debugger panel is already open.");
+		return;
 	}
 
 	const debugPanel = document.createElement("div");

--- a/packages/tools/client-debugger/client-debugger-view/api-report/client-debugger-view.api.md
+++ b/packages/tools/client-debugger/client-debugger-view/api-report/client-debugger-view.api.md
@@ -61,7 +61,7 @@ export interface HasContainerId {
 export type RenderChild = (childObject: unknown) => React_2.ReactElement;
 
 // @public
-export function renderClientDebuggerView(targetElement: HTMLElement | null): Promise<boolean>;
+export function renderClientDebuggerView(targetElement: HTMLElement): Promise<void>;
 
 // @public
 export interface RenderOptions {

--- a/packages/tools/client-debugger/client-debugger-view/src/RenderClientDebugger.ts
+++ b/packages/tools/client-debugger/client-debugger-view/src/RenderClientDebugger.ts
@@ -11,6 +11,11 @@ import { FluidClientDebuggers } from "./Debugger";
  * Renders Fluid client debug view by appending it to the provided DOM element.
  *
  * @param targetElement - The HTML element takes the client debugger view.
+ * 
+ * @remarks
+ * 
+ * Note: this should only be called once for the lifetime of the `targetElement`.
+ * Subsequent calls will result in undesired behavior.
  *
  * @returns A promise that resolves once the debugger view has been rendered for the first time.
  * If rendering fails for any reason, the promise will be rejected.

--- a/packages/tools/client-debugger/client-debugger-view/src/RenderClientDebugger.ts
+++ b/packages/tools/client-debugger/client-debugger-view/src/RenderClientDebugger.ts
@@ -11,9 +11,9 @@ import { FluidClientDebuggers } from "./Debugger";
  * Renders Fluid client debug view by appending it to the provided DOM element.
  *
  * @param targetElement - The HTML element takes the client debugger view.
- * 
+ *
  * @remarks
- * 
+ *
  * Note: this should only be called once for the lifetime of the `targetElement`.
  * Subsequent calls will result in undesired behavior.
  *

--- a/packages/tools/client-debugger/client-debugger-view/src/RenderClientDebugger.ts
+++ b/packages/tools/client-debugger/client-debugger-view/src/RenderClientDebugger.ts
@@ -9,38 +9,21 @@ import { FluidClientDebuggers } from "./Debugger";
 
 /**
  * Renders Fluid client debug view by appending it to the provided DOM element.
- * Will fast return false if the input is `null`.
  *
  * @param targetElement - The HTML element takes the client debugger view.
  *
- * @returns `true` if the debug view was succesfully rendered, otherwise `false`.
+ * @returns A promise that resolves once the debugger view has been rendered for the first time.
+ * If rendering fails for any reason, the promise will be rejected.
  */
-export async function renderClientDebuggerView(
-	// eslint-disable-next-line @rushstack/no-new-null
-	targetElement: HTMLElement | null,
-): Promise<boolean> {
-	if (targetElement === null) {
-		console.log("Provided null targetElement.");
-		return false;
-	}
-
+export async function renderClientDebuggerView(targetElement: HTMLElement): Promise<void> {
 	const debuggerElement = document.createElement("debugger");
 	targetElement.append(debuggerElement);
 
-	return new Promise<boolean>((resolve) => {
+	return new Promise<void>((resolve, reject) => {
 		try {
-			ReactDOM.render(React.createElement(FluidClientDebuggers), debuggerElement, () => {
-				resolve(true);
-			});
+			ReactDOM.render(React.createElement(FluidClientDebuggers), debuggerElement, resolve);
 		} catch (error) {
-			console.error(`Could not open the client debugger view due to an error: ${error}.`);
-			resolve(false);
+			reject(error);
 		}
 	});
 }
-
-// #2: Render "debugger frame" - user passes in element, we wrap that element in a frame containing the debug view
-//    + UI for showing / hiding the "debugger panel".
-//   renderWithClientDebugger(appElement);
-//   const parent = appElement.parent;
-//   render app and frame


### PR DESCRIPTION
Previously, the function returned a `boolean` indicating whether or not rendering was successful, but this was reported as a successful resolution of the promise in either case. This PR simplifies the contract to:
- Not accept a null element as input (removing the need for input validation)
- Reject the promise if rendering fails (and remove boolean return type)