### PR TITLE
Increase the timeout for installing specific packages in back-compat adhoc tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -98,7 +98,7 @@ describeInstallVersions(
 	{
 		requestAbsoluteVersions: [loaderWithoutCompressionField],
 	},
-	/* timeoutMs */ 50000,
+	/* timeoutMs: 3 minutes */ 180000,
 )("Op Compression self-healing with old loader", (getProvider) =>
 	compressionSuite(async () => {
 		const provider = getProvider();

--- a/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
@@ -28,7 +28,7 @@ describeInstallVersions(
 	{
 		requestAbsoluteVersions: [versionWithChunking],
 	},
-	/* timeoutMs */ 50000,
+	/* timeoutMs: 3 minutes */ 180000,
 )("Legacy chunking", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let oldMap: SharedMap;


### PR DESCRIPTION
## Description

We are seeing transient timeouts when trying to run these tests. As they are installing specific versions of Fluid (different than the N-1 and LTS versions installed by default), they need more breathing space.