### PR TITLE
feat(check:policy): Add setting to ignore single-package pnpm workspaces

### DIFF
--- a/build-tools/packages/build-tools/src/common/fluidRepo.ts
+++ b/build-tools/packages/build-tools/src/common/fluidRepo.ts
@@ -133,6 +133,7 @@ export type PreviousVersionStyle =
  */
 export interface PolicyConfig {
 	additionalLockfilePaths?: string[];
+	pnpmSinglePackageWorkspace?: string[];
 	dependencies?: {
 		requireTilde?: string[];
 	};

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/pnpm.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/pnpm.ts
@@ -4,6 +4,7 @@
  */
 import fs from "fs";
 import path from "path";
+import { getFluidBuildConfig } from "../../common/fluidUtils";
 
 import { PackageJson } from "../../common/npmPackage";
 import { Handler, readFile } from "../common";
@@ -11,17 +12,24 @@ import { Handler, readFile } from "../common";
 const match = /(?:^|\/)pnpm-lock\.yaml$/i;
 export const handlers: Handler[] = [
 	{
-		// A package or workspace that uses pnpm must also have a preinstall script that tells the user to use pnpm.
+		// A workspace that uses pnpm must also have a preinstall script that tells the user to use pnpm.
 		name: "pnpm-npm-package-json-preinstall",
 		match,
-		handler: (file) => {
+		handler: (file, root) => {
 			const dirname = path.dirname(file);
 			const packageJsonFile = path.join(dirname, "package.json");
+			const manifest = getFluidBuildConfig(root);
+
 			let json: PackageJson;
 			try {
 				json = JSON.parse(readFile(packageJsonFile));
 			} catch (err) {
 				return "Error parsing JSON file: " + packageJsonFile;
+			}
+
+			// Ignore any paths in the policy configuration.
+			if (manifest.policy?.pnpmSinglePackageWorkspace?.includes(json.name)) {
+				return undefined;
 			}
 
 			const script: string | undefined = json.scripts?.preinstall;

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -59,6 +59,19 @@ module.exports = {
 				"webpack-dev-server",
 			],
 		},
+    // These packages are independently versioned and released, but we use pnpm workspaces in single packages to work
+    // around nested pnpm workspace behavior. These packages are not checked for the preinstall script that standard
+    // pnpm workspaces should have.
+    pnpmSinglePackageWorkspace: [
+      "@fluid-tools/api-markdown-documenter",
+      "@fluid-tools/benchmark",
+      "@fluidframework/build-common",
+      "@fluidframework/common-definitions",
+      "@fluidframework/common-utils",
+      "@fluidframework/eslint-config-fluid",
+      "@fluidframework/protocol-definitions",
+      "@fluidframework/test-tools",
+    ],
 	},
 
 	// This defines the branch release types for type tests. It applies only to the client release group. Settings for


### PR DESCRIPTION
pnpm does not support nesting packages under a workspace that is not managed by the workspace. That is, if there's a `pnpm-workspace.yaml` file anywhere in the parent hierarchy, pnpm doesn't install the package individually like one might expect.

Because we have the client release group at the root of the repo, there's a `pnpm-workspace.yaml` file in the hierarchy for our independent packages as well. We put a workspace file in each independent package so pnpm treats the project as a one-package workspace.

However, for policy-check, we need to be able to treat these single-package workspaces differently. In particular we don't want to enforce the preinstall script that we use in release group roots. This PR adds a new setting to policy-check that contains a list of packages that are single-package workspaces.
