### PR TITLE
fix(tree): prevent MoveId collisions in transactions

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -135,7 +135,7 @@ export abstract class ChangeEncoder<TChange> {
 }
 
 // @alpha (undocumented)
-export interface ChangeFamily<TEditor, TChange> {
+export interface ChangeFamily<TEditor extends ChangeFamilyEditor, TChange> {
     // (undocumented)
     buildEditor(changeReceiver: (change: TChange) => void, anchorSet: AnchorSet): TEditor;
     // (undocumented)
@@ -144,6 +144,12 @@ export interface ChangeFamily<TEditor, TChange> {
     intoDelta(change: TChange): Delta.Root;
     // (undocumented)
     readonly rebaser: ChangeRebaser<TChange>;
+}
+
+// @alpha (undocumented)
+export interface ChangeFamilyEditor {
+    enterTransaction(): void;
+    exitTransaction(): void;
 }
 
 // @alpha
@@ -958,9 +964,15 @@ export interface ModularChangeset {
 
 // @alpha @sealed (undocumented)
 export class ModularEditBuilder extends ProgressiveEditBuilderBase<ModularChangeset> implements ProgressiveEditBuilder<ModularChangeset> {
-    constructor(family: ChangeFamily<unknown, ModularChangeset>, changeReceiver: (change: ModularChangeset) => void, anchors: AnchorSet);
+    constructor(family: ChangeFamily<ChangeFamilyEditor, ModularChangeset>, changeReceiver: (change: ModularChangeset) => void, anchors: AnchorSet);
     // (undocumented)
     apply(change: ModularChangeset): void;
+    // (undocumented)
+    enterTransaction(): void;
+    // (undocumented)
+    exitTransaction(): void;
+    // (undocumented)
+    generateId(): ChangesetLocalId;
     // (undocumented)
     setValue(path: UpPath, value: Value): void;
     submitChange(path: UpPath | undefined, field: FieldKey, fieldKind: FieldKindIdentifier, change: FieldChangeset, maxId?: ChangesetLocalId): void;
@@ -1135,12 +1147,16 @@ export interface ProgressiveEditBuilder<TChange> {
 }
 
 // @alpha (undocumented)
-export abstract class ProgressiveEditBuilderBase<TChange> implements ProgressiveEditBuilder<TChange> {
-    constructor(changeFamily: ChangeFamily<unknown, TChange>, changeReceiver: (change: TChange) => void, anchorSet: AnchorSet);
+export abstract class ProgressiveEditBuilderBase<TChange> implements ProgressiveEditBuilder<TChange>, ChangeFamilyEditor {
+    constructor(changeFamily: ChangeFamily<ChangeFamilyEditor, TChange>, changeReceiver: (change: TChange) => void, anchorSet: AnchorSet);
     // @sealed
     protected applyChange(change: TChange): void;
     // (undocumented)
-    protected readonly changeFamily: ChangeFamily<unknown, TChange>;
+    protected readonly changeFamily: ChangeFamily<ChangeFamilyEditor, TChange>;
+    // (undocumented)
+    enterTransaction(): void;
+    // (undocumented)
+    exitTransaction(): void;
     // @sealed (undocumented)
     getChanges(): TChange[];
 }

--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -10,7 +10,7 @@ import { ChangeEncoder } from "./changeEncoder";
 /**
  * @alpha
  */
-export interface ChangeFamily<TEditor, TChange> {
+export interface ChangeFamily<TEditor extends ChangeFamilyEditor, TChange> {
 	buildEditor(changeReceiver: (change: TChange) => void, anchorSet: AnchorSet): TEditor;
 
 	/**
@@ -20,4 +20,29 @@ export interface ChangeFamily<TEditor, TChange> {
 
 	readonly rebaser: ChangeRebaser<TChange>;
 	readonly encoder: ChangeEncoder<TChange>;
+}
+
+/**
+ * @alpha
+ */
+export interface ChangeFamilyEditor {
+	/**
+	 * Must be called when a new transaction starts.
+	 *
+	 * Note: transactions are an optional feature. It is valid to make edits outside of a transaction.
+	 *
+	 * For each call to this function, a matching call to `exitTransaction` must be made at a later time.
+	 * Can be called repeatedly to indicate the start of nesting transactions.
+	 */
+	enterTransaction(): void;
+
+	/**
+	 * Must be called when a transaction ends.
+	 *
+	 * Note: transactions are an optional feature. It is valid to make edits outside of a transaction.
+	 *
+	 * For each call to this function, a matching call to `enterTransaction` must be made at an earlier time.
+	 * Can be called repeatedly to indicate the end of nesting transactions.
+	 */
+	exitTransaction(): void;
 }

--- a/packages/dds/tree/src/core/change-family/index.ts
+++ b/packages/dds/tree/src/core/change-family/index.ts
@@ -4,5 +4,5 @@
  */
 
 export { ChangeEncoder } from "./changeEncoder";
-export { ChangeFamily } from "./changeFamily";
+export { ChangeFamily, ChangeFamilyEditor } from "./changeFamily";
 export { ProgressiveEditBuilder, ProgressiveEditBuilderBase } from "./progressiveEditBuilder";

--- a/packages/dds/tree/src/core/change-family/progressiveEditBuilder.ts
+++ b/packages/dds/tree/src/core/change-family/progressiveEditBuilder.ts
@@ -4,7 +4,7 @@
  */
 
 import { AnchorSet } from "../tree";
-import { ChangeFamily } from "./changeFamily";
+import { ChangeFamily, ChangeFamilyEditor } from "./changeFamily";
 
 /**
  * @alpha
@@ -20,12 +20,12 @@ export interface ProgressiveEditBuilder<TChange> {
  * @alpha
  */
 export abstract class ProgressiveEditBuilderBase<TChange>
-	implements ProgressiveEditBuilder<TChange>
+	implements ProgressiveEditBuilder<TChange>, ChangeFamilyEditor
 {
 	private readonly changes: TChange[] = [];
 
 	public constructor(
-		protected readonly changeFamily: ChangeFamily<unknown, TChange>,
+		protected readonly changeFamily: ChangeFamily<ChangeFamilyEditor, TChange>,
 		private readonly changeReceiver: (change: TChange) => void,
 		private readonly anchorSet: AnchorSet,
 	) {}
@@ -48,4 +48,7 @@ export abstract class ProgressiveEditBuilderBase<TChange>
 	public getChanges(): TChange[] {
 		return [...this.changes];
 	}
+
+	public enterTransaction(): void {}
+	public exitTransaction(): void {}
 }

--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -134,6 +134,7 @@ export {
 export {
 	ChangeEncoder,
 	ChangeFamily,
+	ChangeFamilyEditor,
 	ProgressiveEditBuilder,
 	ProgressiveEditBuilderBase,
 } from "./change-family";

--- a/packages/dds/tree/src/feature-libraries/editManagerIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/editManagerIndex.ts
@@ -28,6 +28,7 @@ import {
 	SummaryBranch,
 	SequencedCommit,
 	ChangeEncoder,
+	ChangeFamilyEditor,
 } from "../core";
 import {
 	Index,
@@ -57,7 +58,10 @@ export class EditManagerIndex<TChangeset> implements Index, SummaryElement {
 
 	public constructor(
 		private readonly runtime: IFluidDataStoreRuntime,
-		private readonly editManager: EditManager<TChangeset, ChangeFamily<unknown, TChangeset>>,
+		private readonly editManager: EditManager<
+			TChangeset,
+			ChangeFamily<ChangeFamilyEditor, TChangeset>
+		>,
 	) {
 		this.editDataBlob = cachedValue(async (observer) => {
 			recordDependency(observer, this.editManager);

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -71,6 +71,7 @@ export { defaultSchemaPolicy, emptyField, neverField, neverTree } from "./defaul
 
 export {
 	ChangesetLocalId,
+	idAllocatorFromMaxId,
 	isNeverField,
 	ModularChangeFamily,
 	ModularEditBuilder,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/crossFieldQueries.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/crossFieldQueries.ts
@@ -4,7 +4,8 @@
  */
 
 import { RevisionTag } from "../../core";
-import { Brand, NestedSet } from "../../util";
+import { brand, Brand, NestedSet } from "../../util";
+import { IdAllocator } from "./fieldChangeHandler";
 
 export type CrossFieldQuerySet = NestedSet<RevisionTag | undefined, ChangesetLocalId>;
 
@@ -56,3 +57,13 @@ export interface CrossFieldManager<T = unknown> {
  * @alpha
  */
 export type ChangesetLocalId = Brand<number, "ChangesetLocalId">;
+
+/**
+ * @alpha
+ */
+export function idAllocatorFromMaxId(maxId: ChangesetLocalId | undefined = undefined): IdAllocator {
+	let currId = maxId ?? -1;
+	return () => {
+		return brand(++currId);
+	};
+}

--- a/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
@@ -16,6 +16,7 @@ export {
 	CrossFieldManager,
 	CrossFieldQuerySet,
 	CrossFieldTarget,
+	idAllocatorFromMaxId,
 } from "./crossFieldQueries";
 export { FieldKind, FullSchemaPolicy, Multiplicity } from "./fieldKind";
 export {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -817,7 +817,7 @@ export class ModularEditBuilder
 		anchors: AnchorSet,
 	) {
 		super(family, changeReceiver, anchors);
-		this.idAllocator = () => brand(0);
+		this.idAllocator = idAllocatorFromMaxId();
 	}
 
 	public override enterTransaction(): void {
@@ -831,7 +831,7 @@ export class ModularEditBuilder
 		assert(this.transactionDepth > 0, "Cannot exit inexistent transaction");
 		this.transactionDepth -= 1;
 		if (this.transactionDepth === 0) {
-			this.idAllocator = () => brand(0);
+			this.idAllocator = idAllocatorFromMaxId();
 		}
 	}
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -21,6 +21,7 @@ import {
 	RevisionTag,
 	tagChange,
 	makeAnonChange,
+	ChangeFamilyEditor,
 } from "../../core";
 import {
 	addToNestedSet,
@@ -807,7 +808,7 @@ export class ModularEditBuilder
 	implements ProgressiveEditBuilder<ModularChangeset>
 {
 	public constructor(
-		family: ChangeFamily<unknown, ModularChangeset>,
+		family: ChangeFamily<ChangeFamilyEditor, ModularChangeset>,
 		changeReceiver: (change: ModularChangeset) => void,
 		anchors: AnchorSet,
 	) {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -828,7 +828,7 @@ export class ModularEditBuilder
 	}
 
 	public override exitTransaction(): void {
-		assert(this.transactionDepth > 0, "Cannot exist inexistent transaction");
+		assert(this.transactionDepth > 0, "Cannot exit inexistent transaction");
 		this.transactionDepth -= 1;
 		if (this.transactionDepth === 0) {
 			this.idAllocator = () => brand(0);

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -5,7 +5,7 @@
 
 import { jsonableTreeFromCursor } from "../treeTextCursor";
 import { ITreeCursor, RevisionTag } from "../../core";
-import { FieldEditor, NodeReviver } from "../modular-schema";
+import { ChangesetLocalId, FieldEditor, NodeReviver } from "../modular-schema";
 import { brand } from "../../util";
 import { Changeset, Mark, MoveId, NodeChangeType, Reattach } from "./format";
 import { MarkListFactory } from "./markListFactory";
@@ -33,6 +33,7 @@ export interface SequenceFieldEditor extends FieldEditor<Changeset> {
 		sourceIndex: number,
 		count: number,
 		destIndex: number,
+		id: ChangesetLocalId,
 	): [Changeset<never>, Changeset<never>];
 	return(
 		sourceIndex: number,
@@ -84,16 +85,17 @@ export const sequenceFieldEditor = {
 		sourceIndex: number,
 		count: number,
 		destIndex: number,
+		id: ChangesetLocalId,
 	): [Changeset<never>, Changeset<never>] {
 		const moveOut: Mark<never> = {
 			type: "MoveOut",
-			id: brand(0),
+			id,
 			count,
 		};
 
 		const moveIn: Mark<never> = {
 			type: "MoveIn",
-			id: brand(0),
+			id,
 			count,
 		};
 

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -7,6 +7,7 @@ import { assert, unreachableCase } from "@fluidframework/common-utils";
 import { RevisionTag, TaggedChange } from "../../core";
 import {
 	addToNestedSet,
+	brand,
 	fail,
 	getOrAddEmptyToMap,
 	getOrAddInNestedMap,
@@ -16,6 +17,7 @@ import {
 	tryGetFromNestedMap,
 } from "../../util";
 import {
+	ChangesetLocalId,
 	CrossFieldManager,
 	CrossFieldQuerySet,
 	CrossFieldTarget,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -7,7 +7,6 @@ import { assert, unreachableCase } from "@fluidframework/common-utils";
 import { RevisionTag, TaggedChange } from "../../core";
 import {
 	addToNestedSet,
-	brand,
 	fail,
 	getOrAddEmptyToMap,
 	getOrAddInNestedMap,
@@ -17,7 +16,6 @@ import {
 	tryGetFromNestedMap,
 } from "../../util";
 import {
-	ChangesetLocalId,
 	CrossFieldManager,
 	CrossFieldQuerySet,
 	CrossFieldTarget,

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -69,6 +69,7 @@ export {
 	SchemaDataAndPolicy,
 	ChangeEncoder,
 	ChangeFamily,
+	ChangeFamilyEditor,
 	ProgressiveEditBuilder,
 	ProgressiveEditBuilderBase,
 	ChangeRebaser,

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -17,6 +17,7 @@ import {
 	emptyDelta,
 	mintRevisionTag,
 	SeqNumber,
+	ChangeFamilyEditor,
 } from "../../core";
 import { brand, clone, makeArray, RecursiveReadonly } from "../../util";
 import {
@@ -46,7 +47,7 @@ function asDelta(intentions: number[]): Delta.Root {
 
 function changeFamilyFactory(
 	rebaser?: ChangeRebaser<TestChange>,
-): ChangeFamily<unknown, TestChange> {
+): ChangeFamily<ChangeFamilyEditor, TestChange> {
 	const family = {
 		rebaser: rebaser ?? new TestChangeRebaser(),
 		encoder: new TestChangeEncoder(),
@@ -65,7 +66,7 @@ function editManagerFactory(options: {
 } {
 	const family = changeFamilyFactory(options.rebaser);
 	const anchors = new TestAnchorSet();
-	const manager = new EditManager<TestChange, ChangeFamily<unknown, TestChange>>(
+	const manager = new EditManager<TestChange, ChangeFamily<ChangeFamilyEditor, TestChange>>(
 		family,
 		options.sessionId ?? localSessionId,
 		anchors,

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { SequenceField as SF, singleTextCursor } from "../../../feature-libraries";
+import {
+	ChangesetLocalId,
+	SequenceField as SF,
+	singleTextCursor,
+} from "../../../feature-libraries";
 import { brand } from "../../../util";
 import { fakeRepair } from "../../utils";
 import { mintRevisionTag, RevisionTag, TreeSchemaIdentifier } from "../../../core";
@@ -115,8 +119,11 @@ function createMoveChangeset(
 	sourceIndex: number,
 	count: number,
 	destIndex: number,
+	id: ChangesetLocalId = brand(0),
 ): SF.Changeset<never> {
-	return composeAnonChangesShallow(SF.sequenceFieldEditor.move(sourceIndex, count, destIndex));
+	return composeAnonChangesShallow(
+		SF.sequenceFieldEditor.move(sourceIndex, count, destIndex, id),
+	);
 }
 
 function createReturnChangeset(

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -7,6 +7,7 @@ import { assert } from "@fluidframework/common-utils";
 import {
 	ChangesetLocalId,
 	IdAllocator,
+	idAllocatorFromMaxId,
 	RevisionMetadataSource,
 	SequenceField as SF,
 } from "../../../feature-libraries";
@@ -203,11 +204,4 @@ export function normalizeMoveIds(change: SF.Changeset<unknown>): void {
 			mark.id = newId!;
 		}
 	}
-}
-
-export function idAllocatorFromMaxId(maxId: ChangesetLocalId | undefined = undefined): IdAllocator {
-	let currId = maxId ?? -1;
-	return () => {
-		return brand(++currId);
-	};
 }

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -547,16 +547,7 @@ describe("SharedTree", () => {
 			const initialState: JsonableTree = {
 				type: brand("Node"),
 				fields: {
-					foo: [
-						{ type: brand("Node"), value: "a" },
-						{ type: brand("Node"), value: "b" },
-						{ type: brand("Node"), value: "c" },
-					],
-					bar: [
-						{ type: brand("Node"), value: "d" },
-						{ type: brand("Node"), value: "e" },
-						{ type: brand("Node"), value: "f" },
-					],
+					foo: [{ type: brand("Node"), value: "a" }],
 				},
 			};
 			initializeTestTree(tree, initialState);
@@ -568,30 +559,20 @@ describe("SharedTree", () => {
 			};
 			// Perform multiple moves that should each be assigned a unique ID
 			runSynchronous(tree, () => {
-				tree.editor.move(rootPath, brand("foo"), 1, 2, rootPath, brand("bar"), 1);
-				tree.editor.move(rootPath, brand("bar"), 2, 2, rootPath, brand("foo"), 0);
+				tree.editor.move(rootPath, brand("foo"), 0, 1, rootPath, brand("bar"), 0);
+				tree.editor.move(rootPath, brand("bar"), 0, 1, rootPath, brand("baz"), 0);
 				runSynchronous(tree, () => {
-					tree.editor.move(rootPath, brand("bar"), 2, 1, rootPath, brand("foo"), 1);
+					tree.editor.move(rootPath, brand("baz"), 0, 1, rootPath, brand("qux"), 0);
 				});
 			});
-
-			await provider.ensureSynchronized();
 
 			const expectedState: JsonableTree = {
 				type: brand("Node"),
 				fields: {
-					foo: [
-						{ type: brand("Node"), value: "c" },
-						{ type: brand("Node"), value: "f" },
-						{ type: brand("Node"), value: "e" },
-						{ type: brand("Node"), value: "a" },
-					],
-					bar: [
-						{ type: brand("Node"), value: "d" },
-						{ type: brand("Node"), value: "b" },
-					],
+					qux: [{ type: brand("Node"), value: "a" }],
 				},
 			};
+			await provider.ensureSynchronized();
 			validateTree(tree, [expectedState]);
 		});
 	});

--- a/packages/dds/tree/src/test/testChange.ts
+++ b/packages/dds/tree/src/test/testChange.ts
@@ -11,6 +11,7 @@ import {
 	TaggedChange,
 	AnchorSet,
 	Delta,
+	ChangeFamilyEditor,
 } from "../core";
 import { JsonCompatible, JsonCompatibleReadOnly, RecursiveReadonly } from "../util";
 import { deepFreeze } from "./utils";
@@ -252,4 +253,4 @@ export class TestAnchorSet extends AnchorSet implements AnchorRebaseData {
 	public intentions: number[] = [];
 }
 
-export type TestChangeFamily = ChangeFamily<unknown, TestChange>;
+export type TestChangeFamily = ChangeFamily<ChangeFamilyEditor, TestChange>;


### PR DESCRIPTION
The aim of this PR is to ensure that a transaction with multiple move operations uses unique `MoveId`s for each move operation.
This is currently a problem because each operation within a transaction is represented as an anonymous changeset (i.e., with an undefined `RevisionTag`), and each move operation is assigned the same ID. This violates the expectation that each `{ RevisionTag, MoveId }` pair should be unique, which in turn causes errors in the composition of the transaction's changes.

This PR resolves the issue by ensuring each move operation within a transaction is assigned a unique `MoveId`.
This is accomplished by introducing the `ChangeFamilyEditor` interface that exposes methods to notify an editor of transaction boundaries. The `ModularEditBuilder` uses these calls to manage the scope of the IDs it generates.

Long term, the collision of `MoveId`s in those circumstances is likely to be avoided by assigning each edit operation a distinct revision (instead of making them anonymous as is currently the case). It does however seem reasonable for `ChangeFamily` editors to be allowed to maintain some state and for that state to be tied to transaction boundaries.