### PR TITLE
Use Chalk in benchmark

### DIFF
--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -38,6 +38,7 @@
 	},
 	"dependencies": {
 		"chai": "^4.2.0",
+		"chalk": "^4.1.2",
 		"easy-table": "^1.1.1",
 		"mocha": "^10.0.0"
 	},

--- a/tools/benchmark/pnpm-lock.yaml
+++ b/tools/benchmark/pnpm-lock.yaml
@@ -1,50 +1,53 @@
 lockfileVersion: 5.4
 
-specifiers:
-  '@fluidframework/build-common': ^1.1.0
-  '@fluidframework/eslint-config-fluid': ^2.0.0
-  '@fluidframework/mocha-test-setup': ^1.3.1
-  '@microsoft/api-extractor': ^7.22.2
-  '@rushstack/eslint-config': ^2.5.1
-  '@types/benchmark': ^2.1.0
-  '@types/easy-table': ^0.0.32
-  '@types/mocha': ^9.1.1
-  '@types/node': ^14.18.0
-  chai: ^4.2.0
-  concurrently: ^6.2.0
-  copyfiles: ^2.4.1
-  cross-env: ^7.0.2
-  easy-table: ^1.1.1
-  eslint: ~8.6.0
-  mocha: ^10.0.0
-  nyc: ^15.0.0
-  prettier: ~2.6.2
-  rimraf: ^2.6.2
-  typescript: ~4.5.5
+importers:
 
-dependencies:
-  chai: 4.3.7
-  easy-table: 1.2.0
-  mocha: 10.2.0
-
-devDependencies:
-  '@fluidframework/build-common': 1.1.0
-  '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-  '@fluidframework/mocha-test-setup': 1.3.6
-  '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
-  '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
-  '@types/benchmark': 2.1.2
-  '@types/easy-table': 0.0.32
-  '@types/mocha': 9.1.1
-  '@types/node': 14.18.38
-  concurrently: 6.5.1
-  copyfiles: 2.4.1
-  cross-env: 7.0.3
-  eslint: 8.6.0
-  nyc: 15.1.0
-  prettier: 2.6.2
-  rimraf: 2.7.1
-  typescript: 4.5.5
+  .:
+    specifiers:
+      '@fluidframework/build-common': ^1.1.0
+      '@fluidframework/eslint-config-fluid': ^2.0.0
+      '@fluidframework/mocha-test-setup': ^1.3.1
+      '@microsoft/api-extractor': ^7.22.2
+      '@rushstack/eslint-config': ^2.5.1
+      '@types/benchmark': ^2.1.0
+      '@types/easy-table': ^0.0.32
+      '@types/mocha': ^9.1.1
+      '@types/node': ^14.18.0
+      chai: ^4.2.0
+      chalk: ^4.1.2
+      concurrently: ^6.2.0
+      copyfiles: ^2.4.1
+      cross-env: ^7.0.2
+      easy-table: ^1.1.1
+      eslint: ~8.6.0
+      mocha: ^10.0.0
+      nyc: ^15.0.0
+      prettier: ~2.6.2
+      rimraf: ^2.6.2
+      typescript: ~4.5.5
+    dependencies:
+      chai: 4.3.7
+      chalk: 4.1.2
+      easy-table: 1.2.0
+      mocha: 10.2.0
+    devDependencies:
+      '@fluidframework/build-common': 1.1.0
+      '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
+      '@fluidframework/mocha-test-setup': 1.3.6
+      '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
+      '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
+      '@types/benchmark': 2.1.2
+      '@types/easy-table': 0.0.32
+      '@types/mocha': 9.1.1
+      '@types/node': 14.18.38
+      concurrently: 6.5.1
+      copyfiles: 2.4.1
+      cross-env: 7.0.3
+      eslint: 8.6.0
+      nyc: 15.1.0
+      prettier: 2.6.2
+      rimraf: 2.7.1
+      typescript: 4.5.5
 
 packages:
 

--- a/tools/benchmark/src/MochaMemoryTestReporter.ts
+++ b/tools/benchmark/src/MochaMemoryTestReporter.ts
@@ -7,17 +7,9 @@ import * as path from "path";
 import * as fs from "fs";
 import Table from "easy-table";
 import { Runner, Suite, Test } from "mocha";
+import chalk from "chalk";
 import { isChildProcess } from "./Configuration";
