### PR TITLE
v2int 2.4 Port: Improve safety when using and combing app and protocol tree (#14548)

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -113,8 +113,17 @@ export function canBeCoalescedByService(message: ISequencedDocumentMessage | IDo
 // @public
 export const canRetryOnError: (error: any) => boolean;
 
-// @public
-export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolSummary: ISummaryTree): ISummaryTree;
+// @internal
+export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolSummary: ISummaryTree): CombinedAppAndProtocolSummary;
+
+// @internal
+export interface CombinedAppAndProtocolSummary extends ISummaryTree {
+    // (undocumented)
+    tree: {
+        [".app"]: ISummaryTree;
+        [".protocol"]: ISummaryTree;
+    };
+}
 
 // @public
 export function configurableUrlResolver(resolversList: IUrlResolver[], request: IRequest): Promise<IResolvedUrl | undefined>;
@@ -238,6 +247,9 @@ export interface IProgress {
     cancel?: AbortSignal;
     onRetry?(delayInMs: number, error: any): void;
 }
+
+// @internal
+export function isCombinedAppAndProtocolSummary(summary: ISummaryTree | undefined): summary is CombinedAppAndProtocolSummary;
 
 // @public (undocumented)
 export const isFluidResolvedUrl: (resolved: IResolvedUrl | undefined) => resolved is IFluidResolvedUrl;

--- a/packages/loader/driver-utils/src/index.ts
+++ b/packages/loader/driver-utils/src/index.ts
@@ -55,8 +55,10 @@ export { readAndParse } from "./readAndParse";
 export { IProgress, runWithRetry } from "./runWithRetry";
 export {
 	combineAppAndProtocolSummary,
+	CombinedAppAndProtocolSummary,
 	getDocAttributesFromProtocolSummary,
 	getQuorumValuesFromProtocolSummary,
+	isCombinedAppAndProtocolSummary,
 } from "./summaryForCreateNew";
 export { convertSummaryTreeToSnapshotITree } from "./treeConversions";
 export { convertSnapshotAndBlobsToSummaryTree, ISummaryTreeAssemblerProps, SummaryTreeAssembler } from "./treeUtils";

