### PR TITLE
Mark 'core-utils' exports as @internal

### DIFF
--- a/api-report/core-utils.api.md
+++ b/api-report/core-utils.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @public
+// @internal
 export const compareArrays: <T>(left: readonly T[], right: readonly T[], comparator?: (leftItem: T, rightItem: T, index: number) => boolean) => boolean;
 
 // (No @packageDocumentation comment for this package)

--- a/build-tools/packages/build-tools/data/layerInfo.json
+++ b/build-tools/packages/build-tools/data/layerInfo.json
@@ -7,7 +7,6 @@
 				"packages": [
 					"@fluidframework/common-definitions",
 					"@fluidframework/core-interfaces",
-					"@fluidframework/core-utils",
 					"@fluidframework/gitresources"
 				]
 			},
@@ -33,6 +32,10 @@
 			"Base-Utils": {
 				"packages": ["@fluidframework/common-utils"],
 				"deps": ["Base-Definitions"]
+			},
+			"Core-Utils": {
+				"packages": ["@fluidframework/core-utils"],
+				"deps": []
 			},
 			"Protocol-Utils": {
 				"packages": ["@fluidframework/protocol-base"],

--- a/packages/common/core-utils/README.md
+++ b/packages/common/core-utils/README.md
@@ -1,6 +1,10 @@
 # @fluidframework/core-utils
 
-Fluid agnostic utility functions with zero-dependencies
+Intended for internally sharing/promoting best-practice implementations of Fluid agnostic utility functions across packages in the client repo.
+
+Use outside of the Fluid Framework client repo is not supported or recommended.
+
+All exports must be designated @internal. This package must not depend on other packages.
 
 ## Trademark
 

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@fluidframework/core-utils",
 	"version": "2.0.0-internal.3.3.0",
-	"description": "Fluid agnostic utility functions with zero-dependencies",
+	"description": "Not intended for use outside the Fluid client repo.",
 	"homepage": "https://fluidframework.com",
 	"repository": {
 		"type": "git",

--- a/packages/common/core-utils/src/compare.ts
+++ b/packages/common/core-utils/src/compare.ts
@@ -6,6 +6,8 @@
 /**
  * Compare two arrays.  Returns true if their elements are equivalent and in the same order.
  *
+ * @internal
+ *
  * @param left - The first array to compare
  * @param right - The second array to compare
  * @param comparator - The function used to check if two `T`s are equivalent.


### PR DESCRIPTION
Follows up on recommendations by @ChumpChief to discourage use of '@fluidframework/core-utils' outside of the Fluid Framework client repo.