-import {
-	bold,
-	green,
-	italicize,
-	pad,
-	prettyNumber,
-	red,
-	getName,
-	getSuiteName,
-} from "./ReporterUtilities";
+import { pad, prettyNumber, getName, getSuiteName } from "./ReporterUtilities";
 import { MemoryBenchmarkStats } from "./MemoryTestRunner";
 
 /**
@@ -59,7 +51,9 @@ class MochaMemoryTestReporter {
 				});
 			})
 			.on(Runner.constants.EVENT_TEST_FAIL, (test, err) => {
-				console.info(red(`Test ${test.fullTitle()} failed with error: '${err.message}'`));
+				console.info(
+					chalk.red(`Test ${test.fullTitle()} failed with error: '${err.message}'`),
+				);
 			})
 			.on(Runner.constants.EVENT_TEST_END, (test: Test) => {
 				// Type signature for `Test.state` indicates it will never be 'pending',
@@ -74,7 +68,7 @@ class MochaMemoryTestReporter {
 				if (memoryTestStats === undefined) {
 					// Mocha test complected with out reporting data. This is an error, so report it as such.
 					console.error(
-						red(
+						chalk.red(
 							`Test ${test.title} in ${suite} completed with status '${test.state}' without reporting any data.`,
 						),
 					);
@@ -84,7 +78,7 @@ class MochaMemoryTestReporter {
 					// The mocha test failed after reporting benchmark data.
 					// This may indicate the benchmark did not measure what was intended, so mark as aborted.
 					console.info(
-						red(
+						chalk.red(
 							`Test ${test.title} in ${suite} completed with status '${test.state}' after reporting data.`,
 						),
 					);
@@ -110,18 +104,18 @@ class MochaMemoryTestReporter {
 					if (suiteData === undefined) {
 						return;
 					}
-					console.log(`\n${bold(suiteName)}`);
+					console.log(`\n${chalk.bold(suiteName)}`);
 
 					const table = new Table();
 					const failedTests = new Array<[string, MemoryBenchmarkStats]>();
 					suiteData?.forEach(([testName, testData]) => {
 						if (testData.aborted) {
-							table.cell("status", `${pad(4)}${red("×")}`);
+							table.cell("status", `${pad(4)}${chalk.red("×")}`);
 							failedTests.push([testName, testData]);
 						} else {
-							table.cell("status", `${pad(4)}${green("✔")}`);
+							table.cell("status", `${pad(4)}${chalk.green("✔")}`);
 						}
-						table.cell("name", italicize(testName));
+						table.cell("name", chalk.italic(testName));
 						if (!testData.aborted) {
 							table.cell(
 								"Heap Used Avg",
@@ -162,10 +156,10 @@ class MochaMemoryTestReporter {
 					if (failedTests.length > 0) {
 						console.log(
 							"------------------------------------------------------",
-							`\n${red("ERRORS:")}`,
+							`\n${chalk.red("ERRORS:")}`,
 						);
 						failedTests.forEach(([testName, testData]) => {
-							console.log(`\n${red(testName)}`, "\n", testData.error);
+							console.log(`\n${chalk.red(testName)}`, "\n", testData.error);
 						});
 					}
 					this.writeCompletedBenchmarks(suiteName);

--- a/tools/benchmark/src/MochaReporter.ts
+++ b/tools/benchmark/src/MochaReporter.ts
@@ -4,9 +4,10 @@
  */
 
 import { Runner, Suite, Test } from "mocha";
+import chalk from "chalk";
 import { isChildProcess, ReporterOptions } from "./Configuration";
 import { BenchmarkReporter } from "./Reporter";
