### PR TITLE
Optimize Gitrest latest summary pre-compute

### DIFF
--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -23,9 +23,7 @@ services:
       - IS_FLUID_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
-      - /usr/src/server/node_modules/zookeeper
-      - /usr/src/server/node_modules/node-rdkafka
-      - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
+      - /usr/src/server/node_modules
     restart: on-failure
   deli:
     build:
@@ -38,9 +36,7 @@ services:
       - IS_FLUID_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
-      - /usr/src/server/node_modules/zookeeper
-      - /usr/src/server/node_modules/node-rdkafka
-      - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
+      - /usr/src/server/node_modules
     restart: on-failure
   scriptorium:
     build:
@@ -53,9 +49,7 @@ services:
       - IS_FLUID_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
-      - /usr/src/server/node_modules/zookeeper
-      - /usr/src/server/node_modules/node-rdkafka
-      - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
+      - /usr/src/server/node_modules
     restart: on-failure
   copier:
     build:
@@ -68,9 +62,7 @@ services:
       - IS_FLUID_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
-      - /usr/src/server/node_modules/zookeeper
-      - /usr/src/server/node_modules/node-rdkafka
-      - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
+      - /usr/src/server/node_modules
     restart: on-failure
   scribe:
     build:
@@ -83,9 +75,7 @@ services:
       - IS_FLUID_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
-      - /usr/src/server/node_modules/zookeeper
-      - /usr/src/server/node_modules/node-rdkafka
-      - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
+      - /usr/src/server/node_modules
     restart: on-failure
   foreman:
     build:
@@ -98,9 +88,7 @@ services:
       - IS_FLUID_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
-      - /usr/src/server/node_modules/zookeeper
-      - /usr/src/server/node_modules/node-rdkafka
-      - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
+      - /usr/src/server/node_modules
     restart: on-failure
   riddler:
     build:
@@ -117,9 +105,7 @@ services:
       - IS_FLUID_SERVER=true
     volumes:
       - ./routerlicious:/usr/src/server
-      - /usr/src/server/node_modules/zookeeper
-      - /usr/src/server/node_modules/node-rdkafka
-      - /usr/src/server/packages/routerlicious/node_modules/node-rdkafka/
+      - /usr/src/server/node_modules
     restart: on-failure
   historian:
     build:
@@ -145,7 +131,7 @@ services:
     volumes:
       - git:/home/node/documents
       - ./gitrest:/home/node/server
-      - /home/node/server/node_modules/nodegit
+      - /home/node/server/node_modules
     restart: on-failure
   git:
     image: mcr.microsoft.com/fluidframework/routerlicious/gitssh:latest

