### PR TITLE
feat(merge-tree): make some benchmarks take longer

### DIFF
--- a/packages/dds/merge-tree/src/test/Insertion.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/Insertion.perf.spec.ts
@@ -96,7 +96,7 @@ describe("MergeTree insertion", () => {
 	benchmark({
 		type: BenchmarkType.Measurement,
 		title: "insert at end of large tree",
-		benchmarkFnAsync: async () => {
+		benchmarkFn: () => {
 			for (let i = TREE_SIZE; i < TREE_SIZE + 25; i++) {
 				insertText({
 					mergeTree: endTree,

--- a/packages/dds/merge-tree/src/test/Insertion.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/Insertion.perf.spec.ts
@@ -25,6 +25,8 @@ function constructTree(numOfSegments: number): MergeTree {
 	return mergeTree;
 }
 
+const TREE_SIZE: number = 7_500;
+
 describe("MergeTree insertion", () => {
 	benchmark({
 		type: BenchmarkType.Measurement,
@@ -44,66 +46,72 @@ describe("MergeTree insertion", () => {
 		},
 	});
 
-	let startTree = constructTree(1000);
+	let startTree = constructTree(TREE_SIZE);
 	benchmark({
 		type: BenchmarkType.Measurement,
 		title: "insert at start of large tree",
 		benchmarkFn: () => {
-			insertText({
-				mergeTree: startTree,
-				pos: 0,
-				refSeq: 1000,
-				clientId: 0,
-				seq: 1001,
-				text: "a",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+			for (let i = TREE_SIZE; i < TREE_SIZE + 25; i++) {
+				insertText({
+					mergeTree: startTree,
+					pos: 0,
+					refSeq: i,
+					clientId: 0,
+					seq: i + 1,
+					text: "a",
+					props: undefined,
+					opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+				});
+			}
 		},
 		onCycle: () => {
-			startTree = constructTree(1000);
+			startTree = constructTree(TREE_SIZE);
 		},
 	});
 
-	let middleTree = constructTree(1000);
+	let middleTree = constructTree(TREE_SIZE);
 	benchmark({
 		type: BenchmarkType.Measurement,
 		title: "insert at middle of large tree",
 		benchmarkFn: () => {
-			insertText({
-				mergeTree: middleTree,
-				pos: 500,
-				refSeq: 1000,
-				clientId: 0,
-				seq: 1001,
-				text: "a",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+			for (let i = TREE_SIZE; i < TREE_SIZE + 25; i++) {
+				insertText({
+					mergeTree: middleTree,
+					pos: TREE_SIZE / 2,
+					refSeq: i,
+					clientId: 0,
+					seq: i + 1,
+					text: "a",
+					props: undefined,
+					opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+				});
+			}
 		},
 		onCycle: () => {
-			middleTree = constructTree(1000);
+			middleTree = constructTree(TREE_SIZE);
 		},
 	});
 
-	let endTree = constructTree(1000);
+	let endTree = constructTree(TREE_SIZE);
 	benchmark({
 		type: BenchmarkType.Measurement,
 		title: "insert at end of large tree",
-		benchmarkFn: async () => {
-			insertText({
-				mergeTree: endTree,
-				pos: 1000,
-				refSeq: 1000,
-				clientId: 0,
-				seq: 1001,
-				text: "a",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+		benchmarkFnAsync: async () => {
+			for (let i = TREE_SIZE; i < TREE_SIZE + 25; i++) {
+				insertText({
+					mergeTree: endTree,
+					pos: i,
+					refSeq: i,
+					clientId: 0,
+					seq: i + 1,
+					text: "a",
+					props: undefined,
+					opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
+				});
+			}
 		},
 		onCycle: () => {
-			endTree = constructTree(1000);
+			endTree = constructTree(TREE_SIZE);
 		},
 	});
 });

--- a/packages/dds/merge-tree/src/test/PartialLengths.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/PartialLengths.perf.spec.ts
@@ -19,7 +19,7 @@ describe("MergeTree partial lengths", () => {
 			before: () => {
 				MergeTree.options.incrementalUpdate = incremental;
 			},
-			benchmarkFn: async () => {
+			benchmarkFn: () => {
 				const mergeTree = new MergeTree();
 
 				let i = 1;

--- a/packages/dds/merge-tree/src/test/Removal.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/Removal.perf.spec.ts
@@ -24,9 +24,10 @@ describe("MergeTree remove", () => {
 				str.append("a", false);
 			}
 
+			str.applyPendingOps();
 			summary = str.getSummary();
 		},
-		benchmarkFn: async () => {
+		benchmarkFnAsync: async () => {
 			await loadSnapshot(summary);
 		},
 	});
@@ -41,9 +42,10 @@ describe("MergeTree remove", () => {
 				str.append("a", false);
 			}
 
+			str.applyPendingOps();
 			summary = str.getSummary();
 		},
-		benchmarkFn: async () => {
+		benchmarkFnAsync: async () => {
 			const str = await loadSnapshot(summary);
 
 			markRangeRemoved({
@@ -69,9 +71,10 @@ describe("MergeTree remove", () => {
 				str.append("a", false);
 			}
 
+			str.applyPendingOps();
 			summary = str.getSummary();
 		},
-		benchmarkFn: async () => {
+		benchmarkFnAsync: async () => {
 			const str = await loadSnapshot(summary);
 
 			markRangeRemoved({
@@ -97,9 +100,10 @@ describe("MergeTree remove", () => {
 				str.append("a", false);
 			}
 
+			str.applyPendingOps();
 			summary = str.getSummary();
 		},
-		benchmarkFn: async () => {
+		benchmarkFnAsync: async () => {
 			const str = await loadSnapshot(summary);
 
 			markRangeRemoved({
@@ -125,9 +129,10 @@ describe("MergeTree remove", () => {
 				str.append("a", false);
 			}
 
+			str.applyPendingOps();
 			summary = str.getSummary();
 		},
-		benchmarkFn: async () => {
+		benchmarkFnAsync: async () => {
 			const str = await loadSnapshot(summary);
 
 			markRangeRemoved({

--- a/packages/dds/merge-tree/src/test/Snapshot.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/Snapshot.perf.spec.ts
@@ -9,7 +9,7 @@ import { loadSnapshot, TestString } from "./snapshot.utils";
 describe("MergeTree snapshots", () => {
 	let summary;
 
-	for (const summarySize of [10, 100, 1000, 5000, 10_000]) {
+	for (const summarySize of [10, 50, 100, 500, 1000, 5_000, 10_000]) {
 		benchmark({
 			type: BenchmarkType.Measurement,
 			title: `load snapshot with ${summarySize} segments`,
@@ -19,9 +19,11 @@ describe("MergeTree snapshots", () => {
 				for (let i = 0; i < summarySize; i++) {
 					str.append("a", false);
 				}
+
+				str.applyPendingOps();
 				summary = str.getSummary();
 			},
-			benchmarkFn: async () => {
+			benchmarkFnAsync: async () => {
 				await loadSnapshot(summary);
 			},
 			after: () => {

--- a/packages/dds/merge-tree/src/test/snapshot.utils.ts
+++ b/packages/dds/merge-tree/src/test/snapshot.utils.ts
@@ -9,7 +9,7 @@ import { strict as assert } from "assert";
 import { ISequencedDocumentMessage, ISummaryTree } from "@fluidframework/protocol-definitions";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { MockStorage } from "@fluidframework/test-runtime-utils";
-import { IMergeTreeOp } from "../ops";
+import { IMergeTreeOp, ReferenceType } from "../ops";
 import { SnapshotV1 } from "../snapshotV1";
 import { IMergeTreeOptions } from "../mergeTree";
 import { createClientsAtInitialState } from "./testClientLogger";
@@ -59,6 +59,19 @@ export class TestString {
 
 	public append(text: string, increaseMsn: boolean) {
 		this.insert(this.client.getLength(), text, increaseMsn);
+	}
+
+	public insertMarker(pos: number, increaseMsn: boolean) {
+		this.queue(
+			this.client.insertMarkerLocal(pos, ReferenceType.Simple, {
+				segment: this.pending.length,
+			})!,
+			increaseMsn,
+		);
+	}
+
+	public appendMarker(increaseMsn: boolean) {
+		this.insertMarker(this.client.getLength(), increaseMsn);
 	}
 
 	public removeRange(start: number, end: number, increaseMsn: boolean) {


### PR DESCRIPTION
Increase amount of work done by merge-tree benchmarks to make the results less prone to noise.

[ADO](https://dev.azure.com/fluidframework/internal/_workitems/edit/3612)