### PR TITLE
ci: Change ADO feeds used by perf benchmarks + small refactor

### DIFF
--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -9,10 +9,6 @@ parameters:
 - name: testWorkspace
   type: string
 
-# Name of the pipeline from which artifacts will be dowloaded
-- name: artifactPipeline
-  type: string
-
 # Custom steps specified by the "caller" of this template, to actually run perf tests
 - name: customSteps
   type: stepList
@@ -21,12 +17,26 @@ parameters:
   type: string
   default: '@ff-internal/aria-logger'
 
+variables:
+- name: isTestBranch
+  value: startsWith(variables['Build.SourceBranch'], 'refs/heads/test/')
+  readonly: true
+
 jobs:
   - job: runTests
     displayName: Run tests
     pool: ${{ parameters.poolBuild }}
     variables:
-      feed: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
+    - name: feed
+      ${{ if eq(variables.isTestBranch, 'true') }}:
+        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
+      ${{ else }}:
+        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
+    - name: devFeed
+      ${{ if eq(variables.isTestBranch, 'true') }}:
+        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
+      ${{ else }}:
+        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
 
     steps:
     # Setup. Need to checkout the repo in order to run @fluid-tools/telemetry-generator which we don't publish right now.
@@ -38,6 +48,30 @@ jobs:
       displayName: Use Node 16.x
       inputs:
         version: 16.x
+
+    - task: Bash@3
+      displayName: Print Parameters
+      inputs:
+        targetType: 'inline'
+        # Some of the variables
+        script: |
+          echo "
+          Pipeline Parameters:
+            poolBuild=${{ parameters.poolBuild }}
+
+          Pipeline Variables:
+            isTestBranch=${{ variables.isTestBranch}}
+            toolAbsolutePath=${{ variables.toolAbsolutePath }}
+            artifactPipeline=${{ variables.artifactPipeline }}
+            artifactBuildId=${{ variables.artifactBuildId }}
+            feed=${{ variables.feed }}
+            devFeed=${{ variables.devFeed }}
+            testWorkspace=${{ parameters.testWorkspace }}
+            loggerPackage=${{ parameters.loggerPackage }}
+
+          Build Params
+            SourceBranch=$(Build.SourceBranch)
+          "
 
     - task: Bash@3
       displayName: Create test directory
@@ -61,8 +95,8 @@ jobs:
 
           echo "@fluidframework:registry=${{ variables.feed }}" >> ./.npmrc
           echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
-          echo "@fluid-internal:registry=${{ variables.feed }}" >> ./.npmrc
           echo "@fluid-tools:registry=${{ variables.feed }}" >> ./.npmrc
+          echo "@fluid-internal:registry=${{ variables.devFeed }}" >> ./.npmrc
           echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
           echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
           echo "always-auth=true" >> ./.npmrc
@@ -89,26 +123,6 @@ jobs:
         workingDir: ${{ parameters.testWorkspace }}
         customCommand: 'install ${{ parameters.loggerPackage }}'
         customRegistry: 'useNpmrc'
-
-    - task: Bash@3
-      displayName: Print Parameters
-      inputs:
-        targetType: 'inline'
-        # Some of the variables
-        script: |
-          echo "
-          Pipeline Parameters:
-            poolBuild=${{ parameters.poolBuild }}
-
-          Task Variables:
-            toolAbsolutePath=$(toolAbsolutePath)
-            artifactPipeline=${{ parameters.artifactPipeline}}
-            feed=$(feed)
-            testWorkspace=${{ parameters.testWorkspace }}
-
-          Build Params
-            SourceBranch=$(Build.SourceBranch)
-          "
 
     - task: Bash@3
       displayName: 'Prepare telemetry-generator'

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -19,7 +19,7 @@ parameters:
 
 variables:
 - name: isTestBranch
