### PR TITLE
fix(release): Handle released dependency bumps

### DIFF
--- a/build-tools/packages/build-cli/src/handlers/fluidReleaseStateHandler.ts
+++ b/build-tools/packages/build-cli/src/handlers/fluidReleaseStateHandler.ts
@@ -320,7 +320,8 @@ export class FluidReleaseStateHandler extends InitFailedStateHandler {
 				break;
 			}
 
-			case "PromptToPRDeps": {
+			case "PromptToPRDeps":
+      case "PromptToPRReleasedDepsBump": {
 				result = await promptToPRDeps(state, machine, testMode, log, data);
 				break;
 			}
@@ -340,17 +341,6 @@ export class FluidReleaseStateHandler extends InitFailedStateHandler {
 
 			case "PromptToReleaseDeps": {
 				result = await promptToReleaseDeps(state, machine, testMode, log, data);
-				break;
-			}
-
-			case "PromptToPRReleasedDepsBump": {
-				if (testMode) return true;
-
-				log.errorLog(`Not yet implemented`);
-				if (data.exitFunc !== undefined) {
-					data.exitFunc(101);
-				}
-
 				break;
 			}
 

--- a/build-tools/packages/build-cli/src/handlers/fluidReleaseStateHandler.ts
+++ b/build-tools/packages/build-cli/src/handlers/fluidReleaseStateHandler.ts
@@ -321,7 +321,7 @@ export class FluidReleaseStateHandler extends InitFailedStateHandler {
 			}
 
 			case "PromptToPRDeps":
-      case "PromptToPRReleasedDepsBump": {
+			case "PromptToPRReleasedDepsBump": {
 				result = await promptToPRDeps(state, machine, testMode, log, data);
 				break;
 			}


### PR DESCRIPTION
The build tools did not handle the case where a pre-release dependency needs to be bumped. I re-used an existing prompt handler as a quick fix. If needed we can follow up with a better change.