### PR TITLE
Fixed issue where if a deleted blob is de-duped, GC would not know about it

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -209,10 +209,6 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 		// Called when a blob node is requested. blobPath is the path of the blob's node in GC's graph.
 		// blobPath's format - `/<BlobManager.basePath>/<blobId>`.
 		private readonly blobRequested: (blobPath: string) => void,
-		// Called when a reference is added to a blob. For instance, when creating a localId / storageId to storageId
-		// mapping in the redirect table.
-		// Node path formats - `/<BlobManager.basePath>/<blobId>`.
-		private readonly addedBlobReference: (fromNodePath: string, toNodePath: string) => void,
 		// Called to check if a blob has been deleted by GC.
 		// blobPath's format - `/<BlobManager.basePath>/<blobId>`.
 		private readonly isBlobDeleted: (blobPath: string) => boolean,
@@ -292,15 +288,6 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 	}
 
 	/**
-	 * For a blobId, returns its path in GC's graph. The node path is of the format `/<BlobManager.basePath>/<blobId>`
-	 * This path must match the path of the blob handle returned by the createBlob API because blobs are marked
-	 * referenced by storing these handles in a referenced DDS.
-	 */
-	private getBlobGCNodePath(blobId: string) {
-		return `/${BlobManager.basePath}/${blobId}`;
-	}
-
-	/**
 	 * Set of actual storage IDs (i.e., IDs that can be requested from storage). This will be empty if the container is
 	 * detached or there are no (non-pending) attachment blobs in the document
 	 */
@@ -344,7 +331,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 		}
 
 		// Let runtime know that the corresponding GC node was requested.
-		this.blobRequested(this.getBlobGCNodePath(blobId));
+		this.blobRequested(getGCNodePathFromBlobId(blobId));
 
 		return PerformanceEvent.timedExecAsync(
 			this.mc.logger,
@@ -422,11 +409,6 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 	 */
 	private setRedirection(fromId: string, toId: string | undefined) {
 		this.redirectTable.set(fromId, toId);
-		// Notify runtime of a reference added if toId is not undefined. It can be undefined when a blob is uploaded in
-		// detached mode. In this case, the entry will be updated when the blob is updated.
-		if (toId !== undefined) {
-			this.addedBlobReference(this.getBlobGCNodePath(fromId), this.getBlobGCNodePath(toId));
-		}
 	}
 
 	private deleteAndEmitsIfEmpty(id: string) {
@@ -679,6 +661,33 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 		return table;
 	}
 
+	public summarize(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats {
+		// if storageIds is empty, it means we are detached and have only local IDs, or that there are no blobs attached
+		const blobIds =
+			this.storageIds.size > 0
+				? Array.from(this.storageIds)
+				: Array.from(this.redirectTable.keys());
+		const builder = new SummaryTreeBuilder();
+		blobIds.forEach((blobId) => {
+			builder.addAttachment(blobId);
+		});
+
+		// Any non-identity entries in the table need to be saved in the summary
+		if (this.redirectTable.size > blobIds.length) {
+			builder.addBlob(
+				BlobManager.redirectTableBlobName,
+				// filter out identity entries
+				JSON.stringify(
+					Array.from(this.redirectTable.entries()).filter(
+						([localId, storageId]) => localId !== storageId,
+					),
+				),
+			);
+		}
+
+		return builder.getSummaryTree();
+	}
+
 	/**
 	 * Generates data used for garbage collection. Each blob uploaded represents a node in the GC graph as it can be
 	 * individually referenced by storing its handle in a referenced DDS. Returns the list of blob ids as GC nodes.
@@ -689,7 +698,9 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 		const gcData: IGarbageCollectionData = { gcNodes: {} };
 		for (const [localId, storageId] of this.redirectTable) {
 			assert(!!storageId, 0x390 /* Must be attached to get GC data */);
-			gcData.gcNodes[this.getBlobGCNodePath(localId)] = [this.getBlobGCNodePath(storageId)];
+			if (localId !== storageId) {
+				gcData.gcNodes[getGCNodePathFromBlobId(localId)] = [];
+			}
 		}
 		return gcData;
 	}
