### PR TITLE
style(docs): Fix line breaks

### DIFF
--- a/docs/.markdownlint-cli2.cjs
+++ b/docs/.markdownlint-cli2.cjs
@@ -102,7 +102,7 @@ module.exports = {
 
         // We intentionally have unused reference links in a lot of pages, so this rule is disabled
         "link-image-reference-definitions": false, // MD053
-        
+
         "list-marker-space": { // MD030
           "ul_multi": 3,
           "ul_single": 3
@@ -115,6 +115,9 @@ module.exports = {
         "no-inline-html": false, //MD033
         "no-multiple-blanks": { // MD012
             "maximum": 2,
+        },
+        "no-trailing-spaces": { // MD009
+          "br_spaces": 0,
         },
         "proper-names": { // MD044
             "code_blocks": false,

--- a/docs/content/docs/build/container-states-events/index.md
+++ b/docs/content/docs/build/container-states-events/index.md
@@ -8,11 +8,11 @@ This article provides a detailed description of the lifecycle states of the cont
 
 {{< callout note >}}
 
-In this article the term "creating client" refers to the client on which a container is created.  
-When it is important to emphasize that a client is *not* the creating client, it is called a "subsequent client".  
-It is helpful to remember that "client" does not refer to a device or anything that persists between sessions with your application.  
-When a user closes your application, the client no longer exists: a new session is a new client.  
-So, when the creating client is closed, there is no longer any creating client.  
+In this article the term "creating client" refers to the client on which a container is created.
+When it is important to emphasize that a client is *not* the creating client, it is called a "subsequent client".
+It is helpful to remember that "client" does not refer to a device or anything that persists between sessions with your application.
+When a user closes your application, the client no longer exists: a new session is a new client.
+So, when the creating client is closed, there is no longer any creating client.
 The device is a subsequent client in all future sessions.
 
 {{< /callout >}}
@@ -45,7 +45,7 @@ There are four types of states that a container can be in. Every container is in
 
 ### Publication status states
 
-Publication status refers to whether or not the container has been *initially* saved to the Fluid service, and whether it is still persisted there.  
+Publication status refers to whether or not the container has been *initially* saved to the Fluid service, and whether it is still persisted there.
 Think of it as a mainly *service-relative* state because it is primarily about the container's state in the Fluid service and secondarily about its state on the creating client. The following diagram shows the possible publication states and the events that cause a state transition. Details are below the diagram.
 
 <!-- TO MODIFY THIS DIAGRAM, SEE INSTRUCTIONS AT THE BOTTOM OF THIS FILE. -->
@@ -53,11 +53,11 @@ Think of it as a mainly *service-relative* state because it is primarily about t
 
 #### Unpublished
 
-When a [container is created](./containers.md#creating-a-container), it is in **unpublished** state and exists only on the creating client.  
+When a [container is created](./containers.md#creating-a-container), it is in **unpublished** state and exists only on the creating client.
 
-Users, or your code, can start editing the data in the container right away, but the data is not shareable with other clients until the [container is published](./containers.md#publishing-a-container).  
-Use the unpublished state to create initial data to populate your shared objects if needed.  
-This is often useful in scenarios where you want to make sure that all connected clients have a coherent initial state.  
+Users, or your code, can start editing the data in the container right away, but the data is not shareable with other clients until the [container is published](./containers.md#publishing-a-container).
+Use the unpublished state to create initial data to populate your shared objects if needed.
+This is often useful in scenarios where you want to make sure that all connected clients have a coherent initial state.
 For example, if collaboration involves tables, your code can set a minimum table size.
 
 #### Publishing
@@ -72,32 +72,32 @@ In the Fluid APIs, the terms "attach", "attaching", "attached" and "detached" me
 
 #### Published to the service
 
-When publishing completes, the container is **published**, so it exists in the Fluid service as well as the creating client.  
+When publishing completes, the container is **published**, so it exists in the Fluid service as well as the creating client.
 Subsequent clients can [connect to the container](./containers.md#connecting-to-a-container), synchronize with its latest data values, and edit them.
 
 A container can never transition back to an unpublished state, but it can transition to a deleted state.
 
 #### Deleted from the service
 
-A container transitions to **deleted** state when it is deleted.  
-Any connected clients become disconnected (although they may have been already disconnected before the deletion; see [Deleting a container from the service](#deleting-a-container-from-the-service)), but the container is not disposed on the clients.  
-Clients could continue to edit the container's data, but the data isn't shared anymore. Each client's changes are known only to it.  
+A container transitions to **deleted** state when it is deleted.
+Any connected clients become disconnected (although they may have been already disconnected before the deletion; see [Deleting a container from the service](#deleting-a-container-from-the-service)), but the container is not disposed on the clients.
+Clients could continue to edit the container's data, but the data isn't shared anymore. Each client's changes are known only to it.
 
 ##### Deleting a container from the service
 
-Deleting a container is a service-specific feature, so you should refer to the documentation associated with the specific Fluid service you are using for instructions on how to do it.  
-To prevent clients from being suddenly cut off from data sharing, the service may put restrictions on when a container can be deleted.  
-For example, it may allow deletion only if all clients have been disconnected from the container for a specified period of time.  
+Deleting a container is a service-specific feature, so you should refer to the documentation associated with the specific Fluid service you are using for instructions on how to do it.
+To prevent clients from being suddenly cut off from data sharing, the service may put restrictions on when a container can be deleted.
+For example, it may allow deletion only if all clients have been disconnected from the container for a specified period of time.
 
-Once it is deleted, the container cannot move back to the **published** state again.  
-It is possible for a client to create a new container using the same schema as a deleted container.  
-If a record of the final data values of the deleted container are available to the creating client, they can be used to initialize the new container.  
+Once it is deleted, the container cannot move back to the **published** state again.
+It is possible for a client to create a new container using the same schema as a deleted container.
+If a record of the final data values of the deleted container are available to the creating client, they can be used to initialize the new container.
 But the new container has a different ID from the deleted one and subsequent clients will have to connect to it using the new ID.
 
 #### Handling publication status
 
-Your code can test for the publication status with the [container.AttachState]({{< relref "/docs/apis/fluid-static/fluidcontainer-class.md#attachstate-property" >}}) property which has an [AttachState]({{< relref "/docs/apis/container-definitions.md#attachstate-enum" >}}) value.  
-This can be useful if your application will publish the container in some code paths on the creating client, but not others.  
+Your code can test for the publication status with the [container.AttachState]({{< relref "/docs/apis/fluid-static/fluidcontainer-class.md#attachstate-property" >}}) property which has an [AttachState]({{< relref "/docs/apis/container-definitions.md#attachstate-enum" >}}) value.
+This can be useful if your application will publish the container in some code paths on the creating client, but not others.
 For example, on the creating computer, you don't want to call `container.attach` if it has already been called. In simple cases, you can know at coding time if that has happened, but when the creating client in complex code flows and calls of `container.attach` appear in more than one branch, you may need to test for this possibility. The following is a simple example.
 
 ```typescript
@@ -151,14 +151,14 @@ The dotted arrow represents a boolean guard condition. It means that the contain
 
 When a new change is made to the data in a given client, the container moves to **dirty** state *in that client*. When all pending changes are acknowledged, it transitions to the **saved** state.
 
-Note that a container in the **saved** state is not necessarily perfectly synchronized with the service.  
-There may be changes made on other clients that have been saved to the service but have not yet been relayed to this client.  
-Situations like this would normally last only fractions of a second.  
+Note that a container in the **saved** state is not necessarily perfectly synchronized with the service.
+There may be changes made on other clients that have been saved to the service but have not yet been relayed to this client.
+Situations like this would normally last only fractions of a second.
 But if the client is disconnected while in **saved** state, it remains **saved**, but unsynchronized, until it reconnects. See [Connection status states](#connection-status-states) for more about connection.
 
-Users can work with the container's data regardless of whether it is in **dirty** or **saved** state.  
-But there are scenarios in which your code must be aware of the container's state. For this reason, the `FluidContainer` object has a boolean `isDirty` property to specify its state.  
-The `container` object also supports *dirty* and *saved* events, so you can handle the transitions between states.  
+Users can work with the container's data regardless of whether it is in **dirty** or **saved** state.
+But there are scenarios in which your code must be aware of the container's state. For this reason, the `FluidContainer` object has a boolean `isDirty` property to specify its state.
+The `container` object also supports *dirty* and *saved* events, so you can handle the transitions between states.
 The container emits the *saved* event to notify the caller that all the local changes have been acknowledged by the service.
 
 ```typescript {linenos=inline}
@@ -176,8 +176,8 @@ container.on("dirty", () => {
 ```
 
 You should always check the `isDirty` flag before [disposing](#disposed) the container or [disconnecting](#disconnected) from the service.
-If you dispose or disconnect the container while `isDirty === true`, you may lose operations that have not yet been sent to (or sent, but not acknowledged by) the service.  
-For example, suppose you have a function to disconnect a container in response to a period of user inactivity.  
+If you dispose or disconnect the container while `isDirty === true`, you may lose operations that have not yet been sent to (or sent, but not acknowledged by) the service.
+For example, suppose you have a function to disconnect a container in response to a period of user inactivity.
 The following shows how to ensure that the disconnection doesn't happen until the container is **saved**.
 
 ```typescript
@@ -190,8 +190,8 @@ function disconnectFromFluidService {
 }
 ```
 
-When a user is highly active, the container on a client may shift between **dirty** and **saved** states rapidly and repeatedly.  
-You usually do not want a handler to run every time the event is triggered, so take care to have your handler attached only in constrained circumstances.  
+When a user is highly active, the container on a client may shift between **dirty** and **saved** states rapidly and repeatedly.
+You usually do not want a handler to run every time the event is triggered, so take care to have your handler attached only in constrained circumstances.
 In the example above, using `container.once` ensures that the handler is removed after it runs once. When the container reconnects, the *saved* event will not have the handler attached to it.
 
 See [Connection status states](#connection-status-states) for more about connection and disconnection.
@@ -215,17 +215,17 @@ A container is **disconnected** if it is not in any of the other three Connectio
 
 {{< callout important >}}
 
-Disconnection does not automatically block users from editing the shared data objects.  
-Changes they make are stored locally and will be sent to the Fluid service when connection is reestablished.  
-But these changes are *not* being synchronized with other clients while the current client is disconnected, and your application's user may not be aware of that.  
-So, you usually want to block editing if a disconnection continues for some time.  
+Disconnection does not automatically block users from editing the shared data objects.
+Changes they make are stored locally and will be sent to the Fluid service when connection is reestablished.
+But these changes are *not* being synchronized with other clients while the current client is disconnected, and your application's user may not be aware of that.
+So, you usually want to block editing if a disconnection continues for some time.
 For more information, see [Managing connection and disconnection](#managing-connection-and-disconnection).
 
 {{< /callout >}}
 
 #### Establishing connection
 
-In this state, the client is attempting to connect to the Fluid service, but has not yet received an acknowledgement.  
+In this state, the client is attempting to connect to the Fluid service, but has not yet received an acknowledgement.
 A container moves into the **establishing connection** state in any of the following circumstances:
 
 -   On the creating client, your code calls the `container.attach` method. For more information, see [Publishing a container](./containers.md#publishing-a-container). This method publishes the container *and* connects the client to the service.
@@ -245,7 +245,7 @@ This state is normally very brief and the Fluid client then automatically moves 
 
 #### Connected
 
-A container is **connected** when there is an open, two-way web socket connection between the client and the Fluid service.  
+A container is **connected** when there is an open, two-way web socket connection between the client and the Fluid service.
 In the **connected** state, changes to the container's data on the client are sent to the service which relays them to all other connected clients.
 
 The container transitions to this state automatically when it is fully caught up with data from the Fluid service.
@@ -303,13 +303,13 @@ Local Readiness is a *client-relative state*: the container may have a different
 
 In this state, changes to the shared data objects can be made locally. They are shared with the Fluid service when, and only when, the container is in **published** and **connected** status.
 
-A container is automatically in **ready** state as soon as it is created and it remains in this state unless it is disposed.  
+A container is automatically in **ready** state as soon as it is created and it remains in this state unless it is disposed.
 A disposed `FluidContainer` remains disposed forever, but a new **ready** `FluidContainer` can be created by passing its ID to a call of `client.getContainer`.
 
 #### Disposed
 
-In scenarios where a container is no longer needed on the current client, you can dispose it with a call of `container.dispose()`. Disposing removes any server connections, so the Connection status becomes **disconnected**.  
-There is a *disposed* event on the container object that you can handle to add custom clean up logic, such as removing registered events.  
+In scenarios where a container is no longer needed on the current client, you can dispose it with a call of `container.dispose()`. Disposing removes any server connections, so the Connection status becomes **disconnected**.
+There is a *disposed* event on the container object that you can handle to add custom clean up logic, such as removing registered events.
 The following shows the basic syntax:
 
 ```typescript

--- a/docs/content/docs/build/containers.md
+++ b/docs/content/docs/build/containers.md
@@ -77,7 +77,7 @@ Notes:
 -   The `client` object is defined by the service-specific client library. See the documentation for the service you are using for more details about how to use its service-specific client library.
 -   It is a good practice to destructure the object that is returned by `createContainer` into its two main parts; `container` and `services`. For more about the `services` object, see [Container services](#container-services).
 
-A newly created container is in an **unpublished** state. An unpublished container is stored on the local client only and therefore no data is shared with other clients yet. But the data in it can, and sometimes should be, edited while it is unpublished. See [Container states and events](./container-states-events/index.md).
+A newly created container is in an **unpublished** state. An unpublished container is stored on the local client only and therefore no data is shared with other clients yet. But the data in it can, and sometimes should be, edited while it is unpublished. See [Container states and events]({{< relref "container-states-events/index.md" >}}).
 
 ### Publishing a container
 
@@ -94,7 +94,7 @@ Once published, the Fluid container becomes an entity on Fluid service and subse
 Invoking the container's `attach` method returns the unique identifier for the container.
 Subsequent clients use this ID to connect to the container.
 
-Note that once published, a container cannot be unpublished. (But it can be deleted. See [Deleting a container from the service](./container-states-events/index.md#deleting-a-container-from-the-service).)
+Note that once published, a container cannot be unpublished. (But it can be deleted. See [Deleting a container from the service]({{< relref "container-states-events/index.md#deleting-a-container-from-the-service" >}}).)
 
 ```typescript {linenos=inline,hl_lines=[10]}
 const schema = {
@@ -109,7 +109,7 @@ const { container, services } =
 const containerId = await container.attach();
 ```
 
-In addition to publishing the container, the `attach` method also connects the creating client to the published container. See [Connecting to a container](#connecting-to-a-container) and [Connection status states](./container-states-events/index.md#connection-status-states).
+In addition to publishing the container, the `attach` method also connects the creating client to the published container. See [Connecting to a container](#connecting-to-a-container) and [Connection status states]({{< relref "container-states-events/index.md#connection-status-states" >}}).
 
 ### Connecting to a container
 
@@ -132,7 +132,7 @@ const { container, services } =
 
 {{< callout tip >}}
 
-This section provides only basic information about the *most important* states that a container can be in. Details about *all* container states, including state diagrams, state management, editing management, and container event handling are in [Container states and events](./container-states-events/).
+This section provides only basic information about the *most important* states that a container can be in. Details about *all* container states, including state diagrams, state management, editing management, and container event handling are in [Container states and events]({{< relref "container-states-events/index.md" >}}).
 
 {{< /callout >}}
 

--- a/docs/content/docs/build/containers.md
+++ b/docs/content/docs/build/containers.md
@@ -5,9 +5,9 @@ author: skylerjokiel, rick-kirkham
 editor: tylerbutler
 ---
 
-The container is the primary unit of encapsulation in the Fluid Framework.  
-It enables a group of clients to access the same set of shared objects and co-author changes on those objects.  
-It is also a permission boundary ensuring visibility and access only to permitted clients.  
+The container is the primary unit of encapsulation in the Fluid Framework.
+It enables a group of clients to access the same set of shared objects and co-author changes on those objects.
+It is also a permission boundary ensuring visibility and access only to permitted clients.
 A container is represented by the [FluidContainer]({{< relref "/docs/apis/fluid-static/fluidcontainer-class.md" >}}) type and consists of a collection of shared objects and APIs to manage the life cycle of those objects.
 
 This article explains:
@@ -18,26 +18,26 @@ This article explains:
 
 {{< callout note >}}
 
-In this article the term "creating client" refers to the client on which a container is created.  
-When it is important to emphasize that a client is *not* the creating client, it is called a "subsequent client".  
-It is helpful to remember that "client" does not refer to a device or anything that persists between sessions with your application.  
-When a user closes your application, the client no longer exists: a new session is a new client.  
-So, when the creating client is closed, there is no longer any creating client.  
+In this article the term "creating client" refers to the client on which a container is created.
+When it is important to emphasize that a client is *not* the creating client, it is called a "subsequent client".
+It is helpful to remember that "client" does not refer to a device or anything that persists between sessions with your application.
+When a user closes your application, the client no longer exists: a new session is a new client.
+So, when the creating client is closed, there is no longer any creating client.
 The device is a subsequent client in all future sessions.
 
 {{< /callout >}}
 
 ## Creating & connecting
 
-Your code creates containers using APIs provided by a service-specific client library.  
-Each service-specific client library implements a common API for manipulating containers.  
-For example, the [Tinylicious library]({{< relref "Tinylicious" >}}) provides [these APIs]({{< relref "docs/apis/tinylicious-client.md" >}}) for the Tinylicious Fluid service.  
-These common APIs enable your code to specify what shared objects should live in the `FluidContainer`, and to connect to the container once it is created.  
+Your code creates containers using APIs provided by a service-specific client library.
+Each service-specific client library implements a common API for manipulating containers.
+For example, the [Tinylicious library]({{< relref "Tinylicious" >}}) provides [these APIs]({{< relref "docs/apis/tinylicious-client.md" >}}) for the Tinylicious Fluid service.
+These common APIs enable your code to specify what shared objects should live in the `FluidContainer`, and to connect to the container once it is created.
 
 ### Container schema
 
-Your code must define a schema that represents the structure of the data within the container.  
-Only the data *values* are persisted in the Fluid service. The structure and data types are stored as a schema object on each client.  
+Your code must define a schema that represents the structure of the data within the container.
+Only the data *values* are persisted in the Fluid service. The structure and data types are stored as a schema object on each client.
 A schema can specify:
 
 -   Some initial shared objects that are created as soon as the container is created, and are immediately and always available to all connected clients.
@@ -91,7 +91,7 @@ In the Fluid APIs, the terms "attach", "attached" and "detached" mean publish, p
 
 Once published, the Fluid container becomes an entity on Fluid service and subsequent clients can connect to it.
 
-Invoking the container's `attach` method returns the unique identifier for the container.  
+Invoking the container's `attach` method returns the unique identifier for the container.
 Subsequent clients use this ID to connect to the container.
 
 Note that once published, a container cannot be unpublished. (But it can be deleted. See [Deleting a container from the service](./container-states-events/index.md#deleting-a-container-from-the-service).)
@@ -113,9 +113,9 @@ In addition to publishing the container, the `attach` method also connects the c
 
 ### Connecting to a container
 
-The creating client connects to a container when it calls the container's `attach` method.  
-A subsequent client connects to a published container by calling the client's `getContainer` method.  
-The call must pass the `id` of the container as well as the exact same schema definition used to create the container.  
+The creating client connects to a container when it calls the container's `attach` method.
+A subsequent client connects to a published container by calling the client's `getContainer` method.
+The call must pass the `id` of the container as well as the exact same schema definition used to create the container.
 The same container schema is required on all subsequent connections.
 
 ```typescript {linenos=inline}
@@ -185,13 +185,13 @@ Multiple Fluid containers can be loaded from an application or on a web page at 
 
 First, if your application loads two different experiences that have different underlying data structures. *Experience 1* may require a `SharedMap` and *Experience 2* may require a `SharedString`. To minimize the memory footprint of your application, your code can create two different container schemas and load only the schema that is needed. In this case your app has the capability of loading two different containers (two different schemas) but only loads one for a given user.
 
-A more complex scenario involves loading two containers at once. Containers serve as a permissions boundary, so if you have cases where multiple users with different permissions are collaborating together, you may use multiple containers to ensure users have access only to what they should.  
+A more complex scenario involves loading two containers at once. Containers serve as a permissions boundary, so if you have cases where multiple users with different permissions are collaborating together, you may use multiple containers to ensure users have access only to what they should.
 For example, consider an education application where multiple teachers collaborate with students. The students and teachers may have a shared view while the teachers may also have an additional private view on the side. In this scenario the students would be loading one container and the teachers would be loading two.
 
 ## Container services
 
-When you create or connect to a container with `createContainer` or `getContainer`, the Fluid service will also return a service-specific *services* object.  
-This object contains references to useful services you can use to build richer applications.  
+When you create or connect to a container with `createContainer` or `getContainer`, the Fluid service will also return a service-specific *services* object.
+This object contains references to useful services you can use to build richer applications.
 An example of a container service is the [Audience]({{< relref "audience.md" >}}), which provides user information for clients that are connected to the container. See [Working with the audience]({{< relref "audience.md#working-with-the-audience" >}}) for more information.
 
 <!-- AUTO-GENERATED-CONTENT:START (INCLUDE:path=docs/_includes/links.md) -->


### PR DESCRIPTION
There was some trailing whitespace in some articles which led to unexpected line breaks in the rendered content. This change removes the trailing whitespace and adds a lint rule to help prevent future issues.

I was unsure if the double-spaces were meant to indicate new paragraphs or not. I assumed not, but if they were supposed to be new paragraphs, I can change that.