### PR TITLE
Stop exporting internal attribution APIs in merge-tree

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -23,14 +23,8 @@ export function appendToMergeTreeDeltaRevertibles(driver: MergeTreeRevertibleDri
 
 // @alpha @sealed
 export interface AttributionPolicy {
-    // @internal
-    attach: (client: Client) => void;
-    // @internal
-    detach: () => void;
-    // @internal (undocumented)
-    isAttached: boolean;
-    // @internal
-    serializer: IAttributionCollectionSerializer;
+    // (undocumented)
+    readonly _brand?: unique symbol;
 }
 
 // @public (undocumented)
@@ -297,31 +291,10 @@ export function extend<T>(base: MapLike<T>, extension: MapLike<T> | undefined, c
 // @public (undocumented)
 export function extendIfUndefined<T>(base: MapLike<T>, extension: MapLike<T> | undefined): MapLike<T>;
 
-// @alpha (undocumented)
+// @alpha @sealed (undocumented)
 export interface IAttributionCollection<T> {
-    // @internal (undocumented)
-    append(other: IAttributionCollection<T>): void;
-    // @internal (undocumented)
-    clone(): IAttributionCollection<T>;
-    // @internal
-    getAll(): Iterable<{
-        offset: number;
-        key: T;
-    }>;
     getAtOffset(offset: number): T;
     readonly length: number;
-    // @internal (undocumented)
-    splitAt(pos: number): IAttributionCollection<T>;
-}
-
-// @internal @sealed (undocumented)
-export interface IAttributionCollectionSerializer {
-    populateAttributionCollections(segments: Iterable<ISegment>, summary: SerializedAttributionCollection): void;
-    // (undocumented)
-    serializeAttributionCollections(segments: Iterable<{
-        attribution?: IAttributionCollection<AttributionKey>;
-        cachedLength: number;
-    }>): SerializedAttributionCollection;
 }
 
 // @public (undocumented)
@@ -1192,15 +1165,6 @@ export class SegmentGroupCollection {
     pop?(): SegmentGroup | undefined;
     // (undocumented)
     get size(): number;
-}
-
-// @internal (undocumented)
-export interface SerializedAttributionCollection {
-    // (undocumented)
-    length: number;
-    // (undocumented)
-    posBreakpoints: number[];
-    seqs: (number | AttributionKey)[];
 }
 
 // @internal (undocumented)

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -109,6 +109,67 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_BaseSegment": {
+				"backCompat": false
+			},
+			"ClassDeclaration_IncrementalMapState": {
+				"backCompat": false
+			},
+			"ClassDeclaration_Marker": {
+				"backCompat": false
+			},
+			"ClassDeclaration_MergeBlock": {
+				"backCompat": false
+			},
+			"ClassDeclaration_MergeNode": {
+				"backCompat": false
+			},
+			"ClassDeclaration_TextSegment": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_AttributionPolicy": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_IAttributionCollection": {
+				"backCompat": false
+			},
+			"RemovedInterfaceDeclaration_IAttributionCollectionSerializer": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_IConsensusInfo": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_IHierBlock": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_IMergeBlock": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_IMergeNodeCommon": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_InsertContext": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_ISegmentChanges": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_SerializedAttributionCollection": {
+				"backCompat": false
+			},
+			"RemovedInterfaceDeclaration_SerializedAttributionCollection": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"TypeAliasDeclaration_IMergeNode": {
+				"backCompat": false
+			},
+			"TypeAliasDeclaration_SortedSegmentSetItem": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/dds/merge-tree/src/attributionCollection.ts
+++ b/packages/dds/merge-tree/src/attributionCollection.ts
@@ -108,7 +108,7 @@ export function areEqualAttributionKeys(a: AttributionKey, b: AttributionKey): b
 	}
 }
 
