### PR TITLE
feat(benchmark): Add output column "avg ms/iteration" for memory usage tests

### DIFF
--- a/tools/benchmark/package-lock.json
+++ b/tools/benchmark/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluid-tools/benchmark",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/benchmark",
-	"version": "0.46.0",
+	"version": "0.47.0",
 	"description": "Benchmarking tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/tools/benchmark/src/MochaMemoryTestReporter.ts
+++ b/tools/benchmark/src/MochaMemoryTestReporter.ts
@@ -150,6 +150,11 @@ class MochaMemoryTestReporter {
 								testData.stats.sample.length.toString(),
 								Table.padLeft,
 							);
+							table.cell(
+								"Avg ms/iteration",
+								`${prettyNumber(testData.totalRunTimeMs / testData.runs, 2)}`,
+								Table.padLeft,
+							);
 						}
 						table.newRow();
 					});


### PR DESCRIPTION
## Description

Adds a new column to the console output of memory usage tests which states the average ms taken per iteration for a given test. This came in handy when troubleshooting why some memory tests were hitting mocha timeouts in CI [here](https://github.com/microsoft/FluidFramework/pull/14415).
