### PR TITLE
feat(merge-tree): update benchmark suite names

### DIFF
--- a/packages/dds/merge-tree/src/test/Insertion.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/Insertion.perf.spec.ts
@@ -25,7 +25,7 @@ function constructTree(numOfSegments: number): MergeTree {
 	return mergeTree;
 }
 
-describe("insertion perf", () => {
+describe("MergeTree insertion", () => {
 	benchmark({
 		type: BenchmarkType.Measurement,
 		title: "insert into empty tree",

--- a/packages/dds/merge-tree/src/test/PartialLengths.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/PartialLengths.perf.spec.ts
@@ -8,7 +8,7 @@ import { MergeTreeDeltaType } from "../ops";
 import { MergeTree } from "../mergeTree";
 import { insertText, markRangeRemoved } from "./testUtils";
 
-describe("partial lengths perf", () => {
+describe("MergeTree partial lengths", () => {
 	const originalIncrementalUpdate: boolean = MergeTree.options.incrementalUpdate;
 
 	for (const incremental of [true, false]) {

--- a/packages/dds/merge-tree/src/test/Removal.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/Removal.perf.spec.ts
@@ -8,7 +8,7 @@ import { MergeTreeDeltaType } from "../ops";
 import { markRangeRemoved } from "./testUtils";
 import { loadSnapshot, TestString } from "./snapshot.utils";
 
-describe("removal perf", () => {
+describe("MergeTree remove", () => {
 	let summary;
 
 	benchmark({

--- a/packages/dds/merge-tree/src/test/Snapshot.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/Snapshot.perf.spec.ts
@@ -6,10 +6,10 @@
 import { benchmark, BenchmarkType } from "@fluid-tools/benchmark";
 import { loadSnapshot, TestString } from "./snapshot.utils";
 
-describe("snapshot perf", () => {
+describe("MergeTree snapshots", () => {
 	let summary;
 
-	for (const summarySize of [10, 100, 1000, 5000]) {
+	for (const summarySize of [10, 100, 1000, 5000, 10_000]) {
 		benchmark({
 			type: BenchmarkType.Measurement,
 			title: `load snapshot with ${summarySize} segments`,


### PR DESCRIPTION
Adds `MergeTree` prefix to benchmark suite names and makes them fit the tense of other suites