### PR TITLE
fix(client-debugger): Fix and rename window message posting helper

### DIFF
--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -237,7 +237,7 @@ export interface MessageLoggingOptions {
 }
 
 // @internal
-export function postMessageToWindow<TMessage extends IDebuggerMessage>(loggingOptions?: MessageLoggingOptions, ...message: TMessage[]): void;
+export function postMessagesToWindow<TMessage extends IDebuggerMessage>(loggingOptions?: MessageLoggingOptions, ...messages: TMessage[]): void;
 
 // @public
 export interface RegistryChangeMessage extends IDebuggerMessage<RegistryChangeMessageData> {

--- a/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
@@ -21,7 +21,7 @@ import {
 	IDebuggerMessage,
 	InboundHandlers,
 	MessageLoggingOptions,
-	postMessageToWindow,
+	postMessagesToWindow,
 } from "./messaging";
 import { FluidClientDebuggerProps } from "./Registry";
 
@@ -219,7 +219,7 @@ export class FluidClientDebugger
 	 * Posts a {@link IDebuggerMessage} to the window (globalThis).
 	 */
 	private readonly postContainerStateChange = (): void => {
-		postMessageToWindow<IDebuggerMessage>(
+		postMessagesToWindow<IDebuggerMessage>(
 			this.messageLoggingOptions,
 			{
 				source: debuggerMessageSource,

--- a/packages/tools/client-debugger/client-debugger/src/FluidDebuggerLogger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidDebuggerLogger.ts
@@ -10,7 +10,7 @@ import {
 	ChildLogger,
 	ITelemetryLoggerPropertyBags,
 } from "@fluidframework/telemetry-utils";
-import { debuggerMessageSource, postMessageToWindow, TelemetryEventMessage } from "./messaging";
+import { debuggerMessageSource, postMessagesToWindow, TelemetryEventMessage } from "./messaging";
 
 /**
  * Logger implementation that posts all telemetry events to the window (globalThis object).
@@ -82,7 +82,7 @@ export class FluidDebuggerLogger extends TelemetryLogger {
 
 		const newEvent: ITelemetryBaseEvent = this.prepareEvent(event);
 
-		postMessageToWindow<TelemetryEventMessage>(undefined, {
+		postMessagesToWindow<TelemetryEventMessage>(undefined, {
 			source: debuggerMessageSource,
 			type: "TELEMETRY_EVENT",
 			data: {

--- a/packages/tools/client-debugger/client-debugger/src/Registry.ts
+++ b/packages/tools/client-debugger/client-debugger/src/Registry.ts
@@ -15,7 +15,7 @@ import {
 	IDebuggerMessage,
 	InboundHandlers,
 	MessageLoggingOptions,
-	postMessageToWindow,
+	postMessagesToWindow,
 	RegistryChangeMessage,
 } from "./messaging";
 
@@ -141,7 +141,7 @@ export class DebuggerRegistry extends TypedEventEmitter<DebuggerRegistryEvents> 
 	 * Posts a {@link RegistryChangeMessage} to the window (globalThis).
 	 */
 	private readonly postRegistryChange = (): void => {
-		postMessageToWindow<RegistryChangeMessage>(registryMessageLoggingOptions, {
+		postMessagesToWindow<RegistryChangeMessage>(registryMessageLoggingOptions, {
 			source: debuggerMessageSource,
 			type: "REGISTRY_CHANGE",
 			data: {

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -80,7 +80,7 @@ export {
 	InboundHandlers,
 	isDebuggerMessage,
 	MessageLoggingOptions,
-	postMessageToWindow,
+	postMessagesToWindow,
 } from "./messaging";
 export {
 	DebuggerRegistry,

--- a/packages/tools/client-debugger/client-debugger/src/messaging/Utilities.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/Utilities.ts
@@ -8,7 +8,7 @@ import { IDebuggerMessage } from "./Messages";
 /**
  * Posts the provided message to the window (globalThis).
  *
- * @param message - The list of message to be posted
+ * @param messages - The list of message to be posted
  * @param loggingOptions - Settings related to logging to console for troubleshooting.
  * If not passed, this function won't log to console before posting the message.
  *
@@ -16,18 +16,21 @@ import { IDebuggerMessage } from "./Messages";
  *
  * @internal
  */
-export function postMessageToWindow<TMessage extends IDebuggerMessage>(
+export function postMessagesToWindow<TMessage extends IDebuggerMessage>(
 	loggingOptions?: MessageLoggingOptions,
-	...message: TMessage[]
+	...messages: TMessage[]
 ): void {
 	// TODO: remove loggingOptions once things settle.
 	// If we need special logic for globalThis.postMessage maybe keep this function, but otherwise maybe remove it too.
 	if (loggingOptions !== undefined) {
 		const loggingPreamble =
 			loggingOptions?.context === undefined ? "" : `${loggingOptions.context}: `;
-		console.debug(`${loggingPreamble}Posting message to the window:`, message);
+		console.debug(`${loggingPreamble}Posting message to the window:`, messages);
 	}
-	globalThis.postMessage?.(message, "*"); // TODO: verify target is okay
+
+	for (const message of messages) {
+		globalThis.postMessage?.(message, "*");
+	}
 }
 
 /**

--- a/packages/tools/client-debugger/client-debugger/src/messaging/Utilities.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/Utilities.ts
@@ -8,7 +8,7 @@ import { IDebuggerMessage } from "./Messages";
 /**
  * Posts the provided message to the window (globalThis).
  *
- * @param messages - The list of message to be posted
+ * @param messages - The messages to be posted.
  * @param loggingOptions - Settings related to logging to console for troubleshooting.
  * If not passed, this function won't log to console before posting the message.
  *

--- a/packages/tools/client-debugger/client-debugger/src/messaging/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/index.ts
@@ -42,5 +42,5 @@ export {
 	InboundHandlers,
 	isDebuggerMessage,
 	MessageLoggingOptions,
-	postMessageToWindow,
+	postMessagesToWindow,
 } from "./Utilities";


### PR DESCRIPTION
The existing implementation was attempting to send an array of messages as though it were a single message, causing listeners to disregard the incoming data.