### PR TITLE
Remove random-js dependency from merge-tree

### DIFF
--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -94,7 +94,6 @@
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.36",
-		"@types/random-js": "^1.0.31",
 		"concurrently": "^6.2.0",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.2",
@@ -103,7 +102,6 @@
 		"mocha": "^10.0.0",
 		"nyc": "^15.0.0",
 		"prettier": "~2.6.2",
-		"random-js": "^1.0.8",
 		"rimraf": "^2.6.2",
 		"source-map-support": "^0.5.16",
 		"typescript": "~4.5.5"

--- a/packages/dds/merge-tree/src/test/beastTest.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.ts
@@ -1239,7 +1239,7 @@ export function TestPack(verbose = true) {
 				for (let j = 0; j < removeCount; j++) {
 					const dlen = randTextLength();
 					const preLen = cliA.getLength();
-					const pos = random.integer(0, preLen);
+					const pos = random.integer(0, preLen - dlen);
 					const msg = cliA.makeOpMessage(
 						cliA.removeRangeLocal(pos, pos + dlen)!,
 						sequenceNumber++,

--- a/packages/dds/merge-tree/src/test/beastTest.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.ts
@@ -10,11 +10,11 @@
 import { strict as assert } from "assert";
 import fs from "fs";
 import path from "path";
+import { IRandom, makeRandom } from "@fluid-internal/stochastic-test-utils";
 import { Trace } from "@fluidframework/common-utils";
 import { DebugLogger } from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import JsDiff from "diff";
-import random from "random-js";
 import {
 	KeyComparer,
 	Property,
@@ -187,15 +187,13 @@ function elapsedMicroseconds(trace: Trace) {
 }
 
 export function integerTest1() {
-	const mt = random.engines.mt19937();
-	mt.seedWithArray([0xdeadbeef, 0xfeedbed]);
+	const random = makeRandom(0xdeadbeef, 0xfeedbed);
 	const imin = 0;
 	const imax = 10000000;
 	const intCount = 1100000;
-	const distribution = random.integer(imin, imax);
 	const beast = new RedBlackTree<number, number>(compareNumbers);
 
-	const randInt = () => distribution(mt);
+	const randInt = () => random.integer(imin, imax);
 	const pos = new Array<number>(intCount);
 	let i = 0;
 	let redo = false;
@@ -405,12 +403,10 @@ export function mergeTreeLargeTest() {
 	);
 	const insertCount = 1000000;
 	const removeCount = 980000;
-	const mt = random.engines.mt19937();
-	mt.seedWithArray([0xdeadbeef, 0xfeedbed]);
+	const random = makeRandom(0xdeadbeef, 0xfeedbed);
 	const imin = 1;
 	const imax = 9;
-	const distribution = random.integer(imin, imax);
-	const randInt = () => distribution(mt);
+	const randInt = () => random.integer(imin, imax);
 	function randomString(len: number, c: string) {
 		let str = "";
 		for (let i = 0; i < len; i++) {
@@ -425,7 +421,7 @@ export function mergeTreeLargeTest() {
 		const slen = randInt();
 		const s = randomString(slen, String.fromCharCode(48 + slen));
 		const preLen = mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
-		const pos = random.integer(0, preLen)(mt);
+		const pos = random.integer(0, preLen);
 		const clockStart = clock();
 		insertText({
 			mergeTree,
@@ -455,7 +451,7 @@ export function mergeTreeLargeTest() {
 	for (let i = 0; i < removeCount; i++) {
 		const dlen = randInt();
 		const preLen = mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
-		const pos = random.integer(0, preLen)(mt);
+		const pos = random.integer(0, preLen);
 		// Log(itree.toString());
 		const clockStart = clock();
 		mergeTree.markRangeRemoved(
@@ -494,14 +490,12 @@ export function mergeTreeCheckedTest() {
 	const insertCount = 2000;
 	const removeCount = 1400;
 	const largeRemoveCount = 20;
-	const mt = random.engines.mt19937();
-	mt.seedWithArray([0xdeadbeef, 0xfeedbed]);
+	const random = makeRandom(0xdeadbeef, 0xfeedbed);
+
 	const imin = 1;
 	const imax = 9;
-	const distribution = random.integer(imin, imax);
-	const largeDistribution = random.integer(10, 1000);
-	const randInt = () => distribution(mt);
-	const randLargeInt = () => largeDistribution(mt);
+	const randInt = () => random.integer(imin, imax);
+	const randLargeInt = () => random.integer(10, 1000);
 	function randomString(len: number, c: string) {
 		let str = "";
 		for (let i = 0; i < len; i++) {
@@ -517,7 +511,7 @@ export function mergeTreeCheckedTest() {
 		const slen = randInt();
 		const s = randomString(slen, String.fromCharCode(48 + slen));
 		const preLen = mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
-		const pos = random.integer(0, preLen)(mt);
+		const pos = random.integer(0, preLen);
 		if (!checkInsertMergeTree(mergeTree, pos, makeCollabTextSegment(s), true)) {
 			log(
 				`i: ${i} preLen ${preLen} pos: ${pos} slen: ${slen} s: ${s} itree len: ${mergeTree.getLength(
@@ -545,7 +539,7 @@ export function mergeTreeCheckedTest() {
 	for (let i = 0; i < largeRemoveCount; i++) {
 		const dlen = randLargeInt();
 		const preLen = mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
-		const pos = random.integer(0, preLen)(mt);
+		const pos = random.integer(0, preLen);
 		// log(itree.toString());
 		if (!checkMarkRemoveMergeTree(mergeTree, pos, pos + dlen, true)) {
 			log(
@@ -573,7 +567,7 @@ export function mergeTreeCheckedTest() {
 	for (let i = 0; i < removeCount; i++) {
 		const dlen = randInt();
 		const preLen = mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
-		const pos = random.integer(0, preLen)(mt);
+		const pos = random.integer(0, preLen);
 		// log(itree.toString());
 		if (i & 1) {
 			if (!checkMarkRemoveMergeTree(mergeTree, pos, pos + dlen, true)) {
@@ -617,7 +611,7 @@ export function mergeTreeCheckedTest() {
 		const slen = randInt();
 		const s = randomString(slen, String.fromCharCode(48 + slen));
 		const preLen = mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
-		const pos = random.integer(0, preLen)(mt);
+		const pos = random.integer(0, preLen);
 		if (!checkInsertMergeTree(mergeTree, pos, makeCollabTextSegment(s), true)) {
 			log(
 				`i: ${i} preLen ${preLen} pos: ${pos} slen: ${slen} s: ${s} itree len: ${mergeTree.getLength(
@@ -645,7 +639,7 @@ export function mergeTreeCheckedTest() {
 	for (let i = 0; i < removeCount; i++) {
 		const dlen = randInt();
 		const preLen = mergeTree.getLength(UniversalSequenceNumber, LocalClientId);
-		const pos = random.integer(0, preLen)(mt);
+		const pos = random.integer(0, preLen);
 		// log(itree.toString());
 		if (i & 1) {
 			if (!checkMarkRemoveMergeTree(mergeTree, pos, pos + dlen, true)) {
@@ -702,16 +696,12 @@ type SharedStringJSONSegment = IJSONTextSegment & IJSONMarkerSegment;
 // }
 
 export function TestPack(verbose = true) {
-	const mt = random.engines.mt19937();
-	mt.seedWithArray([0xdeadbeef, 0xfeedbed]);
+	const random = makeRandom(0xdeadbeef, 0xfeedbed);
 	const minSegCount = 1;
 	const maxSegCount = 1000;
-	const segmentCountDistribution = random.integer(minSegCount, maxSegCount);
-	const smallSegmentCountDistribution = random.integer(1, 4);
-	const randSmallSegmentCount = () => smallSegmentCountDistribution(mt);
-	const randSegmentCount = () => segmentCountDistribution(mt);
-	const textLengthDistribution = random.integer(1, 5);
-	const randTextLength = () => textLengthDistribution(mt);
+	const randSmallSegmentCount = () => random.integer(1, 4);
+	const randSegmentCount = () => random.integer(minSegCount, maxSegCount);
+	const randTextLength = () => random.integer(1, 5);
 	const zedCode = 48;
 	function randomString(len: number, c: string) {
 		let str = "";
@@ -855,7 +845,7 @@ export function TestPack(verbose = true) {
 			const cliMsgCount = client.getMessageCount();
 			const countToApply = all
 				? cliMsgCount
-				: random.integer(Math.floor((2 * cliMsgCount) / 3), cliMsgCount)(mt);
+				: random.integer(Math.floor((2 * cliMsgCount) / 3), cliMsgCount);
 			client.applyMessages(countToApply);
 		}
 
@@ -863,7 +853,7 @@ export function TestPack(verbose = true) {
 			const svrMsgCount = _server.getMessageCount();
 			const countToApply = all
 				? svrMsgCount
-				: random.integer(Math.floor((2 * svrMsgCount) / 3), svrMsgCount)(mt);
+				: random.integer(Math.floor((2 * svrMsgCount) / 3), svrMsgCount);
 			return _server.applyMessages(countToApply);
 		}
 
@@ -874,7 +864,7 @@ export function TestPack(verbose = true) {
 				String.fromCharCode(zedCode + ((client.getCurrentSeq() + charIndex) % 50)),
 			);
 			const preLen = client.getLength();
-			const pos = random.integer(0, preLen)(mt);
+			const pos = random.integer(0, preLen);
 			if (includeMarkers) {
 				const insertMarkerOp = client.insertMarkerLocal(pos, ReferenceType.Tile, {
 					[reservedTileLabelsKey]: "test",
@@ -892,7 +882,7 @@ export function TestPack(verbose = true) {
 		function randomSpateOfRemoves(client: TestClient) {
 			const dlen = randTextLength();
 			const preLen = client.getLength();
-			const pos = random.integer(0, preLen)(mt);
+			const pos = random.integer(0, preLen);
 			const op = client.removeRangeLocal(pos, pos + dlen);
 			server.enqueueMsg(client.makeOpMessage(op!));
 			if (TestClient.useCheckQ) {
@@ -1189,7 +1179,7 @@ export function TestPack(verbose = true) {
 						String.fromCharCode(zedCode + (sequenceNumber % 50)),
 					);
 					const preLen = cliA.getLength();
-					const pos = random.integer(0, preLen)(mt);
+					const pos = random.integer(0, preLen);
 
 					const msg = cliA.makeOpMessage(
 						cliA.insertTextLocal(pos, text)!,
@@ -1219,7 +1209,7 @@ export function TestPack(verbose = true) {
 						String.fromCharCode(zedCode + (sequenceNumber % 50)),
 					);
 					const preLen = cliB.getLength();
-					const pos = random.integer(0, preLen)(mt);
+					const pos = random.integer(0, preLen);
 					const msg = cliB.makeOpMessage(
 						cliB.insertTextLocal(pos, text)!,
 						sequenceNumber++,
@@ -1249,7 +1239,7 @@ export function TestPack(verbose = true) {
 				for (let j = 0; j < removeCount; j++) {
 					const dlen = randTextLength();
 					const preLen = cliA.getLength();
-					const pos = random.integer(0, preLen)(mt);
+					const pos = random.integer(0, preLen);
 					const msg = cliA.makeOpMessage(
 						cliA.removeRangeLocal(pos, pos + dlen)!,
 						sequenceNumber++,
@@ -1274,7 +1264,7 @@ export function TestPack(verbose = true) {
 				for (let j = 0; j < removeCount; j++) {
 					const dlen = randTextLength();
 					const preLen = cliB.getLength() - 1;
-					const pos = random.integer(0, preLen)(mt);
+					const pos = random.integer(0, preLen);
 					const msg = cliB.makeOpMessage(
 						cliB.removeRangeLocal(pos, pos + dlen)!,
 						sequenceNumber++,
@@ -1614,14 +1604,13 @@ function tst() {
 }
 
 export class RandomPack {
-	mt: Random.MT19937;
+	random: IRandom;
 	constructor() {
-		this.mt = random.engines.mt19937();
-		this.mt.seedWithArray([0xdeadbeef, 0xfeedbed]);
+		this.random = makeRandom(0xdeadbeef, 0xfeedbed);
 	}
 
 	randInteger(min: number, max: number) {
-		return random.integer(min, max)(this.mt);
+		return this.random.integer(min, max);
 	}
 
 	randString(wordCount: number) {

--- a/packages/dds/merge-tree/src/test/beastTest.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.ts
@@ -1238,8 +1238,8 @@ export function TestPack(verbose = true) {
 				const cliAMsgs: ISequencedDocumentMessage[] = [];
 				for (let j = 0; j < removeCount; j++) {
 					const dlen = randTextLength();
-					const preLen = cliA.getLength();
-					const pos = random.integer(0, preLen - dlen);
+					const maxStartPos = cliA.getLength() - dlen;
+					const pos = random.integer(0, maxStartPos);
 					const msg = cliA.makeOpMessage(
 						cliA.removeRangeLocal(pos, pos + dlen)!,
 						sequenceNumber++,
@@ -1263,8 +1263,8 @@ export function TestPack(verbose = true) {
 				const cliBMsgs: ISequencedDocumentMessage[] = [];
 				for (let j = 0; j < removeCount; j++) {
 					const dlen = randTextLength();
-					const preLen = cliB.getLength() - 1;
-					const pos = random.integer(0, preLen);
+					const maxStartPos = cliB.getLength() - dlen;
+					const pos = random.integer(0, maxStartPos);
 					const msg = cliB.makeOpMessage(
 						cliB.removeRangeLocal(pos, pos + dlen)!,
 						sequenceNumber++,

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -4,6 +4,7 @@
  */
 
 import { strict as assert } from "assert";
+import { makeRandom } from "@fluid-internal/stochastic-test-utils";
 import { DebugLogger } from "@fluidframework/telemetry-utils";
 import {
 	ISequencedDocumentMessage,
@@ -13,7 +14,6 @@ import {
 } from "@fluidframework/protocol-definitions";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { MockStorage } from "@fluidframework/test-runtime-utils";
-import random from "random-js";
 import { Trace } from "@fluidframework/common-utils";
 import { AttributionKey } from "@fluidframework/runtime-definitions";
 import { Client } from "../client";
@@ -49,8 +49,7 @@ export function specToSegment(spec: IJSONSegment): ISegment {
 	throw new Error(`Unrecognized IJSONSegment type: '${JSON.stringify(spec)}'`);
 }
 
-const mt = random.engines.mt19937();
-mt.seedWithArray([0xdeadbeef, 0xfeedbed]);
+const random = makeRandom(0xdeadbeef, 0xfeedbed);
 
 export class TestClient extends Client {
 	public static searchChunkSize = 256;
@@ -329,7 +328,7 @@ export class TestClient extends Client {
 
 	public findRandomWord() {
 		const len = this.getLength();
-		const pos = random.integer(0, len)(mt);
+		const pos = random.integer(0, len);
 		const nextWord = this.searchFromPos(pos, /\s\w+\b/);
 		return nextWord;
 	}

--- a/packages/dds/merge-tree/src/test/wordUnitTests.ts
+++ b/packages/dds/merge-tree/src/test/wordUnitTests.ts
@@ -7,7 +7,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import path from "path";
-import random from "random-js";
+import { makeRandom } from "@fluid-internal/stochastic-test-utils";
 import { Trace } from "@fluidframework/common-utils";
 import { ReferenceType } from "../ops";
 import { createMap, extend, MapLike } from "../properties";
@@ -122,12 +122,11 @@ export function propertyCopy() {
 }
 
 function makeBookmarks(client: TestClient, bookmarkCount: number) {
-	const mt = random.engines.mt19937();
-	mt.seedWithArray([0xdeadbeef, 0xfeedbed]);
+	const random = makeRandom(0xdeadbeef, 0xfeedbed);
 	const bookmarks: ReferencePosition[] = [];
 	const len = client.getLength();
 	for (let i = 0; i < bookmarkCount; i++) {
-		const pos = random.integer(0, len - 1)(mt);
+		const pos = random.integer(0, len - 1);
 		const segoff = client.getContainingSegment(pos);
 		let refType = ReferenceType.Simple;
 		if (i & 1) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5375,7 +5375,6 @@ importers:
       '@types/diff': ^3.5.1
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.36
-      '@types/random-js': ^1.0.31
       concurrently: ^6.2.0
       copyfiles: ^2.4.1
       cross-env: ^7.0.2
@@ -5384,7 +5383,6 @@ importers:
       mocha: ^10.0.0
       nyc: ^15.0.0
       prettier: ~2.6.2
-      random-js: ^1.0.8
       rimraf: ^2.6.2
       source-map-support: ^0.5.16
       typescript: ~4.5.5
@@ -5416,7 +5414,6 @@ importers:
       '@types/diff': 3.5.5
       '@types/mocha': 9.1.1
       '@types/node': 14.18.36
-      '@types/random-js': 1.0.31
       concurrently: 6.3.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -5425,7 +5422,6 @@ importers:
       mocha: 10.2.0
       nyc: 15.1.0
       prettier: 2.6.2
-      random-js: 1.0.8
       rimraf: 2.7.1
       source-map-support: 0.5.21
       typescript: 4.5.5
@@ -22192,7 +22188,7 @@ packages:
   /axios/0.21.4_debug@4.3.2:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.2_debug@4.3.2
+      follow-redirects: 1.15.2
     transitivePeerDependencies:
       - debug
 
@@ -27526,17 +27522,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-
-  /follow-redirects/1.15.2_debug@4.3.2:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.2
 
   /follow-redirects/1.15.2_debug@4.3.4:
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}


### PR DESCRIPTION
## Description

Most of merge-tree's stochastic tests were already refactored to use @fluid-internal/stochastic-test-utils, but this removes the last couple usages of random-js and replaces them.