### PR TITLE
Tree: Fix bug with SequenceFieldEditBuilder.move

### DIFF
--- a/packages/dds/tree/src/feature-libraries/defaultChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultChangeFamily.ts
@@ -223,19 +223,28 @@ export class DefaultEditBuilder
 				this.modularBuilder.submitChange(parent, field, sequence.identifier, change);
 			},
 			move: (sourceIndex: number, count: number, destIndex: number): void => {
-				const change: FieldChangeset = brand(
-					sequence.changeHandler.editor.move(
-						sourceIndex,
-						count,
-						destIndex,
-						this.modularBuilder.generateId(),
-					),
+				const moves = sequence.changeHandler.editor.move(
+					sourceIndex,
+					count,
+					destIndex,
+					this.modularBuilder.generateId(),
 				);
-				this.modularBuilder.submitChange(
-					parent,
-					field,
-					sequence.identifier,
-					change,
+
+				this.modularBuilder.submitChanges(
+					[
+						{
+							path: parent,
+							field,
+							fieldKind: sequence.identifier,
+							change: brand(moves[0]),
+						},
+						{
+							path: parent,
+							field,
+							fieldKind: sequence.identifier,
+							change: brand(moves[1]),
+						},
+					],
 					brand(0),
 				);
 			},

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -34,7 +34,7 @@ export interface SequenceFieldEditor extends FieldEditor<Changeset> {
 		count: number,
 		destIndex: number,
 		id: ChangesetLocalId,
-	): [Changeset<never>, Changeset<never>];
+	): [moveOut: Changeset<never>, moveIn: Changeset<never>];
 	return(
 		sourceIndex: number,
 		count: number,
@@ -87,7 +87,7 @@ export const sequenceFieldEditor = {
 		count: number,
 		destIndex: number,
 		id: ChangesetLocalId,
-	): [Changeset<never>, Changeset<never>] {
+	): [moveOut: Changeset<never>, moveIn: Changeset<never>] {
 		const moveOut: Mark<never> = {
 			type: "MoveOut",
 			id,

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -253,8 +253,7 @@ describe("Editing", () => {
 			expectJsonTree([tree1, tree2], ["a", "b", "c"]);
 		});
 
-		// TODO: Re-enable test once TASK 3601 (Fix intra-field move editor API) is completed
-		it.skip("intra-field move", () => {
+		it("intra-field move", () => {
 			const sequencer = new Sequencer();
 			const tree1 = TestTree.fromJson(["a", "b"]);
 


### PR DESCRIPTION
## Description

Fixed an issue where SequenceFieldEditBuilder.move was using the result of SequenceEditBuilder.move (which is a pair of changesets, not a single legal sequence changeset) as if it were a single move edit.