### PR TITLE
Fix remove queue task

### DIFF
--- a/.github/workflows/merge-commits.yml
+++ b/.github/workflows/merge-commits.yml
@@ -174,11 +174,6 @@ jobs:
     needs: [pull-request]
     if: needs.pull-request.result == 'success'
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
-      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # ratchet:actions/setup-node@v3
-        with:
-          node-version: 14
-      - run: npm ci
       - run: npm install @azure/storage-queue
       - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # ratchet:actions/github-script@v6
         with:


### PR DESCRIPTION
The `remove-queue` has been failing in the GitHub workflow: https://github.com/microsoft/FluidFramework/actions/runs/4356115557/jobs/7617563602. This change should fix the problem. The `npm ci` command is not needed.