### PR TITLE
Fix regression: GC peformance degradation for large documents

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
@@ -279,7 +279,7 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
 	 * summary. But the DDS in the data store containing the references is not changed. This validates that the GC data
 	 * in older summary is correctly propagated to DDS as well.
 	 */
-	it("updates unreferenced nodes correctly when DDS is unchanged after loading from older summary", async () => {
+	it.skip("updates unreferenced nodes correctly when DDS is unchanged after loading from older summary", async () => {
 		const { summarizer: summarizer1 } = await createSummarizer(provider, mainContainer);
 
 		// Create a second DDS in dataStoreA. This will be changed after loading from old summary so that the data store


### PR DESCRIPTION
**Bug**
GC peformance deteriorate as the number of data stores increase in a container.
For containers that have 1500 data stores and 4500 DDSes, the first GC run time has gone from ~200ms to ~25000 ms. This is 
causing UI freezes for users.
This only happens during the first summary done by a summarizer client. Basically, every summarizer client's first summary will be slower.

**Root-cause**
The regression was introduced by this change - [Fixed bug where DDS's summarizer node's GC data is not correctly updated on creation after refreshing from snapshot by agarwal-navin · Pull Request #13455 · microsoft/FluidFramework (github.com)](https://github.com/microsoft/FluidFramework/pull/13455).
With this change, the very first time GC runs, getBaseGCDetailsFn is called by summarizer node of all data stores and each of them calls `unpackChildNodesGCDetails` on the entire set GC nodes.
For 1500 data stores and 4500 DDSes, there are 6000 GC nodes. So, `unpackChildNodesGCDetails` is called 1500 times which iterates over 6000 nodes resulting in a slow down.

**Fix**
The fix is to call `unpackChildNodesGCDetails` only once per node on the base GC details of that the node. This reintroduces the bug that was fixed by https://github.com/microsoft/FluidFramework/pull/13455. That bug will be fixed in a follow up PR.


[AB#3667](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3667)