### PR TITLE
[GC-stress] Use container options instead of configs for most GC options

### DIFF
--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -58,9 +58,9 @@ export const generateLoaderOptions = (
 };
 
 const gcOptionsMatrix: OptionsMatrix<IGCRuntimeOptions> = {
-	disableGC: [false],
-	gcAllowed: [true],
-	runFullGC: [false],
+	disableGC: booleanCases,
+	gcAllowed: booleanCases,
+	runFullGC: booleanCases,
 	sweepAllowed: [false],
 	sessionExpiryTimeoutMs: [undefined], // Don't want coverage here
 };

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -208,17 +208,17 @@ async function runnerProcess(
 	const loaderOptions = generateLoaderOptions(
 		seed,
 		runConfig.testConfig?.optionOverrides?.[optionsOverride]?.loader,
-	)[0];
+	);
 
 	const containerOptions = generateRuntimeOptions(
 		seed,
 		runConfig.testConfig?.optionOverrides?.[optionsOverride]?.container,
-	)[0];
+	);
 
 	const configurations = generateConfigurations(
 		seed,
 		runConfig.testConfig?.optionOverrides?.[optionsOverride]?.configurations,
-	)[0];
+	);
 	const testDriver: ITestDriver = await createTestDriver(driver, endpoint, seed, runConfig.runId);
 
 	// Cycle between creating new factory vs. reusing factory.
