### PR TITLE
fix(telemetry-generator): use pnpm in prep steps in pipelines

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -510,8 +510,8 @@ stages:
                 script: |
                   ls -la '${{ variables.toolAbsolutePath }}';
                   ls -la '${{ parameters.buildDirectory }}';
-                  npm install @ff-internal/aria-logger;
-                  npm i;
+                  pnpm install @ff-internal/aria-logger;
+                  pnpm i;
                   npm run build:compile;
 
             - task: Bash@3

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -117,8 +117,8 @@ jobs:
         workingDirectory: $(toolAbsolutePath)
         script: |
           cp ${{ parameters.testWorkspace }}/.npmrc . ;
-          npm install @ff-internal/aria-logger;
-          npm i;
+          pnpm install @ff-internal/aria-logger;
+          pnpm i;
           npm run build:compile;
 
     - ${{ parameters.customSteps }}


### PR DESCRIPTION
## Description

Update pipelines to prep @fluid-tools/telemetry-generator with pnpm instead of npm, to match the fact that the lockfile is now `pnpm-lock.yaml` and not `package-lock.json`. With `package-lock.json` gone, `npm i` during the prep steps in pipelines was probably bringing in dependency versions that we weren't expecting and that might be why we saw a change in behavior (hang) when running the tool.
