### PR TITLE
tree: rename checkout to branch in API

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -101,6 +101,11 @@ type AsNames<T extends (unknown | Named<TName>)[], TName = string> = Assume<T ex
 type Assume<TInput, TAssumeToBe> = TInput extends TAssumeToBe ? TInput : TAssumeToBe;
 
 // @alpha
+export interface BranchEvents {
+    afterBatch(): void;
+}
+
+// @alpha
 export type Brand<ValueType, Name extends string> = ValueType & BrandedType<ValueType, Name>;
 
 // @alpha
@@ -177,11 +182,6 @@ export interface ChangeRebaser<TChangeset> {
 
 // @alpha
 export type ChangesetLocalId = Brand<number, "ChangesetLocalId">;
-
-// @alpha
-export interface CheckoutEvents {
-    afterBatch(): void;
-}
 
 // @alpha
 export type ChildCollection = FieldKey | RootField;
@@ -734,16 +734,16 @@ export type IsEvent<Event> = Event extends (...args: any[]) => any ? true : fals
 export function isGlobalFieldKey(key: FieldKey): key is GlobalFieldKeySymbol;
 
 // @alpha
-export interface ISharedTree extends ISharedObject, ISharedTreeCheckout {
+export interface ISharedTree extends ISharedObject, ISharedTreeBranch {
 }
 
 // @alpha
-export interface ISharedTreeCheckout extends AnchorLocator {
+export interface ISharedTreeBranch extends AnchorLocator {
     readonly context: EditableTreeContext;
     readonly editor: IDefaultEditBuilder;
-    readonly events: ISubscribable<CheckoutEvents>;
+    readonly events: ISubscribable<BranchEvents>;
     readonly forest: IForestSubscription;
-    fork(): ISharedTreeCheckoutFork;
+    fork(): ISharedTreeFork;
     get root(): UnwrappedEditableField;
     set root(data: ContextuallyTypedNodeData | undefined);
     readonly storedSchema: StoredSchemaRepository;
@@ -756,7 +756,7 @@ export interface ISharedTreeCheckout extends AnchorLocator {
 }
 
 // @alpha
-export interface ISharedTreeCheckoutFork extends ISharedTreeCheckout {
+export interface ISharedTreeFork extends ISharedTreeBranch {
     isMerged(): boolean;
     merge(): void;
     pull(): void;
@@ -1266,7 +1266,7 @@ export const rootFieldKey: GlobalFieldKey;
 export const rootFieldKeySymbol: GlobalFieldKeySymbol;
 
 // @alpha
-export function runSynchronous(checkout: ISharedTreeCheckout, transaction: (checkout: ISharedTreeCheckout) => TransactionResult | void): TransactionResult;
+export function runSynchronous(branch: ISharedTreeBranch, transaction: (branch: ISharedTreeBranch) => TransactionResult | void): TransactionResult;
 
 declare namespace SchemaAware {
     export {

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -239,11 +239,11 @@ export const FieldKinds = {
 
 export {
 	ISharedTree,
-	ISharedTreeCheckout,
-	ISharedTreeCheckoutFork,
+	ISharedTreeBranch,
+	ISharedTreeFork,
 	runSynchronous,
 	SharedTreeFactory,
-	CheckoutEvents,
+	BranchEvents,
 } from "./shared-tree";
 
 export { StableId, UuidString } from "./id-compressor";

--- a/packages/dds/tree/src/shared-tree/index.ts
+++ b/packages/dds/tree/src/shared-tree/index.ts
@@ -5,9 +5,9 @@
 
 export {
 	ISharedTree,
-	ISharedTreeCheckout,
-	ISharedTreeCheckoutFork,
+	ISharedTreeBranch,
+	ISharedTreeFork,
 	runSynchronous,
 	SharedTreeFactory,
-	CheckoutEvents,
+	BranchEvents,
 } from "./sharedTree";

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -45,12 +45,12 @@ import { IEmitter, ISubscribable, createEmitter } from "../events";
 import { TransactionResult } from "../util";
 
 /**
- * Events for {@link ISharedTreeCheckout}.
+ * Events for {@link ISharedTreeBranch}.
  * @alpha
  */
-export interface CheckoutEvents {
+export interface BranchEvents {
 	/**
-	 * A batch of changes has finished processing and the checkout is in a consistent state.
+	 * A batch of changes has finished processing and the branch is in a consistent state.
 	 * It is once again safe to access the EditableTree, Forest and AnchorSet.
 	 *
 	 * @remarks
@@ -64,7 +64,7 @@ export interface CheckoutEvents {
  * This includes reading data from the tree and running transactions to mutate the tree.
  * @alpha
  */
-export interface ISharedTreeCheckout extends AnchorLocator {
+export interface ISharedTreeBranch extends AnchorLocator {
 	/**
 	 * Gets or sets the root field of the tree.
 	 *
@@ -83,7 +83,7 @@ export interface ISharedTreeCheckout extends AnchorLocator {
 	set root(data: ContextuallyTypedNodeData | undefined);
 
 	/**
-	 * Context for controlling the EditableTree nodes produced from {@link ISharedTreeCheckout.root}.
+	 * Context for controlling the EditableTree nodes produced from {@link ISharedTreeBranch.root}.
 	 *
 	 * TODO: Exposing access to this should be unneeded once editing APIs are finished.
 	 */
@@ -127,7 +127,7 @@ export interface ISharedTreeCheckout extends AnchorLocator {
 	 * Transactions may nest, meaning that a transaction may be started while a transaction is already ongoing.
 	 *
 	 * To avoid updating observers of the branch state with intermediate results during a transaction,
-	 * use {@link ISharedTreeCheckout#fork} and {@link ISharedTreeCheckoutFork#merge}.
+	 * use {@link ISharedTreeBranch#fork} and {@link ISharedTreeFork#merge}.
 	 */
 	readonly transaction: {
 		/**
@@ -146,44 +146,44 @@ export interface ISharedTreeCheckout extends AnchorLocator {
 		 */
 		abort(): TransactionResult.Abort;
 		/**
-		 * True if there is at least one transaction currently in progress on this checkout, otherwise false.
+		 * True if there is at least one transaction currently in progress on this branch, otherwise false.
 		 */
 		inProgress(): boolean;
 	};
 
 	/**
-	 * Spawn a new checkout which is based off of the current state of this checkout.
-	 * Any mutations of the new checkout will not apply to this checkout until the new checkout is merged back in.
+	 * Spawn a new branch which is based off of the current state of this branch.
+	 * Any mutations of the new branch will not apply to this branch until the new branch is merged back in.
 	 */
-	fork(): ISharedTreeCheckoutFork;
+	fork(): ISharedTreeFork;
 
 	/**
-	 * Events about this checkout.
+	 * Events about this branch.
 	 */
-	readonly events: ISubscribable<CheckoutEvents>;
+	readonly events: ISubscribable<BranchEvents>;
 }
 
 /**
- * An `ISharedTreeCheckout` which has been forked from a pre-existing checkout.
+ * An `ISharedTreeBranch` which has been forked from a pre-existing branch.
  * @alpha
  */
-export interface ISharedTreeCheckoutFork extends ISharedTreeCheckout {
+export interface ISharedTreeFork extends ISharedTreeBranch {
 	/**
-	 * Rebase the changes that have been applied to this checkout over all the changes in the base checkout that have
-	 * occurred since this checkout last pulled (or was forked).
+	 * Rebase the changes that have been applied to this branch over all the changes in the base branch that have
+	 * occurred since this branch last pulled (or was forked).
 	 */
 	pull(): void;
 
 	/**
-	 * Apply all the changes on this checkout to the base checkout from which it was forked.
-	 * If the base checkout has new changes since this checkout last pulled (or was forked),
-	 * then this checkout's changes will be rebased over those first.
-	 * After the merge completes, this checkout may no longer be forked or mutated.
+	 * Apply all the changes on this branch to the base branch from which it was forked.
+	 * If the base branch has new changes since this branch last pulled (or was forked),
+	 * then this branch's changes will be rebased over those first.
+	 * After the merge completes, this branch may no longer be forked or mutated.
 	 */
 	merge(): void;
 
 	/**
-	 * Whether or not this checkout has been merged into its base checkout via `merge()`.
+	 * Whether or not this branch has been merged into its base branch via `merge()`.
 	 * If it has, then it may no longer be forked or mutated.
 	 */
 	isMerged(): boolean;
@@ -196,7 +196,7 @@ export interface ISharedTreeCheckoutFork extends ISharedTreeCheckout {
  * See [the README](../../README.md) for details.
  * @alpha
  */
-export interface ISharedTree extends ISharedObject, ISharedTreeCheckout {}
+export interface ISharedTree extends ISharedObject, ISharedTreeBranch {}
 
 /**
  * Shared tree, configured with a good set of indexes and field kinds which will maintain compatibility over time.
@@ -215,9 +215,9 @@ class SharedTree
 	public readonly context: EditableTreeContext;
 	public readonly forest: IEditableForest;
 	public readonly storedSchema: SchemaEditor<InMemoryStoredSchemaRepository>;
-	public readonly transaction: ISharedTreeCheckout["transaction"];
+	public readonly transaction: ISharedTreeBranch["transaction"];
 
-	public readonly events: ISubscribable<CheckoutEvents> & IEmitter<CheckoutEvents>;
+	public readonly events: ISubscribable<BranchEvents> & IEmitter<BranchEvents>;
 
 	public constructor(
 		id: string,
@@ -246,7 +246,7 @@ class SharedTree
 			telemetryContextPrefix,
 		);
 
-		this.events = createEmitter<CheckoutEvents>();
+		this.events = createEmitter<BranchEvents>();
 		this.forest = forest;
 		this.storedSchema = new SchemaEditor(schema, (op) => this.submitLocalMessage(op));
 
@@ -272,9 +272,9 @@ class SharedTree
 		this.context.unwrappedRoot = data;
 	}
 
-	public fork(): ISharedTreeCheckoutFork {
+	public fork(): ISharedTreeFork {
 		const anchors = new AnchorSet();
-		return new SharedTreeCheckout(
+		return new SharedTreeFork(
 			this.createBranch(anchors),
 			defaultChangeFamily,
 			this.storedSchema.inner.clone(),
@@ -333,8 +333,8 @@ export class SharedTreeFactory implements IChannelFactory {
 	}
 }
 
-class SharedTreeCheckout implements ISharedTreeCheckoutFork {
-	public readonly events = createEmitter<CheckoutEvents>();
+class SharedTreeFork implements ISharedTreeFork {
+	public readonly events = createEmitter<BranchEvents>();
 	public readonly context: EditableTreeContext;
 
 	public constructor(
@@ -355,7 +355,7 @@ class SharedTreeCheckout implements ISharedTreeCheckoutFork {
 		return this.branch.editor;
 	}
 
-	public readonly transaction: ISharedTreeCheckout["transaction"] = {
+	public readonly transaction: ISharedTreeBranch["transaction"] = {
 		start: () => this.branch.startTransaction(new ForestRepairDataStore(() => this.forest)),
 		commit: () => this.branch.commitTransaction(),
 		abort: () => this.branch.abortTransaction(),
@@ -370,10 +370,10 @@ class SharedTreeCheckout implements ISharedTreeCheckoutFork {
 		this.branch.pull();
 	}
 
-	public fork(): ISharedTreeCheckoutFork {
+	public fork(): ISharedTreeFork {
 		const storedSchema = this.storedSchema.clone();
 		const anchors = new AnchorSet();
-		return new SharedTreeCheckout(
+		return new SharedTreeFork(
 			this.branch.fork(anchors),
 			this.changeFamily,
 			storedSchema,
@@ -399,21 +399,21 @@ class SharedTreeCheckout implements ISharedTreeCheckoutFork {
 }
 
 /**
- * Run a synchronous transaction on the given shared tree checkout.
- * This is a convenience helper around the {@link SharedTreeCheckout#transaction} APIs.
- * @param checkout - the checkout on which to run the transaction
- * @param transaction - the transaction function. This will be executed immediately. It is passed `checkout` as an argument for convenience.
+ * Run a synchronous transaction on the given shared tree branch.
+ * This is a convenience helper around the {@link SharedTreeFork#transaction} APIs.
+ * @param branch - the branch on which to run the transaction
+ * @param transaction - the transaction function. This will be executed immediately. It is passed `branch` as an argument for convenience.
  * If this function returns an `Abort` result then the transaction will be aborted. Otherwise, it will be committed.
  * @returns whether or not the transaction was committed or aborted
  * @alpha
  */
 export function runSynchronous(
-	checkout: ISharedTreeCheckout,
-	transaction: (checkout: ISharedTreeCheckout) => TransactionResult | void,
+	branch: ISharedTreeBranch,
+	transaction: (branch: ISharedTreeBranch) => TransactionResult | void,
 ): TransactionResult {
-	checkout.transaction.start();
-	const result = transaction(checkout);
+	branch.transaction.start();
+	const result = transaction(branch);
 	return result === TransactionResult.Abort
-		? checkout.transaction.abort()
-		: checkout.transaction.commit();
+		? branch.transaction.abort()
+		: branch.transaction.commit();
 }

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -2083,8 +2083,8 @@ const testValueSchema = namedTreeSchema({
  * Inserts a single node under the root of the tree with the given value.
  * Use {@link peekTestValue} to read the value.
  */
-function pushTestValue(checkout: ISharedTreeBranch, value: TreeValue): void {
-	insert(checkout, 0, value);
+function pushTestValue(branch: ISharedTreeBranch, value: TreeValue): void {
+	insert(branch, 0, value);
 }
 
 /**


### PR DESCRIPTION
## Description

Alings the shared tree API with the names used in shared tree core, which are the new "branch" related names.

## Breaking Changes

This is all breaking API renames, but in an internal package.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
