### PR TITLE
[GC-stress] Fix validateTestClientUtilsPrevious.generated.ts

### DIFF
--- a/packages/framework/test-client-utils/src/test/types/validateTestClientUtilsPrevious.generated.ts
+++ b/packages/framework/test-client-utils/src/test/types/validateTestClientUtilsPrevious.generated.ts
@@ -60,27 +60,3 @@ declare function use_old_VariableDeclaration_generateTestUser(
     use: TypeOnly<typeof old.generateTestUser>);
 use_old_VariableDeclaration_generateTestUser(
     get_current_VariableDeclaration_generateTestUser());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_InsecureTokenProvider": {"forwardCompat": false}
-*/
-declare function get_old_ClassDeclaration_InsecureTokenProvider():
-    TypeOnly<old.InsecureTokenProvider>;
-declare function use_current_ClassDeclaration_InsecureTokenProvider(
-    use: TypeOnly<current.InsecureTokenProvider>);
-use_current_ClassDeclaration_InsecureTokenProvider(
-    get_old_ClassDeclaration_InsecureTokenProvider());
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_InsecureTokenProvider": {"backCompat": false}
-*/
-declare function get_current_ClassDeclaration_InsecureTokenProvider():
-    TypeOnly<current.InsecureTokenProvider>;
-declare function use_old_ClassDeclaration_InsecureTokenProvider(
-    use: TypeOnly<old.InsecureTokenProvider>);
-use_old_ClassDeclaration_InsecureTokenProvider(
-    get_current_ClassDeclaration_InsecureTokenProvider());


### PR DESCRIPTION
validateTestClientUtilsPrevious.generated.ts is failing CI builds - https://dev.azure.com/fluidframework/internal/_build/results?buildId=137093&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=3d9cdfe2-6d46-50e9-be07-958164188e85&l=13

Attempting to fix it by pushing local changes.