--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -164,7 +164,7 @@ async function createSummary(
 			  });
 		if (latestFullSummary) {
 			if (persistLatestFullSummary) {
-				// Send latest full summary to storage for faster read access
+				// Send latest full summary to storage for faster read access.
 				const persistP = persistLatestFullSummaryInStorage(
 					fileSystemManager,
 					getFullSummaryDirectory(
@@ -187,6 +187,7 @@ async function createSummary(
 					await persistP;
 				}
 			}
+			// Return latest full summary to Historian for caching.
 			return latestFullSummary;
 		}
 	}

--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -148,42 +148,43 @@ async function createSummary(
 
 	// Waiting to pre-compute and persist latest summary would slow down document creation,
 	// so skip this step if it is a new document.
-	if (!isNew && isContainerSummary(payload)) {
-		const latestFullSummary: IWholeFlatSummary | undefined = await wholeSummaryManager
-			.readSummary(writeSummaryResponse.id)
-			.catch((error) => {
-				// This read is for Historian caching purposes, so it should be ignored on failure.
-				Lumberjack.error(
-					"Failed to read latest summary after writing container summary",
-					lumberjackProperties,
-					error,
-				);
-				return undefined;
-			});
+	if (isContainerSummary(payload)) {
+		const latestFullSummary: IWholeFlatSummary | undefined = (
+			writeSummaryResponse as IWholeFlatSummary
+		).trees
+			? writeSummaryResponse
+			: await wholeSummaryManager.readSummary(writeSummaryResponse.id).catch((error) => {
+					// This read is for Historian caching purposes, so it should be ignored on failure.
+					Lumberjack.error(
+						"Failed to read latest summary after writing container summary",
+						lumberjackProperties,
+						error,
+					);
+					return undefined;
+			  });
 		if (latestFullSummary) {
 			if (persistLatestFullSummary) {
-				try {
-					// TODO: does this fail if file is open and still being written to from a previous request?
-					await persistLatestFullSummaryInStorage(
-						fileSystemManager,
-						getFullSummaryDirectory(
-							repoManager,
-							repoManagerParams.storageRoutingId.documentId,
-						),
-						latestFullSummary,
-						lumberjackProperties,
-					);
-				} catch (error) {
+				// Send latest full summary to storage for faster read access
+				const persistP = persistLatestFullSummaryInStorage(
+					fileSystemManager,
+					getFullSummaryDirectory(
+						repoManager,
+						repoManagerParams.storageRoutingId.documentId,
+					),
+					latestFullSummary,
+					lumberjackProperties,
+				).catch((error) => {
+					// Persisting latest summary is an optimization, not a requirement, so do not throw on failure.
 					Lumberjack.error(
 						"Failed to persist latest full summary to storage during createSummary",
 						lumberjackProperties,
 						error,
 					);
-					// TODO: Find and add more information about this failure so that Scribe can retry as necessary.
-					throw new NetworkError(
-						500,
-						"Failed to persist latest full summary to storage during createSummary",
-					);
+				});
+				if (!isNew) {
+					// To avoid any possible race conditions when outside the critical path, we can await the persist operation.
+					// Chances for a race condition are slim and likely inconsequential, but better safe than sorry.
+					await persistP;
 				}
 			}
 			return latestFullSummary;

--- a/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
@@ -81,7 +81,7 @@ interface IWriteSummaryInfo {
 	/**
 	 * Response containing commit sha for "container" write or tree sha for "channel" write.
 	 */
-	writeSummaryResponse: IWriteSummaryResponse;
+	writeSummaryResponse: IWriteSummaryResponse | IWholeFlatSummary;
 }
 
 interface ISummaryWriteOptions {
@@ -160,6 +160,7 @@ function getSummaryObjectFromWholeSummaryTreeEntry(entry: WholeSummaryTreeEntry)
 async function buildFullGitTreeFromGitTree(
 	gitTree: ITree,
 	repoManager: IRepositoryManager,
+	blobCache: Record<string, IBlob> = {},
 	parseInnerFullGitTrees = true,
 	retrieveBlobs = true,
 	depth = 0,
@@ -167,11 +168,13 @@ async function buildFullGitTreeFromGitTree(
 	let parsedFullTreeBlobs = false;
 	const blobPs: Promise<IBlob>[] = [];
 	const treeEntries: ITreeEntry[] = [];
+	const getBlob = async (sha: string): Promise<IBlob> =>
+		blobCache[sha] ?? repoManager.getBlob(sha);
 	for (const treeEntry of gitTree.tree) {
 		if (treeEntry.type === "blob") {
 			if (treeEntry.path.endsWith(fullTreePath) && parseInnerFullGitTrees) {
 				parsedFullTreeBlobs = true;
-				const fullTreeBlob = await repoManager.getBlob(treeEntry.sha);
+				const fullTreeBlob = await getBlob(treeEntry.sha);
 				const fullTree = JSON.parse(
 					fullTreeBlob.encoding === "base64"
 						? // Convert base64 to utf-8 for JSON parsing
@@ -181,6 +184,7 @@ async function buildFullGitTreeFromGitTree(
 				const builtFullGitTree = await buildFullGitTreeFromGitTree(
 					fullTree.tree,
 					repoManager,
+					blobCache,
 					true /* parseInnerFullGitTrees */,
 					// All blobs associated with full git tree are included in the full git tree blob, and
 					// will not exists in storage individually.
@@ -201,7 +205,7 @@ async function buildFullGitTreeFromGitTree(
 				blobPs.push(...Object.values(fullTreeBlobs).map(async (blob) => blob));
 				continue;
 			} else if (retrieveBlobs) {
-				blobPs.push(repoManager.getBlob(treeEntry.sha));
+				blobPs.push(getBlob(treeEntry.sha));
 			}
 		}
 		treeEntries.push(treeEntry);
@@ -415,6 +419,7 @@ export class GitWholeSummaryManager {
 		const fullGitTree = await buildFullGitTreeFromGitTree(
 			rawTree,
 			repoManager,
+			{},
 			true /* parseInnerFullGitTrees */,
 			true /* retrieveBlobs */,
 		);
@@ -490,7 +495,12 @@ export class GitWholeSummaryManager {
 	private async writeChannelSummary(payload: IWholeSummaryPayload): Promise<string> {
 		const useLowIoWrite = this.writeOptions.enableLowIoWrite === true;
 		const existingRef: IRef | undefined = useLowIoWrite ? await this.getDocRef() : undefined;
-		return this.writeSummaryTree(payload.entries, existingRef, useLowIoWrite);
+		const fullGitTree = await this.writeSummaryTree(
+			payload.entries,
+			existingRef,
+			useLowIoWrite,
+		);
+		return fullGitTree.tree.sha;
 	}
 
 	private async writeContainerSummary(
@@ -508,7 +518,11 @@ export class GitWholeSummaryManager {
 			this.writeOptions.enableLowIoWrite === true ||
 			(isNewDocument && this.writeOptions.enableLowIoWrite === "initial");
 
-		const treeHandle = await this.writeSummaryTree(payload.entries, existingRef, useLowIoWrite);
+		const fullGitTree = await this.writeSummaryTree(
+			payload.entries,
+			existingRef,
+			useLowIoWrite,
+		);
 
 		const commitMessage = isNewDocument
 			? "New document"
@@ -523,7 +537,7 @@ export class GitWholeSummaryManager {
 			},
 			message: commitMessage,
 			parents: existingRef ? [existingRef.object.sha] : [],
-			tree: treeHandle,
+			tree: fullGitTree.tree.sha,
 		};
 		const commit = await this.repoManager.createCommit(commitParams);
 
@@ -549,11 +563,23 @@ export class GitWholeSummaryManager {
 			);
 		}
 
+		const fullSummaryTree = convertFullGitTreeToFullSummaryTree(fullGitTree);
+		const wholeFlatSummary: IWholeFlatSummary = {
+			id: commit.sha,
+			trees: [
+				{
+					id: fullGitTree.tree.sha,
+					entries: fullSummaryTree.treeEntries,
+					// We don't store sequence numbers in git
+					sequenceNumber: undefined,
+				},
+			],
+			blobs: fullSummaryTree.blobs,
+		};
+
 		return {
 			isNew: isNewDocument,
-			writeSummaryResponse: {
-				id: commit.sha,
-			},
+			writeSummaryResponse: wholeFlatSummary,
 		};
 	}
 
@@ -561,7 +587,7 @@ export class GitWholeSummaryManager {
 		wholeSummaryTreeEntries: WholeSummaryTreeEntry[],
 		existingRef: IRef | undefined,
 		useLowIoWrite: boolean = false,
-	): Promise<string> {
+	): Promise<IFullGitTree> {
 		if (!useLowIoWrite) {
 			return this.writeSummaryTreeCore(wholeSummaryTreeEntries, this.repoManager);
 		}
@@ -615,7 +641,7 @@ export class GitWholeSummaryManager {
 		wholeSummaryTreeEntries: WholeSummaryTreeEntry[],
 		existingRef: IRef | undefined,
 		inMemoryRepoManager: IRepositoryManager,
-	) {
+	): Promise<IFullGitTree> {
 		if (existingRef) {
 			// Update in-memory repo manager with previous summary for handle references.
 			const previousSummary = await this.readSummary(existingRef.object.sha);
@@ -623,21 +649,10 @@ export class GitWholeSummaryManager {
 				treeEntries: previousSummary.trees[0].entries,
 				blobs: previousSummary.blobs ?? [],
 			});
-			const previousSummaryMemoryHandle = await this.writeSummaryTreeCore(
+			const previousSummaryMemoryFullGitTree = await this.writeSummaryTreeCore(
 				fullSummaryPayload,
 				inMemoryRepoManager,
 			);
-			const previousSummaryMemoryGitTree = await inMemoryRepoManager.getTree(
-				previousSummaryMemoryHandle,
-				true /* recursive */,
-			);
-			const previousSummaryMemoryFullGitTree: IFullGitTree =
-				await buildFullGitTreeFromGitTree(
-					previousSummaryMemoryGitTree,
-					inMemoryRepoManager,
-					true /* parseInnerFullGitTrees */,
-					false /* retrieveBlobs */,
-				);
 			for (const treeEntry of previousSummaryMemoryFullGitTree.tree.tree) {
 				// Update entry handle to object sha map for reference when writing summary handles.
 				this.entryHandleToObjectShaCache.set(
@@ -647,68 +662,19 @@ export class GitWholeSummaryManager {
 			}
 		}
 
-		const inMemorySummaryTreeHandle = await this.writeSummaryTreeCore(
+		const inMemorySummaryFullGitTree = await this.writeSummaryTreeCore(
 			wholeSummaryTreeEntries,
 			inMemoryRepoManager,
 		);
-		const getGitTreeWithStorageFallback = async (
-			treeHandle: string,
-			repoManager: IRepositoryManager,
-			depth: number = 0,
-		): Promise<ITree> => {
-			try {
-				const tree = await repoManager.getTree(treeHandle, true /* recursive */);
-				return tree;
-			} catch (error: any) {
-				if (error.code === "NotFoundError" && typeof error.data.what === "string") {
-					// Likely, In-memory RepoManager is missing a previous channel summary.
-					// We can attempt to recover by retrieving it from storage and writing it back into memory.
-					const missingElementSha = error.data.what;
-					const missingTreeElement = await this.repoManager.getTree(
-						missingElementSha,
-						true /* recursive */,
-					);
-					const fullMissingGitTree: IFullGitTree = await buildFullGitTreeFromGitTree(
-						missingTreeElement,
-						this.repoManager,
-						// We do not want to parse into embedded full git tree blobs here.
-						// It is important that the sha for the tree remains the same. The hidden blobs
-						// in the full git tree blob are handled elsewhere.
-						false /* parseInnerFullGitTrees */,
-					);
-
-					const inMemoryTreeHandle = await this.writeFullGitTreeAsSummaryTree(
-						fullMissingGitTree,
-						inMemoryRepoManager,
-					);
-
-					if (inMemoryTreeHandle !== missingElementSha) {
-						throw new Error(
-							`Recovery tree sha (${inMemoryTreeHandle}) did not match missing tree sha (${missingElementSha}).`,
-						);
-					}
-					return getGitTreeWithStorageFallback(treeHandle, repoManager, depth + 1);
-				}
-				throw error;
-			}
-		};
-		const gitTree = await getGitTreeWithStorageFallback(
-			inMemorySummaryTreeHandle,
-			inMemoryRepoManager,
-		);
-		const fullGitTree = await buildFullGitTreeFromGitTree(
-			gitTree,
-			inMemoryRepoManager,
-			false /* parseInnerFullGitTrees */,
-		);
-		return fullGitTree;
+		return inMemorySummaryFullGitTree;
 	}
 
 	private async writeSummaryTreeCore(
 		wholeSummaryTreeEntries: WholeSummaryTreeEntry[],
 		repoManager: IRepositoryManager,
 		currentPath: string = "",
-	): Promise<string> {
+	): Promise<IFullGitTree> {
+		const blobs: Record<string, IBlob> = {};
 		const entries: ICreateTreeEntry[] = await Promise.all(
 			wholeSummaryTreeEntries.map(async (entry) => {
 				const summaryObject = getSummaryObjectFromWholeSummaryTreeEntry(entry);
@@ -721,6 +687,18 @@ export class GitWholeSummaryManager {
 					repoManager,
 					fullPath,
 				);
+				if (summaryObject.type === SummaryType.Blob) {
+					// Store blob in cache for use upstream
+					const summaryBlob = (entry as IWholeSummaryTreeValueEntry)
+						.value as IWholeSummaryBlob;
+					blobs[pathHandle] = {
+						content: summaryBlob.content,
+						encoding: summaryBlob.encoding,
+						sha: pathHandle,
+						url: "", // Not important for use upstream
+						size: summaryBlob.content.length,
+					};
+				}
 				return {
 					mode: getGitMode(summaryObject),
 					path,
@@ -731,7 +709,7 @@ export class GitWholeSummaryManager {
 		);
 
 		const createdTree = await repoManager.createTree({ tree: entries });
-		return createdTree.sha;
+		return buildFullGitTreeFromGitTree(createdTree, repoManager, blobs, true, true);
 	}
 
 	private async writeSummaryTreeObject(
@@ -748,14 +726,16 @@ export class GitWholeSummaryManager {
 					repoManager,
 				);
 			case SummaryType.Tree:
-				return this.writeSummaryTreeCore(
-					(
-						(wholeSummaryTreeEntry as IWholeSummaryTreeValueEntry)
-							.value as IWholeSummaryTree
-					).entries ?? [],
-					repoManager,
-					currentPath,
-				);
+				return (
+					await this.writeSummaryTreeCore(
+						(
+							(wholeSummaryTreeEntry as IWholeSummaryTreeValueEntry)
+								.value as IWholeSummaryTree
+						).entries ?? [],
+						repoManager,
+						currentPath,
+					)
+				).tree.sha;
 			case SummaryType.Handle:
 				return this.getShaFromTreeHandleEntry(
 					wholeSummaryTreeEntry as IWholeSummaryTreeHandleEntry,
@@ -782,7 +762,8 @@ export class GitWholeSummaryManager {
 	): Promise<string> {
 		const fullSummaryTree = convertFullGitTreeToFullSummaryTree(fullGitTree);
 		const wholeSummaryTreeEntries = convertFullSummaryToWholeSummaryEntries(fullSummaryTree);
-		return this.writeSummaryTreeCore(wholeSummaryTreeEntries, repoManager);
+		const tree = await this.writeSummaryTreeCore(wholeSummaryTreeEntries, repoManager);
+		return tree.tree.sha;
 	}
 
 	private async getShaFromTreeHandleEntry(entry: IWholeSummaryTreeHandleEntry): Promise<string> {
@@ -810,6 +791,7 @@ export class GitWholeSummaryManager {
 		const gitTree: IFullGitTree = await buildFullGitTreeFromGitTree(
 			parentTree,
 			this.repoManager,
+			{},
 			// Parse inner git tree blobs so that we can properly reference blob shas in new summary.
 			true /* parseInnerFullGitTrees */,
 			// We only need shas here, so don't waste resources retrieving blobs that are not included in fullGitTrees.

--- a/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/gitWholeSummaryManager.ts
@@ -419,7 +419,7 @@ export class GitWholeSummaryManager {
 		const fullGitTree = await buildFullGitTreeFromGitTree(
 			rawTree,
 			repoManager,
-			{},
+			{} /* blobCache */,
 			true /* parseInnerFullGitTrees */,
 			true /* retrieveBlobs */,
 		);
@@ -791,7 +791,7 @@ export class GitWholeSummaryManager {
 		const gitTree: IFullGitTree = await buildFullGitTreeFromGitTree(
 			parentTree,
 			this.repoManager,
-			{},
+			{} /* blobCache */,
 			// Parse inner git tree blobs so that we can properly reference blob shas in new summary.
 			true /* parseInnerFullGitTrees */,
 			// We only need shas here, so don't waste resources retrieving blobs that are not included in fullGitTrees.


### PR DESCRIPTION
## Description

We want to pre-compute latest summary after every time that we write a summary in Gitrest. However, reading the latest after writing it is inefficient when we tend to have most, if not all, the necessary information during the write process, so we can compute and send back the latest full summary to Historian without reading it from storage.
