### PR TITLE
Stress: Fix some logs missing profile

### DIFF
--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -139,7 +139,15 @@ async function orchestratorProcess(
 		: // If no testId is provided, (or) if testId is provided but createTestId is not false, then
 		  // create a file;
 		  // In case testId is provided, name of the file to be created is taken as the testId provided
-		  initialize(testDriver, seed, endpoint, profile, args.verbose === true, args.testId));
+		  initialize(
+				testDriver,
+				seed,
+				endpoint,
+				profile,
+				args.verbose === true,
+				args.profileName,
+				args.testId,
+		  ));
 
 	const estRunningTimeMin = Math.floor(
 		(2 * profile.totalSendCount) / (profile.opRatePerMin * profile.numClients),

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -52,7 +52,7 @@ class FileLogger extends TelemetryLogger implements ITelemetryBufferedLogger {
 	public static async createLogger(dimensions: {
 		driverType: string;
 		driverEndpointName: string | undefined;
-		profile: string | undefined;
+		profile: string;
 		runId: number | undefined;
 	}) {
 		return ChildLogger.create(await this.loggerP, undefined, {
@@ -160,8 +160,8 @@ export async function initialize(
 	endpoint: DriverEndpoint | undefined,
 	testConfig: ILoadTestConfig,
 	verbose: boolean,
+	profileName: string,
 	testIdn?: string,
-	profileName?: string,
 ) {
 	const random = makeRandom(seed);
 	const optionsOverride = `${testDriver.type}${endpoint !== undefined ? `-${endpoint}` : ""}`;


### PR DESCRIPTION
## Description
A small number of logs were missing the stress profile name, leading to some aggregation issues. This fixed the missed spot, which is when the initial container is created. Also, made profileName required, to avoid similar issues in the future.