-  value: startsWith(variables['Build.SourceBranch'], 'refs/heads/test/')
+  value: $[ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') ]
   readonly: true
 
 jobs:

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -52,18 +52,21 @@ jobs:
       inputs:
         targetType: 'inline'
         # Some of the variables
+        # Variables declared outside this template will only work with "macro syntax": $().
+        # Variables declared inside this template would work with "template expression syntax": ${{}}, but we use
+        # macro syntax for all variables for consistency.
         script: |
           echo "
           Pipeline Parameters:
             poolBuild=${{ parameters.poolBuild }}
 
           Pipeline Variables:
-            isTestBranch=${{ variables.isTestBranch}}
+            isTestBranch=$(variables.isTestBranch)
             toolAbsolutePath=$(toolAbsolutePath)
-            artifactPipeline=${{ variables.artifactPipeline }}
-            artifactBuildId=${{ variables.artifactBuildId }}
-            feed=${{ variables.feed }}
-            devFeed=${{ variables.devFeed }}
+            artifactPipeline=$(variables.artifactPipeline)
+            artifactBuildId=$(variables.artifactBuildId)
+            feed=$(variables.feed)
+            devFeed=$(variables.devFeed)
             testWorkspace=${{ parameters.testWorkspace }}
             loggerPackage=${{ parameters.loggerPackage }}
 

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -52,21 +52,21 @@ jobs:
       inputs:
         targetType: 'inline'
         # Some of the variables
-        # Variables declared outside this template will only work with "macro syntax": $().
-        # Variables declared inside this template would work with "template expression syntax": ${{}}, but we use
-        # macro syntax for all variables for consistency.
+        # Variables declared outside this template will only work with "macro syntax": $(name).
+        # Variables declared inside this template would work with "template expression syntax": ${{ variables.name }},
+        # but we use macro syntax for all variables for consistency.
         script: |
           echo "
           Pipeline Parameters:
             poolBuild=${{ parameters.poolBuild }}
 
           Pipeline Variables:
-            isTestBranch=$(variables.isTestBranch)
+            isTestBranch=$(isTestBranch)
             toolAbsolutePath=$(toolAbsolutePath)
-            artifactPipeline=$(variables.artifactPipeline)
-            artifactBuildId=$(variables.artifactBuildId)
-            feed=$(variables.feed)
-            devFeed=$(variables.devFeed)
+            artifactPipeline=$(artifactPipeline)
+            artifactBuildId=$(artifactBuildId)
+            feed=$(feed)
+            devFeed=$(devFeed)
             testWorkspace=${{ parameters.testWorkspace }}
             loggerPackage=${{ parameters.loggerPackage }}
 
@@ -94,10 +94,10 @@ jobs:
           echo "registry=https://registry.npmjs.org" >> ./.npmrc
           echo "always-auth=false" >> ./.npmrc
 
-          echo "@fluidframework:registry=${{ variables.feed }}" >> ./.npmrc
-          echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
-          echo "@fluid-tools:registry=${{ variables.feed }}" >> ./.npmrc
-          echo "@fluid-internal:registry=${{ variables.devFeed }}" >> ./.npmrc
+          echo "@fluidframework:registry=$(feed)" >> ./.npmrc
+          echo "@fluid-experimental:registry=$(feed)" >> ./.npmrc
+          echo "@fluid-tools:registry=$(feed)" >> ./.npmrc
+          echo "@fluid-internal:registry=$(devFeed)" >> ./.npmrc
           echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
           echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
           echo "always-auth=true" >> ./.npmrc

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -17,16 +17,14 @@ parameters:
   type: string
   default: '@ff-internal/aria-logger'
 
-variables:
-- name: isTestBranch
-  value: $[ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') ]
-  readonly: true
-
 jobs:
   - job: runTests
     displayName: Run tests
     pool: ${{ parameters.poolBuild }}
     variables:
+    - name: isTestBranch
+      value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}
+      readonly: true
     - name: feed
       ${{ if eq(variables.isTestBranch, 'true') }}:
         value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -59,7 +59,7 @@ jobs:
 
           Pipeline Variables:
             isTestBranch=${{ variables.isTestBranch}}
-            toolAbsolutePath=${{ variables.toolAbsolutePath }}
+            toolAbsolutePath=$(toolAbsolutePath)
             artifactPipeline=${{ variables.artifactPipeline }}
             artifactBuildId=${{ variables.artifactBuildId }}
             feed=${{ variables.feed }}

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -139,6 +139,8 @@ jobs:
               sudo update-ca-certificates
 
       # Print parameters/Vars
+      # Variables declared outside this template will only work with "macro syntax": $(name).
+      # Variables declared inside this template also work with "template expression syntax": ${{ variables.name }}.
       - task: Bash@3
         displayName: Print Parameters and Variables
         inputs:

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -152,7 +152,7 @@ jobs:
               testPackage=${{ parameters.testPackage }}
 
             Pipeline Variables:
-              isTestBranch=${{ variables.isTestBranch}}
+              isTestBranch=${{ variables.isTestBranch }}
               testWorkspace=${{ parameters.testWorkspace }}
               testPackageFilePattern=${{ variables.testPackageFilePattern }}
               feed=${{ variables.feed }}

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -72,6 +72,11 @@ parameters:
   type: stepList
   default: []
 
+variables:
+- name: isTestBranch
+  value: startsWith(variables['Build.SourceBranch'], 'refs/heads/test/')
+  readonly: true
+
 jobs:
   - ${{ each variant in parameters.splitTestVariants }}:
     - job:
@@ -93,23 +98,20 @@ jobs:
         value: $(Pipeline.Workspace)/client/pack/scoped/${{ variables.testPackageFilePattern }}
       - name: skipComponentGovernanceDetection
         value: true
-      - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}:
-        - name: feed
+      - name: feed
+        ${{ if eq(variables.isTestBranch, 'true') }}:
           value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
