### PR TITLE
feat(client-debugger-view): Update `ContainerSelectionDropdown` to be reusable in contexts that don't have direct access to the debugger instance

### DIFF
--- a/packages/tools/client-debugger/client-debugger-view/api-report/client-debugger-view.api.md
+++ b/packages/tools/client-debugger/client-debugger-view/api-report/client-debugger-view.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { ContainerMetadata } from '@fluid-tools/client-debugger';
 import { IClient } from '@fluidframework/protocol-definitions';
 import { IFluidClientDebugger } from '@fluid-tools/client-debugger';
 import { ISharedObject } from '@fluidframework/shared-object-base';
@@ -31,6 +32,16 @@ export const clientDebugViewClassName = "fluid-client-debugger-view";
 // @internal
 export interface ClientDebugViewProps extends HasClientDebugger {
     renderOptions?: RenderOptions;
+}
+
+// @internal
+export function ContainerSelectionDropdown(props: ContainerSelectionDropdownProps): React_2.ReactElement;
+
+// @internal
+export interface ContainerSelectionDropdownProps {
+    initialSelection?: string;
+    onChangeSelection(containerId: string | undefined): void;
+    options: ContainerMetadata[];
 }
 
 // @public

--- a/packages/tools/client-debugger/client-debugger-view/src/Debugger.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/Debugger.tsx
@@ -106,8 +106,11 @@ export function FluidClientDebuggers(props: FluidClientDebuggersProps): React.Re
 	const slectionView: React.ReactElement =
 		clientDebuggers.length > 1 ? (
 			<ContainerSelectionDropdown
-				containerId={String(selectedContainerId)}
-				clientDebuggers={clientDebuggers}
+				initialSelection={selectedContainerId}
+				options={clientDebuggers.map((clientDebugger) => ({
+					id: clientDebugger.containerId,
+					nickname: clientDebugger.containerNickname,
+				}))}
 				onChangeSelection={(containerId): void => setSelectedContainerId(containerId)}
 			/>
 		) : (

--- a/packages/tools/client-debugger/client-debugger-view/src/components/ContainerSelectionDropdown.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/ContainerSelectionDropdown.tsx
@@ -5,22 +5,35 @@
 import { Dropdown, IDropdownOption, IDropdownStyles, IStackTokens, Stack } from "@fluentui/react";
 import React from "react";
 
-import { IFluidClientDebugger } from "@fluid-tools/client-debugger";
-import { HasClientDebuggers, HasContainerId } from "../CommonProps";
+import { ContainerMetadata } from "@fluid-tools/client-debugger";
 
 /**
  * {@link ContainerSelectionDropdownProps} input props.
+ *
+ * @internal
  */
-export interface ContainerSelectionDropdownProps extends HasClientDebuggers, HasContainerId {
+export interface ContainerSelectionDropdownProps {
 	/**
-	 * Take the selected container id to set as current viewed container id.
-	 * @param containerId - current selected container id.
+	 * The Container ID of the current selection.
 	 */
-	onChangeSelection(containerId: string): void;
+	initialSelection?: string;
+
+	/**
+	 * Drop-down options.
+	 */
+	options: ContainerMetadata[];
+
+	/**
+	 * Take the selected container id to set as current viewed container ID.
+	 * @param containerId - The newly selected Container ID.
+	 */
+	onChangeSelection(containerId: string | undefined): void;
 }
 
 /**
  * A dropdown menu for selecting the Fluid Container to display debug information about.
+ *
+ * @internal
  */
 export function ContainerSelectionDropdown(
 	props: ContainerSelectionDropdownProps,
@@ -31,47 +44,23 @@ export function ContainerSelectionDropdown(
 
 	const stackTokens: IStackTokens = { childrenGap: 20 };
 
-	const { clientDebuggers, containerId } = props;
+	const { options, initialSelection, onChangeSelection } = props;
 
-	function renewContainerOptions(debuggers: IFluidClientDebugger[]): IDropdownOption[] {
-		const options: IDropdownOption[] = [];
-		for (const each_debugger of debuggers) {
-			options.push({
-				key: each_debugger.containerId,
-				text: each_debugger.containerNickname ?? each_debugger.containerId,
-			});
-		}
-		return options;
-	}
-
-	const clientDebuggerOptions = renewContainerOptions(clientDebuggers);
-
-	const _onClientDebuggerDropdownChange = (
-		event: React.FormEvent<HTMLDivElement>,
-		option?: IDropdownOption,
-	): void => {
-		if (option !== undefined) {
-			const selectedDebugger = clientDebuggers.find((clientDebugger) => {
-				return clientDebugger.containerId === (option.key as string);
-			});
-
-			if (selectedDebugger === undefined) {
-				throw new Error(
-					`Could not find a debugger associated with Container ID "${option.key}". This likely indicates an internal state issue.`,
-				);
-			}
-			props.onChangeSelection(selectedDebugger.containerId);
-		}
-	};
+	// Options formatted for the Fluent Dropdown component
+	const dropdownOptions: IDropdownOption[] = options.map((option) => ({
+		key: option.id,
+		text: option.nickname ?? option.id,
+		selected: option.id === initialSelection,
+	}));
 
 	return (
 		<Stack tokens={stackTokens}>
 			<Dropdown
-				placeholder="Select an option"
-				selectedKey={containerId}
-				options={clientDebuggerOptions}
+				placeholder="Select an Fluid Container"
+				selectedKey={initialSelection}
+				options={dropdownOptions}
 				styles={dropdownStyles}
-				onChange={_onClientDebuggerDropdownChange}
+				onChange={(event, option): void => onChangeSelection(option?.key as string)}
 			/>
 		</Stack>
 	);

--- a/packages/tools/client-debugger/client-debugger-view/src/components/ContainerSelectionDropdown.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/ContainerSelectionDropdown.tsx
@@ -56,7 +56,7 @@ export function ContainerSelectionDropdown(
 	return (
 		<Stack tokens={stackTokens}>
 			<Dropdown
-				placeholder="Select an Fluid Container"
+				placeholder="Select a Fluid Container"
 				selectedKey={initialSelection}
 				options={dropdownOptions}
 				styles={dropdownStyles}

--- a/packages/tools/client-debugger/client-debugger-view/src/components/ContainerSelectionDropdown.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/ContainerSelectionDropdown.tsx
@@ -19,12 +19,12 @@ export interface ContainerSelectionDropdownProps {
 	initialSelection?: string;
 
 	/**
-	 * Drop-down options.
+	 * Full list of drop-down options.
 	 */
 	options: ContainerMetadata[];
 
 	/**
-	 * Take the selected container id to set as current viewed container ID.
+	 * Called when the selection changes.
 	 * @param containerId - The newly selected Container ID.
 	 */
 	onChangeSelection(containerId: string | undefined): void;

--- a/packages/tools/client-debugger/client-debugger-view/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger-view/src/index.ts
@@ -25,6 +25,8 @@ export {
 	ClientDebugView,
 	clientDebugViewClassName,
 	ClientDebugViewProps,
+	ContainerSelectionDropdown,
+	ContainerSelectionDropdownProps,
 } from "./components";
 
 export { AudienceMember } from "./Audience";

--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -31,6 +31,12 @@ export interface ConnectionStateChangeLogEntry extends StateChangeLogEntry<Conta
     clientId: string | undefined;
 }
 
+// @public
+export interface ContainerMetadata {
+    id: string;
+    nickname?: string;
+}
+
 // @internal
 export enum ContainerStateChangeKind {
     Attached = "attached",

--- a/packages/tools/client-debugger/client-debugger/src/ContainerMetadata.ts
+++ b/packages/tools/client-debugger/client-debugger/src/ContainerMetadata.ts
@@ -1,0 +1,29 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Metadata describing a {@link @fluidframework/container-definitions#IContainer} registered with a debugger.
+ *
+ * @public
+ */
+export interface ContainerMetadata {
+	/**
+	 * The Container ID.
+	 */
+	id: string;
+
+	/**
+	 * Optional Container nickname.
+	 *
+	 * @remarks
+	 *
+	 * Associated tooling may take advantage of this to differentiate between container instances using
+	 * semantically meaningful names, rather than GUIDs.
+	 *
+	 * If not provided, the {@link ContainerMetadata.id} will be used for the purpose of distinguising
+	 * container instances.
+	 */
+	nickname?: string;
+}

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -46,6 +46,7 @@
 export { MemberChangeKind } from "./Audience";
 
 export { ContainerStateChangeKind } from "./Container";
+export { ContainerMetadata } from "./ContainerMetadata";
 
 export { IFluidClientDebugger, IFluidClientDebuggerEvents } from "./IFluidClientDebugger";
 


### PR DESCRIPTION
Updates the dropdown component to operate on metadata, rather than directly accepting debugger instances. This will allow us to reuse the component in our devtools extension, where we do not have access to the debugger instance(s). Also adds component to package exports.