### PR TITLE
Increment GC version to 3

### DIFF
--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -16,7 +16,7 @@ import {
 	gcTestModeKey,
 	gcTombstoneGenerationOptionName,
 	GCVersion,
-	gcVersionUpgradeToV2Key,
+	gcVersionUpgradeToV3Key,
 	IGarbageCollectorConfigs,
 	IGCRuntimeOptions,
 	maxSnapshotCacheExpiryMs,
@@ -158,7 +158,9 @@ export function generateGCConfigs(
 
 	// If version upgrade is not enabled, fall back to the stable GC version.
 	const gcVersionInEffect =
-		mc.config.getBoolean(gcVersionUpgradeToV2Key) === true ? currentGCVersion : stableGCVersion;
+		mc.config.getBoolean(gcVersionUpgradeToV3Key) === false
+			? stableGCVersion
+			: currentGCVersion;
 
 	return {
 		gcEnabled,

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -23,9 +23,9 @@ import {
 export type GCVersion = number;
 
 /** The stable version of garbage collection in production. */
-export const stableGCVersion: GCVersion = 1;
+export const stableGCVersion: GCVersion = 2;
 /** The current version of garbage collection. */
-export const currentGCVersion: GCVersion = 2;
+export const currentGCVersion: GCVersion = 3;
 
 /**
  * This undocumented GC Option (on ContainerRuntime Options) allows an app to disable enforcing GC on old documents by incrementing this value
@@ -60,7 +60,7 @@ export const throwOnTombstoneLoadKey = "Fluid.GarbageCollection.ThrowOnTombstone
 // Feature gate to enable throwing an error when tombstone object is used (e.g. outgoing or incoming ops).
 export const throwOnTombstoneUsageKey = "Fluid.GarbageCollection.ThrowOnTombstoneUsage";
 // Feature gate to enable GC version upgrade.
-export const gcVersionUpgradeToV2Key = "Fluid.GarbageCollection.GCVersionUpgradeToV2";
+export const gcVersionUpgradeToV3Key = "Fluid.GarbageCollection.GCVersionUpgradeToV3";
 // Feature gate to enable GC sweep for datastores.
 // TODO: Remove Test from the flag when we are confident to turn on sweep
 export const sweepDatastoresKey = "Fluid.GarbageCollection.Test.SweepDataStores";

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -23,7 +23,7 @@ import {
 export type GCVersion = number;
 
 /** The stable version of garbage collection in production. */
-export const stableGCVersion: GCVersion = 2;
+export const stableGCVersion: GCVersion = 1;
 /** The current version of garbage collection. */
 export const currentGCVersion: GCVersion = 3;
 

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -15,7 +15,7 @@ export {
 	gcSweepGenerationOptionName,
 	GCFeatureMatrix,
 	GCVersion,
-	gcVersionUpgradeToV2Key,
+	gcVersionUpgradeToV3Key,
 	IGarbageCollectionRuntime,
 	IGarbageCollector,
 	IGarbageCollectorConfigs,

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -36,7 +36,7 @@ import {
 	gcTestModeKey,
 	currentGCVersion,
 	stableGCVersion,
-	gcVersionUpgradeToV2Key,
+	gcVersionUpgradeToV3Key,
 	gcTombstoneGenerationOptionName,
 	gcSweepGenerationOptionName,
 	GCVersion,
@@ -248,7 +248,7 @@ describe("Garbage Collection configurations", () => {
 			const expectedOutputMetadata: IGCMetadata = {
 				...inputMetadata,
 				sweepEnabled: false, // Hardcoded, not used
-				gcFeature: stableGCVersion,
+				gcFeature: currentGCVersion,
 			};
 			assert.deepEqual(
 				outputMetadata,
@@ -256,8 +256,8 @@ describe("Garbage Collection configurations", () => {
 				"getMetadata returned different metadata than loaded from",
 			);
 		});
-		it("Metadata Roundtrip with GC version upgrade to v2 enabled", () => {
-			injectedSettings[gcVersionUpgradeToV2Key] = true;
+		it("Metadata Roundtrip with GC version upgrade to v3 enabled", () => {
+			injectedSettings[gcVersionUpgradeToV3Key] = true;
 			const inputMetadata: IGCMetadata = {
 				sweepEnabled: true, // ignored
 				gcFeature: 1,
@@ -271,6 +271,28 @@ describe("Garbage Collection configurations", () => {
 				...inputMetadata,
 				sweepEnabled: false, // Hardcoded, not used
 				gcFeature: currentGCVersion,
+			};
+			assert.deepEqual(
+				outputMetadata,
+				expectedOutputMetadata,
+				"getMetadata returned different metadata than loaded from",
+			);
+		});
+		it("Metadata Roundtrip with GC version upgrade to v3 disabled", () => {
+			injectedSettings[gcVersionUpgradeToV3Key] = false;
+			const inputMetadata: IGCMetadata = {
+				sweepEnabled: true, // ignored
+				gcFeature: 1,
+				sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
+				sweepTimeoutMs: 123,
+				gcFeatureMatrix: { tombstoneGeneration: 1, sweepGeneration: 1 },
+			};
+			gc = createGcWithPrivateMembers(inputMetadata);
+			const outputMetadata = gc.getMetadata();
+			const expectedOutputMetadata: IGCMetadata = {
+				...inputMetadata,
+				sweepEnabled: false, // Hardcoded, not used
+				gcFeature: stableGCVersion,
 			};
 			assert.deepEqual(
 				outputMetadata,
@@ -292,7 +314,7 @@ describe("Garbage Collection configurations", () => {
 			assert(gc.configs.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
 			assert.equal(
 				gc.summaryStateTracker.latestSummaryGCVersion,
-				stableGCVersion,
+				currentGCVersion,
 				"latestSummaryGCVersion incorrect",
 			);
 		});
@@ -385,7 +407,7 @@ describe("Garbage Collection configurations", () => {
 		it("Metadata Roundtrip", () => {
 			const expectedMetadata: IGCMetadata = {
 				sweepEnabled: false, // hardcoded, not used
-				gcFeature: 1,
+				gcFeature: currentGCVersion,
 				sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
 				sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
 				gcFeatureMatrix: { tombstoneGeneration: 2, sweepGeneration: 2 },
@@ -402,8 +424,8 @@ describe("Garbage Collection configurations", () => {
 				"getMetadata returned different metadata than expected",
 			);
 		});
-		it("Metadata Roundtrip with GC version upgrade to v2 enabled", () => {
-			injectedSettings[gcVersionUpgradeToV2Key] = true;
+		it("Metadata Roundtrip with GC version upgrade to v3 enabled", () => {
+			injectedSettings[gcVersionUpgradeToV3Key] = true;
 			const expectedMetadata: IGCMetadata = {
 				sweepEnabled: false, // hardcoded, not used
 				gcFeature: currentGCVersion,
@@ -422,7 +444,7 @@ describe("Garbage Collection configurations", () => {
 		it("Metadata Roundtrip with only sweepGeneration", () => {
 			const expectedMetadata: IGCMetadata = {
 				sweepEnabled: false, // hardcoded, not used
-				gcFeature: 1,
+				gcFeature: currentGCVersion,
 				sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
 				sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
 				gcFeatureMatrix: { sweepGeneration: 2, tombstoneGeneration: undefined },
@@ -603,7 +625,7 @@ describe("Garbage Collection configurations", () => {
 
 			const expectedMetadata: IGCMetadata = {
 				sweepEnabled: false,
-				gcFeature: 1,
+				gcFeature: currentGCVersion,
 				sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
 				sweepTimeoutMs: expectedSweepTimeoutMs,
 				gcFeatureMatrix: undefined,

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -52,7 +52,6 @@ describe("Garbage Collection Tests", () => {
 			});
 
 			it("Persisted > Current: Do Need Reset", () => {
-				// Set value to true for gcVersionUpgradeToV2Key
 				const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
 					{
 						shouldRunGC: true,


### PR DESCRIPTION
There have been some recent fixes to GC: https://github.com/microsoft/FluidFramework/pull/14289 https://github.com/microsoft/FluidFramework/pull/14391 https://github.com/microsoft/FluidFramework/pull/14690

Documents that ran GC without these fixes may have incorrect GC data. Incrementing the GC version to 3 so that the GC data is regenerated for all documents.

[AB#3425](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3425)

The test snapshots update PR - https://github.com/microsoft/FluidFrameworkTestData/pull/58
