### PR TITLE
tree: Fix encoding for changesets with repair data

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/defaultFieldKinds.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/defaultFieldKinds.spec.ts
@@ -5,6 +5,7 @@
 
 import { strict as assert } from "assert";
 import {
+	FieldChangeEncoder,
 	FieldChangeHandler,
 	FieldKinds,
 	IdAllocator,
@@ -248,28 +249,7 @@ describe("Value field changesets", () => {
 		["with repair data", revertChange2],
 	];
 
-	describe("encoding", () => {
-		const encoder = fieldHandler.encoder;
-		const version = 0;
-
-		for (const [name, data] of encodingTestData) {
-			describe(name, () => {
-				it("roundtrip", () => {
-					const encoded = encoder.encodeForJson(version, data, childEncoder1);
-					const decoded = encoder.decodeJson(version, encoded, childDecoder1);
-					assert.deepEqual(decoded, data);
-				});
-
-				it("json roundtrip", () => {
-					const encoded = JSON.stringify(
-						encoder.encodeForJson(version, data, childEncoder1),
-					);
-					const decoded = encoder.decodeJson(version, JSON.parse(encoded), childDecoder1);
-					assert.deepEqual(decoded, data);
-				});
-			});
-		}
-	});
+	runEncodingTests(fieldHandler.encoder, encodingTestData);
 });
 
 describe("Optional field changesets", () => {
@@ -444,8 +424,14 @@ describe("Optional field changesets", () => {
 		["with repair data", revertChange2],
 	];
 
+	runEncodingTests(fieldHandler.encoder, encodingTestData);
+});
+
+function runEncodingTests<TChangeset>(
+	encoder: FieldChangeEncoder<TChangeset>,
+	encodingTestData: [string, TChangeset][],
+) {
 	describe("encoding", () => {
-		const encoder = fieldHandler.encoder;
 		const version = 0;
 
 		for (const [name, data] of encodingTestData) {
@@ -466,4 +452,4 @@ describe("Optional field changesets", () => {
 			});
 		}
 	});
-});
+}

