### PR TITLE
fix: Make getEntryPoint optional like it should have been

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -139,7 +139,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
     getAudience(): IAudience;
     getCurrentReferenceTimestampMs(): number | undefined;
     // (undocumented)
-    getEntryPoint(): Promise<FluidObject | undefined>;
+    getEntryPoint?(): Promise<FluidObject | undefined>;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     getGCNodePackagePath(nodePath: string): Promise<readonly string[] | undefined>;
     // Warning: (ae-forgotten-export) The symbol "GCNodeType" needs to be exported by the entry point index.d.ts

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1562,7 +1562,7 @@ export class ContainerRuntime
 	/**
 	 * {@inheritDoc @fluidframework/container-definitions#IRuntime.getEntryPoint}
 	 */
-	public async getEntryPoint(): Promise<FluidObject | undefined> {
+	public async getEntryPoint?(): Promise<FluidObject | undefined> {
 		return this.entryPoint;
 	}
 	private readonly entryPoint: LazyPromise<FluidObject | undefined>;

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -942,7 +942,8 @@ describe("Runtime", () => {
 				);
 
 				// The entryPoint should be undefined because the deprecated load() method was used
-				const actualEntryPoint = await containerRuntime.getEntryPoint();
+				assert(containerRuntime.getEntryPoint !== undefined); // The function should exist, though
+				const actualEntryPoint = await containerRuntime.getEntryPoint?.();
 				assert.strictEqual(
 					actualEntryPoint,
 					undefined,
@@ -962,7 +963,7 @@ describe("Runtime", () => {
 				});
 
 				// The entryPoint should come from the provided initialization function.
-				const actualEntryPoint = await containerRuntime.getEntryPoint();
+				const actualEntryPoint = await containerRuntime.getEntryPoint?.();
 				assert(actualEntryPoint !== undefined, "entryPoint was not initialized");
 				assert.deepEqual(
 					actualEntryPoint,


### PR DESCRIPTION
## Description

Follow with a fix to #12487 that somehow wasn't caught by the PR build. `getEntryPoint()` should have been optional.