### PR TITLE
[main > release/v2int/3.0]: Don't proceed to close socket if connection is already disposed in odsp

### DIFF
--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -29,7 +29,8 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     checkpointSequenceNumber: number | undefined;
     get claims(): ITokenClaims;
     get clientId(): string;
-    protected closeSocket(error: IAnyDriverError): void;
+    // (undocumented)
+    protected closeSocketCore(error: IAnyDriverError): void;
     protected createErrorObject(handler: string, error?: any, canRetry?: boolean): IAnyDriverError;
     // (undocumented)
     get details(): IConnected;

--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -23,7 +23,7 @@ import type { Socket } from 'socket.io-client';
 
 // @public
 export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocumentDeltaConnectionEvents> implements IDocumentDeltaConnection, IDisposable {
-    protected constructor(socket: Socket, documentId: string, logger: ITelemetryLogger, enableLongPollingDowngrades?: boolean);
+    protected constructor(socket: Socket, documentId: string, logger: ITelemetryLogger, enableLongPollingDowngrades?: boolean, connectionId?: string | undefined);
     // (undocumented)
     protected addTrackedListener(event: string, listener: (...args: any[]) => void): void;
     checkpointSequenceNumber: number | undefined;
@@ -31,6 +31,8 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     get clientId(): string;
     // (undocumented)
     protected closeSocketCore(error: IAnyDriverError): void;
+    // (undocumented)
+    protected readonly connectionId?: string | undefined;
     protected createErrorObject(handler: string, error?: any, canRetry?: boolean): IAnyDriverError;
     // (undocumented)
     get details(): IConnected;

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -30,6 +30,7 @@ import {
     loggerToMonitoringContext,
     MonitoringContext,
     EventEmitterWithErrorHandling,
+	normalizeError,
 } from "@fluidframework/telemetry-utils";
 import type { Socket } from "socket.io-client";
 // For now, this package is versioned and released in unison with the specific drivers
@@ -80,7 +81,30 @@ export class DocumentDeltaConnection
     }
 
     public get disposed() {
-        assert(this._disposed || this.socket.connected, 0x244 /* "Socket is closed, but connection is not!" */);
+		// Increase the stack trace limit temporarily, so as to debug better in case it occurs.
+		// We are seeing this in telemetry and we are unable to figure out why it is happening, so this should help.
+		const originalStackTraceLimit = (Error as any).stackTraceLimit;
+		try {
+			(Error as any).stackTraceLimit = 50;
+			assert(
+				this._disposed || this.socket.connected,
+				0x244 /* "Socket is closed, but connection is not!" */,
+			);
+		} catch (error) {
+			const normalizedError = normalizeError(error, {
+				props: {
+					details: JSON.stringify({
+						disposed: this._disposed,
+						socketConnected: this.socket?.connected,
+						clientId: this._details?.clientId,
+						conenctionId: this.connectionId,
+					}),
+				},
+			});
+			throw normalizedError;
+		} finally {
+			(Error as any).stackTraceLimit = originalStackTraceLimit;
+		}
         return this._disposed;
     }
 
@@ -116,6 +140,7 @@ export class DocumentDeltaConnection
         public documentId: string,
         logger: ITelemetryLogger,
         private readonly enableLongPollingDowngrades: boolean = false,
