### PR TITLE
ci: Add GitHub releases config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - main-next-integrate
+    authors:
+      - dependabot
+      - msfluid-bot
+  categories:
+    - title: 💥 Breaking changes
+      labels:
+        - breaking change
+    - title: Deprecations
+      labels:
+        - deprecation
+    - title: Other changes
+      labels:
+        - "*"


### PR DESCRIPTION
Adds a file to customize the auto-generated changelog in GitHub releases. After this change, any PR tagged "breaking change" will be included in the _breaking changes_ section, and any PR tagged "deprecation" will be in the _deprecations_ section. (Note that we don't use the "deprecation" tag today.)

The auto-generated changelog is not useable as it is, even with these changes. But it provides useful input when writing release notes.