### PR TITLE
[GC-stress] Reduce totalSendCount as tests are timing out.

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -49,7 +49,7 @@
 			"opRatePerMin": 800,
 			"progressIntervalMs": 5000,
 			"numClients": 10,
-			"totalSendCount": 36000,
+			"totalSendCount": 16000,
 			"faultInjectionMs": {
 				"min": 0,
 				"max": 900000
@@ -95,7 +95,7 @@
 			"opRatePerMin": 800,
 			"progressIntervalMs": 5000,
 			"numClients": 10,
-			"totalSendCount": 36000,
+			"totalSendCount": 16000,
 			"faultInjectionMs": {
 				"min": 0,
 				"max": 900000


### PR DESCRIPTION
The recent test runs have timed out. This could be because of the [xaml changes](https://github.com/microsoft/FluidFramework/pull/14519/files
) or increase of [totalSendCount](https://github.com/microsoft/FluidFramework/pull/13744). Reducing the totalSendCount to see if it helps. 