### PR TITLE
Fix for assert 0x244 in odsp driver

### DIFF
--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -404,7 +404,8 @@ export class DocumentDeltaConnection
 		this._disposed = true;
 
 		// Remove all listeners listening on the socket. These are listeners on socket and not on this connection
-		// object.
+		// object. Anyway since we have disposed this connection object, nobody should listen to event on socket
+		// anymore.
 		this.removeTrackedListeners();
 
 		// Clear the connection/socket before letting the deltaManager/connection manager know about the disconnect.

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -350,11 +350,8 @@ export class DocumentDeltaConnection
 					eventName: "SocketCloseOnDisposedConnection",
 					driverVersion,
 					details: JSON.stringify({
-						disposed: this._disposed,
-						socketConnected: this.socket?.connected,
+						...this.getConnectionDetailsProps(),
 						trackedListenerCount: this.trackedListeners.size,
-						clientId: this.clientId,
-						connectionId: this.connectionId,
 					}),
 				},
 				error,
@@ -378,10 +375,7 @@ export class DocumentDeltaConnection
 			eventName: "ClientClosingDeltaConnection",
 			driverVersion,
 			details: JSON.stringify({
-				disposed: this._disposed,
-				socketConnected: this.socket.connected,
-				clientId: this._details?.clientId,
-				connectionId: this.connectionId,
+				...this.getConnectionDetailsProps(),
 			}),
 		});
 		this.disconnect(
@@ -409,26 +403,23 @@ export class DocumentDeltaConnection
 		// to prevent normal messages from being emitted.
 		this._disposed = true;
 
-		// Let user of connection object know about disconnect. This has to happen in between setting _disposed and
-		// removing all listeners!
+		// Remove all listeners listening on the socket. These are listeners on socket and not on this connection
+		// object.
+		this.removeTrackedListeners();
+
+		// Clear the connection/socket before letting the deltaManager/connection manager know about the disconnect.
+		this.disconnectCore();
+
+		// Let user of connection object know about disconnect.
 		this.emit("disconnect", err);
 		this.logger.sendTelemetryEvent({
 			eventName: "AfterDisconnectEvent",
 			driverVersion,
 			details: JSON.stringify({
-				disposed: this._disposed,
-				clientId: this.clientId,
-				socketConnected: this.socket.connected,
+				...this.getConnectionDetailsProps(),
 				disconnectListenerCount: this.listenerCount("disconnect"),
-				connectionId: this.connectionId,
 			}),
 		});
-		// user of DeltaConnection should have processed "disconnect" event and removed all listeners. Not clear
-		// if we want to enforce that, as some users (like LocalDocumentService) do not unregister any handlers
-		// assert(this.listenerCount("disconnect") === 0, "'disconnect` events should be processed synchronously");
-
-		this.removeTrackedListeners();
-		this.disconnectCore();
 	}
 
 	/**
@@ -640,14 +631,20 @@ export class DocumentDeltaConnection
 		const normalizedError = normalizeError(errorToBeNormalized, {
 			props: {
 				details: JSON.stringify({
-					disposed: this._disposed,
-					socketConnected: this.socket?.connected,
-					clientId: this._details?.clientId,
-					conenctionId: this.connectionId,
+					...this.getConnectionDetailsProps(),
 				}),
 			},
 		});
 		return normalizedError;
+	}
+
+	private getConnectionDetailsProps() {
+		return {
+			disposed: this._disposed,
+			socketConnected: this.socket?.connected,
+			clientId: this._details?.clientId,
+			connectionId: this.connectionId,
+		};
 	}
 
 	protected earlyOpHandler = (documentId: string, msgs: ISequencedDocumentMessage[]) => {
@@ -734,7 +731,12 @@ export class DocumentDeltaConnection
 		const errorObj = createGenericNetworkError(
 			`socket.io (${handler}): ${message}`,
 			{ canRetry },
-			{ driverVersion },
+			{
+				driverVersion,
+				details: JSON.stringify({
+					...this.getConnectionDetailsProps(),
+				}),
+			},
 		);
 
 		return errorObj;


### PR DESCRIPTION
## Description

This was a potential bug where before cleaning everything in the delta connection object we let the user of object know about the disconnection. Looking into the recently added telemetry, the assert occurs after emitting disconnect on the connection object and I see that the disconnectCore login on OdspDocumentDeltaConnection does not get executed and the socket reference/socket removeReference code does not execute, so later on reconnection there is a potential that we get the same socket reference and see the socket as connected because the pendingInitialConnection does not even get set to false. 
The emission of disconnect was after cleanup but seems like with this PR: https://github.com/microsoft/FluidFramework/pull/12223 it was moved before that and could have caused this bug.