### PR TITLE
GC: Move per-document sweep enablement to GC Feature Matrix

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -372,6 +372,7 @@ export interface IGCRuntimeOptions {
     gcAllowed?: boolean;
     runFullGC?: boolean;
     sessionExpiryTimeoutMs?: number;
+    // @deprecated (undocumented)
     sweepAllowed?: boolean;
 }
 

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -618,7 +618,6 @@ export class GarbageCollector implements IGarbageCollector {
 			gcFeature: this.configs.gcEnabled ? this.summaryStateTracker.currentGCVersion : 0,
 			gcFeatureMatrix: this.configs.persistedGcFeatureMatrix,
 			sessionExpiryTimeoutMs: this.configs.sessionExpiryTimeoutMs,
-			sweepEnabled: this.configs.sweepEnabled,
 			sweepTimeoutMs: this.configs.sweepTimeoutMs,
 		};
 	}

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -618,6 +618,7 @@ export class GarbageCollector implements IGarbageCollector {
 			gcFeature: this.configs.gcEnabled ? this.summaryStateTracker.currentGCVersion : 0,
 			gcFeatureMatrix: this.configs.persistedGcFeatureMatrix,
 			sessionExpiryTimeoutMs: this.configs.sessionExpiryTimeoutMs,
+			sweepEnabled: false, // DEPRECATED - to be removed
 			sweepTimeoutMs: this.configs.sweepTimeoutMs,
 		};
 	}

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -26,7 +26,7 @@ import {
 	runSweepKey,
 	stableGCVersion,
 } from "./gcDefinitions";
-import { getGCVersion, shouldAllowGcSweep as shouldAllowGcSweep } from "./gcHelpers";
+import { getGCVersion, shouldAllowGcSweep } from "./gcHelpers";
 
 /**
  * Generates configurations for the Garbage Collector that it uses to determine what to run and how.
@@ -102,8 +102,8 @@ export function generateGCConfigs(
 
 	// Is sweepEnabled for this document?
 	const sweepEnabled = shouldAllowGcSweep(
-		persistedGcFeatureMatrix ?? {},
-		createParams.gcOptions[gcSweepGenerationOptionName],
+		persistedGcFeatureMatrix ?? {} /* persistedGenerations */,
+		createParams.gcOptions[gcSweepGenerationOptionName] /* currentGeneration */,
 	);
 
 	/**

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -23,8 +23,21 @@ export const stableGCVersion: GCVersion = 1;
 /** The current version of garbage collection. */
 export const currentGCVersion: GCVersion = 2;
 
-/** This undocumented GC Option (on ContainerRuntime Options) allows an app to disable enforcing GC on old documents by incrementing this value */
+/**
+ * This undocumented GC Option (on ContainerRuntime Options) allows an app to disable enforcing GC on old documents by incrementing this value
+ *
+ * If unset, GC Tombstone phase will operate as otherwise configured
+ * Otherwise, only enforce GC Tombstone if the passed in value matches the persisted value
+ */
 export const gcTombstoneGenerationOptionName = "gcTombstoneGeneration";
+/**
+ * This GC Option (on ContainerRuntime Options) allows an app to disable GC Sweep on old documents by incrementing this value.
+ *
+ * If unset altogether, Sweep will be disabled.
+ * If 0 is passed in, Sweep will be enabled for any document with gcSweepGeneration OR gcTombstoneGeneration as 0.
+ * If any other number is passed in, Sweep will be enabled only for documents with the same value persisted.
+ */
+export const gcSweepGenerationOptionName = "gcSweepGeneration";
 
 // Feature gate key to turn GC on / off.
 export const runGCKey = "Fluid.GarbageCollection.RunGC";
