### PR TITLE
ci: Fix version comparison in release step

### DIFF
--- a/scripts/check-package-version.cjs
+++ b/scripts/check-package-version.cjs
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * This script is used in CI to compare the version in a package's package.json to the expected version we're releasing,
+ * which is set in the SETVERSION_VERSION environment variable.
+ */
+
+const fs = require("fs");
+
+if (process.env.SETVERSION_VERSION === undefined) {
+	console.error("SETVERSION_VERSION env variable is undefined");
+	process.exit(1);
+}
+
+const pkg = JSON.parse(fs.readFileSync("./package.json"));
+if (pkg.version !== process.env.SETVERSION_VERSION) {
+	console.error(`versions don't match: ${pkg.name}`);
+	process.exit(1);
+}
+
+process.exit(0);

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -152,7 +152,7 @@ steps:
         if [ -f "lerna.json" ]; then
           if [ "$VERSION_RELEASE" = "release" ]; then
             # no need to run anything here, as the version in the package should be correct
-            npx lerna exec "if [ \`npm -s run env echo '\$npm_package_version'\` != '$(SetVersion.version)' ]; then ( exit 1 ) fi"
+            npx lerna exec -- node $(Build.SourcesDirectory)/scripts/check-package-version.cjs
             exit $?
           fi
           npx lerna version $(SetVersion.version) --no-git-tag-version --no-push --yes --exact


### PR DESCRIPTION
Cherry pick of #14692 to main.

We don't fully understand why, but the node 16/npm upgrade broke the old way of comparing versions. This check is only done as a safeguard to make sure that packages we're about to publish all have a version matching the version we're releasing. The check is only done when releasing.

I converted the script that checks the current version to a CJS script to help with shell escaping issues. This change worked in manual testing.