### PR TITLE
tree: Set noImplicitOverride to true and fix errors

### DIFF
--- a/packages/dds/tree/src/core/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/core/edit-manager/editManager.ts
@@ -66,8 +66,6 @@ export class EditManager<
 
 	private minimumSequenceNumber: number = -1;
 
-	public readonly computationName: string = "EditManager";
-
 	private readonly rebaser: Rebaser<TChangeset>;
 
 	/**
@@ -88,7 +86,7 @@ export class EditManager<
 		public readonly localSessionId: SessionId,
 		public readonly anchors?: AnchorSet,
 	) {
-		super();
+		super("EditManager");
 		this.rebaser = new Rebaser(changeFamily.rebaser);
 		this.trunkBase = {
 			revision: nullRevisionTag,

--- a/packages/dds/tree/src/core/schema-stored/storedSchemaRepository.ts
+++ b/packages/dds/tree/src/core/schema-stored/storedSchemaRepository.ts
@@ -68,7 +68,6 @@ export class InMemoryStoredSchemaRepository<TPolicy extends SchemaPolicy = Schem
 	extends SimpleDependee
 	implements StoredSchemaRepository<TPolicy>
 {
-	readonly computationName: string = "StoredSchemaRepository";
 	protected readonly data: MutableSchemaData;
 	private readonly events = createEmitter<SchemaEvents>();
 
@@ -85,7 +84,7 @@ export class InMemoryStoredSchemaRepository<TPolicy extends SchemaPolicy = Schem
 	 * that might provide a decent alternative to extraFields (which is a bit odd).
 	 */
 	public constructor(public readonly policy: TPolicy, data?: SchemaData) {
-		super();
+		super("StoredSchemaRepository");
 		this.data = {
 			treeSchema: new Map(data?.treeSchema ?? []),
 			globalFieldSchema: new Map(data?.globalFieldSchema ?? []),

--- a/packages/dds/tree/src/events/events.ts
+++ b/packages/dds/tree/src/events/events.ts
@@ -226,7 +226,7 @@ class ComposableEventEmitter<E extends Events<E>> extends EventEmitter<E> implem
 		super(noListeners);
 	}
 
-	public emit<K extends keyof Events<E>>(eventName: K, ...args: Parameters<E[K]>): void {
+	public override emit<K extends keyof Events<E>>(eventName: K, ...args: Parameters<E[K]>): void {
 		return super.emit(eventName, ...args);
 	}
 }

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -352,7 +352,7 @@ class Cursor extends BasicChunkCursor implements ITreeSubscriptionCursor {
 		this.indexWithinChunk = 0;
 	}
 
-	public fork(): Cursor {
+	public override fork(): Cursor {
 		// Siblings arrays are not modified during navigation and do not need be be copied.
 		// This allows this copy to be shallow, and `this.siblings` below to not be copied as all.
 		return new Cursor(

--- a/packages/dds/tree/src/feature-libraries/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultFieldKinds.ts
@@ -82,7 +82,7 @@ export class UnitEncoder extends ChangeEncoder<0> {
 		return 0;
 	}
 
-	public encodeBinary(formatVersion: number, change: 0): IsoBuffer {
+	public override encodeBinary(formatVersion: number, change: 0): IsoBuffer {
 		return IsoBuffer.from("");
 	}
 
@@ -90,7 +90,7 @@ export class UnitEncoder extends ChangeEncoder<0> {
 		return 0;
 	}
 
-	public decodeBinary(formatVersion: number, change: IsoBuffer): 0 {
+	public override decodeBinary(formatVersion: number, change: IsoBuffer): 0 {
 		return 0;
 	}
 }

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -332,7 +332,7 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
 		assert(this.innerCursor !== undefined, 0x430 /* Cursor must be current to be used */);
 		return this.innerCursor.exitField();
 	}
-	skipPendingFields(): boolean {
+	override skipPendingFields(): boolean {
 		assert(this.innerCursor !== undefined, 0x431 /* Cursor must be current to be used */);
 		return this.innerCursor.skipPendingFields();
 	}

--- a/packages/dds/tree/src/id-compressor/appendOnlySortedMap.ts
+++ b/packages/dds/tree/src/id-compressor/appendOnlySortedMap.ts
@@ -359,7 +359,7 @@ export class AppendOnlyDoublySortedMap<K, V, S> extends AppendOnlySortedMap<K, V
 		super(keyComparator);
 	}
 
-	public append(key: K, value: V): void {
+	public override append(key: K, value: V): void {
 		if (
 			this.elements.length !== 0 &&
 			this.valueComparator(
@@ -408,7 +408,7 @@ export class AppendOnlyDoublySortedMap<K, V, S> extends AppendOnlySortedMap<K, V
 	/**
 	 * Test-only expensive assertions to check the internal validity of the data structure.
 	 */
-	public assertValid(): void {
+	public override assertValid(): void {
 		super.assertValid();
 		let prev: readonly [unknown, V] | undefined;
 		for (const kv of this.entries()) {

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -340,7 +340,7 @@ export class SharedTreeCore<
 
 	protected onDisconnect() {}
 
-	protected didAttach(): void {
+	protected override didAttach(): void {
 		if (this.detachedRevision !== undefined) {
 			this.detachedRevision = undefined;
 		}
@@ -350,7 +350,7 @@ export class SharedTreeCore<
 		throw new Error("Method not implemented.");
 	}
 
-	public getGCData(fullGC?: boolean): IGarbageCollectionData {
+	public override getGCData(fullGC?: boolean): IGarbageCollectionData {
 		const gcNodes: IGarbageCollectionData["gcNodes"] = {};
 		for (const summaryElement of this.summaryElements) {
 			for (const [id, routes] of Object.entries(summaryElement.getGCData(fullGC).gcNodes)) {

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -293,7 +293,7 @@ class SharedTree
 	 * and its not clear how it would fit into such a system if implemented in shared-tree-core:
 	 * maybe op dispatch is part of the shared-tree level?
 	 */
-	protected processCore(
+	protected override processCore(
 		message: ISequencedDocumentMessage,
 		local: boolean,
 		localOpMetadata: unknown,

--- a/packages/dds/tree/tsconfig.json
+++ b/packages/dds/tree/tsconfig.json
@@ -7,6 +7,7 @@
 		"noImplicitAny": true,
 		"composite": true,
 		"preserveConstEnums": true,
+		"noImplicitOverride": true,
 	},
 	"include": ["src/**/*"],
 }


### PR DESCRIPTION
## Description

noImplicitOverride  was added in TypeScript 4.3. Use it to improve clarity and avoid accidental overrides.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
