### PR TITLE
tree: require public

### DIFF
--- a/packages/dds/tree/.eslintrc.js
+++ b/packages/dds/tree/.eslintrc.js
@@ -12,5 +12,6 @@ module.exports = {
 		"@typescript-eslint/no-namespace": "off",
 		"@typescript-eslint/no-empty-interface": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off",
+		"@typescript-eslint/explicit-member-accessibility": "error",
 	},
 };

--- a/packages/dds/tree/src/core/change-family/progressiveEditBuilder.ts
+++ b/packages/dds/tree/src/core/change-family/progressiveEditBuilder.ts
@@ -24,7 +24,7 @@ export abstract class ProgressiveEditBuilderBase<TChange>
 {
 	private readonly changes: TChange[] = [];
 
-	constructor(
+	public constructor(
 		protected readonly changeFamily: ChangeFamily<unknown, TChange>,
 		private readonly changeReceiver: (change: TChange) => void,
 		private readonly anchorSet: AnchorSet,

--- a/packages/dds/tree/src/core/dependency-tracking/cachedValue.ts
+++ b/packages/dds/tree/src/core/dependency-tracking/cachedValue.ts
@@ -25,7 +25,7 @@ class CachedValue<T> extends SimpleObservingDependent implements ICachedValue<T>
 		}, computationName);
 	}
 
-	get(): T {
+	public get(): T {
 		this.cache ??= this.compute(this);
 		return this.cache;
 	}

--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -583,14 +583,14 @@ class PathNode extends ReferenceCountedBase implements UpPath<PathNode>, AnchorN
 		return this.events.on(eventName, listener);
 	}
 
