### PR TITLE
Tag Asserts for Ports of Improve safety when using and combing app and protocol tree 

### DIFF
--- a/packages/loader/driver-utils/src/summaryForCreateNew.ts
+++ b/packages/loader/driver-utils/src/summaryForCreateNew.ts
@@ -56,10 +56,13 @@ export function combineAppAndProtocolSummary(
 	appSummary: ISummaryTree,
 	protocolSummary: ISummaryTree,
 ): CombinedAppAndProtocolSummary {
-	assert(!isCombinedAppAndProtocolSummary(appSummary), "app summary is already a combined tree!");
+	assert(
+		!isCombinedAppAndProtocolSummary(appSummary),
+		0x5a8 /* app summary is already a combined tree! */,
+	);
 	assert(
 		!isCombinedAppAndProtocolSummary(protocolSummary),
-		"protocol summary is already a combined tree!",
+		0x5a9 /* protocol summary is already a combined tree! */,
 	);
 	const createNewSummary: CombinedAppAndProtocolSummary = {
 		type: SummaryType.Tree,

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1131,5 +1131,7 @@ export const shortCodeMap = {
 	"0x5a4": "Batch should not be empty",
 	"0x5a5": "Expected number of chunks",
 	"0x5a6": "Compression should not have happened if the loader does not support it",
-	"0x5a7": "ContainerRuntime entryPoint was not initialized"
+	"0x5a7": "ContainerRuntime entryPoint was not initialized",
+	"0x5a8": "app summary is already a combined tree!",
+	"0x5a9": "protocol summary is already a combined tree!"
 };


### PR DESCRIPTION
Tag newly added asserts so assert short codes match across versions.

Original PR: #14548
Ports:
 - #14567
 - #14560

related [AB#3717](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3717)