### PR TITLE
[GC-stress] Enable attachment blobs for ODSP

### DIFF
--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -203,7 +203,7 @@ async function runnerProcess(
 	let metricsCleanup: () => void = () => {};
 
 	// Added temporarily to disable attachment blob testing for ODSP.
-	runConfig.testConfig.driverType = driver;
+	// runConfig.testConfig.driverType = driver;
 	const optionsOverride = `${driver}${endpoint !== undefined ? `-${endpoint}` : ""}`;
 	const loaderOptions = generateLoaderOptions(
 		seed,

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -33,7 +33,7 @@
 			"opRatePerMin": 800,
 			"progressIntervalMs": 5000,
 			"numClients": 10,
-			"totalSendCount": 36000,
+			"totalSendCount": 18000,
 			"optionOverrides": {
 				"tinylicious": {
 					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",


### PR DESCRIPTION
Enabling attachment blobs upload / download in ODSP to gauge the impact and get correlation IDs of when the requests get throttled. This will help enagage ODSP folks to understand what the throttling limits are and adjust the tests accordingly.