### PR TITLE
fix(client-debugger): Fix container state message passing

### DIFF
--- a/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
@@ -98,48 +98,48 @@ export class FluidClientDebugger
 	// #region Container-related event handlers
 
 	private readonly containerAttachedHandler = (): void => {
-		this.postContainerStateChange();
 		this._connectionStateLog.push({
 			newState: ContainerStateChangeKind.Attached,
 			timestamp: Date.now(),
 			clientId: undefined,
 		});
+		this.postContainerStateChange();
 	};
 
 	private readonly containerConnectedHandler = (clientId: string): void => {
-		this.postContainerStateChange();
 		this._connectionStateLog.push({
 			newState: ContainerStateChangeKind.Connected,
 			timestamp: Date.now(),
 			clientId,
 		});
+		this.postContainerStateChange();
 	};
 
 	private readonly containerDisconnectedHandler = (): void => {
-		this.postContainerStateChange();
 		this._connectionStateLog.push({
 			newState: ContainerStateChangeKind.Disconnected,
 			timestamp: Date.now(),
 			clientId: undefined,
 		});
+		this.postContainerStateChange();
 	};
 
 	private readonly containerClosedHandler = (): void => {
-		this.postContainerStateChange();
 		this._connectionStateLog.push({
 			newState: ContainerStateChangeKind.Closed,
 			timestamp: Date.now(),
 			clientId: undefined,
 		});
+		this.postContainerStateChange();
 	};
 
 	private readonly containerDisposedHandler = (): void => {
-		this.postContainerStateChange();
 		this._connectionStateLog.push({
 			newState: ContainerStateChangeKind.Disposed,
 			timestamp: Date.now(),
 			clientId: undefined,
 		});
+		this.postContainerStateChange();
 	};
 
 	// #endregion


### PR DESCRIPTION
## Description

Makes it so the latest state change in a container is included in the message we sent in response to it, instead of only sent the next time a state change happens.
