### PR TITLE
Shuagarwal/fix mongo error handling

### DIFF
--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
@@ -267,8 +267,8 @@ class UnauthorizedRule extends BaseMongoExceptionRetryRule {
 	}
 }
 
-// handles transient connection closed errors
-// this is also handled by MongoNetworkError rules but sometimes the errorName is MongoError in this case
+// handles transient connection closed errors, eg: connection 1 to <mongo-name>.mongo.cosmos.azure.com:<port> closed
+// this is also handled by MongoNetworkError retry rule but this handles the case when errorName is MongoError instead of MongoNetworkError
 class ConnectionClosedMongoErrorRule extends BaseMongoExceptionRetryRule {
 	protected defaultRetryDecision: boolean = true;
 
@@ -311,6 +311,7 @@ export function createMongoErrorRetryRuleset(
 		// The rules are using string contains
 		new ServiceUnavailableRule(retryRuleOverride),
 
+		// The rules are using regex
 		new ConnectionClosedMongoErrorRule(retryRuleOverride),
 	];
 	return mongoErrorRetryRuleset;

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -369,7 +369,7 @@ export class MongoCollection<T> implements core.ICollection<T>, core.IRetryable 
 		if (error) {
 			try {
 				Object.keys(error).forEach((key) => {
-					if (key == "_id" || /^\d+$/.test(key)) { // skip mongodb's ObjectId and array indexes
+					if (key === "_id" || /^\d+$/.test(key)) { // skip mongodb's ObjectId and array indexes
 						return;
 					} else if (typeof error[key] === "object") {
 						this.sanitizeError(error[key]);

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -371,7 +371,7 @@ export class MongoCollection<T> implements core.ICollection<T>, core.IRetryable 
 				Object.keys(error).forEach((key) => {
 					if (typeof error[key] === "object") {
 						this.sanitizeError(error[key]);
-					} else if (!errorResponseKeysAllowList.has(key)) {
+					} else if (!(/^\d+$/.test(key)) && !errorResponseKeysAllowList.has(key)) { // sanitize only if key is not a number(i.e. array index)
 						error[key] = errorSanitizationMessage;
 					}
 				});

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -369,9 +369,11 @@ export class MongoCollection<T> implements core.ICollection<T>, core.IRetryable 
 		if (error) {
 			try {
 				Object.keys(error).forEach((key) => {
-					if (typeof error[key] === "object") {
+					if (key == "_id" || /^\d+$/.test(key)) { // skip mongodb's ObjectId and array indexes
+						return;
+					} else if (typeof error[key] === "object") {
 						this.sanitizeError(error[key]);
-					} else if (!(/^\d+$/.test(key)) && !errorResponseKeysAllowList.has(key)) { // sanitize only if key is not a number(i.e. array index)
+					} else if (!errorResponseKeysAllowList.has(key)) {
 						error[key] = errorSanitizationMessage;
 					}
 				});


### PR DESCRIPTION
## Description

A few fixes around mongo db error handling
1. Fix sanitizeError logic so that it doesn't redact the following:
    - array elements. eg: "errorLabels"=>["TransientTransactionError"] shouldnt be converted to "errorLabels"=>["REDACTED"].
    - _id returned from mongodb which is of type "object". As per current logic, this gets redacted incorrectly leading to error "TypeError: Unrecognized or invalid _bsontype: REDACTED".
3. Add retry rule for Connection closed MongoError. We see 2 types of connection closed errors from mongo as below, we are adding a retry rule for the first one. (second one already has the retry rule).
   - {"name":"MongoError","message":"connection 1 to <>.mongo.cosmos.azure.com:10255 closed"}
   - {"name"=>"MongoNetworkError", "errorLabels"=>["TransientTransactionError"], "message"=>"connection 44502 to <>.mongo.cosmos.azure.com:10255 closed"}