-      - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/test/')) }}:
-        - name: feed
+        ${{ else }}:
           value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
-      - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}:
-        - name: devFeed
+      - name: devFeed
+        ${{ if eq(variables.isTestBranch, 'true') }}:
           value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
-      - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/test/')) }}:
-        - name: devFeed
+        ${{ else }}:
           value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
-      - ${{ if eq(parameters.downloadAzureTestArtifacts, true) }}:
-        - name: artifactPipeline
+      - name: artifactPipeline
+        ${{ if eq(parameters.downloadAzureTestArtifacts, true) }}:
           value: Build - azure
-      - ${{ else }}:
-        - name: artifactPipeline
+        ${{ else }}:
           value: Build - client packages
 
       steps:
@@ -152,13 +154,17 @@ jobs:
               testPackage=${{ parameters.testPackage }}
 
             Pipeline Variables:
+              isTestBranch=${{ variables.isTestBranch}}
               testWorkspace=${{ parameters.testWorkspace }}
               testPackageFilePattern=${{ variables.testPackageFilePattern }}
               feed=${{ variables.feed }}
+              devFeed=${{ variables.devFeed }}
               testCommand=${{ parameters.testCommand }}
               continueOnError=${{ parameters.continueOnError }}
               variant.flag=${{ variant.flags }}
               testFileTarName=${{ parameters.testFileTarName }}
+              artifactPipeline=${{ variables.artifactPipeline }}
+              artifactBuildId=${{ parameters.artifactBuildId }}
             "
 
       # Install

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -74,7 +74,7 @@ parameters:
 
 variables:
 - name: isTestBranch
