### PR TITLE
Update scriptorium metric to include timestamps and kafka batch details

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -36,6 +36,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 	private current = new Map<string, ISequencedOperationMessage[]>();
 	private readonly clientFacadeRetryEnabled: boolean;
 	private readonly telemetryEnabled: boolean;
+	private pendingMetric: Lumber<LumberEventName.ScriptoriumProcessBatch> | undefined;
 
 	constructor(
 		private readonly opCollection: ICollection<any>,
@@ -69,6 +70,34 @@ export class ScriptoriumLambda implements IPartitionLambda {
 		}
 
 		this.pendingOffset = message;
+
+		if (this.telemetryEnabled) {
+			if (this.pendingMetric === undefined) {
+				// create a new metric for processing the current kafka batch
+				this.pendingMetric = Lumberjack.newLumberMetric(
+					LumberEventName.ScriptoriumProcessBatch,
+					{
+						timestampReadyToProcess: Date.now(),
+						kafkaPartition: this.pendingOffset?.partition,
+						batchOffsetStart: this.pendingOffset?.offset,
+						batchOffsetEnd: this.pendingOffset?.offset,
+						totalBatchSize: boxcar.contents.length,
+					},
+				);
+			} else {
+				// previous batch is still waiting to be processed, update properties in the existing metric
+				this.pendingMetric.setProperty("batchOffsetEnd", this.pendingOffset?.offset);
+				const currentBatchSize = boxcar.contents.length;
+				const previousBatchSize = Number(
+					this.pendingMetric.properties.get("totalBatchSize"),
+				);
+				this.pendingMetric.setProperty(
+					"totalBatchSize",
+					previousBatchSize + currentBatchSize,
+				);
+			}
+		}
+
 		this.sendPending();
 
 		return undefined;
@@ -88,10 +117,11 @@ export class ScriptoriumLambda implements IPartitionLambda {
 		}
 
 		let metric: Lumber<LumberEventName.ScriptoriumProcessBatch>;
-		if (this.telemetryEnabled) {
-			metric = Lumberjack.newLumberMetric(LumberEventName.ScriptoriumProcessBatch, {
-				batchOffset: this.pendingOffset?.offset,
-			});
+		if (this.telemetryEnabled && this.pendingMetric) {
+			metric = this.pendingMetric;
+			this.pendingMetric = undefined;
+
+			metric.setProperty("timestampProcessingStart", Date.now());
 		}
 
 		let status = ScriptoriumStatus.Processing;
@@ -114,15 +144,18 @@ export class ScriptoriumLambda implements IPartitionLambda {
 			() => {
 				this.current.clear();
 				status = ScriptoriumStatus.ProcessingComplete;
+				metric?.setProperty("timestampProcessingComplete", Date.now());
 
 				// checkpoint batch offset
 				try {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					this.context.checkpoint(batchOffset!);
 					status = ScriptoriumStatus.CheckpointComplete;
+					metric?.setProperty("timestampCheckpointComplete", Date.now());
 				} catch (error) {
 					status = ScriptoriumStatus.CheckpointFailed;
-					const errorMessage = `Scriptorium failed to checkpoint batch with offset ${batchOffset?.offset}`;
+					metric?.setProperty("timestampCheckpointFailed", Date.now());
+					const errorMessage = "Scriptorium failed to checkpoint batch";
 					this.logErrorTelemetry(
 						errorMessage,
 						error,
@@ -134,9 +167,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 				}
 
 				metric?.setProperty("status", status);
-				metric?.success(
-					`Scriptorium completed processing and checkpointing of batch with offset ${batchOffset?.offset}`,
-				);
+				metric?.success("Scriptorium completed processing and checkpointing of batch");
 
 				// continue with next batch
 				this.sendPending();
@@ -144,7 +175,8 @@ export class ScriptoriumLambda implements IPartitionLambda {
 			(error) => {
 				// catches error if any of the promises failed in Promise.all, i.e. any of the ops failed to write to db
 				status = ScriptoriumStatus.ProcessingFailed;
-				const errorMessage = `Scriptorium failed to process batch with offset ${batchOffset?.offset}, going to restart`;
+				metric?.setProperty("timestampProcessingFailed", Date.now());
+				const errorMessage = "Scriptorium failed to process batch, going to restart";
 				this.logErrorTelemetry(errorMessage, error, status, batchOffset?.offset, metric);
 
 				// Restart scriptorium

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -77,7 +77,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 				this.pendingMetric = Lumberjack.newLumberMetric(
 					LumberEventName.ScriptoriumProcessBatch,
 					{
-						timestampReadyToProcess: Date.now(),
+						timestampReadyToProcess: new Date().toISOString(),
 						kafkaPartition: this.pendingOffset?.partition,
 						batchOffsetStart: this.pendingOffset?.offset,
 						batchOffsetEnd: this.pendingOffset?.offset,
@@ -121,7 +121,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 			metric = this.pendingMetric;
 			this.pendingMetric = undefined;
 
-			metric.setProperty("timestampProcessingStart", Date.now());
+			metric.setProperty("timestampProcessingStart", new Date().toISOString());
 		}
 
 		let status = ScriptoriumStatus.Processing;
@@ -144,17 +144,17 @@ export class ScriptoriumLambda implements IPartitionLambda {
 			() => {
 				this.current.clear();
 				status = ScriptoriumStatus.ProcessingComplete;
-				metric?.setProperty("timestampProcessingComplete", Date.now());
+				metric?.setProperty("timestampProcessingComplete", new Date().toISOString());
 
 				// checkpoint batch offset
 				try {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					this.context.checkpoint(batchOffset!);
 					status = ScriptoriumStatus.CheckpointComplete;
-					metric?.setProperty("timestampCheckpointComplete", Date.now());
+					metric?.setProperty("timestampCheckpointComplete", new Date().toISOString());
 				} catch (error) {
 					status = ScriptoriumStatus.CheckpointFailed;
-					metric?.setProperty("timestampCheckpointFailed", Date.now());
+					metric?.setProperty("timestampCheckpointFailed", new Date().toISOString());
 					const errorMessage = "Scriptorium failed to checkpoint batch";
 					this.logErrorTelemetry(
 						errorMessage,
@@ -175,7 +175,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 			(error) => {
 				// catches error if any of the promises failed in Promise.all, i.e. any of the ops failed to write to db
 				status = ScriptoriumStatus.ProcessingFailed;
-				metric?.setProperty("timestampProcessingFailed", Date.now());
+				metric?.setProperty("timestampProcessingFailed", new Date().toISOString());
 				const errorMessage = "Scriptorium failed to process batch, going to restart";
 				this.logErrorTelemetry(errorMessage, error, status, batchOffset?.offset, metric);
 

--- a/server/routerlicious/packages/services-telemetry/src/resources.ts
+++ b/server/routerlicious/packages/services-telemetry/src/resources.ts
@@ -35,6 +35,10 @@ export enum QueuedMessageProperties {
 	topic = "topic",
 	partition = "partition",
 	offset = "offset",
+
+	// use offsetStart and offsetEnd to log the range of kafka offsets being processed
+	offsetStart = "offsetStart",
+	offsetEnd = "offsetEnd",
 }
 
 export enum HttpProperties {
@@ -82,6 +86,7 @@ export enum CommonProperties {
 	restart = "restart",
 	serviceName = "serviceName",
 	telemetryGroupName = "telemetryGroupName",
+	totalBatchSize = "totalBatchSize",
 }
 
 export enum ThrottlingTelemetryProperties {


### PR DESCRIPTION
## Description

Updated scriptorium metric to include
- granular timestamps for better latency insights
- kafka batch size
- kafka batch range (start and end offset) being processed instead of just the last offset

Also starting the metric from handler so that it includes the waiting time for each batch, i.e. if the batch is waiting for the previous batch to finish processing. 
