### PR TITLE
v2int 3.3 Port: Improve safety when using and combing app and protocol tree (#14548)

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -114,8 +114,17 @@ export function canBeCoalescedByService(message: ISequencedDocumentMessage | IDo
 // @public
 export const canRetryOnError: (error: any) => boolean;
 
-// @public
-export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolSummary: ISummaryTree): ISummaryTree;
+// @internal
+export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolSummary: ISummaryTree): CombinedAppAndProtocolSummary;
+
+// @internal
+export interface CombinedAppAndProtocolSummary extends ISummaryTree {
+    // (undocumented)
+    tree: {
+        [".app"]: ISummaryTree;
+        [".protocol"]: ISummaryTree;
+    };
+}
 
 // @public @deprecated
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
@@ -239,6 +248,9 @@ export interface IProgress {
     cancel?: AbortSignal;
     onRetry?(delayInMs: number, error: any): void;
 }
+
+// @internal
+export function isCombinedAppAndProtocolSummary(summary: ISummaryTree | undefined): summary is CombinedAppAndProtocolSummary;
 
 // @public (undocumented)
 export const isFluidResolvedUrl: (resolved: IResolvedUrl | undefined) => resolved is IFluidResolvedUrl;

--- a/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
+++ b/packages/drivers/local-driver/src/localDocumentServiceFactory.ts
@@ -20,6 +20,7 @@ import {
 	ensureFluidResolvedUrl,
 	getDocAttributesFromProtocolSummary,
 	getQuorumValuesFromProtocolSummary,
+	isCombinedAppAndProtocolSummary,
 } from "@fluidframework/driver-utils";
 import { ISummaryTree, NackErrorType } from "@fluidframework/protocol-definitions";
 import { defaultHash } from "@fluidframework/server-services-client";
