### PR TITLE
Do not log containerClose event if lifeCycleState is loading

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -878,14 +878,18 @@ export class Container
 			try {
 				// Raise event first, to ensure we capture _lifecycleState before transition.
 				// This gives us a chance to know what errors happened on open vs. on fully loaded container.
-				this.mc.logger.sendTelemetryEvent(
-					{
-						eventName: "ContainerClose",
-						category: error === undefined ? "generic" : "error",
-					},
-					error,
-				);
-
+				// Do not raise event if container is in loading state, as most errors are not really FF errors 
+				// and this can pollute telemetry
+				if( this._lifecycleState !== "loading" ) {
+					this.mc.logger.sendTelemetryEvent(
+						{
+							eventName: "ContainerClose",
+							category: error === undefined ? "generic" : "error",
+						},
+						error,
+					);
+				}
+				
 				this._lifecycleState = "closing";
 
 				this._protocolHandler?.close();

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -878,9 +878,9 @@ export class Container
 			try {
 				// Raise event first, to ensure we capture _lifecycleState before transition.
 				// This gives us a chance to know what errors happened on open vs. on fully loaded container.
-				// Do not raise event if container is in loading state, as most errors are not really FF errors 
+				// Do not raise event if container is in loading state, as most errors are not really FF errors
 				// and this can pollute telemetry
-				if( this._lifecycleState !== "loading" ) {
+				if (this._lifecycleState !== "loading") {
 					this.mc.logger.sendTelemetryEvent(
 						{
 							eventName: "ContainerClose",
@@ -889,7 +889,7 @@ export class Container
 						error,
 					);
 				}
-				
+
 				this._lifecycleState = "closing";
 
 				this._protocolHandler?.close();

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -878,13 +878,13 @@ export class Container
 			try {
 				// Raise event first, to ensure we capture _lifecycleState before transition.
 				// This gives us a chance to know what errors happened on open vs. on fully loaded container.
-				// Do not raise event if container is in loading state, as most errors are not really FF errors
-				// and this can pollute telemetry
-				if (this._lifecycleState !== "loading") {
+				// Log generic events instead of error events if container is in loading state, as most errors are not really FF errors
+				// and this can pollute telemetry for real errors
+				if (error !== undefined) {
 					this.mc.logger.sendTelemetryEvent(
 						{
 							eventName: "ContainerClose",
-							category: error === undefined ? "generic" : "error",
+							category: this._lifecycleState === "loading" ? "generic" : "error",
 						},
 						error,
 					);

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -879,16 +879,17 @@ export class Container
 				// Raise event first, to ensure we capture _lifecycleState before transition.
 				// This gives us a chance to know what errors happened on open vs. on fully loaded container.
 				// Log generic events instead of error events if container is in loading state, as most errors are not really FF errors
-				// and this can pollute telemetry for real errors
-				if (error !== undefined) {
-					this.mc.logger.sendTelemetryEvent(
-						{
-							eventName: "ContainerClose",
-							category: this._lifecycleState === "loading" ? "generic" : "error",
-						},
-						error,
-					);
-				}
+				// which can pollute telemetry for real bugs
+				this.mc.logger.sendTelemetryEvent(
+					{
+						eventName: "ContainerClose",
+						category:
+							this._lifecycleState !== "loading" && error !== undefined
+								? "error"
+								: "generic",
+					},
+					error,
+				);
 
 				this._lifecycleState = "closing";
 


### PR DESCRIPTION


## Description

right now in our logs, a lot of container close errors are not actual bugs, but permission issue, making it hard to differentiate with actual errors during lifetime of a file. so, we will no longer log container close errors if the container is in loading state
we can still rely on Container:Load_cancel events for these errors