### PR TITLE
Partial Implementation of Representing Muted Changes in Optional Fields

### DIFF
--- a/packages/dds/tree/src/feature-libraries/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultFieldKinds.ts
@@ -15,8 +15,9 @@ import {
 	tagChange,
 	TreeSchemaIdentifier,
 	FieldSchema,
+	RevisionTag,
 } from "../core";
-import { brand, fail, JsonCompatible, JsonCompatibleReadOnly, Mutable } from "../util";
+import { brand, clone, fail, JsonCompatible, JsonCompatibleReadOnly, Mutable } from "../util";
 import { singleTextCursor, jsonableTreeFromCursor } from "./treeTextCursor";
 import {
 	FieldKind,
@@ -246,21 +247,31 @@ export const counter: BrandedFieldKind<
 );
 
 export type NodeUpdate =
-	| { set: JsonableTree }
+	| {
+			set: JsonableTree;
+			changes?: NodeChangeset;
+	  }
 	| {
 			/**
 			 * The node being restored.
 			 */
 			revert: ITreeCursorSynchronous;
+			revision: RevisionTag | undefined;
+			changes?: NodeChangeset;
 	  };
 
 type EncodedNodeUpdate =
-	| { set: JsonableTree }
+	| {
+			set: JsonableTree;
+			changes?: JsonCompatibleReadOnly;
+	  }
 	| {
 			/**
 			 * The node being restored.
 			 */
 			revert: JsonableTree;
+			revision: RevisionTag | undefined;
+			changes?: JsonCompatibleReadOnly;
 	  };
 
 export interface ValueChangeset {
@@ -315,7 +326,7 @@ const valueRebaser: FieldChangeRebaser<ValueChangeset> = isolatedFieldChangeReba
 		}
 		if (change.value !== undefined) {
 			assert(revision !== undefined, 0x591 /* Unable to revert to undefined revision */);
-			inverse.value = { revert: reviver(revision, 0, 1)[0] };
+			inverse.value = { revert: reviver(revision, 0, 1)[0], revision };
 		}
 		return inverse;
 	},
