### PR TITLE
refactor(tree): Shallow-clone changeset marks

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -25,7 +25,6 @@ import {
 import {
 	addToNestedSet,
 	brand,
-	clone,
 	getOrAddEmptyToMap,
 	getOrAddInNestedMap,
 	JsonCompatibleReadOnly,
@@ -221,7 +220,7 @@ export class ModularChangeFamily
 		let valueChange: ValueChange | undefined;
 		for (const change of changes) {
 			if (change.change.valueChange !== undefined) {
-				valueChange = clone(change.change.valueChange);
+				valueChange = { ...change.change.valueChange };
 				valueChange.revision ??= change.revision;
 			}
 			if (change.change.fieldChanges !== undefined) {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
@@ -5,7 +5,7 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { makeAnonChange, RevisionTag, tagChange, TaggedChange } from "../../core";
-import { clone, fail } from "../../util";
+import { fail } from "../../util";
 import { CrossFieldManager, CrossFieldTarget, IdAllocator } from "../modular-schema";
 import {
 	Changeset,
@@ -16,6 +16,7 @@ import {
 	InputSpanningMark,
 	ObjectMark,
 	Reattach,
+	Skip,
 } from "./format";
 import { GapTracker, IndexTracker } from "./tracker";
 import { MarkListFactory } from "./markListFactory";
@@ -36,6 +37,7 @@ import {
 	isBlockedReattach,
 	getOffsetAtRevision,
 	isObjMark,
+	cloneMark,
 } from "./utils";
 
 /**
@@ -212,7 +214,7 @@ function composeMarks<TNodeChange>(
 				case "Delete": {
 					// For now the deletion obliterates all other modifications.
 					// In the long run we want to preserve them.
-					return clone(composeMark(newMark, newRev, composeChild));
+					return composeMark(newMark, newRev, composeChild);
 				}
 				case "MoveOut":
 				case "ReturnFrom": {
@@ -425,7 +427,7 @@ function composeChildChanges<TNodeChange>(
 
 function composeWithBaseChildChanges<
 	TNodeChange,
-	TMark extends InputSpanningMark<TNodeChange> &
+	TMark extends Exclude<InputSpanningMark<TNodeChange>, Skip> &
 		ObjectMark<TNodeChange> &
 		HasChanges<TNodeChange> &
 		HasRevisionTag,
@@ -442,7 +444,7 @@ function composeWithBaseChildChanges<
 		composeChild,
 	);
 
-	const cloned = clone(newMark);
+	const cloned = cloneMark(newMark);
 	if (newRevision !== undefined && cloned.type !== "Modify") {
 		cloned.revision = newRevision;
 	}
@@ -485,7 +487,7 @@ function composeMark<TNodeChange, TMark extends Mark<TNodeChange>>(
 		return mark;
 	}
 
-	const cloned = clone(mark);
+	const cloned = cloneMark(mark);
 	assert(!isSkipMark(cloned), 0x4de /* Cloned should be same type as input mark */);
 	if (revision !== undefined && cloned.type !== "Modify" && cloned.revision === undefined) {
 		cloned.revision = revision;

--- a/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -5,7 +5,7 @@
 
 import { assert, unreachableCase } from "@fluidframework/common-utils";
 import { RevisionTag } from "../../core";
-import { clone, fail } from "../../util";
+import { fail } from "../../util";
 import { CrossFieldManager, CrossFieldTarget, IdAllocator } from "../modular-schema";
 import {
 	InputSpanningMark,
@@ -18,7 +18,7 @@ import {
 	ReturnTo,
 	Skip,
 } from "./format";
-import { getInputLength, getOutputLength, isSkipMark } from "./utils";
+import { cloneMark, getInputLength, getOutputLength, isSkipMark } from "./utils";
 
 export type MoveEffectTable<T> = CrossFieldManager<MoveEffect<T>>;
 
@@ -278,7 +278,7 @@ function applyMoveEffectsToSource<T>(
 	);
 	const result: Mark<T>[] = [];
 	if (!effect.shouldRemove) {
-		const newMark = clone(mark);
+		const newMark = cloneMark(mark);
 		newMark.count = effect.count ?? newMark.count;
 		if (effect.modifyAfter !== undefined) {
 			assert(

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -7,7 +7,6 @@ import { assert, unreachableCase } from "@fluidframework/common-utils";
 import { RevisionTag, TaggedChange } from "../../core";
 import {
 	addToNestedSet,
-	clone,
 	fail,
 	getOrAddEmptyToMap,
 	getOrAddInNestedMap,
@@ -126,6 +125,22 @@ export function isBlockedReattach<TNodeChange>(
 
 export function isConflicted(mark: CanConflict): mark is Conflicted {
 	return mark.conflictsWith !== undefined;
+}
+
+export function cloneMark<TMark extends Mark<TNodeChange>, TNodeChange>(mark: TMark): TMark {
+	if (isSkipMark(mark)) {
+		return mark;
+	}
+	const objMark = mark as Exclude<TMark, Skip>;
+	const clone = { ...objMark };
+	if (clone.type === "Insert") {
+		// TODO: also do this for Revive marks once they carry content
+		clone.content = [...clone.content];
+	}
+	if (isAttach(clone) && clone.lineage !== undefined) {
+		clone.lineage = [...clone.lineage];
+	}
+	return clone;
 }
 
 export function getAttachLength(attach: Attach): number {
@@ -665,7 +680,7 @@ export class DetachedNodeTracker {
 			for (let i = splitMarks.length - 1; i > 0; i--) {
 				iter.push(splitMarks[i]);
 			}
-			const cloned = clone(mark);
+			const cloned = cloneMark(mark);
 			if (isReattach(cloned)) {
 				let remainder: Reattach<T> = cloned;
 				for (let i = 1; i < cloned.count; ++i) {


### PR DESCRIPTION
With this PR operations on changesets now use a shallow `cloneMark` function instead of a function that deep-clones the marks. 

Aside from the performance gain, this means that the tree content stored in changesets (for inserts and revives) no longer needs to be clonable.