+		protected readonly connectionId?: string,
     ) {
         super((name, error) => {
             logger.sendErrorEvent(
@@ -218,7 +243,27 @@ export class DocumentDeltaConnection
     }
 
     private checkNotClosed() {
-        assert(!this.disposed, 0x20c /* "connection disposed" */);
+		// Increase the stack trace limit temporarily, so as to debug better in case it occurs.
+		// We are seeing this in telemetry and we are unable to figure out why it is happening, so this should help.
+		const originalStackTraceLimit = (Error as any).stackTraceLimit;
+		try {
+			(Error as any).stackTraceLimit = 50;
+			assert(!this.disposed, 0x20c /* "connection disposed" */);
+		} catch (error) {
+			const normalizedError = normalizeError(error, {
+				props: {
+					details: JSON.stringify({
+						disposed: this._disposed,
+						socketConnected: this.socket?.connected,
+						clientId: this._details?.clientId,
+						conenctionId: this.connectionId,
+					}),
+				},
+			});
+			throw normalizedError;
+		} finally {
+			(Error as any).stackTraceLimit = originalStackTraceLimit;
+		}
     }
 
     /**
@@ -324,6 +369,8 @@ export class DocumentDeltaConnection
 						disposed: this._disposed,
 						socketConnected: this.socket?.connected,
 						trackedListenerCount: this.trackedListeners.size,
+						clientId: this._details?.clientId,
+						connectionId: this.connectionId,
 					}),
 				},
 				error,
@@ -346,7 +393,14 @@ export class DocumentDeltaConnection
         this.logger.sendTelemetryEvent({
             eventName: "ClientClosingDeltaConnection",
             driverVersion,
-            details: JSON.stringify({ disposed: this._disposed, socketConnected: this.socket.connected }),
+            details: JSON.stringify(
+				{
+					disposed: this._disposed,
+					socketConnected: this.socket.connected,
+					clientId: this._details?.clientId,
+					connectionId: this.connectionId,
+				}
+			),
         });
         this.disconnect(createGenericNetworkError(
             // pre-0.58 error message: clientClosingConnection
@@ -376,8 +430,11 @@ export class DocumentDeltaConnection
             eventName: "AfterDisconnectEvent",
             driverVersion,
             details: JSON.stringify({
+				disposed: this._disposed,
+				clientId: this._details?.clientId,
                 socketConnected: this.socket.connected,
                 disconnectListenerCount: this.listenerCount("disconnect"),
+				connectionId: this.connectionId,
             }),
         });
         // user of DeltaConnection should have processed "disconnect" event and removed all listeners. Not clear

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -91,16 +91,7 @@ export class DocumentDeltaConnection
 				0x244 /* "Socket is closed, but connection is not!" */,
 			);
 		} catch (error) {
-			const normalizedError = normalizeError(error, {
-				props: {
-					details: JSON.stringify({
-						disposed: this._disposed,
-						socketConnected: this.socket?.connected,
-						clientId: this._details?.clientId,
-						conenctionId: this.connectionId,
-					}),
-				},
-			});
+			const normalizedError = this.addPropsToError(error);
 			throw normalizedError;
 		} finally {
 			(Error as any).stackTraceLimit = originalStackTraceLimit;
@@ -250,16 +241,7 @@ export class DocumentDeltaConnection
 			(Error as any).stackTraceLimit = 50;
 			assert(!this.disposed, 0x20c /* "connection disposed" */);
 		} catch (error) {
-			const normalizedError = normalizeError(error, {
-				props: {
-					details: JSON.stringify({
-						disposed: this._disposed,
-						socketConnected: this.socket?.connected,
-						clientId: this._details?.clientId,
-						conenctionId: this.connectionId,
-					}),
-				},
-			});
+			const normalizedError = this.addPropsToError(error);
 			throw normalizedError;
 		} finally {
 			(Error as any).stackTraceLimit = originalStackTraceLimit;
@@ -468,15 +450,35 @@ export class DocumentDeltaConnection
             getMaxInternalSocketReconnectionAttempts() + 1;
 
         this._details = await new Promise<IConnected>((resolve, reject) => {
-            const failAndCloseSocket = (err: IAnyDriverError) => {
-                this.closeSocket(err);
-                reject(err);
-            };
+			const failAndCloseSocket = (err: IAnyDriverError) => {
+				try {
+					this.closeSocket(err);
+				} catch (failError) {
+					const normalizedError = this.addPropsToError(failError);
+					this.logger.sendErrorEvent({ eventName: "CloseSocketError" }, normalizedError);
+				}
+				reject(err);
+			};
 
-            const failConnection = (err: IAnyDriverError) => {
-                this.disconnect(err);
-                reject(err);
-            };
+			const failConnection = (err: IAnyDriverError) => {
+				try {
+					this.disconnect(err);
+				} catch (failError) {
+					const normalizedError = this.addPropsToError(failError);
+					this.logger.sendErrorEvent(
+						{ eventName: "FailConnectionError" },
+						normalizedError,
+					);
+				}
+				reject(err);
+			};
+
+			// Immediately set the connection timeout.
+			// Give extra 2 seconds for handshake on top of socket connection timeout.
+			this.socketConnectionTimeout = setTimeout(() => {
+				failConnection(this.createErrorObject("orderingServiceHandshakeTimeout"));
+			}, timeout + 2000);
+
             // Listen for connection issues
             this.addConnectionListener("connect_error", (error) => {
                 internalSocketConnectionFailureCount++;
@@ -611,15 +613,24 @@ export class DocumentDeltaConnection
             }));
 
             this.socket.emit("connect_document", connectMessage);
-
-            // Give extra 2 seconds for handshake on top of socket connection timeout
-            this.socketConnectionTimeout = setTimeout(() => {
-                failConnection(this.createErrorObject("orderingServiceHandshakeTimeout"));
-            }, timeout + 2000);
         });
 
         assert(!this.disposed, 0x246 /* "checking consistency of socket & _disposed flags" */);
     }
