### PR TITLE
[GC-stress] Added snapshot cache expiry override to ODSP driver

### DIFF
--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -86,11 +86,10 @@ export class EpochTracker implements IPersistedFileCache {
 		this.rateLimiter = new RateLimiter(24);
 
 		// Matches the TestOverride logic for the policy defined in odspDocumentStorageServiceBase.ts
-		this.snapshotCacheExpiryTimeoutMs = loggerToMonitoringContext(logger).config.getBoolean(
-			"Fluid.Driver.Odsp.TestOverride.DisableSnapshotCache",
-		)
-			? 0
-			: defaultCacheExpiryTimeoutMs;
+		this.snapshotCacheExpiryTimeoutMs =
+			loggerToMonitoringContext(logger).config.getNumber(
+				"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs",
+			) ?? defaultCacheExpiryTimeoutMs;
 	}
 
 	// public for UT purposes only!

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
@@ -122,11 +122,9 @@ export abstract class OdspDocumentStorageServiceBase implements IDocumentStorage
 		// which also applies to the code that reads from the cache in epochTracker.ts
 		// This may result in files created for testing being unusable in production sessions,
 		// due to the GC code guarding against this policy changing over the lifetime of a file.
-		const maximumCacheDurationMsInEffect = (
-			config.getBoolean("Fluid.Driver.Odsp.TestOverride.DisableSnapshotCache")
-				? 0
-				: maximumCacheDurationMs
-		) as FiveDaysMs;
+		const maximumCacheDurationMsInEffect = (config.getNumber(
+			"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs",
+		) ?? maximumCacheDurationMs) as FiveDaysMs;
 
 		this.policies = {
 			// By default, ODSP tells the container not to prefetch/cache.

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -5,6 +5,10 @@
 			"progressIntervalMs": 5000,
 			"numClients": 5,
 			"totalSendCount": 1200,
+			"faultInjectionMs": {
+				"min": 0,
+				"max": 20000
+			},
 			"optionOverrides": {
 				"tinylicious": {
 					"comment": "SessionExpiry: 20 seconds. Inactive Timeout: 40 seconds. Sweep Timeout: 45 seconds.",
@@ -20,7 +24,7 @@
 					"comment": "SessionExpiry: 20 seconds. Inactive Timeout: 40 seconds. Sweep Timeout: 45 seconds.",
 					"configurations": {
 						"Fluid.GarbageCollection.RunSessionExpiry": [true],
-						"Fluid.Driver.Odsp.TestOverride.DisableSnapshotCache": [true],
+						"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs": [10000],
 						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [40000],
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [45000],
 						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [20000],
@@ -49,7 +53,7 @@
 					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 					"configurations": {
 						"Fluid.GarbageCollection.RunSessionExpiry": [true],
-						"Fluid.Driver.Odsp.TestOverride.DisableSnapshotCache": [true],
+						"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs": [450000],
 						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [1200000],
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000],
 						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [900000],
@@ -82,7 +86,7 @@
 					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 					"configurations": {
 						"Fluid.GarbageCollection.RunSessionExpiry": [true],
-						"Fluid.Driver.Odsp.TestOverride.DisableSnapshotCache": [true],
+						"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs": [450000],
 						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [1200000],
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000],
 						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [900000],


### PR DESCRIPTION
Snapshot cache expiry is current disabled in snapshot tests. We need snapshot cache to test scenarios where a summarizer loads from a cached snapshot and has to update its summary / GC state from a later summary ack. We have recently seen bugs because of these scenarios and the stress tests should run these.

Added an option to override the snapshot cache expiry timeout in ODSP driver. Updated the test config to use that option. The snapshot cache expiry is configured to be half of max faultInjectionMs. The idea is that on average half the sessions that fail because of faultInjection will load from cached snapshot and other half will not.

[AB#3315](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3315)