### PR TITLE
build: Fix incorrect dependency versions

### DIFF
--- a/experimental/examples/tree-sample/tree-react-api/package.json
+++ b/experimental/examples/tree-sample/tree-react-api/package.json
@@ -69,9 +69,9 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/benchmark": "^0.46.0",
-		"@fluid-tools/build-cli": "^0.13.0",
+		"@fluid-tools/build-cli": "^0.13.1",
 		"@fluidframework/build-common": "^1.1.0",
-		"@fluidframework/build-tools": "^0.13.0",
+		"@fluidframework/build-tools": "^0.13.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.0 <2.0.0-internal.5.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.0 <2.0.0-internal.5.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"preinstall": "node scripts/only-pnpm.cjs",
 		"layer-check": "fluid-layer-check --info build-tools/packages/build-tools/data/layerInfo.json",
 		"lerna": "lerna",
-		"lint": "npm run prettier:root && npm run ci:lint",
+		"lint": "npm run syncpack:deps && npm run syncpack:versions && npm run prettier:root && npm run ci:lint",
 		"lint:fix": "npm run prettier:root:fix && lerna run lint:fix --no-sort --stream",
 		"policy-check": "flub check policy --exclusions build-tools/packages/build-tools/data/exclusions.json",
 		"policy-check:asserts": "flub check policy --exclusions build-tools/packages/build-tools/data/exclusions.json --handler assert-short-codes --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4775,9 +4775,9 @@ importers:
     specifiers:
       '@fluid-internal/tree': '>=2.0.0-internal.4.0.0 <2.0.0-internal.5.0.0'
       '@fluid-tools/benchmark': ^0.46.0
-      '@fluid-tools/build-cli': ^0.13.0
+      '@fluid-tools/build-cli': ^0.13.1
       '@fluidframework/build-common': ^1.1.0
-      '@fluidframework/build-tools': ^0.13.0
+      '@fluidframework/build-tools': ^0.13.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.0 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.0 <2.0.0-internal.5.0.0'
@@ -4807,9 +4807,9 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/benchmark': 0.46.133527
-      '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
+      '@fluid-tools/build-cli': 0.13.1_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
-      '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
+      '@fluidframework/build-tools': 0.13.1_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../../../packages/runtime/test-runtime-utils


### PR DESCRIPTION
There's a build break in main because the dependency versions are out of sync. This corrects that problem.