### PR TITLE
Prefer driver-definitions over driver-utils

### DIFF
--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -18,6 +18,7 @@ import {
 } from "@fluidframework/container-definitions";
 import { GenericError, UsageError } from "@fluidframework/container-utils";
 import {
+	DriverErrorType,
 	IAnyDriverError,
 	IDocumentService,
 	IDocumentDeltaConnection,
@@ -28,7 +29,6 @@ import {
 	createWriteError,
 	createGenericNetworkError,
 	getRetryDelayFromError,
-	DeltaStreamConnectionForbiddenError,
 	logNetworkFailure,
 	isRuntimeMessage,
 } from "@fluidframework/driver-utils";
@@ -552,7 +552,7 @@ export class ConnectionManager implements IConnectionManager {
 				if (
 					typeof origError === "object" &&
 					origError !== null &&
-					origError?.errorType === DeltaStreamConnectionForbiddenError.errorType
+					origError?.errorType === DriverErrorType.deltaStreamConnectionForbidden
 				) {
 					connection = new NoDeltaStream();
 					requestedMode = "read";

--- a/packages/loader/container-loader/src/test/connectionManager.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionManager.spec.ts
@@ -5,8 +5,8 @@
 
 import { strict as assert } from "assert";
 import { Deferred } from "@fluidframework/common-utils";
-import { DriverErrorType } from "@fluidframework/driver-definitions";
-import { IAnyDriverError, NonRetryableError, RetryableError } from "@fluidframework/driver-utils";
+import { DriverErrorType, IAnyDriverError } from "@fluidframework/driver-definitions";
+import { NonRetryableError, RetryableError } from "@fluidframework/driver-utils";
 import { IClient, INack, NackErrorType } from "@fluidframework/protocol-definitions";
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import {

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -21,6 +21,7 @@ import {
 import {
 	DriverErrorType,
 	FiveDaysMs,
+	IAnyDriverError,
 	IDocumentServiceFactory,
 	IFluidResolvedUrl,
 } from "@fluidframework/driver-definitions";
@@ -35,7 +36,7 @@ import {
 	timeoutPromise,
 	waitForContainerConnection,
 } from "@fluidframework/test-utils";
-import { ensureFluidResolvedUrl, IAnyDriverError } from "@fluidframework/driver-utils";
+import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
 	getDataStoreFactory,


### PR DESCRIPTION
Two small things:

- Remove two remaining usages of the deprecated version of `IAnyDriverError` (from driver-utils) and replace with the driver-definitions version.
- Prefer to use `DriverErrorType.deltaStreamConnectionForbidden` (from driver-definitions) for the type, rather than `DeltaStreamConnectionForbiddenError.errorType` (using the static member from the implementation, in driver-utils).  This could eventually allow us to restrict usage of the implementation to the driver layer.