### PR TITLE
Add testing for rollback of complex edits 

### DIFF
--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -399,7 +399,6 @@ describe("client.rollback", () => {
 
 		assert.equal(segment.parent, undefined);
 	});
-	// similar to an existing test - is it worth checking that we can rollback to empty?
 	it("Should rollback multiple overlapping edits", () => {
 		client.insertTextLocal(0, "abcdefg");
 		client.insertTextLocal(3, "123");

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -434,7 +434,10 @@ describe("client.rollback", () => {
 		client.insertTextLocal(4, "xyz");
 		client.removeRangeLocal(2, 5);
 		client.removeRangeLocal(3, 7);
+		client.removeRangeLocal(2, 4);
 
+		client.rollback?.({ type: MergeTreeDeltaType.REMOVE }, client.peekPendingSegmentGroups());
+		assert.equal(client.getText(), "abye");
 		client.rollback?.({ type: MergeTreeDeltaType.REMOVE }, client.peekPendingSegmentGroups());
 		assert.equal(client.getText(), "abyz23de");
 		client.rollback?.({ type: MergeTreeDeltaType.REMOVE }, client.peekPendingSegmentGroups());
@@ -455,6 +458,14 @@ describe("client.rollback", () => {
 		assert.equal(client.getText(), "abc123defg");
 
 		client.annotateRangeLocal(2, 8, { foo: "bar" }, undefined);
+		for (let i = 0; i < client.getText().length; i++) {
+			const props = client.getPropertiesAtPosition(i);
+			if (i >= 2 && i < 8) {
+				assert.equal(props?.foo, "bar");
+			} else {
+				assert(props === undefined || props.foo === undefined);
+			}
+		}
 
 		client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, client.peekPendingSegmentGroups());
 		for (let i = 0; i < client.getText().length; i++) {


### PR DESCRIPTION
Adding more test coverage of local rollback, specifically for overlapping or interleaved edits that do not currently have any test coverage. 

[AB#3776](https://dev.azure.com/fluidframework/internal/_workitems/edit/3776)