### PR TITLE
resolve the installation dependencies error

### DIFF
--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -78,16 +78,6 @@ jobs:
       inputs:
         version: 14.x
 
-    - task: Cache@2
-      displayName: Cache pnpm store
-      inputs:
-        # Caches are already scoped to individual pipelines, so no need to include the release group name or tag
-        # in the cache key
-        key: 'pnpm-store | "$(Agent.OS)" | ${{ parameters.buildDirectory }}/pnpm-lock.yaml'
-        path: ${{ variables.pnpmStorePath }}
-        restoreKeys: |
-          pnpm-store | "$(Agent.OS)"
-
     - task: Bash@3
       displayName: Install and configure pnpm
       inputs:
@@ -189,12 +179,3 @@ jobs:
           searchFolder: ${{ parameters.buildDirectory }}/nyc
           mergeTestResults: false
         condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
-
-    # Prune the pnpm store before it's cached. This removes any deps that are not used by the current build.
-    - task: Bash@3
-      displayName: Prune pnpm store
-      inputs:
-        targetType: 'inline'
-        workingDirectory: ${{ parameters.buildDirectory }}
-        script: |
-          pnpm store prune


### PR DESCRIPTION
Currently the Test Stability pipeline has encountered a failure during the `Install Dependencies` step on both the main and next branches. The issue can be resolved by temporarily disabling the cache pnpm store (the [result](https://dev.azure.com/fluidframework/internal/_build/results?buildId=139828&view=results) on my own test branch). Considering the cache is intended to save time but the Test Stability pipeline is scheduled to run only on weekends. It is feasible to remove the cache temporarily from the Test Stability pipeline (while keeping it in the Build Client pipeline) to allow the pipeline to operate normally.
