### PR TITLE
Fix bug where child summarizer node's base GC details is not always updated correctly

### DIFF
--- a/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/runtime-utils/src/summarizerNode/summarizerNodeWithGc.ts
@@ -142,8 +142,8 @@ class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNode
 		});
 
 		this.childNodesBaseGCDetailsP = new LazyPromise(async () => {
-			const baseGCDetails = await this.baseGCDetailsP;
-			return unpackChildNodesGCDetails(baseGCDetails);
+			await this.loadBaseGCDetails();
+			return unpackChildNodesGCDetails({ gcData: this.gcData, usedRoutes: this.usedRoutes });
 		});
 	}
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
@@ -279,7 +279,7 @@ describeNoCompat("GC loading from older summaries", (getTestObjectProvider) => {
 	 * summary. But the DDS in the data store containing the references is not changed. This validates that the GC data
 	 * in older summary is correctly propagated to DDS as well.
 	 */
-	it.skip("updates unreferenced nodes correctly when DDS is unchanged after loading from older summary", async () => {
+	it("updates unreferenced nodes correctly when DDS is unchanged after loading from older summary", async () => {
 		const { summarizer: summarizer1 } = await createSummarizer(provider, mainContainer);
 
 		// Create a second DDS in dataStoreA. This will be changed after loading from old summary so that the data store


### PR DESCRIPTION
## Bug
When a DDS's summarizer node is created after the container refreshes its state from a snapshot, the DDS's GC details may be incorrect. This can happen if the DDS did not change since refreshing from snapshot. Currently, the DDS's GC data will be updated from the base snapshot the container loaded from and if that's different from the GC data in refreshed snapshot, the DDS will have incorrect GC data.

## Fix
When a child summarizer node is created, the parent node uses its current GC state to generate the base GC details for the child node. This way, if the parent's GC state was updated because of refresh from snapshot, the child will get the updated GC data.

[AB#2962](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2962)