### PR TITLE
Minor release 2.0.0-internal.3.3.0 bump build-tools 

### DIFF
--- a/build-tools/lerna.json
+++ b/build-tools/lerna.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"npmClient": "pnpm",
 	"useWorkspaces": true
 }

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/build-cli",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"description": "Build tools for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-cli/src/packageVersion.ts
+++ b/build-tools/packages/build-cli/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-tools/build-cli";
-export const pkgVersion = "0.11.0";
+export const pkgVersion = "0.12.0";

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/build-tools",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"description": "Fluid Build tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-tools/src/packageVersion.ts
+++ b/build-tools/packages/build-tools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/build-tools";
-export const pkgVersion = "0.11.0";
+export const pkgVersion = "0.12.0";

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/bundle-size-tools",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"description": "Utility for analyzing bundle size regressions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/bundle-size-tools/src/packageVersion.ts
+++ b/build-tools/packages/bundle-size-tools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/bundle-size-tools";
-export const pkgVersion = "0.11.0";
+export const pkgVersion = "0.12.0";

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/version-tools",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"description": "Versioning tools for Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/version-tools/src/packageVersion.ts
+++ b/build-tools/packages/version-tools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-tools/version-tools";
-export const pkgVersion = "0.11.0";
+export const pkgVersion = "0.12.0";


### PR DESCRIPTION
Bumped build-tools from 0.11.0 to 0.12.0.
![image](https://user-images.githubusercontent.com/105010181/223843889-8bb1e783-27a9-4da7-8d55-25f7f96c72a3.png)