-	child(key: FieldKey, index: number): UpPath<AnchorNode> {
+	public child(key: FieldKey, index: number): UpPath<AnchorNode> {
 		// Fast path: if child exists, return it.
 		return (
 			this.tryGetChild(key, index) ?? { parent: this, parentField: key, parentIndex: index }
 		);
 	}
 
-	getOrCreateChildRef(key: FieldKey, index: number): [Anchor, AnchorNode] {
+	public getOrCreateChildRef(key: FieldKey, index: number): [Anchor, AnchorNode] {
 		const anchor = this.anchorSet.track(this.child(key, index));
 		const node =
 			this.anchorSet.locate(anchor) ?? fail("cannot reference child that does not exist");

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -69,7 +69,10 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 		return this.events.on(eventName, listener);
 	}
 
-	clone(schema: StoredSchemaRepository<FullSchemaPolicy>, anchors: AnchorSet): ChunkedForest {
+	public clone(
+		schema: StoredSchemaRepository<FullSchemaPolicy>,
+		anchors: AnchorSet,
+	): ChunkedForest {
 		this.roots.referenceAdded();
 		return new ChunkedForest(this.roots, schema, anchors);
 	}
@@ -78,7 +81,7 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 		this.anchors.forget(anchor);
 	}
 
-	applyDelta(delta: Delta.Root): void {
+	public applyDelta(delta: Delta.Root): void {
 		this.events.emit("beforeDelta", delta);
 		this.invalidateDependents();
 
@@ -237,7 +240,7 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 		);
 	}
 
-	tryMoveCursorToNode(
+	public tryMoveCursorToNode(
 		destination: Anchor,
 		cursorToMove: ITreeSubscriptionCursor,
 	): TreeNavigationResult {
@@ -249,7 +252,7 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 		return TreeNavigationResult.Ok;
 	}
 
-	tryMoveCursorToField(
+	public tryMoveCursorToField(
 		destination: FieldAnchor,
 		cursorToMove: ITreeSubscriptionCursor,
 	): TreeNavigationResult {
@@ -275,7 +278,10 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 	 * This is NOT a relative move: current position is discarded.
 	 * Path must point to existing node.
 	 */
-	moveCursorToPath(destination: UpPath | undefined, cursorToMove: ITreeSubscriptionCursor): void {
+	private moveCursorToPath(
+		destination: UpPath | undefined,
+		cursorToMove: ITreeSubscriptionCursor,
+	): void {
 		assert(
 			cursorToMove instanceof Cursor,
 			0x53c /* ChunkedForest must only be given its own Cursor type */,

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
@@ -115,7 +115,7 @@ export class TreeShape {
 		this.fieldsOffsetArray = [...fields.values()];
 	}
 
-	equals(other: TreeShape): boolean {
+	public equals(other: TreeShape): boolean {
 		// TODO: either dedup instances and/or store a collision resistant hash for fast compare.
 
 		if (
@@ -130,7 +130,7 @@ export class TreeShape {
 		return this.type === other.type && this.hasValue === other.hasValue;
 	}
 
-	withTopLevelLength(topLevelLength: number): ChunkShape {
+	public withTopLevelLength(topLevelLength: number): ChunkShape {
 		return new ChunkShape(this, topLevelLength);
 	}
 }
@@ -189,7 +189,7 @@ export class ChunkShape {
 		this.positions = positions;
 	}
 
-	equals(other: ChunkShape): boolean {
+	public equals(other: ChunkShape): boolean {
 		// TODO: either dedup instances and/or store a collision resistant hash for fast compare.
 		return this.topLevelLength === other.topLevelLength && this.treeShape === other.treeShape;
 	}
@@ -254,7 +254,7 @@ class Cursor extends SynchronousCursor implements ChunkedCursor {
 	private readonly shape: ChunkShape;
 	private readonly positions: readonly (NodePositionInfo | undefined)[];
 
-	mode: CursorLocationType = CursorLocationType.Fields;
+	public mode: CursorLocationType = CursorLocationType.Fields;
 
 	// Undefined when not in fields mode.
 	private fieldKey?: FieldKey;
@@ -334,7 +334,7 @@ class Cursor extends SynchronousCursor implements ChunkedCursor {
 		return this.nodePositionInfo;
 	}
 
-	nextField(): boolean {
+	public nextField(): boolean {
 		this.indexOfField++;
 		const fields = this.nodeInfo(CursorLocationType.Fields).shape.fieldsArray;
 		if (this.indexOfField < fields.length) {
@@ -345,18 +345,18 @@ class Cursor extends SynchronousCursor implements ChunkedCursor {
 		return false;
 	}
 
-	exitField(): void {
+	public exitField(): void {
 		assert(this.mode === CursorLocationType.Fields, 0x4c9 /* exitField when in wrong mode */);
 		assert(this.nodePositionInfo !== undefined, 0x563 /* can not exit root field */);
 		this.fieldKey = undefined;
 		this.mode = CursorLocationType.Nodes;
 	}
 
-	getFieldKey(): FieldKey {
+	public getFieldKey(): FieldKey {
 		return this.fieldKey ?? fail("not in a field");
 	}
 
-	getFieldLength(): number {
+	public getFieldLength(): number {
 		assert(
 			this.mode === CursorLocationType.Fields,
 			0x53f /* tried to access cursor when in wrong mode */,
@@ -371,7 +371,7 @@ class Cursor extends SynchronousCursor implements ChunkedCursor {
 		return fieldInfo[2];
 	}
 
-	firstNode(): boolean {
+	public firstNode(): boolean {
 		assert(
 			this.mode === CursorLocationType.Fields,
 			0x540 /* tried to access cursor when in wrong mode */,
@@ -386,7 +386,7 @@ class Cursor extends SynchronousCursor implements ChunkedCursor {
 		}
 	}
 
-	enterNode(childIndex: number): void {
+	public enterNode(childIndex: number): void {
 		assert(
 			this.mode === CursorLocationType.Fields,
 			0x541 /* tried to access cursor when in wrong mode */,
@@ -433,18 +433,18 @@ class Cursor extends SynchronousCursor implements ChunkedCursor {
 		assert(this.fieldIndex === childIndex, 0x543 /* should be at selected child */);
 	}
 
-	getFieldPath(prefix?: PathRootPrefix): FieldUpPath {
+	public getFieldPath(prefix?: PathRootPrefix): FieldUpPath {
 		return prefixFieldPath(prefix, {
 			field: this.getFieldKey(),
 			parent: this.nodePositionInfo,
 		});
 	}
 
-	getPath(prefix?: PathRootPrefix): UpPath | undefined {
+	public getPath(prefix?: PathRootPrefix): UpPath | undefined {
 		return prefixPath(prefix, this.nodeInfo(CursorLocationType.Nodes));
 	}
 
-	get fieldIndex(): number {
+	public get fieldIndex(): number {
 		return this.nodeInfo(CursorLocationType.Nodes).parentIndex;
 	}
 
@@ -456,7 +456,7 @@ class Cursor extends SynchronousCursor implements ChunkedCursor {
 		return this.nodeInfo(CursorLocationType.Nodes).topLevelLength;
 	}
 
-	seekNodes(offset: number): boolean {
+	public seekNodes(offset: number): boolean {
 		const info = this.nodeInfo(CursorLocationType.Nodes);
 		const index = offset + info.parentIndex;
 		if (index >= 0 && index < info.topLevelLength) {
@@ -467,7 +467,7 @@ class Cursor extends SynchronousCursor implements ChunkedCursor {
 		return false;
 	}
 
-	nextNode(): boolean {
+	public nextNode(): boolean {
 		// This is the same as `return this.seekNodes(1);` but slightly faster.
 
 		const info = this.nodeInfo(CursorLocationType.Nodes);
@@ -480,7 +480,7 @@ class Cursor extends SynchronousCursor implements ChunkedCursor {
 		return true;
 	}
 
-	exitNode(): void {
+	public exitNode(): void {
 		const info = this.nodeInfo(CursorLocationType.Nodes);
 		this.indexOfField =
 			info.indexOfParentField ?? fail("navigation up to root field not yet supported"); // TODO;
@@ -491,7 +491,7 @@ class Cursor extends SynchronousCursor implements ChunkedCursor {
 		); // TODO
 	}
 
-	firstField(): boolean {
+	public firstField(): boolean {
 		const fieldsArray = this.nodeInfo(CursorLocationType.Nodes).shape.fieldsArray;
 		if (fieldsArray.length === 0) {
 			return false;
@@ -502,7 +502,7 @@ class Cursor extends SynchronousCursor implements ChunkedCursor {
 		return true;
 	}
 
-	enterField(key: FieldKey): void {
+	public enterField(key: FieldKey): void {
 		const fieldMap = this.nodeInfo(CursorLocationType.Nodes).shape.fields;
 		const fieldInfo = fieldMap.get(key);
 		this.indexOfField =
@@ -513,11 +513,11 @@ class Cursor extends SynchronousCursor implements ChunkedCursor {
 		this.mode = CursorLocationType.Fields;
 	}
 
-	get type(): TreeSchemaIdentifier {
+	public get type(): TreeSchemaIdentifier {
 		return this.nodeInfo(CursorLocationType.Nodes).shape.type;
 	}
 
-	get value(): Value {
+	public get value(): Value {
 		const info = this.nodeInfo(CursorLocationType.Nodes);
 		return info.shape.hasValue ? this.chunk.values[info.valueOffset] : undefined;
 	}

--- a/packages/dds/tree/src/feature-libraries/defaultChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultChangeFamily.ts
@@ -46,19 +46,19 @@ export class DefaultChangeFamily implements ChangeFamily<DefaultEditBuilder, Def
 		this.modularFamily = new ModularChangeFamily(defaultFieldKinds);
 	}
 
-	get rebaser(): ChangeRebaser<DefaultChangeset> {
+	public get rebaser(): ChangeRebaser<DefaultChangeset> {
 		return this.modularFamily.rebaser;
 	}
 
-	get encoder(): ChangeEncoder<DefaultChangeset> {
+	public get encoder(): ChangeEncoder<DefaultChangeset> {
 		return this.modularFamily.encoder;
 	}
 
-	intoDelta(change: DefaultChangeset): Delta.Root {
+	public intoDelta(change: DefaultChangeset): Delta.Root {
 		return this.modularFamily.intoDelta(change);
 	}
 
-	buildEditor(
+	public buildEditor(
 		changeReceiver: (change: DefaultChangeset) => void,
 		anchorSet: AnchorSet,
 	): DefaultEditBuilder {
@@ -122,7 +122,7 @@ export class DefaultEditBuilder
 {
 	private readonly modularBuilder: ModularEditBuilder;
 
-	constructor(
+	public constructor(
 		family: ChangeFamily<unknown, DefaultChangeset>,
 		changeReceiver: (change: DefaultChangeset) => void,
 		anchors: AnchorSet,

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
@@ -380,7 +380,7 @@ export function makeField(
 export abstract class ProxyTarget<T extends Anchor | FieldAnchor> {
 	private readonly lazyCursor: ITreeSubscriptionCursor;
 
-	constructor(
+	public constructor(
 		public readonly context: ProxyContext,
 		cursor: ITreeSubscriptionCursor,
 		private anchor?: T,
@@ -479,7 +479,7 @@ function getPrimaryArrayKey(
 export class NodeProxyTarget extends ProxyTarget<Anchor> {
 	public readonly proxy: EditableTree;
 	private readonly removeDeleteCallback: () => void;
-	constructor(
+	public constructor(
 		context: ProxyContext,
 		cursor: ITreeSubscriptionCursor,
 		public readonly anchorNode: AnchorNode,
@@ -513,19 +513,19 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 		this.context.forest.anchors.forget(anchor);
 	}
 
-	get typeName(): TreeSchemaIdentifier {
+	public get typeName(): TreeSchemaIdentifier {
 		return this.cursor.type;
 	}
 
-	get type(): TreeSchema {
+	public get type(): TreeSchema {
 		return lookupTreeSchema(this.context.schema, this.typeName);
 	}
 
-	get value(): Value {
+	public get value(): Value {
 		return this.cursor.value;
 	}
 
-	set value(value: Value) {
+	public set value(value: Value) {
 		assert(isPrimitive(this.type), 0x44d /* Cannot set a value of a non-primitive field */);
 		assertPrimitiveValueType(value, this.type);
 		const path = this.cursor.getPath();
@@ -533,7 +533,7 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 		this.context.setNodeValue(path, value);
 	}
 
-	get currentIndex(): number {
+	public get currentIndex(): number {
 		return this.cursor.fieldIndex;
 	}
 
@@ -568,7 +568,7 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 		);
 	}
 
-	[Symbol.iterator](): IterableIterator<EditableField> {
+	public [Symbol.iterator](): IterableIterator<EditableField> {
 		const type = this.type;
 		return mapCursorFields(this.cursor, (cursor) =>
 			makeField(
@@ -905,7 +905,11 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 	public readonly fieldSchema: FieldSchema;
 	public readonly [arrayLikeMarkerSymbol]: true;
 
-	constructor(context: ProxyContext, fieldSchema: FieldSchema, cursor: ITreeSubscriptionCursor) {
+	public constructor(
+		context: ProxyContext,
+		fieldSchema: FieldSchema,
+		cursor: ITreeSubscriptionCursor,
+	) {
 		assert(cursor.mode === CursorLocationType.Fields, 0x453 /* must be in fields mode */);
 		super(context, cursor);
 		this.fieldKey = cursor.getFieldKey();
@@ -913,11 +917,11 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 		this[arrayLikeMarkerSymbol] = true;
 	}
 
-	get [proxyTargetSymbol](): FieldProxyTarget {
+	public get [proxyTargetSymbol](): FieldProxyTarget {
 		return this;
 	}
 
-	get parent(): EditableTree | undefined {
+	public get parent(): EditableTree | undefined {
 		if (this.getAnchor().parent === undefined) {
 			return undefined;
 		}
@@ -976,7 +980,7 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 		return mapCursorField(this.cursor, (cursor) => unwrappedTree(this.context, cursor));
 	}
 
-	[Symbol.iterator](): IterableIterator<UnwrappedEditableTree> {
+	public [Symbol.iterator](): IterableIterator<UnwrappedEditableTree> {
 		return this.asArray().values();
 	}
 

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
@@ -132,7 +132,7 @@ export class ProxyContext implements EditableTreeContext {
 	 * @param forest - the Forest
 	 * @param transactionCheckout - the Checkout applied to a transaction, not required in read-only usecases.
 	 */
-	constructor(
+	public constructor(
 		public readonly forest: IEditableForest,
 		private readonly transactionCheckout?: TransactionCheckout<
 			DefaultEditBuilder,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -67,13 +67,13 @@ import { decodeJsonFormat0, encodeForJsonFormat0 } from "./modularChangeEncoding
 export class ModularChangeFamily
 	implements ChangeFamily<ModularEditBuilder, ModularChangeset>, ChangeRebaser<ModularChangeset>
 {
-	readonly encoder: ChangeEncoder<ModularChangeset>;
+	public readonly encoder: ChangeEncoder<ModularChangeset>;
 
-	constructor(readonly fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKind>) {
+	public constructor(public readonly fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKind>) {
 		this.encoder = new ModularChangeEncoder(this.fieldKinds);
 	}
 
-	get rebaser(): ChangeRebaser<ModularChangeset> {
+	public get rebaser(): ChangeRebaser<ModularChangeset> {
 		return this;
 	}
 
@@ -126,7 +126,7 @@ export class ModularChangeFamily
 		return { fieldKind, changesets: normalizedChanges };
 	}
 
-	compose(changes: TaggedChange<ModularChangeset>[]): ModularChangeset {
+	public compose(changes: TaggedChange<ModularChangeset>[]): ModularChangeset {
 		let maxId = -1;
 		const revInfos: RevisionInfo[] = [];
 		for (const taggedChange of changes) {
@@ -279,7 +279,7 @@ export class ModularChangeFamily
 	 * @param change - The change to invert.
 	 * @param repairStore - The store to query for repair data.
 	 */
-	invert(
+	public invert(
 		change: TaggedChange<ModularChangeset>,
 		repairStore?: ReadonlyRepairDataStore,
 	): ModularChangeset {
@@ -426,7 +426,10 @@ export class ModularChangeFamily
 		return inverse;
 	}
 
-	rebase(change: ModularChangeset, over: TaggedChange<ModularChangeset>): ModularChangeset {
+	public rebase(
+		change: ModularChangeset,
+		over: TaggedChange<ModularChangeset>,
+	): ModularChangeset {
 		let maxId = change.maxId ?? -1;
 		const genId: IdAllocator = () => brand(++maxId);
 		const crossFieldTable = newCrossFieldTable<RebaseData>();
@@ -554,11 +557,11 @@ export class ModularChangeFamily
 		};
 	}
 
-	rebaseAnchors(anchors: AnchorSet, over: ModularChangeset): void {
+	public rebaseAnchors(anchors: AnchorSet, over: ModularChangeset): void {
 		anchors.applyDelta(this.intoDelta(over));
 	}
 
-	intoDelta(change: ModularChangeset): Delta.Root {
+	public intoDelta(change: ModularChangeset): Delta.Root {
 		return this.intoDeltaImpl(change.changes);
 	}
 
@@ -597,7 +600,7 @@ export class ModularChangeFamily
 		return modify;
 	}
 
-	buildEditor(
+	public buildEditor(
 		changeReceiver: (change: ModularChangeset) => void,
 		anchors: AnchorSet,
 	): ModularEditBuilder {
@@ -766,15 +769,15 @@ function makeModularChangeset(
 }
 
 class ModularChangeEncoder extends ChangeEncoder<ModularChangeset> {
-	constructor(private readonly fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKind>) {
+	public constructor(private readonly fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKind>) {
 		super();
 	}
 
-	encodeForJson(formatVersion: number, change: ModularChangeset): JsonCompatibleReadOnly {
+	public encodeForJson(formatVersion: number, change: ModularChangeset): JsonCompatibleReadOnly {
 		return encodeForJsonFormat0(this.fieldKinds, change);
 	}
 
-	decodeJson(formatVersion: number, change: JsonCompatibleReadOnly): ModularChangeset {
+	public decodeJson(formatVersion: number, change: JsonCompatibleReadOnly): ModularChangeset {
 		return decodeJsonFormat0(this.fieldKinds, change);
 	}
 }
@@ -787,7 +790,7 @@ export class ModularEditBuilder
 	extends ProgressiveEditBuilderBase<ModularChangeset>
 	implements ProgressiveEditBuilder<ModularChangeset>
 {
-	constructor(
+	public constructor(
 		family: ChangeFamily<unknown, ModularChangeset>,
 		changeReceiver: (change: ModularChangeset) => void,
 		anchors: AnchorSet,
@@ -807,7 +810,7 @@ export class ModularEditBuilder
 	 * @param change - the change to the field
 	 * @param maxId - the highest `ChangesetLocalId` used in this change
 	 */
-	submitChange(
+	public submitChange(
 		path: UpPath | undefined,
 		field: FieldKey,
 		fieldKind: FieldKindIdentifier,
@@ -818,7 +821,7 @@ export class ModularEditBuilder
 		this.applyChange(makeModularChangeset(changeMap, maxId));
 	}
 
-	submitChanges(changes: EditDescription[], maxId: ChangesetLocalId = brand(-1)) {
+	public submitChanges(changes: EditDescription[], maxId: ChangesetLocalId = brand(-1)) {
 		const changeMaps = changes.map((change) =>
 			makeAnonChange(
 				makeModularChangeset(
@@ -860,7 +863,7 @@ export class ModularEditBuilder
 		return fieldChangeMap;
 	}
 
-	setValue(path: UpPath, value: Value): void {
+	public setValue(path: UpPath, value: Value): void {
 		const valueChange: ValueChange = value === undefined ? {} : { value };
 		const nodeChange: NodeChangeset = { valueChange };
 		const fieldChange = genericFieldKind.changeHandler.editor.buildChildChange(

--- a/packages/dds/tree/src/feature-libraries/modular-schema/view.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/view.ts
@@ -170,7 +170,7 @@ export interface TreeViewSchema extends TreeSchema {}
 export class FieldTypeView<Kind extends FieldKind = FieldKind> implements FieldSchema {
 	public readonly types?: ReadonlySet<TreeSchemaIdentifier>;
 
-	get kind(): FieldKindIdentifier {
+	public get kind(): FieldKindIdentifier {
 		return this.fieldKind.identifier;
 	}
 

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -74,7 +74,7 @@ class ObjectForest extends SimpleDependee implements IEditableForest {
 		return this.events.on(eventName, listener);
 	}
 
-	clone(schema: StoredSchemaRepository, anchors: AnchorSet): ObjectForest {
+	public clone(schema: StoredSchemaRepository, anchors: AnchorSet): ObjectForest {
 		const forest = new ObjectForest(schema, anchors);
 		// Deep copy the trees.
 		for (const [key, value] of this.roots.fields) {
@@ -92,7 +92,7 @@ class ObjectForest extends SimpleDependee implements IEditableForest {
 		this.anchors.forget(anchor);
 	}
 
-	applyDelta(delta: Delta.Root): void {
+	public applyDelta(delta: Delta.Root): void {
 		this.events.emit("beforeDelta", delta);
 		this.invalidateDependents();
 		assert(
@@ -206,11 +206,11 @@ class ObjectForest extends SimpleDependee implements IEditableForest {
 		this.roots.fields.delete(detachedFieldAsKey(field));
 	}
 
-	allocateCursor(): Cursor {
+	public allocateCursor(): Cursor {
 		return new Cursor(this);
 	}
 
-	tryMoveCursorToNode(
+	public tryMoveCursorToNode(
 		destination: Anchor,
 		cursorToMove: ITreeSubscriptionCursor,
 	): TreeNavigationResult {
@@ -222,7 +222,7 @@ class ObjectForest extends SimpleDependee implements IEditableForest {
 		return TreeNavigationResult.Ok;
 	}
 
-	tryMoveCursorToField(
+	public tryMoveCursorToField(
 		destination: FieldAnchor,
 		cursorToMove: ITreeSubscriptionCursor,
 	): TreeNavigationResult {
@@ -243,7 +243,10 @@ class ObjectForest extends SimpleDependee implements IEditableForest {
 	 * This is NOT a relative move: current position is discarded.
 	 * Path must point to existing node.
 	 */
-	moveCursorToPath(destination: UpPath | undefined, cursorToMove: ITreeSubscriptionCursor): void {
+	public moveCursorToPath(
+		destination: UpPath | undefined,
+		cursorToMove: ITreeSubscriptionCursor,
+	): void {
 		assert(
 			cursorToMove instanceof Cursor,
 			0x337 /* ObjectForest must only be given its own Cursor type */,
@@ -290,7 +293,7 @@ type ObjectField = MapTree[];
  * Cursor implementation for ObjectForest.
  */
 class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
-	state: ITreeSubscriptionCursorState;
+	public state: ITreeSubscriptionCursorState;
 
 	/**
 	 * @param forest - forest this cursor navigates
@@ -309,90 +312,90 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
 		}
 	}
 
-	buildFieldAnchor(): FieldAnchor {
+	public buildFieldAnchor(): FieldAnchor {
 		const path = this.getFieldPath();
 		const anchor =
 			path.parent === undefined ? undefined : this.forest.anchors.track(path.parent);
 		return { parent: anchor, fieldKey: path.field };
 	}
-	getFieldPath(prefix?: PathRootPrefix): FieldUpPath {
+	public getFieldPath(prefix?: PathRootPrefix): FieldUpPath {
 		assert(this.innerCursor !== undefined, 0x45f /* Cursor must be current to be used */);
 		return this.innerCursor.getFieldPath(prefix);
 	}
-	get mode(): CursorLocationType {
+	public get mode(): CursorLocationType {
 		assert(this.innerCursor !== undefined, 0x42e /* Cursor must be current to be used */);
 		return this.innerCursor.mode;
 	}
 
-	nextField(): boolean {
+	public nextField(): boolean {
 		assert(this.innerCursor !== undefined, 0x42f /* Cursor must be current to be used */);
 		return this.innerCursor.nextField();
 	}
-	exitField(): void {
+	public exitField(): void {
 		assert(this.innerCursor !== undefined, 0x430 /* Cursor must be current to be used */);
 		return this.innerCursor.exitField();
 	}
-	override skipPendingFields(): boolean {
+	public override skipPendingFields(): boolean {
 		assert(this.innerCursor !== undefined, 0x431 /* Cursor must be current to be used */);
 		return this.innerCursor.skipPendingFields();
 	}
-	getFieldKey(): FieldKey {
+	public getFieldKey(): FieldKey {
 		assert(this.innerCursor !== undefined, 0x432 /* Cursor must be current to be used */);
 		return this.innerCursor.getFieldKey();
 	}
-	getFieldLength(): number {
+	public getFieldLength(): number {
 		assert(this.innerCursor !== undefined, 0x433 /* Cursor must be current to be used */);
 		return this.innerCursor.getFieldLength();
 	}
-	firstNode(): boolean {
+	public firstNode(): boolean {
 		assert(this.innerCursor !== undefined, 0x434 /* Cursor must be current to be used */);
 		return this.innerCursor.firstNode();
 	}
-	enterNode(childIndex: number): void {
+	public enterNode(childIndex: number): void {
 		assert(this.innerCursor !== undefined, 0x435 /* Cursor must be current to be used */);
 		return this.innerCursor.enterNode(childIndex);
 	}
-	getPath(prefix?: PathRootPrefix): UpPath {
+	public getPath(prefix?: PathRootPrefix): UpPath {
 		assert(this.innerCursor !== undefined, 0x436 /* Cursor must be current to be used */);
 		return this.innerCursor.getPath(prefix) ?? fail("no path when at root");
 	}
-	get fieldIndex(): number {
+	public get fieldIndex(): number {
 		assert(this.innerCursor !== undefined, 0x437 /* Cursor must be current to be used */);
 		return this.innerCursor.fieldIndex;
 	}
-	get chunkStart(): number {
+	public get chunkStart(): number {
 		assert(this.innerCursor !== undefined, 0x438 /* Cursor must be current to be used */);
 		return this.innerCursor.chunkStart;
 	}
-	get chunkLength(): number {
+	public get chunkLength(): number {
 		assert(this.innerCursor !== undefined, 0x439 /* Cursor must be current to be used */);
 		return this.innerCursor.chunkLength;
 	}
-	seekNodes(offset: number): boolean {
+	public seekNodes(offset: number): boolean {
 		assert(this.innerCursor !== undefined, 0x43a /* Cursor must be current to be used */);
 		return this.innerCursor.seekNodes(offset);
 	}
-	nextNode(): boolean {
+	public nextNode(): boolean {
 		assert(this.innerCursor !== undefined, 0x43b /* Cursor must be current to be used */);
 		return this.innerCursor.nextNode();
 	}
-	exitNode(): void {
+	public exitNode(): void {
 		assert(this.innerCursor !== undefined, 0x43c /* Cursor must be current to be used */);
 		return this.innerCursor.exitNode();
 	}
-	firstField(): boolean {
+	public firstField(): boolean {
 		assert(this.innerCursor !== undefined, 0x43d /* Cursor must be current to be used */);
 		return this.innerCursor.firstField();
 	}
-	enterField(key: FieldKey): void {
+	public enterField(key: FieldKey): void {
 		assert(this.innerCursor !== undefined, 0x43e /* Cursor must be current to be used */);
 		return this.innerCursor.enterField(key);
 	}
-	get type(): TreeSchemaIdentifier {
+	public get type(): TreeSchemaIdentifier {
 		assert(this.innerCursor !== undefined, 0x43f /* Cursor must be current to be used */);
 		return this.innerCursor.type;
 	}
-	get value(): TreeValue {
+	public get value(): TreeValue {
 		assert(this.innerCursor !== undefined, 0x440 /* Cursor must be current to be used */);
 		return this.innerCursor.value;
 	}
@@ -423,12 +426,12 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
 		this.forest.currentCursors.add(this);
 	}
 
-	getNode(): MapTree {
+	public getNode(): MapTree {
 		assert(this.innerCursor !== undefined, 0x33e /* Cursor must be current to be used */);
 		return this.innerCursor.getNode();
 	}
 
-	getParent(): [MapTree, FieldKey] {
+	public getParent(): [MapTree, FieldKey] {
 		assert(this.innerCursor !== undefined, 0x441 /* Cursor must be current to be used */);
 		// This could be optimized to skip moving it accessing internals of cursor.
 		const key = this.innerCursor.getFieldKey();
@@ -438,12 +441,12 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
 		return [node, key];
 	}
 
-	fork(): ITreeSubscriptionCursor {
+	public fork(): ITreeSubscriptionCursor {
 		assert(this.innerCursor !== undefined, 0x460 /* Cursor must be current to be used */);
 		return new Cursor(this.forest, this.innerCursor.fork());
 	}
 
-	free(): void {
+	public free(): void {
 		assert(
 			this.state !== ITreeSubscriptionCursorState.Freed,
 			0x33f /* Cursor must not be double freed */,
@@ -452,7 +455,7 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
 		this.state = ITreeSubscriptionCursorState.Freed;
 	}
 
-	buildAnchor(): Anchor {
+	public buildAnchor(): Anchor {
 		assert(
 			this.state === ITreeSubscriptionCursorState.Current,
 			0x37a /* Cursor must be current to be used */,

--- a/packages/dds/tree/src/feature-libraries/schemaIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/schemaIndex.ts
@@ -84,7 +84,7 @@ export class SchemaIndex implements Index, SummaryElement {
 		});
 	}
 
-	newLocalState(changeDelta: Delta.Root): void {
+	public newLocalState(changeDelta: Delta.Root): void {
 		// TODO: apply schema changes.
 		// Extend delta to include them, or maybe have some higher level edit type that includes them and deltas?
 	}
@@ -184,7 +184,7 @@ export class SchemaEditor<TRepository extends StoredSchemaRepository>
 	 * TODO: Shared tree needs a pattern for handling non-changeset operations.
 	 * See TODO on `SharedTree.processCore`.
 	 */
-	tryHandleOp(message: ISequencedDocumentMessage): boolean {
+	public tryHandleOp(message: ISequencedDocumentMessage): boolean {
 		const op: JsonCompatibleReadOnly = message.contents;
 		if (isJsonObject(op) && op.type === "SchemaOp") {
 			const data = parseSchemaString(op.data as string);
@@ -195,37 +195,37 @@ export class SchemaEditor<TRepository extends StoredSchemaRepository>
 		return false;
 	}
 
-	update(newSchema: SchemaData): void {
+	public update(newSchema: SchemaData): void {
 		const op: SchemaOp = { type: "SchemaOp", data: getSchemaString(newSchema) };
 		this.submit(op);
 		this.inner.update(newSchema);
 	}
 
-	registerDependent(dependent: Dependent): boolean {
+	public registerDependent(dependent: Dependent): boolean {
 		return this.inner.registerDependent(dependent);
 	}
 
-	removeDependent(dependent: Dependent): void {
+	public removeDependent(dependent: Dependent): void {
 		return this.inner.removeDependent(dependent);
 	}
 
-	get computationName(): string {
+	public get computationName(): string {
 		return this.inner.computationName;
 	}
 
-	get listDependees(): undefined | (() => Iterable<Dependee>) {
+	public get listDependees(): undefined | (() => Iterable<Dependee>) {
 		return this.inner.listDependees?.bind(this.inner);
 	}
 
-	get policy(): SchemaPolicy {
+	public get policy(): SchemaPolicy {
 		return this.inner.policy;
 	}
 
-	get globalFieldSchema(): ReadonlyMap<GlobalFieldKey, FieldSchema> {
+	public get globalFieldSchema(): ReadonlyMap<GlobalFieldKey, FieldSchema> {
 		return this.inner.globalFieldSchema;
 	}
 
-	get treeSchema(): ReadonlyMap<TreeSchemaIdentifier, TreeSchema> {
+	public get treeSchema(): ReadonlyMap<TreeSchemaIdentifier, TreeSchema> {
 		return this.inner.treeSchema;
 	}
 }

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/sequenceEditBuilder.ts
@@ -20,7 +20,7 @@ import { SequenceChangeset } from "./sequenceChangeset";
 export class SequenceEditBuilder extends ProgressiveEditBuilderBase<SequenceChangeset> {
 	private opId: number = 0;
 
-	constructor(changeReceiver: (change: SequenceChangeset) => void, anchorSet: AnchorSet) {
+	public constructor(changeReceiver: (change: SequenceChangeset) => void, anchorSet: AnchorSet) {
 		super(sequenceChangeFamily, changeReceiver, anchorSet);
 	}
 

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
@@ -235,11 +235,11 @@ class WrapperChunk extends ReferenceCountedBase implements TreeChunk {
 		this.chunk.referenceRemoved();
 	}
 
-	get topLevelLength(): number {
+	public get topLevelLength(): number {
 		return this.chunk.topLevelLength;
 	}
 
-	cursor(): ChunkedCursor {
+	public cursor(): ChunkedCursor {
 		return this.chunk.cursor();
 	}
 }

--- a/packages/dds/tree/src/test/shared-tree/testTree.ts
+++ b/packages/dds/tree/src/test/shared-tree/testTree.ts
@@ -72,11 +72,11 @@ function commandWithResult(command: SucceedingCommand) {
  * actual `SharedTree` would be appropriate instead.
  */
 export class TestTree {
-	static fromForest(forest: IEditableForest, options: TestTreeOptions = {}): TestTree {
+	public static fromForest(forest: IEditableForest, options: TestTreeOptions = {}): TestTree {
 		return new TestTree(forest, options);
 	}
 
-	static fromCursor(
+	public static fromCursor(
 		cursor: ITreeCursorSynchronous[] | ITreeCursorSynchronous,
 		options: TestTreeOptions = {},
 	): TestTree {
@@ -87,7 +87,7 @@ export class TestTree {
 		return TestTree.fromForest(forest, options);
 	}
 
-	static fromJson<T>(
+	public static fromJson<T>(
 		json: JsonCompatible[] | JsonCompatible,
 		options: TestTreeOptions = {},
 	): TestTree {

--- a/packages/dds/tree/src/util/stackyIterator.ts
+++ b/packages/dds/tree/src/util/stackyIterator.ts
@@ -15,11 +15,11 @@ export class StackyIterator<T> implements Iterator<T>, Iterable<T> {
 		this.list = list;
 	}
 
-	[Symbol.iterator](): Iterator<T> {
+	public [Symbol.iterator](): Iterator<T> {
 		return this;
 	}
 
-	next(): IteratorResult<T> {
+	public next(): IteratorResult<T> {
 		if (this.done) {
 			return { value: undefined, done: true };
 		}


### PR DESCRIPTION
## Description

In the tree codebase we usually include the "public" modifiers where relevant. 
This enforces consistency by requiring it via the linter.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
