### PR TITLE
ci: Test for invalid Fluid internal version ranges

### DIFF
--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -175,3 +175,31 @@ steps:
 
         # Format the package.json at the root of the release group/package
         npx --no-install prettier --write package.json
+
+# This task is a last-minute verification that no Fluid internal versions show up with caret dependencies. This is to
+# help find and prevent bugs in the version bumping tools.
+- task: Bash@3
+  displayName: Check for caret dependencies on internal versions
+  inputs:
+    targetType: 'inline'
+    workingDirectory: ${{ parameters.buildDirectory }}
+    script: |
+      grep -r -e "\^2.0.0-internal.\d*.\d*.\d*" `find . -type d -name node_modules -prune -o -name 'package.json' -print`
+      if [[ $? == 0 ]]; then
+        echo "##vso[task.logissue type=error]Fluid internal versions shouldn't use caret dependencies"
+        exit -1;
+      fi
+
+# This task is a last-minute verification that no Fluid internal dev versions show up with caret dependencies. This is
+# to help find and prevent bugs in the version bumping tools.
+- task: Bash@3
+  displayName: Check for caret dependencies on dev versions
+  inputs:
+    targetType: 'inline'
+    workingDirectory: ${{ parameters.buildDirectory }}
+    script: |
+      grep -r -e "\^2.0.0-dev.\d*.\d*.\d*.\d*" `find . -type d -name node_modules -prune -o -name 'package.json' -print`
+      if [[ $? == 0 ]]; then
+        echo "##vso[task.logissue type=error]Fluid internal dev versions shouldn't use caret dependencies"
+        exit -1;
+      fi


### PR DESCRIPTION
This is a port of #14751 from main to the internal 3.4 release branch.