### PR TITLE
No need to add unnecessary query params

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -141,21 +141,11 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 		const hashedDocumentId = await getHashedDocumentId(driveId, itemId);
 		assert(!hashedDocumentId.includes("/"), 0x0a8 /* "Docid should not contain slashes!!" */);
 
-		let documentUrl = `fluid-odsp://placeholder/placeholder/${hashedDocumentId}/${removeBeginningSlash(
+		const documentUrl = `fluid-odsp://placeholder/placeholder/${hashedDocumentId}/${removeBeginningSlash(
 			path,
 		)}`;
 
-		if (request.url.length > 0) {
-			// In case of any additional parameters add them back to the url
-			const requestURL = new URL(request.url);
-			const searchParams = requestURL.search;
-			if (searchParams) {
-				documentUrl += searchParams;
-			}
-		}
-
 		const summarizer = !!request.headers?.[DriverHeader.summarizingClient];
-
 		return {
 			type: "fluid",
 			odspResolvedUrl: true,

--- a/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
@@ -103,9 +103,7 @@ describe("Odsp Create Container Test", () => {
 		assert.strictEqual(finalResolverUrl.siteUrl, siteUrl, "SiteUrl should match");
 		assert.strictEqual(finalResolverUrl.hashedDocumentId, docID, "DocId should match");
 
-		const url = `fluid-odsp://placeholder/placeholder/${docID}/?driveId=${driveId}&itemId=${itemId}&path=${encodeURIComponent(
-			"/",
-		)}`;
+		const url = `fluid-odsp://placeholder/placeholder/${docID}/`;
 		const snapshotUrl = `${siteUrl}/_api/v2.1/drives/${driveId}/items/${itemId}/opStream/snapshots`;
 		assert.strictEqual(finalResolverUrl.url, url, "Url should match");
 		assert.strictEqual(

--- a/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
@@ -325,7 +325,7 @@ describe("Odsp Driver Resolver", () => {
 
 		const expectedResolvedUrl =
 			`fluid-odsp://placeholder/placeholder/${resolvedUrl.hashedDocumentId}/` +
-			`${testFilePath}?driveId=${driveId}&path=${testFilePath}&itemId=${itemId}`;
+			`${testFilePath}`;
 		assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
 	});
 
@@ -359,7 +359,7 @@ describe("Odsp Driver Resolver", () => {
 
 		const expectedResolvedUrl =
 			`fluid-odsp://placeholder/placeholder/${resolvedUrl.hashedDocumentId}/` +
-			`${testFilePath}?driveId=${driveId}&path=${testFilePath}&itemId=${itemId}`;
+			`${testFilePath}`;
 		assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
 	});
 
@@ -393,7 +393,7 @@ describe("Odsp Driver Resolver", () => {
 
 		const expectedResolvedUrl =
 			`fluid-odsp://placeholder/placeholder/${resolvedUrl.hashedDocumentId}/` +
-			`${testFilePath}?driveId=${driveId}&path=${testFilePath}&itemId=${itemId}`;
+			`${testFilePath}`;
 		assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
 	});
 
@@ -403,7 +403,7 @@ describe("Odsp Driver Resolver", () => {
 
 		assert.strictEqual(
 			resolvedUrl.url,
-			"fluid-odsp://placeholder/placeholder/AV5r7rhbMqs3T5cL8TUpqk6FpWldev0qKsKlnjkC5mg%3D/?driveId=driveId&itemId=&path=/",
+			"fluid-odsp://placeholder/placeholder/AV5r7rhbMqs3T5cL8TUpqk6FpWldev0qKsKlnjkC5mg%3D/",
 		);
 	});
 
@@ -439,7 +439,7 @@ describe("Odsp Driver Resolver", () => {
 
 		const expectedResolvedUrl =
 			`fluid-odsp://placeholder/placeholder/${resolvedUrl.hashedDocumentId}/` +
-			`${testFilePath}?driveId=${driveId}&path=${testFilePath}&itemId=${itemId}&fileVersion=${fileVersion}`;
+			`${testFilePath}`;
 		assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
 	});
 });

--- a/packages/drivers/odsp-urlResolver/src/test/spoUrlResolver.spec.ts
+++ b/packages/drivers/odsp-urlResolver/src/test/spoUrlResolver.spec.ts
@@ -23,7 +23,7 @@ describe("Spo Url Resolver", () => {
 		);
 		assert.equal(
 			resolved.url,
-			`fluid-odsp://placeholder/placeholder/${resolved.hashedDocumentId}/?driveId=${resolved.driveId}&itemId=${resolved.itemId}&path=`,
+			`fluid-odsp://placeholder/placeholder/${resolved.hashedDocumentId}/`,
 			"fluid url does not match",
 		);
 	});
@@ -43,7 +43,7 @@ describe("Spo Url Resolver", () => {
 		);
 		assert.equal(
 			resolved.url,
-			`fluid-odsp://placeholder/placeholder/${resolved.hashedDocumentId}/?driveId=${resolved.driveId}&itemId=${resolved.itemId}&path=`,
+			`fluid-odsp://placeholder/placeholder/${resolved.hashedDocumentId}/`,
 			"fluid url does not match",
 		);
 	});


### PR DESCRIPTION
## Description

Fix for https://dev.azure.com/fluidframework/internal/_workitems/edit/3453.
There is no need to put all the info like driveid, itemid etc in the query params again on the document url as we decoded nav parma/all this info from that only and they are already present in the resolvedurl.