### PR TITLE
tree: enable strict-boolean-expressions

### DIFF
--- a/packages/dds/tree/.eslintrc.js
+++ b/packages/dds/tree/.eslintrc.js
@@ -11,6 +11,5 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/no-namespace": "off",
 		"@typescript-eslint/no-empty-interface": "off",
-		"@typescript-eslint/strict-boolean-expressions": "off",
 	},
 };

--- a/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
@@ -106,7 +106,7 @@ function composeMarkLists<TNodeChange>(
 	);
 	while (!queue.isEmpty()) {
 		const popped = queue.pop();
-		if (popped.areInverses) {
+		if (popped.areInverses === true) {
 			factory.pushOffset(getInputLength(popped.baseMark));
 			continue;
 		}

--- a/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -215,7 +215,7 @@ function applyMoveEffectsToDest<T>(
 
 	assert(effect.modifyAfter === undefined, 0x566 /* Cannot modify move destination */);
 
-	if (!effect.shouldRemove) {
+	if (effect.shouldRemove !== true) {
 		const newMark: MoveIn | ReturnTo = {
 			...mark,
 			count: effect.count ?? mark.count,
@@ -277,7 +277,7 @@ function applyMoveEffectsToSource<T>(
 		mark.id,
 	);
 	const result: Mark<T>[] = [];
-	if (!effect.shouldRemove) {
+	if (effect.shouldRemove !== true) {
 		const newMark = cloneMark(mark);
 		newMark.count = effect.count ?? newMark.count;
 		if (effect.modifyAfter !== undefined) {

--- a/packages/dds/tree/src/test/domains/json/twitter.ts
+++ b/packages/dds/tree/src/test/domains/json/twitter.ts
@@ -637,13 +637,13 @@ export function parseSentencesIntoWords(inputSentences: string[]) {
 		const spaceSeparatedWords: string[] = inputSentence.split(" ");
 		spaceSeparatedWords.forEach((potentialWord) => {
 			const innerWords: string[] = [];
-			let previousChar: string | null = null;
+			let previousChar: string | undefined;
 			let currentWord = "";
 			for (let i = 0; i < potentialWord.length; i++) {
 				const currentChar = potentialWord.charAt(i);
 				if (isEscapeChar(currentChar) || isJapaneseSymbolOrPunctuation(currentChar)) {
 					if (
-						(previousChar && !isEscapeChar(previousChar)) ||
+						(previousChar !== undefined && !isEscapeChar(previousChar)) ||
 						isJapaneseSymbolOrPunctuation(currentChar)
 					) {
 						innerWords.push(`${currentWord}`);

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -162,7 +162,7 @@ export function* zipIterables<T, U>(
 	const iteratorB = iterableB[Symbol.iterator]();
 	for (
 		let nextA = iteratorA.next(), nextB = iteratorB.next();
-		!nextA.done && !nextB.done;
+		nextA.done !== true && nextB.done !== true;
 		nextA = iteratorA.next(), nextB = iteratorB.next()
 	) {
 		yield [nextA.value, nextB.value];


### PR DESCRIPTION
## Description

Enable strict-boolean-expressions to make code more readable when dealing with cases like optional booleans and strings that might be empty.

Also migrate some test code which was failing these checks to newer apis (Map and "undefined")

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