-import { red, getName, getSuiteName } from "./ReporterUtilities";
+import { getName, getSuiteName } from "./ReporterUtilities";
 import { BenchmarkData, BenchmarkResult } from "./runBenchmark";
 
 /**
@@ -38,7 +39,9 @@ module.exports = class {
 				});
 			})
 			.on(Runner.constants.EVENT_TEST_FAIL, (test, err) => {
-				console.error(red(`Test ${test.fullTitle()} failed with error: '${err.message}'`));
+				console.error(
+					chalk.red(`Test ${test.fullTitle()} failed with error: '${err.message}'`),
+				);
 			})
 			.on(Runner.constants.EVENT_TEST_END, (test: Test) => {
 				// Type signature for `Test.state` indicates it will never be 'pending',
@@ -54,7 +57,7 @@ module.exports = class {
 					// Mocha test complected with out reporting data.
 					// This is an error, so report it as such.
 					const error = `Test ${test.title} in ${suite} completed with status '${test.state}' without reporting any data.`;
-					console.error(red(error));
+					console.error(chalk.red(error));
 					benchmarkReporter.recordTestResult(suite, getName(test.title), { error });
 					return;
 				}
@@ -62,7 +65,7 @@ module.exports = class {
 					// The mocha test failed after reporting benchmark data.
 					// This may indicate the benchmark did not measure what was intended, so mark as aborted.
 					const error = `Test ${test.title} in ${suite} completed with status '${test.state}' after reporting data.`;
-					console.error(red(error));
+					console.error(chalk.red(error));
 					benchmark = { error };
 				}
 

--- a/tools/benchmark/src/Reporter.ts
+++ b/tools/benchmark/src/Reporter.ts
@@ -31,17 +31,8 @@ SOFTWARE.
 import * as path from "path";
 import * as fs from "fs";
 import Table from "easy-table";
-import {
-	bold,
-	geometricMean,
-	italicize,
-	pad,
-	prettyNumber,
-	green,
-	red,
-	yellow,
-	Stats,
-} from "./ReporterUtilities";
+import chalk from "chalk";
+import { geometricMean, pad, prettyNumber, Stats } from "./ReporterUtilities";
 import { BenchmarkData, BenchmarkResult, isResultError } from "./runBenchmark";
 import { ExpectedCell, addCells, numberCell, stringCell } from "./resultFormatting";
 
@@ -51,7 +42,7 @@ interface BenchmarkResults {
 }
 
 const expectedKeys: ExpectedCell[] = [
-	stringCell("error", "error", (message) => red(message || "Error")),
+	stringCell("error", "error", (message) => chalk.red(message || "Error")),
 	{
 		key: "stats",
 		cell: (table, data) => {
@@ -143,11 +134,11 @@ export class BenchmarkReporter {
 
 		benchmarksMap.set(testName, result);
 		if (isResultError(result)) {
-			table.cell("status", `${pad(4)}${red("×")}`);
+			table.cell("status", `${pad(4)}${chalk.red("×")}`);
 		} else {
-			table.cell("status", `${pad(4)}${green("✔")}`);
+			table.cell("status", `${pad(4)}${chalk.green("✔")}`);
 		}
-		table.cell("name", italicize(testName));
+		table.cell("name", chalk.italic(testName));
 
 		// Using this utility to print the data means missing fields don't crash and extra fields are reported.
 		// This is useful if this reporter is given unexpected data (such as from a memory test).
@@ -181,7 +172,7 @@ export class BenchmarkReporter {
 		const { benchmarksMap, table } = results;
 
 		// Output results from suite
-		console.log(`\n${bold(suiteName)}`);
+		console.log(`\n${chalk.bold(suiteName)}`);
 		const filenameFull: string = this.writeCompletedBenchmarks(suiteName, benchmarksMap);
 		console.log(`Results file: ${filenameFull}`);
 		console.log(`${table.toString()}`);
@@ -205,16 +196,16 @@ export class BenchmarkReporter {
 		let statusSymbol: string;
 		switch (benchmarksMap.size) {
 			case countSuccessful:
-				statusSymbol = green("✔");
+				statusSymbol = chalk.green("✔");
 				break;
 			case countFailure:
-				statusSymbol = red("×");
+				statusSymbol = chalk.red("×");
 				break;
 			default:
-				statusSymbol = yellow("!");
+				statusSymbol = chalk.yellow("!");
 		}
 		this.overallSummaryTable.cell("status", pad(4) + statusSymbol);
-		this.overallSummaryTable.cell("suite name", italicize(suiteName));
+		this.overallSummaryTable.cell("suite name", chalk.italic(suiteName));
 		const geometricMeanString: string = prettyNumber(
 			geometricMean(benchmarkPeriodsSeconds) * 1e9,
 			1,
@@ -267,7 +258,7 @@ export class BenchmarkReporter {
 			Table.padLeft,
 		);
 		this.overallSummaryTable.newRow();
-		console.log(`\n\n${bold("Overall summary")}`);
+		console.log(`\n\n${chalk.bold("Overall summary")}`);
 		console.log(`\n${this.overallSummaryTable.toString()}`);
 		if (countFailure > 0) {
 			console.log(

--- a/tools/benchmark/src/ReporterUtilities.ts
+++ b/tools/benchmark/src/ReporterUtilities.ts
@@ -4,6 +4,7 @@
  */
 
 import { assert } from "chai";
