### PR TITLE
feat(client-debugger): Hook up the ability to modify the container state from the Chrome Extension

### DIFF
--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/ContainerSummaryView.tsx
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/ContainerSummaryView.tsx
@@ -93,13 +93,42 @@ export function ContainerSummaryView(props: ContainerStateViewProps): React.Reac
 		return <Waiting label="Waiting for Container Summary data." />;
 	}
 
-	// TODO: connect/disconnect, close handlers
+	function tryConnect(): void {
+		messageRelay?.postMessage({
+			source: extensionMessageSource,
+			type: "CONNECT_CONTAINER",
+			data: {
+				containerId,
+			},
+		});
+	}
+
+	function forceDisconnect(): void {
+		messageRelay?.postMessage({
+			source: extensionMessageSource,
+			type: "DISCONNECT_CONTAINER",
+			data: {
+				containerId,
+			},
+		});
+	}
+
+	function closeContainer(): void {
+		messageRelay?.postMessage({
+			source: extensionMessageSource,
+			type: "CLOSE_CONTAINER",
+			data: {
+				containerId,
+			},
+		});
+	}
+
 	return (
 		<_ContainerSummaryView
 			{...containerState}
-			tryConnect={undefined}
-			forceDisconnect={undefined}
-			closeContainer={undefined}
+			tryConnect={tryConnect}
+			forceDisconnect={forceDisconnect}
+			closeContainer={closeContainer}
 		/>
 	);
 }

