### PR TITLE
[r11s] Updating how we set errorCode in ConnectDocument metric

### DIFF
--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -608,7 +608,7 @@ export function configureWebSocketServices(
 				},
 				(error) => {
 					socket.emit("connect_document_error", error);
-					if (isNetworkError(error)) {
+					if (error?.code !== undefined) {
 						connectMetric.setProperty(CommonProperties.errorCode, error.code);
 					}
 					connectMetric.error(`Connect document failed`, error);


### PR DESCRIPTION
## Description

We recently added an `errorCode` property to `ConnectDocument` metrics (see #13901).
However, that PR did not take into consideration that, sometimes, the ConnectDocument error is a `ThrottlingError`, and not a `NetworkError`. As a result, we were not setting the `errorCode` property appropriately in those cases.

This PR fixes that.

## Breaking Changes

None.

## Validation

Updated throttling limits to verify `errorCode` was appropriately set under `properties in case of throttling:
```json
{
    "durationInMs": 1.2481549999210984,
    "eventName": "ConnectDocument",
    "exception": {
        "message": {
            "message": "Throttling count exceeded by 2.99 at 2023-03-13T23:10:14.226Z",
            "retryAfter": 200,
            "code": 429,
            "type": "ThrottlingError"
        },
        "name": "Error",
        "stack": "..."
    },
    "id": "75d1793e-a18a-4ca0-9399-77b0f3540f64",
    "label": "winston",
    "properties": {
        "tenantId": "fluid",
        "documentId": "ed44061c-7222-45a0-8c28-fdb863075f92",
        "errorCode": 429
    },
    "successful": false,
    "timestamp": "2023-03-13T23:10:54.885Z",
    "type": "Metric"
}
```
