### PR TITLE
tree: expose root events

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -746,6 +746,7 @@ export interface ISharedTreeBranch extends AnchorLocator {
     fork(): ISharedTreeFork;
     get root(): UnwrappedEditableField;
     set root(data: ContextuallyTypedNodeData | undefined);
+    readonly rootEvents: ISubscribable<AnchorSetRootEvents>;
     readonly storedSchema: StoredSchemaRepository;
     readonly transaction: {
         start(): void;

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -20,6 +20,7 @@ import {
 	AnchorSet,
 	AnchorNode,
 	IEditableForest,
+	AnchorSetRootEvents,
 } from "../core";
 import { SharedTreeBranch, SharedTreeCore } from "../shared-tree-core";
 import {
@@ -161,6 +162,11 @@ export interface ISharedTreeBranch extends AnchorLocator {
 	 * Events about this branch.
 	 */
 	readonly events: ISubscribable<BranchEvents>;
+
+	/**
+	 * Events about the root of the tree on this branch.
+	 */
+	readonly rootEvents: ISubscribable<AnchorSetRootEvents>;
 }
 
 /**
@@ -218,6 +224,9 @@ class SharedTree
 	public readonly transaction: ISharedTreeBranch["transaction"];
 
 	public readonly events: ISubscribable<BranchEvents> & IEmitter<BranchEvents>;
+	public get rootEvents(): ISubscribable<AnchorSetRootEvents> {
+		return this.forest.anchors;
+	}
 
 	public constructor(
 		id: string,
@@ -349,6 +358,10 @@ class SharedTreeFork implements ISharedTreeFork {
 			this.forest.applyDelta(delta);
 			this.events.emit("afterBatch");
 		});
+	}
+
+	public get rootEvents(): ISubscribable<AnchorSetRootEvents> {
+		return this.forest.anchors;
 	}
 
 	public get editor() {


### PR DESCRIPTION
## Description

currently there is no way to get to the AnchorSet. This seems fine, except you can't use its events! This fixes that by exposing the events on branches.



## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
