### PR TITLE
[GC-stress] Report if test failed because of GC failures or not

### DIFF
--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -294,11 +294,16 @@ function writeTestResultXmlFile(results: RunnerResult[], durationSec: number) {
 			// Success
 			return { testcase: [{ _attr }] };
 		}
+		let failureReason = "";
+		// The returnCode is -2 for GC failures.
+		if (returnCode === -2) {
+			failureReason = "GC failure - check pipeline logs to find the error."
+		}
 		return {
 			testcase: [
 				{ _attr },
 				// Failure
-				{ failure: "Test Runner failed! Check pipeline logs to find the error" },
+				{ failure: `Test Runner failed! ${failureReason}` },
 			],
 		};
 	});

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -121,8 +121,8 @@ async function main() {
 		if (
 			logEvent.eventName.includes("InactiveObject") ||
 			logEvent.eventName.includes("SweepReadyObject") ||
-			logEvent.eventName.startsWith("GC_Tombstone") ||
-			logEvent.eventName.startsWith("GC_Deleted")
+			logEvent.eventName.includes("GC_Tombstone") ||
+			logEvent.eventName.includes("GC_Deleted")
 		) {
 			testFailed = true;
 			console.error(`xxxxxxxxx ${JSON.stringify(logEvent)}`);
@@ -150,7 +150,7 @@ async function main() {
 		logger.sendErrorEvent({ eventName: "runnerFailed" }, e);
 	} finally {
 		if (testFailed) {
-			result = -1;
+			result = -2;
 		}
 		await safeExit(result, url, runId);
 	}


### PR DESCRIPTION
There are some test stress test runs that are failing but I don't see any of the GC error / event logs in the console or in Kusto. I believe the test is failing due to some other issue but its hard to tell the difference.

This PR changes the return code in case of GC failures to -2. The test result builder uses this value to alter the failure message depending on whether the failure is because of GC errors or not.