### PR TITLE
Disable PropertyDDS backdoor that gets connection details from delta manager

### DIFF
--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -677,6 +677,12 @@ export class SharedPropertyTree extends SharedObject {
 				this.remoteTipView = cloneDeep(this.tipView);
 				this.remoteChanges = [];
 
+				/**
+				 * Commenting this code out - It is part of an experimental feature, which is not used in production.
+				 * It only works, if the corresponding server side component (Moira) is running, which is not the case
+				 * on the Azure backend.
+				 */
+				/*
 				let missingDeltas: ISequencedDocumentMessage[] = [];
 				const firstDelta = Math.min(
 					commitMetadata.minimumSequenceNumber,
@@ -725,6 +731,7 @@ export class SharedPropertyTree extends SharedObject {
 				}
 
 				this.skipSequenceNumber = lastDelta ?? -1;
+				*/
 			}
 		} catch (e) {
 			this.tipView = {};

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -684,7 +684,10 @@ export class SharedPropertyTree extends SharedObject {
 				);
 				const lastDelta = commitMetadata.sequenceNumber;
 
-				const dm = (this.runtime.deltaManager as any).deltaManager;
+				let dm = (this.runtime.deltaManager as any).deltaManager;
+				if (dm.deltaManager !== undefined) {
+					dm = dm.deltaManager;
+				}
 				await dm.getDeltas(
 					"DocumentOpen",
 					firstDelta,

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -193,14 +193,21 @@ export class SharedPropertyTree extends SharedObject {
 	}
 
 	private scopeFutureDeltasToPaths(paths?: string[]) {
+		/**
+		 * Commenting this code out - It is part of an experimental feature, which is not used in production.
+		 * It only works, if the corresponding server side component (Moira) is running, which is not the case on
+		 * the Azure backend.
+		 */
 		// Backdoor to emit "partial_checkout" events on the socket. The delta manager at container runtime layer is
 		// a proxy and the delta manager at the container context layer is yet another proxy, so account for that.
+		/*
 		let dm = (this.runtime.deltaManager as any).deltaManager;
 		if (dm.deltaManager !== undefined) {
 			dm = dm.deltaManager;
 		}
 		const socket = dm.connectionManager.connection.socket;
 		socket.emit("partial_checkout", { paths });
+		*/
 	}
 
 	public _reportDirtinessToView() {


### PR DESCRIPTION
This backdoor is no use. It is part of an experimental feature, which only works if the corresponding server side component (Moira) is running, which is not the case on the Azure backend. Commenting this out for now. This should be re-added if required without dependecny on delta manager internals.

Also, updated another backdoor to account for the new proxy that was missed by this PR - https://github.com/microsoft/FluidFramework/pull/14354

[AB#3553](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3553)