### PR TITLE
Minor cleanup in bubblebench.ts

### DIFF
--- a/experimental/examples/bubblebench/editable-shared-tree/src/bubblebench.ts
+++ b/experimental/examples/bubblebench/editable-shared-tree/src/bubblebench.ts
@@ -8,31 +8,35 @@ import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { AppState } from "./appState";
 import { appSchemaData, ClientTreeProxy } from "./schema";
 
+// Key used to store/retrieve the SharedTree instance within the root SharedMap.
+const treeKey = "treeKey";
+
 export class Bubblebench extends DataObject {
 	public static get Name() {
 		return "@fluid-example/bubblebench-sharedtree";
 	}
+
 	private _tree: ISharedTree | undefined;
 	private _appState: AppState | undefined;
 
 	protected async initializingFirstTime() {
-		this.maybeTree = this.runtime.createChannel(
+		this._tree = this.runtime.createChannel(
 			/* id: */ undefined,
 			new SharedTreeFactory().type,
 		) as ISharedTree;
 
-		this.initializeTree(this.maybeTree);
+		this.initializeTree(this.tree);
 
-		this.root.set("tree", this.maybeTree.handle);
+		this.root.set(treeKey, this.tree.handle);
 	}
 
 	protected async initializingFromExisting() {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		this.maybeTree = await this.root.get<IFluidHandle<ISharedTree>>("tree")!.get();
+		this._tree = await this.root.get<IFluidHandle<ISharedTree>>(treeKey)!.get();
 	}
 
 	protected async hasInitialized() {
-		this.maybeAppState = new AppState(
+		this._appState = new AppState(
 			this.tree.root as ClientTreeProxy[] & EditableField,
 			/* stageWidth: */ 640,
 			/* stageHeight: */ 480,
@@ -72,7 +76,7 @@ export class Bubblebench extends DataObject {
 	 * Cannot be accessed until after initialization has complected.
 	 */
 	private get tree(): ISharedTree {
-		return this.maybeTree ?? fail("not initialized");
+		return this._tree ?? fail("not initialized");
 	}
 
 	/**
@@ -80,7 +84,7 @@ export class Bubblebench extends DataObject {
 	 * Cannot be accessed until after initialization has complected.
 	 */
 	public get appState(): AppState {
-		return this.maybeAppState ?? fail("not initialized");
+		return this._appState ?? fail("not initialized");
 	}
 }
 

--- a/experimental/examples/bubblebench/editable-shared-tree/src/bubblebench.ts
+++ b/experimental/examples/bubblebench/editable-shared-tree/src/bubblebench.ts
@@ -12,8 +12,8 @@ export class Bubblebench extends DataObject {
 	public static get Name() {
 		return "@fluid-example/bubblebench-sharedtree";
 	}
-	private maybeTree?: ISharedTree = undefined;
-	private maybeAppState?: AppState = undefined;
+	private _tree: ISharedTree | undefined;
+	private _appState: AppState | undefined;
 
 	protected async initializingFirstTime() {
 		this.maybeTree = this.runtime.createChannel(

--- a/experimental/examples/bubblebench/editable-shared-tree/src/bubblebench.ts
+++ b/experimental/examples/bubblebench/editable-shared-tree/src/bubblebench.ts
@@ -14,30 +14,24 @@ export class Bubblebench extends DataObject {
 	}
 	private maybeTree?: ISharedTree = undefined;
 	private maybeAppState?: AppState = undefined;
-	static treeFactory = new SharedTreeFactory();
 
 	protected async initializingFirstTime() {
 		this.maybeTree = this.runtime.createChannel(
-			"unique-bubblebench-key-1337",
-			Bubblebench.treeFactory.type,
+			/* id: */ undefined,
+			new SharedTreeFactory().type,
 		) as ISharedTree;
 
 		this.initializeTree(this.maybeTree);
 
-		this.root.set("unique-bubblebench-key-1337", this.maybeTree.handle);
+		this.root.set("tree", this.maybeTree.handle);
 	}
 
 	protected async initializingFromExisting() {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		this.maybeTree = await this.root
-			.get<IFluidHandle<ISharedTree>>("unique-bubblebench-key-1337")!
-			.get();
+		this.maybeTree = await this.root.get<IFluidHandle<ISharedTree>>("tree")!.get();
 	}
 
 	protected async hasInitialized() {
-		if (this.tree === undefined) {
-			throw new Error("hasInitialized called but tree is still undefined");
-		}
 		this.maybeAppState = new AppState(
 			this.tree.root as ClientTreeProxy[] & EditableField,
 			/* stageWidth: */ 640,


### PR DESCRIPTION
Spotted a couple minor opportunities for cleanup while copying code to bootstrap a SharedTree sample.