### PR TITLE
Deprecate attachGraph and bind methods on IFluidHandle

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -15,6 +15,17 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 -   Avoid using code formatting in the title (it's fine to use in the body).
 -   To explain the benefit of your change, use the [What's New](https://fluidframework.com/docs/updates/v1.0.0/) section on FluidFramework.com.
 
+# 2.0.0-internal.3.3.0
+
+## 2.0.0-internal.3.0.0 Upcoming changes
+
+-   [attachGraph and bind methods in IFluidHandle deprecated](#attachGraph-and-bind-methods-in-IFluidHandle-deprecated)
+
+### attachGraph and bind methods in IFluidHandle deprecated
+
+`attachGraph` and `bind` methods in IFluidHandle have been deprecated. These are internal methods used by the Fluid framework and should not be used. They will be removed in a future release.
+
+
 # 2.0.0-internal.3.0.0
 
 ## 2.0.0-internal.3.0.0 Upcoming changes

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -23,8 +23,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 
 ### attachGraph and bind methods in IFluidHandle deprecated
 
-`attachGraph` and `bind` methods in IFluidHandle have been deprecated. These are internal methods used by the Fluid framework and should not be used. They will be removed in a future release.
-
+`attachGraph` and `bind` methods in IFluidHandle have been deprecated. These are internal methods used by the Fluid Framework and should not be used. They will be removed in a future release.
 
 # 2.0.0-internal.3.0.0
 

--- a/api-report/core-interfaces.api.md
+++ b/api-report/core-interfaces.api.md
@@ -45,7 +45,9 @@ export const IFluidHandle: keyof IProvideFluidHandle;
 export interface IFluidHandle<T = FluidObject & IFluidLoadable> extends IProvideFluidHandle {
     // @deprecated (undocumented)
     readonly absolutePath: string;
+    // @deprecated (undocumented)
     attachGraph(): void;
+    // @deprecated (undocumented)
     bind(handle: IFluidHandle): void;
     get(): Promise<T>;
     readonly isAttached: boolean;

--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -67,6 +67,8 @@ export interface IFluidHandle<
 	readonly isAttached: boolean;
 
 	/**
+	 * @deprecated To be removed. This is part of an internal API surface and should not be called.
+	 *
 	 * Runs through the graph and attach the bounded handles.
 	 */
 	attachGraph(): void;
@@ -77,6 +79,8 @@ export interface IFluidHandle<
 	get(): Promise<T>;
 
 	/**
+	 * @deprecated To be removed. This is part of an internal API surface and should not be called.
+	 *
 	 * Binds the given handle to this one or attach the given handle if this handle is attached.
 	 * A bound handle will also be attached once this handle is attached.
 	 */


### PR DESCRIPTION
`attachGraph` and `bind` methods are used internally to attach the Fluid objects associated with the handles. They should be used directly. Deprecated these for now. They will be removed as part of the effort to make IFluidHandle usage better.