### PR TITLE
Remove deprecated PendingStateManager interfaces

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -115,7 +115,7 @@ The `@fluidframework/web-code-loader` and the `ICodeAllowList` were deprecated i
 
 ### Remove deprecated PendingStateManager interfaces
 
-The following interfaces used by the `PendingStateManager` are no longer be exported:
+The following interfaces used by the `PendingStateManager` are no longer exported:
 
 -   `IPendingMessage`
 -   `IPendingFlush`

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -41,6 +41,7 @@ getBaseGCDetails() has been deprecated in IFluidDataStoreContext and CreateChild
 -   [Summarizer node and related items removed](#Summarizer-node-and-related-items-removed)
 -   [web-code-loader and ICodeAllowList removed](#web-code-loader-and-ICodeAllowList-removed)
 -   [Container and IContainer no longer raise events when a new listener is registered](#Container-and-IContainer-no-longer-raise-events-when-a-new-listener-is-registered)
+-   [Remove deprecated PendingStateManager interfaces](#Remove-deprecated-PendingStateManager-interfaces)
 
 ### Container and RelativeLoader no longer exported
 
@@ -111,6 +112,15 @@ The `@fluidframework/web-code-loader` and the `ICodeAllowList` were deprecated i
 		});
 +   }
 ```
+
+### Remove deprecated PendingStateManager interfaces
+
+The following interfaces used by the `PendingStateManager` are no longer be exported:
+
+-   `IPendingMessage`
+-   `IPendingFlush`
+-   `IPendingState`
+-   `IPendingLocalState`
 
 # 2.0.0-internal.3.0.0
 

--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -418,38 +418,6 @@ export interface IOnDemandSummarizeOptions extends ISummarizeOptions {
     readonly reason: string;
 }
 
-// @public @deprecated
-export interface IPendingFlush {
-    // (undocumented)
-    type: "flush";
-}
-
-// @public @deprecated (undocumented)
-export interface IPendingLocalState {
-    pendingStates: IPendingState[];
-}
-
-// @public @deprecated
-export interface IPendingMessage {
-    // (undocumented)
-    clientSequenceNumber: number;
-    // (undocumented)
-    content: any;
-    // (undocumented)
-    localOpMetadata: unknown;
-    // (undocumented)
-    messageType: ContainerMessageType;
-    // (undocumented)
-    opMetadata: Record<string, unknown> | undefined;
-    // (undocumented)
-    referenceSequenceNumber: number;
-    // (undocumented)
-    type: "message";
-}
-
-// @public @deprecated (undocumented)
-export type IPendingState = IPendingMessage | IPendingFlush;
-
 // @public @deprecated (undocumented)
 export interface IProvideSummarizer {
     // @deprecated (undocumented)

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -121,6 +121,22 @@
 			"ClassDeclaration_ContainerRuntime": {
 				"backCompat": false,
 				"forwardCompat": false
+			},
+			"RemovedInterfaceDeclaration_IPendingFlush": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"RemovedInterfaceDeclaration_IPendingLocalState": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"RemovedInterfaceDeclaration_IPendingMessage": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"RemovedTypeAliasDeclaration_IPendingState": {
+				"backCompat": false,
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -28,12 +28,6 @@ export {
 export { FluidDataStoreRegistry } from "./dataStoreRegistry";
 export { IGCRuntimeOptions, IGCStats } from "./gc";
 export {
-	IPendingFlush,
-	IPendingLocalState,
-	IPendingMessage,
-	IPendingState,
-} from "./pendingStateManager";
-export {
 	IAckedSummary,
 	ISummarizer,
 	ISummarizeResults,

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -15,7 +15,6 @@ import { pkgVersion } from "./packageVersion";
 /**
  * This represents a message that has been submitted and is added to the pending queue when `submit` is called on the
  * ContainerRuntime. This message has either not been ack'd by the server or has not been submitted to the server yet.
- * @deprecated - This interface will no longer be exported in a future version
  */
 export interface IPendingMessage {
 	type: "message";
@@ -30,20 +29,13 @@ export interface IPendingMessage {
 /**
  * This represents an explicit flush call and is added to the pending queue when flush is called on the ContainerRuntime
  * to flush pending messages.
- * @deprecated Use batch metadata on IPendingMessage instead. To be removed in 2.0.0-internal.4.0.0 (AB#2496)
  */
 export interface IPendingFlush {
 	type: "flush";
 }
 
-/**
- * @deprecated - This interface will no longer be exported in a future version
- */
 export type IPendingState = IPendingMessage | IPendingFlush;
 
-/**
- * @deprecated - This interface will no longer be exported in a future version
- */
 export interface IPendingLocalState {
 	/**
 	 * list of pending states, including ops and batch information

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -666,98 +666,50 @@ use_old_InterfaceDeclaration_IOnDemandSummarizeOptions(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IPendingFlush": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IPendingFlush": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IPendingFlush():
-    TypeOnly<old.IPendingFlush>;
-declare function use_current_InterfaceDeclaration_IPendingFlush(
-    use: TypeOnly<current.IPendingFlush>);
-use_current_InterfaceDeclaration_IPendingFlush(
-    get_old_InterfaceDeclaration_IPendingFlush());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IPendingFlush": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IPendingFlush": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IPendingFlush():
-    TypeOnly<current.IPendingFlush>;
-declare function use_old_InterfaceDeclaration_IPendingFlush(
-    use: TypeOnly<old.IPendingFlush>);
-use_old_InterfaceDeclaration_IPendingFlush(
-    get_current_InterfaceDeclaration_IPendingFlush());
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IPendingLocalState": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IPendingLocalState": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IPendingLocalState():
-    TypeOnly<old.IPendingLocalState>;
-declare function use_current_InterfaceDeclaration_IPendingLocalState(
-    use: TypeOnly<current.IPendingLocalState>);
-use_current_InterfaceDeclaration_IPendingLocalState(
-    get_old_InterfaceDeclaration_IPendingLocalState());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IPendingLocalState": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IPendingLocalState": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IPendingLocalState():
-    TypeOnly<current.IPendingLocalState>;
-declare function use_old_InterfaceDeclaration_IPendingLocalState(
-    use: TypeOnly<old.IPendingLocalState>);
-use_old_InterfaceDeclaration_IPendingLocalState(
-    get_current_InterfaceDeclaration_IPendingLocalState());
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IPendingMessage": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IPendingMessage": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IPendingMessage():
-    TypeOnly<old.IPendingMessage>;
-declare function use_current_InterfaceDeclaration_IPendingMessage(
-    use: TypeOnly<current.IPendingMessage>);
-use_current_InterfaceDeclaration_IPendingMessage(
-    get_old_InterfaceDeclaration_IPendingMessage());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IPendingMessage": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IPendingMessage": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IPendingMessage():
-    TypeOnly<current.IPendingMessage>;
-declare function use_old_InterfaceDeclaration_IPendingMessage(
-    use: TypeOnly<old.IPendingMessage>);
-use_old_InterfaceDeclaration_IPendingMessage(
-    get_current_InterfaceDeclaration_IPendingMessage());
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_IPendingState": {"forwardCompat": false}
+* "RemovedTypeAliasDeclaration_IPendingState": {"forwardCompat": false}
 */
-declare function get_old_TypeAliasDeclaration_IPendingState():
-    TypeOnly<old.IPendingState>;
-declare function use_current_TypeAliasDeclaration_IPendingState(
-    use: TypeOnly<current.IPendingState>);
-use_current_TypeAliasDeclaration_IPendingState(
-    get_old_TypeAliasDeclaration_IPendingState());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_IPendingState": {"backCompat": false}
+* "RemovedTypeAliasDeclaration_IPendingState": {"backCompat": false}
 */
-declare function get_current_TypeAliasDeclaration_IPendingState():
-    TypeOnly<current.IPendingState>;
-declare function use_old_TypeAliasDeclaration_IPendingState(
-    use: TypeOnly<old.IPendingState>);
-use_old_TypeAliasDeclaration_IPendingState(
-    get_current_TypeAliasDeclaration_IPendingState());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
# [AB#2496](https://dev.azure.com/fluidframework/internal/_workitems/edit/2496)

[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Breaking Changes

The following interfaces used by the `PendingStateManager` are no longer be exported:

-   `IPendingMessage`
-   `IPendingFlush`
-   `IPendingState`
-   `IPendingLocalState`

See https://github.com/microsoft/FluidFramework/pull/13917 and https://github.com/microsoft/FluidFramework/pull/12592