@@ -699,17 +710,20 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 	 * @param unusedRoutes - The routes of the blob nodes that are unused.
 	 */
 	public updateUnusedRoutes(unusedRoutes: string[]): void {
+		// This holds the storage ids for each deleted local id entry in the redirect table.
+		const maybeUnusedStorageIds: string[] = [];
 		// The routes or blob node paths are in the same format as returned in getGCData -
 		// `/<BlobManager.basePath>/<blobId>`.
 		for (const route of unusedRoutes) {
-			const pathParts = route.split("/");
-			assert(
-				pathParts.length === 3 && pathParts[1] === BlobManager.basePath,
-				0x2d5 /* "Invalid blob node id in unused routes." */,
-			);
-			const blobId = pathParts[2];
+			const blobId = getBlobIdFromGCNodePath(route);
+			const storageId = this.redirectTable.get(blobId);
+			if (storageId === undefined) {
+				continue;
+			}
+			maybeUnusedStorageIds.push(storageId);
 			this.redirectTable.delete(blobId);
 		}
+		this.deleteUnusedStorageBlobs(maybeUnusedStorageIds);
 	}
 
 	/**
@@ -723,23 +737,24 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 			return [];
 		}
 
+		// This holds the storage ids for each deleted local id entry in the redirect table.
+		const maybeUnusedStorageIds: string[] = [];
 		// The routes or blob node paths are in the same format as returned in getGCData -
 		// `/<BlobManager.basePath>/<blobId>`.
 		for (const route of sweepReadyBlobRoutes) {
-			const pathParts = route.split("/");
-			assert(
-				pathParts.length === 3 && pathParts[1] === BlobManager.basePath,
-				0x586 /* Invalid blob node id in deleted routes. */,
-			);
-			const blobId = pathParts[2];
-			if (!this.redirectTable.has(blobId)) {
+			const blobId = getBlobIdFromGCNodePath(route);
+			const storageId = this.redirectTable.get(blobId);
+			if (storageId === undefined) {
 				this.mc.logger.sendErrorEvent({
 					eventName: "DeletedAttachmentBlobNotFound",
 					blobId,
 				});
+				continue;
 			}
+			maybeUnusedStorageIds.push(storageId);
 			this.redirectTable.delete(blobId);
 		}
+		this.deleteUnusedStorageBlobs(maybeUnusedStorageIds);
 		return Array.from(sweepReadyBlobRoutes);
 	}
 
@@ -753,12 +768,8 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 		// The routes or blob node paths are in the same format as returned in getGCData -
 		// `/<BlobManager.basePath>/<blobId>`.
 		for (const route of tombstonedRoutes) {
-			const pathParts = route.split("/");
-			assert(
-				pathParts.length === 3 && pathParts[1] === BlobManager.basePath,
-				0x50f /* Invalid blob node id in tombstoned routes. */,
-			);
-			tombstonedBlobsSet.add(pathParts[2]);
+			const blobId = getBlobIdFromGCNodePath(route);
+			tombstonedBlobsSet.add(blobId);
 		}
 
 		// Remove blobs from the tombstone list that were tombstoned but aren't anymore as per the tombstoneRoutes.
@@ -775,6 +786,38 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 	}
 
 	/**
+	 * Delete unused storage blobs, if any. After GC runs and notifies blob manager of local blob ids that are sweep
+	 * ready, blob manager deletes them from the redirect table. This function is then called to delete the storage
+	 * ids of these blobs if they are not used anymore. A blob is unused if there is no entry from the local id to
+	 * storage id in the redirect table, i.e., all local id entries have been deleted.
+	 * @param maybeUnusedBlobIds - List of storage ids for blobs whose local id entries were just deleted and are
+	 * now candidates for deletion.
+	 */
+	private deleteUnusedStorageBlobs(maybeUnusedBlobIds: string[]) {
+		if (maybeUnusedBlobIds.length === 0) {
+			return;
+		}
+
+		const storageBlobsToDelete: Set<string> = new Set(maybeUnusedBlobIds);
+		for (const [localId, storageId] of this.redirectTable.entries()) {
+			// For a storage id that is a candidate for deletion, ignore storageId -> storageId entries. But if the
+			// redirect table contains an entry from a local id to it, it is still in use and should not be deleted.
+			if (
+				storageId !== undefined &&
+				storageBlobsToDelete.has(storageId) &&
+				localId !== storageId
+			) {
+				storageBlobsToDelete.delete(storageId);
+			}
+		}
+
+		// Delete the entries for storage ids that are still in storageBlobsToDelete.
+		for (const storageId of storageBlobsToDelete) {
+			this.redirectTable.delete(storageId);
+		}
+	}
+
+	/**
 	 * Verifies that the blob with given id is valid, i.e., it has not been garbage collected. If the blob is GC'd,
 	 * log an error and throw if necessary.
 	 */
@@ -786,7 +829,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 		 * 3. "valid" - It has not been deleted or tombstoned.
 		 */
 		let state: "valid" | "tombstoned" | "deleted" = "valid";
-		if (this.isBlobDeleted(this.getBlobGCNodePath(blobId))) {
+		if (this.isBlobDeleted(getGCNodePathFromBlobId(blobId))) {
 			state = "deleted";
 		} else if (this.tombstonedBlobs.has(blobId)) {
 			state = "tombstoned";
@@ -827,33 +870,6 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 		}
 	}
 
