### PR TITLE
feat(client-debugger): Logging cleanup

### DIFF
--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/messaging/Utilities.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/messaging/Utilities.ts
@@ -25,13 +25,16 @@ export function relayMessageToWindow<TMessage extends IDebuggerMessage>(
 	messageSource: string,
 	loggingOptions?: MessageLoggingOptions,
 ): void {
-	console.log(
-		formatMessageForLogging(
-			`Relaying message from "${messageSource}" to the window:`,
-			loggingOptions,
-		),
-		message,
-	); // TODO: console.debug
+	// TODO: remove loggingOptions once things settle.
+	if (loggingOptions !== undefined) {
+		console.debug(
+			formatMessageForLogging(
+				`Relaying message from "${messageSource}" to the window:`,
+				loggingOptions,
+			),
+			message,
+		);
+	}
 	window.postMessage(message, "*"); // TODO: verify target is okay
 }
 
@@ -48,13 +51,18 @@ export function relayMessageToPort<TMessage extends IDebuggerMessage>(
 	targetPort: TypedPortConnection<TMessage>,
 	loggingOptions?: MessageLoggingOptions,
 ): void {
-	console.log(
-		formatMessageForLogging(
-			`Relaying message from "${messageSource}" to port "${targetPort.name ?? "(unnamed)"}":`,
-			loggingOptions,
-		),
-		message,
-	); // TODO: console.debug
+	// TODO: remove loggingOptions once things settle.
+	if (loggingOptions !== undefined) {
+		console.debug(
+			formatMessageForLogging(
+				`Relaying message from "${messageSource}" to port "${
+					targetPort.name ?? "(unnamed)"
+				}":`,
+				loggingOptions,
+			),
+			message,
+		);
+	}
 	targetPort.postMessage(message);
 }
 
@@ -70,12 +78,15 @@ export function postMessageToPort<TMessage extends IDebuggerMessage>(
 	targetPort: TypedPortConnection<TMessage>,
 	loggingOptions?: MessageLoggingOptions,
 ): void {
-	console.log(
-		formatMessageForLogging(
-			`Posting message to port "${targetPort.name ?? "(unnamed)"}":`,
-			loggingOptions,
-		),
-		message,
-	); // TODO: console.debug
+	// TODO: remove loggingOptions once things settle.
+	if (loggingOptions !== undefined) {
+		console.debug(
+			formatMessageForLogging(
+				`Posting message to port "${targetPort.name ?? "(unnamed)"}":`,
+				loggingOptions,
+			),
+			message,
+		);
+	}
 	targetPort.postMessage(message);
 }

--- a/packages/tools/client-debugger/client-debugger/src/FluidDebuggerLogger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidDebuggerLogger.ts
@@ -10,12 +10,7 @@ import {
 	ChildLogger,
 	ITelemetryLoggerPropertyBags,
 } from "@fluidframework/telemetry-utils";
-import {
-	debuggerMessageSource,
-	MessageLoggingOptions,
-	postMessageToWindow,
-	TelemetryEventMessage,
-} from "./messaging";
+import { debuggerMessageSource, postMessageToWindow, TelemetryEventMessage } from "./messaging";
 
 /**
  * Logger implementation that posts all telemetry events to the window (globalThis object).
@@ -87,22 +82,12 @@ export class FluidDebuggerLogger extends TelemetryLogger {
 
 		const newEvent: ITelemetryBaseEvent = this.prepareEvent(event);
 
-		postMessageToWindow<TelemetryEventMessage>(
-			{
-				source: debuggerMessageSource,
-				type: "TELEMETRY_EVENT",
-				data: {
-					contents: newEvent,
-				},
+		postMessageToWindow<TelemetryEventMessage>({
+			source: debuggerMessageSource,
+			type: "TELEMETRY_EVENT",
+			data: {
+				contents: newEvent,
 			},
-			FluidDebuggerLogger.RegistryMessageLoggingOptions,
-		);
+		});
 	}
-
-	/**
-	 * Message logging options used by the logger for messages posted to the console.
-	 */
-	private static readonly RegistryMessageLoggingOptions: MessageLoggingOptions = {
-		context: "Debugger(Logger)",
-	};
 }

