### PR TITLE
remove infinite Caching of container

### DIFF
--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -413,8 +413,6 @@ export interface ILoader extends IFluidRouter, Partial<IProvideLoader> {
 // @public
 export interface ILoaderHeader {
     // (undocumented)
-    [LoaderHeader.cache]: boolean;
-    // (undocumented)
     [LoaderHeader.clientDetails]: IClientDetails;
     // (undocumented)
     [LoaderHeader.reconnect]: boolean;
@@ -527,7 +525,6 @@ export interface IUsageError extends IErrorBase {
 
 // @public
 export enum LoaderHeader {
-    cache = "fluid-cache",
     // (undocumented)
     clientDetails = "fluid-client-details",
     loadMode = "loadMode",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -79,6 +79,12 @@
 			"RemovedInterfaceDeclaration_IProvideFluidTokenProvider": {
 				"backCompat": false,
 				"forwardCompat": false
+			},
+			"InterfaceDeclaration_ILoaderHeader": {
+				"backCompat": false
+			},
+			"EnumDeclaration_LoaderHeader": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -541,11 +541,6 @@ export type ILoaderOptions = {
  * Accepted header keys for requests coming to the Loader
  */
 export enum LoaderHeader {
-	/**
-	 * Override the Loader's default caching behavior for this container.
-	 */
-	cache = "fluid-cache",
-
 	clientDetails = "fluid-client-details",
 
 	/**
@@ -609,7 +604,6 @@ export interface IContainerLoadMode {
  * Set of Request Headers that the Loader understands and may inspect or modify
  */
 export interface ILoaderHeader {
-	[LoaderHeader.cache]: boolean;
 	[LoaderHeader.clientDetails]: IClientDetails;
 	[LoaderHeader.loadMode]: IContainerLoadMode;
 	[LoaderHeader.sequenceNumber]: number;

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
@@ -1020,6 +1020,7 @@ declare function get_current_InterfaceDeclaration_ILoaderHeader():
 declare function use_old_InterfaceDeclaration_ILoaderHeader(
     use: TypeOnly<old.ILoaderHeader>);
 use_old_InterfaceDeclaration_ILoaderHeader(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ILoaderHeader());
 
 /*
@@ -1332,6 +1333,7 @@ declare function get_old_EnumDeclaration_LoaderHeader():
 declare function use_current_EnumDeclaration_LoaderHeader(
     use: TypeOnly<current.LoaderHeader>);
 use_current_EnumDeclaration_LoaderHeader(
+    // @ts-expect-error compatibility expected to be broken
     get_old_EnumDeclaration_LoaderHeader());
 
 /*

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -39,14 +39,6 @@ import { IParsedUrl, parseUrl } from "./utils";
 import { pkgVersion } from "./packageVersion";
 import { ProtocolHandlerBuilder } from "./protocol";
 
-function canUseCache(request: IRequest): boolean {
-	if (request.headers === undefined) {
-		return true;
-	}
-
-	return request.headers[LoaderHeader.cache] !== false;
-}
-
 /**
  * @deprecated - In the next release RelativeLoader will no longer be exported. It is an internal class that should not be used directly.
  */
@@ -62,20 +54,16 @@ export class RelativeLoader implements ILoader {
 
 	public async resolve(request: IRequest): Promise<IContainer> {
 		if (request.url.startsWith("/")) {
-			if (canUseCache(request)) {
-				return this.container;
-			} else {
-				const resolvedUrl = this.container.resolvedUrl;
-				ensureFluidResolvedUrl(resolvedUrl);
-				const container = await Container.load(this.loader as Loader, {
-					canReconnect: request.headers?.[LoaderHeader.reconnect],
-					clientDetailsOverride: request.headers?.[LoaderHeader.clientDetails],
-					resolvedUrl: { ...resolvedUrl },
-					version: request.headers?.[LoaderHeader.version] ?? undefined,
-					loadMode: request.headers?.[LoaderHeader.loadMode],
-				});
-				return container;
-			}
+			const resolvedUrl = this.container.resolvedUrl;
+			ensureFluidResolvedUrl(resolvedUrl);
+			const container = await Container.load(this.loader as Loader, {
+				canReconnect: request.headers?.[LoaderHeader.reconnect],
+				clientDetailsOverride: request.headers?.[LoaderHeader.clientDetails],
+				resolvedUrl: { ...resolvedUrl },
+				version: request.headers?.[LoaderHeader.version] ?? undefined,
+				loadMode: request.headers?.[LoaderHeader.loadMode],
+			});
+			return container;
 		}
 
 		if (this.loader === undefined) {

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -5,13 +5,7 @@
 
 import { v4 as uuid } from "uuid";
 import { ITelemetryBaseLogger, ITelemetryLogger } from "@fluidframework/common-definitions";
-import {
-	FluidObject,
-	IFluidRouter,
-	IRequest,
-	IRequestHeader,
-	IResponse,
-} from "@fluidframework/core-interfaces";
+import { FluidObject, IFluidRouter, IRequest, IResponse } from "@fluidframework/core-interfaces";
 import {
 	IContainer,
 	IFluidModule,
@@ -301,11 +295,7 @@ export class Loader implements IHostLoader {
 	}
 
 	public async createDetachedContainer(codeDetails: IFluidCodeDetails): Promise<IContainer> {
-		return Container.createDetached(
-			this,
-			codeDetails,
-			this.protocolHandlerBuilder,
-		);
+		return Container.createDetached(this, codeDetails, this.protocolHandlerBuilder);
 	}
 
 	public async rehydrateDetachedContainerFromSnapshot(snapshot: string): Promise<IContainer> {
@@ -362,7 +352,7 @@ export class Loader implements IHostLoader {
 		}
 
 		const { fromSequenceNumber } = this.parseHeader(parsed, request);
-	
+
 		const container = await this.loadContainer(request, resolvedAsFluid, pendingLocalState);
 
 		if (container.deltaManager.lastSequenceNumber <= fromSequenceNumber) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3351,7 +3351,6 @@ export class ContainerRuntime
 		return async () => {
 			const request: IRequest = {
 				headers: {
-					[LoaderHeader.cache]: false,
 					[LoaderHeader.clientDetails]: {
 						capabilities: { interactive: false },
 						type: summarizerClientType,

--- a/packages/runtime/container-runtime/src/summary/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizer.ts
@@ -120,7 +120,6 @@ export class Summarizer extends EventEmitter implements ISummarizer {
 	public static async create(loader: ILoader, url: string): Promise<ISummarizer> {
 		const request: IRequest = {
 			headers: {
-				[LoaderHeader.cache]: false,
 				[LoaderHeader.clientDetails]: {
 					capabilities: { interactive: false },
 					type: summarizerClientType,

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
@@ -86,7 +86,6 @@ async function loadSummarizer(
 	loaderProps?: Partial<ILoaderProps>,
 ) {
 	const requestHeader = {
-		[LoaderHeader.cache]: false,
 		[LoaderHeader.clientDetails]: {
 			capabilities: { interactive: true },
 			type: "summarizer",

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMap.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMap.ts
@@ -7,7 +7,7 @@
 import * as crypto from "crypto";
 import { strict as assert } from "assert";
 import { v4 as uuid } from "uuid";
-import { IContainer, IHostLoader, LoaderHeader } from "@fluidframework/container-definitions";
+import { IContainer, IHostLoader } from "@fluidframework/container-definitions";
 import { SharedMap } from "@fluidframework/map";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import {
@@ -133,9 +133,6 @@ export class DocumentMap implements IDocumentLoader {
 			this.containerUrl,
 		);
 		const testRequest: IRequest = {
-			headers: {
-				[LoaderHeader.cache]: false,
-			},
 			url: requestUrl,
 		};
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -70,7 +70,6 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
 	 */
 	async function createSummarizerClient(config: ITestContainerConfig) {
 		const requestHeader = {
-			[LoaderHeader.cache]: false,
 			[LoaderHeader.clientDetails]: {
 				capabilities: { interactive: true },
 				type: "summarizer",

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
@@ -45,7 +45,6 @@ async function loadSummarizer(
 	loaderProps?: Partial<ILoaderProps>,
 ) {
 	const requestHeader = {
-		[LoaderHeader.cache]: false,
 		[LoaderHeader.clientDetails]: {
 			capabilities: { interactive: true },
 			type: "summarizer",

--- a/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/loaderTest.spec.ts
@@ -202,7 +202,6 @@ describeNoCompat("Loader.request", (getTestObjectProvider) => {
 	it("loaded container is paused using loader pause flags", async () => {
 		// load the container paused
 		const headers: IRequestHeader = {
-			[LoaderHeader.cache]: false,
 			[LoaderHeader.loadMode]: { deltaConnection: "delayed" },
 		};
 		const url = await container.getAbsoluteUrl("");

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -40,7 +40,6 @@ async function createSummarizerCore(
 
 	const request: IRequest = {
 		headers: {
-			[LoaderHeader.cache]: false,
 			[LoaderHeader.clientDetails]: {
 				capabilities: { interactive: false },
 				type: summarizerClientType,


### PR DESCRIPTION
## Description
we don't need to cache container in Loader layer anymore, it would only affect performance, and current issue is container never will be released even if host does not keep references to the container
need PR for main
properties and functions that were removed:
-`addToContainerCache()`
-`this.cachingEnabled`
-`shouldCache`
-`this.containers`
-`canCacheForRequest()`
-`canUseCache()`
-`getKeyForContainerCache()`
-`LoaderHeader.cache`, `ILoaderHeader.cache` in container-definitions