### PR TITLE
ci: Run prettier in repo-policy-check pipeline

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -103,8 +103,6 @@ extends:
     - ci:test:stress:tinylicious
     - test:copyresults
     checks:
-    - policy-check
-    - layer-check
     - syncpack:deps
     - syncpack:versions
     - prettier

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -55,9 +55,6 @@ steps:
     targetType: 'inline'
     workingDirectory: .
     script: |
-      # Install pnpm globally
-      npm i -g pnpm
-
       # We only want to install the root package deps, so we set recursive-install to false
       pnpm config set recursive-install false
       pnpm install --frozen-lockfile

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -21,12 +21,33 @@ pool:
 variables:
 - name: skipComponentGovernanceDetection
   value: true
+- name: pnpmStorePath
+  value: $(Pipeline.Workspace)/.pnpm-store
 
 steps:
 - task: UseNode@1
   displayName: Use Node 16.x
   inputs:
     version: 16.x
+
+- task: Cache@2
+  displayName: Cache pnpm store
+  inputs:
+    # Caches are already scoped to individual pipelines, so no need to include the release group name or tag
+    # in the cache key
+    key: 'pnpm-store | "$(Agent.OS)" | ${{ parameters.buildDirectory }}/pnpm-lock.yaml'
+    path: ${{ variables.pnpmStorePath }}
+    restoreKeys: |
+      pnpm-store | "$(Agent.OS)"
+
+- task: Bash@3
+  displayName: Install and configure pnpm
+  inputs:
+    targetType: 'inline'
+    workingDirectory: ${{ parameters.buildDirectory }}
+    script: |
+      npm i -g pnpm
+      pnpm config set store-dir $(pnpmStorePath)
 
 - task: Bash@3
   displayName: Install root dependencies
@@ -52,3 +73,17 @@ steps:
   inputs:
     command: 'custom'
     customCommand: 'run layer-check'
+
+- task: Npm@1
+  displayName: npm run prettier:root
+  inputs:
+    command: 'custom'
+    customCommand: 'run prettier:root'
+
+- task: Bash@3
+  displayName: Prune pnpm store
+  inputs:
+    targetType: 'inline'
+    workingDirectory: ${{ parameters.buildDirectory }}
+    script: |
+      pnpm store prune

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -35,7 +35,7 @@ steps:
   inputs:
     # Caches are already scoped to individual pipelines, so no need to include the release group name or tag
     # in the cache key
-    key: 'pnpm-store | "$(Agent.OS)" | ${{ parameters.buildDirectory }}/pnpm-lock.yaml'
+    key: 'pnpm-store | "$(Agent.OS)" | pnpm-lock.yaml'
     path: ${{ variables.pnpmStorePath }}
     restoreKeys: |
       pnpm-store | "$(Agent.OS)"
@@ -44,7 +44,6 @@ steps:
   displayName: Install and configure pnpm
   inputs:
     targetType: 'inline'
-    workingDirectory: ${{ parameters.buildDirectory }}
     script: |
       npm i -g pnpm
       pnpm config set store-dir $(pnpmStorePath)
@@ -81,6 +80,5 @@ steps:
   displayName: Prune pnpm store
   inputs:
     targetType: 'inline'
-    workingDirectory: ${{ parameters.buildDirectory }}
     script: |
       pnpm store prune


### PR DESCRIPTION
There's a gap in our prettier coverage in CI. If you edit a file in the root, or, say, the `scripts` folder, it won't trigger a CI job that includes prettier. The reason is that the client release group pipeline is responsible for running prettier on the root files, but it's not triggered by edits outside the client release group/pipeline.

There is a CI pipeline that runs on every PR: repo-policy-check. I fixed this by adding a step to that pipeline that runs `npm run prettier:root`. I also added pnpm store caching to the repo-policy-check job and removed the layer-check and policy-check from the client pipeline since those checks are repo-wide and done already in repo-policy-check.