### PR TITLE
test(SharedMatrix): Update perf tests

### DIFF
--- a/packages/dds/matrix/.gitignore
+++ b/packages/dds/matrix/.gitignore
@@ -51,5 +51,8 @@ nyc
 intel_modules/
 temp_modules/
 
+# Output folder for memory profiling tests
+.memoryTestsOutput
+
 bench/dist/
 bench/profile.txt

--- a/packages/dds/matrix/src/test/memory/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/matrix.spec.ts
@@ -34,95 +34,119 @@ describe("Matrix memory usage", () => {
 		// See the comment at the top of the test suite for more details.
 	});
 
-	benchmarkMemory(
-		new (class implements IMemoryTestObject {
-			title = "Create empty Matrix";
-			minSampleCount = 500;
-
-			private localMatrix: SharedMatrix = createLocalMatrix("testLocalMatrix");
-
-			async run() {
-				this.localMatrix = createLocalMatrix("testLocalMatrix");
-			}
-		})(),
-	);
-
-	const numbersOfEntriesForTests = [100, 1000, 10_000];
-
-	numbersOfEntriesForTests.forEach((x) => {
+	describe("Detached Matrix", () => {
 		benchmarkMemory(
 			new (class implements IMemoryTestObject {
-				title = `Insert and remove ${x} columns`;
+				title = "Create empty Matrix";
+				minSampleCount = 500;
+
 				private localMatrix: SharedMatrix = createLocalMatrix("testLocalMatrix");
 
 				async run() {
-					for (let i = 0; i < x; i++) {
-						this.localMatrix.insertCols(0, 100);
-						this.localMatrix.removeCols(0, 100);
-					}
-				}
-
-				beforeIteration() {
 					this.localMatrix = createLocalMatrix("testLocalMatrix");
 				}
 			})(),
 		);
 
-		benchmarkMemory(
-			new (class implements IMemoryTestObject {
-				title = `Insert and remove ${x} rows`;
-				private localMatrix: SharedMatrix = createLocalMatrix("testLocalMatrix");
+		const numbersOfEntriesForTests = [100, 1000, 5000];
 
-				async run() {
-					for (let i = 0; i < x; i++) {
-						this.localMatrix.insertRows(0, 100);
-						this.localMatrix.removeRows(0, 100);
+		numbersOfEntriesForTests.forEach((x) => {
+			benchmarkMemory(
+				new (class implements IMemoryTestObject {
+					title = `Insert and remove a column ${x} times`;
+					private localMatrix: SharedMatrix = createLocalMatrix("testLocalMatrix");
+
+					async run() {
+						for (let i = 0; i < x; i++) {
+							this.localMatrix.insertCols(0, 1);
+							this.localMatrix.removeCols(0, 1);
+						}
 					}
-				}
 
-				beforeIteration() {
-					this.localMatrix = createLocalMatrix("testLocalMatrix");
-				}
-			})(),
-		);
-
-		benchmarkMemory(
-			new (class implements IMemoryTestObject {
-				title = `Insert and remove ${x} rows and columns`;
-				private localMatrix: SharedMatrix = createLocalMatrix("testLocalMatrix");
-
-				async run() {
-					for (let i = 0; i < x; i++) {
-						this.localMatrix.insertCols(0, 100);
-						this.localMatrix.insertRows(0, 100);
-						this.localMatrix.removeCols(0, 100);
-						this.localMatrix.removeRows(0, 100);
+					beforeIteration() {
+						this.localMatrix = createLocalMatrix("testLocalMatrix");
 					}
-				}
+				})(),
+			);
 
-				beforeIteration() {
-					this.localMatrix = createLocalMatrix("testLocalMatrix");
-				}
-			})(),
-		);
+			benchmarkMemory(
+				new (class implements IMemoryTestObject {
+					title = `Insert and remove one row ${x} times`;
+					private localMatrix: SharedMatrix = createLocalMatrix("testLocalMatrix");
 
-		benchmarkMemory(
-			new (class implements IMemoryTestObject {
-				title = `Set ${x} cells`;
-				private localMatrix = createLocalMatrix("testLocalMatrix");
-
-				async run() {
-					this.localMatrix.insertCols(0, x);
-					this.localMatrix.insertRows(0, x);
-					for (let i = 0; i < x; i++) {
-						this.localMatrix.setCell(0, i, "a");
+					async run() {
+						for (let i = 0; i < x; i++) {
+							this.localMatrix.insertRows(0, 1);
+							this.localMatrix.removeRows(0, 1);
+						}
 					}
-				}
 
-				beforeIteration() {
-					this.localMatrix = createLocalMatrix("testLocalMatrix");
-				}
-			})(),
-		);
+					beforeIteration() {
+						this.localMatrix = createLocalMatrix("testLocalMatrix");
+					}
+				})(),
+			);
+
+			benchmarkMemory(
+				new (class implements IMemoryTestObject {
+					title = `Insert and remove a row and column ${x} times`;
+					only = true;
+					private localMatrix: SharedMatrix = createLocalMatrix("testLocalMatrix");
+
+					async run() {
+						for (let i = 0; i < x; i++) {
+							this.localMatrix.insertCols(0, 1);
+							this.localMatrix.insertRows(0, 1);
+							this.localMatrix.removeCols(0, 1);
+							this.localMatrix.removeRows(0, 1);
+						}
+					}
+
+					beforeIteration() {
+						this.localMatrix = createLocalMatrix("testLocalMatrix");
+					}
+				})(),
+			);
+
+			benchmarkMemory(
+				new (class implements IMemoryTestObject {
+					title = `Set a 3-character string in ${x} cells`;
+					only = true;
+					private localMatrix = createLocalMatrix("testLocalMatrix");
+
+					async run() {
+						for (let i = 0; i < x; i++) {
+							this.localMatrix.setCell(0, i, "abc");
+						}
+					}
+
+					beforeIteration() {
+						this.localMatrix = createLocalMatrix("testLocalMatrix");
+						this.localMatrix.insertRows(0, 1);
+						this.localMatrix.insertCols(0, x);
+					}
+				})(),
+			);
+
+			benchmarkMemory(
+				new (class implements IMemoryTestObject {
+					title = `Set a number in ${x} cells`;
+					only = true;
+					private localMatrix = createLocalMatrix("testLocalMatrix");
+
+					async run() {
+						for (let i = 0; i < x; i++) {
+							this.localMatrix.setCell(0, i, 1);
+						}
+					}
+
+					beforeIteration() {
+						this.localMatrix = createLocalMatrix("testLocalMatrix");
+						this.localMatrix.insertRows(0, 1);
+						this.localMatrix.insertCols(0, x);
+					}
+				})(),
+			);
+		});
 	});
 });

--- a/packages/dds/matrix/src/test/memory/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/matrix.spec.ts
@@ -90,7 +90,6 @@ describe("Matrix memory usage", () => {
 			benchmarkMemory(
 				new (class implements IMemoryTestObject {
 					title = `Insert and remove a row and column ${x} times`;
-					only = true;
 					private localMatrix: SharedMatrix = createLocalMatrix("testLocalMatrix");
 
 					async run() {
@@ -111,7 +110,6 @@ describe("Matrix memory usage", () => {
 			benchmarkMemory(
 				new (class implements IMemoryTestObject {
 					title = `Set a 3-character string in ${x} cells`;
-					only = true;
 					private localMatrix = createLocalMatrix("testLocalMatrix");
 
 					async run() {
@@ -131,7 +129,6 @@ describe("Matrix memory usage", () => {
 			benchmarkMemory(
 				new (class implements IMemoryTestObject {
 					title = `Set a number in ${x} cells`;
-					only = true;
 					private localMatrix = createLocalMatrix("testLocalMatrix");
 
 					async run() {

--- a/packages/dds/matrix/src/test/memory/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/matrix.spec.ts
@@ -37,7 +37,7 @@ describe("Matrix memory usage", () => {
 	describe("Detached Matrix", () => {
 		benchmarkMemory(
 			new (class implements IMemoryTestObject {
-				title = "Create empty Matrix";
+				readonly title = "Create empty Matrix";
 				minSampleCount = 500;
 
 				private localMatrix: SharedMatrix = createLocalMatrix("testLocalMatrix");
@@ -53,7 +53,7 @@ describe("Matrix memory usage", () => {
 		numbersOfEntriesForTests.forEach((x) => {
 			benchmarkMemory(
 				new (class implements IMemoryTestObject {
-					title = `Insert and remove a column ${x} times`;
+					readonly title = `Insert and remove a column ${x} times`;
 					private localMatrix: SharedMatrix = createLocalMatrix("testLocalMatrix");
 
 					async run() {
@@ -71,7 +71,7 @@ describe("Matrix memory usage", () => {
 
 			benchmarkMemory(
 				new (class implements IMemoryTestObject {
-					title = `Insert and remove one row ${x} times`;
+					readonly title = `Insert and remove one row ${x} times`;
 					private localMatrix: SharedMatrix = createLocalMatrix("testLocalMatrix");
 
 					async run() {
@@ -89,7 +89,7 @@ describe("Matrix memory usage", () => {
 
 			benchmarkMemory(
 				new (class implements IMemoryTestObject {
-					title = `Insert and remove a row and column ${x} times`;
+					readonly title = `Insert and remove a row and column ${x} times`;
 					private localMatrix: SharedMatrix = createLocalMatrix("testLocalMatrix");
 
 					async run() {
@@ -109,7 +109,7 @@ describe("Matrix memory usage", () => {
 
 			benchmarkMemory(
 				new (class implements IMemoryTestObject {
-					title = `Set a 3-character string in ${x} cells`;
+					readonly title = `Set a 3-character string in ${x} cells`;
 					private localMatrix = createLocalMatrix("testLocalMatrix");
 
 					async run() {
@@ -128,7 +128,7 @@ describe("Matrix memory usage", () => {
 
 			benchmarkMemory(
 				new (class implements IMemoryTestObject {
-					title = `Set a number in ${x} cells`;
+					readonly title = `Set a number in ${x} cells`;
 					private localMatrix = createLocalMatrix("testLocalMatrix");
 
 					async run() {


### PR DESCRIPTION
## Description

- Update the perf unit tests for SharedMatrix to be more accurate in what they do VS what they say they do.
- Decrease the maximum number of repetitions for some tests. It seems it legitimately takes a significant amount of time to complete those repetitions, to the point where the actual test runtime plus overhead of the benchmarking infrastructure sometimes hits the mocha timeout of 90s in CI.
- Exclude the output files of the memory perf tests from source control.

In the screenshot below we can see each iteration of the longer tests took ~700ms, and the perf benchmarking package does 50 iterations at a minimum to try to produce statistically significant measurements. That only accounts for 35s out of the 90s that we see the tests take in CI sometimes, but that could vary depending on the particular environment where the tests are running.

![image](https://user-images.githubusercontent.com/716334/222836678-dc4dd472-2d0f-4a78-877c-b569a533cb19.png)

Addresses [AB#2963](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2963) .