--- a/packages/dds/tree/src/test/feature-libraries/defaultFieldKinds.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/defaultFieldKinds.spec.ts
@@ -95,7 +95,6 @@ describe("Value field changesets", () => {
 	const change1 = fieldHandler.editor.set(singleTextCursor(tree1));
 	const change2 = fieldHandler.editor.set(singleTextCursor(tree2));
 
-	const detachedBy: RevisionTag = mintRevisionTag();
 	const revertChange2: FieldKinds.ValueChangeset = {
 		value: { revert: singleTextCursor(tree1) },
 	};
@@ -244,19 +243,32 @@ describe("Value field changesets", () => {
 		assertMarkListEqual(actual, expected);
 	});
 
-	it("can be encoded in JSON", () => {
+	const encodingTestData: [string, FieldKinds.ValueChangeset][] = [
+		["with child change", change1WithChildChange],
+		["with repair data", revertChange2],
+	];
+
+	describe("encoding", () => {
+		const encoder = fieldHandler.encoder;
 		const version = 0;
 
-		const encoded = JSON.stringify(
-			fieldHandler.encoder.encodeForJson(version, change1WithChildChange, childEncoder1),
-		);
+		for (const [name, data] of encodingTestData) {
+			describe(name, () => {
+				it("roundtrip", () => {
+					const encoded = encoder.encodeForJson(version, data, childEncoder1);
+					const decoded = encoder.decodeJson(version, encoded, childDecoder1);
+					assert.deepEqual(decoded, data);
+				});
 
-		const decoded = fieldHandler.encoder.decodeJson(
-			version,
-			JSON.parse(encoded),
-			childDecoder1,
-		);
-		assert.deepEqual(decoded, change1WithChildChange);
+				it("json roundtrip", () => {
+					const encoded = JSON.stringify(
+						encoder.encodeForJson(version, data, childEncoder1),
+					);
+					const decoded = encoder.decodeJson(version, JSON.parse(encoded), childDecoder1);
+					assert.deepEqual(decoded, data);
+				});
+			});
+		}
 	});
 });
 
@@ -427,18 +439,31 @@ describe("Optional field changesets", () => {
 		assertMarkListEqual(fieldHandler.intoDelta(change4, deltaFromChild2), expected);
 	});
 
-	it("can be encoded in JSON", () => {
+	const encodingTestData: [string, FieldKinds.OptionalChangeset][] = [
+		["change", change1],
+		["with repair data", revertChange2],
+	];
+
+	describe("encoding", () => {
+		const encoder = fieldHandler.encoder;
 		const version = 0;
 
-		const encoded = JSON.stringify(
-			fieldHandler.encoder.encodeForJson(version, change1, childEncoder1),
-		);
+		for (const [name, data] of encodingTestData) {
+			describe(name, () => {
+				it("roundtrip", () => {
+					const encoded = encoder.encodeForJson(version, data, childEncoder1);
+					const decoded = encoder.decodeJson(version, encoded, childDecoder1);
+					assert.deepEqual(decoded, data);
+				});
 
-		const decoded = fieldHandler.encoder.decodeJson(
-			version,
-			JSON.parse(encoded),
-			childDecoder1,
-		);
-		assert.deepEqual(decoded, change1);
+				it("json roundtrip", () => {
+					const encoded = JSON.stringify(
+						encoder.encodeForJson(version, data, childEncoder1),
+					);
+					const decoded = encoder.decodeJson(version, JSON.parse(encoded), childDecoder1);
+					assert.deepEqual(decoded, data);
+				});
+			});
+		}
 	});
 });

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldEncoder.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldEncoder.spec.ts
@@ -4,32 +4,46 @@
  */
 
 import { strict as assert } from "assert";
+import { mintRevisionTag } from "../../../core";
 import { SequenceField as SF } from "../../../feature-libraries";
+// eslint-disable-next-line import/no-internal-modules
+import { Changeset } from "../../../feature-libraries/sequence-field";
 import { TestChange, TestChangeEncoder } from "../../testChange";
-import { deepFreeze } from "../../utils";
-import { ChangeMaker as Change, TestChangeset } from "./testEdits";
+import { deepFreeze, fakeRepair } from "../../utils";
+import { ChangeMaker as Change } from "./testEdits";
 
-describe("SequenceField - Encoder", () => {
-	it("with child change", () => {
-		const change: TestChangeset = Change.modify(1, TestChange.mint([], 1));
-		deepFreeze(change);
-		const childEncoder = new TestChangeEncoder();
-		const encoded = JSON.stringify(
-			SF.encodeForJson(0, change, (c) => childEncoder.encodeForJson(0, c)),
-		);
-		const decoded = SF.decodeJson(0, JSON.parse(encoded), (c) => childEncoder.decodeJson(0, c));
-		assert.deepEqual(decoded, change);
-	});
+const encodingTestData: [string, Changeset<TestChange>][] = [
+	["with child change", Change.modify(1, TestChange.mint([], 1))],
+	["without child change", Change.delete(2, 2)],
+	["with repair data", Change.revive(0, 1, mintRevisionTag(), undefined, fakeRepair)],
+];
 
-	it("without child change", () => {
-		const change: TestChangeset = Change.delete(2, 2);
-		deepFreeze(change);
-		const encoded = JSON.stringify(
-			SF.encodeForJson(0, change, () => assert.fail("Child encoder should not be called")),
-		);
-		const decoded = SF.decodeJson(0, JSON.parse(encoded), () =>
-			assert.fail("Child decoder should not be called"),
-		);
-		assert.deepEqual(decoded, change);
-	});
+describe("SequenceField encoding", () => {
+	const version = 0;
+	const childEncoder = new TestChangeEncoder();
+
+	for (const [name, data] of encodingTestData) {
+		describe(name, () => {
+			it("roundtrip", () => {
+				deepFreeze(data);
+				const encoded = SF.encodeForJson<TestChange>(version, data, (c) =>
+					childEncoder.encodeForJson(0, c),
+				);
+				const decoded = SF.decodeJson(version, encoded, (c) =>
+					childEncoder.decodeJson(0, c),
+				);
+				assert.deepEqual(decoded, data);
+			});
+
+			it("json roundtrip", () => {
+				const encoded = JSON.stringify(
+					SF.encodeForJson(version, data, (c) => childEncoder.encodeForJson(0, c)),
+				);
+				const decoded = SF.decodeJson(version, JSON.parse(encoded), (c) =>
+					childEncoder.decodeJson(0, c),
+				);
+				assert.deepEqual(decoded, data);
+			});
+		});
+	}
 });


### PR DESCRIPTION
- Add encoding tests for value, optional, and sequence fields
- Fix encoding and decoding repair data