### PR TITLE
[fluid-runner] Change eventsPerFlush from command line

### DIFF
--- a/packages/tools/fluid-runner/src/fluidRunner.ts
+++ b/packages/tools/fluid-runner/src/fluidRunner.ts
@@ -65,6 +65,12 @@ export function fluidRunner(fluidFileConverter?: IFluidFileConverter) {
 							'Property to add to every telemetry entry. Formatted like "--telemetryProp prop1 value1 --telemetryProp prop2 \\"value 2\\"".',
 						type: "array",
 						demandOption: false,
+					})
+					.option("eventsPerFlush", {
+						describe:
+							"Number of telemetry events per flush to telemetryFile (only applicable for JSON format)",
+						type: "number",
+						demandOption: false,
 					}),
 			// eslint-disable-next-line @typescript-eslint/no-misused-promises
 			async (argv) => {
@@ -76,6 +82,7 @@ export function fluidRunner(fluidFileConverter?: IFluidFileConverter) {
 				const telemetryOptionsResult = validateAndParseTelemetryOptions(
 					argv.telemetryFormat,
 					argv.telemetryProp,
+					argv.eventsPerFlush,
 				);
 				if (!telemetryOptionsResult.success) {
 					console.error(telemetryOptionsResult.error);

--- a/packages/tools/fluid-runner/src/logger/loggerUtils.ts
+++ b/packages/tools/fluid-runner/src/logger/loggerUtils.ts
@@ -56,6 +56,7 @@ export function getTelemetryFileValidationError(telemetryFile: string): string |
 export function validateAndParseTelemetryOptions(
 	format?: string,
 	props?: (string | number)[],
+	eventsPerFlush?: number,
 ): { success: false; error: string } | { success: true; telemetryOptions: ITelemetryOptions } {
 	let outputFormat: OutputFormat | undefined;
 	const defaultProps: Record<string, string | number> = {};
@@ -85,5 +86,12 @@ export function validateAndParseTelemetryOptions(
 		}
 	}
 
-	return { success: true, telemetryOptions: { outputFormat, defaultProps } };
+	if (eventsPerFlush !== undefined && isNaN(eventsPerFlush)) {
+		return {
+			success: false,
+			error: "Invalid eventsPerFlush",
+		};
+	}
+
+	return { success: true, telemetryOptions: { outputFormat, defaultProps, eventsPerFlush } };
 }

--- a/packages/tools/fluid-runner/src/test/fluidRunner.spec.ts
+++ b/packages/tools/fluid-runner/src/test/fluidRunner.spec.ts
@@ -37,7 +37,8 @@ describe("fluid-runner from command line", () => {
 					`--inputFile=${snapshot}`,
 					`--outputFile=${outputFilePath}`,
 					`--telemetryFile=${telemetryFile}`,
-					`--telemetryFormat=CSV`,
+					"--telemetryFormat=CSV",
+					"--eventsPerFlush=-2",
 				],
 				{ encoding: "utf-8" },
 			);


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

The `ITelemetryOptions` interface allows for changing `eventsPerFlush`, but there was no way to do this from the command line (which is where this tool is primarily used).