@@ -68,10 +81,16 @@ export const defaultSessionExpiryDurationMs = 30 * oneDayMs; // 30 days
 export interface GCFeatureMatrix {
 	/**
 	 * The Tombstone Generation value in effect when this file was created.
-	 * Gives a way for an app to disqualify old files from GC Tombstone enforcement
-	 * Provided via Container Runtime Options
+	 * Gives a way for an app to disqualify old files from GC Tombstone enforcement.
+	 * Provided via Container Runtime Options.
 	 */
 	tombstoneGeneration?: number;
+	/**
+	 * The Sweep Generation value in effect when this file was created.
+	 * Gives a way for an app to disqualify old files from GC Sweep.
+	 * Provided via Container Runtime Options.
+	 */
+	sweepGeneration?: number;
 }
 
 export interface IGCMetadata {
@@ -97,6 +116,8 @@ export interface IGCMetadata {
 	 */
 	readonly gcFeatureMatrix?: GCFeatureMatrix;
 	/**
+	 * @deprecated - @see GCFeatureMatrix.sweepGeneration
+	 *
 	 * Tells whether the GC sweep phase is enabled for this container.
 	 * - True means sweep phase is enabled.
 	 * - False means sweep phase is disabled. If GC is disabled as per gcFeature, sweep is also disabled.
@@ -255,6 +276,8 @@ export interface IGCRuntimeOptions {
 	gcAllowed?: boolean;
 
 	/**
+	 * @deprecated -  @see gcSweepGenerationOptionName and @see GCFeatureMatrix.sweepGeneration
+	 *
 	 * Flag that if true, enables GC's sweep phase for a new container.
 	 *
 	 * This will allow GC to eventually delete unreferenced objects from the container.

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -12,6 +12,8 @@ export {
 	GCNodeType,
 	gcTestModeKey,
 	gcTombstoneGenerationOptionName,
+	gcSweepGenerationOptionName,
+	GCFeatureMatrix,
 	GCVersion,
 	gcVersionUpgradeToV2Key,
 	IGarbageCollectionRuntime, // Deprecated
@@ -36,6 +38,7 @@ export {
 	getSnapshotDataFromOldSnapshotFormat,
 	sendGCUnexpectedUsageEvent,
 	shouldAllowGcTombstoneEnforcement,
+	shouldAllowGcSweep,
 } from "./gcHelpers";
 export { GCSummaryStateTracker } from "./gcSummaryStateTracker";
 export {

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -419,6 +419,25 @@ describe("Garbage Collection configurations", () => {
 				"getMetadata returned different metadata than expected",
 			);
 		});
+		it("Metadata Roundtrip with only sweepGeneration", () => {
+			const expectedMetadata: IGCMetadata = {
+				sweepEnabled: false, // hardcoded, not used
+				gcFeature: 1,
+				sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
+				sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
+				gcFeatureMatrix: { sweepGeneration: 2, tombstoneGeneration: undefined },
+			};
+			gc = createGcWithPrivateMembers(undefined /* metadata */, {
+				sweepAllowed: true, // ignored
+				[gcSweepGenerationOptionName]: 2,
+			});
+			const outputMetadata = gc.getMetadata();
+			assert.deepEqual(
+				outputMetadata,
+				expectedMetadata,
+				"getMetadata returned different metadata than expected",
+			);
+		});
 	});
 
 	describe("Session Expiry and Sweep Timeout", () => {

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -38,6 +38,7 @@ import {
 	stableGCVersion,
 	gcVersionUpgradeToV2Key,
 	gcTombstoneGenerationOptionName,
+	gcSweepGenerationOptionName,
 	GCVersion,
 	runSessionExpiryKey,
 } from "../../gc";
@@ -185,10 +186,14 @@ describe("Garbage Collection configurations", () => {
 				"latestSummaryGCVersion incorrect",
 			);
 		});
-		it("gcFeature 0, sweepEnabled true", () => {
-			gc = createGcWithPrivateMembers({ gcFeature: 0, sweepEnabled: true });
+		it("gcFeature 0, Sweep enabled via sweepGeneration", () => {
+			gc = createGcWithPrivateMembers(
+				{ gcFeature: 0, gcFeatureMatrix: { sweepGeneration: 0 } },
+				{ [gcSweepGenerationOptionName]: 0 },
+			);
 			assert(!gc.configs.gcEnabled, "gcEnabled incorrect");
 			assert(gc.configs.sweepEnabled, "sweepEnabled incorrect");
+			assert(!gc.configs.shouldRunSweep, "shouldRunSweep incorrect");
 			assert.equal(
 				gc.summaryStateTracker.latestSummaryGCVersion,
 				0,
@@ -204,8 +209,8 @@ describe("Garbage Collection configurations", () => {
 				"latestSummaryGCVersion incorrect",
 			);
 		});
-		it("sweepEnabled false", () => {
-			gc = createGcWithPrivateMembers({ sweepEnabled: false });
+		it("sweepEnabled value ignored", () => {
+			gc = createGcWithPrivateMembers({ sweepEnabled: true }); // no sweepGeneration option set
 			assert(!gc.configs.sweepEnabled, "sweepEnabled incorrect");
 		});
 		it("sessionExpiryTimeoutMs set (sweepTimeoutMs unset)", () => {
@@ -229,18 +234,20 @@ describe("Garbage Collection configurations", () => {
 		});
 		it("Metadata Roundtrip", () => {
 			const inputMetadata: IGCMetadata = {
-				sweepEnabled: true,
+				sweepEnabled: true, // ignored
 				gcFeature: 1,
 				sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
 				sweepTimeoutMs: 123,
-				gcFeatureMatrix: { tombstoneGeneration: 1 },
+				gcFeatureMatrix: { tombstoneGeneration: 1, sweepGeneration: 1 },
 			};
 			gc = createGcWithPrivateMembers(inputMetadata, {
 				[gcTombstoneGenerationOptionName]: 2, // 2 should not be persisted
+				[gcSweepGenerationOptionName]: 2, // 2 should not be persisted
 			});
 			const outputMetadata = gc.getMetadata();
 			const expectedOutputMetadata: IGCMetadata = {
 				...inputMetadata,
+				sweepEnabled: false, // Hardcoded, not used
 				gcFeature: stableGCVersion,
 			};
 			assert.deepEqual(
@@ -252,16 +259,17 @@ describe("Garbage Collection configurations", () => {
 		it("Metadata Roundtrip with GC version upgrade to v2 enabled", () => {
 			injectedSettings[gcVersionUpgradeToV2Key] = true;
 			const inputMetadata: IGCMetadata = {
-				sweepEnabled: true,
+				sweepEnabled: true, // ignored
 				gcFeature: 1,
 				sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
 				sweepTimeoutMs: 123,
-				gcFeatureMatrix: { tombstoneGeneration: 1 },
+				gcFeatureMatrix: { tombstoneGeneration: 1, sweepGeneration: 1 },
 			};
 			gc = createGcWithPrivateMembers(inputMetadata);
 			const outputMetadata = gc.getMetadata();
 			const expectedOutputMetadata: IGCMetadata = {
 				...inputMetadata,
+				sweepEnabled: false, // Hardcoded, not used
 				gcFeature: currentGCVersion,
 			};
 			assert.deepEqual(
@@ -296,22 +304,30 @@ describe("Garbage Collection configurations", () => {
 			gc = createGcWithPrivateMembers(undefined /* metadata */, { gcAllowed: false });
 			assert(!gc.configs.gcEnabled, "gcEnabled incorrect");
 		});
-		it("sweepAllowed true, gcAllowed false", () => {
+		it("sweepAllowed ignored", () => {
+			gc = createGcWithPrivateMembers(undefined /* metadata */, {
+				gcAllowed: false,
+				sweepAllowed: true, // ignored. Not even checked against gcAllowed.
+				// no sweepGeneration option set
+			});
+			assert(!gc.configs.sweepEnabled, "sweepEnabled incorrect");
+		});
+		it("sweepGeneration specified, gcAllowed false", () => {
 			assert.throws(
 				() => {
 					gc = createGcWithPrivateMembers(undefined /* metadata */, {
 						gcAllowed: false,
-						sweepAllowed: true,
+						[gcSweepGenerationOptionName]: 1,
 					});
 				},
 				(e) => e.errorType === "usageError",
 				"Should be unsupported",
 			);
 		});
-		it("sweepAllowed true, gcAllowed true", () => {
+		it("Sweep enabled via sweepGeneration, gcAllowed true", () => {
 			gc = createGcWithPrivateMembers(undefined /* metadata */, {
 				gcAllowed: true,
-				sweepAllowed: true,
+				[gcSweepGenerationOptionName]: 1,
 			});
 			assert(gc.configs.gcEnabled, "gcEnabled incorrect");
 			assert(gc.configs.sweepEnabled, "sweepEnabled incorrect");
@@ -322,8 +338,8 @@ describe("Garbage Collection configurations", () => {
 				"sessionExpiryTimeoutMs incorrect",
 			);
 		});
-		it("sweepAllowed false, sessionExpiry on", () => {
-			gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
+		it("Sweep disabled (no sweepGeneration), sessionExpiry on", () => {
+			gc = createGcWithPrivateMembers(undefined /* metadata */, {});
 			assert(!gc.configs.sweepEnabled, "sweepEnabled incorrect");
 			assert(
 				gc.configs.sessionExpiryTimeoutMs !== undefined,
@@ -331,11 +347,11 @@ describe("Garbage Collection configurations", () => {
 			);
 			assert(gc.configs.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
 		});
-		it("sweepAllowed true, gcAllowed true, sessionExpiry off", () => {
+		it("Sweep enabled via sweepGeneration, gcAllowed true, sessionExpiry off", () => {
 			injectedSettings[runSessionExpiryKey] = false;
 			gc = createGcWithPrivateMembers(undefined /* metadata */, {
 				gcAllowed: true,
-				sweepAllowed: true,
+				[gcSweepGenerationOptionName]: 1,
 			});
 			assert(gc.configs.gcEnabled, "gcEnabled incorrect");
 			assert(gc.configs.sweepEnabled, "sweepEnabled incorrect");
@@ -345,9 +361,9 @@ describe("Garbage Collection configurations", () => {
 			);
 			assert(gc.configs.sweepTimeoutMs === undefined, "sweepTimeoutMs incorrect");
 		});
-		it("TestOverride.SweepTimeout set, sweepAllowed false, sessionExpiry on", () => {
+		it("TestOverride.SweepTimeout set, Sweep disabled (no sweepGeneration), sessionExpiry on", () => {
 			injectedSettings[testOverrideSweepTimeoutKey] = 123;
-			gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
+			gc = createGcWithPrivateMembers(undefined /* metadata */, {});
 			assert(!gc.configs.sweepEnabled, "sweepEnabled incorrect");
 			assert(
 				gc.configs.sessionExpiryTimeoutMs === defaultSessionExpiryDurationMs,
@@ -355,10 +371,10 @@ describe("Garbage Collection configurations", () => {
 			);
 			assert(gc.configs.sweepTimeoutMs === 123, "sweepTimeoutMs incorrect");
 		});
-		it("TestOverride.SweepTimeout set, sweepAllowed false, sessionExpiry off", () => {
+		it("TestOverride.SweepTimeout set, Sweep disabled (no sweepGeneration), sessionExpiry off", () => {
 			injectedSettings[testOverrideSweepTimeoutKey] = 123;
 			injectedSettings[runSessionExpiryKey] = false;
-			gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: false });
+			gc = createGcWithPrivateMembers(undefined /* metadata */, {});
 			assert(!gc.configs.sweepEnabled, "sweepEnabled incorrect");
 			assert(
 				gc.configs.sessionExpiryTimeoutMs === undefined,
@@ -368,15 +384,16 @@ describe("Garbage Collection configurations", () => {
 		});
 		it("Metadata Roundtrip", () => {
 			const expectedMetadata: IGCMetadata = {
-				sweepEnabled: true,
+				sweepEnabled: false, // hardcoded, not used
 				gcFeature: 1,
 				sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
 				sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
-				gcFeatureMatrix: { tombstoneGeneration: 2 },
+				gcFeatureMatrix: { tombstoneGeneration: 2, sweepGeneration: 2 },
 			};
 			gc = createGcWithPrivateMembers(undefined /* metadata */, {
-				sweepAllowed: true,
+				sweepAllowed: true, // ignored
 				[gcTombstoneGenerationOptionName]: 2,
+				[gcSweepGenerationOptionName]: 2,
 			});
 			const outputMetadata = gc.getMetadata();
 			assert.deepEqual(
@@ -388,13 +405,13 @@ describe("Garbage Collection configurations", () => {
 		it("Metadata Roundtrip with GC version upgrade to v2 enabled", () => {
 			injectedSettings[gcVersionUpgradeToV2Key] = true;
 			const expectedMetadata: IGCMetadata = {
-				sweepEnabled: true,
+				sweepEnabled: false, // hardcoded, not used
 				gcFeature: currentGCVersion,
 				sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
 				sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
 				gcFeatureMatrix: undefined,
 			};
-			gc = createGcWithPrivateMembers(undefined /* metadata */, { sweepAllowed: true });
+			gc = createGcWithPrivateMembers(undefined /* metadata */, {});
 			const outputMetadata = gc.getMetadata();
 			assert.deepEqual(
 				outputMetadata,
@@ -681,9 +698,12 @@ describe("Garbage Collection configurations", () => {
 				it(`Test Case ${JSON.stringify(testCase)}`, () => {
 					injectedSettings[runGCKey] = testCase.shouldRunGC;
 					injectedSettings[runSweepKey] = testCase.shouldRunSweep;
-					gc = createGcWithPrivateMembers(undefined /* metadata */, {
-						sweepAllowed: testCase.sweepEnabled,
-					});
+					gc = createGcWithPrivateMembers(
+						undefined /* metadata */,
+						{
+							[gcSweepGenerationOptionName]: testCase.sweepEnabled ? 1 : undefined,
+						} /* gcOptions */,
+					);
 					assert.equal(
 						gc.configs.shouldRunGC,
 						testCase.shouldRunGC,

--- a/packages/runtime/container-runtime/src/test/gc/gcHelpers.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcHelpers.spec.ts
@@ -9,7 +9,12 @@ import {
 	IGarbageCollectionSnapshotData,
 	IGarbageCollectionSummaryDetailsLegacy,
 } from "@fluidframework/runtime-definitions";
-import { getSnapshotDataFromOldSnapshotFormat, shouldAllowGcTombstoneEnforcement } from "../../gc";
+import {
+	getSnapshotDataFromOldSnapshotFormat,
+	shouldAllowGcTombstoneEnforcement,
+	GCFeatureMatrix,
+	shouldAllowGcSweep,
+} from "../../gc";
 import { IContainerRuntimeMetadata, ReadFluidDataStoreAttributes } from "../../summary";
 
 describe("Garbage Collection Helpers Tests", () => {
@@ -53,6 +58,66 @@ describe("Garbage Collection Helpers Tests", () => {
 		testCases.forEach(({ persisted, current, expectedShouldAllowValue }) => {
 			it(`persisted=${persisted}, current=${current}`, () => {
 				const shouldAllow = shouldAllowGcTombstoneEnforcement(persisted, current);
+				assert.equal(shouldAllow, expectedShouldAllowValue);
+			});
+		});
+	});
+
+	describe("shouldAllowGcSweep", () => {
+		const testCases: {
+			persisted: GCFeatureMatrix;
+			current: number | undefined;
+			expectedShouldAllowValue: boolean;
+		}[] = [
+			{
+				persisted: {},
+				current: undefined,
+				expectedShouldAllowValue: false,
+			},
+			{
+				persisted: { sweepGeneration: 1 },
+				current: undefined,
+				expectedShouldAllowValue: false,
+			},
+			{
+				persisted: {},
+				current: 0,
+				expectedShouldAllowValue: false,
+			},
+			{
+				persisted: { tombstoneGeneration: 0 },
+				current: 0,
+				expectedShouldAllowValue: true,
+			},
+			{
+				persisted: { tombstoneGeneration: 1 },
+				current: 0,
+				expectedShouldAllowValue: false,
+			},
+			{
+				persisted: { sweepGeneration: 0 },
+				current: 0,
+				expectedShouldAllowValue: true,
+			},
+			{
+				persisted: { sweepGeneration: 1 },
+				current: 1,
+				expectedShouldAllowValue: true,
+			},
+			{
+				persisted: { sweepGeneration: 1 },
+				current: 2,
+				expectedShouldAllowValue: false,
+			},
+			{
+				persisted: { sweepGeneration: 2 },
+				current: 1,
+				expectedShouldAllowValue: false,
+			},
+		];
+		testCases.forEach(({ persisted, current, expectedShouldAllowValue }) => {
+			it(`persisted=${JSON.stringify(persisted)}, current=${current}`, () => {
+				const shouldAllow = shouldAllowGcSweep(persisted, current);
 				assert.equal(shouldAllow, expectedShouldAllowValue);
 			});
 		});


### PR DESCRIPTION
## Description

Previously, per-document sweep enablement was a "global" boolean - meaning, once a document was marked as eligible for Sweep, it could never be excluded going forward.

We believe there could conceivably be a class of bugs discovered even after Sweep is first enabled that "poison" documents created at that time, until a fix can be made.  In this case, we want to provide a way for apps to indicate a new point in time where only documents after that (i.e. after a fix has been made) are eligible for Sweep, even though previously older docs had too.

GCFeatureMatrix.sweepGeneration provides this mechanism, along similar lines to tombstoneGeneration.

## Reviewer Guidance

Couple things to call out

* I'm not putting the GC Option key on the official type yet, but we probably would eventually
* I'm letting `0` be a special case, that will also match files with `tombstoneGeneration` of 0, as an optimistic measure in case no bugs are found during Tombstone Phase that would disqualify a document from Sweep, to broaden coverage of Sweep.

I haven't written tests yet - wanted to get feedback on that 2nd point first.

## Follow-ups

* Move sweepGeneration option key to the type rather than being undocumented on the side
* Remove deprecated sweepEnabled/sweepAllowed properties
* Stop writing `sweepEnabled: false` to the snapshot and update the snapshot tests