### PR TITLE
Deprecate IDocumentServiceFactory.protocolName and remove remaining usage

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -45,6 +45,7 @@ The deltaManager property in IConnectableRuntime has been moved to ISummarizerRu
 -   [web-code-loader and ICodeAllowList deprecated](#web-code-loader-and-ICodeAllowList-deprecated)
 -   [driver-utils members deprecated](#driver-utils-members-deprecated)
 -   [Aqueduct members deprecated](#Aqueduct-members-deprecated)
+-   [IDocumentServiceFactory.protocolName deprecated](#IDocumentServiceFactory.protocolName-deprecated)
 
 ### For Driver Authors: Document Storage Service policy may become required
 
@@ -134,6 +135,10 @@ The following members of the `@fluidframework/aqueduct` package have been deprec
 
 -   `waitForAttach()`
     -   Prefer not to inspect and react to the attach state unless necessary. If needed, instead inspect the IFluidDataStoreRuntime's attachState property, and await the "attached" event if not attached.
+
+### IDocumentServiceFactory.protocolName deprecated
+
+Document service factories should not be distinguished by unique non-standard protocols, and so the `IDocumentServiceFactory.protocolName` member will be removed in an upcoming release. Instead prefer to map urls to factories using standards-compliant components of the url (e.g. host name, path, etc.).
 
 ## 2.0.0-internal.3.0.0 Breaking changes
 

--- a/api-report/debugger.api.md
+++ b/api-report/debugger.api.md
@@ -128,7 +128,7 @@ export class DebugReplayController extends ReplayController implements IDebugger
 export namespace FluidDebugger {
     export function createFromService(documentService: IDocumentService): Promise<IDocumentService>;
     // (undocumented)
-    export function createFromServiceFactory(documentServiceFactory: IDocumentServiceFactory): Promise<ReplayDocumentServiceFactory | IDocumentServiceFactory>;
+    export function createFromServiceFactory(documentServiceFactory: IDocumentServiceFactory): Promise<IDocumentServiceFactory | ReplayDocumentServiceFactory>;
 }
 
 // @public (undocumented)

--- a/api-report/debugger.api.md
+++ b/api-report/debugger.api.md
@@ -128,7 +128,7 @@ export class DebugReplayController extends ReplayController implements IDebugger
 export namespace FluidDebugger {
     export function createFromService(documentService: IDocumentService): Promise<IDocumentService>;
     // (undocumented)
-    export function createFromServiceFactory(documentServiceFactory: IDocumentServiceFactory): Promise<IDocumentServiceFactory | ReplayDocumentServiceFactory>;
+    export function createFromServiceFactory(documentServiceFactory: IDocumentServiceFactory): Promise<ReplayDocumentServiceFactory | IDocumentServiceFactory>;
 }
 
 // @public (undocumented)

--- a/api-report/driver-definitions.api.md
+++ b/api-report/driver-definitions.api.md
@@ -161,6 +161,7 @@ export interface IDocumentService {
 export interface IDocumentServiceFactory {
     createContainer(createNewSummary: ISummaryTree | undefined, createNewResolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
     createDocumentService(resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
+    // @deprecated
     protocolName: string;
 }
 

--- a/api-report/file-driver.api.md
+++ b/api-report/file-driver.api.md
@@ -40,7 +40,7 @@ export class FileDeltaStorageService implements IDocumentDeltaStorageService {
     getFromWebSocket(from: number, to: number): api.ISequencedDocumentMessage[];
     // (undocumented)
     get ops(): readonly Readonly<api.ISequencedDocumentMessage>[];
-    }
+}
 
 // @public
 export class FileDocumentService implements api_2.IDocumentService {
@@ -54,7 +54,7 @@ export class FileDocumentService implements api_2.IDocumentService {
     dispose(): void;
     // (undocumented)
     get resolvedUrl(): api_2.IResolvedUrl;
-    }
+}
 
 // @public
 export class FileDocumentServiceFactory implements IDocumentServiceFactory {
@@ -62,9 +62,9 @@ export class FileDocumentServiceFactory implements IDocumentServiceFactory {
     // (undocumented)
     createContainer(createNewSummary: ISummaryTree, resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
     createDocumentService(fileURL: IResolvedUrl, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
-    // (undocumented)
+    // @deprecated (undocumented)
     readonly protocolName = "fluid-file:";
-    }
+}
 
 // @public (undocumented)
 export const FileSnapshotWriterClassFactory: <TBase extends ReaderConstructor>(Base: TBase) => {
@@ -100,7 +100,7 @@ export class FluidFetchReader extends ReadDocumentStorageServiceBase implements 
     getVersions(versionId: string | null, count: number): Promise<api.IVersion[]>;
     // (undocumented)
     readBlob(sha: string): Promise<ArrayBufferLike>;
-    }
+}
 
 // @public (undocumented)
 export const FluidFetchReaderFileSnapshotWriter: {
@@ -183,7 +183,6 @@ export class ReplayFileDeltaConnection extends TypedEventEmitter<IDocumentDeltaC
     // (undocumented)
     get version(): string;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/api-report/odsp-driver.api.md
+++ b/api-report/odsp-driver.api.md
@@ -126,7 +126,7 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
     protected createDocumentServiceCore(resolvedUrl: IResolvedUrl, odspLogger: TelemetryLogger, cacheAndTrackerArg?: ICacheAndTracker, clientIsSummarizer?: boolean): Promise<IDocumentService>;
     // (undocumented)
     protected persistedCache: IPersistedCache;
-    // (undocumented)
+    // @deprecated (undocumented)
     readonly protocolName = "fluid-odsp:";
     // Warning: (ae-forgotten-export) The symbol "IPrefetchSnapshotContents" needs to be exported by the entry point index.d.ts
     //

--- a/api-report/replay-driver.api.md
+++ b/api-report/replay-driver.api.md
@@ -117,7 +117,7 @@ export class ReplayDocumentServiceFactory implements IDocumentServiceFactory {
     // (undocumented)
     createContainer(createNewSummary: ISummaryTree, resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
     createDocumentService(resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
-    // (undocumented)
+    // @deprecated (undocumented)
     readonly protocolName: any;
 }
 
@@ -151,7 +151,7 @@ export class StaticStorageDocumentService implements IDocumentService {
     dispose(): void;
     // (undocumented)
     get resolvedUrl(): IResolvedUrl;
-    }
+}
 
 // @public (undocumented)
 export class StaticStorageDocumentServiceFactory implements IDocumentServiceFactory {
@@ -160,12 +160,11 @@ export class StaticStorageDocumentServiceFactory implements IDocumentServiceFact
     createContainer(createNewSummary: ISummaryTree, resolvedUrl: IResolvedUrl, logger: ITelemetryLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
     // (undocumented)
     createDocumentService(fileURL: IResolvedUrl, logger?: ITelemetryLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
-    // (undocumented)
+    // @deprecated (undocumented)
     readonly protocolName = "fluid-static-storage:";
     // (undocumented)
     protected readonly storage: IDocumentStorageService;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/api-report/routerlicious-driver.api.md
+++ b/api-report/routerlicious-driver.api.md
@@ -68,7 +68,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
     createContainer(createNewSummary: ISummaryTree | undefined, resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
     // (undocumented)
     createDocumentService(resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean, session?: ISession): Promise<IDocumentService>;
-    // (undocumented)
+    // @deprecated (undocumented)
     readonly protocolName = "fluid:";
 }
 

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -346,6 +346,8 @@ export interface IDocumentService {
 export interface IDocumentServiceFactory {
 	/**
 	 * Name of the protocol used by factory
+	 *
+	 * @deprecated 2.0.0-internal.3.3.0 Document service factories should not be distinguished by unique non-standard protocols. To be removed in an upcoming release.
 	 */
 	protocolName: string;
 

--- a/packages/drivers/file-driver/src/fileDocumentServiceFactory.ts
+++ b/packages/drivers/file-driver/src/fileDocumentServiceFactory.ts
@@ -20,6 +20,9 @@ import { FileDocumentService } from "./fileDocumentService";
  * use the local file storage as underlying storage.
  */
 export class FileDocumentServiceFactory implements IDocumentServiceFactory {
+	/**
+	 * @deprecated 2.0.0-internal.3.3.0 Document service factories should not be distinguished by unique non-standard protocols. To be removed in an upcoming release.
+	 */
 	public readonly protocolName = "fluid-file:";
 	constructor(
 		private readonly storage: IDocumentStorageService,

--- a/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
+++ b/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
@@ -30,6 +30,9 @@ import { createLocalDocumentService } from "./localDocumentService";
  * Implementation of document service factory for local use.
  */
 export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
+	/**
+	 * @deprecated 2.0.0-internal.3.3.0 Document service factories should not be distinguished by unique non-standard protocols. To be removed in an upcoming release.
+	 */
 	public readonly protocolName = "fluid-test:";
 
 	// A map of clientId to LocalDocumentService.

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -49,6 +49,9 @@ import {
  * to leverage code splitting as a means to keep bundles as small as possible.
  */
 export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
+	/**
+	 * @deprecated 2.0.0-internal.3.3.0 Document service factories should not be distinguished by unique non-standard protocols. To be removed in an upcoming release.
+	 */
 	public readonly protocolName = "fluid-odsp:";
 
 	private readonly nonPersistentCache: INonPersistentCache = new NonPersistentCache();

--- a/packages/drivers/replay-driver/src/replayDocumentServiceFactory.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentServiceFactory.ts
@@ -27,6 +27,9 @@ export class ReplayDocumentServiceFactory implements IDocumentServiceFactory {
 		);
 	}
 
+	/**
+	 * @deprecated 2.0.0-internal.3.3.0 Document service factories should not be distinguished by unique non-standard protocols. To be removed in an upcoming release.
+	 */
 	public readonly protocolName;
 
 	public constructor(

--- a/packages/drivers/replay-driver/src/storageImplementations.ts
+++ b/packages/drivers/replay-driver/src/storageImplementations.ts
@@ -172,6 +172,9 @@ export class StaticStorageDocumentService implements IDocumentService {
 }
 
 export class StaticStorageDocumentServiceFactory implements IDocumentServiceFactory {
+	/**
+	 * @deprecated 2.0.0-internal.3.3.0 Document service factories should not be distinguished by unique non-standard protocols. To be removed in an upcoming release.
+	 */
 	public readonly protocolName = "fluid-static-storage:";
 	public constructor(protected readonly storage: IDocumentStorageService) {}
 

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -51,6 +51,9 @@ const defaultRouterliciousDriverPolicies: IRouterliciousDriverPolicies = {
  * use the routerlicious implementation.
  */
 export class RouterliciousDocumentServiceFactory implements IDocumentServiceFactory {
+	/**
+	 * @deprecated 2.0.0-internal.3.3.0 Document service factories should not be distinguished by unique non-standard protocols. To be removed in an upcoming release.
+	 */
 	public readonly protocolName = "fluid:";
 	private readonly driverPolicies: IRouterliciousDriverPolicies;
 	private readonly blobCache: ICache<ArrayBufferLike>;

--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -27,6 +27,9 @@ import { LoggingError } from "@fluidframework/telemetry-utils";
 export class FaultInjectionDocumentServiceFactory implements IDocumentServiceFactory {
 	private readonly _documentServices = new Map<IResolvedUrl, FaultInjectionDocumentService>();
 
+	/**
+	 * @deprecated 2.0.0-internal.3.3.0 Document service factories should not be distinguished by unique non-standard protocols. To be removed in an upcoming release.
+	 */
 	public get protocolName() {
 		return this.internal.protocolName;
 	}

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -33,6 +33,7 @@
 		"@fluid-tools/fluidapp-odsp-urlresolver": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/common-utils": "^1.1.1",
 		"@fluidframework/container-runtime": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
+		"@fluidframework/core-interfaces": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/datastore": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/driver-definitions": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",
 		"@fluidframework/driver-utils": ">=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9868,6 +9868,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-runtime': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
+      '@fluidframework/core-interfaces': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.3.0 <2.0.0-internal.4.0.0'
@@ -9894,6 +9895,7 @@ importers:
       '@fluid-tools/fluidapp-odsp-urlresolver': link:../../drivers/fluidapp-odsp-urlResolver
       '@fluidframework/common-utils': 1.1.1
       '@fluidframework/container-runtime': link:../../runtime/container-runtime
+      '@fluidframework/core-interfaces': link:../../common/core-interfaces
       '@fluidframework/datastore': link:../../runtime/datastore
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
       '@fluidframework/driver-utils': link:../../loader/driver-utils


### PR DESCRIPTION
`IDocumentServiceFactory.protocolName` was used in `MultiDocumentServiceFactory`, deprecated in #14265 (and I'll be removing after that change ports to `next`).  With that usage removed, we have no more need for this member.

Additionally, we want to discourage using unique non-standard protocol names as this blocks usage of standard `URL()` and requires a non-standard polyfill instead (see #9236).

In general, this member was intended to help with mapping a URL to a respective document service factory that knew how to handle it - with this change, the responsibility is on whoever is doing the mapping to understand that relationship (and probably use some standard feature of the url, like host name, path, etc.).

EDIT: I decided to also go ahead and remove the only remaining non-deprecated usage in our repo, in the fetch-tool.  This removes the usage of the now-deprecated `configurableUrlResolver` as well.