### PR TITLE
ci: Enable prereleases for benchmark and api-markdown-documenter

### DIFF
--- a/tools/pipelines/build-api-markdown-documenter.yml
+++ b/tools/pipelines/build-api-markdown-documenter.yml
@@ -12,6 +12,7 @@ parameters:
   default: none
   values:
     - none
+    - prerelease
     - release
 - name: publishOverride
   displayName: Publish Override (default = based on branch)
@@ -66,4 +67,3 @@ extends:
     taskLint: true
     taskTest:
     - test
-    buildNumberInPatch: false # Publish as is, do override patch with build number

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -12,6 +12,7 @@ parameters:
   default: none
   values:
     - none
+    - prerelease
     - release
 - name: publishOverride
   displayName: Publish Override (default = based on branch)
@@ -73,4 +74,3 @@ extends:
     taskLint: true
     taskTest:
     - test
-    buildNumberInPatch: true


### PR DESCRIPTION
The benchmark and api-markdown-documenter projects support prereleases because they don't use the `buildNumberInPatch` setting in CI, which puts the build number in the patch section of the semver. With this change, these packages can be prereleased using the ADO UI like most of our other pipelines.