### PR TITLE
sanitize error at root level

### DIFF
--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -140,11 +140,12 @@ export class MongoCollection<T> implements core.ICollection<T>, core.IRetryable 
 	public async insertMany(values: T[], ordered: boolean): Promise<void> {
 		const req = async () => {
 			try {
-				this.collection.insertMany(values, { ordered: false });
+				await this.collection.insertMany(values, { ordered: false });
 			} catch (error) {
 				this.sanitizeError(error);
 				throw error;
 			};
+		}
 		await this.requestWithRetry(
 			req, // request
 			"MongoCollection.insertMany", // callerName

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -15,7 +15,7 @@ const MaxRetryAttempts = 3;
 const InitialRetryIntervalInMs = 1000;
 const redactJsonKeys = fastRedact({
 	// we want to redact the 'op' key at the following paths within error JSON object.
-	paths: ["op", "err.op", "result.writeErrors[*].op"],
+	paths: ["op", "err.op", "result.writeErrors[*].op", "writeErrors[*].op"],
 	// this instructs fast-redact to mutate the original object,
 	// instead of returning the serialization of the modified object.
 	serialize: false,


### PR DESCRIPTION
## Description

Mongo facade/retry has multiple layers:

1. api layer(root level)
2. facade layer (no log)
3. Consumer layer 
3.1 mongo retry analyzer runwithRetry layer (error already sanitized here)
3.2 scriptorium own RunWithRetry layer(even no retry, with where the CC data is out)

The change here is to sanitize the log at 2, so no consumer layer would miss that

## Breaking Changes

none

## Reviewer Guidance

none