+import chalk from "chalk";
 import { Suite } from "mocha";
 import {
 	benchmarkTypes,
@@ -49,27 +50,27 @@ export function getName(name: string): string {
 /**
  * @returns a red version of the input string
  */
-export const red = (s: string): string => `\u001b[31m${s}\u001b[0m`;
+export const red = (s: string): string => chalk.red(s);
 
 /**
  * @returns a green version of the input string
  */
-export const green = (s: string): string => `\u001b[32m${s}\u001b[0m`;
+export const green = (s: string): string => chalk.green(s);
 
 /**
  * @returns a yellow version of the input string
  */
-export const yellow = (s: string): string => `\u001b[33m${s}\u001b[0m`;
+export const yellow = (s: string): string => chalk.yellow(s);
 
 /**
  * @returns an italicized version of the input string
  */
-export const italicize = (s: string): string => `\x1b[3m${s}\x1b[23m`;
+export const italicize = (s: string): string => chalk.italic(s);
 
 /**
  * @returns a bolded version of the input string
  */
-export const bold = (s: string): string => `\x1B[1m${s}\x1B[22m`;
+export const bold = (s: string): string => chalk.bold(s);
 
 /**
  * @param num - Number of characters to pad

--- a/tools/benchmark/src/ReporterUtilities.ts
+++ b/tools/benchmark/src/ReporterUtilities.ts
@@ -4,7 +4,6 @@
  */
 
 import { assert } from "chai";
-import chalk from "chalk";
 import { Suite } from "mocha";
 import {
 	benchmarkTypes,
@@ -46,31 +45,6 @@ export function getName(name: string): string {
 	}
 	return s.trim();
 }
-
-/**
- * @returns a red version of the input string
- */
-export const red = (s: string): string => chalk.red(s);
-
-/**
- * @returns a green version of the input string
- */
-export const green = (s: string): string => chalk.green(s);
-
-/**
- * @returns a yellow version of the input string
- */
-export const yellow = (s: string): string => chalk.yellow(s);
-
-/**
- * @returns an italicized version of the input string
- */
-export const italicize = (s: string): string => chalk.italic(s);
-
-/**
- * @returns a bolded version of the input string
- */
-export const bold = (s: string): string => chalk.bold(s);
 
 /**
  * @param num - Number of characters to pad

--- a/tools/benchmark/src/resultFormatting.ts
+++ b/tools/benchmark/src/resultFormatting.ts
@@ -4,7 +4,7 @@
  */
 
 import Table from "easy-table";
-import { red } from "./ReporterUtilities";
+import chalk from "chalk";
 
 /**
  * Library for converting a `Record<string, unknown>` into formatted table cells.
@@ -25,7 +25,7 @@ export function numberCell(key: string, title: string, f: (v: number) => string)
 		cell: (table, data) => {
 			const field = data[key];
 			const content =
-				typeof field === "number" ? f(field) : red(`Expected number got "${field}"`);
+				typeof field === "number" ? f(field) : chalk.red(`Expected number got "${field}"`);
 			table.cell(title, content, Table.padLeft);
 		},
 	};
@@ -37,7 +37,7 @@ export function stringCell(key: string, title: string, f: (s: string) => string)
 		cell: (table, data) => {
 			const field = data[key];
 			const content =
-				typeof field === "string" ? f(field) : red(`Expected string got "${field}"`);
+				typeof field === "string" ? f(field) : chalk.red(`Expected string got "${field}"`);
 			table.cell(title, content);
 		},
 	};
@@ -48,7 +48,9 @@ export function arrayCell(key: string, title: string, f: (a: unknown[]) => strin
 		key,
 		cell: (table, data) => {
 			const field = data[key];
-			const content = Array.isArray(field) ? f(field) : red(`Expected array got "${field}"`);
+			const content = Array.isArray(field)
+				? f(field)
+				: chalk.red(`Expected array got "${field}"`);
 			table.cell(title, content);
 		},
 	};
@@ -60,7 +62,7 @@ export function objectCell(key: string, title: string, f: (a: object) => string)
 		cell: (table, data) => {
 			const field = data[key];
 			const content =
-				typeof field === "object" ? f(field) : red(`Expected object got "${field}"`);
+				typeof field === "object" ? f(field) : chalk.red(`Expected object got "${field}"`);
 			table.cell(title, content);
 		},
 	};


### PR DESCRIPTION
## Description

Replace hard coded console color escapes with Chalk, which detects color support. This avoids filling log files (when redirecting output) with escapes, making comparting large runs of benchmarks manually easier.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
