### PR TITLE
Bump client type tests

### DIFF
--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -51,7 +51,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.3.1.0",
+		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -44,7 +44,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.3.1.0",
+		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -47,7 +47,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.3.1.0",
+		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -75,7 +75,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.3.1.0",
+		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -74,7 +74,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.3.1.0",
+		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.3.1.0",
+		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.3.2.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.22.2",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.3.1.0",
+		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.3.2.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.22.2",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -86,7 +86,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.3.1.0",
+		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.3.2.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.22.2",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.3.1.0",
+		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.3.2.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-pairwise-generator": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.3.1.0",
+		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.3.2.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.3.1.0",
+		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.3.2.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -92,7 +92,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/gitresources": "^0.1038.2000",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.3.1.0",
+		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.3.2.0",
 		"@fluidframework/server-services-client": "^0.1038.2000",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.22.2",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.3.1.0",
+		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.3.2.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.3.1.0",
+		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.3.2.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.3.1.0",
+		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.3.2.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -46,7 +46,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.3.1.0",
+		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -44,7 +44,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
-		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.3.1.0",
+		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -48,7 +48,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.3.1.0",
+		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -47,7 +47,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.3.1.0",
+		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/node": "^14.18.36",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -47,7 +47,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "0.11.0-135362",
-		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.3.1.0",
+		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.3.2.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -80,7 +80,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.3.1.0",
+		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.3.2.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/jsrsasign": "^8.0.8",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -45,7 +45,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.3.1.0",
+		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.3.2.0",
 		"@fluidframework/protocol-definitions": "^1.1.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.generated.ts
+++ b/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.generated.ts
@@ -664,6 +664,30 @@ use_old_InterfaceDeclaration_TokenResponse(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_getKeyForCacheEntry": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_getKeyForCacheEntry():
+    TypeOnly<typeof old.getKeyForCacheEntry>;
+declare function use_current_FunctionDeclaration_getKeyForCacheEntry(
+    use: TypeOnly<typeof current.getKeyForCacheEntry>);
+use_current_FunctionDeclaration_getKeyForCacheEntry(
+    get_old_FunctionDeclaration_getKeyForCacheEntry());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_getKeyForCacheEntry": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_getKeyForCacheEntry():
+    TypeOnly<typeof current.getKeyForCacheEntry>;
+declare function use_old_FunctionDeclaration_getKeyForCacheEntry(
+    use: TypeOnly<typeof old.getKeyForCacheEntry>);
+use_old_FunctionDeclaration_getKeyForCacheEntry(
+    get_current_FunctionDeclaration_getKeyForCacheEntry());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "VariableDeclaration_isTokenFromCache": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_isTokenFromCache():

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.3.1.0",
+		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",
@@ -105,16 +105,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_OdspDocumentServiceFactory": {
-				"forwardCompat": false
-			},
-			"ClassDeclaration_OdspDocumentServiceFactoryCore": {
-				"forwardCompat": false
-			},
-			"ClassDeclaration_OdspDocumentServiceFactoryWithCodeSplit": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.generated.ts
+++ b/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.generated.ts
@@ -167,7 +167,6 @@ declare function get_old_ClassDeclaration_OdspDocumentServiceFactory():
 declare function use_current_ClassDeclaration_OdspDocumentServiceFactory(
     use: TypeOnly<current.OdspDocumentServiceFactory>);
 use_current_ClassDeclaration_OdspDocumentServiceFactory(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_OdspDocumentServiceFactory());
 
 /*
@@ -192,7 +191,6 @@ declare function get_old_ClassDeclaration_OdspDocumentServiceFactoryCore():
 declare function use_current_ClassDeclaration_OdspDocumentServiceFactoryCore(
     use: TypeOnly<current.OdspDocumentServiceFactoryCore>);
 use_current_ClassDeclaration_OdspDocumentServiceFactoryCore(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_OdspDocumentServiceFactoryCore());
 
 /*
@@ -217,7 +215,6 @@ declare function get_old_ClassDeclaration_OdspDocumentServiceFactoryWithCodeSpli
 declare function use_current_ClassDeclaration_OdspDocumentServiceFactoryWithCodeSplit(
     use: TypeOnly<current.OdspDocumentServiceFactoryWithCodeSplit>);
 use_current_ClassDeclaration_OdspDocumentServiceFactoryWithCodeSplit(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_OdspDocumentServiceFactoryWithCodeSplit());
 
 /*

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -50,7 +50,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.3.1.0",
+		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.3.2.0",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.36",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -48,7 +48,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.3.1.0",
+		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.3.1.0",
+		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -52,7 +52,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.3.1.0",
+		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.3.2.0",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",
 		"@types/nconf": "^0.10.0",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -49,7 +49,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/test-tools": "^0.2.3074",
-		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.3.1.0",
+		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.3.2.0",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "0.11.0-135362",
-		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.3.1.0",
+		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.3.2.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -84,7 +84,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "0.11.0-135362",
-		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.3.1.0",
+		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.3.2.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -75,7 +75,7 @@
 	"devDependencies": {
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
-		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.3.1.0",
+		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.22.2",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -73,7 +73,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.3.1.0",
+		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -63,10 +63,6 @@
 	},
 	"typeValidation": {
 		"disabled": true,
-		"broken": {
-			"EnumDeclaration_DriverErrorType": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -79,7 +79,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.3.1.0",
+		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.3.2.0",
 		"@fluidframework/map": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/sequence": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -74,7 +74,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.3.1.0",
+		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.3.2.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -72,7 +72,7 @@
 		"@fluidframework/datastore": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.3.1.0",
+		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -49,7 +49,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@2.0.0-internal.3.1.0",
+		"@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/uuid": "^8.3.0",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -64,7 +64,7 @@
 		"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/test-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.3.1.0",
+		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.3.1.0",
+		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/diff": "^3.5.1",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -42,7 +42,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.3.1.0",
+		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/react": "^17.0.44",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -39,7 +39,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.3.1.0",
+		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/react": "^17.0.44",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -84,7 +84,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.3.1.0",
+		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-loader-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -73,7 +73,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.3.1.0",
+		"@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -78,7 +78,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.3.1.0",
+		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -73,7 +73,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.3.1.0",
+		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.3.2.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.22.2",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -42,7 +42,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@2.0.0-internal.3.1.0",
+		"@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@2.0.0-internal.3.2.0",
 		"@rushstack/eslint-config": "^2.5.1",
 		"concurrently": "^6.2.0",
 		"eslint": "~8.6.0",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -43,7 +43,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/protocol-definitions": "^1.1.0",
-		"@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@2.0.0-internal.3.1.0",
+		"@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/isomorphic-fetch": "^0.0.35",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -45,7 +45,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.3.1.0",
+		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -87,7 +87,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.3.1.0",
+		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
@@ -110,13 +110,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"EnumDeclaration_RuntimeHeaders": {
-				"forwardCompat": false
-			},
-			"ClassDeclaration_ContainerRuntime": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -95,7 +95,6 @@ declare function get_old_ClassDeclaration_ContainerRuntime():
 declare function use_current_ClassDeclaration_ContainerRuntime(
     use: TypeOnly<current.ContainerRuntime>);
 use_current_ClassDeclaration_ContainerRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_ContainerRuntime());
 
 /*
@@ -1416,7 +1415,6 @@ declare function get_old_EnumDeclaration_RuntimeHeaders():
 declare function use_current_EnumDeclaration_RuntimeHeaders(
     use: TypeOnly<current.RuntimeHeaders>);
 use_current_EnumDeclaration_RuntimeHeaders(
-    // @ts-expect-error compatibility expected to be broken
     get_old_EnumDeclaration_RuntimeHeaders());
 
 /*

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -45,7 +45,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.3.1.0",
+		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -84,7 +84,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
-		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.3.1.0",
+		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.3.2.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@2.0.0-internal.3.1.0",
+		"@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@2.0.0-internal.3.2.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -46,7 +46,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.3.1.0",
+		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"concurrently": "^6.2.0",
@@ -57,17 +57,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"InterfaceDeclaration_ITelemetryContext": {
-				"forwardCompat": false
-			},
-			"RemovedEnumDeclaration_BindState": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"InterfaceDeclaration_IFluidDataStoreChannel": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -88,18 +88,6 @@ use_old_TypeAliasDeclaration_AttributionKey(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedEnumDeclaration_BindState": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedEnumDeclaration_BindState": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "TypeAliasDeclaration_CreateChildSummarizerNodeFn": {"forwardCompat": false}
 */
 declare function get_old_TypeAliasDeclaration_CreateChildSummarizerNodeFn():
