### PR TITLE
[GC-stress] Fix test result not reported

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -343,7 +343,7 @@ jobs:
         inputs:
           testResultsFormat: 'JUnit'
           testResultsFiles: '**/*junit-report.xml'
-          searchFolder: ${{ variables.testPackageDir }}/nyc
+          searchFolder: ${{ variables.testPackageDir }}
           mergeTestResults: false
           failTaskOnFailedTests: true
         condition: succeededOrFailed()

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -70,8 +70,6 @@ stages:
     displayName: Stress tests - tinylicious
     dependsOn: []
     jobs:
-    - job:
-      displayName: Tombstone Mode
     - template: templates/include-test-real-service.yml
       parameters:
         poolBuild: Large
@@ -80,10 +78,10 @@ stages:
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 200
         testCommand: start:t9s:gc:ci:tombstone
+        splitTestVariants: 
+          - name: Tombstone Mode
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-    - job:
-      displayName: Sweep Mode
     - template: templates/include-test-real-service.yml
       parameters:
         poolBuild: Large
@@ -92,5 +90,7 @@ stages:
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 200
         testCommand: start:t9s:gc:ci:sweep
+        splitTestVariants: 
+          - name: Tombstone Mode
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -91,6 +91,6 @@ stages:
         timeoutInMinutes: 200
         testCommand: start:t9s:gc:ci:sweep
         splitTestVariants: 
-          - name: Tombstone Mode
+          - name: Sweep Mode
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject


### PR DESCRIPTION
Fixed couple of issues:
1. Test results were not reported because the results search folder contains "nyc" whereas the results xml was not under "nyc".
2. The test was reporting extra stages because in tinylicious because of - job. Removed it.