### PR TITLE
Change GC Version semantics to inequality

### DIFF
--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -298,6 +298,7 @@ export class GarbageCollector implements IGarbageCollector {
 			return { gcData: { gcNodes }, usedRoutes };
 		});
 
+		//* Log current GC Version (maybe add to gcConfigs)
 		// Log all the GC options and the state determined by the garbage collector. This is interesting only for the
 		// summarizer client since it is the only one that runs GC. It also helps keep the telemetry less noisy.
 		if (this.isSummarizerClient) {

--- a/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
@@ -118,7 +118,7 @@ export class GCSummaryStateTracker {
 	public doesSummaryStateNeedReset(): boolean {
 		return (
 			this.doesGCStateNeedReset() ||
-			(this.shouldRunGC && this.latestSummaryGCVersion < this.currentGCVersion)
+			(this.shouldRunGC && this.latestSummaryGCVersion !== this.currentGCVersion)
 		);
 	}
 

--- a/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
@@ -118,7 +118,7 @@ export class GCSummaryStateTracker {
 	public doesSummaryStateNeedReset(): boolean {
 		return (
 			this.doesGCStateNeedReset() ||
-			(this.shouldRunGC && this.latestSummaryGCVersion !== this.currentGCVersion)
+			(this.shouldRunGC && this.latestSummaryGCVersion < this.currentGCVersion)
 		);
 	}
 

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -1,0 +1,80 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+	MockLogger,
+	MonitoringContext,
+	mixinMonitoringContext,
+} from "@fluidframework/telemetry-utils";
+import { GCSummaryStateTracker, GCVersion } from "../../gc";
+
+type GCSummaryStateTrackerWithPrivates = Omit<GCSummaryStateTracker, "latestSummaryGCVersion"> & {
+	latestSummaryGCVersion: GCVersion;
+};
+
+describe("Garbage Collection Tests", () => {
+	//* ONLY
+	describe.only("GCSummaryStateTracker", () => {
+		const mockLogger = new MockLogger();
+		const mc: MonitoringContext = mixinMonitoringContext(mockLogger);
+		describe("latestSummaryGCVersion", () => {
+			it("Persisted < Current: Do Need Reset", () => {
+				const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
+					true /* shouldRunGC */,
+					false /* tombstoneMode */,
+					mc,
+					true /* wasGCRunInBaseSnapshot */,
+					0 /* gcVersionInBaseSnapshot */,
+				) as any;
+				assert.equal(tracker.doesGCStateNeedReset(), false, "Precondition 1");
+				assert.equal(tracker.currentGCVersion, 1, "Precondition 2");
+				assert.equal(
+					tracker.doesSummaryStateNeedReset(),
+					true,
+					"Should need reset: Persisted GC Version was old",
+				);
+			});
+
+			it("Persisted === Current: Don't Need Reset", () => {
+				const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
+					true /* shouldRunGC */,
+					false /* tombstoneMode */,
+					mc,
+					true /* wasGCRunInBaseSnapshot */,
+					1 /* gcVersionInBaseSnapshot */,
+				) as any;
+				assert.equal(tracker.doesGCStateNeedReset(), false, "Precondition 1");
+				assert.equal(tracker.currentGCVersion, 1, "Precondition 2");
+				assert.equal(
+					tracker.doesSummaryStateNeedReset(),
+					false,
+					"Shouldn't need reset: GC Versions match",
+				);
+			});
+
+			it("Persisted > Current: Don't Need Reset", () => {
+				// Set value to true for gcVersionUpgradeToV2Key
+				//*				const mc: MonitoringContext = mixinMonitoringContext(mockLogger, { getRawConfig: (name: string) => name === gcVersionUpgradeToV2Key ? true : undefined });
+				const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
+					true /* shouldRunGC */,
+					false /* tombstoneMode */,
+					mc,
+					true /* wasGCRunInBaseSnapshot */,
+					2 /* gcVersionInBaseSnapshot */,
+				) as any;
+				assert.equal(tracker.doesGCStateNeedReset(), false, "Precondition 1");
+				assert.equal(tracker.currentGCVersion, 1, "Precondition 2");
+
+				// This covers the case where we rolled back an upgrade. Containers that successfully "upgraded" (reset) shouldn't need to do it again.
+				assert.equal(
+					tracker.doesSummaryStateNeedReset(),
+					false,
+					"Shouldn't need reset: Persisted GC Version is not old",
+				);
+			});
+		});
+	});
+});

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -16,8 +16,7 @@ type GCSummaryStateTrackerWithPrivates = Omit<GCSummaryStateTracker, "latestSumm
 };
 
 describe("Garbage Collection Tests", () => {
-	//* ONLY
-	describe.only("GCSummaryStateTracker", () => {
+	describe("GCSummaryStateTracker", () => {
 		const mockLogger = new MockLogger();
 		const mc: MonitoringContext = mixinMonitoringContext(mockLogger);
 		describe("latestSummaryGCVersion", () => {
@@ -55,7 +54,7 @@ describe("Garbage Collection Tests", () => {
 				);
 			});
 
-			it("Persisted > Current: Don't Need Reset", () => {
+			it("Persisted > Current: Do Need Reset", () => {
 				// Set value to true for gcVersionUpgradeToV2Key
 				//*				const mc: MonitoringContext = mixinMonitoringContext(mockLogger, { getRawConfig: (name: string) => name === gcVersionUpgradeToV2Key ? true : undefined });
 				const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
@@ -71,8 +70,8 @@ describe("Garbage Collection Tests", () => {
 				// This covers the case where we rolled back an upgrade. Containers that successfully "upgraded" (reset) shouldn't need to do it again.
 				assert.equal(
 					tracker.doesSummaryStateNeedReset(),
-					false,
-					"Shouldn't need reset: Persisted GC Version is not old",
+					true,
+					"Should need reset: Persisted GC Version is not old",
 				);
 			});
 		});


### PR DESCRIPTION
## Description

When deploying a change to the current GC Version, a document may have collaborators with different values - hence the Running Summarizer could jump between these, the "current" GC Version may fluctuate up and down.

In the current code, every time that happens fullTree will be used for GC.  We can avoid this thrashing by switching the semantics to inequality, so fullTree is only used if the persisted value is strictly less than the current value.