@@ -244,6 +232,30 @@ use_old_EnumDeclaration_FlushMode(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "EnumDeclaration_FlushModeExperimental": {"forwardCompat": false}
+*/
+declare function get_old_EnumDeclaration_FlushModeExperimental():
+    TypeOnly<old.FlushModeExperimental>;
+declare function use_current_EnumDeclaration_FlushModeExperimental(
+    use: TypeOnly<current.FlushModeExperimental>);
+use_current_EnumDeclaration_FlushModeExperimental(
+    get_old_EnumDeclaration_FlushModeExperimental());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "EnumDeclaration_FlushModeExperimental": {"backCompat": false}
+*/
+declare function get_current_EnumDeclaration_FlushModeExperimental():
+    TypeOnly<current.FlushModeExperimental>;
+declare function use_old_EnumDeclaration_FlushModeExperimental(
+    use: TypeOnly<old.FlushModeExperimental>);
+use_old_EnumDeclaration_FlushModeExperimental(
+    get_current_EnumDeclaration_FlushModeExperimental());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IAttachMessage": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IAttachMessage():
@@ -371,7 +383,6 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreChannel():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreChannel(
     use: TypeOnly<current.IFluidDataStoreChannel>);
 use_current_InterfaceDeclaration_IFluidDataStoreChannel(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreChannel());
 
 /*
@@ -996,7 +1007,6 @@ declare function get_old_InterfaceDeclaration_ITelemetryContext():
 declare function use_current_InterfaceDeclaration_ITelemetryContext(
     use: TypeOnly<current.ITelemetryContext>);
 use_current_InterfaceDeclaration_ITelemetryContext(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ITelemetryContext());
 
 /*

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.3.1.0",
+		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",
@@ -98,10 +98,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_TelemetryContext": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
@@ -287,7 +287,6 @@ declare function get_old_ClassDeclaration_TelemetryContext():
 declare function use_current_ClassDeclaration_TelemetryContext(
     use: TypeOnly<current.TelemetryContext>);
 use_current_ClassDeclaration_TelemetryContext(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TelemetryContext());
 
 /*

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.3.1.0",
+		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/jsrsasign": "^8.0.8",
@@ -101,10 +101,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_MockFluidDataStoreRuntime": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -311,7 +311,6 @@ declare function get_old_ClassDeclaration_MockFluidDataStoreRuntime():
 declare function use_current_ClassDeclaration_MockFluidDataStoreRuntime(
     use: TypeOnly<current.MockFluidDataStoreRuntime>);
 use_current_ClassDeclaration_MockFluidDataStoreRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockFluidDataStoreRuntime());
 
 /*

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -63,7 +63,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.3.1.0",
+		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -84,7 +84,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@2.0.0-internal.3.1.0",
+		"@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -128,6 +128,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
+		"@fluidframework/test-end-to-end-tests-previous": "npm:@fluidframework/test-end-to-end-tests@2.0.0-internal.3.2.0",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -61,7 +61,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@2.0.0-internal.3.1.0",
+		"@fluidframework/test-pairwise-generator-previous": "npm:@fluidframework/test-pairwise-generator@2.0.0-internal.3.2.0",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.36",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -92,7 +92,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.3.1.0",
+		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/debug": "^4.1.5",
@@ -114,15 +114,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"FunctionDeclaration_createSummarizerWithContainer": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedFunctionDeclaration_createSummarizerWithContainer": {
-				"forwardCompat": false,
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -544,18 +544,6 @@ use_old_FunctionDeclaration_createSummarizerFromFactory(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_createSummarizerWithContainer": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_createSummarizerWithContainer": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "VariableDeclaration_createTestContainerRuntimeFactory": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_createTestContainerRuntimeFactory():

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -93,7 +93,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@2.0.0-internal.3.1.0",
+		"@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@2.0.0-internal.3.2.0",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -50,6 +50,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "0.11.0-135362",
+		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.3.2.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@rushstack/eslint-config": "^2.5.1",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -74,7 +74,7 @@
 		"@fluid-tools/build-cli": "0.11.0-135362",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.3.1.0",
+		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.3.2.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -95,7 +95,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "0.11.0-135362",
-		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.3.1.0",
+		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.3.2.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.3.1.0",
+		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.3.2.0",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.36",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.3.1.0",
+		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/debug": "^4.1.5",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-tools": "0.11.0-135362",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
-		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.3.1.0",
+		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.3.2.0",
 		"@microsoft/api-extractor": "^7.22.2",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/debug": "^4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4850,7 +4850,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/common-definitions': ^0.20.1
-      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.3.2.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -4875,7 +4875,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -4892,7 +4892,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -4907,7 +4907,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -4972,7 +4972,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.3.1.0
+      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@microsoft/api-extractor': ^7.22.2
@@ -4991,7 +4991,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.3.1.0
+      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -5008,7 +5008,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.3.1.0
+      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.3.2.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -5045,7 +5045,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.3.1.0
+      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -5070,7 +5070,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.3.1.0
+      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.3.2.0
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -5104,7 +5104,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.3.1.0
+      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -5132,7 +5132,7 @@ importers:
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.3.1.0
+      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -5165,7 +5165,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.3.1.0
+      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
@@ -5196,7 +5196,7 @@ importers:
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.3.1.0
+      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -5238,7 +5238,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.3.1.0
+      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
@@ -5268,7 +5268,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.3.1.0
+      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.3.2.0
       '@fluidframework/merge-tree': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.2000
@@ -5322,7 +5322,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.3.1.0
+      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
@@ -5359,7 +5359,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.3.1.0
+      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -5405,7 +5405,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.3.1.0
+      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-pairwise-generator': link:../../test/test-pairwise-generator
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -5439,7 +5439,7 @@ importers:
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.3.1.0
+      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -5475,7 +5475,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.3.1.0
+      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.3.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -5567,7 +5567,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.2000
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.3.1.0
+      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.3.2.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/shared-object-base': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -5599,7 +5599,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.3.1.0
+      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.3.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -5636,7 +5636,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.3.1.0
+      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.3.2.0
       '@fluidframework/server-services-client': ^0.1038.2000
       '@fluidframework/shared-object-base': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -5683,7 +5683,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/gitresources': 0.1038.3000
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.3.1.0
+      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.3.2.0
       '@fluidframework/server-services-client': 0.1038.2000
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
@@ -5722,7 +5722,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.3.1.0
+      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.3.2.0
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
@@ -5762,7 +5762,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.3.1.0
+      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.3.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -5795,7 +5795,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/shared-object-base': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.3.1.0
+      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.3.2.0
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -5826,7 +5826,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.3.1.0
+      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.3.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -5864,7 +5864,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/shared-object-base': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.3.1.0
+      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.3.2.0
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -5902,7 +5902,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.3.1.0
+      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.3.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -6055,7 +6055,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.3.1.0
+      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.3.2.0
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -6084,7 +6084,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.3.1.0
+      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -6104,7 +6104,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.3.1.0
+      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.3.2.0
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -6130,7 +6130,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
-      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.3.1.0
+      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -6149,7 +6149,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/common-definitions': ^0.20.1
-      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.3.1.0
+      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -6175,7 +6175,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.3.1.0
+      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -6200,7 +6200,7 @@ importers:
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.3.1.0
+      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/replay-driver': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
@@ -6224,7 +6224,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.3.1.0
+      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/node': 14.18.36
@@ -6238,7 +6238,7 @@ importers:
   packages/drivers/fluidapp-odsp-urlResolver:
     specifiers:
       '@fluid-tools/build-cli': 0.11.0-135362
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.3.1.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.3.2.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/common-utils': ^1.1.1
@@ -6266,7 +6266,7 @@ importers:
       '@fluidframework/odsp-driver-definitions': link:../odsp-driver-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.11.0-135362
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.1.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.2.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -6293,7 +6293,7 @@ importers:
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.3.1.0
+      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.2000
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -6343,7 +6343,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.3.1.0
+      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/jsrsasign': 8.0.13
@@ -6375,7 +6375,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-doclib-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.3.1.0
+      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.3.2.0
       '@fluidframework/protocol-base': ^0.1038.2000
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -6423,7 +6423,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.3.1.0
+      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -6449,7 +6449,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.3.1.0
+      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -6467,7 +6467,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.1.0
+      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': 1.1.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -6490,7 +6490,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.3.1.0
+      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.3.2.0
       '@rushstack/eslint-config': ^2.5.1
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.36
@@ -6512,7 +6512,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.3.1.0
+      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.3.2.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
       '@types/node': 14.18.36
@@ -6535,7 +6535,7 @@ importers:
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.3.1.0
+      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.3.2.0
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -6562,7 +6562,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.3.1.0
+      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -6592,7 +6592,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.2000
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.3.1.0
+      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.3.2.0
       '@fluidframework/server-services-client': ^0.1038.2000
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
@@ -6644,7 +6644,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.3.1.0
+      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -6677,7 +6677,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.3.1.0
+      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.3.2.0
       '@rushstack/eslint-config': ^2.5.1
       '@types/mocha': ^9.1.1
       '@types/nconf': ^0.10.0
@@ -6705,7 +6705,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.1.0
+      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.2.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
       '@types/nconf': 0.10.3
@@ -6732,7 +6732,7 @@ importers:
       '@fluidframework/routerlicious-driver': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/server-services-client': ^0.1038.2000
       '@fluidframework/test-tools': ^0.2.3074
-      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.3.1.0
+      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.3.2.0
       '@rushstack/eslint-config': ^2.5.1
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
@@ -6761,7 +6761,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/test-tools': 0.2.3074
-      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.3.1.0
+      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.3.2.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
@@ -6777,7 +6777,7 @@ importers:
   packages/framework/agent-scheduler:
     specifiers:
       '@fluid-tools/build-cli': 0.11.0-135362
-      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.3.1.0
+      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.3.2.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/common-definitions': ^0.20.1
@@ -6820,7 +6820,7 @@ importers:
       uuid: 8.3.2
     devDependencies:
       '@fluid-tools/build-cli': 0.11.0-135362
-      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.3.1.0
+      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.3.2.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -6838,7 +6838,7 @@ importers:
   packages/framework/aqueduct:
     specifiers:
       '@fluid-tools/build-cli': 0.11.0-135362
-      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.3.1.0
+      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.3.2.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/common-definitions': ^0.20.1
@@ -6891,7 +6891,7 @@ importers:
       uuid: 8.3.2
     devDependencies:
       '@fluid-tools/build-cli': 0.11.0-135362
-      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.3.1.0
+      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.3.2.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -6994,7 +6994,7 @@ importers:
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/container-runtime': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.3.1.0
+      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.3.2.0
       '@fluidframework/datastore': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -7030,7 +7030,7 @@ importers:
     devDependencies:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
-      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.3.1.0
+      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.22.2
@@ -7052,7 +7052,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.3.1.0
+      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/merge-tree': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -7087,7 +7087,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.3.1.0
+      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -7170,7 +7170,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.3.1.0
+      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.3.2.0
       '@fluidframework/map': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -7209,7 +7209,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.3.1.0
+      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.3.2.0
       '@fluidframework/map': link:../../dds/map
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/sequence': link:../../dds/sequence
@@ -7292,7 +7292,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.3.1.0
+      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.3.2.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -7325,7 +7325,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.3.1.0
+      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.3.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -7354,7 +7354,7 @@ importers:
       '@fluidframework/datastore': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.3.1.0
+      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.3.2.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/mocha': ^9.1.1
@@ -7376,7 +7376,7 @@ importers:
       '@fluidframework/datastore': link:../../runtime/datastore
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.3.1.0
+      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -7398,7 +7398,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/test-client-utils-previous': npm:@fluidframework/test-client-utils@2.0.0-internal.3.1.0
+      '@fluidframework/test-client-utils-previous': npm:@fluidframework/test-client-utils@2.0.0-internal.3.2.0
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -7421,7 +7421,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-client-utils-previous': /@fluidframework/test-client-utils/2.0.0-internal.3.1.0
+      '@fluidframework/test-client-utils-previous': /@fluidframework/test-client-utils/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/uuid': 8.3.4
@@ -7453,7 +7453,7 @@ importers:
       '@fluidframework/routerlicious-driver': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.3.1.0
+      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.3.2.0
       '@fluidframework/tinylicious-driver': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -7492,7 +7492,7 @@ importers:
       '@fluidframework/container-runtime-definitions': link:../../runtime/container-runtime-definitions
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/test-utils': link:../../test/test-utils
-      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.3.1.0
+      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -7519,7 +7519,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/sequence': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.3.1.0
+      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.3.2.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/diff': ^3.5.1
@@ -7552,7 +7552,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.3.1.0
+      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/diff': 3.5.5
@@ -7578,7 +7578,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.3.1.0
+      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.3.2.0
       '@fluidframework/view-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -7601,7 +7601,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.3.1.0
+      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/react': 17.0.52
@@ -7619,7 +7619,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.3.1.0
+      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.3.2.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/react': ^17.0.44
@@ -7636,7 +7636,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.3.1.0
+      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/react': 17.0.52
@@ -7656,7 +7656,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.3.1.0
+      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.3.2.0
       '@fluidframework/container-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -7712,7 +7712,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.3.1.0
+      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-loader-utils': link:../test-loader-utils
@@ -7743,7 +7743,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/container-utils-previous': npm:@fluidframework/container-utils@2.0.0-internal.3.1.0
+      '@fluidframework/container-utils-previous': npm:@fluidframework/container-utils@2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -7772,7 +7772,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/container-utils-previous': /@fluidframework/container-utils/2.0.0-internal.3.1.0
+      '@fluidframework/container-utils-previous': /@fluidframework/container-utils/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -7799,7 +7799,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.3.1.0
+      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources': ^0.1038.2000
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -7841,7 +7841,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.3.1.0
+      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
@@ -7870,7 +7870,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.3.1.0
+      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -7897,7 +7897,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.3.1.0
+      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.22.2
@@ -7924,7 +7924,7 @@ importers:
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/test-loader-utils-previous': npm:@fluidframework/test-loader-utils@2.0.0-internal.3.1.0
+      '@fluidframework/test-loader-utils-previous': npm:@fluidframework/test-loader-utils@2.0.0-internal.3.2.0
       '@rushstack/eslint-config': ^2.5.1
       concurrently: ^6.2.0
       eslint: ~8.6.0
@@ -7941,7 +7941,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-loader-utils-previous': /@fluidframework/test-loader-utils/2.0.0-internal.3.1.0
+      '@fluidframework/test-loader-utils-previous': /@fluidframework/test-loader-utils/2.0.0-internal.3.2.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       concurrently: 6.3.0
       eslint: 8.6.0
@@ -7957,7 +7957,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/web-code-loader-previous': npm:@fluidframework/web-code-loader@2.0.0-internal.3.1.0
+      '@fluidframework/web-code-loader-previous': npm:@fluidframework/web-code-loader@2.0.0-internal.3.2.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/isomorphic-fetch': ^0.0.35
@@ -7979,7 +7979,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/web-code-loader-previous': /@fluidframework/web-code-loader/2.0.0-internal.3.1.0
+      '@fluidframework/web-code-loader-previous': /@fluidframework/web-code-loader/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/isomorphic-fetch': 0.0.35
@@ -8001,7 +8001,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/container-runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.3.1.0
+      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.3.2.0
       '@fluidframework/container-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -8061,7 +8061,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.3.1.0
+      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -8090,7 +8090,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.3.1.0
+      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.3.2.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -8115,7 +8115,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.3.1.0
+      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -8137,7 +8137,7 @@ importers:
       '@fluidframework/container-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.3.1.0
+      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.3.2.0
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -8186,7 +8186,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.3.1.0
+      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -8214,7 +8214,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.3.1.0
+      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -8237,7 +8237,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
-      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.3.1.0
+      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.3.2.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -8256,7 +8256,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/garbage-collector-previous': npm:@fluidframework/garbage-collector@2.0.0-internal.3.1.0
+      '@fluidframework/garbage-collector-previous': npm:@fluidframework/garbage-collector@2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -8284,7 +8284,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/garbage-collector-previous': /@fluidframework/garbage-collector/2.0.0-internal.3.1.0
+      '@fluidframework/garbage-collector-previous': /@fluidframework/garbage-collector/2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -8313,7 +8313,7 @@ importers:
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.3.2.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       concurrently: ^6.2.0
@@ -8334,7 +8334,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       concurrently: 6.3.0
@@ -8361,7 +8361,7 @@ importers:
       '@fluidframework/protocol-base': ^0.1038.2000
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.3.1.0
+      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.3.2.0
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -8396,7 +8396,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.3.1.0
+      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -8432,7 +8432,7 @@ importers:
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.3.1.0
+      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.3.2.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/jsrsasign': ^8.0.8
@@ -8475,7 +8475,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.3.1.0
+      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/jsrsasign': 8.0.13
@@ -8677,7 +8677,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.3.1.0
+      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.3.2.0
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
@@ -8699,7 +8699,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.3.1.0
+      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -8941,7 +8941,7 @@ importers:
       '@fluidframework/routerlicious-driver': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/server-local-server': ^0.1038.2000
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-drivers-previous': npm:@fluidframework/test-drivers@2.0.0-internal.3.1.0
+      '@fluidframework/test-drivers-previous': npm:@fluidframework/test-drivers@2.0.0-internal.3.2.0
       '@fluidframework/test-pairwise-generator': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/tinylicious-driver': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -8987,7 +8987,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-drivers-previous': /@fluidframework/test-drivers/2.0.0-internal.3.1.0
+      '@fluidframework/test-drivers-previous': /@fluidframework/test-drivers/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -9043,6 +9043,7 @@ importers:
       '@fluidframework/shared-object-base': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
+      '@fluidframework/test-end-to-end-tests-previous': npm:@fluidframework/test-end-to-end-tests@2.0.0-internal.3.2.0
       '@fluidframework/test-loader-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-pairwise-generator': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -9125,6 +9126,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@fluidframework/test-end-to-end-tests-previous': /@fluidframework/test-end-to-end-tests/2.0.0-internal.3.2.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -9234,7 +9236,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-pairwise-generator-previous': npm:@fluidframework/test-pairwise-generator@2.0.0-internal.3.1.0
+      '@fluidframework/test-pairwise-generator-previous': npm:@fluidframework/test-pairwise-generator@2.0.0-internal.3.2.0
       '@rushstack/eslint-config': ^2.5.1
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.36
@@ -9255,7 +9257,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@fluidframework/test-pairwise-generator-previous': /@fluidframework/test-pairwise-generator/2.0.0-internal.3.1.0
+      '@fluidframework/test-pairwise-generator-previous': /@fluidframework/test-pairwise-generator/2.0.0-internal.3.2.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
       '@types/node': 14.18.36
@@ -9388,7 +9390,7 @@ importers:
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.3.1.0
+      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.3.2.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/debug': ^4.1.5
@@ -9443,7 +9445,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.3.1.0
+      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/debug': 4.1.7
@@ -9497,7 +9499,7 @@ importers:
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-drivers': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/test-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-version-utils-previous': npm:@fluidframework/test-version-utils@2.0.0-internal.3.1.0
+      '@fluidframework/test-version-utils-previous': npm:@fluidframework/test-version-utils@2.0.0-internal.3.2.0
       '@rushstack/eslint-config': ^2.5.1
       '@types/mocha': ^9.1.1
       '@types/nock': ^9.3.0
@@ -9556,7 +9558,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@fluidframework/test-version-utils-previous': /@fluidframework/test-version-utils/2.0.0-internal.3.1.0
+      '@fluidframework/test-version-utils-previous': /@fluidframework/test-version-utils/2.0.0-internal.3.2.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -9861,6 +9863,7 @@ importers:
   packages/tools/fetch-tool:
     specifiers:
       '@fluid-tools/build-cli': 0.11.0-135362
+      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.3.2.0
       '@fluid-tools/fluidapp-odsp-urlresolver': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/common-utils': ^1.1.1
@@ -9907,6 +9910,7 @@ importers:
       '@fluidframework/tool-utils': link:../../utils/tool-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.11.0-135362
+      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.3.2.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
@@ -9928,7 +9932,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.3.1.0
+      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -9963,7 +9967,7 @@ importers:
       '@fluid-tools/build-cli': 0.11.0-135362
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.3.1.0
+      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.3.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
@@ -10070,7 +10074,7 @@ importers:
   packages/tools/webpack-fluid-loader:
     specifiers:
       '@fluid-tools/build-cli': 0.11.0-135362
-      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.3.1.0
+      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.3.2.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/common-utils': ^1.1.1
@@ -10152,7 +10156,7 @@ importers:
       webpack-dev-server: 4.6.0_yun2zgl4yozo3m574tzxmts4re
     devDependencies:
       '@fluid-tools/build-cli': 0.11.0-135362_webpack-cli@4.10.0
-      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.3.1.0_yun2zgl4yozo3m574tzxmts4re
+      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.3.2.0_yun2zgl4yozo3m574tzxmts4re
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.11.0-135362_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -10187,7 +10191,7 @@ importers:
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.3.1.0
+      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.3.2.0
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@rushstack/eslint-config': ^2.5.1
@@ -10217,7 +10221,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.1.0
+      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.2.0
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/mocha': 9.1.1
       '@types/node': 14.18.36
@@ -10240,7 +10244,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
-      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.3.2.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/debug': ^4.1.5
@@ -10273,7 +10277,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/debug': 4.1.7
@@ -10303,7 +10307,7 @@ importers:
       '@fluidframework/odsp-doclib-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.2000
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.3.1.0
+      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.3.2.0
       '@microsoft/api-extractor': ^7.22.2
       '@rushstack/eslint-config': ^2.5.1
       '@types/debug': ^4.1.5
@@ -10338,7 +10342,7 @@ importers:
       '@fluidframework/build-tools': 0.11.0-135362
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.3.1.0
+      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.3.2.0
       '@microsoft/api-extractor': 7.22.2
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/debug': 4.1.7
@@ -12482,15 +12486,15 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@fluid-experimental/sequence-deprecated/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-kZ0zg3UBWlWt2gxsGbEzZt2WyXr14Qacn3joBosuRN4lsj07Bh8KaMTcUGIwmPqX/L7rXiMH5faAjtHDgzm4KQ==}
+  /@fluid-experimental/sequence-deprecated/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-en6cuHzq1oZqqq9j5KUctCliagudHYIqORLByUGowe5pj1uqrVdodoZk0gQfAbFPNGSJyXSiBca76hj8HdJ5xA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/merge-tree': 2.0.0-internal.3.1.0
-      '@fluidframework/sequence': 2.0.0-internal.3.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/merge-tree': 2.0.0-internal.3.2.2
+      '@fluidframework/sequence': 2.0.0-internal.3.2.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.2
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -12512,6 +12516,15 @@ packages:
     transitivePeerDependencies:
       - debug
       - supports-color
+    dev: true
+
+  /@fluid-tools/benchmark/0.45.112032:
+    resolution: {integrity: sha512-mCZgefqxqEWiWNRb9SpUDb2xW+vt/tjx5wLAMG1fOPTEUSMMBwT/baIuDF9EURYq8MbysWLfZsuw5cE7zFYxMg==}
+    dependencies:
+      benchmark: 2.1.4
+      chai: 4.3.7
+      easy-table: 1.2.0
+      mocha: 10.2.0
     dev: true
 
   /@fluid-tools/benchmark/0.46.133527:
@@ -12614,14 +12627,43 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-ssjOZuumEqFh3TKZKIn6hXXpToDWu4me69lZxsDb4p8EUAUZX3E0P408j4F8QxPBOZefYfriV+ZdDYC0E6ft4g==}
+  /@fluid-tools/fetch-tool/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-cx7ImmVbVPAeu1AAlW/7wNXSQCqtetjKDFkyJuWgAwT4T5ii5UiOfcmARImV/E8OqX9YXkDWrQJUurwn1g0Vbw==}
+    hasBin: true
+    dependencies:
+      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.3.2.0
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-runtime': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-urlresolver': 2.0.0-internal.3.2.0
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.2.0
+      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/test-client-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/tool-utils': 2.0.0-internal.3.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-a0R5L2LZ74yvVnHPXI8eyqvfVisiSlZGs9QjZdSdH2CVwidpcfO7VJAJkhidf2cvKf6UcZDA4VvUJThD6zjEcA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.2.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -12648,30 +12690,30 @@ packages:
       - supports-color
     dev: true
 
-  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.3.1.0_yun2zgl4yozo3m574tzxmts4re:
-    resolution: {integrity: sha512-dUGqZW8f+zG8PWdIGTY92BcshNS8sO7F2Q3gnvev4LT5wPk3dvx3Mg8AWY5DnpZaLzzvXFPVE7/4iuFJVR8l6w==}
+  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.3.2.0_yun2zgl4yozo3m574tzxmts4re:
+    resolution: {integrity: sha512-6ej1DoYX6mV6rQMuxWsHAff7AypfbPKPSlL5dRc7YxSonj7yF6GJLWlyJcBaWy9+51cfC7/16ZgroOP+XWlqmA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/local-driver': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/local-driver': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
       '@fluidframework/server-local-server': 0.1038.2000
       '@fluidframework/server-services-client': 0.1038.2000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/tool-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/view-adapters': 2.0.0-internal.3.1.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/web-code-loader': 2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/tool-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/view-adapters': 2.0.0-internal.3.2.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/web-code-loader': 2.0.0-internal.3.2.0
       axios: 0.26.1
       buffer: 6.0.3
       express: 4.18.2
@@ -12690,89 +12732,89 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/agent-scheduler/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-amIWsqjZTd6XlYTJeBPm7g0ADgEnvIp80qgjaD/e/X4d8j9hgpO+5DGG/psXaKWB4cA85ZMfcCWVlUL6mWHNug==}
+  /@fluidframework/agent-scheduler/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-EXrrygI8QefV1XZcDd1SQaKnHiB8KIuYGt6NyJj8qAeJ0CdiPVjc34YdLyIyBY9aOkmDmqIpc9JlvH+pD4eYag==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/map': 2.0.0-internal.3.1.0
-      '@fluidframework/register-collection': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/map': 2.0.0-internal.3.2.0
+      '@fluidframework/register-collection': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-fW8NHqV9JZVEVDg2o5u99ibfRNhKwTQgi/kFGy9rlLW+5535VUaKeXjdomMVUTMmwmbzNuQX55R+P+UPY3atYw==}
+  /@fluidframework/aqueduct/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-ZjX7pPuTUPt/z1rY7aENDmf37FIsCV7nnCtNx0S9EUhkKq6RvpM90u9PXHy/TGeDACKNWnD9T3LfS+yuaIcQDA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.3.1.0
-      '@fluidframework/container-runtime': 2.0.0-internal.3.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/map': 2.0.0-internal.3.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/synthesize': 2.0.0-internal.3.1.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/map': 2.0.0-internal.3.2.0
+      '@fluidframework/request-handler': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/synthesize': 2.0.0-internal.3.2.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.3.2.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.3.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-fW8NHqV9JZVEVDg2o5u99ibfRNhKwTQgi/kFGy9rlLW+5535VUaKeXjdomMVUTMmwmbzNuQX55R+P+UPY3atYw==}
+  /@fluidframework/aqueduct/2.0.0-internal.3.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-ZjX7pPuTUPt/z1rY7aENDmf37FIsCV7nnCtNx0S9EUhkKq6RvpM90u9PXHy/TGeDACKNWnD9T3LfS+yuaIcQDA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/container-runtime': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/map': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/request-handler': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/synthesize': 2.0.0-internal.3.1.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/container-runtime': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/map': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/synthesize': 2.0.0-internal.3.2.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.3.2.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/attributor/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-8oGCM8JT/UBar7zu9dOfYHGLVsZVnqf/XlV2n9iqFscx7UBLApfYWtXjAaYBrU78sKT2YTZeBHUOgj0UNgTyVg==}
+  /@fluidframework/attributor/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-3B+AX6HydWyfYYVIcp+hw4QLxOTbABZbdtdtmFZIq5du5xseppPWHwl0XpyHkpqjs32LWZubR8GbqcpHPLk88Q==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-runtime': 2.0.0-internal.3.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/container-runtime': 2.0.0-internal.3.2.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       lz4js: 0.2.0
     transitivePeerDependencies:
       - debug
@@ -12898,17 +12940,17 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/cell/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-ndhz1eHJlhhjnID0+ScVvdz5rivz+wcZ0wXanKFd992F05avLI+O0tfaijTcrQzU1HKa2kOIDfpUIAEpEkEiiQ==}
+  /@fluidframework/cell/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-/Gg/SjmV/SNAmZrWxY+2yde2vcmhHOgLEE/vvVEd0au8LUKJy0NcpDImlgBdPFlZ5TImYQR4WXvTI4mT/1JBBA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -12938,29 +12980,39 @@ packages:
       events: 3.3.0
     dev: true
 
-  /@fluidframework/container-definitions/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-2NItX/2jneAEFLUQBSeSV8uXkRsbcg156L9pu7Hut1rjRYeEyUgBTvDR7SZ673Y6aB/C+kxRCG/kF/Q7CWfcdw==}
+  /@fluidframework/container-definitions/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-qwZ0+nVhxjhy6nks41S/hOTXg/6LowL4Qp1WGsTQ2qJEQ7iGzNkgx0tprLtcpe4K5Ak808R0WGB5N+GuRYhF/Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
       events: 3.3.0
     dev: true
 
-  /@fluidframework/container-loader/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-Kc5apLtps2CoI9/pPwy3xVBeSCuJe1FxHYPsvA0XQoId5vtEwxxS6Iqap6DflZDWopfRVXIdObTWj5c8v11Vjg==}
+  /@fluidframework/container-definitions/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-vq+nNMUez2se68SjSPdLEJEIoWYlreLbFahO2IuWjHENPcT80Exh2xKdiNcPzgsiNN6OrY0SRznm+n6WwNh+zg==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/protocol-definitions': 1.1.0
+      events: 3.3.0
+    dev: true
+
+  /@fluidframework/container-loader/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-bsFWzfqdPfyk7ldumau+Qngsk9fK+4Cd2hULUnZV9rmiYBQv3/BUL3+aSR6B6sdekvzBzOU8MWu+X68g+XNmmQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       abort-controller: 3.0.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -12972,19 +13024,19 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-loader/2.0.0-internal.3.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-Kc5apLtps2CoI9/pPwy3xVBeSCuJe1FxHYPsvA0XQoId5vtEwxxS6Iqap6DflZDWopfRVXIdObTWj5c8v11Vjg==}
+  /@fluidframework/container-loader/2.0.0-internal.3.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-bsFWzfqdPfyk7ldumau+Qngsk9fK+4Cd2hULUnZV9rmiYBQv3/BUL3+aSR6B6sdekvzBzOU8MWu+X68g+XNmmQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2_debug@4.3.4
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       abort-controller: 3.0.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -13007,15 +13059,26 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.0
     dev: true
 
-  /@fluidframework/container-runtime-definitions/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-vwgb8dqbjUuF7fomBYnFjEYnGJ3qqlrcTV1lUYQzP1eINNFJc4BoztNLyUv2NXX+f8Gwi1p2nhWiqcIDsaPG8g==}
+  /@fluidframework/container-runtime-definitions/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-AsXBy6Ct4p18O9hTlx11U91c4Gbx6ZHP/v4jhUst+UG0ODWsdw+T7xhCIhNR+iC63FuIuXzK10CLHtWrSWSShQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+    dev: true
+
+  /@fluidframework/container-runtime-definitions/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-qtG2AV9IzLisifDZRQQGXC+++j0BTr5+Rgew38qtAEEWlpjEXVQ2HCYUwVOR0Jit2nyBlP8YpzYR8YgOgN+XiQ==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
     dev: true
 
   /@fluidframework/container-runtime/2.0.0-internal.2.4.0:
@@ -13045,24 +13108,24 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==}
+  /@fluidframework/container-runtime/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-+jMECGYgs0CEa+MmkQ+8K8v7g5swxxpFY0cj9oDEVNgdUMmHL93dgUcPxi+M9O8HuDqKm+7KMU+8b9StOB6Myg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -13072,24 +13135,51 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.3.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-CzVTtjq6Tsc342dec7l2spWsb0AFZ3DTZSV9PhjayUUg/IIfpXf40HZWH/Akchxkq4ji/b0AlESp4H8W67L0Rw==}
+  /@fluidframework/container-runtime/2.0.0-internal.3.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-+jMECGYgs0CEa+MmkQ+8K8v7g5swxxpFY0cj9oDEVNgdUMmHL93dgUcPxi+M9O8HuDqKm+7KMU+8b9StOB6Myg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2_debug@4.3.4
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
+      double-ended-queue: 2.1.0-0
+      events: 3.3.0
+      lz4js: 0.2.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/container-runtime/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-x6Zk43L6WhtvmfBgqSNGQ3OPZ1oNoll4If3Gz+o6ib4REOVukukZpmReHZ+VPYHTrp8gvEfhiaigMG/UpgoVlA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.2.2
+      '@fluidframework/protocol-base': 0.1038.3000
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -13111,14 +13201,26 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-utils/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-R3XBiqeXHmihaIKwmPKBnudHra0H4H5iN04nJHZZSnTDiYCBugapiChmhCxHS44Rkhha1LXWQy20/oXXTcHUrg==}
+  /@fluidframework/container-utils/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-KZNRvslw2GiZeP2Ig1SUYzRswCarwK25LFnNAgRJo+xhZ7A1qi4eYi3aUiQeteyxjPyFwKTRS0tfc52FuX9cpQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/container-utils/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-TPFQCCOI0l4igh/xG4AddnSqeCQAzrQNwRzGtAsvyHVHvuM0AdRfIZnZFzoR7BiCSx1WbFSmLUkKP2/XC6AE2Q==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13127,39 +13229,43 @@ packages:
     resolution: {integrity: sha512-Fnox1Hgk7PbhVCH1lCQe3Cr/204r4vaQBSOYLMfO/ai3xvfy9oirEfFcBYdt3+5gs2f+fY85ip2zvmE0wTXwyw==}
     dev: true
 
-  /@fluidframework/core-interfaces/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-XI4a/gc9bE3rGHO5Kq2zF+aCHlDSeRi0tKDJnYCbXzgBSUsXVthSz5ueMKJ0fO6FNMfc8GS3MHKy4G8CVw44Ww==}
+  /@fluidframework/core-interfaces/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-6dX5P+uxxv5QxZy+uIuV4QH7FQeaLvlxk2+u9qdhZI4z5CL77F3XkO/UU03h7mAOQsJ2fmi/63uYOKQxdDVFPg==}
     dev: true
 
-  /@fluidframework/counter/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-/dvu6kMUOgwbpgRnWmeRvzwmQJUNYX4TDUZ1ZenOxzxeTXDrOTMMrsFsby8+4iJYShbAtAMoFbwDzwQMjWHDXQ==}
+  /@fluidframework/core-interfaces/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-/JGlFAQMKHgqFtMeubDu5w7W7FKFCw4ek/JpmS3HMitqdVuZnwBFkkLoMgJ8Z/rnAmVZpMQWmlcCyZAI7kwbbQ==}
+    dev: true
+
+  /@fluidframework/counter/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-9gIvOC706DCHMRVhQ5asmnnyOJC1tLuY8xQU4Ra6eq796cmQMuEr++O+Aj2qZyRPYxlqntNtO2PT/Lg4/MQX/A==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/data-object-base/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-tuhzvNycjGO/VBrrr3+nJuX0sUX6Okm3VZ/JZ1RHmwKefvZlUieNGiNpfnPbbJFgpvK2z9kqAUNO/jTxjC0nrQ==}
+  /@fluidframework/data-object-base/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-fCqEgSFmNroHixhVbA34FaFYXd5luAVtBPQb8k5Rv5KrDuImCdFpttg8kt/iQBIKiAiOH1YSPb57kDOcnUfedg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-runtime': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/request-handler': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.2
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13176,15 +13282,26 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.0
     dev: true
 
-  /@fluidframework/datastore-definitions/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-kVWxpqO7RxPweXLnZGMBWhtdR6Yx3r05jIcnPhpENWl2vObgQhxjAE8ry2eRHGAqQmNIqXeRhdy8tLCfgm3cJg==}
+  /@fluidframework/datastore-definitions/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-FDVmQu1ak8tSx+5G2mWSJgBG1eZkwR1tSLzzaKTUJbW50LjvQ1zy/rzOig9m2sYToneIeeqLZjnuKSOZQFm0mQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+    dev: true
+
+  /@fluidframework/datastore-definitions/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-TB0qCkESc60gDdtD/TLT4X+802XqeUcALRU8lFbPJUyNBZDI9EKYSZi/ARIToTnvCWmoKGncf4FmB/b74TuSdw==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
     dev: true
 
   /@fluidframework/datastore/2.0.0-internal.2.4.0:
@@ -13211,23 +13328,23 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==}
+  /@fluidframework/datastore/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-TVjht4LLXjTL6vdJLVNizH52btN14QZXgZL9PQKRoCLsqJOxWbOCyz7zOq7dAo6vpBv/AQUbECf9YL1d8eVurg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       lodash: 4.17.21
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -13235,23 +13352,23 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.3.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-C6iB0C7RXBApyisOU9dAp2hLBPbfpxZF7qCqfsNHBxsVVoWxrAbBXCiByiqqAD1qZXpY7JXh5HGukiHLUzx+mQ==}
+  /@fluidframework/datastore/2.0.0-internal.3.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-TVjht4LLXjTL6vdJLVNizH52btN14QZXgZL9PQKRoCLsqJOxWbOCyz7zOq7dAo6vpBv/AQUbECf9YL1d8eVurg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2_debug@4.3.4
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       lodash: 4.17.21
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -13259,56 +13376,80 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/dds-interceptions/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-kMkScfi+QkyLVg14LYkKE+2diAcdvuLs4Abf5B3KV5yXTdO9DkpGPGFu9SidFLmQEdkKj+8d5C70k6ewp5DLzQ==}
+  /@fluidframework/datastore/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-Hia0OsVGY3M3xtKK1ceayYTN2Xmn1I/OBfD7yrHP4tLVGEQX8obdO7HK3M7C6UGQzeTFDsQSr281DMPJvZAdxg==}
     dependencies:
+      '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/map': 2.0.0-internal.3.1.0
-      '@fluidframework/merge-tree': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/sequence': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.2.2
+      '@fluidframework/protocol-base': 0.1038.3000
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
+      lodash: 4.17.21
+      uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/debugger/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-WadsiDxc6PAWtRq/FJFf+Tx4CKzU46+Y8V4abMG0GPBJjqa/fOMP0k7Ft+VXcHV1pZki+ql9+eQr/o2OFauY2w==}
+  /@fluidframework/dds-interceptions/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-SvIY/J9FNiQGXY31WWvW+vc6Pwoec6dBV+frwuh55+a0Y2kQL+SF6BqOrVBG9MzmY85FYZJUIiNDooGUbANhnw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/map': 2.0.0-internal.3.2.0
+      '@fluidframework/merge-tree': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/sequence': 2.0.0-internal.3.2.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/debugger/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-2C+zFZTx+nwSAZ34pJ7XXvj92y2fApnIYurRqTTHn0NuzbYAd99ovyASjPMFuOmAyCATHk4G4wQ6UECJNMuSkA==}
+    dependencies:
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/replay-driver': 2.0.0-internal.3.1.0
+      '@fluidframework/replay-driver': 2.0.0-internal.3.2.0
       jsonschema: 1.4.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-J8O/UBo2f7k3FLHWInsTW/QZ2pdSvzIXyasUumx2u48lBQArykEouHdQPK8Hct2CbuHNhY0Vq7SO0Rle3Wgqng==}
+  /@fluidframework/driver-base/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-xPH31GtvDo4qLU4o/F0GYv8iwVWTmTYEJF279XZzbWpSNzh/kTAHD7ALeNFuE9cAZht3p1Ypi1wVJ0FPR5IiRg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.3.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-J8O/UBo2f7k3FLHWInsTW/QZ2pdSvzIXyasUumx2u48lBQArykEouHdQPK8Hct2CbuHNhY0Vq7SO0Rle3Wgqng==}
+  /@fluidframework/driver-base/2.0.0-internal.3.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-xPH31GtvDo4qLU4o/F0GYv8iwVWTmTYEJF279XZzbWpSNzh/kTAHD7ALeNFuE9cAZht3p1Ypi1wVJ0FPR5IiRg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13322,11 +13463,19 @@ packages:
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
-  /@fluidframework/driver-definitions/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-okVoDj7TN3ELn9EJECVixSVV3sepwMnYkWXjH4r4LDkmXVPiSOC+Mq0JYCxItvvGVyVoMre16M7f+ekOat18uA==}
+  /@fluidframework/driver-definitions/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-dw08xt+k6/FZ70P1cBh2N6aiglWxbkehcVoPlDSrafnmZ+jYiA68ql8SBj7hbxnPtN+G9zy+baCqN3ah9tqyEA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/protocol-definitions': 1.1.0
+    dev: true
+
+  /@fluidframework/driver-definitions/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-85xRX8N9JbtRmm2DCYN4l7QgQ6Rj4xOOl+wxay3wQyGhCgpnKWbCMjzNxYy3ZxhQ2XOWub/EnCpZIt4PUClNfA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
@@ -13349,17 +13498,17 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==}
+  /@fluidframework/driver-utils/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-tZgy1yoTTmeZkPDErRaTV5bd9X7Rte8WX1fq/X4nIowBVPQfTCVTTiPk4Tn4yFfD4SJGTrs5efJ6mpDNmQlKZQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
       '@fluidframework/gitresources': 0.1038.3000
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       axios: 0.26.1
       url: 0.11.0
       uuid: 8.3.2
@@ -13368,17 +13517,17 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.3.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-QNis7N8deKKTWAfKzEaud4j/7hvbybsqs5a9mQTLfg/c5wNgNU0r1BFo/fZikrUb4wmmmI7HyPy5JHQkjzHE2g==}
+  /@fluidframework/driver-utils/2.0.0-internal.3.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-tZgy1yoTTmeZkPDErRaTV5bd9X7Rte8WX1fq/X4nIowBVPQfTCVTTiPk4Tn4yFfD4SJGTrs5efJ6mpDNmQlKZQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
       '@fluidframework/gitresources': 0.1038.3000
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       axios: 0.26.1_debug@4.3.4
       url: 0.11.0
       uuid: 8.3.2
@@ -13387,12 +13536,50 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-web-cache/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-mlF3bVz5YqJKcYLt5gOVeqSQOuZQX8hFs8/HAoDKTKNzQdRi+K4IqPnM6S20phq5vI84+U/ZcKSgGVGWhoyaTA==}
+  /@fluidframework/driver-utils/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-5crkHkCskJ3hHZQs1+v2ahy7MxgGDgu7FyuDX6w2UP0hFEzzsUdPSU3+vNSHaHev2pZesd8MHYqoXfd2oi0LsQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/gitresources': 0.1038.3000
+      '@fluidframework/protocol-base': 0.1038.3000
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
+      axios: 0.26.1
+      url: 0.11.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/driver-utils/2.0.0-internal.3.2.2_debug@4.3.4:
+    resolution: {integrity: sha512-5crkHkCskJ3hHZQs1+v2ahy7MxgGDgu7FyuDX6w2UP0hFEzzsUdPSU3+vNSHaHev2pZesd8MHYqoXfd2oi0LsQ==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/gitresources': 0.1038.3000
+      '@fluidframework/protocol-base': 0.1038.3000
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
+      axios: 0.26.1_debug@4.3.4
+      url: 0.11.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/driver-web-cache/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-x38jxmQF4btBMX3oFvZcYQuk8gm7btN+UE4/E/Sr/a1ByRXxBLELUDA1sNKRdJ8lyN/s4WXtrvcS9HD+UtbcJQ==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -13424,33 +13611,33 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/file-driver/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-iwiBnsoXjxO/qgNOUIBTSyQH4ZGOkT2pHDeUWjy+aedbue1MN2y+u7xXRyryNeLeJT0sAqbbl4O+57vmdOafDQ==}
+  /@fluidframework/file-driver/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-9ZCP9VjvxcJXi07KJlrf7VvkFsVf4Tlf/KBX0g+GRyoBxyp7F55vNtEzO9s5Jsu8v+a+ZV/S4sITZR0TfJ0A6A==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/replay-driver': 2.0.0-internal.3.1.0
+      '@fluidframework/replay-driver': 2.0.0-internal.3.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/fluid-runner/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-o1i4TtHv8cw+f2FB6EZ+o/6nOTET/sroer4we8oW8TgdwOUP6XUmkTnpUNtC/1thAf0MkVGLSYb2Ej7bHoNuDg==}
+  /@fluidframework/fluid-runner/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-xWUIaNfEHNv8Nl72z7ESqJE1nPO3IiS3CeTpgTlRD5KZunkj45LBEDTKW1gW3U0zG+Ud1pU7Jeq2l/EnsNlXmw==}
     hasBin: true
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.3.1.0
+      '@fluidframework/aqueduct': 2.0.0-internal.3.2.0
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       json2csv: 5.0.7
       yargs: 13.2.2
     transitivePeerDependencies:
@@ -13461,21 +13648,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/fluid-static/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-83Gzt/LVludXzq7RZadJyIR797+rpdg4fo3moJCfl1B00v1IaijycJSUhU5Etb4GlIk8vmfI5l8pPTD9hkWNmg==}
+  /@fluidframework/fluid-static/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-0OesqwiGz9ctRDdZWlKyODFYY+cag8eHdDDBwDGeXZWu89n7yE8lvm2o2z/xycmuRpCJ2twJFRDMINk1rHNIug==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.3.1.0
+      '@fluidframework/aqueduct': 2.0.0-internal.3.2.0
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.3.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/request-handler': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13490,51 +13677,60 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.0
     dev: true
 
-  /@fluidframework/garbage-collector/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-1wBOsep4KwGs6k01UG/jSBgglHP+Jky5XziiEXoUP6SWWs0AMyd8zNSgzE86y0XKIbnu7kCLcMgFRd1zw1BzNA==}
+  /@fluidframework/garbage-collector/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-tQ/+eIsM23fJMENXncgpgSm1RG/QN6yF35KtHNvkNGgJxzFP5j6g670tqoI68hssfNkSH33BLicQrTkxGVQwJw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+    dev: true
+
+  /@fluidframework/garbage-collector/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-rQYJyLLur2VYzMU2koln6yw77ULK+paUt0MNDXd91nsCymsR1mG0go+aIdWx15l+k/IljFd0o+wLx4+XOkl5Sw==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
     dev: true
 
   /@fluidframework/gitresources/0.1038.3000:
     resolution: {integrity: sha512-w4vuRUnb6t5hPVq5/4vYDC41NRhS3SXBwcaRIPJ1jT8/H792BjVT0tKnR5x/sqR6maKOLdll3Z4itzq+pdeisQ==}
 
-  /@fluidframework/ink/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-HZm5IvHJoBDMCS5KbcmmXyQI+i5mvyxXzbBTM6c72La68mUFEvM73Uj+6cEH61TCLgXjX1vUqz9HqM/FAkjxhg==}
+  /@fluidframework/ink/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-ylql+kDaPtPp1GvxC2ysIcveFQrOVhhslLLHD0zwzlnIBDDjPrkZQ3++lSxRyMWKywL+ITn794/GPImC4bg1oA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-ato6fpQhy+AbOZRIcuTjy3PT5940sbsvwm6DrXEIH2eQlxDqov0u6oJygQibnbAq/fMJOIsupASSMWbSdLCNuQ==}
+  /@fluidframework/local-driver/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-ctAHUgpIN8C6fcfJppeZIGlwGJ3QE2kSYkFndBERIY4Pb90P6HPy8xCXbEIZnNH0cDOXwRcT+w7aYHg+sn+V8g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-base': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-base': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.2.0
       '@fluidframework/server-local-server': 0.1038.2000
       '@fluidframework/server-services-client': 0.1038.2000
       '@fluidframework/server-services-core': 0.1038.2000
       '@fluidframework/server-test-utils': 0.1038.2000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       events: 3.3.0
       jsrsasign: 10.6.1
       url: 0.11.0
@@ -13547,23 +13743,23 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.3.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-ato6fpQhy+AbOZRIcuTjy3PT5940sbsvwm6DrXEIH2eQlxDqov0u6oJygQibnbAq/fMJOIsupASSMWbSdLCNuQ==}
+  /@fluidframework/local-driver/2.0.0-internal.3.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-ctAHUgpIN8C6fcfJppeZIGlwGJ3QE2kSYkFndBERIY4Pb90P6HPy8xCXbEIZnNH0cDOXwRcT+w7aYHg+sn+V8g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-base': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0_debug@4.3.4
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-base': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2_debug@4.3.4
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.1.0_debug@4.3.4
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.2.0_debug@4.3.4
       '@fluidframework/server-local-server': 0.1038.2000
       '@fluidframework/server-services-client': 0.1038.2000
       '@fluidframework/server-services-core': 0.1038.2000
       '@fluidframework/server-test-utils': 0.1038.2000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       events: 3.3.0
       jsrsasign: 10.6.1
       url: 0.11.0
@@ -13576,69 +13772,69 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/location-redirection-utils/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-VkGL4gHJNHdQhHaev+9nkmzArm+3C2WCntt3lf4n6ma2NCIGk556a4ONp4aqvsMDP+7BpO8PId4z+C7QSu0Btw==}
+  /@fluidframework/location-redirection-utils/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-RZhB/NjJI2LG46I7qMlXzsRYo+vLGQPmWtFmaO2fZozIMhFZPV0NXfwxcL4BySpsc7aPkp3Tom22iD0Q5exNcw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/map/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-tvdOOshLtCbDBNXVZC5PeLgbUeMUwGWBhqFHQNnrRas+zm9itmV59bVZdW1OCsxc5yMLIrEWbXAL+VMV8Xj3VA==}
+  /@fluidframework/map/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-CZYl0nj9Zvb2ibEuRjbE62tuk1sNFV5Q/vVDmXlnbTGnbeqxcQ5nknQCcAU1FZzH1kEZibqG0/3CAZQRxWhySg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/map/2.0.0-internal.3.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-tvdOOshLtCbDBNXVZC5PeLgbUeMUwGWBhqFHQNnrRas+zm9itmV59bVZdW1OCsxc5yMLIrEWbXAL+VMV8Xj3VA==}
+  /@fluidframework/map/2.0.0-internal.3.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-CZYl0nj9Zvb2ibEuRjbE62tuk1sNFV5Q/vVDmXlnbTGnbeqxcQ5nknQCcAU1FZzH1kEZibqG0/3CAZQRxWhySg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0_debug@4.3.4
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.1.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.0_debug@4.3.4
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/matrix/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-8uFxameyPF5O8Sp5z2bDCw7wo/iJ46my45l05YAXTDlJa+qfhphg40jw4ZacSpvRtZZ2DyvXauZ1ys80zg19gQ==}
+  /@fluidframework/matrix/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-HghTmkCx3BWIWaAz4qA9Fm3V8TKGmqmq4v2jRztCnoauxRhDiPflkz4bqhEkxPpCZQodaIVJZfKiBq5z+quZ5A==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/merge-tree': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/merge-tree': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.0
       '@tiny-calc/nano': 0.0.0-alpha.5
       events: 3.3.0
       tslib: 1.14.1
@@ -13647,42 +13843,61 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/merge-tree/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-/Hu7Ytke3xJgSde+EY/qnNVIKh9bROeJkHxBXAvThHdGbr+k4dx/HBfn4cgQ0zfqP8zO4FGXc46xJY9D+qCNsg==}
+  /@fluidframework/merge-tree/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-cazYDLeIXz86trBbCNVhiMnOffD9+QChuWKfa+H/USykXjCPfs/jQIoNbAaDeLyI8jrsfGb4YyCL2ZZmgYmyWg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/mocha-test-setup/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-EwiY9V2mjN8px6lakrNeD4RYWTi7ERl6W5c8XLcXCoFCIOh7P4yBYondYogghcnyWjs+wivwg9Vz7uQEyr6RVg==}
+  /@fluidframework/merge-tree/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-xPies+5mgwiJy4P7bpvB/iLTLw2HkleUdSNhY9EbWgln1XLNtuecHlPK+DSOqOdiN5K75gLZA0a2SuoIcY0PUA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/mocha-test-setup/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-LZMcnGk1ccVak3NOsLaM1emUNIS6+Un3Ivdweo0uz8GF5WJSgeDTLxthjwX3GO6OQ7xiUpMk0OLXyAeguBjmCg==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.2.2
       mocha: 10.2.0
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-Sv47A4jGSycmBgolM42ir2/OO+BfA2Vj5JGvDdtTm10UQp5xBsVCY6Z0U6/aPZ4j05D8XaahX5+6HJ5fJ0KIuw==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-GshBGwxZwbt2HjUVfRTInLxGcT9feybg3iJXVNcSBsEsv2lBavxPdSQEzXUmY8sYcKSj6f98ZBFEUgvtLuhrTw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       node-fetch: 2.6.9
     transitivePeerDependencies:
       - debug
@@ -13690,15 +13905,15 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-Sv47A4jGSycmBgolM42ir2/OO+BfA2Vj5JGvDdtTm10UQp5xBsVCY6Z0U6/aPZ4j05D8XaahX5+6HJ5fJ0KIuw==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-GshBGwxZwbt2HjUVfRTInLxGcT9feybg3iJXVNcSBsEsv2lBavxPdSQEzXUmY8sYcKSj6f98ZBFEUgvtLuhrTw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2_debug@4.3.4
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       node-fetch: 2.6.9
     transitivePeerDependencies:
       - debug
@@ -13706,27 +13921,27 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-Ky6lRRO2KaSnPJeTsFYJu1geimtQDmN4+/1v547k1ekoBQNg2179a+6nWXGBoyTmwBkfQ5K56JZ0Z6Fl0EcCow==}
+  /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-S2ojncuUUXmznSdHJdPk1JTQiVHGisyNvBJ3/Q6ZlwwTBAxg2Lge/3IxOSpqaZJCwzuWNzxXoXRSEmtdcW+u2w==}
     dependencies:
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
     dev: true
 
-  /@fluidframework/odsp-driver/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-7BoZGHSKxjv9czZBHEGdM/wVrdqLQ2UCEfMBleRAX/aSW/iUoGzsqfwSpI3L9A13+iAfY04Lypfh7Wth0uNewQ==}
+  /@fluidframework/odsp-driver/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-ell+1uDdrsAvDX/c9sowlrvwzeMYYg7S+EWrPyomjKSyU3SKBjoXFzPXyWWl0eXEx0fokefmNROrorpBff11ew==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-base': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-base': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
       '@fluidframework/gitresources': 0.1038.3000
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       abort-controller: 3.0.0
       node-fetch: 2.6.9
       socket.io-client: 4.5.4
@@ -13739,13 +13954,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/odsp-urlresolver/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-54ejRWu4nBHn1krkI3ArPef7claEN6h5dOeqhnp9WtiJPhUrK1lBqB4FjJRQo9OcFObyVSL104UNGaqY3k3r1w==}
+  /@fluidframework/odsp-urlresolver/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-nipuppWvjBzcyHNVac/+ApOM1GyIfgreV3BShmseogY6/E92R0gjtl3btfPwk0LUxsEaZhCcWfRIJ5HJjc7IXg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.2.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -13754,16 +13969,16 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/ordered-collection/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-gBTJL4G8OYRw1dSe1Xf6YKsz8PCzFwUaHcGzgLGMregdtlbnjyHPvr0igpuggyTIsQxCd+/rMrAnnYQQ5jtWSg==}
+  /@fluidframework/ordered-collection/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-44oSz5XqCOVs9WHaY2gFaw9r/WmldVL++Wq1O3655dcZTdAm79XtSk5Bj2m/0gAxUBmYm/pxKBXGEXcJHzg3TQ==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -13784,60 +13999,60 @@ packages:
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
 
-  /@fluidframework/register-collection/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-pE7++Vp7QOqTq8eGtaxMOAjAf7NTlRUxbkT+Ev5qzN0q7UxC7aWmkjXPs/yQHfXIxY65CT0tuhOZIHqEeIbasQ==}
+  /@fluidframework/register-collection/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-rFBMkXx+sxpGrOhjS08soiPoKFjU2ADU0DMyQweo3mqx70RmS6CsKvuohfjL0PnWeY32SCgJ35MYUeypVfRqOQ==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/replay-driver/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-nGgGyMN9FYmSsTSlk0o2gKKdSU0TTd+WIUHCFQqckOn+D+1Lh/kGBRtLE50cDmSMYyMN4SQTZicm4cupErN64g==}
+  /@fluidframework/replay-driver/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-mS7oI16b2+SrfsTmuEx5w9+wROIavR5nMlCRWLS1PK1KzDeJ4HwH8xDa6DPe7rYP6PfYyLSryPrCNmNmitHOEg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/request-handler/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-cJLxF6bpiwBspO/idJY9ktR5dYWkZ+UJpO7/ENAXQkPlpS0nvxyJ00St5aL7M43+7U+zRnA9vmXD7MzElVnE1Q==}
+  /@fluidframework/request-handler/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-Ibo63Q8Tx5f/9RG0k9/XGK7naoMphyLGjmYmVP6GEfF7P9QwXKJ1rdXNL+LvtfN8uSHuWmNygZ2YWnjhq+X4bQ==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-6dk+i2Ac/aybpeS6JnLIFLAwgNb5XF3oLxyL9G+dQ1r1HvoVr/8y3FVZTGjxSUb+MdVv5axytLbNlVy41vlIIQ==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-gLLONsTz1trnW1wtCQtXhPyYdy+qQNcI4wNs+ZfPviWKKFwG8LAd9o6lX6VTB7f6CXani3q3USffFvrxKQDhPA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/driver-base': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
       '@fluidframework/gitresources': 0.1038.3000
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
       '@fluidframework/server-services-client': 0.1038.2000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       cross-fetch: 3.1.5
       json-stringify-safe: 5.0.1
       querystring: 0.2.1
@@ -13852,19 +14067,19 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.3.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-6dk+i2Ac/aybpeS6JnLIFLAwgNb5XF3oLxyL9G+dQ1r1HvoVr/8y3FVZTGjxSUb+MdVv5axytLbNlVy41vlIIQ==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.3.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-gLLONsTz1trnW1wtCQtXhPyYdy+qQNcI4wNs+ZfPviWKKFwG8LAd9o6lX6VTB7f6CXani3q3USffFvrxKQDhPA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0_debug@4.3.4
+      '@fluidframework/driver-base': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2_debug@4.3.4
       '@fluidframework/gitresources': 0.1038.3000
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
       '@fluidframework/server-services-client': 0.1038.2000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       cross-fetch: 3.1.5
       json-stringify-safe: 5.0.1
       querystring: 0.2.1
@@ -13879,12 +14094,12 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-gyZThjWTjuSJGFDJ4PDYd/H8PcBKArBFnGObS6iaVK/NZdubGqrccnQgPMsmO7Y3aChgtmzuxjUnKc4XlsDPCQ==}
+  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-ol2F4Ux7sRq40JS3D6BUUfd/yqTGjhNaw3AMWm2HfeQ/hizFNAckvLdeqxFzJg//3bEGtueaQ1CfUFUPJebIsw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
       nconf: 0.12.0
       url: 0.11.0
@@ -13901,14 +14116,25 @@ packages:
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
-  /@fluidframework/runtime-definitions/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-d+MgQ2fLQ+6Gpw2ZL1Hz7dQ4WJEEvIM8uJ8JS4f+9RR1W2NNqP18hQbndpokh4RGs+RBZBxkwM20CIgP1I/RcA==}
+  /@fluidframework/runtime-definitions/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-l28uA04tYt9c28yo0kexz7cw0sgwVkce0ruLfvpE6gHtxG/mnbJO6NzokBTL5TDdF6pVukzMhUBzSTRT3RcYHw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/protocol-definitions': 1.1.0
+    dev: true
+
+  /@fluidframework/runtime-definitions/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-mdGMs1wcudCO+Ae4+MCRYB54IYDq72vJkH5LjRcCPhDsg1uLCrPIPWrrmV43sstlRgXEw+6z+8VoRTWRqaRdFA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
@@ -13930,39 +14156,78 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/runtime-utils/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-wj++gtOu6LdJ80xp8fv2TE45Jb3BHZP4QblyTY6g3ZHCU47vtY4DEklFGmYJK5pWAxbwj9kcDEkp0On6qlvgpQ==}
+  /@fluidframework/runtime-utils/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-EG9kLvnEERriEoKQJAq6gBfzQK7gk412zFjiTaYSvVN6pzY+xNB3OXnxjmRMOuYOkOu9N03dAuoAZ4Mu0TMU7Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/sequence/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-INsbIn6GmGt7Kwbg+ExEoe4X3BNsNVWhRSgaj9dnWv/gQtySHOiXNF71RslAuNdzZ8ssfQwqjvHimt/Kvvqmzg==}
+  /@fluidframework/runtime-utils/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-20zvGrvSUgKH6O8MijvRU7vDQCmxP+N088gcTG/denOwIuLp7wiMYNpu815/77k9oe2uuRhSmfJsWvH0ONjcQg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/merge-tree': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.2.2
+      '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/sequence/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-I6UCsATCKKGfftrSnEOHs4JtZfAmIezO3V34IB6G416ykiOn9iSrzj3gpfiHG3tFFGwOzREODYR4DeMmtDn3bA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/merge-tree': 2.0.0-internal.3.2.0
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/sequence/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-cEk+7JUvXcJw0aYgJjru19Euj5k73Qfiu0NH7rvhxQ57HyiLXnMxqfoeEnnltGw9m48uKfZmhAfrA/wEaucX1g==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/merge-tree': 2.0.0-internal.3.2.2
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -14211,80 +14476,101 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/shared-object-base/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==}
+  /@fluidframework/shared-object-base/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-n9aSMWNx+s12WDkfxJVle2BWr9glvQSfNxVl5ZUSji6fcP8TRfBEhZl8oblqJVpMjTLuoYbS25rfegZPam3bmg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-runtime': 2.0.0-internal.3.1.0
-      '@fluidframework/container-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.3.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-object-base/2.0.0-internal.3.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-uT8YD12XmNvj0JX8++vuVNmGSVHw36L0NwBXqjZA/ghpfxzTAFOMxxfL05iBXcCPHtzSEbXMmmno6tBXU4sopg==}
+  /@fluidframework/shared-object-base/2.0.0-internal.3.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-n9aSMWNx+s12WDkfxJVle2BWr9glvQSfNxVl5ZUSji6fcP8TRfBEhZl8oblqJVpMjTLuoYbS25rfegZPam3bmg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-runtime': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/container-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-summary-block/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-+1vo7IGiGHB8LeEemNDkyyrzxJIdauSFswr2eXiNkW49PWkY80eZo9NFkjZPz2ahKN+3gb88SLeDHtpLJjG3QA==}
+  /@fluidframework/shared-object-base/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-pPLgo7i2oI0IwowW9MDMiLBbopZwOD4rf8XZxoeg5doEzXGNLNs+BAbUX2sJTCT94QoSr8WLmV2Uv9RRPMDQXw==}
     dependencies:
+      '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/container-runtime': 2.0.0-internal.3.2.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
+      uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/synthesize/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-/1yPs0z8QJyCryyXSHQE243ey+2OPEzaLhgug3dlwKQ7839L0bnGd2FhYgtdVRx7DiLP5pWWHnAS6+W00mEwbQ==}
+  /@fluidframework/shared-summary-block/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-xNKeEUKtFSj/wTOkGKNmV/C6nOBDHxd3Q7aGeiLEaKEFASDGYvXOahpb2KkWcjLQ7YlzG9sx9j5iHbyKpEE37Q==}
+    dependencies:
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
     dev: true
 
-  /@fluidframework/task-manager/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-Z4El3LxUud+cXlZhK3n5wRqcPsej9XmavTpoPDL4EjIX5YwpwaLjRBi4anyZkO3i6Howp2oKQYUSJ7gGTkOKbA==}
+  /@fluidframework/synthesize/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-lJbTdNe2vl/zpawe5i3MnFcslaBQLxMLWs8S+miFTGL5GkVeisFZ34D+q8Cm7EMTb0/Kv6z90kMEfs8LCQDsOg==}
+    dev: true
+
+  /@fluidframework/task-manager/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-W0LGdGvFff0+T0UD/94NI3TZKcK13nHOsL98yHC5w2bGn0Up7yJmOfo82zAGe0XGSVu2lZ0SWLkmlLfE4POFRg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.2
       events: 3.3.0
     transitivePeerDependencies:
       - debug
@@ -14303,8 +14589,8 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/telemetry-utils/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-Cbb1DmxzVu71A/Ip2/qgyVf2xBz59OuykePnNHQL7rsBGPzFV1/Hqs93eQATHJGbJwRiXvh8lCdwHeHbj0N8Bw==}
+  /@fluidframework/telemetry-utils/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-+h+r/mSNsEUAoqmMtcm6ETb+LAohD92TJWnPrE1r0VM4pgbSry1DBWKwohnIkYOFdgW4Nh4mAMU8MMzZOWB3BQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
@@ -14315,11 +14601,23 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/test-client-utils/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-sZamfGoIjw66byikx/oAQSwc+ZspgZEz9jvAxQ1GF3RFYgcT0oOr8oefQ9q9EspdyHESaLudSiK5ZcbDB48dEg==}
+  /@fluidframework/telemetry-utils/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-ge2hidTqP6PIKCFYUFn6m3FjHFpvzHbXwv+JhMpdNdq/xIy6Ae1xkeyitFOVFL7CEgBCf3SuSXdMq4mzBd6uCw==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      debug: 4.3.4
+      events: 3.3.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/test-client-utils/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-WylamsOD6oCcOq6sYhU1woplNW/YKyABnjjAOCIyRnrraDDaZEe9PDVGGaomNXuicLGu3oASxHfKBC8vqAGLVA==}
     dependencies:
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.2.0
       sillyname: 0.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -14330,36 +14628,36 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-driver-definitions/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-EHhNRZiUJHNYF5QJYoK1sasd22PzmNPuStkgxX9sVZAOoQ/SSjfu1QWLRxS5bN+HRXdRnjBm+ZxjWeDQypxvdg==}
+  /@fluidframework/test-driver-definitions/2.0.0-internal.3.2.2:
+    resolution: {integrity: sha512-F/gbsN5sZWFzi4QgWXzZ+BJ2t/DOwwTQKOFgQZ6LYuvrxaYez5yiNj/9HEbCgwXOang8g7qCBde9MjecPc88tg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
       uuid: 8.3.2
     dev: true
 
-  /@fluidframework/test-drivers/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-D4Zy71wSjXTyg509pp92eKtpLuOx3UvTx7rRfH2K/NH7XFruP4TK2Mqonmt8Pb2dUgOiPBLDQUi5l1/gFw0RVg==}
+  /@fluidframework/test-drivers/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-Ai8sjFFhINr2bzPh56IohVZ86O2F4vqqhbJHAz4xidKsFTSpmD+guhp0ogHVITumCEV94nkacQeN+LgKvSkIog==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/local-driver': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/odsp-urlresolver': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/local-driver': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-urlresolver': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.2.0
       '@fluidframework/server-local-server': 0.1038.2000
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/test-pairwise-generator': 2.0.0-internal.3.1.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/tinylicious-driver': 2.0.0-internal.3.1.0
-      '@fluidframework/tool-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/test-pairwise-generator': 2.0.0-internal.3.2.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/tinylicious-driver': 2.0.0-internal.3.2.0
+      '@fluidframework/tool-utils': 2.0.0-internal.3.2.0
       axios: 0.26.1
       semver: 7.3.8
       uuid: 8.3.2
@@ -14371,41 +14669,103 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-loader-utils/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-VsGG3r9U+hv/2mKHrqUoPGfPyqCxzSQtqKKm3V0D8gY5XHp9EdTX7pjGcLFzdtlNS9sVV902IO6Z2VCI+untEQ==}
+  /@fluidframework/test-end-to-end-tests/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-/Altf290r34gFVvGkO+foP1KuhaMiO5T+CXdkDNskyqTEAoUM72Tb5RMkbX1z/bqO7egEFCZ1efe5Y8oI2PwOw==}
+    dependencies:
+      '@fluid-experimental/sequence-deprecated': 2.0.0-internal.3.2.2
+      '@fluid-tools/benchmark': 0.45.112032
+      '@fluidframework/agent-scheduler': 2.0.0-internal.3.2.0
+      '@fluidframework/aqueduct': 2.0.0-internal.3.2.0
+      '@fluidframework/attributor': 2.0.0-internal.3.2.2
+      '@fluidframework/cell': 2.0.0-internal.3.2.0
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/counter': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.2.0
+      '@fluidframework/ink': 2.0.0-internal.3.2.0
+      '@fluidframework/map': 2.0.0-internal.3.2.0
+      '@fluidframework/matrix': 2.0.0-internal.3.2.0
+      '@fluidframework/merge-tree': 2.0.0-internal.3.2.0
+      '@fluidframework/mocha-test-setup': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/ordered-collection': 2.0.0-internal.3.2.0
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/register-collection': 2.0.0-internal.3.2.0
+      '@fluidframework/request-handler': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/sequence': 2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/test-loader-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/test-pairwise-generator': 2.0.0-internal.3.2.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/test-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/test-version-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/undo-redo': 2.0.0-internal.3.2.0
+      cross-env: 7.0.3
+      mocha: 10.2.0
+      semver: 7.3.8
+      sinon: 7.5.0
+      start-server-and-test: 1.14.0
+      tinylicious: 0.5.0
+      url: 0.11.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /@fluidframework/test-loader-utils/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-Xp5Oc7Tx/GAX68DcupvMRWkpKS72hn1dnE7diI98hu8Iw6wmvdZQznJRV4HcMTDfOD/y7wFwAZ/OB8Q+LUgdMw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/test-pairwise-generator/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-+i6WPEosbBY/E++C8annToPVdWUGpzSjY5STZB1T+L/kFNncpFlfsmq8fuYwM/yA6chgUlcR49j0qRBRcTJObA==}
+  /@fluidframework/test-pairwise-generator/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-SK3fKt+uPAs37AJpjw22snlSYnI/f6vgdgxptEw9kkPlWA4xWA63qYWQl3XpRvl9nbUMGpPfMyTZhd/ldpm81w==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
       random-js: 1.0.8
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-0tZWzxz0lkYvC5IfdizuOnKj6RiSq2q14S5znjcGSx87LQpxrZZWLOV9I/O5PVFgxLW1rPFyzJARnCUfr6ecqw==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-rrulWN8F0h11R1KQJ7q8IUxueTIB5279VpLYjIf5mbuT6dxw397MvtTYxux/6m0R8538aKHtab0159+mSKAx/w==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       axios: 0.26.1
       events: 3.3.0
       jsrsasign: 10.6.1
@@ -14418,21 +14778,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.3.1.0_debug@4.3.4:
-    resolution: {integrity: sha512-0tZWzxz0lkYvC5IfdizuOnKj6RiSq2q14S5znjcGSx87LQpxrZZWLOV9I/O5PVFgxLW1rPFyzJARnCUfr6ecqw==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.3.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-rrulWN8F0h11R1KQJ7q8IUxueTIB5279VpLYjIf5mbuT6dxw397MvtTYxux/6m0R8538aKHtab0159+mSKAx/w==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
       axios: 0.26.1_debug@4.3.4
       events: 3.3.0
       jsrsasign: 10.6.1
@@ -14450,32 +14810,32 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/test-utils/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-hHvFsTi+MQowVCcHzkLiYadAI6aajaIQ2H4WHGs98cpOThX4AEUsMGik3jo0ozWwHU6SD9NTG/FJn9vHDMexag==}
+  /@fluidframework/test-utils/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-1r+Gu0j690iBD0K9kQg+p3Nz30zmElC8lS0nQ2qR+pfjvhO8Mi0noyxm3ChnrQknP6+h9mmghrXXaRwIPtTuQQ==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.3.1.0_debug@4.3.4
+      '@fluidframework/aqueduct': 2.0.0-internal.3.2.0_debug@4.3.4
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/container-runtime': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/local-driver': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/map': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/mocha-test-setup': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/container-runtime': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/datastore': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2_debug@4.3.4
+      '@fluidframework/local-driver': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/map': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/mocha-test-setup': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.3.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.1.0_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.1.0_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.3.2.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.2.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.2.0_debug@4.3.4
       best-random: 1.0.3
       debug: 4.3.4
       uuid: 8.3.2
@@ -14486,34 +14846,35 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-version-utils/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-L8ycuivyLD364oynrNrkUvMmR0T+wtLJoQ0LTuSYDIvtkJKbw5dYJp6b4yUmMohTKAOQHhgA4wYkIKtyI95Rag==}
+  /@fluidframework/test-version-utils/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-InJCIkQ/Y5yBu+TPz+VhQx8mlQrmwLtBRDswrAHp3CN54D2NqjRkrLisLupITPOzYnXu7znS9b9FfjSWI0F18w==}
     dependencies:
-      '@fluid-experimental/sequence-deprecated': 2.0.0-internal.3.1.0
-      '@fluidframework/aqueduct': 2.0.0-internal.3.1.0
-      '@fluidframework/attributor': 2.0.0-internal.3.1.0
-      '@fluidframework/cell': 2.0.0-internal.3.1.0
+      '@fluid-experimental/sequence-deprecated': 2.0.0-internal.3.2.2
+      '@fluidframework/aqueduct': 2.0.0-internal.3.2.0
+      '@fluidframework/attributor': 2.0.0-internal.3.2.2
+      '@fluidframework/cell': 2.0.0-internal.3.2.0
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.3.1.0
-      '@fluidframework/container-runtime': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/counter': 2.0.0-internal.3.1.0
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/ink': 2.0.0-internal.3.1.0
-      '@fluidframework/map': 2.0.0-internal.3.1.0
-      '@fluidframework/matrix': 2.0.0-internal.3.1.0
-      '@fluidframework/ordered-collection': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/counter': 2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/ink': 2.0.0-internal.3.2.0
+      '@fluidframework/map': 2.0.0-internal.3.2.0
+      '@fluidframework/matrix': 2.0.0-internal.3.2.0
+      '@fluidframework/ordered-collection': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/register-collection': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/sequence': 2.0.0-internal.3.1.0
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/test-drivers': 2.0.0-internal.3.1.0
-      '@fluidframework/test-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/register-collection': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/sequence': 2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/test-drivers': 2.0.0-internal.3.2.0
+      '@fluidframework/test-utils': 2.0.0-internal.3.2.0
       nconf: 0.12.0
       proper-lockfile: 4.1.2
       semver: 7.3.8
@@ -14525,26 +14886,26 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-client/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-r2UqdKZRsIdHAEWJOALlKQG9G4JHwZmuxeJhqGu9O/W25UhziF8yLgYrZ9AjtJRUNkswD+P52A5IdC0IWSC1kA==}
+  /@fluidframework/tinylicious-client/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-9g/HnsT3nUMLEP3QRBb7EatnBZOqcQ2vK6HcaOiiwOZG7RyMV5H6bpBRr+EusNjHsTbozNDXOvcYeCyRfCHoFg==}
     peerDependencies:
-      fluid-framework: '>=2.0.0-internal.2.1.0 <2.0.0-internal.3.0.0'
+      fluid-framework: '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
     peerDependenciesMeta:
       fluid-framework:
         optional: true
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/container-loader': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/fluid-static': 2.0.0-internal.3.1.0
-      '@fluidframework/map': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/container-loader': 2.0.0-internal.3.2.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
+      '@fluidframework/fluid-static': 2.0.0-internal.3.2.0
+      '@fluidframework/map': 2.0.0-internal.3.2.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.1.0
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.1.0
-      '@fluidframework/tinylicious-driver': 2.0.0-internal.3.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.2.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.2.0
+      '@fluidframework/tinylicious-driver': 2.0.0-internal.3.2.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -14554,14 +14915,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-driver/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-1VghzUTqxCt8GjBpIzHODlW1zJ4xpqD73r1IW/glRP7+rRikqdtTZRdMsmjHs8ui1HcfL3pSK7lZo+2gRlEwPQ==}
+  /@fluidframework/tinylicious-driver/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-ObO4ONwwpAEtANqNFCWyw5xZrF56AYlMARcuqZMb8TjmrLl373IDm4G8T2+QMQ1Ij5zp6tV8PsTNvnQoXuG7fg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/driver-utils': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.2.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.2.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.1.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.2.0
       '@fluidframework/server-services-client': 0.1038.2000
       jsrsasign: 10.6.1
       uuid: 8.3.2
@@ -14573,11 +14934,11 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tool-utils/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-2NoJc64YmvYNy5LUdhP+Ng3P7PDX1UgF4IUQjHAUW5Z7plWydxsxsX46pD/cgsOqHyiOG6Oy5cQkLMlzvk2KoQ==}
+  /@fluidframework/tool-utils/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-WRvLSGzx3pU5Npo1n1xyjW4iUi3HYkyMAEFi/E2/pSQ4Q/C5fRVt3aQ1pd5CGUQjgkqiKBwNduh82Ib83Hj8dQ==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.1.0_debug@4.3.4
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.2.0_debug@4.3.4
       '@fluidframework/protocol-base': 0.1038.3000
       '@fluidframework/protocol-definitions': 1.1.0
       async-mutex: 0.3.2
@@ -14589,39 +14950,39 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/undo-redo/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-igcabvue1afLrK6iiN/azvTqDtzpX6IF4LU3DkfjZGwBa5lWkMI3e96IX9gK2GHtcpSyRalj4lOvVAMmGDUNyw==}
+  /@fluidframework/undo-redo/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-WjV1sRNEy+ilXvjJFiZyDg3Sx4d9+hDefjYbMMkNqaSxBZm9M0S/KMucx1VYdX2jRYeTm/LpMgozPVMis3tjnw==}
     dependencies:
-      '@fluidframework/map': 2.0.0-internal.3.1.0
-      '@fluidframework/matrix': 2.0.0-internal.3.1.0
-      '@fluidframework/merge-tree': 2.0.0-internal.3.1.0
-      '@fluidframework/sequence': 2.0.0-internal.3.1.0
+      '@fluidframework/map': 2.0.0-internal.3.2.0
+      '@fluidframework/matrix': 2.0.0-internal.3.2.0
+      '@fluidframework/merge-tree': 2.0.0-internal.3.2.0
+      '@fluidframework/sequence': 2.0.0-internal.3.2.0
       events: 3.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/view-adapters/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-hPYD0CS/9tx6UGJVxfpZDCxU5BubLF0uGbIPlHOPLYD4Wo81hLBesEkS53lzX0sgB0qrficrGFAjqv5WkJ1I2A==}
+  /@fluidframework/view-adapters/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-PYDZ25qm6KrpeDxzG6KQ3c9K8trpq17lWstBjHnKe6IcuuKF9xacj8jZtdniP0pNuHjmW7SJeP9nS/xIQzefiA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
+      '@fluidframework/view-interfaces': 2.0.0-internal.3.2.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
-  /@fluidframework/view-interfaces/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-R4KOWbPofQRqKeEE45DuQw9DEZqadrZYcy7Lh8SKp9SOMyT+BYkavNuS7q2UjSx/W5/YxIC/wuwfGuX5p5fSLA==}
+  /@fluidframework/view-interfaces/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-kwMOGl/stYyRiiL0+C7RwKLQewQHNghEVAD1HyJspDZ42fHA27SUOFfleCU6bz+lmZv+CRgNiXZynzFI1s//IA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
     dev: true
 
-  /@fluidframework/web-code-loader/2.0.0-internal.3.1.0:
-    resolution: {integrity: sha512-7v7cVy/mAT6uXoivGd+gNALMNv0FRVwOOoqmmbYt9fLoky+u5Pqw1FngB/gfvEmj+yZc+fjWZ0+ZErJ1A9y+jQ==}
+  /@fluidframework/web-code-loader/2.0.0-internal.3.2.0:
+    resolution: {integrity: sha512-3cUzcac5/s9lE4n54CcyOa3dXv8i2eErGr7v+fh+9hZAkdcc/O6VxMyLz5QmDkwnE6KwC9pleuf63RSXzyaSww==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.3.1.0
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.1.0
+      '@fluidframework/container-definitions': 2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.2.2
       isomorphic-fetch: 3.0.0
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
## Description

Update baselines for type tests in client to `2.0.0-internal.3.2.0`

`pnpm exec flub typetests -g client -p --reset`

and

`pnpm run build:fast`

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
