### PR TITLE
ci: Fix build pipeline for `markdown-magic` to correctly use pnpm

### DIFF
--- a/tools/pipelines/build-markdown-magic.yml
+++ b/tools/pipelines/build-markdown-magic.yml
@@ -66,6 +66,6 @@ extends:
     tagName: markdown-magic
     taskBuild: build
     taskBuildDocs: true
-    taskLint: true
+    taskLint: false
     taskTest:
     - test

--- a/tools/pipelines/build-markdown-magic.yml
+++ b/tools/pipelines/build-markdown-magic.yml
@@ -65,7 +65,7 @@ extends:
     packageManager: pnpm
     tagName: markdown-magic
     taskBuild: build
-    taskBuildDocs: true
+    taskBuildDocs: false
     taskLint: false
     taskTest:
     - test

--- a/tools/pipelines/build-markdown-magic.yml
+++ b/tools/pipelines/build-markdown-magic.yml
@@ -12,6 +12,7 @@ parameters:
   default: none
   values:
     - none
+    - prerelease
     - release
 - name: publishOverride
   displayName: Publish Override (default = based on branch)
@@ -60,6 +61,8 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: tools/markdown-magic
+    packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
+    packageManager: pnpm
     tagName: markdown-magic
     taskBuild: build
     taskBuildDocs: true


### PR DESCRIPTION
Pipeline was added while we were migrating individual packages to pnpm. The new pipeline wasn't correctly updated alongside the infrastructure in that PR (#14629).