### PR TITLE
Making SummarizerFetchValidation test to be full compat

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/SummarizeFetchValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizeFetchValidation.spec.ts
@@ -21,7 +21,7 @@ import {
 	summarizeNow,
 	createSummarizerFromFactory,
 } from "@fluidframework/test-utils";
-import { describeNoCompat, getContainerRuntimeApi } from "@fluidframework/test-version-utils";
+import { describeFullCompat, getContainerRuntimeApi } from "@fluidframework/test-version-utils";
 import { IContainerRuntimeBase, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import { ISummaryContext } from "@fluidframework/driver-definitions";
@@ -108,7 +108,7 @@ async function createSummarizer(
 /**
  * Validates the scenario in which we always retrieve the latest snapshot.
  */
-describeNoCompat("Summarizer fetches expected number of times", (getTestObjectProvider) => {
+describeFullCompat("Summarizer fetches expected number of times", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let mainContainer: IContainer;
 	let mainDataStore: TestDataObject1;


### PR DESCRIPTION

## Description

There was a recent regression on the Summarization, that could have been identified if we had fullCompat on the Summarizer Fetch Validation . Changing the test to guarantee it won't happen again.  Additional info can be found on the [ICM incident]( https://portal.microsofticm.com/imp/v3/incidents/details/364621580/postmortem)