-	public summarize(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats {
-		// if storageIds is empty, it means we are detached and have only local IDs, or that there are no blobs attached
-		const blobIds =
-			this.storageIds.size > 0
-				? Array.from(this.storageIds)
-				: Array.from(this.redirectTable.keys());
-		const builder = new SummaryTreeBuilder();
-		blobIds.forEach((blobId) => {
-			builder.addAttachment(blobId);
-		});
-
-		// Any non-identity entries in the table need to be saved in the summary
-		if (this.redirectTable.size > blobIds.length) {
-			builder.addBlob(
-				BlobManager.redirectTableBlobName,
-				// filter out identity entries
-				JSON.stringify(
-					Array.from(this.redirectTable.entries()).filter(
-						([localId, storageId]) => localId !== storageId,
-					),
-				),
-			);
-		}
-
-		return builder.getSummaryTree();
-	}
-
 	public setRedirectTable(table: Map<string, string>) {
 		assert(
 			this.runtime.attachState === AttachState.Detached,
@@ -881,4 +897,25 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 		}
 		return blobs;
 	}
+}
+
+/**
+ * For a blobId, returns its path in GC's graph. The node path is of the format `/<BlobManager.basePath>/<blobId>`.
+ * This path must match the path of the blob handle returned by the createBlob API because blobs are marked
+ * referenced by storing these handles in a referenced DDS.
+ */
+function getGCNodePathFromBlobId(blobId: string) {
+	return `/${BlobManager.basePath}/${blobId}`;
+}
+
+/**
+ * For a given GC node path, return the blobId. The node path is of the format `/<BlobManager.basePath>/<blobId>`.
+ */
+function getBlobIdFromGCNodePath(nodePath: string) {
+	const pathParts = nodePath.split("/");
+	assert(
+		pathParts.length === 3 && pathParts[1] === BlobManager.basePath,
+		"Invalid blob node path",
+	);
+	return pathParts[2];
 }

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -698,6 +698,10 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 		const gcData: IGarbageCollectionData = { gcNodes: {} };
 		for (const [localId, storageId] of this.redirectTable) {
 			assert(!!storageId, 0x390 /* Must be attached to get GC data */);
+			// Only return local ids as GC nodes because a blob can only be referenced via its local id. The storage
+			// id entries have the same key and value, ignore them.
+			// The outbound routes are empty because a blob node cannot reference other nodes. It can only be referenced
+			// by adding its handle to a referenced DDS.
 			if (localId !== storageId) {
 				gcData.gcNodes[getGCNodePathFromBlobId(localId)] = [];
 			}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1226,8 +1226,6 @@ export class ContainerRuntime
 				}
 			},
 			(blobPath: string) => this.garbageCollector.nodeUpdated(blobPath, "Loaded"),
-			(fromPath: string, toPath: string) =>
-				this.garbageCollector.addedOutboundReference(fromPath, toPath),
 			(blobPath: string) => this.garbageCollector.isNodeDeleted(blobPath),
 			this,
 			pendingRuntimeState?.pendingAttachmentBlobs,

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -16,9 +16,15 @@ import {
 	ISequencedDocumentMessage,
 	SummaryType,
 } from "@fluidframework/protocol-definitions";
-import { TelemetryNullLogger } from "@fluidframework/telemetry-utils";
+import {
+	ConfigTypes,
+	loggerToMonitoringContext,
+	sessionStorageConfigProvider,
+	TelemetryNullLogger,
+} from "@fluidframework/telemetry-utils";
 
 import { BlobManager, IBlobManagerLoadInfo, IBlobManagerRuntime } from "../blobManager";
+import { sweepAttachmentBlobsKey } from "../gc";
 
 abstract class BaseMockBlobStorage
 	implements Pick<IDocumentStorageService, "readBlob" | "createBlob">
@@ -61,7 +67,6 @@ class MockRuntime
 			snapshot,
 			() => this.getStorage(),
 			(localId: string, blobId?: string) => this.sendBlobAttachOp(localId, blobId),
-			() => undefined,
 			() => undefined,
 			(blobPath: string) => this.isBlobDeleted(blobPath),
 			this,
@@ -128,7 +133,8 @@ class MockRuntime
 	public attachState: AttachState;
 	public attachedStorage = new DedupeStorage();
 	public detachedStorage = new NonDedupeStorage();
-	public logger = new TelemetryNullLogger();
+	public mc = loggerToMonitoringContext(new TelemetryNullLogger());
+	public logger = this.mc.logger;
 
 	private ops: any[] = [];
 	private processBlobsP = new Deferred<void>();
