### PR TITLE
fix(container-runtime): Nullish coalescence bug introduced by eslint

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2639,7 +2639,7 @@ export class ContainerRuntime
 			const forcedFullTree = this.garbageCollector.summaryStateNeedsReset;
 			try {
 				summarizeResult = await this.summarize({
-					fullTree: fullTree ?? forcedFullTree,
+					fullTree: (fullTree ?? false) || forcedFullTree,
 					trackState: true,
 					summaryLogger: summaryNumberLogger,
 					runGC: this.garbageCollector.shouldRunGC,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2544,7 +2544,7 @@ export class ContainerRuntime
 	 * @param options - options controlling how the summary is generated or submitted
 	 */
 	public async submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult> {
-		const { fullTree, refreshLatestAck, summaryLogger } = options;
+		const { fullTree = false, refreshLatestAck, summaryLogger } = options;
 		// The summary number for this summary. This will be updated during the summary process, so get it now and
 		// use it for all events logged during this summary.
 		const summaryNumber = this.nextSummaryNumber;
@@ -2639,7 +2639,7 @@ export class ContainerRuntime
 			const forcedFullTree = this.garbageCollector.summaryStateNeedsReset;
 			try {
 				summarizeResult = await this.summarize({
-					fullTree: (fullTree ?? false) || forcedFullTree,
+					fullTree: fullTree || forcedFullTree,
 					trackState: true,
 					summaryLogger: summaryNumberLogger,
 					runGC: this.garbageCollector.shouldRunGC,


### PR DESCRIPTION
This bug was introduced in #11977 via eslint. The eslint rule in question is [prefer-nullish-coalescing](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md). In this case `<boolean | undefined> || <boolean>` was updated to use null-ish coalescing, even though it changes the behavior (`false || true` => `true`,  while `false ?? true` => `false`). 

Supposedly, this auto-fix bug was already resolved in `typescript-eslint` (see [this issue](https://github.com/typescript-eslint/typescript-eslint/issues/1768), but the behavior seems to have regressed. I will be separately attempting to update our plugin dependencies to see if doing so fixes this, otherwise I will file a new bug for the plugin so we don't stumble into this in the future.