+
+	private addPropsToError(errorToBeNormalized: unknown) {
+		const normalizedError = normalizeError(errorToBeNormalized, {
+			props: {
+				details: JSON.stringify({
+					disposed: this._disposed,
+					socketConnected: this.socket?.connected,
+					clientId: this._details?.clientId,
+					conenctionId: this.connectionId,
+				}),
+			},
+		});
+		return normalizedError;
+	}
 
     protected earlyOpHandler = (documentId: string, msgs: ISequencedDocumentMessage[]) => {
         this.queuedMessages.push(...msgs);

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -313,9 +313,29 @@ export class DocumentDeltaConnection
     /**
      * Disconnect from the websocket and close the websocket too.
      */
-    protected closeSocket(error: IAnyDriverError) {
-        this.disconnect(error);
-    }
+	private closeSocket(error: IAnyDriverError) {
+		if (this._disposed) {
+			// This would be rare situation due to complexity around socket emitting events.
+			this.logger.sendTelemetryEvent(
+				{
+					eventName: "SocketCloseOnDisposedConnection",
+					driverVersion,
+					details: JSON.stringify({
+						disposed: this._disposed,
+						socketConnected: this.socket?.connected,
+						trackedListenerCount: this.trackedListeners.size,
+					}),
+				},
+				error,
+			);
+			return;
+		}
+		this.closeSocketCore(error);
+	}
+
+	protected closeSocketCore(error: IAnyDriverError) {
+		this.disconnect(error);
+	}
 
     /**
      * Disconnect from the websocket, and permanently disable this DocumentDeltaConnection and close the socket.

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -356,7 +356,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
         logger: ITelemetryLogger,
         private readonly enableMultiplexing?: boolean,
     ) {
-        super(socket, documentId, logger);
+        super(socket, documentId, logger, false, uuid());
         this.socketReference = socketReference;
         this.requestOpsNoncePrefix = `${uuid()}-`;
     }

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -602,7 +602,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
      * Critical path where we need to also close the socket for an error.
      * @param error - Error causing the socket to close.
      */
-    protected closeSocket(error: IAnyDriverError) {
+    protected closeSocketCore(error: IAnyDriverError) {
         const socket = this.socketReference;
         assert(socket !== undefined, 0x416 /* reentrancy not supported in close socket */);
         socket.closeSocket(error);

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -628,9 +628,10 @@ export class ConnectionManager implements IConnectionManager {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this._outbound.pause();
         this._outbound.clear();
-        this.props.disconnectHandler(reason);
 
         connection.dispose();
+
+        this.props.disconnectHandler(reason);
 
         this._connectionVerboseProps = {};
 


### PR DESCRIPTION
## Description

ADO item link: https://dev.azure.com/fluidframework/internal/_workitems/edit/3648
1.) Adding more telemetry in flows where the socket is getting closed on connect/reconnect to better understand the state of the system.
2.) We see that connect_error or some other error is fired on socket and we go through the socket close flow and telemetry shows that we do successfully close the socket and remove listeners but then we again have the errror on socket which again go into the socket close flow and cause reentrancy issues with uncaught 0x416 assert. Seems like there is a possibility that there was some micro task already scheduled by socket to call the error listener which causes us to go through the socket close flow again. In the end, the initial call to recoonect in connectionManager.ts after disconnect hangs and we never try to connect again.