### PR TITLE
build: Remove @trivago/prettier-plugin-sort-imports

### DIFF
--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -73,7 +73,6 @@
 		"@fluidframework/mocha-test-setup": "^1.2.5",
 		"@fluidframework/test-utils": "^1.2.5",
 		"@microsoft/api-extractor": "^7.34.4",
-		"@trivago/prettier-plugin-sort-imports": "^3.3.0",
 		"@types/chai": "^4",
 		"@types/fs-extra": "^9.0.13",
 		"@types/mocha": "^9.1.1",

--- a/tools/api-markdown-documenter/pnpm-lock.yaml
+++ b/tools/api-markdown-documenter/pnpm-lock.yaml
@@ -14,7 +14,6 @@ importers:
       '@microsoft/api-extractor-model': ^7.26.4
       '@microsoft/tsdoc': ^0.14.2
       '@rushstack/node-core-library': ^3.50.1
-      '@trivago/prettier-plugin-sort-imports': ^3.3.0
       '@types/chai': ^4
       '@types/fs-extra': ^9.0.13
       '@types/mocha': ^9.1.1
@@ -48,7 +47,6 @@ importers:
       '@fluidframework/mocha-test-setup': 1.2.5
       '@fluidframework/test-utils': 1.2.5
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
-      '@trivago/prettier-plugin-sort-imports': 3.3.0_prettier@2.6.2
       '@types/chai': 4.3.1
       '@types/fs-extra': 9.0.13
       '@types/mocha': 9.1.1
@@ -112,15 +110,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@babel/generator/7.17.7:
-    resolution: {integrity: sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.18.10
-      jsesc: 2.5.2
-      source-map: 0.5.7
     dev: true
 
   /@babel/generator/7.18.12:
@@ -237,14 +226,6 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@babel/parser/7.17.8:
-    resolution: {integrity: sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.18.10
-    dev: true
-
   /@babel/parser/7.18.11:
     resolution: {integrity: sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==}
     engines: {node: '>=6.0.0'}
@@ -270,24 +251,6 @@ packages:
       '@babel/types': 7.18.10
     dev: true
 
-  /@babel/traverse/7.17.3:
-    resolution: {integrity: sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.18.12
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.18.9
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.18.11
-      '@babel/types': 7.18.10
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/traverse/7.18.11:
     resolution: {integrity: sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==}
     engines: {node: '>=6.9.0'}
@@ -304,14 +267,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@babel/types/7.17.0:
-    resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.18.6
-      to-fast-properties: 2.0.0
     dev: true
 
   /@babel/types/7.18.10:
@@ -1575,23 +1530,6 @@ packages:
 
   /@socket.io/component-emitter/3.1.0:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
-    dev: true
-
-  /@trivago/prettier-plugin-sort-imports/3.3.0_prettier@2.6.2:
-    resolution: {integrity: sha512-1y44bVZuIN0RsS3oIiGd5k8Vm3IZXYZnp4VsP2Z/S5L9WAOw43HE2clso66M2S/dDeJ+8sKPqnHsEfh39Vjs3w==}
-    peerDependencies:
-      prettier: 2.x
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/generator': 7.17.7
-      '@babel/parser': 7.17.8
-      '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
-      javascript-natural-sort: 0.7.1
-      lodash: 4.17.21
-      prettier: 2.6.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@ts-morph/common/0.5.2:
@@ -4307,10 +4245,6 @@ packages:
       minimatch: 3.1.2
     dev: true
 
-  /javascript-natural-sort/0.7.1:
-    resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
-    dev: true
-
   /jest-worker/27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
@@ -5828,11 +5762,6 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
-    dev: true
-
-  /source-map/0.5.7:
-    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
-    engines: {node: '>=0.10.0'}
     dev: true
 
   /source-map/0.6.1:

--- a/tools/api-markdown-documenter/prettier.config.cjs
+++ b/tools/api-markdown-documenter/prettier.config.cjs
@@ -5,7 +5,6 @@
 
 module.exports = {
 	...require("@fluidframework/build-common/prettier.config.cjs"),
-	plugins: ["@trivago/prettier-plugin-sort-imports"],
 	importOrder: [
 		"^node:(.*)$", // Special-case `node:` imports
 		"<THIRD_PARTY_MODULES>",


### PR DESCRIPTION
The @trivago/prettier-plugin-sort-imports prettier plugin is not used across the repo, and due to limitations in prettier, we can't use it for some projects and not others. So I have removed the plugin from the last remaining place it's used.