### PR TITLE
Proof of concept map incremental plus minimal runtime changes

### DIFF
--- a/api-report/datastore-definitions.api.md
+++ b/api-report/datastore-definitions.api.md
@@ -18,6 +18,7 @@ import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
 import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
+import { IIncrementalContext } from '@fluidframework/runtime-definitions';
 import { ILoaderOptions } from '@fluidframework/container-definitions';
 import { IProvideFluidDataStoreRegistry } from '@fluidframework/runtime-definitions';
 import { IQuorumClients } from '@fluidframework/protocol-definitions';
@@ -37,7 +38,7 @@ export interface IChannel extends IFluidLoadable {
     isAttached(): boolean;
     // (undocumented)
     readonly owner?: string;
-    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
+    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalContext?: IIncrementalContext): Promise<ISummaryTreeWithStats>;
 }
 
 // @public

--- a/api-report/fluid-framework.api.md
+++ b/api-report/fluid-framework.api.md
@@ -72,6 +72,7 @@ import { LoadableObjectCtor } from '@fluidframework/fluid-static';
 import { LoadableObjectRecord } from '@fluidframework/fluid-static';
 import { LocalValueMaker } from '@fluidframework/map';
 import { MapFactory } from '@fluidframework/map';
+import { MapIncrementalFactory } from '@fluidframework/map';
 import { MemberChangedListener } from '@fluidframework/fluid-static';
 import { RootDataObject } from '@fluidframework/fluid-static';
 import { RootDataObjectProps } from '@fluidframework/fluid-static';
@@ -228,6 +229,8 @@ export { LoadableObjectRecord }
 export { LocalValueMaker }
 
 export { MapFactory }
+
+export { MapIncrementalFactory }
 
 export { MemberChangedListener }
 

--- a/api-report/map.api.md
+++ b/api-report/map.api.md
@@ -15,6 +15,7 @@ import { IEventThisPlaceHolder } from '@fluidframework/common-definitions';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidSerializer } from '@fluidframework/shared-object-base';
+import { IIncrementalContext } from '@fluidframework/runtime-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISharedObject } from '@fluidframework/shared-object-base';
 import { ISharedObjectEvents } from '@fluidframework/shared-object-base';
@@ -213,6 +214,22 @@ export class MapFactory implements IChannelFactory {
 }
 
 // @public @sealed
+export class MapIncrementalFactory implements IChannelFactory {
+    // (undocumented)
+    static readonly Attributes: IChannelAttributes;
+    // (undocumented)
+    get attributes(): IChannelAttributes;
+    // (undocumented)
+    create(runtime: IFluidDataStoreRuntime, id: string): ISharedMap;
+    // (undocumented)
+    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, attributes: IChannelAttributes): Promise<ISharedMap>;
+    // (undocumented)
+    static readonly Type = "https://graph.microsoft.com/types/map-incremental";
+    // (undocumented)
+    get type(): string;
+}
+
+// @public @sealed
 export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implements ISharedDirectory {
     [Symbol.iterator](): IterableIterator<[string, any]>;
     [Symbol.toStringTag]: string;
@@ -293,6 +310,39 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
     get size(): number;
     // @internal (undocumented)
     protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+    values(): IterableIterator<any>;
+}
+
+// @public
+export class SharedMapIncremental extends SharedObject<ISharedMapEvents> implements ISharedMap {
+    [Symbol.iterator](): IterableIterator<[string, any]>;
+    readonly [Symbol.toStringTag]: string;
+    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
+    // @internal (undocumented)
+    protected applyStashedOp(content: unknown): unknown;
+    clear(): void;
+    static create(runtime: IFluidDataStoreRuntime, id?: string): SharedMapIncremental;
+    delete(key: string): boolean;
+    entries(): IterableIterator<[string, any]>;
+    forEach(callbackFn: (value: any, key: string, map: Map<string, any>) => void): void;
+    get<T = any>(key: string): T | undefined;
+    static getFactory(): IChannelFactory;
+    has(key: string): boolean;
+    keys(): IterableIterator<string>;
+    // @internal (undocumented)
+    protected loadCore(storage: IChannelStorageService): Promise<void>;
+    // @internal (undocumented)
+    protected onDisconnect(): void;
+    // @internal (undocumented)
+    protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
+    // @internal (undocumented)
+    protected reSubmitCore(content: unknown, localOpMetadata: unknown): void;
+    // @internal (undocumented)
+    protected rollback(content: unknown, localOpMetadata: unknown): void;
+    set(key: string, value: unknown): this;
+    get size(): number;
+    // @internal (undocumented)
+    protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext, incrementalContext?: IIncrementalContext): ISummaryTreeWithStats;
     values(): IterableIterator<any>;
 }
 

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -310,6 +310,16 @@ export interface IInboundSignalMessage extends ISignalMessage {
     type: string;
 }
 
+// @public (undocumented)
+export interface IIncrementalContext {
+    // (undocumented)
+    parentPath: string;
+    // (undocumented)
+    previousSequenceNumber: number;
+    // (undocumented)
+    sequenceNumber: number;
+}
+
 // @public
 export type InboundAttachMessage = Omit<IAttachMessage, "snapshot"> & {
     snapshot: IAttachMessage["snapshot"] | null;
@@ -445,7 +455,7 @@ export interface OpAttributionKey {
 }
 
 // @public (undocumented)
-export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext) => Promise<ISummarizeInternalResult>;
+export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext, incrementalContext?: IIncrementalContext) => Promise<ISummarizeInternalResult>;
 
 // @public (undocumented)
 export const totalBlobSizePropertyName = "TotalBlobSize";

--- a/api-report/shared-object-base.api.md
+++ b/api-report/shared-object-base.api.md
@@ -17,6 +17,7 @@ import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidHandleContext } from '@fluidframework/core-interfaces';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
+import { IIncrementalContext } from '@fluidframework/runtime-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
@@ -95,8 +96,8 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
     // (undocumented)
     protected get serializer(): IFluidSerializer;
     // (undocumented)
-    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
-    protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalContext?: IIncrementalContext): Promise<ISummaryTreeWithStats>;
+    protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext, incrementalContext?: IIncrementalContext): ISummaryTreeWithStats;
 }
 
 // @public

--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -80,6 +80,12 @@ export function createSummarizerFromFactory(provider: ITestObjectProvider, conta
 }>;
 
 // @public