@@ -244,12 +244,14 @@ async function runnerProcess(
 			const loader = new Loader({
 				urlResolver: testDriver.createUrlResolver(),
 				documentServiceFactory,
-				codeLoader: createCodeLoader(containerOptions),
+				codeLoader: createCodeLoader(
+					containerOptions[runConfig.runId % containerOptions.length],
+				),
 				logger: runConfig.logger,
-				options: loaderOptions,
+				options: loaderOptions[runConfig.runId % containerOptions.length],
 				configProvider: {
 					getRawConfig(name) {
-						return configurations[name];
+						return configurations[runConfig.runId % configurations.length][name];
 					},
 				},
 			});

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -181,18 +181,21 @@ export async function initialize(
 	const randEng = random.engines.mt19937();
 	randEng.seed(seed);
 	const optionsOverride = `${testDriver.type}${endpoint !== undefined ? `-${endpoint}` : ""}`;
-	const loaderOptions = generateLoaderOptions(
-		seed,
-		testConfig.optionOverrides?.[optionsOverride]?.loader,
-	)[0];
-	const containerOptions = generateRuntimeOptions(
-		seed,
-		testConfig.optionOverrides?.[optionsOverride]?.container,
-	)[0];
-	const configurations = generateConfigurations(
-		seed,
-		testConfig?.optionOverrides?.[optionsOverride]?.configurations,
-	)[0];
+	const loaderOptions = random.pick(
+		randEng,
+		generateLoaderOptions(seed, testConfig.optionOverrides?.[optionsOverride]?.loader),
+	);
+	const containerOptions = random.pick(
+		randEng,
+		generateRuntimeOptions(seed, testConfig.optionOverrides?.[optionsOverride]?.container),
+	);
+	const configurations = random.pick(
+		randEng,
+		generateConfigurations(
+			seed,
+			testConfig?.optionOverrides?.[optionsOverride]?.configurations,
+		),
+	);
 
 	const logger = await createLogger({
 		driverType: testDriver.type,

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -10,25 +10,37 @@
 				"max": 20000
 			},
 			"optionOverrides": {
+				"comment": "SessionExpiry: 20 seconds. Inactive Timeout: 40 seconds. Sweep Timeout: 45 seconds.",
 				"tinylicious": {
-					"comment": "SessionExpiry: 20 seconds. Inactive Timeout: 40 seconds. Sweep Timeout: 45 seconds.",
 					"configurations": {
-						"Fluid.GarbageCollection.RunSessionExpiry": [true],
-						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [40000],
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [45000],
-						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [20000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
+					},
+					"container": {
+						"gcOptions": {
+							"gcAllowed": [true],
+							"sweepAllowed": [false],
+							"disableGC": [false],
+							"runFullGC": [false],
+							"inactiveTimeoutMs": [40000],
+							"sessionExpiryTimeoutMs": [20000]
+						}
 					}
 				},
 				"odsp": {
-					"comment": "SessionExpiry: 20 seconds. Inactive Timeout: 40 seconds. Sweep Timeout: 45 seconds.",
 					"configurations": {
-						"Fluid.GarbageCollection.RunSessionExpiry": [true],
-						"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs": [10000],
-						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [40000],
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [45000],
-						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [20000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
+					},
+					"container": {
+						"gcOptions": {
+							"gcAllowed": [true],
+							"sweepAllowed": [false],
+							"disableGC": [false],
+							"runFullGC": [false],
+							"inactiveTimeoutMs": [40000],
+							"sessionExpiryTimeoutMs": [20000]
+						}
 					}
 				}
 			}
@@ -39,25 +51,38 @@
 			"numClients": 10,
 			"totalSendCount": 18000,
 			"optionOverrides": {
+				"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 				"tinylicious": {
-					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 					"configurations": {
-						"Fluid.GarbageCollection.RunSessionExpiry": [true],
-						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [1200000],
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000],
-						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [900000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
+					},
+					"container": {
+						"gcOptions": {
+							"gcAllowed": [true],
+							"sweepAllowed": [false],
+							"disableGC": [false],
+							"runFullGC": [false],
+							"inactiveTimeoutMs": [1200000],
+							"sessionExpiryTimeoutMs": [900000]
+						}
 					}
 				},
 				"odsp": {
-					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 					"configurations": {
-						"Fluid.GarbageCollection.RunSessionExpiry": [true],
 						"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs": [450000],
-						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [1200000],
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000],
-						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [900000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
+					},
+					"container": {
+						"gcOptions": {
+							"gcAllowed": [true],
+							"sweepAllowed": [false],
+							"disableGC": [false],
+							"runFullGC": [false],
+							"inactiveTimeoutMs": [1200000],
+							"sessionExpiryTimeoutMs": [900000]
+						}
 					}
 				}
 			}
@@ -72,25 +97,38 @@
 				"max": 900000
 			},
 			"optionOverrides": {
+				"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 				"tinylicious": {
-					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 					"configurations": {
-						"Fluid.GarbageCollection.RunSessionExpiry": [true],
-						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [1200000],
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000],
-						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [900000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
+					},
+					"container": {
+						"gcOptions": {
+							"gcAllowed": [true],
+							"sweepAllowed": [false],
+							"disableGC": [false],
+							"runFullGC": [false],
+							"inactiveTimeoutMs": [1200000],
+							"sessionExpiryTimeoutMs": [900000]
+						}
 					}
 				},
 				"odsp": {
-					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 					"configurations": {
-						"Fluid.GarbageCollection.RunSessionExpiry": [true],
 						"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs": [450000],
-						"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs": [1200000],
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000],
-						"Fluid.GarbageCollection.TestOverride.SessionExpiryMs": [900000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
+					},
+					"container": {
+						"gcOptions": {
+							"gcAllowed": [true],
+							"sweepAllowed": [false],
+							"disableGC": [false],
+							"runFullGC": [false],
+							"inactiveTimeoutMs": [1200000],
+							"sessionExpiryTimeoutMs": [900000]
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Updated the tests to use container runtime GC options instead of configurations. The advantage of using gc options over configs is that most of them are persisted in the summary and won't change for the clients. For example, configs like gcEnabled, sweepEnabled, session expiry timeout and session timeout should not change for a file or else, it will lead to errors.

Also, reverted some of the changes that removed randomization of configs and container options. Since we are using container options override now, randomization will be fine.