-export class AttributionCollection implements IAttributionCollection<AttributionKey> {
+export class AttributionCollection implements IAttributionCollectionInternal<AttributionKey> {
 	private offsets: number[];
 	private keys: AttributionKey[];
 

--- a/packages/dds/merge-tree/src/index.ts
+++ b/packages/dds/merge-tree/src/index.ts
@@ -3,12 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export {
-	IAttributionCollection,
-	IAttributionCollectionSerializer,
-	createInsertOnlyAttributionPolicy,
-	SerializedAttributionCollection,
-} from "./attributionCollection";
+export { IAttributionCollection, createInsertOnlyAttributionPolicy } from "./attributionCollection";
 export { IIntegerRange } from "./base";
 export { Client } from "./client";
 export {

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -466,6 +466,10 @@ export interface IMergeTreeAttributionOptions {
  * @sealed
  */
 export interface AttributionPolicy {
+	readonly _brand?: unique symbol;
+}
+
+export interface AttributionPolicyInternal extends AttributionPolicy {
 	/**
 	 * Enables tracking attribution information for operations on this merge-tree.
 	 * This function is expected to subscribe to appropriate change events in order
@@ -535,7 +539,7 @@ export class MergeTree {
 		return this.segmentsToScour;
 	}
 
-	public readonly attributionPolicy: AttributionPolicy | undefined;
+	public readonly attributionPolicy: AttributionPolicyInternal | undefined;
 
 	/**
 	 * Whether or not all blocks in the mergeTree currently have information about local partial lengths computed.
@@ -554,7 +558,8 @@ export class MergeTree {
 	public constructor(public options?: IMergeTreeOptions) {
 		this._root = this.makeBlock(0);
 		this._root.mergeTree = this;
-		this.attributionPolicy = options?.attribution?.policyFactory?.();
+		this.attributionPolicy =
+			options?.attribution?.policyFactory?.() as AttributionPolicyInternal;
 	}
 
 	private _root: IRootMergeBlock;

--- a/packages/dds/merge-tree/src/test/attributionCollection.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/attributionCollection.perf.spec.ts
@@ -10,6 +10,7 @@ import {
 	areEqualAttributionKeys,
 	AttributionCollection as NewAttributionCollection,
 	IAttributionCollection,
+	IAttributionCollectionInternal,
 	SerializedAttributionCollection,
 } from "../attributionCollection";
 import { TextSegmentGranularity } from "../textSegment";
@@ -17,11 +18,11 @@ import { compareNumbers, ISegment } from "../mergeTreeNodes";
 import { RedBlackTree } from "../collections";
 
 interface IAttributionCollectionCtor {
-	new (key: AttributionKey, length: number): IAttributionCollection<AttributionKey>;
+	new (key: AttributionKey, length: number): IAttributionCollectionInternal<AttributionKey>;
 
 	serializeAttributionCollections(
 		segments: Iterable<{
-			attribution?: IAttributionCollection<AttributionKey>;
+			attribution?: IAttributionCollectionInternal<AttributionKey>;
 			cachedLength: number;
 		}>,
 	): SerializedAttributionCollection;
@@ -37,7 +38,7 @@ function getCollectionSizes(
 	baseSuiteType: BenchmarkType,
 ): {
 	name: string;
-	collection: IAttributionCollection<AttributionKey>;
+	collection: IAttributionCollectionInternal<AttributionKey>;
 	type: BenchmarkType;
 }[] {
 	const singleKeyCollection = new ctor({ type: "op", seq: 5 }, 42);
@@ -264,7 +265,9 @@ export class TreeAttributionCollection implements IAttributionCollection<Attribu
 		for (const segment of segments) {
 			if (segment.attribution) {
 				segmentsWithAttribution++;
-				for (const { offset, key: info } of segment.attribution?.getAll() ?? []) {
+				for (const { offset, key: info } of (
+					segment.attribution as IAttributionCollectionInternal<AttributionKey>
+				)?.getAll() ?? []) {
 					if (
 						!mostRecentAttributionKey ||
 						!areEqualAttributionKeys(info, mostRecentAttributionKey)

--- a/packages/dds/merge-tree/src/test/attributionCollection.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/attributionCollection.perf.spec.ts
@@ -137,7 +137,7 @@ function runAttributionCollectionSuite(
 	});
 }
 
-export class TreeAttributionCollection implements IAttributionCollection<AttributionKey> {
+export class TreeAttributionCollection implements IAttributionCollectionInternal<AttributionKey> {
 	private readonly entries: RedBlackTree<number, AttributionKey> = new RedBlackTree(
 		compareNumbers,
 	);

--- a/packages/dds/merge-tree/src/test/attributionCollection.spec.ts
+++ b/packages/dds/merge-tree/src/test/attributionCollection.spec.ts
@@ -13,7 +13,11 @@ import {
 	take,
 } from "@fluid-internal/stochastic-test-utils";
 import { AttributionKey } from "@fluidframework/runtime-definitions";
-import { AttributionCollection, SerializedAttributionCollection } from "../attributionCollection";
+import {
+	AttributionCollection,
+	IAttributionCollectionInternal,
+	SerializedAttributionCollection,
+} from "../attributionCollection";
 import { BaseSegment, ISegment } from "../mergeTreeNodes";
 
 describe("AttributionCollection", () => {
@@ -129,8 +133,11 @@ describe("AttributionCollection", () => {
 	});
 
 	describe(".populateAttributionCollections", () => {
+		type ISegmentInternal = ISegment & {
+			attribution?: IAttributionCollectionInternal<AttributionKey>;
+		};
 		it("correctly splits segment boundaries on breakpoints", () => {
-			const segments = [{ cachedLength: 5 }, { cachedLength: 4 }] as ISegment[];
+			const segments = [{ cachedLength: 5 }, { cachedLength: 4 }] as ISegmentInternal[];
 			AttributionCollection.populateAttributionCollections(segments, {
 				length: 9,
 				posBreakpoints: [0, 2, 5, 7],
@@ -152,7 +159,7 @@ describe("AttributionCollection", () => {
 		});
 
 		it("correctly splits segment boundaries between breakpoints", () => {
-			const segments = [{ cachedLength: 4 }, { cachedLength: 5 }] as ISegment[];
+			const segments = [{ cachedLength: 4 }, { cachedLength: 5 }] as ISegmentInternal[];
 			AttributionCollection.populateAttributionCollections(segments, {
 				length: 9,
 				posBreakpoints: [0, 2, 5, 7],

--- a/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
+++ b/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
@@ -23,6 +23,7 @@ declare function get_old_InterfaceDeclaration_AttributionPolicy():
 declare function use_current_InterfaceDeclaration_AttributionPolicy(
     use: TypeOnly<current.AttributionPolicy>);
 use_current_InterfaceDeclaration_AttributionPolicy(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_AttributionPolicy());
 
 /*
@@ -35,6 +36,7 @@ declare function get_current_InterfaceDeclaration_AttributionPolicy():
 declare function use_old_InterfaceDeclaration_AttributionPolicy(
     use: TypeOnly<old.AttributionPolicy>);
 use_old_InterfaceDeclaration_AttributionPolicy(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_AttributionPolicy());
 
 /*
@@ -59,6 +61,7 @@ declare function get_current_ClassDeclaration_BaseSegment():
 declare function use_old_ClassDeclaration_BaseSegment(
     use: TypeOnly<old.BaseSegment>);
 use_old_ClassDeclaration_BaseSegment(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_BaseSegment());
 
 /*
@@ -251,31 +254,20 @@ declare function get_current_InterfaceDeclaration_IAttributionCollection():
 declare function use_old_InterfaceDeclaration_IAttributionCollection(
     use: TypeOnly<old.IAttributionCollection<any>>);
 use_old_InterfaceDeclaration_IAttributionCollection(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IAttributionCollection());
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IAttributionCollectionSerializer": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IAttributionCollectionSerializer": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IAttributionCollectionSerializer():
-    TypeOnly<old.IAttributionCollectionSerializer>;
-declare function use_current_InterfaceDeclaration_IAttributionCollectionSerializer(
-    use: TypeOnly<current.IAttributionCollectionSerializer>);
-use_current_InterfaceDeclaration_IAttributionCollectionSerializer(
-    get_old_InterfaceDeclaration_IAttributionCollectionSerializer());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IAttributionCollectionSerializer": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IAttributionCollectionSerializer": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IAttributionCollectionSerializer():
-    TypeOnly<current.IAttributionCollectionSerializer>;
-declare function use_old_InterfaceDeclaration_IAttributionCollectionSerializer(
-    use: TypeOnly<old.IAttributionCollectionSerializer>);
-use_old_InterfaceDeclaration_IAttributionCollectionSerializer(
-    get_current_InterfaceDeclaration_IAttributionCollectionSerializer());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -323,6 +315,7 @@ declare function get_current_InterfaceDeclaration_IConsensusInfo():
 declare function use_old_InterfaceDeclaration_IConsensusInfo(
     use: TypeOnly<old.IConsensusInfo>);
 use_old_InterfaceDeclaration_IConsensusInfo(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IConsensusInfo());
 
 /*
@@ -371,6 +364,7 @@ declare function get_current_InterfaceDeclaration_IHierBlock():
 declare function use_old_InterfaceDeclaration_IHierBlock(
     use: TypeOnly<old.IHierBlock>);
 use_old_InterfaceDeclaration_IHierBlock(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IHierBlock());
 
 /*
@@ -539,6 +533,7 @@ declare function get_current_InterfaceDeclaration_IMergeBlock():
 declare function use_old_InterfaceDeclaration_IMergeBlock(
     use: TypeOnly<old.IMergeBlock>);
 use_old_InterfaceDeclaration_IMergeBlock(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IMergeBlock());
 
 /*
@@ -563,6 +558,7 @@ declare function get_current_TypeAliasDeclaration_IMergeNode():
 declare function use_old_TypeAliasDeclaration_IMergeNode(
     use: TypeOnly<old.IMergeNode>);
 use_old_TypeAliasDeclaration_IMergeNode(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_IMergeNode());
 
 /*
@@ -587,6 +583,7 @@ declare function get_current_InterfaceDeclaration_IMergeNodeCommon():
 declare function use_old_InterfaceDeclaration_IMergeNodeCommon(
     use: TypeOnly<old.IMergeNodeCommon>);
 use_old_InterfaceDeclaration_IMergeNodeCommon(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IMergeNodeCommon());
 
 /*
@@ -1115,6 +1112,7 @@ declare function get_current_InterfaceDeclaration_ISegmentChanges():
 declare function use_old_InterfaceDeclaration_ISegmentChanges(
     use: TypeOnly<old.ISegmentChanges>);
 use_old_InterfaceDeclaration_ISegmentChanges(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISegmentChanges());
 
 /*
@@ -1187,6 +1185,7 @@ declare function get_current_ClassDeclaration_IncrementalMapState():
 declare function use_old_ClassDeclaration_IncrementalMapState(
     use: TypeOnly<old.IncrementalMapState<any>>);
 use_old_ClassDeclaration_IncrementalMapState(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_IncrementalMapState());
 
 /*
@@ -1259,6 +1258,7 @@ declare function get_current_InterfaceDeclaration_InsertContext():
 declare function use_old_InterfaceDeclaration_InsertContext(
     use: TypeOnly<old.InsertContext>);
 use_old_InterfaceDeclaration_InsertContext(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_InsertContext());
 
 /*
@@ -1403,6 +1403,7 @@ declare function get_current_ClassDeclaration_Marker():
 declare function use_old_ClassDeclaration_Marker(
     use: TypeOnly<old.Marker>);
 use_old_ClassDeclaration_Marker(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_Marker());
 
 /*
@@ -1451,6 +1452,7 @@ declare function get_current_ClassDeclaration_MergeBlock():
 declare function use_old_ClassDeclaration_MergeBlock(
     use: TypeOnly<old.MergeBlock>);
 use_old_ClassDeclaration_MergeBlock(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_MergeBlock());
 
 /*
@@ -1475,6 +1477,7 @@ declare function get_current_ClassDeclaration_MergeNode():
 declare function use_old_ClassDeclaration_MergeNode(
     use: TypeOnly<old.MergeNode>);
 use_old_ClassDeclaration_MergeNode(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_MergeNode());
 
 /*
@@ -2248,26 +2251,14 @@ use_old_ClassDeclaration_SegmentGroupCollection(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_SerializedAttributionCollection": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_SerializedAttributionCollection": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_SerializedAttributionCollection():
-    TypeOnly<old.SerializedAttributionCollection>;
-declare function use_current_InterfaceDeclaration_SerializedAttributionCollection(
-    use: TypeOnly<current.SerializedAttributionCollection>);
-use_current_InterfaceDeclaration_SerializedAttributionCollection(
-    get_old_InterfaceDeclaration_SerializedAttributionCollection());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_SerializedAttributionCollection": {"backCompat": false}
+* "RemovedInterfaceDeclaration_SerializedAttributionCollection": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_SerializedAttributionCollection():
-    TypeOnly<current.SerializedAttributionCollection>;
-declare function use_old_InterfaceDeclaration_SerializedAttributionCollection(
-    use: TypeOnly<old.SerializedAttributionCollection>);
-use_old_InterfaceDeclaration_SerializedAttributionCollection(
-    get_current_InterfaceDeclaration_SerializedAttributionCollection());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -2339,6 +2330,7 @@ declare function get_current_TypeAliasDeclaration_SortedSegmentSetItem():
 declare function use_old_TypeAliasDeclaration_SortedSegmentSetItem(
     use: TypeOnly<old.SortedSegmentSetItem>);
 use_old_TypeAliasDeclaration_SortedSegmentSetItem(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_SortedSegmentSetItem());
 
 /*
@@ -2411,6 +2403,7 @@ declare function get_current_ClassDeclaration_TextSegment():
 declare function use_old_ClassDeclaration_TextSegment(
     use: TypeOnly<old.TextSegment>);
 use_old_ClassDeclaration_TextSegment(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_TextSegment());
 
 /*


### PR DESCRIPTION
## Description

This hides all attribution-related APIs on merge-tree which aren't intended to be public. It leverages opaque types in a couple places and involves some casts that are only acceptable due to attribution policy and attribution collection being marked sealed.

My primary motivation for this is that it makes changes to internal API signatures not require marking lots of other merge-tree interfaces/classes as breaking back-compat/forward-compat, since the type tests don't understand API-extractor tags. It also makes the API surface less cluttered and easier to understand. That comes at the cost of some ugliness in the implementation (more casting required).