### PR TITLE
Hide combineAppAndProtocolSummary

### DIFF
--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -114,7 +114,7 @@ export function canBeCoalescedByService(message: ISequencedDocumentMessage | IDo
 // @public
 export const canRetryOnError: (error: any) => boolean;
 
-// @internal
+// @internal @deprecated
 export function combineAppAndProtocolSummary(appSummary: ISummaryTree, protocolSummary: ISummaryTree): CombinedAppAndProtocolSummary;
 
 // @internal

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -44,6 +44,7 @@ import {
 	combineAppAndProtocolSummary,
 	runWithRetry,
 	isFluidResolvedUrl,
+	isCombinedAppAndProtocolSummary,
 } from "@fluidframework/driver-utils";
 import { IQuorumSnapshot } from "@fluidframework/protocol-base";
 import {
@@ -771,10 +772,15 @@ export class Container
 			this.connectionStateHandler.containerSaved();
 		});
 
+		const addProtocolSummaryIfMissing = (summaryTree: ISummaryTree) =>
+			isCombinedAppAndProtocolSummary(summaryTree) === true
+				? summaryTree
+				: combineAppAndProtocolSummary(summaryTree, this.captureProtocolSummary());
+
 		this.storageService = new ContainerStorageAdapter(
 			this.loader.services.detachedBlobStorage,
 			this.mc.logger,
-			() => this.captureProtocolSummary(),
+			addProtocolSummaryIfMissing,
 			this.options,
 		);
 

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -21,7 +21,7 @@ import {
 	ISummaryTree,
 	IVersion,
 } from "@fluidframework/protocol-definitions";
-import { IDetachedBlobStorage, ILoaderOptions } from "./loader";
+import { IDetachedBlobStorage } from "./loader";
 import { ProtocolTreeStorageService } from "./protocolTreeDocumentStorageService";
 import { RetriableDocumentStorageService } from "./retriableDocumentStorageService";
 
@@ -37,7 +37,7 @@ export class ContainerStorageAdapter implements IDocumentStorageService, IDispos
 		detachedBlobStorage: IDetachedBlobStorage | undefined,
 		private readonly logger: ITelemetryLogger,
 		private readonly addProtocolSummaryIfMissing: (summaryTree: ISummaryTree) => ISummaryTree,
-		private readonly options: ILoaderOptions,
+		private readonly forceEnableSummarizeProtocolTree: boolean,
 	) {
 		this._storageService = new BlobOnlyStorage(detachedBlobStorage, logger);
 	}
@@ -59,9 +59,10 @@ export class ContainerStorageAdapter implements IDocumentStorageService, IDispos
 			this.logger,
 		));
 
