### PR TITLE
breaking.md notes about LoaderHeader.cache deprecation

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -31,7 +31,7 @@ ensureFluidResolvedUrl will be deprecated and removed due to this.
 
 ## LoaderHeader.cache deprecated
 
-In @fluidframework/container-definitions, the enum `LoaderHeader` has property cache, is deprecated.
+In `@fluidframework/container-definitions`, the `cache` value from the `LoaderHeader` enum has been deprecated.
 Therefore, `ILoaderHeader` has property `[LoaderHeader.cache]` is also deprecated. They will both be removed in the next major release, as well as all caching functionality of containers.
 
 # 2.0.0-internal.3.3.0

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -20,12 +20,17 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 ## 2.0.0-internal.3.4.0 Upcoming changes
 
 [IResolvedUrl will be equivalent to IFluidResolvedUrl](#IResolvedUrl-will-be-equivalent-to-IFluidResolvedUrl)
-
+[LoaderHeader.cache deprecated]
+(#LoaderHeader.cache-deprecated)
 ## IResolvedUrl will be equivalent to IFluidResolvedUrl
 
 In @fluidframework/driver-definitions IResolvedUrlBase and IWebResolvedUrl are deprecated as they are not used.
 This will make IResolvedUrl and IFluidResolvedUrl equivalent. Since all ResolvedUrls will now be FluidResolvedUrls we no longer need to differentiate them. In @fluidframework/driver-utils isFluidResolvedUrl and
 ensureFluidResolvedUrl will be deprecated and removed due to this.
+
+## LoaderHeader.cache deprecated
+In @fluidframework/container-definitions, the enum `LoaderHeader` has property cache, is deprecated.
+Therefore, `ILoaderHeader` has property `[LoaderHeader.cache]` is also deprecated. They will both be removed in the next major release, as well as all caching functionality of containers.
 
 # 2.0.0-internal.3.3.0
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -22,6 +22,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 [IResolvedUrl will be equivalent to IFluidResolvedUrl](#IResolvedUrl-will-be-equivalent-to-IFluidResolvedUrl)
 [LoaderHeader.cache deprecated]
 (#LoaderHeader.cache-deprecated)
+
 ## IResolvedUrl will be equivalent to IFluidResolvedUrl
 
 In @fluidframework/driver-definitions IResolvedUrlBase and IWebResolvedUrl are deprecated as they are not used.
@@ -29,6 +30,7 @@ This will make IResolvedUrl and IFluidResolvedUrl equivalent. Since all Resolved
 ensureFluidResolvedUrl will be deprecated and removed due to this.
 
 ## LoaderHeader.cache deprecated
+
 In @fluidframework/container-definitions, the enum `LoaderHeader` has property cache, is deprecated.
 Therefore, `ILoaderHeader` has property `[LoaderHeader.cache]` is also deprecated. They will both be removed in the next major release, as well as all caching functionality of containers.
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -32,7 +32,7 @@ ensureFluidResolvedUrl will be deprecated and removed due to this.
 ## LoaderHeader.cache deprecated
 
 In `@fluidframework/container-definitions`, the `cache` value from the `LoaderHeader` enum has been deprecated.
-Therefore, `ILoaderHeader` has property `[LoaderHeader.cache]` is also deprecated. They will both be removed in the next major release, as well as all caching functionality of containers.
+Therefore, the `[LoaderHeader.cache]` property from `ILoaderHeader` is also deprecated. They will both be removed in the next major release, as well as all caching functionality of containers.
 
 # 2.0.0-internal.3.3.0
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -31,7 +31,7 @@ ensureFluidResolvedUrl will be deprecated and removed due to this.
 ## LoaderHeader.cache deprecated
 
 In `@fluidframework/container-definitions`, the `cache` value from the `LoaderHeader` enum has been deprecated.
-Therefore, the `[LoaderHeader.cache]` property from `ILoaderHeader` is also deprecated. They will both be removed in the next major release, as well as all caching functionality of containers.
+Therefore, the `[LoaderHeader.cache]` property from `ILoaderHeader` is also deprecated. They will both be removed in the next major release, as well as all caching functionality of containers. Cache support will be removed soon, please try not to rely on caching, and inform us if you cannot do so.
 
 # 2.0.0-internal.3.3.0
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -19,9 +19,9 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 
 ## 2.0.0-internal.3.4.0 Upcoming changes
 
-[IResolvedUrl will be equivalent to IFluidResolvedUrl](#IResolvedUrl-will-be-equivalent-to-IFluidResolvedUrl)
-[LoaderHeader.cache deprecated]
-(#LoaderHeader.cache-deprecated)
+-   [IResolvedUrl will be equivalent to IFluidResolvedUrl](#IResolvedUrl-will-be-equivalent-to-IFluidResolvedUrl)
+
+-   [LoaderHeader.cache deprecated](#LoaderHeadercache-deprecated)
 
 ## IResolvedUrl will be equivalent to IFluidResolvedUrl
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -20,7 +20,6 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 ## 2.0.0-internal.3.4.0 Upcoming changes
 
 -   [IResolvedUrl will be equivalent to IFluidResolvedUrl](#IResolvedUrl-will-be-equivalent-to-IFluidResolvedUrl)
-
 -   [LoaderHeader.cache deprecated](#LoaderHeadercache-deprecated)
 
 ## IResolvedUrl will be equivalent to IFluidResolvedUrl

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -421,7 +421,7 @@ export interface ILoader extends IFluidRouter, Partial<IProvideLoader> {
 
 // @public
 export interface ILoaderHeader {
-    // (undocumented)
+    // @deprecated (undocumented)
     [LoaderHeader.cache]: boolean;
     // (undocumented)
     [LoaderHeader.clientDetails]: IClientDetails;

--- a/api-report/container-definitions.api.md
+++ b/api-report/container-definitions.api.md
@@ -542,6 +542,7 @@ export interface IUsageError extends IErrorBase {
 
 // @public
 export enum LoaderHeader {
+    // @deprecated (undocumented)
     cache = "fluid-cache",
     // (undocumented)
     clientDetails = "fluid-client-details",

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -542,7 +542,7 @@ export type ILoaderOptions = {
  */
 export enum LoaderHeader {
 	/**
-	 * @deprecated
+	 * @deprecated In next release, all caching functionality will be removed, and this is not useful anymore
 	 * Override the Loader's default caching behavior for this container.
 	 */
 	cache = "fluid-cache",

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -542,6 +542,7 @@ export type ILoaderOptions = {
  */
 export enum LoaderHeader {
 	/**
+	 * @deprecated
 	 * Override the Loader's default caching behavior for this container.
 	 */
 	cache = "fluid-cache",

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -610,6 +610,9 @@ export interface IContainerLoadMode {
  * Set of Request Headers that the Loader understands and may inspect or modify
  */
 export interface ILoaderHeader {
+	/**
+	 * @deprecated In next release, all caching functionality will be removed, and this is not useful anymore
+	 */
 	[LoaderHeader.cache]: boolean;
 	[LoaderHeader.clientDetails]: IClientDetails;
 	[LoaderHeader.loadMode]: IContainerLoadMode;


### PR DESCRIPTION


## Description

added notes about LoaderHeader.cache is deprecated, and will be removed