### PR TITLE
r11s-driver: Use correct id for snapshot version cache

### DIFF
--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -248,19 +248,21 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 		);
 		const normalizedWholeSummary =
 			convertWholeFlatSummaryToSnapshotTreeAndBlobs(wholeFlatSummary);
+		assert(
+			normalizedWholeSummary.snapshotTree.id !== undefined,
+			0x275 /* "Root tree should contain the id" */,
+		);
 		const wholeFlatSummaryId: string = wholeFlatSummary.id;
-		const snapshotTreeId = normalizedWholeSummary.snapshotTree.id;
-		assert(snapshotTreeId !== undefined, 0x275 /* "Root tree should contain the id" */);
 		const snapshotTreeVersion = {
 			id: wholeFlatSummaryId,
 			snapshotTree: normalizedWholeSummary.snapshotTree,
 		};
 
 		const cachePs: Promise<any>[] = [
-			this.snapshotTreeCache.put(this.getCacheKey(snapshotTreeId), snapshotTreeVersion),
+			this.snapshotTreeCache.put(this.getCacheKey(wholeFlatSummaryId), snapshotTreeVersion),
 			this.initBlobCache(normalizedWholeSummary.blobs),
 		];
-		if (snapshotTreeId !== versionId) {
+		if (wholeFlatSummaryId !== versionId) {
 			// versionId could be "latest". When summarizer checks cache for "latest", we want it to be available.
 			// TODO: For in-memory cache, <latest,snapshotTree> will be a shared pointer with <snapshotId,snapshotTree>,
 			// However, for something like Redis, this will cache the same value twice. Alternatively, could we simply


### PR DESCRIPTION
## Description

The R11s Driver relies on an internal in-memory cache to optimize the "latest" summary call on initial load. This works fine in FRS right now with SummaryStorage, but it doesn't work well with Gitrest due to a typo in the cache keys. SummaryStorage is fine because snapshot versionId === treeId, but in Gitrest, these are different, thus, we are just now seeing this bug as we ramp up testing with Gitrest.
