### PR TITLE
test(tree): Add tests for competing deletes

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -34,6 +34,31 @@ describe("Editing", () => {
 			expectJsonTree([tree1, tree2, tree3, tree4], ["x", "y"]);
 		});
 
+		it("can handle competing deletes", () => {
+			for (const index of [0, 1, 2, 3]) {
+				const sequencer = new Sequencer();
+				const startingState = ["A", "B", "C", "D"];
+				const tree1 = TestTree.fromJson(startingState);
+				const tree2 = tree1.fork();
+				const tree3 = tree1.fork();
+				const tree4 = tree1.fork();
+
+				const del1 = remove(tree1, index, 1);
+				const del2 = remove(tree2, index, 1);
+				const del3 = remove(tree3, index, 1);
+
+				const sequenced = sequencer.sequence([del1, del2, del3]);
+				tree1.receive(sequenced);
+				tree2.receive(sequenced);
+				tree3.receive(sequenced);
+				tree4.receive(sequenced);
+
+				const expected = [...startingState];
+				expected.splice(index, 1);
+				expectJsonTree([tree1, tree2, tree3, tree4], expected);
+			}
+		});
+
 		it("can rebase local dependent inserts", () => {
 			const sequencer = new Sequencer();
 			const tree1 = TestTree.fromJson("y");


### PR DESCRIPTION
Adds high-level tests that verify multiple clients can concurrently attempt to delete the same node in a sequence field.

This was already tested at sequence field implementation. The new tests were an attempt at finding a bug. No bug was found but having the high-level test seems good.