@@ -68,11 +69,11 @@ export class LocalDocumentServiceFactory implements IDocumentServiceFactory {
 		const documentStorage = (this.localDeltaConnectionServer as LocalDeltaConnectionServer)
 			.documentStorage;
 
-		const protocolSummary = createNewSummary.tree[".protocol"] as ISummaryTree;
-		const appSummary = createNewSummary.tree[".app"] as ISummaryTree;
-		if (!(protocolSummary && appSummary)) {
+		if (!isCombinedAppAndProtocolSummary(createNewSummary)) {
 			throw new Error("Protocol and App Summary required in the full summary");
 		}
+		const protocolSummary = createNewSummary.tree[".protocol"];
+		const appSummary = createNewSummary.tree[".app"];
 		const documentAttributes = getDocAttributesFromProtocolSummary(protocolSummary);
 		const quorumValues = getQuorumValuesFromProtocolSummary(protocolSummary);
 		const sequenceNumber = documentAttributes.sequenceNumber;

--- a/packages/drivers/odsp-driver/src/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createNewUtils.ts
@@ -10,7 +10,10 @@ import {
 	SummaryType,
 	ISnapshotTree,
 } from "@fluidframework/protocol-definitions";
-import { getDocAttributesFromProtocolSummary } from "@fluidframework/driver-utils";
+import {
+	getDocAttributesFromProtocolSummary,
+	isCombinedAppAndProtocolSummary,
+} from "@fluidframework/driver-utils";
 import { stringToBuffer, Uint8ArrayToString, unreachableCase } from "@fluidframework/common-utils";
 import { getGitType } from "@fluidframework/protocol-base";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
@@ -96,11 +99,11 @@ function convertCreateNewSummaryTreeToTreeAndBlobsCore(
 }
 
 export function convertSummaryIntoContainerSnapshot(createNewSummary: ISummaryTree) {
-	const appSummary = createNewSummary.tree[".app"] as ISummaryTree;
-	const protocolSummary = createNewSummary.tree[".protocol"] as ISummaryTree;
-	if (!(appSummary && protocolSummary)) {
+	if (!isCombinedAppAndProtocolSummary(createNewSummary)) {
 		throw new Error("App and protocol summary required for create new path!!");
 	}
+	const appSummary = createNewSummary.tree[".app"];
+	const protocolSummary = createNewSummary.tree[".protocol"];
 	const documentAttributes = getDocAttributesFromProtocolSummary(protocolSummary);
 	const attributesSummaryBlob: ISummaryBlob = {
 		type: SummaryType.Blob,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -14,6 +14,7 @@ import { TelemetryLogger, PerformanceEvent } from "@fluidframework/telemetry-uti
 import {
 	getDocAttributesFromProtocolSummary,
 	ensureFluidResolvedUrl,
+	isCombinedAppAndProtocolSummary,
 } from "@fluidframework/driver-utils";
 import {
 	TokenFetchOptions,
@@ -106,10 +107,9 @@ export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory {
 			throw new Error("A new or existing file must be specified to create container!");
 		}
 
-		const protocolSummary = createNewSummary?.tree[".protocol"];
-		if (protocolSummary) {
+		if (isCombinedAppAndProtocolSummary(createNewSummary)) {
 			const documentAttributes = getDocAttributesFromProtocolSummary(
-				protocolSummary as ISummaryTree,
+				createNewSummary.tree[".protocol"],
 			);
 			if (documentAttributes?.sequenceNumber !== 0) {
 				throw new Error("Seq number in detached ODSP container should be 0");

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -14,6 +14,7 @@ import {
 	MonitoringContext,
 	PerformanceEvent,
 } from "@fluidframework/telemetry-utils";
+import { isCombinedAppAndProtocolSummary } from "@fluidframework/driver-utils";
 import {
 	IOdspSummaryPayload,
 	IWriteSummaryResponse,
@@ -78,7 +79,7 @@ export class OdspSummaryUploadManager {
 		referenceSequenceNumber: number,
 		tree: api.ISummaryTree,
 	): Promise<IWriteSummaryResponse> {
-		const containsProtocolTree = Object.keys(tree.tree).includes(".protocol");
+		const containsProtocolTree = isCombinedAppAndProtocolSummary(tree);
 		const { snapshotTree, blobs } = await this.convertSummaryToSnapshotTree(
 			parentHandle,
 			tree,

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -19,6 +19,7 @@ import {
 	ensureFluidResolvedUrl,
 	getDocAttributesFromProtocolSummary,
 	getQuorumValuesFromProtocolSummary,
+	isCombinedAppAndProtocolSummary,
 	RateLimiter,
 } from "@fluidframework/driver-utils";
 import { ChildLogger, PerformanceEvent } from "@fluidframework/telemetry-utils";
@@ -99,11 +100,12 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 		}
 		const [, tenantId] = parsedUrl.pathname.split("/");
 
-		const protocolSummary = createNewSummary.tree[".protocol"] as ISummaryTree;
-		const appSummary = createNewSummary.tree[".app"] as ISummaryTree;
-		if (!(protocolSummary && appSummary)) {
+		if (!isCombinedAppAndProtocolSummary(createNewSummary)) {
 			throw new Error("Protocol and App Summary required in the full summary");
 		}
+		const protocolSummary = createNewSummary.tree[".protocol"];
+		const appSummary = createNewSummary.tree[".app"];
+
 		const documentAttributes = getDocAttributesFromProtocolSummary(protocolSummary);
 		const quorumValues = getQuorumValuesFromProtocolSummary(protocolSummary);
 

--- a/packages/loader/container-loader/src/protocolTreeDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/protocolTreeDocumentStorageService.ts
@@ -5,7 +5,10 @@
 
 import { IDisposable } from "@fluidframework/common-definitions";
 import { IDocumentStorageService, ISummaryContext } from "@fluidframework/driver-definitions";
-import { combineAppAndProtocolSummary } from "@fluidframework/driver-utils";
+import {
+	combineAppAndProtocolSummary,
+	isCombinedAppAndProtocolSummary,
+} from "@fluidframework/driver-utils";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 
 export class ProtocolTreeStorageService implements IDocumentStorageService, IDisposable {
@@ -35,7 +38,9 @@ export class ProtocolTreeStorageService implements IDocumentStorageService, IDis
 		context: ISummaryContext,
 	): Promise<string> {
 		return this.internalStorageService.uploadSummaryWithContext(
-			combineAppAndProtocolSummary(summary, this.generateProtocolTree()),
+			isCombinedAppAndProtocolSummary(summary) === true
+				? summary
+				: combineAppAndProtocolSummary(summary, this.generateProtocolTree()),
 			context,
 		);
 	}

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -13,6 +13,7 @@ import {
 } from "@fluidframework/common-utils";
 import { ISummaryTree, ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { LoggingError } from "@fluidframework/telemetry-utils";
+import { isCombinedAppAndProtocolSummary } from "@fluidframework/driver-utils";
 
 // This is used when we rehydrate a container from the snapshot. Here we put the blob contents
 // in separate property: blobContents.
@@ -126,12 +127,12 @@ export function convertProtocolAndAppSummaryToSnapshotTree(
 // This function converts the snapshot taken in detached container(by serialize api) to snapshotTree with which
 // a detached container can be rehydrated.
 export const getSnapshotTreeFromSerializedContainer = (detachedContainerSnapshot: ISummaryTree) => {
-	const protocolSummaryTree = detachedContainerSnapshot.tree[".protocol"] as ISummaryTree;
-	const appSummaryTree = detachedContainerSnapshot.tree[".app"] as ISummaryTree;
 	assert(
-		protocolSummaryTree !== undefined && appSummaryTree !== undefined,
+		isCombinedAppAndProtocolSummary(detachedContainerSnapshot),
 		0x1e0 /* "Protocol and App summary trees should be present" */,
 	);
+	const protocolSummaryTree = detachedContainerSnapshot.tree[".protocol"];
+	const appSummaryTree = detachedContainerSnapshot.tree[".app"];
 	const snapshotTreeWithBlobContents = convertProtocolAndAppSummaryToSnapshotTree(
 		protocolSummaryTree,
 		appSummaryTree,

--- a/packages/loader/driver-utils/src/index.ts
+++ b/packages/loader/driver-utils/src/index.ts
@@ -55,8 +55,10 @@ export { readAndParse } from "./readAndParse";
 export { IProgress, runWithRetry } from "./runWithRetry";
 export {
 	combineAppAndProtocolSummary,
+	CombinedAppAndProtocolSummary,
 	getDocAttributesFromProtocolSummary,
 	getQuorumValuesFromProtocolSummary,
+	isCombinedAppAndProtocolSummary,
 } from "./summaryForCreateNew";
 export { convertSummaryTreeToSnapshotITree } from "./treeConversions";
 export {

--- a/packages/loader/driver-utils/src/summaryForCreateNew.ts
+++ b/packages/loader/driver-utils/src/summaryForCreateNew.ts
@@ -56,10 +56,13 @@ export function combineAppAndProtocolSummary(
 	appSummary: ISummaryTree,
 	protocolSummary: ISummaryTree,
 ): CombinedAppAndProtocolSummary {
-	assert(!isCombinedAppAndProtocolSummary(appSummary), "app summary is already a combined tree!");
+	assert(
+		!isCombinedAppAndProtocolSummary(appSummary),
+		0x5a8 /* app summary is already a combined tree! */,
+	);
 	assert(
 		!isCombinedAppAndProtocolSummary(protocolSummary),
-		"protocol summary is already a combined tree!",
+		0x5a9 /* protocol summary is already a combined tree! */,
 	);
 	const createNewSummary: CombinedAppAndProtocolSummary = {
 		type: SummaryType.Tree,

--- a/packages/loader/driver-utils/src/summaryForCreateNew.ts
+++ b/packages/loader/driver-utils/src/summaryForCreateNew.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/common-utils";
 import {
 	ISummaryTree,
 	SummaryType,
@@ -12,15 +13,55 @@ import {
 } from "@fluidframework/protocol-definitions";
 
 /**
+ * Defines the current layout of an .app + .protocol summary tree
+ * this is used internally for create new, and single commit summary
+ * @internal
+ */
+export interface CombinedAppAndProtocolSummary extends ISummaryTree {
+	tree: {
+		[".app"]: ISummaryTree;
+		[".protocol"]: ISummaryTree;
+	};
+}
+
+/**
+ * Validates the current layout of an .app + .protocol summary tree
+ * this is used internally for create new, and single commit summary
+ * @internal
+ */
+export function isCombinedAppAndProtocolSummary(
+	summary: ISummaryTree | undefined,
+): summary is CombinedAppAndProtocolSummary {
+	if (
+		summary?.tree === undefined ||
+		summary.tree?.[".app"]?.type !== SummaryType.Tree ||
+		summary.tree?.[".protocol"]?.type !== SummaryType.Tree
+	) {
+		return false;
+	}
+	const treeKeys = Object.keys(summary.tree);
+	if (treeKeys.length !== 2) {
+		return false;
+	}
+	return true;
+}
+
+/**
  * Combine the app summary and protocol summary in 1 tree.
  * @param appSummary - Summary of the app.
  * @param protocolSummary - Summary of the protocol.
+ * @internal
  */
 export function combineAppAndProtocolSummary(
 	appSummary: ISummaryTree,
 	protocolSummary: ISummaryTree,
-): ISummaryTree {
-	const createNewSummary: ISummaryTree = {
+): CombinedAppAndProtocolSummary {
+	assert(!isCombinedAppAndProtocolSummary(appSummary), "app summary is already a combined tree!");
+	assert(
+		!isCombinedAppAndProtocolSummary(protocolSummary),
+		"protocol summary is already a combined tree!",
+	);
+	const createNewSummary: CombinedAppAndProtocolSummary = {
 		type: SummaryType.Tree,
 		tree: {
 			".protocol": protocolSummary,

--- a/packages/loader/driver-utils/src/treeConversions.ts
+++ b/packages/loader/driver-utils/src/treeConversions.ts
@@ -6,6 +6,7 @@
 import { Uint8ArrayToString, unreachableCase } from "@fluidframework/common-utils";
 import { AttachmentTreeEntry, BlobTreeEntry, TreeTreeEntry } from "@fluidframework/protocol-base";
 import { ISummaryTree, ITree, ITreeEntry, SummaryType } from "@fluidframework/protocol-definitions";
+import { isCombinedAppAndProtocolSummary } from "./summaryForCreateNew";
 
 /**
  * Converts ISummaryTree to ITree format.
@@ -13,17 +14,15 @@ import { ISummaryTree, ITree, ITreeEntry, SummaryType } from "@fluidframework/pr
  */
 export function convertSummaryTreeToSnapshotITree(summaryTree: ISummaryTree): ITree {
 	const entries: ITreeEntry[] = [];
-	const protocolSummary = summaryTree.tree[".protocol"] as ISummaryTree;
-	const appSummary = summaryTree.tree[".app"] as ISummaryTree;
-	// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-	const adaptSumaryTree = protocolSummary && appSummary;
-	// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+	const adaptSumaryTree = isCombinedAppAndProtocolSummary(summaryTree);
 	const allSummaryEntries = adaptSumaryTree
-		? [...Object.entries(protocolSummary.tree), ...Object.entries(appSummary.tree)]
+		? [
+				...Object.entries(summaryTree.tree[".protocol"].tree),
+				...Object.entries(summaryTree.tree[".app"].tree),
+		  ]
 		: Object.entries(summaryTree.tree);
 
 	for (const [key, value] of allSummaryEntries) {
-		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 		const k = adaptSumaryTree && ["attributes"].includes(key) ? `.${key}` : key;
 		switch (value.type) {
 			case SummaryType.Blob: {

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1131,5 +1131,7 @@ export const shortCodeMap = {
 	"0x5a4": "Batch should not be empty",
 	"0x5a5": "Expected number of chunks",
 	"0x5a6": "Compression should not have happened if the loader does not support it",
-	"0x5a7": "ContainerRuntime entryPoint was not initialized"
+	"0x5a7": "ContainerRuntime entryPoint was not initialized",
+	"0x5a8": "app summary is already a combined tree!",
+	"0x5a9": "protocol summary is already a combined tree!"
 };

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -287,46 +287,56 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
 		assert.strictEqual(snapshot2.stats.treeNodeCount, 1);
 		assert.strictEqual(snapshot1.summary.tree[0].id, snapshot2.summary.tree[0].id);
 	});
+	for (const summarizeProtocolTree of [undefined, true, false]) {
+		itExpects(
+			`works in detached container. summarizeProtocolTree: ${summarizeProtocolTree}`,
+			ContainerCloseUsageError,
+			async function () {
+				const detachedBlobStorage = new MockDetachedBlobStorage();
+				const loader = provider.makeTestLoader({
+					...testContainerConfig,
+					loaderProps: {
+						detachedBlobStorage,
+						options: { summarizeProtocolTree },
+					},
+				});
+				const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
 
-	itExpects("works in detached container", ContainerCloseUsageError, async function () {
-		const detachedBlobStorage = new MockDetachedBlobStorage();
-		const loader = provider.makeTestLoader({
-			...testContainerConfig,
-			loaderProps: { detachedBlobStorage },
-		});
-		const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
+				const text = "this is some example text";
+				const dataStore = await requestFluidObject<ITestDataObject>(container, "default");
+				const blobHandle = await dataStore._runtime.uploadBlob(
+					stringToBuffer(text, "utf-8"),
+				);
+				assert.strictEqual(bufferToString(await blobHandle.get(), "utf-8"), text);
 
-		const text = "this is some example text";
-		const dataStore = await requestFluidObject<ITestDataObject>(container, "default");
-		const blobHandle = await dataStore._runtime.uploadBlob(stringToBuffer(text, "utf-8"));
-		assert.strictEqual(bufferToString(await blobHandle.get(), "utf-8"), text);
+				dataStore._root.set("my blob", blobHandle);
+				assert.strictEqual(
+					bufferToString(await dataStore._root.get("my blob").get(), "utf-8"),
+					text,
+				);
 
-		dataStore._root.set("my blob", blobHandle);
-		assert.strictEqual(
-			bufferToString(await dataStore._root.get("my blob").get(), "utf-8"),
-			text,
+				const attachP = container.attach(
+					provider.driver.createCreateNewRequest(provider.documentId),
+				);
+				if (provider.driver.type !== "odsp") {
+					// this flow is currently only supported on ODSP, the others should explicitly reject on attach
+					return assert.rejects(attachP, (err) => err.message === usageErrorMessage);
+				}
+				await attachP;
+
+				// make sure we're getting the blob from actual storage
+				detachedBlobStorage.blobs.clear();
+
+				// old handle still works
+				assert.strictEqual(bufferToString(await blobHandle.get(), "utf-8"), text);
+				// new handle works
+				assert.strictEqual(
+					bufferToString(await dataStore._root.get("my blob").get(), "utf-8"),
+					text,
+				);
+			},
 		);
-
-		const attachP = container.attach(
-			provider.driver.createCreateNewRequest(provider.documentId),
-		);
-		if (provider.driver.type !== "odsp") {
-			// this flow is currently only supported on ODSP, the others should explicitly reject on attach
-			return assert.rejects(attachP, (err) => err.message === usageErrorMessage);
-		}
-		await attachP;
-
-		// make sure we're getting the blob from actual storage
-		detachedBlobStorage.blobs.clear();
-
-		// old handle still works
-		assert.strictEqual(bufferToString(await blobHandle.get(), "utf-8"), text);
-		// new handle works
-		assert.strictEqual(
-			bufferToString(await dataStore._root.get("my blob").get(), "utf-8"),
-			text,
-		);
-	});
+	}
 
 	it("serialize/rehydrate container with blobs", async function () {
 		const loader = provider.makeTestLoader({

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -80,14 +80,6 @@ function buildSummaryTree(attr, quorumVal, summarizer): ISummaryTree {
 	return {
 		type: SummaryType.Tree,
 		tree: {
-			".metadata": {
-				type: 2,
-				content: "{}",
-			},
-			".electedSummarizer": {
-				type: 2,
-				content: JSON.stringify(summarizer),
-			},
 			".protocol": {
 				type: 1,
 				tree: {
@@ -115,6 +107,14 @@ function buildSummaryTree(attr, quorumVal, summarizer): ISummaryTree {
 					[".channels"]: {
 						type: SummaryType.Tree,
 						tree: {},
+					},
+					".metadata": {
+						type: 2,
+						content: "{}",
+					},
+					".electedSummarizer": {
+						type: 2,
+						content: JSON.stringify(summarizer),
 					},
 				},
 			},


### PR DESCRIPTION
## Description
There is a bug in the code when a detached container with blobs is uploaded with the single commit summary flow. The bug results from combineAppAndProtocolSummary being called twice on the same summary. This change fixes that issue by improving typing and defensiveness when using and combing app and protocol trees, such that double wrapping can be detected, and thrown as an error. The fix for the specific issue is in
`packages\loader\container-loader\src\protocolTreeDocumentStorageService.ts`. Additionally, i've updated a number of usage of the combined tree to remove unsafe casting.

Validated the issue via test modifications, which now pass with fixes. 
Fixes [AB#3711](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3711)
Related [AB#3717](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3717)