### PR TITLE
IResolvedUrl will be equivalent to IFluidResolvedUrl

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -15,6 +15,18 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 -   Avoid using code formatting in the title (it's fine to use in the body).
 -   To explain the benefit of your change, use the [What's New](https://fluidframework.com/docs/updates/v1.0.0/) section on FluidFramework.com.
 
+# 2.0.0-internal.3.4.0
+
+## 2.0.0-internal.3.4.0 Upcoming changes
+
+[IResolvedUrl will be equivalent to IFluidResolvedUrl](#IResolvedUrl-will-be-equivalent-to-IFluidResolvedUrl)
+
+## IResolvedUrl will be equivalent to IFluidResolvedUrl
+
+In @fluidframework/driver-definitions IResolvedUrlBase and IWebResolvedUrl are deprecated as they are not used.
+This will make IResolvedUrl and IFluidResolvedUrl equivalent. Since all ResolvedUrls will now be FluidResolvedUrls we no longer need to differentiate them. In @fluidframework/driver-utils isFluidResolvedUrl and
+ensureFluidResolvedUrl will be deprecated and removed due to this.
+
 # 2.0.0-internal.3.3.0
 
 ## 2.0.0-internal.3.3.0 Upcoming changes

--- a/api-report/driver-definitions.api.md
+++ b/api-report/driver-definitions.api.md
@@ -251,7 +251,7 @@ export interface ILocationRedirectionError extends IDriverErrorBase {
 // @public (undocumented)
 export type IResolvedUrl = IWebResolvedUrl | IFluidResolvedUrl;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IResolvedUrlBase {
     // (undocumented)
     type: string;
@@ -294,7 +294,7 @@ export interface IUrlResolver {
     resolve(request: IRequest): Promise<IResolvedUrl | undefined>;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IWebResolvedUrl extends IResolvedUrlBase {
     // (undocumented)
     data: string;

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -193,7 +193,7 @@ export class EmptyDocumentDeltaStorageService implements IDocumentDeltaStorageSe
 // @public (undocumented)
 export const emptyMessageStream: IStream<ISequencedDocumentMessage[]>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function ensureFluidResolvedUrl(resolved: IResolvedUrl | undefined): asserts resolved is IFluidResolvedUrl;
 
 // @public
@@ -252,7 +252,7 @@ export interface IProgress {
 // @internal
 export function isCombinedAppAndProtocolSummary(summary: ISummaryTree | undefined): summary is CombinedAppAndProtocolSummary;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const isFluidResolvedUrl: (resolved: IResolvedUrl | undefined) => resolved is IFluidResolvedUrl;
 
 // @public (undocumented)

--- a/packages/common/driver-definitions/src/urlResolver.ts
+++ b/packages/common/driver-definitions/src/urlResolver.ts
@@ -6,10 +6,16 @@ import { IRequest } from "@fluidframework/core-interfaces";
 
 export type IResolvedUrl = IWebResolvedUrl | IFluidResolvedUrl;
 
+/**
+ * @deprecated This interface is unused and will be remove.
+ */
 export interface IResolvedUrlBase {
 	type: string;
 }
 
+/**
+ * @deprecated This interface is unused and will be remove.
+ */
 export interface IWebResolvedUrl extends IResolvedUrlBase {
 	type: "web";
 	data: string;

--- a/packages/common/driver-definitions/src/urlResolver.ts
+++ b/packages/common/driver-definitions/src/urlResolver.ts
@@ -7,14 +7,14 @@ import { IRequest } from "@fluidframework/core-interfaces";
 export type IResolvedUrl = IWebResolvedUrl | IFluidResolvedUrl;
 
 /**
- * @deprecated This interface is unused and will be remove.
+ * @deprecated This interface is unused and will be removed in the next major release.
  */
 export interface IResolvedUrlBase {
 	type: string;
 }
 
 /**
- * @deprecated This interface is unused and will be remove.
+ * @deprecated This interface is unused and will be removed in the next major release.
  */
 export interface IWebResolvedUrl extends IResolvedUrlBase {
 	type: "web";

--- a/packages/loader/driver-utils/src/fluidResolvedUrl.ts
+++ b/packages/loader/driver-utils/src/fluidResolvedUrl.ts
@@ -5,10 +5,18 @@
 
 import { IResolvedUrl, IFluidResolvedUrl } from "@fluidframework/driver-definitions";
 
+/**
+ * @deprecated In the next major release all IResolvedUrl will be IFluidResolvedUrl,
+ * so this method is no longer necessary.
+ */
 export const isFluidResolvedUrl = (
 	resolved: IResolvedUrl | undefined,
 ): resolved is IFluidResolvedUrl => resolved?.type === "fluid";
 
+/**
+ * @deprecated In the next major release all IResolvedUrl will be IFluidResolvedUrl,
+ * so this method is no longer necessary.
+ */
 export function ensureFluidResolvedUrl(
 	resolved: IResolvedUrl | undefined,
 ): asserts resolved is IFluidResolvedUrl {


### PR DESCRIPTION
## Description
In @fluidframework/driver-definitions IResolvedUrlBase and IWebResolvedUrl are deprecated as they are not used.
This will make IResolvedUrl and IFluidResolvedUrl equivalent. Since all ResolvedUrls will now be FluidResolvedUrls we no longer need to differentiate them. In @fluidframework/driver-utils isFluidResolvedUrl and
ensureFluidResolvedUrl will be deprecated and removed due to this.