-		this.options.summarizeProtocolTree =
-			this.options.summarizeProtocolTree ?? service.policies?.summarizeProtocolTree;
-		if (this.options.summarizeProtocolTree === true) {
+		const enableSummarizeProtocolTree =
+			this.forceEnableSummarizeProtocolTree ||
+			service.policies?.summarizeProtocolTree === true;
+		if (enableSummarizeProtocolTree) {
 			this.logger.sendTelemetryEvent({ eventName: "summarizeProtocolTreeEnabled" });
 			this._storageService = new ProtocolTreeStorageService(
 				retriableStorage,

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -33,13 +33,31 @@ export class ContainerStorageAdapter implements IDocumentStorageService, IDispos
 	private readonly blobContents: { [id: string]: ArrayBufferLike } = {};
 	private _storageService: IDocumentStorageService & Partial<IDisposable>;
 
-	constructor(
+	private _summarizeProtocolTree: boolean | undefined;
+	/**
+	 * Whether the adapter will enforce sending combined summary trees.
+	 */
+	public get summarizeProtocolTree() {
+		return this._summarizeProtocolTree === true;
+	}
+
+	/**
+	 * An adapter that ensures we're using detachedBlobStorage up until we connect to a real service, and then
+	 * after connecting to a real service augments it with retry and combined summary tree enforcement.
+	 * @param detachedBlobStorage - The detached blob storage to use up until we connect to a real service
+	 * @param logger - Telemetry logger
+	 * @param addProtocolSummaryIfMissing - a callback to permit the container to inspect the summary we're about to
+	 * upload, and fix it up with a protocol tree if needed
+	 * @param forceEnableSummarizeProtocolTree - Enforce uploading a protocol summary regardless of the service's policy
+	 */
+	public constructor(
 		detachedBlobStorage: IDetachedBlobStorage | undefined,
 		private readonly logger: ITelemetryLogger,
 		private readonly addProtocolSummaryIfMissing: (summaryTree: ISummaryTree) => ISummaryTree,
-		private readonly forceEnableSummarizeProtocolTree: boolean,
+		forceEnableSummarizeProtocolTree: boolean | undefined,
 	) {
 		this._storageService = new BlobOnlyStorage(detachedBlobStorage, logger);
+		this._summarizeProtocolTree = forceEnableSummarizeProtocolTree;
 	}
 
 	disposed: boolean = false;
@@ -59,10 +77,9 @@ export class ContainerStorageAdapter implements IDocumentStorageService, IDispos
 			this.logger,
 		));
 
-		const enableSummarizeProtocolTree =
-			this.forceEnableSummarizeProtocolTree ||
-			service.policies?.summarizeProtocolTree === true;
-		if (enableSummarizeProtocolTree) {
+		this._summarizeProtocolTree =
+			this._summarizeProtocolTree ?? service.policies?.summarizeProtocolTree;
+		if (this.summarizeProtocolTree) {
 			this.logger.sendTelemetryEvent({ eventName: "summarizeProtocolTreeEnabled" });
 			this._storageService = new ProtocolTreeStorageService(
 				retriableStorage,

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -36,7 +36,7 @@ export class ContainerStorageAdapter implements IDocumentStorageService, IDispos
 	constructor(
 		detachedBlobStorage: IDetachedBlobStorage | undefined,
 		private readonly logger: ITelemetryLogger,
-		private readonly captureProtocolSummary: () => ISummaryTree,
+		private readonly addProtocolSummaryIfMissing: (summaryTree: ISummaryTree) => ISummaryTree,
 		private readonly options: ILoaderOptions,
 	) {
 		this._storageService = new BlobOnlyStorage(detachedBlobStorage, logger);
@@ -65,7 +65,7 @@ export class ContainerStorageAdapter implements IDocumentStorageService, IDispos
 			this.logger.sendTelemetryEvent({ eventName: "summarizeProtocolTreeEnabled" });
 			this._storageService = new ProtocolTreeStorageService(
 				retriableStorage,
-				this.captureProtocolSummary,
+				this.addProtocolSummaryIfMissing,
 			);
 		}
 

--- a/packages/loader/container-loader/src/protocolTreeDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/protocolTreeDocumentStorageService.ts
@@ -5,16 +5,12 @@
 
 import { IDisposable } from "@fluidframework/common-definitions";
 import { IDocumentStorageService, ISummaryContext } from "@fluidframework/driver-definitions";
-import {
-	combineAppAndProtocolSummary,
-	isCombinedAppAndProtocolSummary,
-} from "@fluidframework/driver-utils";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 
 export class ProtocolTreeStorageService implements IDocumentStorageService, IDisposable {
 	constructor(
 		private readonly internalStorageService: IDocumentStorageService & IDisposable,
-		private readonly generateProtocolTree: () => ISummaryTree,
+		private readonly addProtocolSummaryIfMissing: (summaryTree: ISummaryTree) => ISummaryTree,
 	) {}
 	public get policies() {
 		return this.internalStorageService.policies;
@@ -38,9 +34,7 @@ export class ProtocolTreeStorageService implements IDocumentStorageService, IDis
 		context: ISummaryContext,
 	): Promise<string> {
 		return this.internalStorageService.uploadSummaryWithContext(
-			isCombinedAppAndProtocolSummary(summary) === true
-				? summary
-				: combineAppAndProtocolSummary(summary, this.generateProtocolTree()),
+			this.addProtocolSummaryIfMissing(summary),
 			context,
 		);
 	}

--- a/packages/loader/container-loader/src/protocolTreeDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/protocolTreeDocumentStorageService.ts
@@ -7,6 +7,10 @@ import { IDisposable } from "@fluidframework/common-definitions";
 import { IDocumentStorageService, ISummaryContext } from "@fluidframework/driver-definitions";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 
+/**
+ * A storage service wrapper whose sole job is to intercept calls to uploadSummaryWithContext and ensure they include
+ * the protocol summary, using the provided callback to add it if necessary.
+ */
 export class ProtocolTreeStorageService implements IDocumentStorageService, IDisposable {
 	constructor(
 		private readonly internalStorageService: IDocumentStorageService & IDisposable,

--- a/packages/loader/driver-utils/src/summaryForCreateNew.ts
+++ b/packages/loader/driver-utils/src/summaryForCreateNew.ts
@@ -51,6 +51,8 @@ export function isCombinedAppAndProtocolSummary(
  * @param appSummary - Summary of the app.
  * @param protocolSummary - Summary of the protocol.
  * @internal
+ *
+ * @deprecated 2.0.0-internal.3.4.0 - Not intended for public use.  Will be moved to container-loader and no longer exported in an upcoming release.
  */
 export function combineAppAndProtocolSummary(
 	appSummary: ISummaryTree,

--- a/packages/loader/driver-utils/src/treeConversions.ts
+++ b/packages/loader/driver-utils/src/treeConversions.ts
@@ -14,8 +14,8 @@ import { isCombinedAppAndProtocolSummary } from "./summaryForCreateNew";
  */
 export function convertSummaryTreeToSnapshotITree(summaryTree: ISummaryTree): ITree {
 	const entries: ITreeEntry[] = [];
-	const adaptSumaryTree = isCombinedAppAndProtocolSummary(summaryTree);
-	const allSummaryEntries = adaptSumaryTree
+	const adaptSummaryTree = isCombinedAppAndProtocolSummary(summaryTree);
+	const allSummaryEntries = adaptSummaryTree
 		? [
 				...Object.entries(summaryTree.tree[".protocol"].tree),
 				...Object.entries(summaryTree.tree[".app"].tree),
@@ -23,7 +23,7 @@ export function convertSummaryTreeToSnapshotITree(summaryTree: ISummaryTree): IT
 		: Object.entries(summaryTree.tree);
 
 	for (const [key, value] of allSummaryEntries) {
-		const k = adaptSumaryTree && key === "attributes" ? ".attributes" : key;
+		const k = adaptSummaryTree && key === "attributes" ? ".attributes" : key;
 		switch (value.type) {
 			case SummaryType.Blob: {
 				let parsedContent: string;

--- a/packages/loader/driver-utils/src/treeConversions.ts
+++ b/packages/loader/driver-utils/src/treeConversions.ts
@@ -23,7 +23,7 @@ export function convertSummaryTreeToSnapshotITree(summaryTree: ISummaryTree): IT
 		: Object.entries(summaryTree.tree);
 
 	for (const [key, value] of allSummaryEntries) {
-		const k = adaptSumaryTree && ["attributes"].includes(key) ? `.${key}` : key;
+		const k = adaptSumaryTree && key === "attributes" ? ".attributes" : key;
 		switch (value.type) {
 			case SummaryType.Blob: {
 				let parsedContent: string;


### PR DESCRIPTION
After looking at #14548 I saw some opportunity to encapsulate better here.  A couple guiding principles here:

1. There should be a single consolidated place where the final combined summary is assembled and also where it is interpreted.  Since that place needs to know about both the app and protocol trees it needs to be the loader today.
2. The summary format should be a blackbox to everyone else, e.g. the drivers should not peek inside and interpret the contents.  Unfortunately this is not the case today, but we should try to make progress in closing that off.

This change sets us up to make private the creation of the final combined summary, and also withholds the ability to directly generate a protocol tree.  They can both become secrets of the Container.

Ideally we would go even further and outright remove `ProtocolTreeStorageService`.  Its entire job is to distrust that the caller of `uploadSummaryWithContext()` has correctly combined the summary -- which if the loader is the single place it gets called then the loader can do its own validation.  However it's unfortunately still needed due to `ContainerRuntime.submitSummary()`.  That call bypasses the centralized source of truth for summary creation (the loader) and talks directly to an `IDocumentStorageService`, which is why the current design needs to sneak in the `ProtocolTreeStorageService` to prevent non-combined summaries from being submitted.  Really the runtime should not be making direct calls to `uploadSummaryWithContext()`, since it can only ever have a partial summary.

This also takes the flag off the container options to reduce exposure -- it's not needed, and at worst can be dangerously modified at runtime since it's a public member.  Part of the reason for this is to permit `ContainerStorageAdapter` to secretly update the value after connecting to the service, but instead we can just have an explicit contract on the `ContainerStorageAdapter`.

In any case -- if this looks good, I'd follow it up with hiding `combineAppAndProtocolSummary()` in `next` branch.