### PR TITLE
docs: Update outdated reactjs.org links

### DIFF
--- a/packages/tools/client-debugger/client-debugger-view/README.md
+++ b/packages/tools/client-debugger/client-debugger-view/README.md
@@ -8,7 +8,7 @@ The package exposes 2 primary entry-points:
 
 -   [renderClientDebuggerView](https://fluidframework.com/docs/apis/client-debugger-view/docs/apis/client-debugger-view#renderclientdebuggerview-function): A general-purpose function for rendering the debug view to a provided [DOM]() element.
 
--   [FluidClientDebugger](https://fluidframework.com/docs/apis/client-debugger-view/docs/apis/client-debugger-view#fluidclientdebugger-function): A [React Component](https://reactjs.org/docs/react-component.html) for embedding the debug view into your own React tree.
+-   [FluidClientDebugger](https://fluidframework.com/docs/apis/client-debugger-view/docs/apis/client-debugger-view#fluidclientdebugger-function): A [React Component](https://react.dev/reference/react/Component) for embedding the debug view into your own React tree.
 
 The library is intended to be extensible and customizable.
 

--- a/packages/tools/client-debugger/client-debugger-view/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger-view/src/index.ts
@@ -12,7 +12,7 @@
  *
  * - {@link renderClientDebuggerView}: A general-purpose rendering utility for displaying debug information.
  *
- * - {@link FluidClientDebugger}: A {@link https://reactjs.org/docs/react-component.html | React Component} for displaying debug information,
+ * - {@link FluidClientDebugger}: A {@link https://react.dev/reference/react/Component | React Component} for displaying debug information,
  * which can be added to your Fluid-backed React app.
  *
  * @privateRemarks TODO: Add examples once the API surface has solidified.


### PR DESCRIPTION
The React docs have moved, so we need to update links.