### PR TITLE
Change benchmarkAll as not to use the external object.

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
@@ -80,30 +80,29 @@ export interface IBenchmarkParameters {
 /**
  * In order to share the files between memory and benchmark tests, we need to create a test object that can be passed and used
  * in both tests. This function creates the test object and calls the appropriate test function.
- * @param this - The context of the test object.
  * @param title - The title of the test.
  * @param obj - The test object that will be persisted across runs (mainly used on Memory runs).
  * @param params - The {@link IBenchmarkParameters} parameters for the test.
  */
-export function benchmarkAll<T>(this: any, title: string, obj: T, params: IBenchmarkParameters) {
+export function benchmarkAll<T extends IBenchmarkParameters>(title: string, obj: T) {
 	const t: IMemoryTestObject = {
 		title,
 		...obj,
-		run: params.run.bind(this),
-		beforeIteration: params.beforeIteration?.bind(this),
-		afterIteration: params.afterIteration?.bind(this),
-		before: params.before?.bind(this),
-		after: params.after?.bind(this),
+		run: obj.run.bind(obj),
+		beforeIteration: obj.beforeIteration?.bind(obj),
+		afterIteration: obj.afterIteration?.bind(obj),
+		before: obj.before?.bind(obj),
+		after: obj.after?.bind(obj),
 	};
 	benchmarkMemory(t);
 
 	const t1: BenchmarkArguments = {
 		title,
 		...obj,
-		benchmarkFnAsync: params.run.bind(this),
-		before: params.before?.bind(this),
-		after: params.after?.bind(this),
-		onCycle: params.onCycle?.bind(this),
+		benchmarkFnAsync: obj.run.bind(obj),
+		before: obj.before?.bind(obj),
+		after: obj.after?.bind(obj),
+		onCycle: obj.onCycle?.bind(obj),
 	};
 	benchmark(t1);
 }

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarizationDocument.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarizationDocument.all.spec.ts
@@ -9,6 +9,7 @@ import { describeE2EDocRun, getCurrentBenchmarkType } from "@fluid-internal/test
 import {
 	benchmarkAll,
 	createDocument,
+	IBenchmarkParameters,
 	IDocumentLoaderAndSummarizer,
 	ISummarizeResult,
 } from "./DocumentCreator";
@@ -41,30 +42,29 @@ describeE2EDocRun(scenarioTitle, (getTestObjectProvider, getDocumentInfo) => {
 	 * a. Benchmark Time tests: {@link https://benchmarkjs.com/docs#options} or  {@link BenchmarkOptions}
 	 * b. Benchmark Memory tests: {@link MemoryTestObjectProps}
 	 */
-	class PerformanceTestWrapper {
-		container: IContainer | undefined;
-		summarizerClient: ISummarizeResult | undefined;
-		minSampleCount = getDocumentInfo().minSampleCount;
-	}
 
-	const obj = new PerformanceTestWrapper();
+	benchmarkAll(
+		scenarioTitle,
+		new (class PerformanceTestWrapper implements IBenchmarkParameters {
+			container: IContainer | undefined;
+			summarizerClient: ISummarizeResult | undefined;
+			minSampleCount = getDocumentInfo().minSampleCount;
+			async run(): Promise<void> {
+				this.container = await documentWrapper.loadDocument();
+				assert(this.container !== undefined, "container needs to be defined.");
+				await provider.ensureSynchronized();
 
-	benchmarkAll(scenarioTitle, obj, {
-		run: async () => {
-			obj.container = await documentWrapper.loadDocument();
-			assert(obj.container !== undefined, "container needs to be defined.");
-			await provider.ensureSynchronized();
-
-			obj.summarizerClient = await documentWrapper.summarize(summaryVersion);
-			assert(
-				obj.summarizerClient.summaryVersion !== undefined,
-				"summaryVersion needs to be defined.",
-			);
-			summaryVersion = obj.summarizerClient.summaryVersion;
-		},
-		beforeIteration: () => {
-			obj.container = undefined;
-			obj.summarizerClient = undefined;
-		},
-	});
+				this.summarizerClient = await documentWrapper.summarize(summaryVersion);
+				assert(
+					this.summarizerClient.summaryVersion !== undefined,
+					"summaryVersion needs to be defined.",
+				);
+				summaryVersion = this.summarizerClient.summaryVersion;
+			}
+			beforeIteration(): void {
+				this.container = undefined;
+				this.summarizerClient = undefined;
+			}
+		})(),
+	);
 });


### PR DESCRIPTION


## Description
We got some feedback as not to use an external class to identify properties that would not be garbage collected. As an alternative, we moved the class creation, as the memory tests used to do, to make it easier to consume/understand it. 