+export function createSummarizerWithTestContainerConfig(provider: ITestObjectProvider, container: IContainer, testContainerConfig?: ITestContainerConfig): Promise<{
+    container: IContainer;
+    summarizer: ISummarizer;
+}>;
+
+// @public
 export const createTestContainerRuntimeFactory: (containerRuntimeCtor: typeof ContainerRuntime) => {
     new (type: string, dataStoreFactory: IFluidDataStoreFactory, runtimeOptions?: IContainerRuntimeOptions, requestHandlers?: RuntimeRequestHandler[]): {
         type: string;

--- a/packages/dds/map/src/index.ts
+++ b/packages/dds/map/src/index.ts
@@ -45,3 +45,4 @@ export {
 } from "./interfaces";
 export { LocalValueMaker, ILocalValue } from "./localValues";
 export { MapFactory, SharedMap } from "./map";
+export { MapIncrementalFactory, SharedMapIncremental } from "./mapIncremental";

--- a/packages/dds/map/src/mapIncremental.ts
+++ b/packages/dds/map/src/mapIncremental.ts
@@ -1,0 +1,466 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	ISequencedDocumentMessage,
+	MessageType,
+	SummaryType,
+} from "@fluidframework/protocol-definitions";
+import {
+	IChannelAttributes,
+	IFluidDataStoreRuntime,
+	IChannelStorageService,
+	IChannelServices,
+	IChannelFactory,
+} from "@fluidframework/datastore-definitions";
+import {
+	IIncrementalContext,
+	ISummaryTreeWithStats,
+	ITelemetryContext,
+} from "@fluidframework/runtime-definitions";
+import { readAndParse } from "@fluidframework/driver-utils";
+import { IFluidSerializer, SharedObject } from "@fluidframework/shared-object-base";
+import { SummaryTreeBuilder } from "@fluidframework/runtime-utils";
+import { ISharedMap, ISharedMapEvents } from "./interfaces";
+import { IMapDataObjectSerializable, IMapOperation, MapKernel } from "./mapKernel";
+import { pkgVersion } from "./packageVersion";
+
+interface IMapSerializationFormat {
+	blobs?: string[];
+	content: IMapDataObjectSerializable;
+}
+
+const snapshotFileName = "header";
+
+function addBlobOrHandle(
+	parentPath: string,
+	blobName: string,
+	previousBlob: string,
+	currentBlob: string,
+	builder: SummaryTreeBuilder,
+) {
+	if (currentBlob === previousBlob) {
+		builder.addHandle(blobName, SummaryType.Blob, `${parentPath}/${blobName}`);
+	} else {
+		builder.addBlob(blobName, currentBlob);
+	}
+}
+
+/**
+ * {@link @fluidframework/datastore-definitions#IChannelFactory} for {@link SharedMapIncremental}.
+ *
+ * @sealed
+ */
+export class MapIncrementalFactory implements IChannelFactory {
+	/**
+	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory."type"}
+	 */
+	public static readonly Type = "https://graph.microsoft.com/types/map-incremental";
+
+	/**
+	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.attributes}
+	 */
+	public static readonly Attributes: IChannelAttributes = {
+		type: MapIncrementalFactory.Type,
+		snapshotFormatVersion: "0.2",
+		packageVersion: pkgVersion,
+	};
+
+	/**
+	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory."type"}
+	 */
+	public get type(): string {
+		return MapIncrementalFactory.Type;
+	}
+
+	/**
+	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.attributes}
+	 */
+	public get attributes(): IChannelAttributes {
+		return MapIncrementalFactory.Attributes;
+	}
+
+	/**
+	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.load}
+	 */
+	public async load(
+		runtime: IFluidDataStoreRuntime,
+		id: string,
+		services: IChannelServices,
+		attributes: IChannelAttributes,
+	): Promise<ISharedMap> {
+		const map = new SharedMapIncremental(id, runtime, attributes);
+		await map.load(services);
+
+		return map;
+	}
+
+	/**
+	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.create}
+	 */
+	public create(runtime: IFluidDataStoreRuntime, id: string): ISharedMap {
+		const map = new SharedMapIncremental(id, runtime, MapIncrementalFactory.Attributes);
+		map.initializeLocal();
+
+		return map;
+	}
+}
+
+// If single property exceeds this size, it goes into its own blob
+const MinValueSizeSeparateSnapshotBlob = 140;
+
+// Maximum blob size for multiple map properties
+// Should be bigger than MinValueSizeSeparateSnapshotBlob
+const MaxSnapshotBlobSize = 280;
+
+/**
+ * {@inheritDoc ISharedMap}
+ */
+export class SharedMapIncremental extends SharedObject<ISharedMapEvents> implements ISharedMap {
+	/**
+	 * Create a new shared map.
+	 * @param runtime - The data store runtime that the new shared map belongs to.
+	 * @param id - Optional name of the shared map.
+	 * @returns Newly created shared map.
+	 *
+	 * @example
+	 * To create a `SharedMapIncremental`, call the static create method:
+	 *
+	 * ```typescript
+	 * const myMap = SharedMapIncremental.create(this.runtime, id);
+	 * ```
+	 */
+	public static create(runtime: IFluidDataStoreRuntime, id?: string): SharedMapIncremental {
+		return runtime.createChannel(id, MapIncrementalFactory.Type) as SharedMapIncremental;
+	}
+
+	/**
+	 * Get a factory for SharedMapIncremental to register with the data store.
+	 * @returns A factory that creates SharedMapIncrementals and loads them from storage.
+	 */
+	public static getFactory(): IChannelFactory {
+		return new MapIncrementalFactory();
+	}
+
+	/**
+	 * String representation for the class.
+	 */
+	public readonly [Symbol.toStringTag]: string = "SharedMapIncremental";
+
+	/**
+	 * MapKernel which manages actual map operations.
+	 */
+	private readonly kernel: MapKernel;
+	private readonly lastSummaryContent: Map<string, string> = new Map();
+
+	/**
+	 * Do not call the constructor. Instead, you should use the {@link SharedMapIncremental.create | create method}.
+	 *
+	 * @param id - String identifier.
+	 * @param runtime - Data store runtime.
+	 * @param attributes - The attributes for the map.
+	 */
+	public constructor(
+		id: string,
+		runtime: IFluidDataStoreRuntime,
+		attributes: IChannelAttributes,
+	) {
+		super(id, runtime, attributes, "fluid_map_");
+		this.kernel = new MapKernel(
+			this.serializer,
+			this.handle,
+			(op, localOpMetadata) => this.submitLocalMessage(op, localOpMetadata),
+			() => this.isAttached(),
+			this,
+		);
+	}
+
+	/**
+	 * Get an iterator over the keys in this map.
+	 * @returns The iterator
+	 */
+	public keys(): IterableIterator<string> {
+		return this.kernel.keys();
+	}
+
+	/**
+	 * Get an iterator over the entries in this map.
+	 * @returns The iterator
+	 */
+	// TODO: Use `unknown` instead (breaking change).
+
+	public entries(): IterableIterator<[string, any]> {
+		return this.kernel.entries();
+	}
+
+	/**
+	 * Get an iterator over the values in this map.
+	 * @returns The iterator
+	 */
+	// TODO: Use `unknown` instead (breaking change).
+
+	public values(): IterableIterator<any> {
+		return this.kernel.values();
+	}
+
+	/**
+	 * Get an iterator over the entries in this map.
+	 * @returns The iterator
+	 */
+	// TODO: Use `unknown` instead (breaking change).
+
+	public [Symbol.iterator](): IterableIterator<[string, any]> {
+		return this.kernel.entries();
+	}
+
+	/**
+	 * The number of key/value pairs stored in the map.
+	 */
+	public get size(): number {
+		return this.kernel.size;
+	}
+
+	/**
+	 * Executes the given callback on each entry in the map.
+	 * @param callbackFn - Callback function
+	 */
+	// TODO: Use `unknown` instead (breaking change).
+
+	public forEach(callbackFn: (value: any, key: string, map: Map<string, any>) => void): void {
+		this.kernel.forEach(callbackFn);
+	}
+
+	/**
+	 * {@inheritDoc ISharedMap.get}
+	 */
+	// TODO: Use `unknown` instead (breaking change).
+
+	public get<T = any>(key: string): T | undefined {
+		return this.kernel.get<T>(key);
+	}
+
+	/**
+	 * Check if a key exists in the map.
+	 * @param key - The key to check
+	 * @returns True if the key exists, false otherwise
+	 */
+	public has(key: string): boolean {
+		return this.kernel.has(key);
+	}
+
+	/**
+	 * {@inheritDoc ISharedMap.set}
+	 */
+	public set(key: string, value: unknown): this {
+		this.kernel.set(key, value);
+		return this;
+	}
+
+	/**
+	 * Delete a key from the map.
+	 * @param key - Key to delete
+	 * @returns True if the key existed and was deleted, false if it did not exist
+	 */
+	public delete(key: string): boolean {
+		return this.kernel.delete(key);
+	}
+
+	/**
+	 * Clear all data from the map.
+	 */
+	public clear(): void {
+		this.kernel.clear();
+	}
+
+	/**
+	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.summarizeCore}
+	 * @internal
+	 */
+	protected summarizeCore(
+		serializer: IFluidSerializer,
+		telemetryContext?: ITelemetryContext,
+		incrementalContext?: IIncrementalContext,
+	): ISummaryTreeWithStats {
+		let currentSize = 0;
+		let counter = 0;
+		let headerBlob: IMapDataObjectSerializable = {};
+		const blobs: string[] = [];
+
+		const builder = new SummaryTreeBuilder();
+
+		const data = this.kernel.getSerializedStorage(serializer);
+
+		console.log(`mapIncrementalSummarizeCore: ${JSON.stringify(incrementalContext)}`);
+
+		// Partitioning algorithm:
+		// 1) Split large (over MinValueSizeSeparateSnapshotBlob = 8K) properties into their own blobs.
+		//    Naming (across snapshots) of such blob does not have to be stable across snapshots,
+		//    As de-duping process (in driver) should not care about paths, only content.
+		// 2) Split remaining properties into blobs of MaxSnapshotBlobSize (16K) size.
+		//    This process does not produce stable partitioning. This means
+		//    modification (including addition / deletion) of property can shift properties across blobs
+		//    and result in non-incremental snapshot.
+		//    This can be improved in the future, without being format breaking change, as loading sequence
+		//    loads all blobs at once and partitioning schema has no impact on that process.
+		const keysInOrder = Object.keys(data).sort();
+		for (const key of keysInOrder) {
+			const value = data[key];
+			if (value.value && value.value.length >= MinValueSizeSeparateSnapshotBlob) {
+				counter++;
+				const blobName = `blob${counter}`;
+				counter++;
+				blobs.push(blobName);
+				const content: IMapDataObjectSerializable = {
+					[key]: {
+						type: value.type,
+						value: JSON.parse(value.value) as unknown,
+					},
+				};
+				const serializedContent = JSON.stringify(content);
+				if (incrementalContext !== undefined) {
+					const mapPath = `${incrementalContext.parentPath}`;
+					addBlobOrHandle(
+						mapPath,
+						blobName,
+						this.lastSummaryContent.get(blobName) ?? "",
+						serializedContent,
+						builder,
+					);
+
+					this.lastSummaryContent.set(blobName, serializedContent);
+				} else {
+					builder.addBlob(blobName, serializedContent);
+				}
+			} else {
+				currentSize += value.type.length + 21; // Approximation cost of property header
+				if (value.value) {
+					currentSize += value.value.length;
+				}
+
+				if (currentSize > MaxSnapshotBlobSize) {
+					const blobName = `blob${counter}`;
+					counter++;
+					blobs.push(blobName);
+					const serializedContent = JSON.stringify(headerBlob);
+					if (incrementalContext !== undefined) {
+						const mapPath = `${incrementalContext.parentPath}`;
+						addBlobOrHandle(
+							mapPath,
+							blobName,
+							this.lastSummaryContent.get(blobName) ?? "",
+							serializedContent,
+							builder,
+						);
+
+						this.lastSummaryContent.set(blobName, serializedContent);
+					} else {
+						builder.addBlob(blobName, serializedContent);
+					}
+					headerBlob = {};
+					currentSize = 0;
+				}
+				headerBlob[key] = {
+					type: value.type,
+					value:
+						value.value === undefined
+							? undefined
+							: (JSON.parse(value.value) as unknown),
+				};
+			}
+		}
+
+		const header: IMapSerializationFormat = {
+			blobs,
+			content: headerBlob,
+		};
+		const headerSerialized = JSON.stringify(header);
+
+		if (incrementalContext !== undefined) {
+			const mapPath = `${incrementalContext.parentPath}`;
+			addBlobOrHandle(
+				mapPath,
+				snapshotFileName,
+				this.lastSummaryContent.get(snapshotFileName) ?? "",
+				headerSerialized,
+				builder,
+			);
+
+			this.lastSummaryContent.set(snapshotFileName, headerSerialized);
+		} else {
+			builder.addBlob(snapshotFileName, headerSerialized);
+		}
+		const tree = builder.getSummaryTree();
+		console.log(JSON.stringify(tree));
+		return tree;
+	}
+
+	/**
+	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.loadCore}
+	 * @internal
+	 */
+	protected async loadCore(storage: IChannelStorageService): Promise<void> {
+		const json = await readAndParse<object>(storage, snapshotFileName);
+		const newFormat = json as IMapSerializationFormat;
+		if (Array.isArray(newFormat.blobs)) {
+			this.kernel.populateFromSerializable(newFormat.content);
+			await Promise.all(
+				newFormat.blobs.map(async (value) => {
+					const content = await readAndParse<IMapDataObjectSerializable>(storage, value);
+					this.kernel.populateFromSerializable(content);
+				}),
+			);
+		} else {
+			this.kernel.populateFromSerializable(json as IMapDataObjectSerializable);
+		}
+	}
+
+	/**
+	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.onDisconnect}
+	 * @internal
+	 */
+	protected onDisconnect(): void {}
+
+	/**
+	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.reSubmitCore}
+	 * @internal
+	 */
+	protected reSubmitCore(content: unknown, localOpMetadata: unknown): void {
+		this.kernel.trySubmitMessage(content as IMapOperation, localOpMetadata);
+	}
+
+	/**
+	 * {@inheritDoc @fluidframework/shared-object-base#SharedObjectCore.applyStashedOp}
+	 * @internal
+	 */
+	protected applyStashedOp(content: unknown): unknown {
+		return this.kernel.tryApplyStashedOp(content as IMapOperation);
+	}
+
+	/**
+	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.processCore}
+	 * @internal
+	 */
+	protected processCore(
+		message: ISequencedDocumentMessage,
+		local: boolean,
+		localOpMetadata: unknown,
+	): void {
+		if (message.type === MessageType.Operation) {
+			this.kernel.tryProcessMessage(
+				message.contents as IMapOperation,
+				local,
+				localOpMetadata,
+			);
+		}
+	}
+
+	/**
+	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.rollback}
+	 * @internal
+	 */
+	protected rollback(content: unknown, localOpMetadata: unknown): void {
+		this.kernel.rollback(content, localOpMetadata);
+	}
+}

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -17,6 +17,7 @@ import {
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import {
 	IGarbageCollectionData,
+	IIncrementalContext,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
 	blobCountPropertyName,
@@ -656,8 +657,9 @@ export abstract class SharedObject<
 		fullTree: boolean = false,
 		trackState: boolean = false,
 		telemetryContext?: ITelemetryContext,
+		incrementalContext?: IIncrementalContext,
 	): Promise<ISummaryTreeWithStats> {
-		const result = this.summarizeCore(this.serializer, telemetryContext);
+		const result = this.summarizeCore(this.serializer, telemetryContext, incrementalContext);
 		this.incrementTelemetryMetric(
 			blobCountPropertyName,
 			result.stats.blobNodeCount,
@@ -722,6 +724,7 @@ export abstract class SharedObject<
 	protected abstract summarizeCore(
 		serializer: IFluidSerializer,
 		telemetryContext?: ITelemetryContext,
+		incrementalContext?: IIncrementalContext,
 	): ISummaryTreeWithStats;
 
 	private incrementTelemetryMetric(

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -66,6 +66,7 @@ export {
 	IValueChanged,
 	LocalValueMaker,
 	MapFactory,
+	MapIncrementalFactory,
 	SharedDirectory,
 	SharedMap,
 } from "@fluidframework/map";

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -12,6 +12,7 @@ import {
 	CreateSummarizerNodeSource,
 	SummarizeInternalFn,
 	ITelemetryContext,
+	IIncrementalContext,
 } from "@fluidframework/runtime-definitions";
 import {
 	ISequencedDocumentMessage,
@@ -159,7 +160,20 @@ export class SummarizerNode implements IRootSummarizerNode {
 			}
 		}
 
-		const result = await this.summarizeInternalFn(fullTree, true, telemetryContext);
+		const incrementalContext: IIncrementalContext = {
+			sequenceNumber: this.wipReferenceSequenceNumber ?? this._changeSequenceNumber,
+			previousSequenceNumber: this._latestSummary?.referenceSequenceNumber ?? 0,
+			parentPath: this._latestSummary?.fullPath.path ?? "",
+		};
+		console.log(JSON.stringify(incrementalContext));
+		console.log(JSON.stringify(incrementalContext));
+		const result = await this.summarizeInternalFn(
+			fullTree,
+			true,
+			telemetryContext,
+			incrementalContext,
+		);
+
 		this.wipLocalPaths = { localPath: EscapedPath.create(result.id) };
 		if (result.pathPartsForChildren !== undefined) {
 			this.wipLocalPaths.additionalPath = EscapedPath.createAndConcat(

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
@@ -24,6 +24,7 @@ import {
 	ISummarizerNodeWithGC,
 	SummarizeInternalFn,
 	ITelemetryContext,
+	IIncrementalContext,
 } from "@fluidframework/runtime-definitions";
 import { LoggingError, TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { ReadAndParseBlob } from "@fluidframework/runtime-utils";
@@ -107,6 +108,7 @@ class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNode
 			fullTree: boolean,
 			trackState: boolean,
 			telemetryContext?: ITelemetryContext,
+			incrementalContext?: IIncrementalContext,
 		) => Promise<ISummarizeInternalResult>,
 		config: ISummarizerNodeConfigWithGC,
 		changeSequenceNumber: number,
@@ -121,8 +123,12 @@ class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNode
 	) {
 		super(
 			logger,
-			async (fullTree: boolean, _trackState: boolean, telemetryContext?: ITelemetryContext) =>
-				summarizeFn(fullTree, true /* trackState */, telemetryContext),
+			async (
+				fullTree: boolean,
+				_trackState: boolean,
+				telemetryContext?: ITelemetryContext,
+				incrementalContext?: IIncrementalContext,
+			) => summarizeFn(fullTree, true /* trackState */, telemetryContext, incrementalContext),
 			config,
 			changeSequenceNumber,
 			latestSummary,

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -7,6 +7,7 @@ import { IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import {
 	IGarbageCollectionData,
+	IIncrementalContext,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions";
@@ -91,6 +92,7 @@ export interface IChannel extends IFluidLoadable {
 		fullTree?: boolean,
 		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
+		incrementalContext?: IIncrementalContext,
 	): Promise<ISummaryTreeWithStats>;
 
 	/**

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -10,6 +10,7 @@ import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import {
 	IGarbageCollectionData,
+	IIncrementalContext,
 	ISummarizeResult,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
@@ -99,8 +100,14 @@ export async function summarizeChannelAsync(
 	fullTree: boolean = false,
 	trackState: boolean = false,
 	telemetryContext?: ITelemetryContext,
+	incrementalContext?: IIncrementalContext,
 ): Promise<ISummaryTreeWithStats> {
-	const summarizeResult = await channel.summarize(fullTree, trackState, telemetryContext);
+	const summarizeResult = await channel.summarize(
+		fullTree,
+		trackState,
+		telemetryContext,
+		incrementalContext,
+	);
 
 	// Add the channel attributes to the returned result.
 	addBlobToSummary(summarizeResult, attributesBlobKey, JSON.stringify(channel.attributes));

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -20,6 +20,7 @@ import {
 	CreateChildSummarizerNodeFn,
 	IFluidDataStoreContext,
 	IGarbageCollectionData,
+	IIncrementalContext,
 	ISummarizeInternalResult,
 	ISummarizeResult,
 	ISummarizerNodeWithGC,
@@ -84,7 +85,8 @@ export class RemoteChannelContext implements IChannelContext {
 			fullTree: boolean,
 			trackState: boolean,
 			telemetryContext?: ITelemetryContext,
-		) => this.summarizeInternal(fullTree, trackState, telemetryContext);
+			summaryContext?: IIncrementalContext,
+		) => this.summarizeInternal(fullTree, trackState, telemetryContext, summaryContext);
 
 		this.summarizerNode = createSummarizerNode(
 			thisSummarizeInternal,
@@ -167,13 +169,16 @@ export class RemoteChannelContext implements IChannelContext {
 		fullTree: boolean,
 		trackState: boolean,
 		telemetryContext?: ITelemetryContext,
+		incrementalContext?: IIncrementalContext,
 	): Promise<ISummarizeInternalResult> {
+		console.log(`channel context summarize internal: ${incrementalContext}`);
 		const channel = await this.getChannel();
 		const summarizeResult = await summarizeChannelAsync(
 			channel,
 			fullTree,
 			trackState,
 			telemetryContext,
+			incrementalContext,
 		);
 		return { ...summarizeResult, id: this.id };
 	}

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -62,6 +62,7 @@ export {
 	ISummarizerNodeConfig,
 	ISummarizerNodeConfigWithGC,
 	ISummarizerNodeWithGC,
+	IIncrementalContext,
 	ISummaryStats,
 	ISummaryTreeWithStats,
 	ITelemetryContext,

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -121,6 +121,7 @@ export type SummarizeInternalFn = (
 	fullTree: boolean,
 	trackState: boolean,
 	telemetryContext?: ITelemetryContext,
+	incrementalContext?: IIncrementalContext,
 ) => Promise<ISummarizeInternalResult>;
 
 export interface ISummarizerNodeConfig {
@@ -353,6 +354,12 @@ export interface ITelemetryContext {
 	 * Should be used when logging in telemetry events.
 	 */
 	serialize(): string;
+}
+
+export interface IIncrementalContext {
+	sequenceNumber: number;
+	previousSequenceNumber: number;
+	parentPath: string;
 }
 
 export const blobCountPropertyName = "BlobCount";

--- a/packages/test/test-end-to-end-tests/src/test/mapIncrementalTest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mapIncrementalTest.spec.ts
@@ -1,0 +1,626 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+
+import { ContainerRuntime } from "@fluidframework/container-runtime";
+import { ISharedMap, IValueChanged, SharedMapIncremental } from "@fluidframework/map";
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
+import {
+	createSummarizerWithTestContainerConfig,
+	ITestObjectProvider,
+	ITestContainerConfig,
+	DataObjectFactoryType,
+	ChannelFactoryRegistry,
+	ITestFluidObject,
+	summarizeNow,
+} from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluid-internal/test-version-utils";
+import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
+import { SummaryType } from "@fluidframework/protocol-definitions";
+
+const mapId = "mapKey";
+const registry: ChannelFactoryRegistry = [[mapId, SharedMapIncremental.getFactory()]];
+const testContainerConfig: ITestContainerConfig = {
+	fluidDataObjectType: DataObjectFactoryType.Test,
+	registry,
+};
+
+describeNoCompat("SharedMap", (getTestObjectProvider) => {
+	let provider: ITestObjectProvider;
+	beforeEach(() => {
+		provider = getTestObjectProvider();
+	});
+
+	let dataObject1: ITestFluidObject;
+	let sharedMap1: ISharedMap;
+	let sharedMap2: ISharedMap;
+	let sharedMap3: ISharedMap;
+
+	beforeEach(async () => {
+		const container1 = await provider.makeTestContainer(testContainerConfig);
+		dataObject1 = await requestFluidObject<ITestFluidObject>(container1, "default");
+		sharedMap1 = await dataObject1.getSharedObject<SharedMapIncremental>(mapId);
+
+		const container2 = await provider.loadTestContainer(testContainerConfig);
+		const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
+		sharedMap2 = await dataObject2.getSharedObject<SharedMapIncremental>(mapId);
+
+		const container3 = await provider.loadTestContainer(testContainerConfig);
+		const dataObject3 = await requestFluidObject<ITestFluidObject>(container3, "default");
+		sharedMap3 = await dataObject3.getSharedObject<SharedMapIncremental>(mapId);
+
+		sharedMap1.set("testKey1", "testValue");
+
+		await provider.ensureSynchronized();
+	});
+
+	function expectAllValues(msg, key, value1, value2, value3) {
+		const user1Value = sharedMap1.get(key);
+		assert.equal(user1Value, value1, `Incorrect value for ${key} in container 1 ${msg}`);
+		const user2Value = sharedMap2.get(key);
+		assert.equal(user2Value, value2, `Incorrect value for ${key} in container 2 ${msg}`);
+		const user3Value = sharedMap3.get(key);
+		assert.equal(user3Value, value3, `Incorrect value for ${key} in container 3 ${msg}`);
+	}
+
+	function expectAllBeforeValues(key, value1, value2, value3) {
+		expectAllValues("before process", key, value1, value2, value3);
+	}
+
+	function expectAllAfterValues(key, value) {
+		expectAllValues("after process", key, value, value, value);
+	}
+
+	function expectAllSize(size) {
+		const keys1 = Array.from(sharedMap1.keys());
+		assert.equal(keys1.length, size, "Incorrect number of Keys in container 1");
+		const keys2 = Array.from(sharedMap2.keys());
+		assert.equal(keys2.length, size, "Incorrect number of Keys in container 2");
+		const keys3 = Array.from(sharedMap3.keys());
+		assert.equal(keys3.length, size, "Incorrect number of Keys in container 3");
+
+		assert.equal(sharedMap1.size, size, "Incorrect map size in container 1");
+		assert.equal(sharedMap2.size, size, "Incorrect map size in container 2");
+		assert.equal(sharedMap3.size, size, "Incorrect map size in container 3");
+	}
+
+	it("should set key value in three containers correctly", async () => {
+		expectAllAfterValues("testKey1", "testValue");
+	});
+
+	it("should set key value to undefined in three containers correctly", async () => {
+		sharedMap2.set("testKey1", undefined);
+		sharedMap2.set("testKey2", undefined);
+
+		await provider.ensureSynchronized();
+
+		expectAllAfterValues("testKey1", undefined);
+		expectAllAfterValues("testKey2", undefined);
+	});
+
+	it("Should delete values in 3 containers correctly", async () => {
+		sharedMap2.delete("testKey1");
+
+		await provider.ensureSynchronized();
+
+		const hasKey1 = sharedMap1.has("testKey1");
+		assert.equal(hasKey1, false, "testKey1 not deleted in container 1");
+
+		const hasKey2 = sharedMap2.has("testKey1");
+		assert.equal(hasKey2, false, "testKey1 not deleted in container 1");
+
+		const hasKey3 = sharedMap3.has("testKey1");
+		assert.equal(hasKey3, false, "testKey1 not deleted in container 1");
+	});
+
+	it("Should check if three containers has same number of keys", async () => {
+		sharedMap3.set("testKey3", true);
+
+		await provider.ensureSynchronized();
+
+		expectAllSize(2);
+	});
+
+	it("Should update value and trigger onValueChanged on other two containers", async () => {
+		let user1ValueChangedCount: number = 0;
+		let user2ValueChangedCount: number = 0;
+		let user3ValueChangedCount: number = 0;
+		sharedMap1.on("valueChanged", (changed, local) => {
+			if (!local) {
+				assert.equal(
+					changed.key,
+					"testKey1",
+					"Incorrect value for testKey1 in container 1",
+				);
+				user1ValueChangedCount = user1ValueChangedCount + 1;
+			}
+		});
+		sharedMap2.on("valueChanged", (changed, local) => {
+			if (!local) {
+				assert.equal(
+					changed.key,
+					"testKey1",
+					"Incorrect value for testKey1 in container 2",
+				);
+				user2ValueChangedCount = user2ValueChangedCount + 1;
+			}
+		});
+		sharedMap3.on("valueChanged", (changed, local) => {
+			if (!local) {
+				assert.equal(
+					changed.key,
+					"testKey1",
+					"Incorrect value for testKey1 in container 3",
+				);
+				user3ValueChangedCount = user3ValueChangedCount + 1;
+			}
+		});
+
+		sharedMap1.set("testKey1", "updatedValue");
+
+		await provider.ensureSynchronized();
+
+		assert.equal(
+			user1ValueChangedCount,
+			0,
+			"Incorrect number of valueChanged op received in container 1",
+		);
+		assert.equal(
+			user2ValueChangedCount,
+			1,
+			"Incorrect number of valueChanged op received in container 2",
+		);
+		assert.equal(
+			user3ValueChangedCount,
+			1,
+			"Incorrect number of valueChanged op received in container 3",
+		);
+
+		expectAllAfterValues("testKey1", "updatedValue");
+	});
+
+	it("Simultaneous set should reach eventual consistency with the same value", async () => {
+		sharedMap1.set("testKey1", "value1");
+		sharedMap2.set("testKey1", "value2");
+		sharedMap3.set("testKey1", "value0");
+
+		// drain the outgoing so that the next set will come after
+		await provider.opProcessingController.processOutgoing();
+
+		sharedMap3.set("testKey1", "value3");
+
+		expectAllBeforeValues("testKey1", "value1", "value2", "value3");
+
+		await provider.ensureSynchronized();
+
+		expectAllAfterValues("testKey1", "value3");
+	});
+
+	it("Simultaneous delete/set should reach eventual consistency with the same value", async () => {
+		// set after delete
+		sharedMap1.set("testKey1", "value1.1");
+		sharedMap2.delete("testKey1");
+
+		// drain the outgoing so that the next set will come after
+		await provider.opProcessingController.processOutgoing();
+
+		sharedMap3.set("testKey1", "value1.3");
+
+		expectAllBeforeValues("testKey1", "value1.1", undefined, "value1.3");
+
+		await provider.ensureSynchronized();
+
+		expectAllAfterValues("testKey1", "value1.3");
+	});
+
+	it("Simultaneous delete/set on same map should reach eventual consistency with the same value", async () => {
+		// delete and then set on the same map
+		sharedMap1.set("testKey2", "value2.1");
+		sharedMap2.delete("testKey2");
+		sharedMap3.set("testKey2", "value2.3");
+
+		// drain the outgoing so that the next set will come after
+		await provider.opProcessingController.processOutgoing();
+
+		sharedMap2.set("testKey2", "value2.2");
+		expectAllBeforeValues("testKey2", "value2.1", "value2.2", "value2.3");
+
+		await provider.ensureSynchronized();
+
+		expectAllAfterValues("testKey2", "value2.2");
+	});
+
+	it("Simultaneous set/delete should reach eventual consistency with the same value", async () => {
+		// delete after set
+		sharedMap1.set("testKey3", "value3.1");
+		sharedMap2.set("testKey3", "value3.2");
+
+		// drain the outgoing so that the next set will come after
+		await provider.opProcessingController.processOutgoing();
+
+		sharedMap3.delete("testKey3");
+
+		expectAllBeforeValues("testKey3", "value3.1", "value3.2", undefined);
+
+		await provider.ensureSynchronized();
+
+		expectAllAfterValues("testKey3", undefined);
+	});
+
+	it("Simultaneous set/clear on a key should reach eventual consistency with the same value", async () => {
+		// clear after set
+		sharedMap1.set("testKey1", "value1.1");
+		sharedMap2.set("testKey1", "value1.2");
+
+		// drain the outgoing so that the next set will come after
+		await provider.opProcessingController.processOutgoing();
+
+		sharedMap3.clear();
+		expectAllBeforeValues("testKey1", "value1.1", "value1.2", undefined);
+		assert.equal(sharedMap3.size, 0, "Incorrect map size after clear");
+
+		await provider.ensureSynchronized();
+
+		expectAllAfterValues("testKey1", undefined);
+		expectAllSize(0);
+	});
+
+	it("Simultaneous clear/set on same map should reach eventual consistency with the same value", async () => {
+		// set after clear on the same map
+		sharedMap1.set("testKey2", "value2.1");
+		sharedMap2.clear();
+		sharedMap3.set("testKey2", "value2.3");
+
+		// drain the outgoing so that the next set will come after
+		await provider.opProcessingController.processOutgoing();
+
+		sharedMap2.set("testKey2", "value2.2");
+		expectAllBeforeValues("testKey2", "value2.1", "value2.2", "value2.3");
+
+		await provider.ensureSynchronized();
+
+		expectAllAfterValues("testKey2", "value2.2");
+		expectAllSize(1);
+	});
+
+	it("Simultaneous clear/set should reach eventual consistency and resolve to the same value", async () => {
+		// set after clear
+		sharedMap1.set("testKey3", "value3.1");
+		sharedMap2.clear();
+
+		// drain the outgoing so that the next set will come after
+		await provider.opProcessingController.processOutgoing();
+
+		sharedMap3.set("testKey3", "value3.3");
+		expectAllBeforeValues("testKey3", "value3.1", undefined, "value3.3");
+
+		await provider.ensureSynchronized();
+
+		expectAllAfterValues("testKey3", "value3.3");
+		expectAllSize(1);
+	});
+
+	it("should load new map with data from local state and can then process ops", async () => {
+		/**
+		 * This tests test the scenario found in the following bug:
+		 * https://github.com/microsoft/FluidFramework/issues/2400
+		 *
+		 * - A SharedMap in local (detached) state set a key.
+		 *
+		 * - The map is then attached so that it is available to remote clients.
+		 *
+		 * - One of the remote clients sets a new value to the same key.
+		 *
+		 * - The expected behavior is that the first SharedMap updates the key with the new value. But in the bug
+		 * the first SharedMap stores the key in its pending state even though it does not send out an op. So,
+		 * when it gets a remote op with the same key, it ignores it as it has a pending set with the same key.
+		 */
+
+		// Create a new map in local (detached) state.
+		const newSharedMap1 = SharedMapIncremental.create(dataObject1.runtime);
+
+		// Set a value while in local state.
+		newSharedMap1.set("newKey", "newValue");
+
+		// Now add the handle to an attached map so the new map gets attached too.
+		sharedMap1.set("newSharedMap", newSharedMap1.handle);
+
+		await provider.ensureSynchronized();
+
+		// The new map should be available in the remote client and it should contain that key that was
+		// set in local state.
+		const newSharedMap2 = await sharedMap2
+			.get<IFluidHandle<SharedMapIncremental>>("newSharedMap")
+			?.get();
+		assert(newSharedMap2);
+		assert.equal(
+			newSharedMap2.get("newKey"),
+			"newValue",
+			"The data set in local state is not available in map 2",
+		);
+
+		// Set a new value for the same key in the remote map.
+		newSharedMap2.set("newKey", "anotherNewValue");
+
+		await provider.ensureSynchronized();
+
+		// Verify that the new value is updated in both the maps.
+		assert.equal(
+			newSharedMap2.get("newKey"),
+			"anotherNewValue",
+			"The new value is not updated in map 2",
+		);
+		assert.equal(
+			newSharedMap1.get("newKey"),
+			"anotherNewValue",
+			"The new value is not updated in map 1",
+		);
+	});
+
+	it("attaches if referring SharedMap becomes attached or is already attached", async () => {
+		const detachedMap1: ISharedMap = SharedMapIncremental.create(dataObject1.runtime);
+		const detachedMap2: ISharedMap = SharedMapIncremental.create(dataObject1.runtime);
+
+		// When an unattached map refers to another unattached map, both remain unattached
+		detachedMap1.set("newSharedMap", detachedMap2.handle);
+		assert.equal(sharedMap1.isAttached(), true, "sharedMap1 should be attached");
+		assert.equal(detachedMap1.isAttached(), false, "detachedMap1 should not be attached");
+		assert.equal(detachedMap2.isAttached(), false, "detachedMap2 should not be attached");
+
+		// When referring map becomes attached, the referred map becomes attached
+		// and the attachment transitively passes to a second referred map
+		sharedMap1.set("newSharedMap", detachedMap1.handle);
+		assert.equal(sharedMap1.isAttached(), true, "sharedMap1 should be attached");
+		assert.equal(detachedMap1.isAttached(), true, "detachedMap1 should be attached");
+		assert.equal(detachedMap2.isAttached(), true, "detachedMap2 should be attached");
+	});
+});
+
+describeNoCompat("SharedMap orderSequentially", (getTestObjectProvider) => {
+	let provider: ITestObjectProvider;
+	beforeEach(() => {
+		provider = getTestObjectProvider();
+	});
+
+	let container: IContainer;
+	let dataObject: ITestFluidObject;
+	let sharedMap: SharedMapIncremental;
+
+	let containerRuntime: ContainerRuntime;
+	let clearEventCount: number;
+	let changedEventData: IValueChanged[];
+
+	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+		getRawConfig: (name: string): ConfigTypes => settings[name],
+	});
+	const errorMessage = "callback failure";
+
+	beforeEach(async () => {
+		const configWithFeatureGates = {
+			...testContainerConfig,
+			loaderProps: {
+				configProvider: configProvider({
+					"Fluid.ContainerRuntime.EnableRollback": true,
+				}),
+			},
+		};
+
+		container = await provider.makeTestContainer(configWithFeatureGates);
+		dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
+		sharedMap = await dataObject.getSharedObject<SharedMapIncremental>(mapId);
+		containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
+		clearEventCount = 0;
+		changedEventData = [];
+		sharedMap.on("valueChanged", (changed, local, target) => {
+			changedEventData.push(changed);
+		});
+		sharedMap.on("clear", (local, target) => {
+			clearEventCount++;
+		});
+	});
+
+	it("Should rollback set", async () => {
+		let error: Error | undefined;
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedMap.set("key", 0);
+				throw new Error(errorMessage);
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false);
+		assert.equal(sharedMap.size, 0);
+		assert.equal(sharedMap.has("key"), false);
+		assert.equal(clearEventCount, 0);
+		assert.equal(changedEventData.length, 2);
+		assert.equal(changedEventData[0].key, "key");
+		assert.equal(changedEventData[0].previousValue, undefined);
+		// rollback
+		assert.equal(changedEventData[1].key, "key");
+		assert.equal(changedEventData[1].previousValue, 0);
+	});
+
+	it("Should rollback set to prior value", async () => {
+		sharedMap.set("key", "old");
+		let error: Error | undefined;
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedMap.set("key", "new");
+				sharedMap.set("key", "last");
+				throw new Error("callback failure");
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false);
+		assert.equal(sharedMap.size, 1);
+		assert.equal(sharedMap.get("key"), "old", `Unexpected value ${sharedMap.get("key")}`);
+		assert.equal(clearEventCount, 0);
+		assert.equal(changedEventData.length, 5);
+		assert.equal(changedEventData[0].key, "key");
+		assert.equal(changedEventData[0].previousValue, undefined);
+		assert.equal(changedEventData[1].key, "key");
+		assert.equal(changedEventData[1].previousValue, "old");
+		assert.equal(changedEventData[2].key, "key");
+		assert.equal(changedEventData[2].previousValue, "new");
+		// rollback
+		assert.equal(changedEventData[3].key, "key");
+		assert.equal(changedEventData[3].previousValue, "last");
+		assert.equal(changedEventData[4].key, "key");
+		assert.equal(changedEventData[4].previousValue, "new");
+	});
+
+	it("Should rollback delete", async () => {
+		sharedMap.set("key", "old");
+		let error: Error | undefined;
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedMap.delete("key");
+				throw new Error("callback failure");
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false);
+		assert.equal(sharedMap.size, 1);
+		assert.equal(sharedMap.get("key"), "old", `Unexpected value ${sharedMap.get("key")}`);
+		assert.equal(clearEventCount, 0);
+		assert.equal(changedEventData.length, 3);
+		assert.equal(changedEventData[0].key, "key");
+		assert.equal(changedEventData[0].previousValue, undefined);
+		assert.equal(changedEventData[1].key, "key");
+		assert.equal(changedEventData[1].previousValue, "old");
+		// rollback
+		assert.equal(changedEventData[2].key, "key");
+		assert.equal(changedEventData[2].previousValue, undefined);
+	});
+
+	it("Should rollback clear", async () => {
+		sharedMap.set("key1", "old1");
+		sharedMap.set("key2", "old2");
+		let error: Error | undefined;
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedMap.clear();
+				throw new Error("callback failure");
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false);
+		assert.equal(sharedMap.size, 2);
+		assert.equal(sharedMap.get("key1"), "old1", `Unexpected value ${sharedMap.get("key1")}`);
+		assert.equal(sharedMap.get("key2"), "old2", `Unexpected value ${sharedMap.get("key2")}`);
+		assert.equal(changedEventData.length, 4);
+		assert.equal(changedEventData[0].key, "key1");
+		assert.equal(changedEventData[0].previousValue, undefined);
+		assert.equal(changedEventData[1].key, "key2");
+		assert.equal(changedEventData[1].previousValue, undefined);
+		assert.equal(clearEventCount, 1);
+		// rollback
+		assert.equal(changedEventData[2].key, "key1");
+		assert.equal(changedEventData[2].previousValue, undefined);
+		assert.equal(changedEventData[3].key, "key2");
+		assert.equal(changedEventData[3].previousValue, undefined);
+	});
+});
+
+describeNoCompat("SharedMapIncremental", (getTestObjectProvider) => {
+	let provider: ITestObjectProvider;
+	let container: IContainer;
+	let dataObject: ITestFluidObject;
+	let sharedMap: SharedMapIncremental;
+
+	let containerRuntime: ContainerRuntime;
+
+	const summaryTestContainerConfig: ITestContainerConfig = {
+		...testContainerConfig,
+		runtimeOptions: {
+			summaryOptions: { summaryConfigOverrides: { state: "disabled" } },
+		},
+	};
+
+	beforeEach(async () => {
+		provider = getTestObjectProvider();
+		container = await provider.makeTestContainer(summaryTestContainerConfig);
+		dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
+		sharedMap = await dataObject.getSharedObject<SharedMapIncremental>(mapId);
+		containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
+	});
+
+	it("Should be able to get and retrieve", async () => {
+		const { summarizer } = await createSummarizerWithTestContainerConfig(
+			provider,
+			container,
+			summaryTestContainerConfig,
+		);
+		await provider.ensureSynchronized();
+		await summarizeNow(summarizer);
+
+		sharedMap.set("0", "A boat load of data hopefully and we will keep on adding 123456789123");
+		sharedMap.set("1", "A boat load of data hopefully and we will keep on adding 123456789123");
+		sharedMap.set("2", "A boat load of data hopefully and we will keep on adding 123456789123");
+		sharedMap.set("3", "A boat load of data hopefully and we will keep on adding 123456789123");
+		sharedMap.set("4", "A boat load of data hopefully and we will keep on adding 123456789123");
+		sharedMap.set("5", "A boat load of data hopefully and we will keep on adding 123456789123");
+		sharedMap.set("6", "A boat load of data hopefully and we will keep on adding 123456789123");
+		sharedMap.set("7", "A boat load of data hopefully and we will keep on adding 123456789123");
+		sharedMap.set("8", "A boat load of data hopefully and we will keep on adding 123456789123");
+		sharedMap.set("9", "A boat load of data hopefully and we will keep on adding 123456789123");
+
+		await provider.ensureSynchronized();
+		const summary1 = await summarizeNow(summarizer);
+		const tree1 = (summary1.summaryTree as any).tree[".channels"].tree.default.tree[".channels"]
+			.tree.mapKey.tree;
+		assert.notEqual(tree1, undefined);
+
+		sharedMap.set("9", "test change");
+		await provider.ensureSynchronized();
+		const summary2 = await summarizeNow(summarizer);
+		const tree2 = (summary2.summaryTree as any).tree[".channels"].tree.default.tree[".channels"]
+			.tree.mapKey.tree;
+		assert.notEqual(tree2, undefined);
+		const tree1Blob0Serialized = JSON.stringify(tree1.blob0);
+		const tree2Blob0Serialized = JSON.stringify(tree2.blob0);
+		assert.equal(tree1.blob0.type, SummaryType.Blob);
+		assert.equal(tree2.blob0.type, SummaryType.Handle);
+		console.log(tree1Blob0Serialized);
+		console.log(tree2Blob0Serialized);
+
+		assert.notEqual(tree1Blob0Serialized, tree2Blob0Serialized);
+		const container2 = await provider.loadTestContainer(summaryTestContainerConfig, {
+			[LoaderHeader.version]: summary2.summaryVersion,
+		});
+		const dataObject2 = await requestFluidObject<ITestFluidObject>(container2, "default");
+		const sharedMap2 = await dataObject2.getSharedObject<SharedMapIncremental>(mapId);
+
+		assert.equal(sharedMap.get("0"), sharedMap2.get("0"));
+		assert.equal(sharedMap.get("1"), sharedMap2.get("1"));
+		assert.equal(sharedMap.get("2"), sharedMap2.get("2"));
+		assert.equal(sharedMap.get("3"), sharedMap2.get("3"));
+		assert.equal(sharedMap.get("4"), sharedMap2.get("4"));
+		assert.equal(sharedMap.get("5"), sharedMap2.get("5"));
+		assert.equal(sharedMap.get("6"), sharedMap2.get("6"));
+		assert.equal(sharedMap.get("7"), sharedMap2.get("7"));
+		assert.equal(sharedMap.get("8"), sharedMap2.get("8"));
+		assert.equal(sharedMap.get("9"), sharedMap2.get("9"));
+	});
+});

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -132,6 +132,25 @@ export async function createSummarizer(
 }
 
 /**
+ * Creates a summarizer client from the given container and returns the summarizer client's IContainer and ISummarizer.
+ * The ISummarizer can be used to generate on-demand summaries. The IContainer can be used to fetch data stores, etc.
+ */
+export async function createSummarizerWithTestContainerConfig(
+	provider: ITestObjectProvider,
+	container: IContainer,
+	testContainerConfig?: ITestContainerConfig,
+): Promise<{ container: IContainer; summarizer: ISummarizer }> {
+	const summarizerConfig: ITestContainerConfig = {
+		...testContainerConfig,
+		runtimeOptions: {
+			summaryOptions: defaultSummaryOptions,
+		},
+	};
+	const loader = provider.makeTestLoader(summarizerConfig);
+	return createSummarizerCore(container, loader);
+}
+
+/**
  * Summarizes on demand and returns the summary tree, the version number and the reference sequence number of the
  * submitted summary.
  */

--- a/packages/test/test-utils/src/index.ts
+++ b/packages/test/test-utils/src/index.ts
@@ -29,7 +29,12 @@ export {
 	ITestObjectProvider,
 	TestObjectProvider,
 } from "./testObjectProvider";
-export { createSummarizer, createSummarizerFromFactory, summarizeNow } from "./TestSummaryUtils";
+export {
+	createSummarizer,
+	createSummarizerFromFactory,
+	createSummarizerWithTestContainerConfig,
+	summarizeNow,
+} from "./TestSummaryUtils";
 export {
 	defaultTimeoutDurationMs,
 	timeoutAwait,

--- a/packages/test/test-version-utils/src/testApi.ts
+++ b/packages/test/test-version-utils/src/testApi.ts
@@ -16,7 +16,7 @@ import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { SharedCell } from "@fluidframework/cell";
 import { SharedCounter } from "@fluidframework/counter";
 import { Ink } from "@fluidframework/ink";
-import { SharedDirectory, SharedMap } from "@fluidframework/map";
+import { SharedDirectory, SharedMap, SharedMapIncremental } from "@fluidframework/map";
 import { SharedMatrix } from "@fluidframework/matrix";
 import { ConsensusQueue } from "@fluidframework/ordered-collection";
 import { ConsensusRegisterCollection } from "@fluidframework/register-collection";
@@ -95,6 +95,7 @@ const DataRuntimeApi = {
 		Ink,
 		SharedDirectory,
 		SharedMap,
+		SharedMapIncremental,
 		SharedMatrix,
 		ConsensusQueue,
 		ConsensusRegisterCollection,
@@ -159,6 +160,8 @@ export function getDataRuntimeApi(
 			Ink: loadPackage(modulePath, "@fluidframework/ink").Ink,
 			SharedDirectory: loadPackage(modulePath, "@fluidframework/map").SharedDirectory,
 			SharedMap: loadPackage(modulePath, "@fluidframework/map").SharedMap,
+			SharedMapIncremental: loadPackage(modulePath, "@fluidframework/map-incremental")
+				.SharedMapIncremental,
 			SharedMatrix: loadPackage(modulePath, "@fluidframework/matrix").SharedMatrix,
 			ConsensusQueue: loadPackage(modulePath, "@fluidframework/ordered-collection")
 				.ConsensusQueue,


### PR DESCRIPTION
[AB#3250](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3250)

Create a bare minimal proof of concept of DDS level incremental summaries.

This is an example of how SharedMap could be made incremental.

The partition algorithm is very basic and thus would need to be improved to actually provide a better solution than what shared map can currently do.

The blob partition algorithm is currently just based on the order of the keys, so if we have keys 0-9, and key0 changes, then the whole SharedMapIncremental would be summarized as all the blob partitions are likely to have changed. No summary handles would be generated.

The example test has keys 0-9 in which key9 changes and most of the blobs are handles instead of content.

The SharedMapIncremental blob partition sized was reduced specifically for the test from 8 * 1024 to 140 to make it easier to create multiple blobs.

The test scenario:
1. Set 0-9 keys.
2. Summarize creating summary1
3. Set key 9 to a different value
4. Summarize creating summary2
5. Validate that some summary handles were generated instead of the blobs
6. Validate that creating a new container from summary2 should contain the same values as the original container.