### PR TITLE
improvement(client-debugger-chrome-extension): Add `useMessageRelay` helper hook to simplify context consumption

### DIFF
--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/ContainerSummaryView.tsx
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/ContainerSummaryView.tsx
@@ -16,7 +16,7 @@ import { _ContainerSummaryView } from "@fluid-tools/client-debugger-view";
 
 import { extensionMessageSource } from "../messaging";
 import { Waiting } from "./Waiting";
-import { MessageRelayContext } from "./MessageRelayContext";
+import { useMessageRelay } from "./MessageRelayContext";
 
 const loggingContext = "EXTENSION(ContainerSummaryView)";
 
@@ -33,16 +33,11 @@ interface ContainerStateViewProps extends HasContainerId {}
 export function ContainerSummaryView(props: ContainerStateViewProps): React.ReactElement {
 	const { containerId } = props;
 
+	const messageRelay = useMessageRelay();
+
 	const [containerState, setContainerState] = React.useState<
 		ContainerStateMetadata | undefined
 	>();
-
-	const messageRelay = React.useContext(MessageRelayContext);
-	if (messageRelay === undefined) {
-		throw new Error(
-			"MessageRelayContext was not defined. Parent component is responsible for ensuring this has been constructed.",
-		);
-	}
 
 	React.useEffect(() => {
 		/**

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/DebuggerPanel.tsx
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/DebuggerPanel.tsx
@@ -19,7 +19,7 @@ import { ContainerSelectionDropdown } from "@fluid-tools/client-debugger-view";
 import { extensionMessageSource } from "../messaging";
 import { ContainerView } from "./ContainerView";
 import { Waiting } from "./Waiting";
-import { MessageRelayContext } from "./MessageRelayContext";
+import { useMessageRelay } from "./MessageRelayContext";
 
 const loggingContext = "EXTENSION(DebuggerPanel)";
 
@@ -40,12 +40,7 @@ const getContainerListMessage: IDebuggerMessage = {
 export function DebuggerPanel(): React.ReactElement {
 	const [containers, setContainers] = React.useState<ContainerMetadata[] | undefined>();
 
-	const messageRelay = React.useContext(MessageRelayContext);
-	if (messageRelay === undefined) {
-		throw new Error(
-			"MessageRelayContext was not defined. Parent component is responsible for ensuring this has been constructed.",
-		);
-	}
+	const messageRelay = useMessageRelay();
 
 	const refreshButtonTooltipId = useId("refresh-button-tooltip");
 

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/MessageRelayContext.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/MessageRelayContext.ts
@@ -21,3 +21,18 @@ export const MessageRelayContext = React.createContext<IMessageRelay | undefined
 	// eslint-disable-next-line unicorn/no-useless-undefined
 	undefined,
 );
+
+/**
+ * Gets the {@link IMessageRelay} from the local {@link MessageRelayContext}.
+ *
+ * @throws If {@link MessageRelayContext} has not been set.
+ */
+export function useMessageRelay(): IMessageRelay {
+	const messageRelay = React.useContext(MessageRelayContext);
+	if (messageRelay === undefined) {
+		throw new Error(
+			"MessageRelayContext was not defined. Parent component is responsible for ensuring this has been constructed.",
+		);
+	}
+	return messageRelay;
+}

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/TelemetryView.tsx
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/TelemetryView.tsx
@@ -13,7 +13,7 @@ import {
 } from "@fluid-tools/client-debugger";
 import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
 import { _TelemetryView } from "@fluid-tools/client-debugger-view";
-import { MessageRelayContext } from "./MessageRelayContext";
+import { useMessageRelay } from "./MessageRelayContext";
 
 const loggingContext = "EXTENSION(DebuggerPanel:Telemetry)";
 
@@ -23,12 +23,7 @@ const loggingContext = "EXTENSION(DebuggerPanel:Telemetry)";
  * @remarks Must be run under a {@link MessageRelayContext}.
  */
 export function TelemetryView(): React.ReactElement {
-	const messageRelay = React.useContext(MessageRelayContext);
-	if (messageRelay === undefined) {
-		throw new Error(
-			"MessageRelayContext was not defined. Parent component is responsible for ensuring this has been constructed.",
-		);
-	}
+	const messageRelay = useMessageRelay();
 
 	const [telemetryEvents, setTelemetryEvents] = React.useState<ITelemetryBaseEvent[]>([]);
 


### PR DESCRIPTION
Encapsulates the error case checking into the helper function such that each component doesn't have to make the `=== undefined` check.