--- a/packages/tools/client-debugger/client-debugger-view/src/components/ClientDebugView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/ClientDebugView.tsx
@@ -53,74 +53,50 @@ export interface ClientDebugViewProps extends HasClientDebugger {
  */
 export function ClientDebugView(props: ClientDebugViewProps): React.ReactElement {
 	const { clientDebugger, renderOptions: userRenderOptions } = props;
-	const { container } = clientDebugger;
-
 	const renderOptions: Required<RenderOptions> = getRenderOptionsWithDefaults(userRenderOptions);
-
-	const [isContainerClosed, setIsContainerClosed] = React.useState<boolean>(container.closed);
-
-	React.useEffect(() => {
-		function onContainerClose(): void {
-			setIsContainerClosed(true);
-		}
-
-		container.on("closed", onContainerClose);
-
-		setIsContainerClosed(container.closed);
-
-		return (): void => {
-			container.off("closed", onContainerClose);
-		};
-	}, [container, setIsContainerClosed]);
 
 	// Inner view selection
 	const [innerViewSelection, setInnerViewSelection] = React.useState<PanelView>(
 		PanelView.ContainerData,
 	);
-
-	let view: React.ReactElement;
-	if (isContainerClosed) {
-		view = <div>The Container has been closed.</div>;
-	} else {
-		let innerView: React.ReactElement;
-		switch (innerViewSelection) {
-			case PanelView.ContainerData:
-				innerView = (
-					<DataObjectsView
-						clientDebugger={clientDebugger}
-						renderOptions={renderOptions.sharedObjectRenderOptions}
-					/>
-				);
-				break;
-			case PanelView.Audience:
-				innerView = (
-					<AudienceView
-						clientDebugger={clientDebugger}
-						onRenderAudienceMember={renderOptions.onRenderAudienceMember}
-					/>
-				);
-				break;
-			case PanelView.Telemetry:
-				innerView = <TelemetryView />;
-				break;
-			// TODO: add the Telemetry view here, without ReactContext
-
-			case PanelView.ContainerStateHistory:
-				innerView = <ContainerHistoryView clientDebugger={clientDebugger} />;
-				break;
-			default:
-				throw new Error(`Unrecognized PanelView selection value: "${innerViewSelection}".`);
-		}
-		view = (
-			<Stack tokens={{ childrenGap: 10 }}>
-				<PanelViewSelectionMenu
-					currentSelection={innerViewSelection}
-					updateSelection={setInnerViewSelection}
+	let innerView: React.ReactElement;
+	switch (innerViewSelection) {
+		case PanelView.ContainerData:
+			innerView = (
+				<DataObjectsView
+					clientDebugger={clientDebugger}
+					renderOptions={renderOptions.sharedObjectRenderOptions}
 				/>
-				{innerView}
-			</Stack>
-		);
+			);
+			break;
+		case PanelView.Audience:
+			innerView = (
+				<AudienceView
+					clientDebugger={clientDebugger}
+					onRenderAudienceMember={renderOptions.onRenderAudienceMember}
+				/>
+			);
+			break;
+		case PanelView.Telemetry:
+			innerView = <TelemetryView />;
+			break;
+		// TODO: add the Telemetry view here, without ReactContext
+
+		case PanelView.ContainerStateHistory:
+			innerView = <ContainerHistoryView clientDebugger={clientDebugger} />;
+			break;
+		default:
+			throw new Error(`Unrecognized PanelView selection value: "${innerViewSelection}".`);
 	}
+	const view = (
+		<Stack tokens={{ childrenGap: 10 }}>
+			<PanelViewSelectionMenu
+				currentSelection={innerViewSelection}
+				updateSelection={setInnerViewSelection}
+			/>
+			{innerView}
+		</Stack>
+	);
 
 	return (
 		<Stack

--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -30,7 +30,25 @@ export interface AudienceChangeLogEntry extends LogEntry {
 export function clearDebuggerRegistry(): void;
 
 // @public
+export interface CloseContainerMessage extends IDebuggerMessage<CloseContainerMessageData> {
+    // (undocumented)
+    type: "CLOSE_CONTAINER";
+}
+
+// @public
+export type CloseContainerMessageData = HasContainerId;
+
+// @public
 export function closeFluidClientDebugger(containerId: string): void;
+
+// @public
+export interface ConnectContainerMessage extends IDebuggerMessage<ConnectContainerMessageData> {
+    // (undocumented)
+    type: "CONNECT_CONTAINER";
+}
+
+// @public
+export type ConnectContainerMessageData = HasContainerId;
 
 // @internal
 export interface ConnectionStateChangeLogEntry extends StateChangeLogEntry<ContainerStateChangeKind> {
@@ -93,6 +111,15 @@ export interface DebuggerRegistryEvents extends IEvent {
     // @eventProperty
     (event: "debuggerClosed", listener: (containerId: string) => void): void;
 }
+
+// @public
+export interface DisconnectContainerMessage extends IDebuggerMessage<DisconnectContainerMessageData> {
+    // (undocumented)
+    type: "DISCONNECT_CONTAINER";
+}
+
+// @public
+export type DisconnectContainerMessageData = HasContainerId;
 
 // @public
 export interface FluidClientDebuggerProps {

--- a/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
@@ -12,8 +12,11 @@ import { ContainerStateMetadata } from "./ContainerMetadata";
 import { IFluidClientDebugger, IFluidClientDebuggerEvents } from "./IFluidClientDebugger";
 import { AudienceChangeLogEntry, ConnectionStateChangeLogEntry } from "./Logs";
 import {
+	CloseContainerMessage,
+	ConnectContainerMessage,
 	ContainerStateChangeMessage,
 	debuggerMessageSource,
+	DisconnectContainerMessage,
 	GetContainerStateMessage,
 	handleIncomingWindowMessage,
 	IDebuggerMessage,
@@ -34,14 +37,15 @@ import { FluidClientDebuggerProps } from "./Registry";
  * **Messages it listens for:**
  *
  * - {@link GetContainerStateMessage}: When received (if the container ID matches), the debugger will broadcast {@link ContainerStateChangeMessage}.
- *
+ * - {@link ConnectContainerMessage}: When received (if the container ID matches), the debugger will connect to the container.
+ * - {@link DisconnectContainerMessage}: When received (if the container ID matches), the debugger will disconnect from the container.
+ * - {@link CloseContainerMessage}: When received (if the container ID matches), the debugger will close the container.
  * TODO: Document others as they are added.
  *
  * **Messages it posts:**
  *
  * - {@link ContainerStateChangeMessage}: This is posted any time relevant Container state changes,
  * or when requested (via {@link GetContainerStateMessage}).
- *
  * TODO: Document others as they are added.
  *
  * @sealed
@@ -173,6 +177,30 @@ export class FluidClientDebugger
 			const message = untypedMessage as GetContainerStateMessage;
 			if (message.data.containerId === this.containerId) {
 				this.postContainerStateChange();
+				return true;
+			}
+			return false;
+		},
+		["CONNECT_CONTAINER"]: (untypedMessage) => {
+			const message = untypedMessage as ConnectContainerMessage;
+			if (message.data.containerId === this.containerId) {
+				this.container.connect();
+				return true;
+			}
+			return false;
+		},
+		["DISCONNECT_CONTAINER"]: (untypedMessage) => {
+			const message = untypedMessage as DisconnectContainerMessage;
+			if (message.data.containerId === this.containerId) {
+				this.container.disconnect(/* TODO: Specify debugger reason here once it is supported */);
+				return true;
+			}
+			return false;
+		},
+		["CLOSE_CONTAINER"]: (untypedMessage) => {
+			const message = untypedMessage as CloseContainerMessage;
+			if (message.data.containerId === this.containerId) {
+				this.container.close(/* TODO: Specify debugger reason here once it is supported */);
 				return true;
 			}
 			return false;

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -57,6 +57,12 @@ export {
 export {
 	debuggerMessageSource,
 	HasContainerId,
+	ConnectContainerMessage,
+	ConnectContainerMessageData,
+	DisconnectContainerMessage,
+	DisconnectContainerMessageData,
+	CloseContainerMessage,
+	CloseContainerMessageData,
 	ContainerStateChangeMessage,
 	ContainerStateChangeMessageData,
 	IDebuggerMessage,

--- a/packages/tools/client-debugger/client-debugger/src/messaging/DebuggerMessages.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/DebuggerMessages.ts
@@ -29,6 +29,27 @@ export interface HasContainerId {
 export type GetContainerStateMessageData = HasContainerId;
 
 /**
+ * Message data format used by {@link ConnectContainerMessage}.
+ *
+ * @public
+ */
+export type ConnectContainerMessageData = HasContainerId;
+
+/**
+ * Message data format used by {@link DisconnectContainerMessage}.
+ *
+ * @public
+ */
+export type DisconnectContainerMessageData = HasContainerId;
+
+/**
+ * Message data format used by {@link CloseContainerMessage}.
+ *
+ * @public
+ */
+export type CloseContainerMessageData = HasContainerId;
+
+/**
  * Inbound event requesting the {@link ContainerStateMetadata} of the Container with the specified ID.
  * Will result in the {@link ContainerStateChangeMessage} message being posted.
  *
@@ -64,6 +85,34 @@ export interface ContainerStateChangeMessageData extends HasContainerId {
 export interface ContainerStateChangeMessage
 	extends IDebuggerMessage<ContainerStateChangeMessageData> {
 	type: "CONTAINER_STATE_CHANGE";
+}
+
+/**
+ * Inbound event indicating Container connected.
+ *
+ * @public
+ */
+export interface ConnectContainerMessage extends IDebuggerMessage<ConnectContainerMessageData> {
+	type: "CONNECT_CONTAINER";
+}
+
+/**
+ * Inbound event indicating Container disconnected.
+ *
+ * @public
+ */
+export interface DisconnectContainerMessage
+	extends IDebuggerMessage<DisconnectContainerMessageData> {
+	type: "DISCONNECT_CONTAINER";
+}
+
+/**
+ * Inbound event indicating Container closed.
+ *
+ * @public
+ */
+export interface CloseContainerMessage extends IDebuggerMessage<CloseContainerMessageData> {
+	type: "CLOSE_CONTAINER";
 }
 
 // #endregion

--- a/packages/tools/client-debugger/client-debugger/src/messaging/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/index.ts
@@ -16,6 +16,12 @@
 export { debuggerMessageSource } from "./Constants";
 export {
 	HasContainerId,
+	ConnectContainerMessage,
+	ConnectContainerMessageData,
+	DisconnectContainerMessage,
+	DisconnectContainerMessageData,
+	CloseContainerMessage,
+	CloseContainerMessageData,
 	ContainerStateChangeMessage,
 	ContainerStateChangeMessageData,
 	GetContainerStateMessage,


### PR DESCRIPTION
## Description

Hook up the ability to disconnect/reconnect the container / close the container from the Chrome Extension (via message passing)

The Fluid developer should be able to make these changes interactively and have the state reflected

##sample
<img width="1637" alt="Screenshot 2023-03-08 194718" src="https://user-images.githubusercontent.com/114451900/223912327-33d3f173-a1f7-46a6-8f02-c033a23b2ec2.png">
