### PR TITLE
feat(client-debugger): Add container state history in browser debug window

### DIFF
--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/ContainerHistoryView.tsx
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/ContainerHistoryView.tsx
@@ -11,7 +11,8 @@ import {
 	InboundHandlers,
 	handleIncomingMessage,
 	HasContainerId,
- ConnectionStateChangeLogEntry } from "@fluid-tools/client-debugger";
+	ConnectionStateChangeLogEntry,
+} from "@fluid-tools/client-debugger";
 import { _ContainerHistoryView } from "@fluid-tools/client-debugger-view";
 import { Waiting } from "./Waiting";
 import { MessageRelayContext } from "./MessageRelayContext";
@@ -21,7 +22,10 @@ const loggingContext = "EXTENSION(ContainerHistoryView)";
 /**
  * {@link ContainerHistory} input props.
  */
-type ContainerHistoryProps = HasContainerId;
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ContainerHistoryProps extends HasContainerId {
+	// TODO
+}
 
 /**
  * Displays information about the provided {@link IFluidClientDebugger.getContainerConnectionLog}.
@@ -65,12 +69,10 @@ export function ContainerHistoryView(props: ContainerHistoryProps): React.ReactE
 
 		messageRelay.on("message", messageHandler);
 
-		// Send a message to the webpage to request the container state history. (???)
-
 		return (): void => {
 			messageRelay.off("message", messageHandler);
 		};
-	}, [containerId, messageRelay, setContainerHistory]);
+	}, [containerHistory, messageRelay, setContainerHistory]);
 
 	if (containerHistory === undefined) {
 		return <Waiting label="Waiting for Container Summary data." />;

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/ContainerHistoryView.tsx
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/ContainerHistoryView.tsx
@@ -1,0 +1,93 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { Stack, StackItem } from "@fluentui/react";
+import React from "react";
+
+import {
+	ContainerStateHistoryMessage,
+	IDebuggerMessage,
+	InboundHandlers,
+	handleIncomingMessage,
+	HasContainerId,
+ ConnectionStateChangeLogEntry } from "@fluid-tools/client-debugger";
+import { _ContainerHistoryView } from "@fluid-tools/client-debugger-view";
+import { Waiting } from "./Waiting";
+import { MessageRelayContext } from "./MessageRelayContext";
+
+const loggingContext = "EXTENSION(ContainerHistoryView)";
+
+/**
+ * {@link ContainerHistory} input props.
+ */
+type ContainerHistoryProps = HasContainerId;
+
+/**
+ * Displays information about the provided {@link IFluidClientDebugger.getContainerConnectionLog}.
+ */
+export function ContainerHistoryView(props: ContainerHistoryProps): React.ReactElement {
+	const { containerId } = props;
+	const messageRelay = React.useContext(MessageRelayContext);
+	if (messageRelay === undefined) {
+		throw new Error(
+			"MessageRelayContext was not defined. Parent component is responsible for ensuring this has been constructed.",
+		);
+	}
+
+	const [containerHistory, setContainerHistory] = React.useState<
+		ConnectionStateChangeLogEntry[] | undefined
+	>();
+
+	React.useEffect(() => {
+		/**
+		 * Handlers for inbound messages related to the registry.
+		 */
+		const inboundMessageHandlers: InboundHandlers = {
+			["CONTAINER_STATE_HISTORY"]: (untypedMessage) => {
+				const message = untypedMessage as ContainerStateHistoryMessage;
+				if (message.data.containerId === containerId) {
+					setContainerHistory(message.data.history);
+					return true;
+				}
+				return false;
+			},
+		};
+
+		/**
+		 * Event handler for messages coming from the webpage.
+		 */
+		function messageHandler(message: Partial<IDebuggerMessage>): void {
+			handleIncomingMessage(message, inboundMessageHandlers, {
+				context: loggingContext,
+			});
+		}
+
+		messageRelay.on("message", messageHandler);
+
+		// Send a message to the webpage to request the container state history. (???)
+
+		return (): void => {
+			messageRelay.off("message", messageHandler);
+		};
+	}, [containerId, messageRelay, setContainerHistory]);
+
+	if (containerHistory === undefined) {
+		return <Waiting label="Waiting for Container Summary data." />;
+	}
+
+	return (
+		<Stack
+			styles={{
+				root: {
+					height: "100%",
+				},
+			}}
+		>
+			<StackItem>
+				<h3>Container State History</h3>
+				<_ContainerHistoryView containerHistory={containerHistory} />
+			</StackItem>
+		</Stack>
+	);
+}

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/ContainerView.tsx
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/ContainerView.tsx
@@ -9,6 +9,7 @@ import { Stack, StackItem } from "@fluentui/react";
 import { HasContainerId } from "@fluid-tools/client-debugger";
 import { PanelView, PanelViewSelectionMenu } from "@fluid-tools/client-debugger-view";
 
