### PR TITLE
Deprecate waitForAttach

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -109,7 +109,7 @@ The following members of the `@fluidframework/driver-utils` package have been de
 The following members of the `@fluidframework/aqueduct` package have been deprecated and will be removed in an upcoming release:
 
 -   `waitForAttach()`
-    -   Instead inspect the IFluidDataStoreRuntime's attachState property, and await the "attached" event if not attached.
+    -   Prefer not to inspect and react to the attach state unless necessary. If needed, instead inspect the IFluidDataStoreRuntime's attachState property, and await the "attached" event if not attached.
 
 ## 2.0.0-internal.3.0.0 Breaking changes
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -109,7 +109,7 @@ The following members of the `@fluidframework/driver-utils` package have been de
 The following members of the `@fluidframework/aqueduct` package have been deprecated and will be removed in an upcoming release:
 
 -   `waitForAttach()`
-    - Instead inspect the IFluidDataStoreRuntime's attachState property, and await the "attached" event if not attached.
+    -   Instead inspect the IFluidDataStoreRuntime's attachState property, and await the "attached" event if not attached.
 
 ## 2.0.0-internal.3.0.0 Breaking changes
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -29,6 +29,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 -   [IFluidTokenProvider deprecated](#IFluidTokenProvider-deprecated)
 -   [web-code-loader and ICodeAllowList deprecated](#web-code-loader-and-ICodeAllowList-deprecated)
 -   [driver-utils members deprecated](#driver-utils-members-deprecated)
+-   [Aqueduct members deprecated](#Aqueduct-members-deprecated)
 
 ### For Driver Authors: Document Storage Service policy may become required
 
@@ -102,6 +103,13 @@ The `@fluidframework/web-code-loader` and the `ICodeAllowList` interface from th
 The following members of the `@fluidframework/driver-utils` package have been deprecated and will be removed in an upcoming release:
 
 -   `waitForConnectedState`
+
+### Aqueduct members deprecated
+
+The following members of the `@fluidframework/aqueduct` package have been deprecated and will be removed in an upcoming release:
+
+-   `waitForAttach()`
+    - Instead inspect the IFluidDataStoreRuntime's attachState property, and await the "attached" event if not attached.
 
 ## 2.0.0-internal.3.0.0 Breaking changes
 

--- a/api-report/aqueduct.api.md
+++ b/api-report/aqueduct.api.md
@@ -199,7 +199,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
 // @public (undocumented)
 export const serviceRoutePathRoot = "_services";
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function waitForAttach(dataStoreRuntime: IFluidDataStoreRuntime): Promise<void>;
 
 ```

--- a/packages/framework/aqueduct/src/utils/attachUtils.ts
+++ b/packages/framework/aqueduct/src/utils/attachUtils.ts
@@ -6,6 +6,9 @@
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { AttachState } from "@fluidframework/container-definitions";
 
+/**
+ * @deprecated 2.0.0-internal.3.3.0 Instead inspect the IFluidDataStoreRuntime's attachState property, and await the "attached" event if not attached.
+ */
 export async function waitForAttach(dataStoreRuntime: IFluidDataStoreRuntime): Promise<void> {
 	if (dataStoreRuntime.attachState === AttachState.Attached) {
 		return;

--- a/packages/framework/aqueduct/src/utils/attachUtils.ts
+++ b/packages/framework/aqueduct/src/utils/attachUtils.ts
@@ -7,7 +7,7 @@ import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { AttachState } from "@fluidframework/container-definitions";
 
 /**
- * @deprecated 2.0.0-internal.3.3.0 Instead inspect the IFluidDataStoreRuntime's attachState property, and await the "attached" event if not attached.
+ * @deprecated 2.0.0-internal.3.3.0 Prefer not to inspect and react to the attach state unless necessary. If needed, instead inspect the IFluidDataStoreRuntime's attachState property, and await the "attached" event if not attached.
  */
 export async function waitForAttach(dataStoreRuntime: IFluidDataStoreRuntime): Promise<void> {
 	if (dataStoreRuntime.attachState === AttachState.Attached) {


### PR DESCRIPTION
Trivial to implement inline, which has the added benefit of allowing synchronous progress if already attached.  I have a PR open to remove the Loop usage.