--- a/packages/loader/driver-utils/src/summaryForCreateNew.ts
+++ b/packages/loader/driver-utils/src/summaryForCreateNew.ts
@@ -56,10 +56,13 @@ export function combineAppAndProtocolSummary(
 	appSummary: ISummaryTree,
 	protocolSummary: ISummaryTree,
 ): CombinedAppAndProtocolSummary {
-	assert(!isCombinedAppAndProtocolSummary(appSummary), "app summary is already a combined tree!");
+	assert(
+		!isCombinedAppAndProtocolSummary(appSummary),
+		0x5a8 /* app summary is already a combined tree! */,
+	);
 	assert(
 		!isCombinedAppAndProtocolSummary(protocolSummary),
-		"protocol summary is already a combined tree!",
+		0x5a9 /* protocol summary is already a combined tree! */,
 	);
 	const createNewSummary: CombinedAppAndProtocolSummary = {
 		type: SummaryType.Tree,

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1080,5 +1080,7 @@ export const shortCodeMap = {
     "0x549": "Child effects should have size",
     "0x54a": "Should define count when splitting a mark",
     "0x54b": "Inconsistent merge info",
-    "0x54c": "Container already disposed"
+    "0x54c": "Container already disposed",
+		"0x5a8": "app summary is already a combined tree!",
+		"0x5a9": "protocol summary is already a combined tree!"
 };

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -239,36 +239,38 @@ describeNoCompat("blobs", (getTestObjectProvider) => {
         assert.strictEqual(snapshot2.stats.treeNodeCount, 1);
         assert.strictEqual(snapshot1.summary.tree[0].id, snapshot2.summary.tree[0].id);
     });
+    
+	for (const summarizeProtocolTree of [undefined, true, false]) {
+        itExpects(`works in detached container. summarizeProtocolTree: ${summarizeProtocolTree}`, ContainerCloseUsageError, async function() {
+            const detachedBlobStorage = new MockDetachedBlobStorage();
+            const loader = provider.makeTestLoader({ ...testContainerConfig, loaderProps: { detachedBlobStorage } });
+            const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
 
-    itExpects("works in detached container", ContainerCloseUsageError, async function() {
-        const detachedBlobStorage = new MockDetachedBlobStorage();
-        const loader = provider.makeTestLoader({ ...testContainerConfig, loaderProps: { detachedBlobStorage } });
-        const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
+            const text = "this is some example text";
+            const dataStore = await requestFluidObject<ITestDataObject>(container, "default");
+            const blobHandle = await dataStore._runtime.uploadBlob(stringToBuffer(text, "utf-8"));
+            assert.strictEqual(bufferToString(await blobHandle.get(), "utf-8"), text);
 
-        const text = "this is some example text";
-        const dataStore = await requestFluidObject<ITestDataObject>(container, "default");
-        const blobHandle = await dataStore._runtime.uploadBlob(stringToBuffer(text, "utf-8"));
-        assert.strictEqual(bufferToString(await blobHandle.get(), "utf-8"), text);
+            dataStore._root.set("my blob", blobHandle);
+            assert.strictEqual(bufferToString(await (dataStore._root.get("my blob")).get(), "utf-8"), text);
 
-        dataStore._root.set("my blob", blobHandle);
-        assert.strictEqual(bufferToString(await (dataStore._root.get("my blob")).get(), "utf-8"), text);
+            const attachP = container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+            if (provider.driver.type !== "odsp") {
+                // this flow is currently only supported on ODSP, the others should explicitly reject on attach
+                return assert.rejects(attachP,
+                    (err) => err.message === usageErrorMessage);
+            }
+            await attachP;
 
-        const attachP = container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-        if (provider.driver.type !== "odsp") {
-            // this flow is currently only supported on ODSP, the others should explicitly reject on attach
-            return assert.rejects(attachP,
-                (err) => err.message === usageErrorMessage);
-        }
-        await attachP;
+            // make sure we're getting the blob from actual storage
+            detachedBlobStorage.blobs.clear();
 
-        // make sure we're getting the blob from actual storage
-        detachedBlobStorage.blobs.clear();
-
-        // old handle still works
-        assert.strictEqual(bufferToString(await blobHandle.get(), "utf-8"), text);
-        // new handle works
-        assert.strictEqual(bufferToString(await (dataStore._root.get("my blob")).get(), "utf-8"), text);
-    });
+            // old handle still works
+            assert.strictEqual(bufferToString(await blobHandle.get(), "utf-8"), text);
+            // new handle works
+            assert.strictEqual(bufferToString(await (dataStore._root.get("my blob")).get(), "utf-8"), text);
+        });
+    }
 
     it("serialize/rehydrate container with blobs", async function() {
         const loader = provider.makeTestLoader(

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -69,49 +69,49 @@ const baseSummarizer = {
 };
 
 function buildSummaryTree(attr, quorumVal, summarizer): ISummaryTree {
-    return {
-        type: SummaryType.Tree,
-        tree: {
-            ".metadata": {
-                type: 2,
-                content: "{}",
-            },
-            ".electedSummarizer": {
-                type: 2,
-                content: JSON.stringify(summarizer),
-            },
-            ".protocol": {
-                type: 1,
-                tree: {
-                    quorumMembers: {
-                        type: SummaryType.Blob,
-                        content: "[]",
-                    },
-                    quorumProposals: {
-                        type: SummaryType.Blob,
-                        content: "[]",
-                    },
-                    quorumValues: {
-                        type: SummaryType.Blob,
-                        content: JSON.stringify(quorumVal),
-                    },
-                    attributes: {
-                        type: SummaryType.Blob,
-                        content: JSON.stringify(attr),
-                    },
-                },
-            },
-            ".app": {
-                type: 1,
-                tree: {
-                    [".channels"]: {
-                        type: SummaryType.Tree,
-                        tree: {},
-                    },
-                },
-            },
-        },
-    };
+	return {
+		type: SummaryType.Tree,
+		tree: {
+			".protocol": {
+				type: 1,
+				tree: {
+					quorumMembers: {
+						type: SummaryType.Blob,
+						content: "[]",
+					},
+					quorumProposals: {
+						type: SummaryType.Blob,
+						content: "[]",
+					},
+					quorumValues: {
+						type: SummaryType.Blob,
+						content: JSON.stringify(quorumVal),
+					},
+					attributes: {
+						type: SummaryType.Blob,
+						content: JSON.stringify(attr),
+					},
+				},
+			},
+			".app": {
+				type: 1,
+				tree: {
+					[".channels"]: {
+						type: SummaryType.Tree,
+						tree: {},
+					},
+					".metadata": {
+						type: 2,
+						content: "{}",
+					},
+					".electedSummarizer": {
+						type: 2,
+						content: JSON.stringify(summarizer),
+					},
+				},
+			},
+		},
+	};
 }
 
 describeFullCompat(`Dehydrate Rehydrate Container Test`, (getTestObjectProvider) => {


### PR DESCRIPTION
# Description
There is a bug in the code when a detached container with blobs is uploaded with the single commit summary flow. The bug results from combineAppAndProtocolSummary being called twice on the same summary. This change fixes that issue by improving typing and defensiveness when using and combing app and protocol trees, such that double wrapping can be detected, and thrown as an error. The fix for the specific issue is in
packages\loader\container-loader\src\protocolTreeDocumentStorageService.ts. Additionally, i've updated a number of usage of the combined tree to remove unsafe casting.

Validated the issue via test modifications, which now pass with fixes.
Fixes [AB#3711](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3711)
Related [AB#3717](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3717)