@@ -244,6 +250,12 @@ describe("BlobManager", () => {
 	let runtime: MockRuntime;
 	let createBlob: (blob: ArrayBufferLike) => Promise<void>;
 	let waitForBlob: (blob: ArrayBufferLike) => Promise<void>;
+	const oldRawConfig = sessionStorageConfigProvider.value.getRawConfig;
+	let injectedSettings: Record<string, ConfigTypes> = {};
+
+	before(() => {
+		sessionStorageConfigProvider.value.getRawConfig = (name) => injectedSettings[name];
+	});
 
 	beforeEach(() => {
 		runtime = new MockRuntime();
@@ -279,6 +291,11 @@ describe("BlobManager", () => {
 	afterEach(async () => {
 		await Promise.all(handlePs);
 		assert((runtime.blobManager as any).pendingBlobs.size === 0);
+		injectedSettings = {};
+	});
+
+	after(() => {
+		sessionStorageConfigProvider.value.getRawConfig = oldRawConfig;
 	});
 
 	it("empty snapshot", () => {
@@ -569,46 +586,158 @@ describe("BlobManager", () => {
 		assert.strictEqual(summaryData?.redirectTable.size, 3);
 	});
 
-	it("fetching deleted blob fails", async () => {
-		await runtime.attach();
-		await runtime.connect();
-		const blob1Contents = IsoBuffer.from("blob1", "utf8");
-		const blob2Contents = IsoBuffer.from("blob2", "utf8");
-		const handle1P = runtime.createBlob(blob1Contents);
-		const handle2P = runtime.createBlob(blob2Contents);
-		await runtime.processAll();
+	describe("Garbage Collection", () => {
+		let redirectTable: Map<string, string | undefined>;
 
-		const blob1Handle = await handle1P;
-		const blob2Handle = await handle2P;
+		/** Creates a blob with the given content and returns its local and storage id. */
+		async function createBlobAndGetIds(content: string) {
+			// For a given blob's GC node id, returns the blob id.
+			const getBlobIdFromGCNodeId = (gcNodeId: string) => {
+				const pathParts = gcNodeId.split("/");
+				assert(
+					pathParts.length === 3 && pathParts[1] === BlobManager.basePath,
+					"Invalid blob node path",
+				);
+				return pathParts[2];
+			};
 
-		// Validate that the blobs can be retrieved.
-		assert.strictEqual(await runtime.getBlob(blob1Handle), blob1Contents);
-		assert.strictEqual(await runtime.getBlob(blob2Handle), blob2Contents);
+			// For a given blob's id, returns the GC node id.
+			const getGCNodeIdFromBlobId = (blobId: string) => {
+				return `/${BlobManager.basePath}/${blobId}`;
+			};
 
-		// Delete blob1. Retrieving it should result in an error.
-		runtime.deleteBlob(blob1Handle);
-		await assert.rejects(
-			async () => runtime.getBlob(blob1Handle),
-			(error) => {
-				const blob1Id = blob1Handle.absolutePath.split("/")[2];
-				const correctErrorType = error.code === 404;
-				const correctErrorMessage = error.message === `Blob was deleted: ${blob1Id}`;
-				return correctErrorType && correctErrorMessage;
-			},
-			"Deleted blob2 fetch should have failed",
-		);
+			const blobContents = IsoBuffer.from(content, "utf8");
+			const handleP = runtime.createBlob(blobContents);
+			await runtime.processAll();
 
-		// Delete blob2. Retrieving it should result in an error.
-		runtime.deleteBlob(blob2Handle);
-		await assert.rejects(
-			async () => runtime.getBlob(blob2Handle),
-			(error) => {
-				const blob2Id = blob2Handle.absolutePath.split("/")[2];
-				const correctErrorType = error.code === 404;
-				const correctErrorMessage = error.message === `Blob was deleted: ${blob2Id}`;
-				return correctErrorType && correctErrorMessage;
-			},
-			"Deleted blob2 fetch should have failed",
-		);
+			const blobHandle = await handleP;
+			const localId = getBlobIdFromGCNodeId(blobHandle.absolutePath);
+			assert(redirectTable.has(localId), "blob not found in redirect table");
+			const storageId = redirectTable.get(localId);
+			assert(storageId !== undefined, "storage id not found in redirect table");
+			return {
+				localId,
+				localGCNodeId: getGCNodeIdFromBlobId(localId),
+				storageId,
+				storageGCNodeId: getGCNodeIdFromBlobId(storageId),
+			};
+		}
+
+		beforeEach(() => {
+			injectedSettings[sweepAttachmentBlobsKey] = true;
+			redirectTable = (runtime.blobManager as any).redirectTable;
+		});
+
+		it("fetching deleted blob fails", async () => {
+			await runtime.attach();
+			await runtime.connect();
+			const blob1Contents = IsoBuffer.from("blob1", "utf8");
+			const blob2Contents = IsoBuffer.from("blob2", "utf8");
+			const handle1P = runtime.createBlob(blob1Contents);
+			const handle2P = runtime.createBlob(blob2Contents);
+			await runtime.processAll();
+
+			const blob1Handle = await handle1P;
+			const blob2Handle = await handle2P;
+
+			// Validate that the blobs can be retrieved.
+			assert.strictEqual(await runtime.getBlob(blob1Handle), blob1Contents);
+			assert.strictEqual(await runtime.getBlob(blob2Handle), blob2Contents);
+
+			// Delete blob1. Retrieving it should result in an error.
+			runtime.deleteBlob(blob1Handle);
+			await assert.rejects(
+				async () => runtime.getBlob(blob1Handle),
+				(error) => {
+					const blob1Id = blob1Handle.absolutePath.split("/")[2];
+					const correctErrorType = error.code === 404;
+					const correctErrorMessage = error.message === `Blob was deleted: ${blob1Id}`;
+					return correctErrorType && correctErrorMessage;
+				},
+				"Deleted blob2 fetch should have failed",
+			);
+
+			// Delete blob2. Retrieving it should result in an error.
+			runtime.deleteBlob(blob2Handle);
+			await assert.rejects(
+				async () => runtime.getBlob(blob2Handle),
+				(error) => {
+					const blob2Id = blob2Handle.absolutePath.split("/")[2];
+					const correctErrorType = error.code === 404;
+					const correctErrorMessage = error.message === `Blob was deleted: ${blob2Id}`;
+					return correctErrorType && correctErrorMessage;
+				},
+				"Deleted blob2 fetch should have failed",
+			);
+		});
+
+		it("deletes unused blobs", async () => {
+			await runtime.attach();
+			await runtime.connect();
+
+			const blob1 = await createBlobAndGetIds("blob1");
+			const blob2 = await createBlobAndGetIds("blob2");
+
+			// Delete blob1's local id. The local id and the storage id should both be deleted from the redirect table
+			// since the blob only had one reference.
+			runtime.blobManager.deleteSweepReadyNodes([blob1.localGCNodeId]);
+			assert(!redirectTable.has(blob1.localId));
+			assert(!redirectTable.has(blob1.storageId));
+
+			// Delete blob2's local id. The local id and the storage id should both be deleted from the redirect table
+			// since the blob only had one reference.
+			runtime.blobManager.deleteSweepReadyNodes([blob2.localGCNodeId]);
+			assert(!redirectTable.has(blob2.localId));
+			assert(!redirectTable.has(blob2.storageId));
+		});
+
+		it("deletes unused de-duped blobs", async () => {
+			await runtime.attach();
+			await runtime.connect();
+
+			// Create 2 blobs with the same content. They should get de-duped.
+			const blob1 = await createBlobAndGetIds("blob1");
+			const blob1Duplicate = await createBlobAndGetIds("blob1");
+			assert(blob1.storageId === blob1Duplicate.storageId, "blob1 not de-duped");
+
+			// Create another 2 blobs with the same content. They should get de-duped.
+			const blob2 = await createBlobAndGetIds("blob2");
+			const blob2Duplicate = await createBlobAndGetIds("blob2");
+			assert(blob2.storageId === blob2Duplicate.storageId, "blob2 not de-duped");
+
+			// Delete blob1's local id. The local id should both be deleted from the redirect table but the storage id
+			// should not because the blob has another referenced from the de-duped blob.
+			runtime.blobManager.deleteSweepReadyNodes([blob1.localGCNodeId]);
+			assert(!redirectTable.has(blob1.localId), "blob1 localId should have been deleted");
+			assert(
+				redirectTable.has(blob1.storageId),
+				"blob1 storageId should not have been deleted",
+			);
+			// Delete blob1's de-duped local id. The local id and the storage id should both be deleted from the redirect table
+			// since all the references for the blob are now deleted.
+			runtime.blobManager.deleteSweepReadyNodes([blob1Duplicate.localGCNodeId]);
+			assert(
+				!redirectTable.has(blob1Duplicate.localId),
+				"blob1Duplicate localId should have been deleted",
+			);
+			assert(!redirectTable.has(blob1.storageId), "blob1 storageId should have been deleted");
+
+			// Delete blob2's local id. The local id should both be deleted from the redirect table but the storage id
+			// should not because the blob has another referenced from the de-duped blob.
+			runtime.blobManager.deleteSweepReadyNodes([blob2.localGCNodeId]);
+			assert(!redirectTable.has(blob2.localId), "blob2 localId should have been deleted");
+			assert(
+				redirectTable.has(blob2.storageId),
+				"blob2 storageId should not have been deleted",
+			);
+			// Delete blob2's de-duped local id. The local id and the storage id should both be deleted from the redirect table
+			// since all the references for the blob are now deleted.
+			runtime.blobManager.deleteSweepReadyNodes([blob2Duplicate.localGCNodeId]);
+			assert(
+				!redirectTable.has(blob2Duplicate.localId),
+				"blob2Duplicate localId should have been deleted",
+			);
+			assert(!redirectTable.has(blob2.storageId), "blob2 storageId should have been deleted");
+		});
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
@@ -274,14 +274,9 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 			);
 			defaultDataStore._root.set("local2", localHandle2);
 
-			// Validate that storing the localId handle makes both the localId and storageId nodes as referenced since
-			// localId is simply an alias to the storageId.
+			// Validate that both the localId nodes are referenced.
 			const s1 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
-			assert.strictEqual(s1.size, 3, "There should be 3 blob entries in GC data");
-			const storageId = getStorageIdFromReferenceMap(s1, [
-				localHandle1.absolutePath,
-				localHandle2.absolutePath,
-			]);
+			assert.strictEqual(s1.size, 2, "There should be 2 blob entries in GC data");
 			assert(
 				s1.get(localHandle1.absolutePath) === "referenced",
 				"local id 1 blob should be referenced",
@@ -290,12 +285,8 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 				s1.get(localHandle2.absolutePath) === "referenced",
 				"local id 2 blob should be referenced",
 			);
-			assert(
-				s1.get(storageId) === "referenced",
-				"storage id blob should also be referenced (1)",
-			);
 
-			// Delete blob localId handles. This should make the localId and storageId nodes unreferenced.
+			// Delete blob localId handles. This should make the localId nodes unreferenced.
 			defaultDataStore._root.delete("local1");
 			defaultDataStore._root.delete("local2");
 			const s2 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
@@ -307,10 +298,9 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 				s2.get(localHandle2.absolutePath) === "unreferenced",
 				"local id 2 blob should be unreferenced",
 			);
-			assert(s2.get(storageId) === "unreferenced", "storage id blob should be unreferenced");
 
 			// Add the localId1 handle back. If deleteUnreferencedContent is true, all the nodes would have been
-			// deleted from the GC state. Else, localId1 nad storageId would be referenced and localId2 unreferenced.
+			// deleted from the GC state. Else, localId1 would be referenced and localId2 unreferenced.
 			defaultDataStore._root.set("local1", localHandle1);
 			const s3 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
 			if (deleteUnreferencedContent) {
@@ -322,10 +312,6 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 					s3.get(localHandle2.absolutePath) === undefined,
 					"local id 2 blob should not have a GC entry",
 				);
-				assert(
-					s3.get(storageId) === undefined,
-					"storage id blob should not have a GC entry",
-				);
 			} else {
 				assert(
 					s3.get(localHandle1.absolutePath) === "referenced",
@@ -334,10 +320,6 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 				assert(
 					s3.get(localHandle2.absolutePath) === "unreferenced",
 					"local id 2 blob should still be unreferenced",
-				);
-				assert(
-					s3.get(storageId) === "referenced",
-					"storage id blob should be re-referenced",
 				);
 			}
 		});
@@ -370,18 +352,12 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 				stringToBuffer(blobContents, "utf-8"),
 			);
 
-			// Validate that storing the localId handles makes both the localId and storageId nodes as referenced since
-			// localId is simply an alias to the storageId.
+			// Validate that storing the localId handles makes them referenced.
 			defaultDataStore._root.set("local1", localHandle1);
 			defaultDataStore._root.set("local2", localHandle2);
 			defaultDataStore._root.set("local3", localHandle3);
 			const s1 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
-			assert.strictEqual(s1.size, 4, "There should be 4 blob entries in GC data");
-			const storageId = getStorageIdFromReferenceMap(s1, [
-				localHandle1.absolutePath,
-				localHandle2.absolutePath,
-				localHandle3.absolutePath,
-			]);
+			assert.strictEqual(s1.size, 3, "There should be 3 blob entries in GC data");
 			assert(
 				s1.get(localHandle1.absolutePath) === "referenced",
 				"local id 1 blob should be referenced (1)",
@@ -394,9 +370,8 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 				s1.get(localHandle3.absolutePath) === "referenced",
 				"local id 3 blob should be referenced (1)",
 			);
-			assert(s1.get(storageId) === "referenced", "storage id blob should be referenced (1)");
 
-			// Delete the localId handles. This would make localId1 node unreferenced.
+			// Delete the localId handles. This would make them unreferenced.
 			defaultDataStore._root.delete("local1");
 			defaultDataStore._root.delete("local2");
 			defaultDataStore._root.delete("local3");
@@ -413,10 +388,9 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 				s2.get(localHandle3.absolutePath) === "unreferenced",
 				"local id 3 blob should be unreferenced",
 			);
-			assert(s2.get(storageId) === "unreferenced", "storage id blob should be unreferenced");
 
 			// Add the localId1 handle back. If deleteUnreferencedContent is true, all the nodes would have been
-			// deleted from the GC state. Else, localId1 and storageId nodes will be referenced and others unreferenced.
+			// deleted from the GC state. Else, localId1 node will be referenced and others unreferenced.
 			defaultDataStore._root.set("local1", localHandle1);
 			const s3 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
 			if (deleteUnreferencedContent) {
@@ -432,10 +406,6 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 					s3.get(localHandle3.absolutePath) === undefined,
 					"local id 3 blob should not have a GC entry",
 				);
-				assert(
-					s3.get(storageId) === undefined,
-					"storage id blob should not have a GC entry",
-				);
 			} else {
 				assert(
 					s3.get(localHandle1.absolutePath) === "referenced",
@@ -448,10 +418,6 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 				assert(
 					s3.get(localHandle3.absolutePath) === "unreferenced",
 					"local id 3 blob should still be unreferenced",
-				);
-				assert(
-					s3.get(storageId) === "referenced",
-					"storage id blob should be re-referenced",
 				);
 			}
 		});
@@ -486,16 +452,13 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 			container2.connect();
 			await waitForContainerConnection(container2, true);
 
-			// Validate that the localId and storageId nodes are referenced. This should not log any
-			// gcUnknownOutboundReferences error when a reference from localId to storageId would be created.
+			// Validate that the localId node is referenced.
 			const s1 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
-			assert.strictEqual(s1.size, 2, "There should be 2 blob entries in GC data");
-			const storageId = getStorageIdFromReferenceMap(s1, [localHandle1.absolutePath]);
+			assert.strictEqual(s1.size, 1, "There should be 1 blob entries in GC data");
 			assert(
 				s1.get(localHandle1.absolutePath) === "referenced",
 				"local id blob should be referenced",
 			);
-			assert(s1.get(storageId) === "referenced", "storage id blob should be referenced");
 
 			// Upload the same blob. This will get de-duped and we will get back a handle with another localId. This and
 			// the blob uploaded in disconnected mode should map to the same storageId.
@@ -503,7 +466,7 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 				stringToBuffer(blobContents, "utf-8"),
 			);
 
-			// Add the localId2 handle and remove the localId1 handle. Validate that localId2 and storageId nodes are
+			// Add the localId2 handle and remove the localId1 handle. Validate that localId2 nodes is
 			// referenced and localId1 node is unreferenced.
 			defaultDataStore._root.set("local2", localHandle2);
 			defaultDataStore._root.delete("local1");
@@ -516,9 +479,8 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 				s2.get(localHandle2.absolutePath) === "referenced",
 				"local id 2 blob should be referenced",
 			);
-			assert(s2.get(storageId) === "referenced", "storage id blob should also be referenced");
 
-			// Remove the localId2 handle. Validate that localId2 and storageId nodes are now unreferenced. Also, if
+			// Remove the localId2 handle. Validate that localId2 node is now unreferenced as well. Also, if
 			// deleteUnreferencedContent is true, localId1 node would have been deleted.
 			defaultDataStore._root.delete("local2");
 			const s3 = await summarizeAndGetUnreferencedNodeStates(summarizerRuntime);
@@ -536,10 +498,6 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 			assert(
 				s3.get(localHandle2.absolutePath) === "unreferenced",
 				"local id 2 blob should still be unreferenced",
-			);
-			assert(
-				s3.get(storageId) === "unreferenced",
-				"storage id blob should still be unreferenced",
 			);
 		});
 	};

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
@@ -101,15 +101,15 @@ describeNoCompat("Garbage Collection Stats", (getTestObjectProvider) => {
 			"",
 		);
 		const expectedGCStats: IGCStats = {
-			nodeCount: 11,
+			nodeCount: 9,
 			unrefNodeCount: 0,
-			updatedNodeCount: 11,
+			updatedNodeCount: 9,
 			dataStoreCount: 3,
 			unrefDataStoreCount: 0,
 			updatedDataStoreCount: 3,
-			attachmentBlobCount: 4,
+			attachmentBlobCount: 2,
 			unrefAttachmentBlobCount: 0,
-			updatedAttachmentBlobCount: 4,
+			updatedAttachmentBlobCount: 2,
 		};
 
 		// Add both data store handles in default data store to mark them referenced.
@@ -154,15 +154,15 @@ describeNoCompat("Garbage Collection Stats", (getTestObjectProvider) => {
 			"",
 		);
 		const expectedGCStats: IGCStats = {
-			nodeCount: 11,
+			nodeCount: 9,
 			unrefNodeCount: 0,
-			updatedNodeCount: 11,
+			updatedNodeCount: 9,
 			dataStoreCount: 3,
 			unrefDataStoreCount: 0,
 			updatedDataStoreCount: 3,
-			attachmentBlobCount: 4,
+			attachmentBlobCount: 2,
 			unrefAttachmentBlobCount: 0,
-			updatedAttachmentBlobCount: 4,
+			updatedAttachmentBlobCount: 2,
 		};
 
 		// Add both data store handles in default data store to mark them referenced.
@@ -195,12 +195,12 @@ describeNoCompat("Garbage Collection Stats", (getTestObjectProvider) => {
 
 		// dataStore1, its DDS and blob1 should be now unreferenced. Also, their reference state updated from referenced
 		// to unreferenced.
-		expectedGCStats.unrefNodeCount = 4;
-		expectedGCStats.updatedNodeCount = 4;
+		expectedGCStats.unrefNodeCount = 3;
+		expectedGCStats.updatedNodeCount = 3;
 		expectedGCStats.unrefDataStoreCount = 1;
 		expectedGCStats.updatedDataStoreCount = 1;
-		expectedGCStats.unrefAttachmentBlobCount = 2;
-		expectedGCStats.updatedAttachmentBlobCount = 2;
+		expectedGCStats.unrefAttachmentBlobCount = 1;
+		expectedGCStats.updatedAttachmentBlobCount = 1;
 
 		gcStats = await containerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
@@ -220,14 +220,14 @@ describeNoCompat("Garbage Collection Stats", (getTestObjectProvider) => {
 		mainDataStore._root.delete("blob2");
 		await provider.ensureSynchronized();
 
-		// dataStore1, dataStore2, their DDS and blob2 should be now unreferenced. Also, dataStore2, its DDS and blob2's
-		// reference state updated from referenced to unreferenced.
-		expectedGCStats.unrefNodeCount = 8;
-		expectedGCStats.updatedNodeCount = 4;
+		// dataStore1, dataStore2, their DDS, blob1 and blob2 should be now unreferenced. Also, dataStore2, its DDS
+		// and blob2's reference state updated from referenced to unreferenced.
+		expectedGCStats.unrefNodeCount = 6;
+		expectedGCStats.updatedNodeCount = 3;
 		expectedGCStats.unrefDataStoreCount = 2;
 		expectedGCStats.updatedDataStoreCount = 1;
-		expectedGCStats.unrefAttachmentBlobCount = 4;
-		expectedGCStats.updatedAttachmentBlobCount = 2;
+		expectedGCStats.unrefAttachmentBlobCount = 2;
+		expectedGCStats.updatedAttachmentBlobCount = 1;
 
 		gcStats = await containerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
@@ -254,15 +254,15 @@ describeNoCompat("Garbage Collection Stats", (getTestObjectProvider) => {
 			"",
 		);
 		const expectedGCStats: IGCStats = {
-			nodeCount: 11,
+			nodeCount: 9,
 			unrefNodeCount: 0,
-			updatedNodeCount: 11,
+			updatedNodeCount: 9,
 			dataStoreCount: 3,
 			unrefDataStoreCount: 0,
 			updatedDataStoreCount: 3,
-			attachmentBlobCount: 4,
+			attachmentBlobCount: 2,
 			unrefAttachmentBlobCount: 0,
-			updatedAttachmentBlobCount: 4,
+			updatedAttachmentBlobCount: 2,
 		};
 
 		// Add both data store handles in default data store to mark them referenced.


### PR DESCRIPTION
## Bug
Blob de-duping has the following issues w.r.t. GC:
- In tombstone mode, after a blob has been tombstoned, its localId1 and storageId1 are both added to the tombstone list. If this blob is de-duped, a reference from localId2 will be added to storageId1. GC will be notified of this and it will log error / throw because it thinks a tombstoned blob was referenced.
- In sweep mode, the same problem as the above exists. The difference is that the blob is added to a deleted list and an error is thrown because GC thinks a deleted blob was referenced. In addition, the deleted storageId1 will not be removed from the deleted list ever since GC only ever appends to the list. This means that even after the new reference from localId2 -> storageId1 is added, the blob will still be in the deleted list. This should not have any functionality impact because a blob will never be referenced by its storage id. However, its still incorrect and can lead to other issues.

## Fix
Today, BlobManager gives both local and storage ids to GC when getGCData() is called and they both participate in GC. However, with [this change](https://github.com/microsoft/FluidFramework/pull/13486), a storage id is never exposed by the blob manager, and so, it can never make a blob referenced / unreferenced. In other words, it does not need to participate in GC.

The fix is for the BlobManager to only return local ids in getGCData(). Storage ids then will never be tombstoned / deleted and the bug described above will not happen.
BlobManager does an additional step in the sweep process - After local blob ids have been deleted (since they participate in GC), for the corresponding storage ids, it checks whether any localId -> storageId entry exists. If there isn't an entry, the storage id is deleted as well.
Another side benefit of this change is that BlobManager does not need to notify GC of localId -> storageId references. In other words, GC does not have to deal with blob de-duping at all.

[AB#2746](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2746)

## Alternative fix which was not done
When a reference from localId -> storageId is added, GC detects that and doesn't log any tombstone or sweep errors. Additionally, it removes the storageId from the deleted list. This solution is simple but it feels a little hacky because GC now has to understand blob manager specifics.
