### PR TITLE
demo (external-data): Prototype /broadcast-signal endpoint (without custom signal type)

### DIFF
--- a/examples/hosts/app-integration/external-data/src/model/appModel.ts
+++ b/examples/hosts/app-integration/external-data/src/model/appModel.ts
@@ -28,7 +28,7 @@ export class AppModel extends TypedEventEmitter<IAppModelEvents> implements IApp
 	 */
 	public readonly sendCustomDebugSignal = (): void => {
 		this.runtime.submitSignal("debugSignal", {
-			type: "ExternalDataChange",
+			type: "ExternalDataChanged",
 			taskListId: "task-list-1",
 		});
 	};

--- a/examples/hosts/app-integration/external-data/src/model/containerCode.ts
+++ b/examples/hosts/app-integration/external-data/src/model/containerCode.ts
@@ -20,7 +20,7 @@ const taskListCollectionId = "base-document";
  * fetching the new data. This is an enum as there may be more signals that need to be created.
  */
 const SignalType = {
-	ExternalDataChanged: "ExternalDataChange",
+	ExternalDataChanged: "ExternalDataChanged",
 };
 
 /**

--- a/examples/hosts/app-integration/external-data/src/view/debugView.tsx
+++ b/examples/hosts/app-integration/external-data/src/view/debugView.tsx
@@ -263,7 +263,10 @@ export const ExternalServerTaskListView: React.FC<ExternalServerTaskListViewProp
 			// TODO: display error status to user?
 		}
 		// Send signal to simulate RuntimeSignal that will get sent from alfred in the dev branch
-		model.sendCustomDebugSignal();
+		// Commenting it out here because this PR has a hacked Signal that is broadcast from alfred
+		// without being the full RuntimeSignal.
+		// model.sendCustomDebugSignal();
+		console.log(model);
 	};
 
 	return (

--- a/experimental/framework/react-inputs/src/CollaborativeInput.tsx
+++ b/experimental/framework/react-inputs/src/CollaborativeInput.tsx
@@ -59,9 +59,9 @@ export class CollaborativeInput extends React.Component<
 	public componentDidMount() {
 		// Sets an event listener so we can update our state as the value changes
 		this.props.sharedString.on("sequenceDelta", (ev: SequenceDeltaEvent) => {
-			if (!ev.isLocal) {
-				this.updateInputFromSharedString();
-			}
+			// if (!ev.isLocal) {
+			this.updateInputFromSharedString();
+			// }
 		});
 		this.updateInputFromSharedString();
 	}

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -11,7 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"scripts": {
-		"build": "npm run policy-check && npm run build:genver && npm run build:compile && npm run lint && npm run build:docs",
+		"build": "npm run build:genver && npm run build:compile && npm run lint && npm run build:docs",
 		"build:compile": "lerna run build:compile --stream",
 		"build:docs": "lerna run build:docs --stream --parallel",
 		"build:fast": "fluid-build --root ../.. --server",

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -583,6 +583,9 @@ export function configureWebSocketServices(
 			let clientSignalSequenceNumber = 0;
 			// Only for debugging purposes
 			eventEmitter.on("broadcast-signal", (taskData, containerUrl, taskListId) => {
+				eventEmitter.off("broadcast-signal", (_taskData, _containerUrl, _taskListId) => {
+					console.log("remove listener");
+				});
 				const documentId = containerUrl.split("/")[containerUrl.split("/").length - 1];
 				const tenantId = containerUrl.split("/")[containerUrl.split("/").length - 2];
 				const roomFromBroadcastSignal: IRoom = { tenantId, documentId };
@@ -611,10 +614,6 @@ export function configureWebSocketServices(
 					"signal",
 					signalMessageRuntimeMessage,
 				);
-			});
-
-			eventEmitter.off("broadcast-signal", (taskData, containerUrl, taskListId) => {
-				console.log("remove listener");
 			});
 		}
 

--- a/server/tinylicious/src/app.ts
+++ b/server/tinylicious/src/app.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { EventEmitter } from "events";
 import { IDocumentStorage, MongoManager } from "@fluidframework/server-services-core";
 import { RestLessServer } from "@fluidframework/server-services-shared";
 import { json, urlencoded } from "body-parser";
@@ -26,7 +27,12 @@ const stream = split().on("data", (message) => {
 	winston.info(message);
 });
 
-export function create(config: Provider, storage: IDocumentStorage, mongoManager: MongoManager) {
+export function create(
+	config: Provider,
+	storage: IDocumentStorage,
+	mongoManager: MongoManager,
+	eventEmitter: EventEmitter,
+) {
 	// Maximum REST request size
 	const requestSize = config.get("alfred:restJsonSize");
 
@@ -68,6 +74,21 @@ export function create(config: Provider, storage: IDocumentStorage, mongoManager
 			res.status(200).send(
 				"This is Tinylicious. Learn more at https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious",
 			);
+		}),
+	);
+
+	// API to broadcast a signal to a container
+	app.use(
+		Router().post("/broadcast-signal", (req, res) => {
+			try {
+				const taskData = req.body?.data;
+				const containerUrl = req.body?.containerUrl;
+				const externalTaskListId = req.body?.externalTaskListId;
+				eventEmitter.emit("broadcast-signal", taskData, containerUrl, externalTaskListId);
+				res.status(200).send("Triggering debug signal from tinylicious");
+			} catch (error) {
+				res.status(500).send(error);
+			}
 		}),
 	);
 

--- a/server/tinylicious/src/runner.ts
+++ b/server/tinylicious/src/runner.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { EventEmitter } from "events";
 import {
 	IDocumentStorage,
 	IOrdererManager,
@@ -52,7 +53,8 @@ export class TinyliciousRunner implements IRunner {
 			throw e;
 		}
 
-		const alfred = app.create(this.config, this.storage, this.mongoManager);
+		const eventEmitter = new EventEmitter();
+		const alfred = app.create(this.config, this.storage, this.mongoManager, eventEmitter);
 		alfred.set("port", this.port);
 
 		this.server = this.serverFactory.create(alfred);
@@ -66,8 +68,22 @@ export class TinyliciousRunner implements IRunner {
 			new TestClientManager(),
 			new DefaultMetricClient(),
 			winston,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			httpServer,
+			eventEmitter,
 		);
-
 		// Listen on provided port, on all network interfaces.
 		httpServer.listen(this.port);
 		httpServer.on("error", (error) => this.onError(error));

--- a/server/tinylicious/src/services/tenantManager.ts
+++ b/server/tinylicious/src/services/tenantManager.ts
@@ -48,6 +48,12 @@ export class TinyliciousTenant implements ITenant {
 export class TenantManager implements ITenantManager {
 	constructor(private readonly url: string) {}
 
+	// This is only here to allow npm linking between the server libraries. This is not part of the
+	// necessary code.
+	public async getTenantGitManager(tenantId: string, documentId: string): Promise<GitManager> {
+		throw new Error("Method not implemented.");
+	}
+
 	public async createTenant(tenantId?: string): Promise<ITenantConfig & { key: string }> {
 		throw new Error("Method not implemented.");
 	}


### PR DESCRIPTION
**EDIT: This is a prototype PR and is not intended to be merged into main. We are simply using this branch as a playground for hacking around in for now.**

This PR explores a new endpoint `/broadcast-signal` and a hacked a signal that will be emitted from the server to the container in the client that the source of truth for the data that the client has changed and that the container in the client should do something with that information.

In order to try it out yourself, please do the following:
1. Navigate to routerlicious,  then install and build the libraries there:
`$ cd server/routerlicious`
`$ pnpm i`
`$ npm run build`
2. Navigate to `server/routerlicious/packages/lambdas` and link from there because the package name and the directory name are different:
`$ cd packages/lambdas`
`$ npm run build`
`$ npm link`
3. Navigate to `server/routerlicious/packages/services-core` and link from there because the package name and the directory name are different:
`$ cd packages/services-core`
`$ npm run build`
`$ npm link`
3. Navigate to `server/routerlicious/packages/local-server` and link from there because the package name and the directory name are different:
`$ cd packages/local-server`
`$ npm run build`
`$ npm link`
5. Navigate to the tinylicious directory from routerlicious, install and link all packages we build the links for above and then build:
`$ cd ../../tinylicious`
`$ npm i` 
`$ npm link @fluidframework/server-services-core`
`$ npm link @fluidframework/server-local-server`
`$ npm link @fluidframework/server-lambdas`
`$ npm run build`
6. Run tinylicious: `$ npm run start` (or `node dist/index.js` if you want to see the terminal output)
7. Navigate to the example directory and run it:
`$ cd ../../examples/hosts/app-integration/external-data`
`$ npm run start:app`

This is what the app should look like: 

![odsp-demo](https://user-images.githubusercontent.com/6777404/226959314-4695d8e4-c27d-46a5-ac20-5859079bdb91.gif)
