### PR TITLE
Add timestamp when message was queued to kafka in scriptorium metric

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -79,6 +79,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 				this.pendingMetric = Lumberjack.newLumberMetric(
 					LumberEventName.ScriptoriumProcessBatch,
 					{
+						timestampQueuedMessage: message.timestamp ? new Date(message.timestamp).toISOString() : null,
 						timestampReadyToProcess: new Date().toISOString(),
 						[QueuedMessageProperties.partition]: this.pendingOffset?.partition,
 						[QueuedMessageProperties.offsetStart]: this.pendingOffset?.offset,

--- a/server/routerlicious/packages/services-core/src/queue.ts
+++ b/server/routerlicious/packages/services-core/src/queue.ts
@@ -11,6 +11,7 @@ export interface IQueuedMessage {
 	partition: number;
 	offset: number;
 	value: string | any;
+	timestamp?: number | undefined;
 }
 
 export interface IPartition {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -339,7 +339,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 				boxcar.partitionId ?? null, // partition id or null for consistent random for keyed messages
 				message, // message
 				boxcar.documentId, // key
-				undefined, // timestamp
+				Date.now(), // timestamp
 				(ex: any, offset?: number) => {
 					this.inflightPromises.delete(boxcar.deferred);
 


### PR DESCRIPTION
## Description

Did the following changes to be able to calculate kafka lag for each kafka message received in scriptorium, i.e. time spent in kafka. This would help us analyse if there are any delays in reading the messages specially during scriptorium restarts.

- Added timestamp to the message payload before producing the message to kafka
- Reading the timestamp in scriptorium lambda and logging it in the ScriptoriumProcessBatch metric

