### PR TITLE
[main > release/v2int/2.4]: Don't proceed to close socket if connection is already disposed in odsp

### DIFF
--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -23,13 +23,16 @@ import type { Socket } from 'socket.io-client';
 
 // @public
 export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocumentDeltaConnectionEvents> implements IDocumentDeltaConnection, IDisposable {
-    protected constructor(socket: Socket, documentId: string, logger: ITelemetryLogger, enableLongPollingDowngrades?: boolean);
+    protected constructor(socket: Socket, documentId: string, logger: ITelemetryLogger, enableLongPollingDowngrades?: boolean, connectionId?: string | undefined);
     // (undocumented)
     protected addTrackedListener(event: string, listener: (...args: any[]) => void): void;
     checkpointSequenceNumber: number | undefined;
     get claims(): ITokenClaims;
     get clientId(): string;
-    protected closeSocket(error: IAnyDriverError): void;
+    // (undocumented)
+    protected closeSocketCore(error: IAnyDriverError): void;
+    // (undocumented)
+    protected readonly connectionId?: string | undefined;
     protected createErrorObject(handler: string, error?: any, canRetry?: boolean): IAnyDriverError;
     // (undocumented)
     get details(): IConnected;

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -356,7 +356,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
         logger: ITelemetryLogger,
         private readonly enableMultiplexing?: boolean,
     ) {
-        super(socket, documentId, logger);
+        super(socket, documentId, logger, false, uuid());
         this.socketReference = socketReference;
         this.requestOpsNoncePrefix = `${uuid()}-`;
     }
@@ -602,7 +602,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
      * Critical path where we need to also close the socket for an error.
      * @param error - Error causing the socket to close.
      */
-    protected closeSocket(error: IAnyDriverError) {
+    protected closeSocketCore(error: IAnyDriverError) {
         const socket = this.socketReference;
         assert(socket !== undefined, 0x416 /* reentrancy not supported in close socket */);
         socket.closeSocket(error);

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -628,9 +628,10 @@ export class ConnectionManager implements IConnectionManager {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this._outbound.pause();
         this._outbound.clear();
-        this.props.disconnectHandler(reason);
 
         connection.dispose();
+
+        this.props.disconnectHandler(reason);
 
         this._connectionVerboseProps = {};
 


### PR DESCRIPTION
## Description

ADO item link:
https://dev.azure.com/fluidframework/internal/_workitems/edit/3648 

1.) Adding more telemetry in flows where the socket is getting closed on connect/reconnect to better understand the state of the system. 
2.) We see that connect_error or some other error is fired on socket and we go through the socket close flow and telemetry shows that we do successfully close the socket and remove listeners but then we again have the errror on socket which again go into the socket close flow and cause reentrancy issues with uncaught 0x416 assert. Seems like there is a possibility that there was some micro task already scheduled by socket to call the error listener which causes us to go through the socket close flow again. In the end, the initial call to recoonect in connectionManager.ts after disconnect hangs and we never try to connect again.