--- a/packages/tools/client-debugger/client-debugger/src/FluidDebuggerLogger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidDebuggerLogger.ts
@@ -103,6 +103,6 @@ export class FluidDebuggerLogger extends TelemetryLogger {
 	 * Message logging options used by the logger for messages posted to the console.
 	 */
 	private static readonly RegistryMessageLoggingOptions: MessageLoggingOptions = {
-		context: "DEBUGGER TELEMETRY",
+		context: "Debugger(Logger)",
 	};
 }

--- a/packages/tools/client-debugger/client-debugger/src/messaging/Utilities.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/Utilities.ts
@@ -8,6 +8,10 @@ import { IDebuggerMessage } from "./Messages";
 /**
  * Posts the provided message to the window (globalThis).
  *
+ * @param message - The message to be posted
+ * @param loggingOptions - Settings related to logging to console for troubleshooting.
+ * If not passed, this function won't log to console before posting the message.
+ *
  * @remarks Thin wrapper to provide some message-wise type-safety.
  *
  * @internal
@@ -16,9 +20,13 @@ export function postMessageToWindow<TMessage extends IDebuggerMessage>(
 	message: TMessage,
 	loggingOptions?: MessageLoggingOptions,
 ): void {
-	const loggingPreamble =
-		loggingOptions?.context === undefined ? "" : `${loggingOptions.context}: `;
-	console.log(`${loggingPreamble}Posting message to the window:`, message); // TODO: console.debug
+	// TODO: remove loggingOptions once things settle.
+	// If we need special logic for globalThis.postMessage maybe keep this function, but otherwise maybe remove it too.
+	if (loggingOptions !== undefined) {
+		const loggingPreamble =
+			loggingOptions?.context === undefined ? "" : `${loggingOptions.context}: `;
+		console.debug(`${loggingPreamble}Posting message to the window:`, message);
+	}
 	globalThis.postMessage?.(message, "*"); // TODO: verify target is okay
 }
 
@@ -57,6 +65,8 @@ export interface MessageLoggingOptions {
  * @param handlers - List of handlers for particular event types.
  * If the incoming event's message type has a corresponding handler callback, that callback will be invoked.
  * Otherwise, this function will no-op.
+ * @param loggingOptions - Settings related to logging to console for troubleshooting.
+ * If not passed, this function won't log to console after the message has been handled.
  *
  * @internal
  */
@@ -65,6 +75,7 @@ export function handleIncomingWindowMessage(
 	handlers: InboundHandlers,
 	loggingOptions?: MessageLoggingOptions,
 ): void {
+	// TODO: remove loggingOptions once things settle.
 	return handleIncomingMessage(event.data, handlers, loggingOptions);
 }
 
@@ -75,6 +86,8 @@ export function handleIncomingWindowMessage(
  * @param handlers - List of handlers for particular event types.
  * If the incoming event's message type has a corresponding handler callback, that callback will be invoked.
  * Otherwise, this function will no-op.
+ * @param loggingOptions - Settings related to logging to console for troubleshooting.
+ * If not passed, this function won't log to console after the message has been handled.
  *
  * @internal
  */
@@ -83,6 +96,8 @@ export function handleIncomingMessage(
 	handlers: InboundHandlers,
 	loggingOptions?: MessageLoggingOptions,
 ): void {
+	// TODO: remove loggingOptions once things settle.
+
 	if (message === undefined || !isDebuggerMessage(message)) {
 		return;
 	}
@@ -95,10 +110,10 @@ export function handleIncomingMessage(
 	const handled = handlers[message.type](message);
 
 	// Only log if the message was actually handled by the recipient.
-	if (handled) {
+	if (handled && loggingOptions !== undefined) {
 		const loggingPreamble =
 			loggingOptions?.context === undefined ? "" : `${loggingOptions.context}: `;
-		console.log(`${loggingPreamble} message handled:`, message); // TODO: console.debug
+		console.debug(`${loggingPreamble} message handled:`, message);
 	}
 }
 


### PR DESCRIPTION
## Description

- Move to `console.debug()` instead of `console.log()` for some troubleshooting messages (that should probably go away at some point). This means now they'll only show up in the browser console if we have the Verbose logging level enabled:
  
<img width="346" alt="image" src="https://user-images.githubusercontent.com/716334/223873282-03b32c08-d7b5-4743-aae4-0bc07d5930b4.png">

- Wrap said troubleshooting messages so they're only generated if a "context" (options object) is passed to the functions that generate them. Telemetry was logging these too much.
