### PR TITLE
refactor: Make MockLogger internal and fix behavior for empty-list edge case

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -50,6 +50,7 @@ Previously, `DataObject` would perform undocumented special handling for request
 
 -   [Ability to enable grouped batching](#Ability-to-enable-grouped-batching)
 -   [Testing support for LTS is moved from 0.45 to 1.3.4](#Testing-support-for-LTS-is-moved-from-0.45-to-1.3.4)
+-   [MockLogger is now internal](#mocklogger-is-now-internal)
 
 ### Ability to enable grouped batching
 
@@ -70,6 +71,13 @@ and verifying that the following expectation changes won't have any effects:
 ### Testing support for LTS is moved from 0.45.0 to 1.3.4
 
 Internal end-to-end full-compatibility testing for the loader-runtime boundary has been bumped from the oldest loader LTS version in 0.45.0 to the new oldest loader LTS version 1.3.4. For customers using azure packages, the loader-runtime are bundled together.
+
+### MockLogger is now internal
+
+The `MockLogger` class in `@fluidframework/telemetry-utils` is now internal.
+This means its API surface could change at any time and no guarantees are made on backwards or forwards compatibility.
+It was never intended for public use so no replacement is being provided for outside consumers.
+If you rely on its functionality, we recommend that you copy it into your own repository and use that version going forward.
 
 ## 2.0.0-internal.4.1.0 Upcoming changes
 

--- a/api-report/telemetry-utils.api.md
+++ b/api-report/telemetry-utils.api.md
@@ -228,21 +228,18 @@ export function logIfFalse(condition: any, logger: ITelemetryBaseLogger, event: 
 // @public (undocumented)
 export function mixinMonitoringContext<L extends ITelemetryBaseLogger = ITelemetryLogger>(logger: L, ...configs: (IConfigProviderBase | undefined)[]): MonitoringContext<L>;
 
-// @public
+// @internal
 export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
     constructor();
     assertMatch(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean): void;
     assertMatchAny(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean): void;
     assertMatchNone(disallowedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean): void;
     assertMatchStrict(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean): void;
-    // (undocumented)
     clear(): void;
-    // (undocumented)
     events: ITelemetryBaseEvent[];
     matchAnyEvent(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean): boolean;
     matchEvents(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean): boolean;
     matchEventStrict(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean): boolean;
-    // (undocumented)
     send(event: ITelemetryBaseEvent): void;
 }
 

--- a/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
@@ -194,12 +194,16 @@ describe("GC Telemetry Tracker", () => {
 				}
 			}
 
-			// Note that mock logger clears all events after one of the `match` functions is called. Since we call match
-			// functions twice, cache the events and repopulate the mock logger with if after the first match call.
+			// Note that mock logger clears all events after one of the `match` functions is called. Since we might call match
+			// functions twice, cache the events and repopulate the mock logger with them if we do the first match call.
 			const cachedEvents = Array.from(mockLogger.events);
-			mockLogger.assertMatch(expectedEvents, message, true /* inlineDetailsProp */);
-			mockLogger.events = cachedEvents;
-			mockLogger.assertMatchNone(unexpectedEvents, message, true /* inlineDetailsProp */);
+			if (expectedEvents.length > 0) {
+				mockLogger.assertMatch(expectedEvents, message, true /* inlineDetailsProp */);
+				mockLogger.events = cachedEvents;
+			}
+			if (unexpectedEvents.length > 0) {
+				mockLogger.assertMatchNone(unexpectedEvents, message, true /* inlineDetailsProp */);
+			}
 		}
 
 		it("generates inactive and sweep ready events when nodes are used after time out", async () => {

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -21,21 +21,14 @@ export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
 	 *
 	 * @remarks
 	 * Gets cleared when any of the validation functions on this class gets called.
-	 *
-	 * @internal
 	 */
 	events: ITelemetryBaseEvent[] = [];
-
-	/**
-	 * @internal
-	 */
 	constructor() {
 		super();
 	}
 
 	/**
 	 * Clears {@link MockLogger.events}.
-	 * @internal
 	 */
 	clear() {
 		this.events = [];
@@ -43,8 +36,6 @@ export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
 
 	/**
 	 * {@inheritdoc TelemetryLogger.send}
-	 *
-	 * @internal
 	 */
 	send(event: ITelemetryBaseEvent): void {
 		this.events.push(event);
@@ -64,8 +55,6 @@ export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
 	 *
 	 * @remarks
 	 * Calling this method will clear the internal buffer of saved events.
-	 *
-	 * @internal
 	 */
 	matchEvents(
 		expectedEvents: Omit<ITelemetryBaseEvent, "category">[],
@@ -84,8 +73,6 @@ export class MockLogger extends TelemetryLogger implements ITelemetryLogger {
 	 *
 	 * @remarks
 	 * Calling this method will clear the internal buffer of saved events.
-	 *
-	 * @internal
 	 */
 	assertMatch(
 		expectedEvents: Omit<ITelemetryBaseEvent, "category">[],
@@ -116,8 +103,6 @@ ${JSON.stringify(actualEvents)}`);
 	 *
 	 * @remarks
 	 * Calling this method will clear the internal buffer of saved events.
-	 *
-	 * @internal
 	 */
 	matchAnyEvent(
 		expectedEvents: Omit<ITelemetryBaseEvent, "category">[],
@@ -135,8 +120,6 @@ ${JSON.stringify(actualEvents)}`);
 	 *
 	 * @remarks
 	 * Calling this method will clear the internal buffer of saved events.
-	 *
-	 * @internal
 	 */
 	assertMatchAny(
 		expectedEvents: Omit<ITelemetryBaseEvent, "category">[],
@@ -165,8 +148,6 @@ ${JSON.stringify(actualEvents)}`);
 	 *
 	 * @remarks
 	 * Calling this method will clear the internal buffer of saved events.
-	 *
-	 * @internal
 	 */
 	matchEventStrict(
 		expectedEvents: Omit<ITelemetryBaseEvent, "category">[],
@@ -188,8 +169,6 @@ ${JSON.stringify(actualEvents)}`);
 	 *
 	 * @remarks
 	 * Calling this method will clear the internal buffer of saved events.
-	 *
-	 * @internal
 	 */
 	assertMatchStrict(
 		expectedEvents: Omit<ITelemetryBaseEvent, "category">[],
@@ -212,8 +191,6 @@ ${JSON.stringify(actualEvents)}`);
 	 *
 	 * @remarks
 	 * Calling this method will clear the internal buffer of saved events.
-	 *
-	 * @internal
 	 */
 	assertMatchNone(
 		disallowedEvents: Omit<ITelemetryBaseEvent, "category">[],

--- a/packages/utils/telemetry-utils/src/test/mockLogger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/mockLogger.spec.ts
@@ -13,17 +13,15 @@ describe("MockLogger", () => {
 			mockLogger = new MockLogger();
 		});
 
-		it("empty log, none expected", () => {
-			assert(mockLogger.matchEvents([]));
+		it("throws if passed an empty events list", () => {
+			assert.throws(
+				() => mockLogger.matchEvents([]),
+				(e) => e?.message === "Must specify at least 1 event",
+			);
 		});
 
 		it("empty log, one expected", () => {
 			assert(!mockLogger.matchEvents([{ eventName: "A", a: 1 }]));
-		});
-
-		it("One logged, none expected", () => {
-			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
-			assert(mockLogger.matchEvents([]));
 		});
 
 		it("One logged, exact match expected", () => {
@@ -98,12 +96,6 @@ describe("MockLogger", () => {
 					{ eventName: "A", a: 1 },
 				]),
 			);
-		});
-
-		it("Two logged, none expected", () => {
-			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
-			mockLogger.sendTelemetryEvent({ eventName: "B", b: 2 });
-			assert(mockLogger.matchEvents([]));
 		});
 
 		it("Two sequences, matching expected", () => {
@@ -203,6 +195,325 @@ describe("MockLogger", () => {
 					true /* inlineDetailsProp */,
 				),
 			);
+		});
+
+		it("clears internal events buffer", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.matchEvents([{ eventName: "A", a: 1 }]);
+			assert.strictEqual(mockLogger.events.length, 0);
+		});
+	});
+
+	describe("assertMatch", () => {
+		let mockLogger: MockLogger;
+		beforeEach(() => {
+			mockLogger = new MockLogger();
+		});
+
+		it("throws if passed an empty events list", () => {
+			assert.throws(
+				() => mockLogger.assertMatch([]),
+				(e) => e?.message === "Must specify at least 1 event",
+			);
+		});
+
+		it("doesn't throw when all expected events are found", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.sendTelemetryEvent({ eventName: "B", a: 2 });
+			mockLogger.assertMatch([
+				{ eventName: "A", a: 1 },
+				{ eventName: "B", a: 2 },
+			]);
+			// Doesn't throw
+		});
+
+		it("throws when expected event is not found", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			assert.throws(
+				() => mockLogger.assertMatch([{ eventName: "B", a: 2 }], "my error message"),
+				(err) =>
+					err.message ===
+					`my error message
+expected:
+[{"eventName":"B","a":2}]
+
+actual:
+[{"category":"generic","eventName":"A","a":1}]`,
+			);
+		});
+
+		it("clears internal events buffer", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.assertMatch([{ eventName: "A", a: 1 }]);
+			assert.strictEqual(mockLogger.events.length, 0);
+		});
+	});
+
+	describe("assertMatchStrict", () => {
+		let mockLogger: MockLogger;
+		beforeEach(() => {
+			mockLogger = new MockLogger();
+		});
+
+		it("doesn't throw when expecting no events and none are found", () => {
+			mockLogger.assertMatchStrict([]);
+			// Doesn't throw
+		});
+
+		it("doesn't throw when exactly the expected events are found", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.sendTelemetryEvent({ eventName: "B", a: 2 });
+			mockLogger.assertMatchStrict([
+				{ eventName: "A", a: 1 },
+				{ eventName: "B", a: 2 },
+			]);
+			// Doesn't throw
+		});
+
+		it("throws if expected events are not in order", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "B", a: 2 });
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			assert.throws(
+				() =>
+					mockLogger.assertMatchStrict(
+						[
+							{ eventName: "A", a: 1 },
+							{ eventName: "B", a: 2 },
+						],
+						"my error message",
+					),
+				(err) =>
+					err.message ===
+					`my error message
+expected:
+[{"eventName":"A","a":1},{"eventName":"B","a":2}]
+
+actual:
+[{"category":"generic","eventName":"B","a":2},{"category":"generic","eventName":"A","a":1}]`,
+			);
+		});
+
+		it("throws if no events are expected but some are found", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			assert.throws(
+				() => mockLogger.assertMatchStrict([], "my error message"),
+				(err) =>
+					err.message ===
+					`my error message
+expected:
+[]
+
+actual:
+[{"category":"generic","eventName":"A","a":1}]`,
+			);
+		});
+
+		it("throws if not all the expected events are found", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			assert.throws(
+				() =>
+					mockLogger.assertMatchStrict(
+						[
+							{ eventName: "A", a: 1 },
+							{ eventName: "B", a: 2 },
+						],
+						"my error message",
+					),
+				(err) =>
+					err.message ===
+					`my error message
+expected:
+[{"eventName":"A","a":1},{"eventName":"B","a":2}]
+
+actual:
+[{"category":"generic","eventName":"A","a":1}]`,
+			);
+		});
+
+		it("throws if events other than the expected ones are found", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.sendTelemetryEvent({ eventName: "B", a: 2 });
+			mockLogger.sendTelemetryEvent({ eventName: "C", a: 3 });
+			assert.throws(
+				() =>
+					mockLogger.assertMatchStrict(
+						[
+							{ eventName: "A", a: 1 },
+							{ eventName: "B", a: 2 },
+						],
+						"my error message",
+					),
+				(err) =>
+					err.message ===
+					`my error message
+expected:
+[{"eventName":"A","a":1},{"eventName":"B","a":2}]
+
+actual:
+[{"category":"generic","eventName":"A","a":1},{"category":"generic","eventName":"B","a":2},{"category":"generic","eventName":"C","a":3}]`,
+			);
+		});
+
+		it("clears internal events buffer", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.assertMatchStrict([{ eventName: "A", a: 1 }]);
+			assert.strictEqual(mockLogger.events.length, 0);
+		});
+	});
+
+	describe("matchAnyEvent", () => {
+		let mockLogger: MockLogger;
+		beforeEach(() => {
+			mockLogger = new MockLogger();
+		});
+
+		it("throws if passed an empty events list", () => {
+			assert.throws(
+				() => mockLogger.matchAnyEvent([]),
+				(e) => e?.message === "Must specify at least 1 event",
+			);
+		});
+
+		it("returns true when one expected event is found", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.sendTelemetryEvent({ eventName: "B", a: 2 });
+			const result = mockLogger.matchAnyEvent([
+				{ eventName: "A", a: 1 },
+				{ eventName: "C", c: 1 },
+			]);
+			assert.strictEqual(result, true);
+		});
+
+		it("returns false if none of the expected events are found", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.sendTelemetryEvent({ eventName: "B", a: 2 });
+			const result = mockLogger.matchAnyEvent([
+				{ eventName: "C", c: 1 },
+				{ eventName: "D", d: 1 },
+			]);
+			assert.strictEqual(result, false);
+		});
+
+		it("clears internal events buffer", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.matchAnyEvent([{ eventName: "A", a: 1 }]);
+			assert.strictEqual(mockLogger.events.length, 0);
+		});
+	});
+
+	describe("assertMatchAny", () => {
+		let mockLogger: MockLogger;
+		beforeEach(() => {
+			mockLogger = new MockLogger();
+		});
+
+		it("throws if passed an empty events list", () => {
+			assert.throws(
+				() => mockLogger.assertMatchAny([]),
+				(e) => e?.message === "Must specify at least 1 event",
+			);
+		});
+
+		it("throws if none of the expected events are found", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.sendTelemetryEvent({ eventName: "B", a: 2 });
+			assert.throws(
+				() =>
+					mockLogger.assertMatchAny(
+						[
+							{ eventName: "C", c: 1 },
+							{ eventName: "D", d: 1 },
+						],
+						"my error message",
+					),
+				(e) =>
+					e?.message ===
+					`my error message
+expected:
+[{"eventName":"C","c":1},{"eventName":"D","d":1}]
+
+actual:
+[{"category":"generic","eventName":"A","a":1},{"category":"generic","eventName":"B","a":2}]`,
+			);
+		});
+
+		it("doesn't throw when one expected event is found", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.sendTelemetryEvent({ eventName: "B", a: 2 });
+
+			// Doesn't throw when matching the first existing event
+			mockLogger.assertMatchAny([
+				{ eventName: "A", a: 1 },
+				{ eventName: "C", c: 1 },
+			]);
+
+			// Log messages again since previous call cleared them
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.sendTelemetryEvent({ eventName: "B", a: 2 });
+
+			// Doesn't throw when matching the second existing event
+			mockLogger.assertMatchAny([
+				{ eventName: "B", a: 2 },
+				{ eventName: "C", c: 1 },
+			]);
+		});
+
+		it("doesn't throw when all expected events are found", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.sendTelemetryEvent({ eventName: "B", a: 2 });
+
+			mockLogger.assertMatchAny([
+				{ eventName: "A", a: 1 },
+				{ eventName: "B", b: 2 },
+			]);
+			// Doesn't throw
+		});
+
+		it("clears internal events buffer", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.assertMatchAny([{ eventName: "A", a: 1 }]);
+			assert.strictEqual(mockLogger.events.length, 0);
+		});
+	});
+
+	describe("assertMatchNone", () => {
+		let mockLogger: MockLogger;
+		beforeEach(() => {
+			mockLogger = new MockLogger();
+		});
+
+		it("throws if passed an empty events list", () => {
+			assert.throws(
+				() => mockLogger.assertMatchNone([]),
+				(e) => e?.message === "Must specify at least 1 event",
+			);
+		});
+
+		it("throws if disallowed event found", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			assert.throws(
+				() => mockLogger.assertMatchNone([{ eventName: "A", a: 1 }], "my error message"),
+				(e) =>
+					e?.message ===
+					`my error message
+disallowed events:
+[{"eventName":"A","a":1}]
+
+actual:
+[{"category":"generic","eventName":"A","a":1}]`,
+			);
+		});
+
+		it("doesn't throw if disallowed event is not found", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "A", a: 1 });
+			mockLogger.assertMatchNone([{ eventName: "B", b: 1 }]);
+			// Doesn't throw
+		});
+
+		it("clears internal events buffer", () => {
+			mockLogger.sendTelemetryEvent({ eventName: "B", b: 2 });
+			mockLogger.assertMatchNone([{ eventName: "A", a: 1 }]);
+			assert.strictEqual(mockLogger.events.length, 0);
 		});
 	});
 });


### PR DESCRIPTION
## Description

- `MockLogger` in `@fluidframework/telemetry-utils` seems designed for our internal use in tests. I checked our partner repos and found no use, so making it `@internal`.
- Improvement / bugfix for the `matchEvents`, `assertMatch`, `matchAnyEvent`, `assertMatchAny`, `assertMatchNone` methods to reject an empty list, which doesn't make sense for those methods based on how they work.
  - Some tests that were passing empty lists were addressed in #14562 .
  - `matchEventStrict`/`assertMatchStrict` can still take empty lists to check that no events were logged at all.
- Adds unit tests for the validation methods that didn't have any.

## Breaking Changes

This is technically changing the behavior of some of the class methods here, but I'd argue it's a bugfix and not a breaking change of intended functionality. Plus, the fact that I found no use of this class in our partner's repos makes me think this is ok to do in `main`.
