### PR TITLE
Extending timeout to address failures during benchmark run.

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/.mocharc.memory.js
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/.mocharc.memory.js
@@ -24,6 +24,6 @@ const newConfig = {
 		"dist/test/benchmark/**/*.all.spec.js",
 		"--perfMode",
 	],
-	"timeout": "60000",
+	"timeout": "120000",
 };
 module.exports = newConfig;

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/.mocharc.time.js
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/.mocharc.time.js
@@ -24,6 +24,6 @@ const newConfig = {
 		"dist/test/benchmark/**/*.all.spec.js",
 		"--perfMode",
 	],
-	"timeout": "60000",
+	"timeout": "12000",
 };
 module.exports = newConfig;


### PR DESCRIPTION

## Description

The performance end-to-end tests are timing out during summarization tests. Extending timeout for now until we can see what number of iterations is more reliable. 