+import { ContainerHistoryView } from "./ContainerHistoryView";
 import { ContainerSummaryView } from "./ContainerSummaryView";
 import { ContainerDataView } from "./ContainerDataView";
 import { AudienceView } from "./AudienceView";
@@ -46,6 +47,9 @@ export function ContainerView(props: ContainerViewProps): React.ReactElement {
 				break;
 			case PanelView.Telemetry:
 				innerView = <TelemetryView />;
+				break;
+			case PanelView.ContainerStateHistory:
+				innerView = <ContainerHistoryView containerId={containerId} />;
 				break;
 			default:
 				throw new Error(`Unrecognized RootView selection value: "${viewSelection}".`);

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/ContainerView.tsx
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/ContainerView.tsx
@@ -39,17 +39,17 @@ export function ContainerView(props: ContainerViewProps): React.ReactElement {
 	} else {
 		let innerView: React.ReactElement;
 		switch (viewSelection) {
-			case PanelView.ContainerData:
-				innerView = <ContainerDataView containerId={containerId} />;
-				break;
 			case PanelView.Audience:
 				innerView = <AudienceView containerId={containerId} />;
 				break;
-			case PanelView.Telemetry:
-				innerView = <TelemetryView />;
+			case PanelView.ContainerData:
+				innerView = <ContainerDataView containerId={containerId} />;
 				break;
 			case PanelView.ContainerStateHistory:
 				innerView = <ContainerHistoryView containerId={containerId} />;
+				break;
+			case PanelView.Telemetry:
+				innerView = <TelemetryView />;
 				break;
 			default:
 				throw new Error(`Unrecognized RootView selection value: "${viewSelection}".`);

--- a/packages/tools/client-debugger/client-debugger-view/api-report/client-debugger-view.api.md
+++ b/packages/tools/client-debugger/client-debugger-view/api-report/client-debugger-view.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { ConnectionStateChangeLogEntry } from '@fluid-tools/client-debugger';
 import { ContainerMetadata } from '@fluid-tools/client-debugger';
 import { ContainerStateMetadata } from '@fluid-tools/client-debugger';
 import { IClient } from '@fluidframework/protocol-definitions';
@@ -34,6 +35,14 @@ export const clientDebugViewClassName = "fluid-client-debugger-view";
 // @internal
 export interface ClientDebugViewProps extends HasClientDebugger {
     renderOptions?: RenderOptions;
+}
+
+// @public
+export function _ContainerHistoryView(props: _ContainerHistoryViewProps): React_2.ReactElement;
+
+// @public
+export interface _ContainerHistoryViewProps {
+    containerHistory: readonly ConnectionStateChangeLogEntry[];
 }
 
 // @internal

--- a/packages/tools/client-debugger/client-debugger-view/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger-view/src/index.ts
@@ -21,6 +21,8 @@
  */
 
 export {
+	_ContainerHistoryView,
+	_ContainerHistoryViewProps,
 	_ContainerSummaryView,
 	_ContainerSummaryViewProps,
 	_TelemetryView,

--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -82,6 +82,18 @@ export interface ContainerStateChangeMessageData extends HasContainerId {
 }
 
 // @public
+export interface ContainerStateHistoryMessage extends IDebuggerMessage<ContainerStateHistoryMessageData> {
+    // (undocumented)
+    type: "CONTAINER_STATE_HISTORY";
+}
+
+// @public
+export interface ContainerStateHistoryMessageData extends HasContainerId {
+    // Warning: (ae-incompatible-release-tags) The symbol "history" is marked as @public, but its signature references "ConnectionStateChangeLogEntry" which is marked as @internal
+    history: ConnectionStateChangeLogEntry[];
+}
+
+// @public
 export interface ContainerStateMetadata extends ContainerMetadata {
     // (undocumented)
     attachState: AttachState;

--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -50,7 +50,10 @@ export interface ConnectContainerMessage extends IDebuggerMessage<ConnectContain
 // @public
 export type ConnectContainerMessageData = HasContainerId;
 
-// @internal
+// Warning: (ae-incompatible-release-tags) The symbol "ConnectionStateChangeLogEntry" is marked as @public, but its signature references "StateChangeLogEntry" which is marked as @internal
+// Warning: (ae-incompatible-release-tags) The symbol "ConnectionStateChangeLogEntry" is marked as @public, but its signature references "ContainerStateChangeKind" which is marked as @internal
+//
+// @public
 export interface ConnectionStateChangeLogEntry extends StateChangeLogEntry<ContainerStateChangeKind> {
     clientId: string | undefined;
 }
@@ -89,7 +92,6 @@ export interface ContainerStateHistoryMessage extends IDebuggerMessage<Container
 
 // @public
 export interface ContainerStateHistoryMessageData extends HasContainerId {
-    // Warning: (ae-incompatible-release-tags) The symbol "history" is marked as @public, but its signature references "ConnectionStateChangeLogEntry" which is marked as @internal
     history: ConnectionStateChangeLogEntry[];
 }
 
@@ -235,7 +237,7 @@ export interface MessageLoggingOptions {
 }
 
 // @internal
-export function postMessageToWindow<TMessage extends IDebuggerMessage>(message: TMessage, loggingOptions?: MessageLoggingOptions): void;
+export function postMessageToWindow<TMessage extends IDebuggerMessage>(loggingOptions?: MessageLoggingOptions, ...message: TMessage[]): void;
 
 // @public
 export interface RegistryChangeMessage extends IDebuggerMessage<RegistryChangeMessageData> {

--- a/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
@@ -14,8 +14,6 @@ import { AudienceChangeLogEntry, ConnectionStateChangeLogEntry } from "./Logs";
 import {
 	CloseContainerMessage,
 	ConnectContainerMessage,
-	ContainerStateChangeMessage,
-	ContainerStateHistoryMessage,
 	debuggerMessageSource,
 	DisconnectContainerMessage,
 	GetContainerStateMessage,
@@ -218,10 +216,11 @@ export class FluidClientDebugger
 	};
 
 	/**
-	 * Posts a {@link ContainerStateChangeMessage} to the window (globalThis).
+	 * Posts a {@link IDebuggerMessage} to the window (globalThis).
 	 */
 	private readonly postContainerStateChange = (): void => {
-		postMessageToWindow<ContainerStateChangeMessage>(
+		postMessageToWindow<IDebuggerMessage>(
+			this.messageLoggingOptions,
 			{
 				source: debuggerMessageSource,
 				type: "CONTAINER_STATE_CHANGE",
@@ -230,10 +229,6 @@ export class FluidClientDebugger
 					containerState: this.getContainerState(),
 				},
 			},
-			this.messageLoggingOptions,
-		);
-
-		postMessageToWindow<ContainerStateHistoryMessage>(
 			{
 				source: debuggerMessageSource,
 				type: "CONTAINER_STATE_HISTORY",
@@ -242,7 +237,6 @@ export class FluidClientDebugger
 					history: [...this._connectionStateLog],
 				},
 			},
-			this.messageLoggingOptions,
 		);
 	};
 

--- a/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
@@ -15,6 +15,7 @@ import {
 	CloseContainerMessage,
 	ConnectContainerMessage,
 	ContainerStateChangeMessage,
+	ContainerStateHistoryMessage,
 	debuggerMessageSource,
 	DisconnectContainerMessage,
 	GetContainerStateMessage,
@@ -227,6 +228,18 @@ export class FluidClientDebugger
 				data: {
 					containerId: this.containerId,
 					containerState: this.getContainerState(),
+				},
+			},
+			this.messageLoggingOptions,
+		);
+
+		postMessageToWindow<ContainerStateHistoryMessage>(
+			{
+				source: debuggerMessageSource,
+				type: "CONTAINER_STATE_HISTORY",
+				data: {
+					containerId: this.containerId,
+					history: [...this._connectionStateLog],
 				},
 			},
 			this.messageLoggingOptions,

--- a/packages/tools/client-debugger/client-debugger/src/FluidDebuggerLogger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidDebuggerLogger.ts
@@ -82,7 +82,7 @@ export class FluidDebuggerLogger extends TelemetryLogger {
 
 		const newEvent: ITelemetryBaseEvent = this.prepareEvent(event);
 
-		postMessageToWindow<TelemetryEventMessage>({
+		postMessageToWindow<TelemetryEventMessage>(undefined, {
 			source: debuggerMessageSource,
 			type: "TELEMETRY_EVENT",
 			data: {

--- a/packages/tools/client-debugger/client-debugger/src/Logs.ts
+++ b/packages/tools/client-debugger/client-debugger/src/Logs.ts
@@ -34,7 +34,7 @@ export interface StateChangeLogEntry<TState> extends LogEntry {
 /**
  * Represents a {@link @fluidframework/container-loader#ConnectionState} change.
  *
- * @internal
+ * @public
  */
 export interface ConnectionStateChangeLogEntry
 	extends StateChangeLogEntry<ContainerStateChangeKind> {

--- a/packages/tools/client-debugger/client-debugger/src/Registry.ts
+++ b/packages/tools/client-debugger/client-debugger/src/Registry.ts
@@ -141,19 +141,16 @@ export class DebuggerRegistry extends TypedEventEmitter<DebuggerRegistryEvents> 
 	 * Posts a {@link RegistryChangeMessage} to the window (globalThis).
 	 */
 	private readonly postRegistryChange = (): void => {
-		postMessageToWindow<RegistryChangeMessage>(
-			{
-				source: debuggerMessageSource,
-				type: "REGISTRY_CHANGE",
-				data: {
-					containers: [...this.registeredDebuggers.values()].map((clientDebugger) => ({
-						id: clientDebugger.containerId,
-						nickname: clientDebugger.containerNickname,
-					})),
-				},
+		postMessageToWindow<RegistryChangeMessage>(registryMessageLoggingOptions, {
+			source: debuggerMessageSource,
+			type: "REGISTRY_CHANGE",
+			data: {
+				containers: [...this.registeredDebuggers.values()].map((clientDebugger) => ({
+					id: clientDebugger.containerId,
+					nickname: clientDebugger.containerNickname,
+				})),
 			},
-			registryMessageLoggingOptions,
-		);
+		});
 	};
 
 	// #endregion

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -65,6 +65,8 @@ export {
 	CloseContainerMessageData,
 	ContainerStateChangeMessage,
 	ContainerStateChangeMessageData,
+	ContainerStateHistoryMessage,
+	ContainerStateHistoryMessageData,
 	IDebuggerMessage,
 	GetContainerListMessage,
 	GetContainerStateMessage,

--- a/packages/tools/client-debugger/client-debugger/src/messaging/DebuggerMessages.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/DebuggerMessages.ts
@@ -4,6 +4,7 @@
  */
 
 import { ContainerStateMetadata } from "../ContainerMetadata";
+import { ConnectionStateChangeLogEntry } from "../Logs";
 import { IDebuggerMessage } from "./Messages";
 
 /**
@@ -48,6 +49,18 @@ export type DisconnectContainerMessageData = HasContainerId;
  * @public
  */
 export type CloseContainerMessageData = HasContainerId;
+
+/**
+ * Message data format used by {@link ContainerStateHistoryMessage}.
+ *
+ * @public
+ */
+export interface ContainerStateHistoryMessageData extends HasContainerId {
+	/**
+	 * The Container's connection state history.
+	 */
+	history: ConnectionStateChangeLogEntry[];
+}
 
 /**
  * Inbound event requesting the {@link ContainerStateMetadata} of the Container with the specified ID.
@@ -115,4 +128,13 @@ export interface CloseContainerMessage extends IDebuggerMessage<CloseContainerMe
 	type: "CLOSE_CONTAINER";
 }
 
+/**
+ * Outbound event indicating Container state history.
+ *
+ * @public
+ */
+export interface ContainerStateHistoryMessage
+	extends IDebuggerMessage<ContainerStateHistoryMessageData> {
+	type: "CONTAINER_STATE_HISTORY";
+}
 // #endregion

--- a/packages/tools/client-debugger/client-debugger/src/messaging/Utilities.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/Utilities.ts
@@ -8,7 +8,7 @@ import { IDebuggerMessage } from "./Messages";
 /**
  * Posts the provided message to the window (globalThis).
  *
- * @param message - The message to be posted
+ * @param message - The list of message to be posted
  * @param loggingOptions - Settings related to logging to console for troubleshooting.
  * If not passed, this function won't log to console before posting the message.
  *
@@ -17,8 +17,8 @@ import { IDebuggerMessage } from "./Messages";
  * @internal
  */
 export function postMessageToWindow<TMessage extends IDebuggerMessage>(
-	message: TMessage,
 	loggingOptions?: MessageLoggingOptions,
+	...message: TMessage[]
 ): void {
 	// TODO: remove loggingOptions once things settle.
 	// If we need special logic for globalThis.postMessage maybe keep this function, but otherwise maybe remove it too.

--- a/packages/tools/client-debugger/client-debugger/src/messaging/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/index.ts
@@ -24,6 +24,8 @@ export {
 	CloseContainerMessageData,
 	ContainerStateChangeMessage,
 	ContainerStateChangeMessageData,
+	ContainerStateHistoryMessage,
+	ContainerStateHistoryMessageData,
 	GetContainerStateMessage,
 	GetContainerStateMessageData,
 } from "./DebuggerMessages";


### PR DESCRIPTION
## Description
To be compatible with Chrome Extensions, we need to be able to pass "summaries" (not to be confused with Fluid Summaries) of each Data Object's state across the extension interop boundary. Currently, our prototyped extensibility model is based on rendering visuals; this will need to change.


## Breaking Changes
![1](https://user-images.githubusercontent.com/114451900/225487896-f631f643-48c8-4e7a-839c-2841a7f10d26.png)



