### PR TITLE
fix(bump): Fix invalid flag configuration

### DIFF
--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @fluid-tools/build-cli
 $ flub COMMAND
 running command...
 $ flub (--version|-V)
-@fluid-tools/build-cli/0.11.0
+@fluid-tools/build-cli/0.12.0
 $ flub --help [COMMAND]
 USAGE
   $ flub COMMAND

--- a/build-tools/packages/build-cli/docs/bump.md
+++ b/build-tools/packages/build-cli/docs/bump.md
@@ -12,8 +12,8 @@ Bumps the version of a release group or package to the next minor, major, or pat
 
 ```
 USAGE
-  $ flub bump PACKAGE_OR_RELEASE_GROUP [-v] [-t major|minor|patch | --exact <value>] [--exactDepType ^|~|
-    ] [--scheme semver|internal|virtualPatch | ] [-x | --install | --commit |  |  | ]
+  $ flub bump PACKAGE_OR_RELEASE_GROUP [-v] [-t major|minor|patch | --exact <value>] [--exactDepType ^|~|]
+    [--scheme semver|internal|virtualPatch | ] [-x | --install | --commit |  |  | ]
 
 ARGUMENTS
   PACKAGE_OR_RELEASE_GROUP  The name of a package or a release group.

--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -54,7 +54,6 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 		exactDepType: Flags.string({
 			description:
 				"When using the exact flag, controls the type of dependency that is used between packages within the release group.",
-			dependsOn: ["exact"],
 			options: ["^", "~", ""],
 			default: "^",
 		}),

--- a/build-tools/packages/version-tools/README.md
+++ b/build-tools/packages/version-tools/README.md
@@ -78,7 +78,7 @@ $ npm install -g @fluid-tools/version-tools
 $ fluv COMMAND
 running command...
 $ fluv (--version|-V)
-@fluid-tools/version-tools/0.11.0
+@fluid-tools/version-tools/0.12.0
 $ fluv --help [COMMAND]
 USAGE
   $ fluv COMMAND


### PR DESCRIPTION
The `--exactDepType` flag has a default value but also said it required the `--exact` flag be passed. This resulted in any command failing with the following error:

```shell
$ flub bump build-tools -t minor
 ›   Error: The following error occurred:
 ›     All of the following must be provided when using --exactDepType: --exact
 ›   See more help with --help
```

I removed `dependsOn`, which resolved the problem.