-  value: startsWith(variables['Build.SourceBranch'], 'refs/heads/test/')
+  value: $[ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') ]
   readonly: true
 
 jobs:

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -72,11 +72,6 @@ parameters:
   type: stepList
   default: []
 
-variables:
-- name: isTestBranch
-  value: $[ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') ]
-  readonly: true
-
 jobs:
   - ${{ each variant in parameters.splitTestVariants }}:
     - job:
@@ -85,6 +80,9 @@ jobs:
       condition: ${{ parameters.condition }}
       timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
       variables:
+      - name: isTestBranch
+        value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}
+        readonly: true
       # We use 'chalk' to colorize output, which auto-detects color support in the
       # running terminal.  The log output shown in Azure DevOps job runs only has
       # basic ANSI color support though, so force that in the pipeline

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -231,7 +231,6 @@ stages:
       parameters:
         poolBuild: ${{ parameters.poolBuild }}
         testWorkspace: ${{ variables.testWorkspace }}
-        artifactPipeline: ${{ variables.artifactPipeline }}
         customSteps:
 
         # Download Artifact - Test Files
@@ -400,7 +399,6 @@ stages:
       parameters:
         poolBuild: ${{ parameters.poolBuild }}
         testWorkspace: ${{ variables.testWorkspace }}
-        artifactPipeline: ${{ variables.artifactPipeline }}
         customSteps:
 
         # Download test package

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -49,10 +49,10 @@ variables:
     value: $(Pipeline.Workspace)/test
     readonly: true
   - name: artifactPipeline
-    value: $(resources.pipeline.client.pipelineName)
+    value: ${{ resources.pipeline.client.pipelineName }}
     readonly: true
   - name: artifactBuildId
-    value: $(resources.pipeline.client.runID)
+    value: ${{ resources.pipeline.client.runID }}
     readonly: true
   - name: toolAbsolutePath
     value: $(Build.SourcesDirectory)/tools/telemetry-generator

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -73,7 +73,6 @@ stages:
       parameters:
         poolBuild: ${{ parameters.poolBuild }}
         testWorkspace: ${{ variables.testWorkspace }}
-        artifactPipeline: ${{ variables.artifactPipeline }}
         customSteps:
 
         # Download artifact with test files

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -49,10 +49,10 @@ variables:
     value: $(Pipeline.Workspace)/test
     readonly: true
   - name: artifactPipeline
-    value: ${{ resources.pipeline.client.pipelineName }}
+    value: $(resources.pipeline.client.pipelineName)
     readonly: true
   - name: artifactBuildId
-    value: ${{ resources.pipeline.client.runID }}
+    value: $(resources.pipeline.client.runID)
     readonly: true
   - name: toolAbsolutePath
     value: $(Build.SourcesDirectory)/tools/telemetry-generator


### PR DESCRIPTION
## Description

Updates the feeds that the performance benchmarks pipeline uses to get packages, to match the ones used by the e2e tests pipeline (`build` feed for all fluid scopes except `@fluid-internal`, which comes from the `dev` feed).

I suspect the issue we see every now and then where the performance benchmarks pipeline complains that it can't find some version of a package that it wants to install, has to do with a delay between the time when the packages are published to the `build` feed, and when they can be downloaded from the `dev` feed (which has `build` as an upstream). Telling the pipeline to download packages straight from the source should (hopefully) get rid of the intermittent error.

[Relevant teams thread](https://teams.microsoft.com/l/message/19:07c78dc203f74d24a204f097ffa0fd6b@thread.skype/1676400986526?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=9ce27575-2f82-4689-abdb-bcff07e8063b&parentMessageId=1676400986526&teamName=Fluid%20Framework&channelName=Fluid%20Hot&createdTime=1676400986526) (msft internal).

Also, small refactor:
- Simplify the use of conditionals around some variable assignments
- Add a few missing variables/parameters to the output for troubleshooting
- Removed the `artifactPipeline` parameter from a template that didn't use it
- Moved printing of variables/parameters for the performance benchmarks pipeline to be closer to the start

## Testing

(msft internal links) 

- [E2E tests pipeline run](https://dev.azure.com/fluidframework/internal/_build/results?buildId=143182&view=logs&j=0ab14b9f-e499-56d5-97b1-fd98b70ea339&t=56b8c61d-01ee-5e3d-faeb-f236d12ee786) that shows the change in logic to generate the `feed`, `devFeed` and `artifactPipeline` variables still works, and the appropriate feed/devFeed values for a test/ branch.
- [Performance benchmarks pipeline run](https://dev.azure.com/fluidframework/internal/_build/results?buildId=143180&view=logs&j=7ae61878-56ab-5f49-9b2b-64c3a2782972&t=5ecd1659-5160-505e-5301-8ec4e88626ca) showing the same thing.

We can't really validate that the issue is gone since it's so non-deterministic.