### PR TITLE
fix(tree): maintain anchors through transaction abort

### DIFF
--- a/packages/dds/tree/src/core/edit-manager/editManager.ts
+++ b/packages/dds/tree/src/core/edit-manager/editManager.ts
@@ -325,7 +325,7 @@ export class EditManager<
 	}
 
 	/**
-	 * Given a revision on the local branch, remove all commits after it.
+	 * Given a revision on the local branch, remove all commits after it, and updates anchors accordingly.
 	 * @param startRevision - the revision on the local branch that will become the new head
 	 * @param repairStore - an optional repair data store to assist with generating inverses of the removed commits
 	 * @returns an iterator of deltas where each delta describes the change from rolling back one of the removed commits.
@@ -341,14 +341,14 @@ export class EditManager<
 
 		for (let i = commits.length - 1; i >= 0; i--) {
 			const { change, revision } = commits[i];
-			if (this.anchors !== undefined) {
-				this.changeFamily.rebaser.rebaseAnchors(this.anchors, change);
-			}
 			const inverse = this.changeFamily.rebaser.invert(
 				tagChange(change, revision),
 				false,
 				repairStore,
 			);
+			if (this.anchors !== undefined) {
+				this.changeFamily.rebaser.rebaseAnchors(this.anchors, inverse);
+			}
 			yield this.changeFamily.intoDelta(inverse);
 		}
 	}

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -18,11 +18,9 @@ import {
 	mintRevisionTag,
 	SeqNumber,
 	ChangeFamilyEditor,
-	AnchorSet,
 } from "../../core";
 import { brand, clone, makeArray, RecursiveReadonly } from "../../util";
 import {
-	AnchorRebaseData,
 	TestAnchorSet,
 	TestChangeEncoder,
 	TestChangeFamily,

--- a/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
+++ b/packages/dds/tree/src/test/edit-manager/editManager.spec.ts
@@ -18,6 +18,7 @@ import {
 	mintRevisionTag,
 	SeqNumber,
 	ChangeFamilyEditor,
+	AnchorSet,
 } from "../../core";
 import { brand, clone, makeArray, RecursiveReadonly } from "../../util";
 import {
@@ -62,7 +63,8 @@ function editManagerFactory(options: {
 	sessionId?: SessionId;
 }): {
 	manager: TestEditManager;
-	anchors: AnchorRebaseData;
+	anchors: TestAnchorSet;
+	family: ChangeFamily<ChangeFamilyEditor, TestChange>;
 } {
 	const family = changeFamilyFactory(options.rebaser);
 	const anchors = new TestAnchorSet();
@@ -71,7 +73,7 @@ function editManagerFactory(options: {
 		options.sessionId ?? localSessionId,
 		anchors,
 	);
-	return { manager, anchors };
+	return { manager, anchors, family };
 }
 
 const localSessionId: SessionId = "0";
@@ -280,6 +282,54 @@ describe("EditManager", () => {
 			assert.equal(manager.getTrunk().length, 10);
 			manager.advanceMinimumSequenceNumber(brand(5));
 			assert(manager.getTrunk().length < 10);
+		});
+
+		it("Rebases anchors over local changes", () => {
+			const { manager, anchors } = editManagerFactory({});
+			const change = TestChange.mint([], 1);
+			manager.addLocalChange(mintRevisionTag(), change, true);
+			assert.deepEqual(anchors.rebases, [change]);
+			assert.deepEqual(anchors.intentions, change.intentions);
+		});
+
+		it("Rebases anchors over sequenced changes", () => {
+			const { manager, anchors } = editManagerFactory({});
+			const change = TestChange.mint([], 1);
+			manager.addSequencedChange(
+				{
+					change,
+					revision: mintRevisionTag(),
+					sessionId: peer1,
+				},
+				brand(1),
+				brand(0),
+			);
+			assert.deepEqual(anchors.rebases, [change]);
+			assert.deepEqual(anchors.intentions, change.intentions);
+		});
+
+		it("Can rollback changes", () => {
+			const { manager, anchors, family } = editManagerFactory({});
+			const startingRevision = manager.getLocalBranchHead().revision;
+			const changes = [
+				TestChange.mint([], 1),
+				TestChange.mint([1], 2),
+				TestChange.mint([1, 2], -2),
+				TestChange.mint([1], 3),
+			];
+			for (const change of changes) {
+				manager.addLocalChange(mintRevisionTag(), change, true);
+			}
+			assert.deepEqual(anchors.rebases, changes);
+			assert.deepEqual(anchors.intentions, [1, 3]);
+
+			const inverseChanges = changes.map(TestChange.invert).reverse();
+			const inverseDeltas = inverseChanges.map(family.intoDelta);
+			const deltas = Array.from(manager.rollbackLocalChanges(startingRevision));
+			assert.deepEqual(deltas, inverseDeltas);
+			const totalRebases = [...changes, ...inverseChanges];
+			assert.deepEqual(anchors.rebases, totalRebases);
+			assert.deepEqual(anchors.intentions, []);
 		});
 
 		it("Updates local branch when loading from summary", () => {

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -33,15 +33,12 @@ import {
 	SchemaData,
 	EditManager,
 	ValueSchema,
-	TreeSchemaIdentifier,
-	Anchor,
 } from "../../core";
 import { checkTreesAreSynchronized } from "./sharedTreeFuzzTests";
 
 const fooKey: FieldKey = brand("foo");
 const globalFieldKey: GlobalFieldKey = brand("globalFieldKey");
 const globalFieldKeySymbol = symbolFromKey(globalFieldKey);
-const type: TreeSchemaIdentifier = brand("NodeType");
 
 describe("SharedTree", () => {
 	it("reads only one node", async () => {
@@ -984,22 +981,6 @@ describe("SharedTree", () => {
 	});
 
 	describe("Anchors", () => {
-		function getAnchorFromIndex(tree: ISharedTreeBranch, index: number): Anchor {
-			const cursor = tree.forest.allocateCursor();
-			moveToDetachedField(tree.forest, cursor);
-			cursor.enterNode(1);
-			const anchor = cursor.buildAnchor();
-			cursor.free();
-			return anchor;
-		}
-
-		function cursorFromAnchor(tree: ISharedTreeBranch, anchor: Anchor) {
-			const cursor = tree.forest.allocateCursor();
-			moveToDetachedField(tree.forest, cursor);
-			tree.forest.tryMoveCursorToNode(anchor, cursor);
-			return cursor;
-		}
-
 		it("Anchors can be created and dereferenced", async () => {
 			const provider = await TestTreeProvider.create(1);
 			const tree = provider.trees[0];
@@ -1035,62 +1016,6 @@ describe("SharedTree", () => {
 				parentIndex: 1,
 			};
 			assert(compareUpPaths(childPath, expected));
-		});
-
-		it("Anchors are adjusted in the face of edits", async () => {
-			const provider = await TestTreeProvider.create(1);
-			const tree = provider.trees[0];
-
-			const initialState: JsonableTree[] = [
-				{ type, value: "bar" },
-				{ type, value: "baz" },
-			];
-			initializeTestTree(tree, initialState);
-
-			const baz = getAnchorFromIndex(tree, 1);
-
-			tree.editor
-				.sequenceField(undefined, rootFieldKeySymbol)
-				.insert(0, singleTextCursor({ type: brand("Node"), value: "foo" }));
-
-			const afterInsert = cursorFromAnchor(tree, baz);
-			assert.equal(afterInsert.value, "baz");
-			afterInsert.free();
-
-			tree.editor.sequenceField(undefined, rootFieldKeySymbol).delete(0, 2);
-
-			const afterDelete = cursorFromAnchor(tree, baz);
-			assert.equal(afterDelete.value, "baz");
-			afterDelete.free();
-		});
-
-		it("Anchors are restored in the face of aborted transactions", async () => {
-			const provider = await TestTreeProvider.create(1);
-			const tree = provider.trees[0];
-
-			const initialState: JsonableTree[] = [
-				{ type, value: "bar" },
-				{ type, value: "baz" },
-			];
-			initializeTestTree(tree, initialState);
-
-			const baz = getAnchorFromIndex(tree, 1);
-
-			tree.transaction.start();
-			tree.editor
-				.sequenceField(undefined, rootFieldKeySymbol)
-				.insert(0, singleTextCursor({ type: brand("Node"), value: "foo" }));
-
-			const afterInsert = cursorFromAnchor(tree, baz);
-			assert.equal(afterInsert.value, "baz");
-			afterInsert.free();
-
-			tree.editor.sequenceField(undefined, rootFieldKeySymbol).delete(0, 2);
-			tree.transaction.abort();
-
-			const afterDelete = cursorFromAnchor(tree, baz);
-			assert.equal(afterDelete.value, "baz");
-			afterDelete.free();
 		});
 	});
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -33,12 +33,15 @@ import {
 	SchemaData,
 	EditManager,
 	ValueSchema,
+	TreeSchemaIdentifier,
+	Anchor,
 } from "../../core";
 import { checkTreesAreSynchronized } from "./sharedTreeFuzzTests";
 
 const fooKey: FieldKey = brand("foo");
 const globalFieldKey: GlobalFieldKey = brand("globalFieldKey");
 const globalFieldKeySymbol = symbolFromKey(globalFieldKey);
+const type: TreeSchemaIdentifier = brand("NodeType");
 
 describe("SharedTree", () => {
 	it("reads only one node", async () => {
@@ -981,6 +984,22 @@ describe("SharedTree", () => {
 	});
 
 	describe("Anchors", () => {
+		function getAnchorFromIndex(tree: ISharedTreeBranch, index: number): Anchor {
+			const cursor = tree.forest.allocateCursor();
+			moveToDetachedField(tree.forest, cursor);
+			cursor.enterNode(1);
+			const anchor = cursor.buildAnchor();
+			cursor.free();
+			return anchor;
+		}
+
+		function cursorFromAnchor(tree: ISharedTreeBranch, anchor: Anchor) {
+			const cursor = tree.forest.allocateCursor();
+			moveToDetachedField(tree.forest, cursor);
+			tree.forest.tryMoveCursorToNode(anchor, cursor);
+			return cursor;
+		}
+
 		it("Anchors can be created and dereferenced", async () => {
 			const provider = await TestTreeProvider.create(1);
 			const tree = provider.trees[0];
@@ -1016,6 +1035,62 @@ describe("SharedTree", () => {
 				parentIndex: 1,
 			};
 			assert(compareUpPaths(childPath, expected));
+		});
+
+		it("Anchors are adjusted in the face of edits", async () => {
+			const provider = await TestTreeProvider.create(1);
+			const tree = provider.trees[0];
+
+			const initialState: JsonableTree[] = [
+				{ type, value: "bar" },
+				{ type, value: "baz" },
+			];
+			initializeTestTree(tree, initialState);
+
+			const baz = getAnchorFromIndex(tree, 1);
+
+			tree.editor
+				.sequenceField(undefined, rootFieldKeySymbol)
+				.insert(0, singleTextCursor({ type: brand("Node"), value: "foo" }));
+
+			const afterInsert = cursorFromAnchor(tree, baz);
+			assert.equal(afterInsert.value, "baz");
+			afterInsert.free();
+
+			tree.editor.sequenceField(undefined, rootFieldKeySymbol).delete(0, 2);
+
+			const afterDelete = cursorFromAnchor(tree, baz);
+			assert.equal(afterDelete.value, "baz");
+			afterDelete.free();
+		});
+
+		it("Anchors are restored in the face of aborted transactions", async () => {
+			const provider = await TestTreeProvider.create(1);
+			const tree = provider.trees[0];
+
+			const initialState: JsonableTree[] = [
+				{ type, value: "bar" },
+				{ type, value: "baz" },
+			];
+			initializeTestTree(tree, initialState);
+
+			const baz = getAnchorFromIndex(tree, 1);
+
+			tree.transaction.start();
+			tree.editor
+				.sequenceField(undefined, rootFieldKeySymbol)
+				.insert(0, singleTextCursor({ type: brand("Node"), value: "foo" }));
+
+			const afterInsert = cursorFromAnchor(tree, baz);
+			assert.equal(afterInsert.value, "baz");
+			afterInsert.free();
+
+			tree.editor.sequenceField(undefined, rootFieldKeySymbol).delete(0, 2);
+			tree.transaction.abort();
+
+			const afterDelete = cursorFromAnchor(tree, baz);
+			assert.equal(afterDelete.value, "baz");
+			afterDelete.free();
 		});
 	});
 


### PR DESCRIPTION
This PR fixes a bug where anchors were not properly updated in the face of transaction abort.