@@ -345,12 +356,7 @@ const valueFieldEncoder: FieldChangeEncoder<ValueChangeset> = {
 	) => {
 		const encoded: EncodedValueChangeset & JsonCompatibleReadOnly = {};
 		if (change.value !== undefined) {
-			encoded.value =
-				"revert" in change.value
-					? {
-							revert: jsonableTreeFromCursor(change.value.revert),
-					  }
-					: change.value;
+			encoded.value = encodeNodeUpdate(change.value, encodeChild);
 		}
 
 		if (change.changes !== undefined) {
@@ -368,12 +374,7 @@ const valueFieldEncoder: FieldChangeEncoder<ValueChangeset> = {
 		const encoded = change as EncodedValueChangeset;
 		const decoded: ValueChangeset = {};
 		if (encoded.value !== undefined) {
-			decoded.value =
-				"revert" in encoded.value
-					? {
-							revert: singleTextCursor(encoded.value.revert),
-					  }
-					: encoded.value;
+			decoded.value = decodeNodeUpdate(encoded.value, decodeChild);
 		}
 
 		if (encoded.changes !== undefined) {
@@ -383,6 +384,40 @@ const valueFieldEncoder: FieldChangeEncoder<ValueChangeset> = {
 		return decoded;
 	},
 };
+
+function encodeNodeUpdate(update: NodeUpdate, encodeChild: NodeChangeEncoder): EncodedNodeUpdate {
+	const encoded: EncodedNodeUpdate =
+		"revert" in update
+			? {
+					revert: jsonableTreeFromCursor(update.revert),
+					revision: update.revision,
+			  }
+			: {
+					set: update.set,
+			  };
+
+	if (update.changes !== undefined) {
+		encoded.changes = encodeChild(update.changes);
+	}
+
+	return encoded;
+}
+
+function decodeNodeUpdate(encoded: EncodedNodeUpdate, decodeChild: NodeChangeDecoder): NodeUpdate {
+	const decoded: NodeUpdate =
+		"revert" in encoded
+			? {
+					revert: singleTextCursor(encoded.revert),
+					revision: encoded.revision,
+			  }
+			: { set: encoded.set };
+
+	if (encoded.changes !== undefined) {
+		decoded.changes = decodeChild(encoded.changes);
+	}
+
+	return decoded;
+}
 
 export interface ValueFieldEditor extends FieldEditor<ValueChangeset> {
 	/**
@@ -454,9 +489,15 @@ export interface OptionalChangeset {
 	fieldChange?: OptionalFieldChange;
 
 	/**
-	 * Changes to the node which will be in the field after this changeset is applied.
+	 * Changes to the node which were in the field before this changeset is applied, or the node deleted in this field in the given revision
 	 */
 	childChange?: NodeChangeset;
+
+	/**
+	 * The revision the node `childChange` is referring to was deleted in.
+	 * If undefined, `childChange` refers to the node currently in this field.
+	 */
+	deletedBy?: RevisionTag;
 }
 
 const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = isolatedFieldChangeRebaser({
@@ -465,35 +506,53 @@ const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = isolatedFie
 		composeChild: NodeChangeComposer,
 	): OptionalChangeset => {
 		let fieldChange: OptionalFieldChange | undefined;
-		const childChanges: TaggedChange<NodeChangeset>[] = [];
+		const origNodeChange: TaggedChange<NodeChangeset>[] = [];
+		const newNodeChanges: TaggedChange<NodeChangeset>[] = [];
 		for (const { change, revision } of changes) {
+			if (change.deletedBy === undefined && change.childChange !== undefined) {
+				const taggedChange = tagChange(change.childChange, revision);
+				if (fieldChange === undefined) {
+					origNodeChange.push(taggedChange);
+				} else {
+					newNodeChanges.push(taggedChange);
+				}
+			}
+
 			if (change.fieldChange !== undefined) {
 				if (fieldChange === undefined) {
 					fieldChange = { wasEmpty: change.fieldChange.wasEmpty };
 				}
 
 				if (change.fieldChange.newContent !== undefined) {
-					fieldChange.newContent = change.fieldChange.newContent;
+					fieldChange.newContent = clone(change.fieldChange.newContent);
 				} else {
 					delete fieldChange.newContent;
 				}
 
 				// The previous changes applied to a different value, so we discard them.
 				// TODO: Represent muted changes
-				childChanges.length = 0;
-			}
-			if (change.childChange !== undefined) {
-				childChanges.push(tagChange(change.childChange, revision));
+				newNodeChanges.length = 0;
+
+				if (change.fieldChange.newContent?.changes !== undefined) {
+					newNodeChanges.push(tagChange(change.fieldChange.newContent.changes, revision));
+				}
 			}
 		}
 
 		const composed: OptionalChangeset = {};
 		if (fieldChange !== undefined) {
+			if (newNodeChanges.length > 0) {
+				assert(
+					fieldChange.newContent !== undefined,
+					"Shouldn't have new node changes if there is no new node",
+				);
+				fieldChange.newContent.changes = composeChild(newNodeChanges);
+			}
 			composed.fieldChange = fieldChange;
 		}
 
-		if (childChanges.length > 0) {
-			composed.childChange = composeChild(childChanges);
+		if (origNodeChange.length > 0) {
+			composed.childChange = composeChild(origNodeChange);
 		}
 
 		return composed;
@@ -509,14 +568,28 @@ const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = isolatedFie
 		const fieldChange = change.fieldChange;
 		if (fieldChange !== undefined) {
 			inverse.fieldChange = { wasEmpty: fieldChange.newContent === undefined };
+			if (fieldChange.newContent?.changes !== undefined) {
+				// The node inserted by change will be the node deleted by inverse
+				// Move the inverted changes to the child change field
+				inverse.childChange = invertChild(fieldChange.newContent.changes, 0);
+			}
+
 			if (!fieldChange.wasEmpty) {
 				assert(revision !== undefined, 0x592 /* Unable to revert to undefined revision */);
-				inverse.fieldChange.newContent = { revert: reviver(revision, 0, 1)[0] };
+				inverse.fieldChange.newContent = { revert: reviver(revision, 0, 1)[0], revision };
+				if (change.childChange !== undefined) {
+					assert(change.deletedBy === undefined, "Unhandled scenario");
+					inverse.fieldChange.newContent.changes = invertChild(change.childChange, 0);
+				}
 			}
-		}
+		} else {
+			if (change.childChange !== undefined) {
+				inverse.childChange = invertChild(change.childChange, 0);
+			}
 
-		if (change.childChange !== undefined) {
-			inverse.childChange = invertChild(change.childChange, 0);
+			if (change.deletedBy !== undefined) {
+				inverse.deletedBy = change.deletedBy;
+			}
 		}
 
 		return inverse;
@@ -532,29 +605,63 @@ const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = isolatedFie
 			if (over.fieldChange !== undefined) {
 				const wasEmpty = over.fieldChange.newContent === undefined;
 
-				// We don't have to rebase the child changes, since the other child changes don't apply to the same node
+				// TODO: Handle rebasing child changes.
 				return {
 					...change,
 					fieldChange: { ...change.fieldChange, wasEmpty },
 				};
 			}
 
-			return change;
+			const rebasedChange = { ...change };
+			const overChildChange =
+				change.deletedBy === over.deletedBy ? over.childChange : undefined;
+			const rebasedChildChange = rebaseChild(change.childChange, overChildChange);
+			if (rebasedChildChange !== undefined) {
+				rebasedChange.childChange = rebasedChildChange;
+			} else {
+				delete rebasedChange.childChange;
+			}
+
+			return rebasedChange;
 		}
 
 		if (change.childChange !== undefined) {
 			if (over.fieldChange !== undefined) {
-				// The node the child changes applied to no longer exists so we drop the changes.
-				// TODO: Represent muted changes
-				return {};
-			}
-
-			if (over.childChange !== undefined) {
-				return { childChange: rebaseChild(change.childChange, over.childChange) };
+				if (change.deletedBy === undefined) {
+					// `change.childChange` refers to the node being deleted by `over`.
+					return {
+						childChange: rebaseChild(change.childChange, over.childChange),
+						deletedBy: overTagged.revision,
+					};
+				} else if (
+					over.fieldChange.newContent !== undefined &&
+					"revert" in over.fieldChange.newContent &&
+					over.fieldChange.newContent.revision === change.deletedBy
+				) {
+					// Remove deletedBy because we revived the node that childChange refers to
+					return {
+						childChange: rebaseChild(
+							change.childChange,
+							over.fieldChange.newContent.changes,
+						),
+					};
+				}
 			}
 		}
 
-		return change;
+		{
+			const rebasedChange = { ...change };
+			const overChildChange =
+				change.deletedBy === over.deletedBy ? over.childChange : undefined;
+			const rebasedChildChange = rebaseChild(change.childChange, overChildChange);
+			if (rebasedChildChange !== undefined) {
+				rebasedChange.childChange = rebasedChildChange;
+			} else {
+				delete rebasedChange.childChange;
+			}
+
+			return rebasedChange;
+		}
 	},
 });
 
@@ -611,18 +718,13 @@ const optionalFieldEncoder: FieldChangeEncoder<OptionalChangeset> = {
 	) => {
 		const encoded: EncodedOptionalChangeset & JsonCompatibleReadOnly = {};
 		if (change.fieldChange !== undefined) {
-			encoded.fieldChange =
-				change.fieldChange.newContent !== undefined &&
-				"revert" in change.fieldChange.newContent
-					? {
-							...change.fieldChange,
-							newContent: {
-								revert: jsonableTreeFromCursor(
-									change.fieldChange.newContent.revert,
-								),
-							},
-					  }
-					: change.fieldChange;
+			encoded.fieldChange = { wasEmpty: change.fieldChange.wasEmpty };
+			if (change.fieldChange.newContent !== undefined) {
+				encoded.fieldChange.newContent = encodeNodeUpdate(
+					change.fieldChange.newContent,
+					encodeChild,
+				);
+			}
 		}
 
 		if (change.childChange !== undefined) {
@@ -645,12 +747,10 @@ const optionalFieldEncoder: FieldChangeEncoder<OptionalChangeset> = {
 			};
 
 			if (encoded.fieldChange.newContent !== undefined) {
-				decoded.fieldChange.newContent =
-					"revert" in encoded.fieldChange.newContent
-						? {
-								revert: singleTextCursor(encoded.fieldChange.newContent.revert),
-						  }
-						: encoded.fieldChange.newContent;
+				decoded.fieldChange.newContent = decodeNodeUpdate(
+					encoded.fieldChange.newContent,
+					decodeChild,
+				);
 			}
 		}
 
@@ -686,6 +786,24 @@ function deltaFromInsertAndChange(
 	return [];
 }
 
+function deltaForDelete(
+	nodeExists: boolean,
+	nodeChange: NodeChangeset | undefined,
+	deltaFromNode: ToDelta,
+): Delta.Mark[] {
+	if (!nodeExists) {
+		return [];
+	}
+
+	const deleteDelta: Mutable<Delta.Delete> = { type: Delta.MarkType.Delete, count: 1 };
+	if (nodeChange !== undefined) {
+		const modify = deltaFromNode(nodeChange);
+		deleteDelta.setValue = modify.setValue;
+		deleteDelta.fields = modify.fields;
+	}
+	return [deleteDelta];
+}
+
 /**
  * 0 or 1 items.
  */
@@ -698,6 +816,20 @@ export const optional: FieldKind<OptionalFieldEditor, Multiplicity.Optional> = n
 		editor: optionalFieldEditor,
 
 		intoDelta: (change: OptionalChangeset, deltaFromChild: ToDelta) => {
+			if (change.fieldChange === undefined) {
+				if (change.deletedBy === undefined && change.childChange !== undefined) {
+					return [deltaFromChild(change.childChange)];
+				}
+				return [];
+			}
+
+			assert(change.deletedBy === undefined, "Unhandled");
+			const deleteDelta = deltaForDelete(
+				!change.fieldChange.wasEmpty,
+				change.childChange,
+				deltaFromChild,
+			);
+
 			const update = change.fieldChange?.newContent;
 			let content: ITreeCursorSynchronous | undefined;
 			if (update === undefined) {
@@ -707,17 +839,10 @@ export const optional: FieldKind<OptionalFieldEditor, Multiplicity.Optional> = n
 			} else {
 				content = update.revert;
 			}
-			const insertDelta = deltaFromInsertAndChange(
-				content,
-				change.childChange,
-				deltaFromChild,
-			);
 
-			if (change.fieldChange !== undefined && !change.fieldChange.wasEmpty) {
-				return [{ type: Delta.MarkType.Delete, count: 1 }, ...insertDelta];
-			}
+			const insertDelta = deltaFromInsertAndChange(content, update?.changes, deltaFromChild);
 
-			return insertDelta;
+			return [...deleteDelta, ...insertDelta];
 		},
 
 		isEmpty: (change: OptionalChangeset) =>

--- a/packages/dds/tree/src/feature-libraries/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultFieldKinds.ts
@@ -648,7 +648,9 @@ const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = isolatedFie
 					"revert" in over.fieldChange.newContent &&
 					over.fieldChange.newContent.revision === change.deletedBy
 				) {
-					// Remove deletedBy because we revived the node that childChange refers to
+					// Over is reviving the node that change.childChange is referring to.
+					// Rebase change.childChange and remove deletedBy
+					// because we revived the node that childChange refers to
 					return {
 						childChange: rebaseChild(
 							change.childChange,
@@ -664,9 +666,7 @@ const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = isolatedFie
 
 			let overChildChange: NodeChangeset | undefined;
 			if (change.deletedBy === undefined && over.deletedBy === undefined) {
-				if (change.deletedBy === over.deletedBy) {
-					overChildChange = over.childChange;
-				}
+				overChildChange = over.childChange;
 			}
 
 			const rebasedChildChange = rebaseChild(change.childChange, overChildChange);

--- a/packages/dds/tree/src/test/feature-libraries/defaultFieldKinds.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/defaultFieldKinds.spec.ts
@@ -29,6 +29,7 @@ import {
 	Delta,
 	mintRevisionTag,
 	ValueSchema,
+	tagChange,
 } from "../../core";
 import { JsonCompatibleReadOnly } from "../../util";
 import { assertMarkListEqual, fakeRepair } from "../utils";
@@ -49,6 +50,7 @@ const tree1ContextuallyTyped: ContextuallyTypedNodeDataObject = {
 // Therefore it should not be using JsonableTrees.
 // The usages of this (and other JsonableTrees) such as ValueChangeset should be changed to use
 // a tree format intended for in memory use, such as Cursor or MapTree.
+// TODO: Figure out issue with deepfreezing here
 const tree1 = jsonableTreeFromCursor(
 	cursorFromContextualData(schemaData, new Set([nodeSchema.name]), tree1ContextuallyTyped),
 );
@@ -120,11 +122,11 @@ describe("Value field changesets", () => {
 	const childChange2: FieldKinds.ValueChangeset = { changes: nodeChange2 };
 	const childChange3: FieldKinds.ValueChangeset = { changes: nodeChange3 };
 
-	const change1 = fieldHandler.editor.set(singleTextCursor(tree1));
-	const change2 = fieldHandler.editor.set(singleTextCursor(tree2));
+	const change1 = tagChange(fieldHandler.editor.set(singleTextCursor(tree1)), mintRevisionTag());
+	const change2 = tagChange(fieldHandler.editor.set(singleTextCursor(tree2)), mintRevisionTag());
 
 	const revertChange2: FieldKinds.ValueChangeset = {
-		value: { revert: singleTextCursor(tree1) },
+		value: { revert: singleTextCursor(tree1), revision: change1.revision },
 	};
 
 	const simpleChildComposer = (changes: TaggedChange<NodeChangeset>[]) => {
@@ -134,25 +136,25 @@ describe("Value field changesets", () => {
 
 	it("can be created", () => {
 		const expected: FieldKinds.ValueChangeset = { value: { set: tree1 } };
-		assert.deepEqual(change1, expected);
+		assert.deepEqual(change1.change, expected);
 	});
 
 	it("can be composed", () => {
 		const composed = fieldHandler.rebaser.compose(
-			[makeAnonChange(change1), makeAnonChange(change2)],
+			[change1, change2],
 			simpleChildComposer,
 			idAllocator,
 			crossFieldManager,
 			revisionMetadata,
 		);
 
-		assert.deepEqual(composed, change2);
+		assert.deepEqual(composed, change2.change);
 	});
 
 	it("can be composed with child changes", () => {
 		assert.deepEqual(
 			fieldHandler.rebaser.compose(
-				[makeAnonChange(change1), makeAnonChange(childChange1)],
+				[change1, tagChange(childChange1, mintRevisionTag())],
 				simpleChildComposer,
 				idAllocator,
 				crossFieldManager,
@@ -169,13 +171,13 @@ describe("Value field changesets", () => {
 		assert.deepEqual(change1WithChildChange, expected);
 		assert.deepEqual(
 			fieldHandler.rebaser.compose(
-				[makeAnonChange(childChange1), makeAnonChange(change1)],
+				[makeAnonChange(childChange1), change1],
 				simpleChildComposer,
 				idAllocator,
 				crossFieldManager,
 				revisionMetadata,
 			),
-			change1,
+			change1.change,
 		);
 
 		assert.deepEqual(
@@ -212,14 +214,14 @@ describe("Value field changesets", () => {
 
 		assert.deepEqual(
 			fieldHandler.rebaser.rebase(
-				change2,
+				change2.change,
 				makeAnonChange(change1WithChildChange),
 				childRebaser,
 				idAllocator,
 				crossFieldManager,
 				revisionMetadata,
 			),
-			change2,
+			change2.change,
 		);
 	});
 
@@ -287,19 +289,36 @@ describe("Optional field changesets", () => {
 	const editor: FieldKinds.OptionalFieldEditor =
 		fieldHandler.editor as FieldKinds.OptionalFieldEditor;
 
-	const change1: FieldKinds.OptionalChangeset = {
-		fieldChange: { newContent: { set: tree1 }, wasEmpty: true },
-		childChange: nodeChange1,
-	};
+	const change1: TaggedChange<FieldKinds.OptionalChangeset> = tagChange(
+		{
+			fieldChange: { newContent: { set: tree1, changes: nodeChange1 }, wasEmpty: true },
+		},
+		mintRevisionTag(),
+	);
 
-	const detachedBy: RevisionTag = mintRevisionTag();
-	const revertChange2: FieldKinds.OptionalChangeset = {
-		fieldChange: { newContent: { revert: singleTextCursor(tree1) }, wasEmpty: false },
-	};
+	const change2: TaggedChange<FieldKinds.OptionalChangeset> = tagChange(
+		editor.set(singleTextCursor(tree2), false),
+		mintRevisionTag(),
+	);
 
-	const change2: FieldKinds.OptionalChangeset = editor.set(singleTextCursor(tree2), false);
-	const change3: FieldKinds.OptionalChangeset = editor.set(singleTextCursor(tree2), true);
-	const change4: FieldKinds.OptionalChangeset = editor.buildChildChange(0, nodeChange2);
+	const revertChange2: TaggedChange<FieldKinds.OptionalChangeset> = tagChange(
+		{
+			fieldChange: {
+				newContent: { revert: singleTextCursor(tree1), revision: change2.revision },
+				wasEmpty: false,
+			},
+		},
+		mintRevisionTag(),
+	);
+
+	const change3: TaggedChange<FieldKinds.OptionalChangeset> = tagChange(
+		editor.set(singleTextCursor(tree2), true),
+		mintRevisionTag(),
+	);
+	const change4: TaggedChange<FieldKinds.OptionalChangeset> = tagChange(
+		editor.buildChildChange(0, nodeChange2),
+		mintRevisionTag(),
+	);
 
 	it("can be created", () => {
 		const actual: FieldKinds.OptionalChangeset = editor.set(singleTextCursor(tree1), true);
@@ -313,24 +332,23 @@ describe("Optional field changesets", () => {
 		const childComposer = (_: TaggedChange<NodeChangeset>[]) =>
 			assert.fail("Should not be called");
 		const composed = fieldHandler.rebaser.compose(
-			[makeAnonChange(change1), makeAnonChange(change2)],
+			[change1, change2],
 			childComposer,
 			idAllocator,
 			crossFieldManager,
 			revisionMetadata,
 		);
-		assert.deepEqual(composed, change3);
+		assert.deepEqual(composed, change3.change);
 	});
 
 	it("can compose child changes", () => {
 		const expected: FieldKinds.OptionalChangeset = {
-			fieldChange: change1.fieldChange,
-			childChange: nodeChange3,
+			fieldChange: { wasEmpty: true, newContent: { set: tree1, changes: nodeChange3 } },
 		};
 
 		assert.deepEqual(
 			fieldHandler.rebaser.compose(
-				[makeAnonChange(change1), makeAnonChange(change4)],
+				[change1, change4],
 				childComposer1_2,
 				idAllocator,
 				crossFieldManager,
@@ -352,7 +370,7 @@ describe("Optional field changesets", () => {
 		};
 
 		const repair: NodeReviver = (revision: RevisionTag, index: number, count: number) => {
-			assert.equal(revision, detachedBy);
+			assert.equal(revision, change1.revision);
 			assert.equal(index, 0);
 			assert.equal(count, 1);
 			return [singleTextCursor(tree1)];
@@ -360,7 +378,7 @@ describe("Optional field changesets", () => {
 
 		assert.deepEqual(
 			fieldHandler.rebaser.invert(
-				makeAnonChange(change1),
+				change1,
 				childInverter,
 				repair,
 				idAllocator,
@@ -370,50 +388,98 @@ describe("Optional field changesets", () => {
 		);
 	});
 
-	it("can be rebased", () => {
-		const childRebaser = (
-			_change: NodeChangeset | undefined,
-			_base: NodeChangeset | undefined,
-		) => assert.fail("Should not be called");
-		assert.deepEqual(
-			fieldHandler.rebaser.rebase(
-				change3,
-				makeAnonChange(change1),
-				childRebaser,
-				idAllocator,
-				crossFieldManager,
-				revisionMetadata,
-			),
-			change2,
-		);
-	});
+	describe("Rebasing", () => {
+		it("can be rebased", () => {
+			const childRebaser = (
+				_change: NodeChangeset | undefined,
+				_base: NodeChangeset | undefined,
+			) => assert.fail("Should not be called");
+			assert.deepEqual(
+				fieldHandler.rebaser.rebase(
+					change3.change,
+					change1,
+					childRebaser,
+					idAllocator,
+					crossFieldManager,
+					revisionMetadata,
+				),
+				change2.change,
+			);
+		});
 
-	it("can rebase child change", () => {
-		const baseChange: FieldKinds.OptionalChangeset = { childChange: nodeChange1 };
-		const changeToRebase: FieldKinds.OptionalChangeset = { childChange: nodeChange2 };
+		it("can rebase child change", () => {
+			const baseChange: FieldKinds.OptionalChangeset = { childChange: nodeChange1 };
+			const changeToRebase: FieldKinds.OptionalChangeset = { childChange: nodeChange2 };
 
-		const childRebaser = (
-			change: NodeChangeset | undefined,
-			base: NodeChangeset | undefined,
-		): NodeChangeset | undefined => {
-			assert.deepEqual(change, nodeChange2);
-			assert.deepEqual(base, nodeChange1);
-			return nodeChange3;
-		};
+			const childRebaser = (
+				change: NodeChangeset | undefined,
+				base: NodeChangeset | undefined,
+			): NodeChangeset | undefined => {
+				assert.deepEqual(change, nodeChange2);
+				assert.deepEqual(base, nodeChange1);
+				return nodeChange3;
+			};
 
-		const expected: FieldKinds.OptionalChangeset = { childChange: nodeChange3 };
+			const expected: FieldKinds.OptionalChangeset = { childChange: nodeChange3 };
 
-		assert.deepEqual(
-			fieldHandler.rebaser.rebase(
+			assert.deepEqual(
+				fieldHandler.rebaser.rebase(
+					changeToRebase,
+					makeAnonChange(baseChange),
+					childRebaser,
+					idAllocator,
+					crossFieldManager,
+					revisionMetadata,
+				),
+				expected,
+			);
+		});
+
+		it("can rebase a child change over a delete and revive of target node", () => {
+			const tag1 = mintRevisionTag();
+			const tag2 = mintRevisionTag();
+			const changeToRebase = editor.buildChildChange(0, nodeChange1);
+			const deletion = tagChange(editor.set(undefined, false), tag1);
+			const revive = tagChange(
+				fieldHandler.rebaser.invert(
+					deletion,
+					() => assert.fail("Should not need to invert children"),
+					fakeRepair,
+					idAllocator,
+					crossFieldManager,
+				),
+				tag2,
+			);
+
+			const childRebaser = (
+				nodeChange: NodeChangeset | undefined,
+				baseNodeChange: NodeChangeset | undefined,
+			) => {
+				assert(baseNodeChange === undefined);
+				assert(nodeChange === nodeChange1);
+				return nodeChange;
+			};
+
+			const changeToRebase2 = fieldHandler.rebaser.rebase(
 				changeToRebase,
-				makeAnonChange(baseChange),
+				deletion,
 				childRebaser,
 				idAllocator,
 				crossFieldManager,
 				revisionMetadata,
-			),
-			expected,
-		);
+			);
+
+			const changeToRebase3 = fieldHandler.rebaser.rebase(
+				changeToRebase2,
+				revive,
+				childRebaser,
+				idAllocator,
+				crossFieldManager,
+				revisionMetadata,
+			);
+
+			assert.deepEqual(changeToRebase3, changeToRebase);
+		});
 	});
 
 	it("can be converted to a delta when field was empty", () => {
@@ -425,7 +491,7 @@ describe("Optional field changesets", () => {
 			},
 		];
 
-		assertMarkListEqual(fieldHandler.intoDelta(change1, deltaFromChild1), expected);
+		assertMarkListEqual(fieldHandler.intoDelta(change1.change, deltaFromChild1), expected);
 	});
 
 	it("can be converted to a delta when replacing content", () => {
@@ -434,7 +500,7 @@ describe("Optional field changesets", () => {
 			{ type: Delta.MarkType.Insert, content: [singleTextCursor(tree2)] },
 		];
 
-		assertMarkListEqual(fieldHandler.intoDelta(change2, deltaFromChild1), expected);
+		assertMarkListEqual(fieldHandler.intoDelta(change2.change, deltaFromChild1), expected);
 	});
 
 	it("can be converted to a delta when restoring content", () => {
@@ -443,19 +509,19 @@ describe("Optional field changesets", () => {
 			{ type: Delta.MarkType.Insert, content: [singleTextCursor(tree1)] },
 		];
 
-		const actual = fieldHandler.intoDelta(revertChange2, deltaFromChild1);
+		const actual = fieldHandler.intoDelta(revertChange2.change, deltaFromChild1);
 		assertMarkListEqual(actual, expected);
 	});
 
 	it("can be converted to a delta with only child changes", () => {
 		const expected: Delta.MarkList = [{ type: Delta.MarkType.Modify, setValue: "value4" }];
 
-		assertMarkListEqual(fieldHandler.intoDelta(change4, deltaFromChild2), expected);
+		assertMarkListEqual(fieldHandler.intoDelta(change4.change, deltaFromChild2), expected);
 	});
 
 	const encodingTestData: [string, FieldKinds.OptionalChangeset][] = [
-		["change", change1],
-		["with repair data", revertChange2],
+		["change", change1.change],
+		["with repair data", revertChange2.change],
 	];
 
 	runEncodingTests(fieldHandler.encoder, encodingTestData);

--- a/packages/dds/tree/src/test/feature-libraries/defaultFieldKinds.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/defaultFieldKinds.spec.ts
@@ -126,7 +126,7 @@ describe("Value field changesets", () => {
 	const change2 = tagChange(fieldHandler.editor.set(singleTextCursor(tree2)), mintRevisionTag());
 
 	const revertChange2: FieldKinds.ValueChangeset = {
-		value: { revert: singleTextCursor(tree1), revision: change1.revision },
+		value: { revert: singleTextCursor(tree1), revision: change2.revision },
 	};
 
 	const simpleChildComposer = (changes: TaggedChange<NodeChangeset>[]) => {

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -4,7 +4,7 @@
  */
 import { strict as assert } from "assert";
 import { singleTextCursor } from "../../feature-libraries";
-import { jsonString } from "../../domains";
+import { jsonString, singleJsonCursor } from "../../domains";
 import { moveToDetachedField, rootFieldKeySymbol, UpPath } from "../../core";
 import { brand, JsonCompatible } from "../../util";
 import { fakeRepair } from "../utils";
@@ -290,6 +290,45 @@ describe("Editing", () => {
 			tree1.receive(seqChange);
 
 			expectJsonTree(tree1, ["x", { foo: ["b", "a"] }]);
+		});
+	});
+
+	describe("Optional Field", () => {
+		it.skip("can rebase an insert of and edit to a node", async () => {
+			const sequencer = new Sequencer();
+			const tree1 = TestTree.fromJson([]);
+			const tree2 = tree1.fork();
+
+			const rootPath = {
+				parent: undefined,
+				parentField: rootFieldKeySymbol,
+				parentIndex: 0,
+			};
+
+			// Cause a rebase of tree2's edits
+			const e1 = tree1.runTransaction((forest, editor) => {
+				const field = editor.optionalField(undefined, rootFieldKeySymbol);
+				field.set(singleJsonCursor("41"), true);
+			});
+
+			const e2 = tree2.runTransaction((forest, editor) => {
+				const field = editor.optionalField(undefined, rootFieldKeySymbol);
+				field.set(singleJsonCursor("42"), true);
+			});
+
+			const e3 = tree2.runTransaction((forest, editor) => {
+				editor.setValue(rootPath, "43");
+			});
+
+			const sequenced = sequencer.sequence([e1, e2, e3]);
+			// Rebasing e3 over e2⁻¹ mutes e3
+			// Rebasing the muted e3 over e1 doesn't affect it
+			// Rebasing the muted e3 over e2' fails to unmute the change because e2' is expressed
+			// as `set` operation instead of a `revert`.
+			tree1.receive(sequenced);
+			tree2.receive(sequenced);
+
+			expectJsonTree([tree1, tree2], ["43"]);
 		});
 	});
 });

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -294,7 +294,7 @@ describe("Editing", () => {
 	});
 
 	describe("Optional Field", () => {
-		it.skip("can rebase an insert of and edit to a node", async () => {
+		it.skip("can rebase an insert of and edit to a node", () => {
 			const sequencer = new Sequencer();
 			const tree1 = TestTree.fromJson([]);
 			const tree2 = tree1.fork();

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -329,37 +329,6 @@ describe("SharedTree", () => {
 			assert.equal(peekTestValue(tree2), 43);
 		});
 
-		it.skip("can rebase an insert of and edit to a node in an optional field", async () => {
-			const provider = await TestTreeProvider.create(2);
-			const [tree1, tree2] = provider.trees;
-
-			const rootPath = {
-				parent: undefined,
-				parentField: rootFieldKeySymbol,
-				parentIndex: 0,
-			};
-
-			// Cause a rebase of tree2's edits
-			runSynchronous(tree1, () => {
-				const field = tree1.editor.optionalField(undefined, rootFieldKeySymbol);
-				field.set(singleTextCursor({ type: brand("TestValue"), value: "41" }), true);
-			});
-
-			// TODO: Explain what's happening
-			runSynchronous(tree2, () => {
-				const field = tree1.editor.optionalField(undefined, rootFieldKeySymbol);
-				field.set(singleTextCursor({ type: brand("TestValue"), value: "42" }), true);
-			});
-
-			runSynchronous(tree2, () => {
-				tree1.editor.setValue(rootPath, "43");
-			});
-
-			await provider.ensureSynchronized();
-			assert.equal(peekTestValue(tree1), "43");
-			assert.equal(peekTestValue(tree2), "43");
-		});
-
 		it("can edit a global field", async () => {
 			const provider = await TestTreeProvider.create(2);
 			const [tree1, tree2] = provider.trees;

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -329,8 +329,7 @@ describe("SharedTree", () => {
 			assert.equal(peekTestValue(tree2), 43);
 		});
 
-		// TODO: Instead of setting a value do an insert into a sequence field: needs to not be idempotent
-		it("can rebase an insert of and edit to a node in an optional field", async () => {
+		it.skip("can rebase an insert of and edit to a node in an optional field", async () => {
 			const provider = await TestTreeProvider.create(2);
 			const [tree1, tree2] = provider.trees;
 


### PR DESCRIPTION
## Description
This PR adds a representation for changes made to deleted nodes. It's only complete to the point that a node exists constraint could be written that will work in a unit test but not an end to end test. There's an included skipped end to end test that isn't working yet properly as we're not sure how to go about representing intermediate changes in composition.

This PR adds a new contract with regard to representation as follows:

If the `deletedBy` property is set in an OptionalFieldChange, `childChange` refers to the node deleted in the field in the revision given by `deletedBy`. Otherwise, `childChange` refers to the node currently present in the field.


