### PR TITLE
feat(client-debugger): Add Container state history tab to the debug panel

### DIFF
--- a/packages/tools/client-debugger/client-debugger-view/api-report/client-debugger-view.api.md
+++ b/packages/tools/client-debugger/client-debugger-view/api-report/client-debugger-view.api.md
@@ -89,6 +89,7 @@ export interface IContainerActions {
 export enum PanelView {
     Audience = "Audience",
     ContainerData = "Data",
+    ContainerStateHistory = "States",
     Telemetry = "Telemetry"
 }
 

--- a/packages/tools/client-debugger/client-debugger-view/src/components/AudienceView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/AudienceView.tsx
@@ -157,19 +157,16 @@ function HistoryView(props: HistoryViewProps): React.ReactElement {
 	const { history } = props;
 
 	const nowTimeStamp = new Date();
-
-	// Reverse history such that newest events are displayed first
-	const reversedHistoryLog = [...history].reverse();
-
 	const historyViews: React.ReactElement[] = [];
 
-	for (const changeEntry of reversedHistoryLog) {
-		const changeTimeStamp = new Date(changeEntry.timestamp);
+	// Reverse history such that newest events are displayed first
+	for (let i = history.length - 1; i >= 0; i--) {
+		const changeTimeStamp = new Date(history[i].timestamp);
 		const wasChangeToday = nowTimeStamp.getDate() === changeTimeStamp.getDate();
 
 		const accordianBackgroundColor: IStackItemStyles = {
 			root: {
-				background: changeEntry.changeKind === "added" ? "#90ee90" : "#FF7377",
+				background: history[i].changeKind === "added" ? "#90ee90" : "#FF7377",
 				borderStyle: "solid",
 				borderWidth: 1,
 				borderColor: DefaultPalette.neutralTertiary,
@@ -184,22 +181,22 @@ function HistoryView(props: HistoryViewProps): React.ReactElement {
 		};
 
 		historyViews.push(
-			<div>
+			<div key={`audience-history-info-${i}`}>
 				<Stack horizontal={true} styles={accordianBackgroundColor}>
 					<StackItem styles={iconStyle}>
 						<Icon
 							iconName={
-								changeEntry.changeKind === "added" ? "AddFriend" : "UserRemove"
+								history[i].changeKind === "added" ? "AddFriend" : "UserRemove"
 							}
 							title={
-								changeEntry.changeKind === "added" ? "Member Joined" : "Member Left"
+								history[i].changeKind === "added" ? "Member Joined" : "Member Left"
 							}
 						/>
 					</StackItem>
 					<StackItem>
-						<div key={`${changeEntry.clientId}-${changeEntry.changeKind}`}>
+						<div key={`${history[i].clientId}-${history[i].changeKind}`}>
 							<b>Client ID: </b>
-							{changeEntry.clientId}
+							{history[i].clientId}
 							<br />
 							<b>Time: </b>{" "}
 							{wasChangeToday

--- a/packages/tools/client-debugger/client-debugger-view/src/components/ClientDebugView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/ClientDebugView.tsx
@@ -9,6 +9,7 @@ import { HasClientDebugger } from "../CommonProps";
 import { initializeFluentUiIcons } from "../InitializeIcons";
 import { RenderOptions, getRenderOptionsWithDefaults } from "../RendererOptions";
 import { AudienceView } from "./AudienceView";
+import { ContainerHistoryView } from "./ContainerHistoryView";
 import { ContainerSummaryView } from "./ContainerSummaryView";
 import { DataObjectsView } from "./DataObjectsView";
 import { TelemetryView } from "./TelemetryView";
@@ -103,6 +104,10 @@ export function ClientDebugView(props: ClientDebugViewProps): React.ReactElement
 				innerView = <TelemetryView />;
 				break;
 			// TODO: add the Telemetry view here, without ReactContext
+
+			case PanelView.ContainerStateHistory:
+				innerView = <ContainerHistoryView clientDebugger={clientDebugger} />;
+				break;
 			default:
 				throw new Error(`Unrecognized PanelView selection value: "${innerViewSelection}".`);
 		}
@@ -153,12 +158,16 @@ export enum PanelView {
 	Audience = "Audience",
 
 	/**
-	 * Display view of Telemetry events
+	 * Display view of Telemetry events.
 	 */
 	Telemetry = "Telemetry",
 
+	/**
+	 * Display view of Container state history.
+	 */
+	ContainerStateHistory = "States",
+
 	// TODOs:
-	// - Container state history
 	// - Network stats
 	// - Ops/message latency stats
 }

--- a/packages/tools/client-debugger/client-debugger-view/src/components/ContainerHistoryView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/ContainerHistoryView.tsx
@@ -1,0 +1,174 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { DefaultPalette, IStackItemStyles, Icon, Stack, StackItem } from "@fluentui/react";
+import React from "react";
+
+import {
+	ConnectionStateChangeLogEntry,
+	ContainerStateChangeKind,
+} from "@fluid-tools/client-debugger";
+
+import { HasClientDebugger } from "../CommonProps";
+
+/**
+ * {@link ContainerHistory} input props.
+ */
+export type ContainerHistoryProps = HasClientDebugger;
+
+/**
+ * Displays information about the provided {@link IFluidClientDebugger.getContainerConnectionLog}.
+ *
+ * @param props - See {@link ContainerHistoryViewProps}.
+ */
+export function ContainerHistoryView(props: ContainerHistoryProps): React.ReactElement {
+	const { clientDebugger } = props;
+	const { container } = clientDebugger;
+
+	const [containerHistory, setContainerHistory] = React.useState<
+		readonly ConnectionStateChangeLogEntry[]
+	>(clientDebugger.getContainerConnectionLog());
+
+	React.useEffect(() => {
+		function onContainerHistoryChanged(): void {
+			setContainerHistory(clientDebugger.getContainerConnectionLog());
+		}
+
+		container.on("attached", onContainerHistoryChanged);
+		container.on("connected", onContainerHistoryChanged);
+		container.on("disconnected", onContainerHistoryChanged);
+		container.on("disposed", onContainerHistoryChanged);
+		container.on("closed", onContainerHistoryChanged);
+
+		return (): void => {
+			container.off("attached", onContainerHistoryChanged);
+			container.off("connected", onContainerHistoryChanged);
+			container.off("disconnected", onContainerHistoryChanged);
+			container.off("disposed", onContainerHistoryChanged);
+			container.off("closed", onContainerHistoryChanged);
+		};
+	}, [clientDebugger, container, setContainerHistory]);
+
+	return (
+		<Stack
+			styles={{
+				root: {
+					height: "100%",
+				},
+			}}
+		>
+			<StackItem>
+				<h3>Container State History</h3>
+				<_ContainerHistoryView containerHistory={containerHistory} />
+			</StackItem>
+		</Stack>
+	);
+}
+
+/**
+ * Input props for {@link _ContainerHistoryView}
+ */
+export interface _ContainerHistoryViewProps {
+	/**
+	 * The connection state history of the container.
+	 */
+	containerHistory: readonly ConnectionStateChangeLogEntry[];
+}
+
+/**
+ * Displays a container's history of connection state changes.
+ */
+export function _ContainerHistoryView(props: _ContainerHistoryViewProps): React.ReactElement {
+	const { containerHistory } = props;
+	const nowTimeStamp = new Date();
+	const historyViews: React.ReactElement[] = [];
+
+	// Newest events are displayed first
+	for (let i = containerHistory.length - 1; i >= 0; i--) {
+		const changeTimeStamp = new Date(containerHistory[i].timestamp);
+		const wasChangeToday = nowTimeStamp.getDate() === changeTimeStamp.getDate();
+
+		const accordionBackgroundColor: IStackItemStyles = {
+			root: {
+				background:
+					containerHistory[i].newState === ContainerStateChangeKind.Connected
+						? "#F0FFF0" // green
+						: containerHistory[i].newState === ContainerStateChangeKind.Attached
+						? "#F0FFFF" // blue
+						: containerHistory[i].newState === ContainerStateChangeKind.Disconnected
+						? "#FDF5E6" // yellow
+						: containerHistory[i].newState === ContainerStateChangeKind.Closed
+						? "#FFF0F5" // red
+						: containerHistory[i].newState === ContainerStateChangeKind.Disposed
+						? "#FFE4E1" // dark red
+						: "#C0C0C0", // grey for unknown state
+				borderStyle: "solid",
+				borderWidth: 1,
+				borderColor: DefaultPalette.neutralTertiary,
+				padding: 3,
+			},
+		};
+
+		const iconStyle: IStackItemStyles = {
+			root: {
+				padding: 10,
+			},
+		};
+
+		historyViews.push(
+			<div key={`container-history-info-${i}`}>
+				<Stack horizontal={true} styles={accordionBackgroundColor}>
+					<StackItem styles={iconStyle}>
+						<Icon
+							iconName={
+								containerHistory[i].newState === ContainerStateChangeKind.Connected
+									? "PlugConnected"
+									: containerHistory[i].newState ===
+									  ContainerStateChangeKind.Attached
+									? "Attach"
+									: containerHistory[i].newState ===
+									  ContainerStateChangeKind.Disconnected
+									? "PlugDisconnected"
+									: containerHistory[i].newState ===
+									  ContainerStateChangeKind.Disposed
+									? "RemoveLink"
+									: containerHistory[i].newState ===
+									  ContainerStateChangeKind.Closed
+									? "SkypeCircleMinus"
+									: "Help"
+							}
+						/>
+					</StackItem>
+					<StackItem>
+						<div
+							key={`${containerHistory[i].newState}-${containerHistory[i].timestamp}`}
+						>
+							<b>State: </b>
+							{containerHistory[i].newState}
+							<br />
+							<b>Time: </b>
+							{wasChangeToday
+								? changeTimeStamp.toTimeString()
+								: changeTimeStamp.toDateString()}
+							<br />
+						</div>
+					</StackItem>
+				</Stack>
+			</div>,
+		);
+	}
+
+	return (
+		<Stack
+			styles={{
+				root: {
+					overflowY: "auto",
+					height: "300px",
+				},
+			}}
+		>
+			<div style={{ overflowY: "scroll" }}>{historyViews}</div>
+		</Stack>
+	);
+}

--- a/packages/tools/client-debugger/client-debugger-view/src/components/index.ts
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/index.ts
@@ -11,6 +11,7 @@ export * from "./data-object-views";
 
 export * from "./AudienceView";
 export * from "./ClientDebugView";
+export * from "./ContainerHistoryView";
 export * from "./ContainerSelectionDropdown";
 export * from "./ContainerSummaryView";
 export * from "./TelemetryView";


### PR DESCRIPTION
## Description
After we've updated IFluidClientDebugger to track and expose the Container state history, we should update the debugger view to include a tab to display this history. Visually, I think this can look basically like our Audience history view.

## Sample
<img width="988" alt="1" src="https://user-images.githubusercontent.com/114451900/224192537-648b533c-f4f0-415b-9f8a-6dca68018f7b.png">

