### PR TITLE
Add GitHub action to notify when merge-next label is added

### DIFF
--- a/.github/workflows/merge-commits.yml
+++ b/.github/workflows/merge-commits.yml
@@ -163,7 +163,6 @@ jobs:
               labels: [
                 'main-next-integrate',
                 'do-not-squash-merge',
-                'msftbot: merge-next'
               ]
             })
   remove-from-queue:

--- a/.github/workflows/merge-next-notify.yml
+++ b/.github/workflows/merge-next-notify.yml
@@ -3,6 +3,8 @@ name: "Merge Next Notifier"
 on:
   pull_request:
     types: [ labeled ]
+    branches:
+      - next
 
 jobs:
   build:
@@ -15,4 +17,4 @@ jobs:
         with:
           only_create: true
           message: |
-            Hi @scottn12 check this out :)
+            Please review this PR: @scottn12

--- a/.github/workflows/merge-next-notify.yml
+++ b/.github/workflows/merge-next-notify.yml
@@ -20,6 +20,5 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           recreate: true
-          number: ${{ steps.load_pr.outputs.pr }}
           message: |
             Hi @scottn12 check this out :)

--- a/.github/workflows/merge-next-notify.yml
+++ b/.github/workflows/merge-next-notify.yml
@@ -1,0 +1,24 @@
+name: "Merge Next Notifier"
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  build:
+    if: ${{ github.event.label.name == 'msftbot: merge-next' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Load PR number
+        id: load_pr
+        run: echo "pr=$(cat pr)" >> $GITHUB_OUTPUT
+        working-directory: ./results
+
+      - name: Notify in comment
+        uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
+        with:
+          recreate: true
+          number: ${{ steps.load_pr.outputs.pr }}
+          message: |
+            Hi @scottn12 check this out :)

--- a/.github/workflows/merge-next-notify.yml
+++ b/.github/workflows/merge-next-notify.yml
@@ -11,11 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Load PR number
-        id: load_pr
-        run: echo "pr=$(cat pr)" >> $GITHUB_OUTPUT
-        working-directory: ./results
-
       - name: Notify in comment
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:

--- a/.github/workflows/merge-next-notify.yml
+++ b/.github/workflows/merge-next-notify.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [ labeled ]
     branches:
-      - next
+      - main
 
 jobs:
   build:

--- a/.github/workflows/merge-next-notify.yml
+++ b/.github/workflows/merge-next-notify.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   build:
-    if: ${{ github.event.label.name == 'msftbot: merge-next' }}
+    if: |
+      ${{ github.event.label.name == 'msftbot: merge-next' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/merge-next-notify.yml
+++ b/.github/workflows/merge-next-notify.yml
@@ -11,8 +11,8 @@ jobs:
 
     steps:
       - name: Notify in comment
-        only_create: true
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
+          only_create: true
           message: |
             Hi @scottn12 check this out :)

--- a/.github/workflows/merge-next-notify.yml
+++ b/.github/workflows/merge-next-notify.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [ labeled ]
     branches:
-      - main
+      - next
 
 jobs:
   build:
@@ -17,4 +17,4 @@ jobs:
         with:
           only_create: true
           message: |
-            Please review this PR: @scottn12
+            Please review this PR: @sonalideshpandemsft @tylerbutler @scottn12

--- a/.github/workflows/merge-next-notify.yml
+++ b/.github/workflows/merge-next-notify.yml
@@ -12,8 +12,8 @@ jobs:
 
     steps:
       - name: Notify in comment
+        only_create: true
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
-          recreate: true
           message: |
             Hi @scottn12 check this out :)

--- a/.github/workflows/merge-next-notify.yml
+++ b/.github/workflows/merge-next-notify.yml
@@ -6,8 +6,7 @@ on:
 
 jobs:
   build:
-    if: |
-      ${{ github.event.label.name == 'msftbot: merge-next' }}
+    if: "${{ github.event.label.name == 'msftbot: merge-next' }}"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description

This PR adds a GitHub action to notify the engineers with merge-next permissions when a PR targeting next gets the "msftbot: merge-next" label added.

It also disables auto-adding the label to new automation PRs.

## Misc

[AB#3731](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3731)
