### PR TITLE
build: Update type tests for 4.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 		"tsc": "lerna run tsc --stream",
 		"tsc:fast": "fluid-build  --root . -s tsc",
 		"typetests:gen": "pnpm -r typetests:gen",
-		"typetests:prepare": "flub generate typetests --prepare --releaseGroup client --pin",
+		"typetests:prepare": "flub typetests -g client --reset --previous --normalize",
 		"watch": "concurrently \"npm run watch:tsc\" \"npm run watch:esnext\" \"npm run watch:webpack\"",
 		"watch:esnext": "lerna run --parallel build:esnext -- --watch",
 		"watch:tsc": "lerna run --parallel tsc -- --watch",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -51,7 +51,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.3.2.0",
+		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/events": "^3.0.0",
@@ -63,22 +63,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"InterfaceDeclaration_IConnectionDetails": {
-				"backCompat": false
-			},
-			"RemovedVariableDeclaration_IFluidTokenProvider": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedInterfaceDeclaration_IFluidTokenProvider": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedInterfaceDeclaration_IProvideFluidTokenProvider": {
-				"backCompat": false,
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
@@ -347,8 +347,31 @@ declare function get_current_InterfaceDeclaration_IConnectionDetails():
 declare function use_old_InterfaceDeclaration_IConnectionDetails(
     use: TypeOnly<old.IConnectionDetails>);
 use_old_InterfaceDeclaration_IConnectionDetails(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IConnectionDetails());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IConnectionDetailsInternal": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IConnectionDetailsInternal():
+    TypeOnly<old.IConnectionDetailsInternal>;
+declare function use_current_InterfaceDeclaration_IConnectionDetailsInternal(
+    use: TypeOnly<current.IConnectionDetailsInternal>);
+use_current_InterfaceDeclaration_IConnectionDetailsInternal(
+    get_old_InterfaceDeclaration_IConnectionDetailsInternal());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IConnectionDetailsInternal": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IConnectionDetailsInternal():
+    TypeOnly<current.IConnectionDetailsInternal>;
+declare function use_old_InterfaceDeclaration_IConnectionDetailsInternal(
+    use: TypeOnly<old.IConnectionDetailsInternal>);
+use_old_InterfaceDeclaration_IConnectionDetailsInternal(
+    get_current_InterfaceDeclaration_IConnectionDetailsInternal());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -905,30 +928,6 @@ use_old_InterfaceDeclaration_IFluidPackageEnvironment(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_IFluidTokenProvider": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_IFluidTokenProvider": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IFluidTokenProvider": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IFluidTokenProvider": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IGenericError": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IGenericError():
@@ -1093,18 +1092,6 @@ declare function use_old_InterfaceDeclaration_IProvideFluidCodeDetailsComparer(
     use: TypeOnly<old.IProvideFluidCodeDetailsComparer>);
 use_old_InterfaceDeclaration_IProvideFluidCodeDetailsComparer(
     get_current_InterfaceDeclaration_IProvideFluidCodeDetailsComparer());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IProvideFluidTokenProvider": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IProvideFluidTokenProvider": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -44,7 +44,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.3.2.0",
+		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/node": "^14.18.38",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -47,7 +47,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.3.2.0",
+		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",
@@ -58,10 +58,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"InterfaceDeclaration_IDocumentServiceFactory": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.generated.ts
+++ b/packages/common/driver-definitions/src/test/types/validateDriverDefinitionsPrevious.generated.ts
@@ -395,7 +395,6 @@ declare function get_current_InterfaceDeclaration_IDocumentServiceFactory():
 declare function use_old_InterfaceDeclaration_IDocumentServiceFactory(
     use: TypeOnly<old.IDocumentServiceFactory>);
 use_old_InterfaceDeclaration_IDocumentServiceFactory(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDocumentServiceFactory());
 
 /*

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -75,7 +75,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.3.2.0",
+		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -74,7 +74,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.3.2.0",
+		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.3.2.0",
+		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.4.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.3.2.0",
+		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.4.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/map/src/test/types/validateMapPrevious.generated.ts
+++ b/packages/dds/map/src/test/types/validateMapPrevious.generated.ts
@@ -40,6 +40,30 @@ use_old_ClassDeclaration_DirectoryFactory(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ICreateInfo": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ICreateInfo():
+    TypeOnly<old.ICreateInfo>;
+declare function use_current_InterfaceDeclaration_ICreateInfo(
+    use: TypeOnly<current.ICreateInfo>);
+use_current_InterfaceDeclaration_ICreateInfo(
+    get_old_InterfaceDeclaration_ICreateInfo());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ICreateInfo": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ICreateInfo():
+    TypeOnly<current.ICreateInfo>;
+declare function use_old_InterfaceDeclaration_ICreateInfo(
+    use: TypeOnly<old.ICreateInfo>);
+use_old_InterfaceDeclaration_ICreateInfo(
+    get_current_InterfaceDeclaration_ICreateInfo());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IDirectory": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IDirectory():

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -86,7 +86,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.3.2.0",
+		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.4.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -86,7 +86,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.3.2.0",
+		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.4.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.3.2.0",
+		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.3.2.0",
+		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -92,7 +92,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/gitresources": "^0.1038.4000",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.3.2.0",
+		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.4.0.0",
 		"@fluidframework/server-services-client": "^0.1038.4000",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.3.2.0",
+		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.3.2.0",
+		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.3.2.0",
+		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -46,7 +46,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.3.2.0",
+		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -47,7 +47,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.3.2.0",
+		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/node": "^14.18.38",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -48,7 +48,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.3.2.0",
+		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/jest": "22.2.3",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -47,7 +47,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.3.2.0",
+		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/node": "^14.18.38",
 		"concurrently": "^7.6.0",
@@ -58,10 +58,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_FileDocumentServiceFactory": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/drivers/file-driver/src/test/types/validateFileDriverPrevious.generated.ts
+++ b/packages/drivers/file-driver/src/test/types/validateFileDriverPrevious.generated.ts
@@ -83,7 +83,6 @@ declare function get_current_ClassDeclaration_FileDocumentServiceFactory():
 declare function use_old_ClassDeclaration_FileDocumentServiceFactory(
     use: TypeOnly<old.FileDocumentServiceFactory>);
 use_old_ClassDeclaration_FileDocumentServiceFactory(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_FileDocumentServiceFactory());
 
 /*

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -47,7 +47,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.13.0",
-		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.3.2.0",
+		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.4.0.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -87,7 +87,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.3.2.0",
+		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.4.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/jsrsasign": "^8.0.8",
@@ -104,10 +104,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_LocalDocumentServiceFactory": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/drivers/local-driver/src/test/types/validateLocalDriverPrevious.generated.ts
+++ b/packages/drivers/local-driver/src/test/types/validateLocalDriverPrevious.generated.ts
@@ -107,7 +107,6 @@ declare function get_current_ClassDeclaration_LocalDocumentServiceFactory():
 declare function use_old_ClassDeclaration_LocalDocumentServiceFactory(
     use: TypeOnly<old.LocalDocumentServiceFactory>);
 use_old_ClassDeclaration_LocalDocumentServiceFactory(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_LocalDocumentServiceFactory());
 
 /*

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -45,7 +45,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.3.2.0",
+		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.4.0.0",
 		"@fluidframework/protocol-definitions": "^1.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.3.2.0",
+		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
@@ -104,16 +104,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_OdspDocumentServiceFactory": {
-				"backCompat": false
-			},
-			"ClassDeclaration_OdspDocumentServiceFactoryCore": {
-				"backCompat": false
-			},
-			"ClassDeclaration_OdspDocumentServiceFactoryWithCodeSplit": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.generated.ts
+++ b/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.generated.ts
@@ -179,7 +179,6 @@ declare function get_current_ClassDeclaration_OdspDocumentServiceFactory():
 declare function use_old_ClassDeclaration_OdspDocumentServiceFactory(
     use: TypeOnly<old.OdspDocumentServiceFactory>);
 use_old_ClassDeclaration_OdspDocumentServiceFactory(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_OdspDocumentServiceFactory());
 
 /*
@@ -204,7 +203,6 @@ declare function get_current_ClassDeclaration_OdspDocumentServiceFactoryCore():
 declare function use_old_ClassDeclaration_OdspDocumentServiceFactoryCore(
     use: TypeOnly<old.OdspDocumentServiceFactoryCore>);
 use_old_ClassDeclaration_OdspDocumentServiceFactoryCore(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_OdspDocumentServiceFactoryCore());
 
 /*
@@ -229,7 +227,6 @@ declare function get_current_ClassDeclaration_OdspDocumentServiceFactoryWithCode
 declare function use_old_ClassDeclaration_OdspDocumentServiceFactoryWithCodeSplit(
     use: TypeOnly<old.OdspDocumentServiceFactoryWithCodeSplit>);
 use_old_ClassDeclaration_OdspDocumentServiceFactoryWithCodeSplit(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_OdspDocumentServiceFactoryWithCodeSplit());
 
 /*

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -50,7 +50,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.3.2.0",
+		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.4.0.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
 		"concurrently": "^7.6.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -48,7 +48,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.3.2.0",
+		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",
@@ -63,13 +63,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_ReplayDocumentServiceFactory": {
-				"backCompat": false
-			},
-			"ClassDeclaration_StaticStorageDocumentServiceFactory": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/drivers/replay-driver/src/test/types/validateReplayDriverPrevious.generated.ts
+++ b/packages/drivers/replay-driver/src/test/types/validateReplayDriverPrevious.generated.ts
@@ -179,7 +179,6 @@ declare function get_current_ClassDeclaration_ReplayDocumentServiceFactory():
 declare function use_old_ClassDeclaration_ReplayDocumentServiceFactory(
     use: TypeOnly<old.ReplayDocumentServiceFactory>);
 use_old_ClassDeclaration_ReplayDocumentServiceFactory(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_ReplayDocumentServiceFactory());
 
 /*
@@ -252,5 +251,4 @@ declare function get_current_ClassDeclaration_StaticStorageDocumentServiceFactor
 declare function use_old_ClassDeclaration_StaticStorageDocumentServiceFactory(
     use: TypeOnly<old.StaticStorageDocumentServiceFactory>);
 use_old_ClassDeclaration_StaticStorageDocumentServiceFactory(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_StaticStorageDocumentServiceFactory());

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.3.2.0",
+		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",
@@ -107,10 +107,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_RouterliciousDocumentServiceFactory": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/drivers/routerlicious-driver/src/test/types/validateRouterliciousDriverPrevious.generated.ts
+++ b/packages/drivers/routerlicious-driver/src/test/types/validateRouterliciousDriverPrevious.generated.ts
@@ -179,7 +179,6 @@ declare function get_current_ClassDeclaration_RouterliciousDocumentServiceFactor
 declare function use_old_ClassDeclaration_RouterliciousDocumentServiceFactory(
     use: TypeOnly<old.RouterliciousDocumentServiceFactory>);
 use_old_ClassDeclaration_RouterliciousDocumentServiceFactory(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_RouterliciousDocumentServiceFactory());
 
 /*

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -52,7 +52,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.3.2.0",
+		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.4.0.0",
 		"@types/mocha": "^9.1.1",
 		"@types/nconf": "^0.10.0",
 		"@types/node": "^14.18.38",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -53,7 +53,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/test-tools": "^0.2.3074",
-		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.3.2.0",
+		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.4.0.0",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.13.0",
-		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.3.2.0",
+		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.4.0.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -84,7 +84,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.13.0",
-		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.3.2.0",
+		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.4.0.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
@@ -104,27 +104,6 @@
 	},
 	"module:es5": "es5/index.js",
 	"typeValidation": {
-		"broken": {
-			"RemovedClassDeclaration_BaseContainerService": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedVariableDeclaration_generateContainerServicesRequestHandler": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedTypeAliasDeclaration_ContainerServiceRegistryEntries": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedVariableDeclaration_serviceRoutePathRoot": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedFunctionDeclaration_waitForAttach": {
-				"forwardCompat": false,
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
+++ b/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
@@ -40,18 +40,6 @@ use_old_ClassDeclaration_BaseContainerRuntimeFactory(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_BaseContainerService": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_BaseContainerService": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_ContainerRuntimeFactoryWithDefaultDataStore": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_ContainerRuntimeFactoryWithDefaultDataStore():
@@ -72,18 +60,6 @@ declare function use_old_ClassDeclaration_ContainerRuntimeFactoryWithDefaultData
     use: TypeOnly<old.ContainerRuntimeFactoryWithDefaultDataStore>);
 use_old_ClassDeclaration_ContainerRuntimeFactoryWithDefaultDataStore(
     get_current_ClassDeclaration_ContainerRuntimeFactoryWithDefaultDataStore());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedTypeAliasDeclaration_ContainerServiceRegistryEntries": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedTypeAliasDeclaration_ContainerServiceRegistryEntries": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -304,18 +280,6 @@ use_old_VariableDeclaration_defaultRouteRequestHandler(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_generateContainerServicesRequestHandler": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_generateContainerServicesRequestHandler": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "FunctionDeclaration_getDefaultObjectFromContainer": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_getDefaultObjectFromContainer():
@@ -408,27 +372,3 @@ declare function use_old_VariableDeclaration_mountableViewRequestHandler(
     use: TypeOnly<typeof old.mountableViewRequestHandler>);
 use_old_VariableDeclaration_mountableViewRequestHandler(
     get_current_VariableDeclaration_mountableViewRequestHandler());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_serviceRoutePathRoot": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_serviceRoutePathRoot": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_waitForAttach": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_waitForAttach": {"backCompat": false}
-*/

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -79,7 +79,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.3.2.0",
+		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -73,7 +73,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.3.2.0",
+		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -79,7 +79,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.3.2.0",
+		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.4.0.0",
 		"@fluidframework/map": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/sequence": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",

--- a/packages/framework/oldest-client-observer/package.json
+++ b/packages/framework/oldest-client-observer/package.json
@@ -85,7 +85,7 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {},
-		"disabled": true
+		"disabled": true,
+		"broken": {}
 	}
 }

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -74,7 +74,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.3.2.0",
+		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/diff": "^3.5.1",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -72,7 +72,7 @@
 		"@fluidframework/datastore": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.3.2.0",
+		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -49,7 +49,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/uuid": "^8.3.0",
 		"concurrently": "^7.6.0",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -64,7 +64,7 @@
 		"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/test-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.3.2.0",
+		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.3.2.0",
+		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/diff": "^3.5.1",
 		"@types/events": "^3.0.0",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -48,7 +48,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.3.2.0",
+		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",
@@ -60,19 +60,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"RemovedClassDeclaration_HTMLViewAdapter": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedInterfaceDeclaration_IReactViewAdapterProps": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedClassDeclaration_ReactViewAdapter": {
-				"forwardCompat": false,
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/framework/view-adapters/src/test/types/validateViewAdaptersPrevious.generated.ts
+++ b/packages/framework/view-adapters/src/test/types/validateViewAdaptersPrevious.generated.ts
@@ -16,30 +16,6 @@ type TypeOnly<T> = {
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_HTMLViewAdapter": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_HTMLViewAdapter": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IReactViewAdapterProps": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IReactViewAdapterProps": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_MountableView": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_MountableView():
@@ -60,15 +36,3 @@ declare function use_old_ClassDeclaration_MountableView(
     use: TypeOnly<old.MountableView>);
 use_old_ClassDeclaration_MountableView(
     get_current_ClassDeclaration_MountableView());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_ReactViewAdapter": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_ReactViewAdapter": {"backCompat": false}
-*/

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -45,7 +45,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.3.2.0",
+		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",
@@ -57,23 +57,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"RemovedInterfaceDeclaration_IFluidHTMLOptions": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedVariableDeclaration_IFluidHTMLView": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedInterfaceDeclaration_IFluidHTMLView": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedInterfaceDeclaration_IProvideFluidHTMLView": {
-				"forwardCompat": false,
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/framework/view-interfaces/src/test/types/validateViewInterfacesPrevious.generated.ts
+++ b/packages/framework/view-interfaces/src/test/types/validateViewInterfacesPrevious.generated.ts
@@ -16,42 +16,6 @@ type TypeOnly<T> = {
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IFluidHTMLOptions": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IFluidHTMLOptions": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_IFluidHTMLView": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_IFluidHTMLView": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IFluidHTMLView": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IFluidHTMLView": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "VariableDeclaration_IFluidMountableView": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_IFluidMountableView():
@@ -120,18 +84,6 @@ declare function use_old_InterfaceDeclaration_IFluidMountableViewClass(
     use: TypeOnly<old.IFluidMountableViewClass>);
 use_old_InterfaceDeclaration_IFluidMountableViewClass(
     get_current_InterfaceDeclaration_IFluidMountableViewClass());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IProvideFluidHTMLView": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IProvideFluidHTMLView": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -85,7 +85,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.3.2.0",
+		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
@@ -107,24 +107,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"RemovedClassDeclaration_Container": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedClassDeclaration_RelativeLoader": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"InterfaceDeclaration_ILoaderProps": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_ILoaderServices": {
-				"backCompat": false
-			},
-			"ClassDeclaration_Loader": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
+++ b/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
@@ -40,18 +40,6 @@ use_old_EnumDeclaration_ConnectionState(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_Container": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_Container": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ICodeDetailsLoader": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ICodeDetailsLoader():
@@ -215,7 +203,6 @@ declare function get_current_InterfaceDeclaration_ILoaderProps():
 declare function use_old_InterfaceDeclaration_ILoaderProps(
     use: TypeOnly<old.ILoaderProps>);
 use_old_InterfaceDeclaration_ILoaderProps(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ILoaderProps());
 
 /*
@@ -240,7 +227,6 @@ declare function get_current_InterfaceDeclaration_ILoaderServices():
 declare function use_old_InterfaceDeclaration_ILoaderServices(
     use: TypeOnly<old.ILoaderServices>);
 use_old_InterfaceDeclaration_ILoaderServices(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ILoaderServices());
 
 /*
@@ -313,7 +299,6 @@ declare function get_current_ClassDeclaration_Loader():
 declare function use_old_ClassDeclaration_Loader(
     use: TypeOnly<old.Loader>);
 use_old_ClassDeclaration_Loader(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_Loader());
 
 /*
@@ -339,18 +324,6 @@ declare function use_old_TypeAliasDeclaration_ProtocolHandlerBuilder(
     use: TypeOnly<old.ProtocolHandlerBuilder>);
 use_old_TypeAliasDeclaration_ProtocolHandlerBuilder(
     get_current_TypeAliasDeclaration_ProtocolHandlerBuilder());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_RelativeLoader": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_RelativeLoader": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -73,7 +73,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",

--- a/packages/loader/container-utils/src/test/types/validateContainerUtilsPrevious.generated.ts
+++ b/packages/loader/container-utils/src/test/types/validateContainerUtilsPrevious.generated.ts
@@ -88,6 +88,30 @@ use_old_ClassDeclaration_DataProcessingError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_DeltaManagerProxyBase": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_DeltaManagerProxyBase():
+    TypeOnly<old.DeltaManagerProxyBase>;
+declare function use_current_ClassDeclaration_DeltaManagerProxyBase(
+    use: TypeOnly<current.DeltaManagerProxyBase>);
+use_current_ClassDeclaration_DeltaManagerProxyBase(
+    get_old_ClassDeclaration_DeltaManagerProxyBase());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_DeltaManagerProxyBase": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_DeltaManagerProxyBase():
+    TypeOnly<current.DeltaManagerProxyBase>;
+declare function use_old_ClassDeclaration_DeltaManagerProxyBase(
+    use: TypeOnly<old.DeltaManagerProxyBase>);
+use_old_ClassDeclaration_DeltaManagerProxyBase(
+    get_current_ClassDeclaration_DeltaManagerProxyBase());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_GenericError": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_GenericError():

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -78,7 +78,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
@@ -98,63 +98,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"RemovedClassDeclaration_MapWithExpiration": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedClassDeclaration_MultiUrlResolver": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedFunctionDeclaration_configurableUrlResolver": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedClassDeclaration_MultiDocumentServiceFactory": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedClassDeclaration_BlobCacheStorageService": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedClassDeclaration_EmptyDocumentDeltaStorageService": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedInterfaceDeclaration_ISummaryTreeAssemblerProps": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedClassDeclaration_SummaryTreeAssembler": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedFunctionDeclaration_convertSnapshotAndBlobsToSummaryTree": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedFunctionDeclaration_waitForConnectedState": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedClassDeclaration_BlobAggregationStorage": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedClassDeclaration_SnapshotExtractor": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedFunctionDeclaration_isUnpackedRuntimeMessage": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedInterfaceDeclaration_IAnyDriverError": {
-				"backCompat": false,
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.generated.ts
+++ b/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.generated.ts
@@ -40,26 +40,26 @@ use_old_ClassDeclaration_AuthorizationError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_BlobAggregationStorage": {"forwardCompat": false}
+* "InterfaceDeclaration_CombinedAppAndProtocolSummary": {"forwardCompat": false}
 */
+declare function get_old_InterfaceDeclaration_CombinedAppAndProtocolSummary():
+    TypeOnly<old.CombinedAppAndProtocolSummary>;
+declare function use_current_InterfaceDeclaration_CombinedAppAndProtocolSummary(
+    use: TypeOnly<current.CombinedAppAndProtocolSummary>);
+use_current_InterfaceDeclaration_CombinedAppAndProtocolSummary(
+    get_old_InterfaceDeclaration_CombinedAppAndProtocolSummary());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_BlobAggregationStorage": {"backCompat": false}
+* "InterfaceDeclaration_CombinedAppAndProtocolSummary": {"backCompat": false}
 */
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_BlobCacheStorageService": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_BlobCacheStorageService": {"backCompat": false}
-*/
+declare function get_current_InterfaceDeclaration_CombinedAppAndProtocolSummary():
+    TypeOnly<current.CombinedAppAndProtocolSummary>;
+declare function use_old_InterfaceDeclaration_CombinedAppAndProtocolSummary(
+    use: TypeOnly<old.CombinedAppAndProtocolSummary>);
+use_old_InterfaceDeclaration_CombinedAppAndProtocolSummary(
+    get_current_InterfaceDeclaration_CombinedAppAndProtocolSummary());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -136,18 +136,6 @@ use_old_TypeAliasDeclaration_DriverErrorTelemetryProps(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_EmptyDocumentDeltaStorageService": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_EmptyDocumentDeltaStorageService": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_FluidInvalidSchemaError": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_FluidInvalidSchemaError():
@@ -196,18 +184,6 @@ use_old_ClassDeclaration_GenericNetworkError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IAnyDriverError": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IAnyDriverError": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IProgress": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IProgress():
@@ -228,18 +204,6 @@ declare function use_old_InterfaceDeclaration_IProgress(
     use: TypeOnly<old.IProgress>);
 use_old_InterfaceDeclaration_IProgress(
     get_current_InterfaceDeclaration_IProgress());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_ISummaryTreeAssemblerProps": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_ISummaryTreeAssemblerProps": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -292,18 +256,6 @@ use_old_ClassDeclaration_LocationRedirectionError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_MapWithExpiration": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_MapWithExpiration": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "EnumDeclaration_MessageType2": {"forwardCompat": false}
 */
 declare function get_old_EnumDeclaration_MessageType2():
@@ -324,30 +276,6 @@ declare function use_old_EnumDeclaration_MessageType2(
     use: TypeOnly<old.MessageType2>);
 use_old_EnumDeclaration_MessageType2(
     get_current_EnumDeclaration_MessageType2());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_MultiDocumentServiceFactory": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_MultiDocumentServiceFactory": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_MultiUrlResolver": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_MultiUrlResolver": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -544,30 +472,6 @@ use_old_ClassDeclaration_RetryableError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_SnapshotExtractor": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_SnapshotExtractor": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_SummaryTreeAssembler": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedClassDeclaration_SummaryTreeAssembler": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_ThrottlingError": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_ThrottlingError():
@@ -708,30 +612,6 @@ declare function use_old_FunctionDeclaration_combineAppAndProtocolSummary(
     use: TypeOnly<typeof old.combineAppAndProtocolSummary>);
 use_old_FunctionDeclaration_combineAppAndProtocolSummary(
     get_current_FunctionDeclaration_combineAppAndProtocolSummary());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_configurableUrlResolver": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_configurableUrlResolver": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_convertSnapshotAndBlobsToSummaryTree": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_convertSnapshotAndBlobsToSummaryTree": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -952,6 +832,30 @@ use_old_VariableDeclaration_getRetryDelaySecondsFromError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_isCombinedAppAndProtocolSummary": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_isCombinedAppAndProtocolSummary():
+    TypeOnly<typeof old.isCombinedAppAndProtocolSummary>;
+declare function use_current_FunctionDeclaration_isCombinedAppAndProtocolSummary(
+    use: TypeOnly<typeof current.isCombinedAppAndProtocolSummary>);
+use_current_FunctionDeclaration_isCombinedAppAndProtocolSummary(
+    get_old_FunctionDeclaration_isCombinedAppAndProtocolSummary());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_isCombinedAppAndProtocolSummary": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_isCombinedAppAndProtocolSummary():
+    TypeOnly<typeof current.isCombinedAppAndProtocolSummary>;
+declare function use_old_FunctionDeclaration_isCombinedAppAndProtocolSummary(
+    use: TypeOnly<typeof old.isCombinedAppAndProtocolSummary>);
+use_old_FunctionDeclaration_isCombinedAppAndProtocolSummary(
+    get_current_FunctionDeclaration_isCombinedAppAndProtocolSummary());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "VariableDeclaration_isFluidResolvedUrl": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_isFluidResolvedUrl():
@@ -1020,18 +924,6 @@ declare function use_old_FunctionDeclaration_isRuntimeMessage(
     use: TypeOnly<typeof old.isRuntimeMessage>);
 use_old_FunctionDeclaration_isRuntimeMessage(
     get_current_FunctionDeclaration_isRuntimeMessage());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_isUnpackedRuntimeMessage": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_isUnpackedRuntimeMessage": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1176,15 +1068,3 @@ declare function use_old_FunctionDeclaration_streamObserver(
     use: TypeOnly<typeof old.streamObserver>);
 use_old_FunctionDeclaration_streamObserver(
     get_current_FunctionDeclaration_streamObserver());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_waitForConnectedState": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_waitForConnectedState": {"backCompat": false}
-*/

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -73,7 +73,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.4.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -45,7 +45,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.3.2.0",
+		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -87,7 +87,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.3.2.0",
+		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
@@ -109,43 +109,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_ContainerRuntime": {
-				"backCompat": false
-			},
-			"RemovedInterfaceDeclaration_IPendingFlush": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedInterfaceDeclaration_IPendingLocalState": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedInterfaceDeclaration_IPendingMessage": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedTypeAliasDeclaration_IPendingState": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"InterfaceDeclaration_IConnectableRuntime": {
-				"backCompat": false
-			},
-			"RemovedInterfaceDeclaration_IProvideSummarizer": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedVariableDeclaration_ISummarizer": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"InterfaceDeclaration_ISummarizer": {
-				"backCompat": false
-			},
-			"ClassDeclaration_Summarizer": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -107,7 +107,6 @@ declare function get_current_ClassDeclaration_ContainerRuntime():
 declare function use_old_ClassDeclaration_ContainerRuntime(
     use: TypeOnly<old.ContainerRuntime>);
 use_old_ClassDeclaration_ContainerRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_ContainerRuntime());
 
 /*
@@ -444,7 +443,6 @@ declare function get_current_InterfaceDeclaration_IConnectableRuntime():
 declare function use_old_InterfaceDeclaration_IConnectableRuntime(
     use: TypeOnly<old.IConnectableRuntime>);
 use_old_InterfaceDeclaration_IConnectableRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IConnectableRuntime());
 
 /*
@@ -642,66 +640,6 @@ use_old_InterfaceDeclaration_IOnDemandSummarizeOptions(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IPendingFlush": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IPendingFlush": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IPendingLocalState": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IPendingLocalState": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IPendingMessage": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IPendingMessage": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedTypeAliasDeclaration_IPendingState": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedTypeAliasDeclaration_IPendingState": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IProvideSummarizer": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IProvideSummarizer": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IRefreshSummaryAckOptions": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IRefreshSummaryAckOptions():
@@ -846,18 +784,6 @@ use_old_InterfaceDeclaration_ISummarizeResults(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_ISummarizer": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_ISummarizer": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ISummarizer": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ISummarizer():
@@ -877,7 +803,6 @@ declare function get_current_InterfaceDeclaration_ISummarizer():
 declare function use_old_InterfaceDeclaration_ISummarizer(
     use: TypeOnly<old.ISummarizer>);
 use_old_InterfaceDeclaration_ISummarizer(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISummarizer());
 
 /*
@@ -1454,7 +1379,6 @@ declare function get_current_ClassDeclaration_Summarizer():
 declare function use_old_ClassDeclaration_Summarizer(
     use: TypeOnly<old.Summarizer>);
 use_old_ClassDeclaration_Summarizer(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_Summarizer());
 
 /*

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -45,7 +45,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.3.2.0",
+		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -84,7 +84,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.3.2.0",
+		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@2.0.0-internal.3.2.0",
+		"@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@2.0.0-internal.4.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/events": "^3.0.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -46,7 +46,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.3.2.0",
+		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",
 		"copyfiles": "^2.4.1",
@@ -56,14 +56,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"TypeAliasDeclaration_AttributionKey": {
-				"backCompat": false
-			},
-			"RemovedEnumDeclaration_BindState": {
-				"forwardCompat": false,
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -83,7 +83,6 @@ declare function get_current_TypeAliasDeclaration_AttributionKey():
 declare function use_old_TypeAliasDeclaration_AttributionKey(
     use: TypeOnly<old.AttributionKey>);
 use_old_TypeAliasDeclaration_AttributionKey(
-    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_AttributionKey());
 
 /*
@@ -1045,6 +1044,30 @@ declare function use_old_TypeAliasDeclaration_InboundAttachMessage(
     use: TypeOnly<old.InboundAttachMessage>);
 use_old_TypeAliasDeclaration_InboundAttachMessage(
     get_current_TypeAliasDeclaration_InboundAttachMessage());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_LocalAttributionKey": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_LocalAttributionKey():
+    TypeOnly<old.LocalAttributionKey>;
+declare function use_current_InterfaceDeclaration_LocalAttributionKey(
+    use: TypeOnly<current.LocalAttributionKey>);
+use_current_InterfaceDeclaration_LocalAttributionKey(
+    get_old_InterfaceDeclaration_LocalAttributionKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_LocalAttributionKey": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_LocalAttributionKey():
+    TypeOnly<current.LocalAttributionKey>;
+declare function use_old_InterfaceDeclaration_LocalAttributionKey(
+    use: TypeOnly<old.LocalAttributionKey>);
+use_old_InterfaceDeclaration_LocalAttributionKey(
+    get_current_InterfaceDeclaration_LocalAttributionKey());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -79,7 +79,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
@@ -96,35 +96,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"RemovedVariableDeclaration_createRootSummarizerNode": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedVariableDeclaration_createRootSummarizerNodeWithGC": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedInterfaceDeclaration_IFetchSnapshotResult": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedInterfaceDeclaration_IRootSummarizerNode": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedInterfaceDeclaration_IRootSummarizerNodeWithGC": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedInterfaceDeclaration_ISummarizerNodeRootContract": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedTypeAliasDeclaration_RefreshSummaryResult": {
-				"forwardCompat": false,
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
@@ -40,54 +40,6 @@ use_old_TypeAliasDeclaration_Factory(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IFetchSnapshotResult": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IFetchSnapshotResult": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IRootSummarizerNode": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IRootSummarizerNode": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IRootSummarizerNodeWithGC": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_IRootSummarizerNodeWithGC": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_ISummarizerNodeRootContract": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_ISummarizerNodeRootContract": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_ObjectStoragePartition": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_ObjectStoragePartition():
@@ -132,18 +84,6 @@ declare function use_old_TypeAliasDeclaration_ReadAndParseBlob(
     use: TypeOnly<old.ReadAndParseBlob>);
 use_old_TypeAliasDeclaration_ReadAndParseBlob(
     get_current_TypeAliasDeclaration_ReadAndParseBlob());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedTypeAliasDeclaration_RefreshSummaryResult": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedTypeAliasDeclaration_RefreshSummaryResult": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -504,30 +444,6 @@ declare function use_old_FunctionDeclaration_createResponseError(
     use: TypeOnly<typeof old.createResponseError>);
 use_old_FunctionDeclaration_createResponseError(
     get_current_FunctionDeclaration_createResponseError());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_createRootSummarizerNode": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_createRootSummarizerNode": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_createRootSummarizerNodeWithGC": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedVariableDeclaration_createRootSummarizerNodeWithGC": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -66,7 +66,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.3.2.0",
+		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -69,7 +69,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.3.2.0",
+		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"concurrently": "^7.6.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -141,7 +141,7 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {},
-    "disabled": true
+		"disabled": true,
+		"broken": {}
 	}
 }

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -128,7 +128,6 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-end-to-end-tests-previous": "npm:@fluidframework/test-end-to-end-tests@2.0.0-internal.3.2.0",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^14.18.38",
@@ -142,6 +141,7 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {},
+    "disabled": true
 	}
 }

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -92,7 +92,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/debug": "^4.1.5",
 		"@types/diff": "^3.5.1",
@@ -113,25 +113,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"RemovedFunctionDeclaration_ensureContainerConnected": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"FunctionDeclaration_createSummarizerWithContainer": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedFunctionDeclaration_createSummarizerWithContainer": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"InterfaceDeclaration_ITestObjectProvider": {
-				"backCompat": false
-			},
-			"ClassDeclaration_TestObjectProvider": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -203,7 +203,6 @@ declare function get_current_InterfaceDeclaration_ITestObjectProvider():
 declare function use_old_InterfaceDeclaration_ITestObjectProvider(
     use: TypeOnly<old.ITestObjectProvider>);
 use_old_InterfaceDeclaration_ITestObjectProvider(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITestObjectProvider());
 
 /*
@@ -372,7 +371,6 @@ declare function get_current_ClassDeclaration_TestObjectProvider():
 declare function use_old_ClassDeclaration_TestObjectProvider(
     use: TypeOnly<old.TestObjectProvider>);
 use_old_ClassDeclaration_TestObjectProvider(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_TestObjectProvider());
 
 /*
@@ -590,18 +588,6 @@ declare function use_old_VariableDeclaration_defaultTimeoutDurationMs(
     use: TypeOnly<typeof old.defaultTimeoutDurationMs>);
 use_old_VariableDeclaration_defaultTimeoutDurationMs(
     get_current_VariableDeclaration_defaultTimeoutDurationMs());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_ensureContainerConnected": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_ensureContainerConnected": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -49,7 +49,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.13.0",
-		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.3.2.0",
+		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.4.0.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@types/node": "^14.18.38",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.3.2.0",
+		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.4.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -94,7 +94,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.13.0",
-		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.3.2.0",
+		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.4.0.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.4.0.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
 		"@types/node-fetch": "^2.5.10",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/debug": "^4.1.5",
 		"@types/events": "^3.0.0",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0",
-		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/debug": "^4.1.5",
 		"@types/jwt-decode": "^2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8790,7 +8790,6 @@ importers:
       '@fluidframework/shared-object-base': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/test-end-to-end-tests-previous': npm:@fluidframework/test-end-to-end-tests@2.0.0-internal.3.2.0
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/test-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/undo-redo': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -8869,7 +8868,6 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-end-to-end-tests-previous': /@fluidframework/test-end-to-end-tests/2.0.0-internal.3.2.0
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
       '@types/node': 14.18.38
@@ -12194,40 +12192,6 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@fluid-experimental/attributor/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-bqiKxr8xsGWJNQNu7iZ+NQyQUypSDUOm168jbfxpIFO6GB1iOvRL5W5pSu7zujJF9Fc2Ya+2y3qAID+WdkA8xQ==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      lz4js: 0.2.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluid-experimental/sequence-deprecated/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-ukjtDCF0RTYDwCH0IYCU14ae8yLPU5T5a8/a66hckFcV8tKChvpG/CEA1Dk0XyNrWql8wkK9KtCXv9fTzmJWDw==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/sequence': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
   /@fluid-experimental/task-manager/2.0.0-internal.2.1.1:
     resolution: {integrity: sha512-7oRVdnok0F5ijo2DftLzae68KsFT3KlyhSKgfjwBlV5T14TqdkJTUXSDbmMtGPOy7MiHqlPmlHaNLQip0jtVSw==}
     dependencies:
@@ -12244,15 +12208,6 @@ packages:
     transitivePeerDependencies:
       - debug
       - supports-color
-    dev: true
-
-  /@fluid-tools/benchmark/0.45.112032:
-    resolution: {integrity: sha512-mCZgefqxqEWiWNRb9SpUDb2xW+vt/tjx5wLAMG1fOPTEUSMMBwT/baIuDF9EURYq8MbysWLfZsuw5cE7zFYxMg==}
-    dependencies:
-      benchmark: 2.1.4
-      chai: 4.3.7
-      easy-table: 1.2.0
-      mocha: 10.2.0
     dev: true
 
   /@fluid-tools/benchmark/0.46.133527:
@@ -12546,27 +12501,6 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/agent-scheduler/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-/r2cYunW9Sh5YrSO4LKOJ3dB+5AkNDjBQFh1wPM9wcSntesxMzVWVvHqESLU7EAIFJjcKN7PXa4VN3rx2f34gA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/register-collection': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
   /@fluidframework/aqueduct/2.0.0-internal.3.2.0:
     resolution: {integrity: sha512-ZjX7pPuTUPt/z1rY7aENDmf37FIsCV7nnCtNx0S9EUhkKq6RvpM90u9PXHy/TGeDACKNWnD9T3LfS+yuaIcQDA==}
     dependencies:
@@ -12634,26 +12568,6 @@ packages:
       '@fluidframework/synthesize': 2.0.0-internal.3.3.1
       '@fluidframework/view-interfaces': 2.0.0-internal.3.3.1
       uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/attributor/2.0.0-internal.3.2.2:
-    resolution: {integrity: sha512-3B+AX6HydWyfYYVIcp+hw4QLxOTbABZbdtdtmFZIq5du5xseppPWHwl0XpyHkpqjs32LWZubR8GbqcpHPLk88Q==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      lz4js: 0.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -12879,21 +12793,6 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
       '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
       '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/cell/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-+b9rF8q623OcVTgd9CKCPjNHfNlrz/L2ifczXAFtTuzQkHKwoiZSHJPpw1C841JYkyQLmGGekvUmOj7O/EmjzA==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13206,21 +13105,6 @@ packages:
 
   /@fluidframework/counter/2.0.0-internal.3.2.0:
     resolution: {integrity: sha512-9gIvOC706DCHMRVhQ5asmnnyOJC1tLuY8xQU4Ra6eq796cmQMuEr++O+Aj2qZyRPYxlqntNtO2PT/Lg4/MQX/A==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/counter/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-qW9yMZv09ctWz9UTJ6YnTn3FD37At7c8Us4BGDfz9IUJrBJn2K3iMpLJvdBVKy3XvU52dgKAOLqE40KhzdcFlA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
       '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
@@ -13714,22 +13598,6 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/ink/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-xCY1hxqDUlXfw5M2FdDjWafBi/D023PoZ+C/W73OSCmAcPifUOy0jacgb92758X06IByZwycpcFQ2dq69HLiXA==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
   /@fluidframework/local-driver/2.0.0-internal.3.2.0:
     resolution: {integrity: sha512-ctAHUgpIN8C6fcfJppeZIGlwGJ3QE2kSYkFndBERIY4Pb90P6HPy8xCXbEIZnNH0cDOXwRcT+w7aYHg+sn+V8g==}
     dependencies:
@@ -14143,22 +14011,6 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/ordered-collection/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-LsgtthNWES+C2q/JvoD6grpk/dffiJDs4RFXQQDp/lJ129X1N2yR8S/kdqfeAK5Q30OmBETG/5uDtRoxJ3+xMQ==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
   /@fluidframework/protocol-base/0.1038.3000:
     resolution: {integrity: sha512-e0G1JSlcpWiZTgIJqpU28EnmqNyfmwoiTZOL8DVrxOWArawqhEsBFBZUhL3zP2Y4vobrcjS9lMhQDsSXptwYSg==}
     dependencies:
@@ -14538,36 +14390,6 @@ packages:
     transitivePeerDependencies:
       - debug
       - supports-color
-
-  /@fluidframework/server-lambdas/0.1038.4000:
-    resolution: {integrity: sha512-uy/XrfKPSjo9RHWW6NWdEzkIiLhMZDZCNck1UyWAYiaCWNjcpQJ98Wv/HO0fpTPxGPn7CysGlX7qreXqBRkwoQ==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/gitresources': 0.1038.4000
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/server-lambdas-driver': 0.1038.4000
-      '@fluidframework/server-services-client': 0.1038.4000
-      '@fluidframework/server-services-core': 0.1038.4000
-      '@fluidframework/server-services-telemetry': 0.1038.4000
-      '@types/semver': 6.2.3
-      assert: 2.0.0
-      async: 3.2.4
-      axios: 0.26.1
-      buffer: 6.0.3
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      json-stringify-safe: 5.0.1
-      lodash: 4.17.21
-      nconf: 0.12.0
-      semver: 6.3.0
-      sha.js: 2.4.11
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
 
   /@fluidframework/server-lambdas/0.1038.4000_debug@4.3.4:
     resolution: {integrity: sha512-uy/XrfKPSjo9RHWW6NWdEzkIiLhMZDZCNck1UyWAYiaCWNjcpQJ98Wv/HO0fpTPxGPn7CysGlX7qreXqBRkwoQ==}
@@ -15084,119 +14906,6 @@ packages:
       uuid: 8.3.2
     dev: true
 
-  /@fluidframework/test-drivers/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-WvWE9F94xQdSpe6KwMFGLSvKLnBCjG9g6oIYal/7xV/INblm/iyN2QsCNqijLqg1Z3zrDNDXtBk9NdgGJMa9FQ==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/local-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-urlresolver': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/server-local-server': 0.1038.4000
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/test-pairwise-generator': 2.0.0-internal.3.3.1
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/tinylicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/tool-utils': 2.0.0-internal.3.3.1
-      axios: 0.26.1
-      semver: 7.3.8
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/test-end-to-end-tests/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-/Altf290r34gFVvGkO+foP1KuhaMiO5T+CXdkDNskyqTEAoUM72Tb5RMkbX1z/bqO7egEFCZ1efe5Y8oI2PwOw==}
-    dependencies:
-      '@fluid-experimental/sequence-deprecated': 2.0.0-internal.3.3.1
-      '@fluid-tools/benchmark': 0.45.112032
-      '@fluidframework/agent-scheduler': 2.0.0-internal.3.3.1
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1
-      '@fluidframework/attributor': 2.0.0-internal.3.2.2
-      '@fluidframework/cell': 2.0.0-internal.3.3.1
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/counter': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
-      '@fluidframework/ink': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/matrix': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/mocha-test-setup': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/ordered-collection': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/register-collection': 2.0.0-internal.3.3.1
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/sequence': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/test-loader-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-pairwise-generator': 2.0.0-internal.3.3.1
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-version-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/undo-redo': 2.0.0-internal.3.3.1
-      cross-env: 7.0.3
-      mocha: 10.2.0
-      semver: 7.3.8
-      sinon: 7.5.0
-      start-server-and-test: 1.14.0
-      tinylicious: 0.5.0
-      url: 0.11.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/test-loader-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-tbUEXnNoExtUVLUrXiDOPsrveuzRKm9MxYv1RJCvKWXXshMOf+/7+x2eZ5dFq5gIW6/zOGitDSW/RcR0zzIYkg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/test-pairwise-generator/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-VPU/qtTDqZxRdav+TW/Anx6KHHu3HWEVSrcfQx9ZXEg5n5m8dVdNQ6dmNqa4rZGexQ4aEoxG6ojK2p6tqerbCw==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      random-js: 1.0.8
-    dev: true
-
   /@fluidframework/test-runtime-utils/2.0.0-internal.3.2.0:
     resolution: {integrity: sha512-rrulWN8F0h11R1KQJ7q8IUxueTIB5279VpLYjIf5mbuT6dxw397MvtTYxux/6m0R8538aKHtab0159+mSKAx/w==}
     dependencies:
@@ -15319,82 +15028,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-fEiGaxrQFYPAwQ82HWM2smKnsUvYHomz3c1U35S5t8agfwvKtFNz6c+e055YRsqd0mZZeDVPR8sUOS4nT04XRg==}
-    dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/local-driver': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/map': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/mocha-test-setup': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      best-random: 1.0.3
-      debug: 4.3.4
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/test-version-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-ujxUasNowOUAuvwEuyomZPyVO6EeYLPVmWQrTtUv+oVYar2vHIkX3dwjdqiPiDLLbKGZZum9Jnzq9gR76RbMUw==}
-    dependencies:
-      '@fluid-experimental/attributor': 2.0.0-internal.3.3.1
-      '@fluid-experimental/sequence-deprecated': 2.0.0-internal.3.3.1
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1
-      '@fluidframework/cell': 2.0.0-internal.3.3.1
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/counter': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/ink': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/matrix': 2.0.0-internal.3.3.1
-      '@fluidframework/ordered-collection': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/register-collection': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/sequence': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/test-drivers': 2.0.0-internal.3.3.1
-      '@fluidframework/test-utils': 2.0.0-internal.3.3.1
-      nconf: 0.12.0
-      proper-lockfile: 4.1.2
-      semver: 7.3.8
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /@fluidframework/tinylicious-client/2.0.0-internal.3.2.0:
     resolution: {integrity: sha512-9g/HnsT3nUMLEP3QRBb7EatnBZOqcQ2vK6HcaOiiwOZG7RyMV5H6bpBRr+EusNjHsTbozNDXOvcYeCyRfCHoFg==}
     peerDependencies:
@@ -15496,19 +15129,6 @@ packages:
 
   /@fluidframework/undo-redo/2.0.0-internal.3.2.0:
     resolution: {integrity: sha512-WjV1sRNEy+ilXvjJFiZyDg3Sx4d9+hDefjYbMMkNqaSxBZm9M0S/KMucx1VYdX2jRYeTm/LpMgozPVMis3tjnw==}
-    dependencies:
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/matrix': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/sequence': 2.0.0-internal.3.3.1
-      events: 3.3.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/undo-redo/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-iUZH0unt1zj788sK/6kLL1O7730N3MZ96H650tbPtoXQDEUh66QDWg01eGBvKQtWYlWHx6aDeEoCcu1/LhnJiw==}
     dependencies:
       '@fluidframework/map': 2.0.0-internal.3.3.1
       '@fluidframework/matrix': 2.0.0-internal.3.3.1
@@ -30730,24 +30350,6 @@ packages:
       sha.js: 2.4.11
       simple-get: 4.0.1
 
-  /isomorphic-git/1.22.0:
-    resolution: {integrity: sha512-ZFmfyjj28DthNDDj/aQvxeUIVCj18YGMEjatVGig8ixvUe3oGfqjS7lAbqFXxJQ928oSgmUMcKv6+wz6YMiqZA==}
-    engines: {node: '>=12'}
-    hasBin: true
-    dependencies:
-      async-lock: 1.4.0
-      clean-git-ref: 2.0.1
-      crc-32: 1.2.2
-      diff3: 0.0.3
-      ignore: 5.2.4
-      minimisted: 2.0.1
-      pako: 1.0.11
-      pify: 4.0.1
-      readable-stream: 3.6.2
-      sha.js: 2.4.11
-      simple-get: 4.0.1
-    dev: true
-
   /isomorphic-unfetch/3.1.0:
     resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
     dependencies:
@@ -39782,51 +39384,6 @@ packages:
   /tiny-warning/1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
     dev: false
-
-  /tinylicious/0.5.0:
-    resolution: {integrity: sha512-gpsLV9/Fmyc/jiFWEfj1jQYOZISCVIxemahN/c/USzunqCfLx7J6OYBvcVli6Q9n41ZXsid7Xv06gMuPav7PBg==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/gitresources': 0.1038.4000
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/server-lambdas': 0.1038.4000
-      '@fluidframework/server-local-server': 0.1038.4000
-      '@fluidframework/server-memory-orderer': 0.1038.4000
-      '@fluidframework/server-services-client': 0.1038.4000
-      '@fluidframework/server-services-core': 0.1038.4000
-      '@fluidframework/server-services-shared': 0.1038.3000
-      '@fluidframework/server-services-telemetry': 0.1038.4000
-      '@fluidframework/server-services-utils': 0.1038.3000
-      '@fluidframework/server-test-utils': 0.1038.4000
-      agentkeepalive: 4.3.0
-      axios: 0.26.1
-      body-parser: 1.20.2
-      charwise: 3.0.1
-      compression: 1.7.4
-      cookie-parser: 1.4.6
-      cors: 2.8.5
-      detect-port: 1.5.1
-      express: 4.18.2
-      isomorphic-git: 1.22.0
-      json-stringify-safe: 5.0.1
-      level: 8.0.0
-      level-sublevel: 6.6.4
-      lodash: 4.17.21
-      morgan: 1.10.0
-      nconf: 0.12.0
-      socket.io: 4.6.1
-      split: 1.0.1
-      uuid: 8.3.2
-      winston: 3.8.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-    dev: true
 
   /tinylicious/0.6.0:
     resolution: {integrity: sha512-xOhIuwJt4Y9vYesQHzT61piJciFwz+dQnFA52B6CSb5i3dkcLhBMxMX6VvG07zN4HjaR2Sl4HTT7I1lHRM1zBA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4755,7 +4755,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
-      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.3.2.0
+      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.4.0.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -4779,7 +4779,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
-      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.3.2.0
+      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4
       '@types/events': 3.0.0
@@ -4795,7 +4795,7 @@ importers:
       '@fluid-tools/build-cli': ^0.13.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
-      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/node': ^14.18.38
@@ -4809,7 +4809,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/node': 14.18.38
@@ -4871,7 +4871,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.3.2.0
+      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@microsoft/api-extractor': ^7.34.4
@@ -4889,7 +4889,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
-      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.3.2.0
+      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4
       concurrently: 7.6.0
@@ -4905,7 +4905,7 @@ importers:
       '@fluid-tools/build-cli': ^0.13.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
-      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.3.2.0
+      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.4.0.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -4941,7 +4941,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.3.2.0
+      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -4965,7 +4965,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.3.2.0
+      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.4.0.0
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -4998,7 +4998,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.3.2.0
+      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -5025,7 +5025,7 @@ importers:
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.3.2.0
+      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -5057,7 +5057,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.3.2.0
+      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4
@@ -5087,7 +5087,7 @@ importers:
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.3.2.0
+      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -5128,7 +5128,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.3.2.0
+      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
@@ -5157,7 +5157,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.3.2.0
+      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.4.0.0
       '@fluidframework/merge-tree': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/protocol-base': ^0.1038.4000
@@ -5210,7 +5210,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.3.2.0
+      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
@@ -5247,7 +5247,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.3.2.0
+      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -5290,7 +5290,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.3.2.0
+      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
@@ -5320,7 +5320,7 @@ importers:
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.3.2.0
+      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -5355,7 +5355,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.3.2.0
+      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.4.0.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
@@ -5444,7 +5444,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/protocol-base': ^0.1038.4000
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.3.2.0
+      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.4.0.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/shared-object-base': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -5475,7 +5475,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.3.2.0
+      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.4.0.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
@@ -5511,7 +5511,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.3.2.0
+      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.4.0.0
       '@fluidframework/server-services-client': ^0.1038.4000
       '@fluidframework/shared-object-base': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -5557,7 +5557,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/gitresources': 0.1038.4000
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.3.2.0
+      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.4.0.0
       '@fluidframework/server-services-client': 0.1038.4000
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
@@ -5595,7 +5595,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.4.0.0
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@microsoft/api-extractor': ^7.34.4
@@ -5634,7 +5634,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.4.0.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/benchmark': 2.1.2
@@ -5666,7 +5666,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/shared-object-base': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.3.2.0
+      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.4.0.0
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/benchmark': ^2.1.0
@@ -5696,7 +5696,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.3.2.0
+      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.4.0.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/benchmark': 2.1.2
@@ -5733,7 +5733,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/shared-object-base': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.3.2.0
+      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.4.0.0
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -5770,7 +5770,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.3.2.0
+      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.4.0.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
@@ -5920,7 +5920,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.3.2.0
+      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.4.0.0
       '@fluidframework/driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -5948,7 +5948,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.3.2.0
+      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
@@ -5968,7 +5968,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.3.2.0
+      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.4.0.0
       '@fluidframework/driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -5994,7 +5994,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.3.2.0
+      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/node': 14.18.38
@@ -6012,7 +6012,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
-      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.3.2.0
+      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -6037,7 +6037,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.3.2.0
+      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/jest': 22.2.3
@@ -6061,7 +6061,7 @@ importers:
       '@fluidframework/driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.3.2.0
+      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/replay-driver': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@microsoft/api-extractor': ^7.34.4
@@ -6084,7 +6084,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.3.2.0
+      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/node': 14.18.38
       concurrently: 7.6.0
@@ -6097,7 +6097,7 @@ importers:
   packages/drivers/fluidapp-odsp-urlResolver:
     specifiers:
       '@fluid-tools/build-cli': ^0.13.0
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.3.2.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.4.0.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-utils': ^1.1.1
@@ -6124,7 +6124,7 @@ importers:
       '@fluidframework/odsp-driver-definitions': link:../odsp-driver-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.2.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.4.0.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -6151,7 +6151,7 @@ importers:
       '@fluidframework/driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.3.2.0
+      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/protocol-base': ^0.1038.4000
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -6202,7 +6202,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.3.2.0
+      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/jsrsasign': 8.0.13
@@ -6234,7 +6234,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/odsp-doclib-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.4.0.0
       '@fluidframework/protocol-base': ^0.1038.4000
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -6281,7 +6281,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -6306,7 +6306,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@microsoft/api-extractor': ^7.34.4
       concurrently: ^7.6.0
@@ -6323,7 +6323,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
       '@microsoft/api-extractor': 7.34.4
       concurrently: 7.6.0
@@ -6345,7 +6345,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/odsp-driver': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.3.2.0
+      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.4.0.0
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
       concurrently: ^7.6.0
@@ -6366,7 +6366,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.3.2.0
+      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.4.0.0
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
       concurrently: 7.6.0
@@ -6388,7 +6388,7 @@ importers:
       '@fluidframework/driver-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.3.2.0
+      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.4.0.0
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -6414,7 +6414,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.3.2.0
+      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -6443,7 +6443,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/protocol-base': ^0.1038.4000
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.3.2.0
+      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.4.0.0
       '@fluidframework/server-services-client': ^0.1038.4000
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@microsoft/api-extractor': ^7.34.4
@@ -6494,7 +6494,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.3.2.0
+      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -6526,7 +6526,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.3.2.0
+      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.4.0.0
       '@types/mocha': ^9.1.1
       '@types/nconf': ^0.10.0
       '@types/node': ^14.18.38
@@ -6553,7 +6553,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.2.0
+      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.4.0.0
       '@types/mocha': 9.1.1
       '@types/nconf': 0.10.3
       '@types/node': 14.18.38
@@ -6580,7 +6580,7 @@ importers:
       '@fluidframework/routerlicious-driver': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/server-services-client': ^0.1038.4000
       '@fluidframework/test-tools': ^0.2.3074
-      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.3.2.0
+      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.4.0.0
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
@@ -6610,7 +6610,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-tools': 0.2.3074
-      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.3.2.0
+      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.4.0.0
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -6626,7 +6626,7 @@ importers:
   packages/framework/agent-scheduler:
     specifiers:
       '@fluid-tools/build-cli': ^0.13.0
-      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.3.2.0
+      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.4.0.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
@@ -6668,7 +6668,7 @@ importers:
       uuid: 8.3.2
     devDependencies:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
-      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.3.2.0
+      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.4.0.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -6685,7 +6685,7 @@ importers:
   packages/framework/aqueduct:
     specifiers:
       '@fluid-tools/build-cli': ^0.13.0
-      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.3.2.0
+      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.4.0.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
@@ -6737,7 +6737,7 @@ importers:
       uuid: 8.3.2
     devDependencies:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
-      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.3.2.0
+      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.4.0.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -6839,7 +6839,7 @@ importers:
       '@fluidframework/container-runtime': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/container-runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.3.2.0
+      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.4.0.0
       '@fluidframework/datastore': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -6876,7 +6876,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.3.2.0
+      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
@@ -6897,7 +6897,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.3.2.0
+      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/merge-tree': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -6931,7 +6931,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.3.2.0
+      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -7011,7 +7011,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.3.2.0
+      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.4.0.0
       '@fluidframework/map': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -7049,7 +7049,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.3.2.0
+      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.4.0.0
       '@fluidframework/map': link:../../dds/map
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/sequence': link:../../dds/sequence
@@ -7129,7 +7129,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.3.2.0
+      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.4.0.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -7161,7 +7161,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.3.2.0
+      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.4.0.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/diff': 3.5.5
@@ -7189,7 +7189,7 @@ importers:
       '@fluidframework/datastore': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.3.2.0
+      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.4.0.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
@@ -7210,7 +7210,7 @@ importers:
       '@fluidframework/datastore': link:../../runtime/datastore
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.3.2.0
+      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -7231,7 +7231,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/test-client-utils-previous': npm:@fluidframework/test-client-utils@2.0.0-internal.3.2.0
+      '@fluidframework/test-client-utils-previous': npm:@fluidframework/test-client-utils@2.0.0-internal.4.0.0
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/uuid': ^8.3.0
@@ -7253,7 +7253,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-client-utils-previous': /@fluidframework/test-client-utils/2.0.0-internal.3.2.0
+      '@fluidframework/test-client-utils-previous': /@fluidframework/test-client-utils/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4
       '@types/uuid': 8.3.4
       concurrently: 7.6.0
@@ -7284,7 +7284,7 @@ importers:
       '@fluidframework/routerlicious-driver': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/test-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.3.2.0
+      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.4.0.0
       '@fluidframework/tinylicious-driver': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -7322,7 +7322,7 @@ importers:
       '@fluidframework/container-runtime-definitions': link:../../runtime/container-runtime-definitions
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/test-utils': link:../../test/test-utils
-      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.3.2.0
+      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -7348,7 +7348,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/sequence': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.3.2.0
+      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.4.0.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/diff': ^3.5.1
       '@types/events': ^3.0.0
@@ -7380,7 +7380,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.3.2.0
+      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/diff': 3.5.5
       '@types/events': 3.0.0
@@ -7406,7 +7406,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.3.2.0
+      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.4.0.0
       '@fluidframework/view-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/react': ^17.0.44
@@ -7429,7 +7429,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.3.2.0
+      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
@@ -7447,7 +7447,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.3.2.0
+      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.4.0.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -7464,7 +7464,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.3.2.0
+      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
@@ -7484,7 +7484,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.3.2.0
+      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.4.0.0
       '@fluidframework/container-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -7539,7 +7539,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.3.2.0
+      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
@@ -7568,7 +7568,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/container-utils-previous': npm:@fluidframework/container-utils@2.0.0-internal.3.2.0
+      '@fluidframework/container-utils-previous': npm:@fluidframework/container-utils@2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -7596,7 +7596,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/container-utils-previous': /@fluidframework/container-utils/2.0.0-internal.3.2.0
+      '@fluidframework/container-utils-previous': /@fluidframework/container-utils/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -7622,7 +7622,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.3.2.0
+      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources': ^0.1038.4000
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -7663,7 +7663,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.3.2.0
+      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
@@ -7691,7 +7691,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.3.2.0
+      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -7717,7 +7717,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.3.2.0
+      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
@@ -7775,7 +7775,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/container-runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.4.0.0
       '@fluidframework/container-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/datastore': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -7834,7 +7834,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
-      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -7862,7 +7862,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.4.0.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -7886,7 +7886,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
-      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4
       concurrently: 7.6.0
@@ -7907,7 +7907,7 @@ importers:
       '@fluidframework/container-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.3.2.0
+      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.4.0.0
       '@fluidframework/driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -7955,7 +7955,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.3.2.0
+      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -7982,7 +7982,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -8004,7 +8004,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
-      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.4.0.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4
       concurrently: 7.6.0
@@ -8022,7 +8022,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/garbage-collector-previous': npm:@fluidframework/garbage-collector@2.0.0-internal.3.2.0
+      '@fluidframework/garbage-collector-previous': npm:@fluidframework/garbage-collector@2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -8049,7 +8049,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/garbage-collector-previous': /@fluidframework/garbage-collector/2.0.0-internal.3.2.0
+      '@fluidframework/garbage-collector-previous': /@fluidframework/garbage-collector/2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/events': 3.0.0
@@ -8077,7 +8077,7 @@ importers:
       '@fluidframework/driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.3.2.0
+      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.4.0.0
       '@microsoft/api-extractor': ^7.34.4
       concurrently: ^7.6.0
       copyfiles: ^2.4.1
@@ -8097,7 +8097,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.3.2.0
+      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4
       concurrently: 7.6.0
       copyfiles: 2.4.1
@@ -8122,7 +8122,7 @@ importers:
       '@fluidframework/protocol-base': ^0.1038.4000
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.3.2.0
+      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.4.0.0
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -8155,7 +8155,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.3.2.0
+      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -8190,7 +8190,7 @@ importers:
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.3.2.0
+      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.4.0.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
@@ -8232,7 +8232,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.3.2.0
+      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
@@ -8430,7 +8430,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.3.2.0
+      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.4.0.0
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -8452,7 +8452,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.3.2.0
+      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -8635,7 +8635,7 @@ importers:
       '@fluidframework/driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/test-driver-definitions-previous': npm:@fluidframework/test-driver-definitions@2.0.0-internal.3.2.0
+      '@fluidframework/test-driver-definitions-previous': npm:@fluidframework/test-driver-definitions@2.0.0-internal.4.0.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
       concurrently: ^7.6.0
@@ -8658,7 +8658,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.3.2.0
+      '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4
       '@types/mocha': 9.1.1
       concurrently: 7.6.0
@@ -9122,7 +9122,7 @@ importers:
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.3.2.0
+      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.4.0.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/diff': ^3.5.1
@@ -9176,7 +9176,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.3.2.0
+      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/debug': 4.1.7
       '@types/diff': 3.5.5
@@ -9593,7 +9593,7 @@ importers:
   packages/tools/fetch-tool:
     specifiers:
       '@fluid-tools/build-cli': ^0.13.0
-      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.3.2.0
+      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.4.0.0
       '@fluid-tools/fluidapp-odsp-urlresolver': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/common-utils': ^1.1.1
@@ -9637,7 +9637,7 @@ importers:
       '@fluidframework/tool-utils': link:../../utils/tool-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
-      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.3.2.0
+      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.4.0.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@types/node': 14.18.38
@@ -9659,7 +9659,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.3.2.0
+      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/odsp-driver': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
@@ -9694,7 +9694,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.3.2.0
+      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.4.0.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -9798,7 +9798,7 @@ importers:
   packages/tools/webpack-fluid-loader:
     specifiers:
       '@fluid-tools/build-cli': ^0.13.0
-      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.3.2.0
+      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.4.0.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-utils': ^1.1.1
@@ -9877,7 +9877,7 @@ importers:
       webpack-dev-server: 4.6.0_stkfwfapuzpz4fwxpm6s7uwghy
     devDependencies:
       '@fluid-tools/build-cli': 0.13.0_gcaeyjp6ykwlupauelnobztche
-      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.3.2.0_stkfwfapuzpz4fwxpm6s7uwghy
+      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.4.0.0_stkfwfapuzpz4fwxpm6s7uwghy
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_gcaeyjp6ykwlupauelnobztche
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -9911,7 +9911,7 @@ importers:
       '@fluidframework/driver-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.3.2.0
+      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.4.0.0
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@types/mocha': ^9.1.1
@@ -9940,7 +9940,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.2.0
+      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.4.0.0
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
       '@types/node-fetch': 2.6.2
@@ -9962,7 +9962,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
-      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.4.0.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/events': ^3.0.0
@@ -9994,7 +9994,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/debug': 4.1.7
       '@types/events': 3.0.0
@@ -10023,7 +10023,7 @@ importers:
       '@fluidframework/odsp-doclib-utils': '>=2.0.0-internal.4.0.1 <2.0.0-internal.5.0.0'
       '@fluidframework/protocol-base': ^0.1038.4000
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.3.2.0
+      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.4.0.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/jwt-decode': ^2.2.1
@@ -10057,7 +10057,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.3.2.0
+      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.4.0.0
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/debug': 4.1.7
       '@types/jwt-decode': 2.2.1
@@ -12359,27 +12359,26 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/fetch-tool/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-cx7ImmVbVPAeu1AAlW/7wNXSQCqtetjKDFkyJuWgAwT4T5ii5UiOfcmARImV/E8OqX9YXkDWrQJUurwn1g0Vbw==}
+  /@fluid-tools/fetch-tool/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-zY3nJhKG09pjl3Bu14AZIh6rJrr3G7WHumS5Q5SwRWw/7n1BF7T1GuXqAtirbfqN42AziK7LtuRyVGCaBB5vvw==}
     hasBin: true
     dependencies:
-      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.3.3.1
+      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.4.0.0
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-urlresolver': 2.0.0-internal.3.3.1
+      '@fluidframework/container-runtime': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-urlresolver': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-client-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/tool-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.4.0.0
+      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/test-client-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/tool-utils': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -12388,30 +12387,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-a0R5L2LZ74yvVnHPXI8eyqvfVisiSlZGs9QjZdSdH2CVwidpcfO7VJAJkhidf2cvKf6UcZDA4VvUJThD6zjEcA==}
+  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-NaO3Uh/pCd8uLf5aoOM+LIEnNhq9eL0kcDY8Tkj2x3dBxivmS8IqwEF8DUMzyNtPJMtLxtBTVVqgZSLlw1SLfg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-J7F3QjWVy+naY/TI0ovNFZRaGaIdBFqEJeQRrpNh62D0Mu4itF8PK3TONMNyYaBdgJYqmXoxAVKDL0tJ9lOg8w==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -12438,33 +12421,32 @@ packages:
       - supports-color
     dev: true
 
-  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.3.2.0_stkfwfapuzpz4fwxpm6s7uwghy:
-    resolution: {integrity: sha512-6ej1DoYX6mV6rQMuxWsHAff7AypfbPKPSlL5dRc7YxSonj7yF6GJLWlyJcBaWy9+51cfC7/16ZgroOP+XWlqmA==}
+  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.4.0.0_stkfwfapuzpz4fwxpm6s7uwghy:
+    resolution: {integrity: sha512-fdXqgCIbC0BO9KwYUaW/zQrry95Tx1XeMiD3VHeWwyCFx3mLe4o1tsnqXSHwPINeZgtLAQQCRI1CIpTGi0TVYQ==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/local-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/local-driver': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
       '@fluidframework/server-local-server': 0.1038.4000
       '@fluidframework/server-services-client': 0.1038.4000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/tool-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/view-adapters': 2.0.0-internal.3.3.1
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/web-code-loader': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/tool-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.4.0.0
       axios: 0.26.1
       buffer: 6.0.3
       express: 4.18.2
+      isomorphic-fetch: 3.0.0
       nconf: 0.12.0
       sillyname: 0.1.0
       uuid: 8.3.2
@@ -12480,93 +12462,69 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/agent-scheduler/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-EXrrygI8QefV1XZcDd1SQaKnHiB8KIuYGt6NyJj8qAeJ0CdiPVjc34YdLyIyBY9aOkmDmqIpc9JlvH+pD4eYag==}
+  /@fluidframework/agent-scheduler/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-0abFUB9as1kLAaBlNHfIlZyyynukfo6JIQV2bcU7551s0nwKgdS+GZiN7mpY1nq73GJ0WLiTM7GmXSYzf+WThA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/register-collection': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/map': 2.0.0-internal.4.0.0
+      '@fluidframework/register-collection': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-ZjX7pPuTUPt/z1rY7aENDmf37FIsCV7nnCtNx0S9EUhkKq6RvpM90u9PXHy/TGeDACKNWnD9T3LfS+yuaIcQDA==}
+  /@fluidframework/aqueduct/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-ss393BKocNgzrSjSpT4VEvtw91OP9hdg9DA6v8qSirYAe8b0t+sq48l4IYsIsGCya+ljUW1QvF6USeOfxvr3Sw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/synthesize': 2.0.0-internal.3.3.1
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.4.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.4.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/map': 2.0.0-internal.4.0.0
+      '@fluidframework/request-handler': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/synthesize': 2.0.0-internal.4.0.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.4.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-YPbaNRk0w36HO8lPBu7ujl6Xe59Mos1kOQwIKfJj4ekXJvbjRwcogBXFq67MntWgqdwN0eBzRD3KxMKpb3qA7g==}
+  /@fluidframework/aqueduct/2.0.0-internal.4.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-ss393BKocNgzrSjSpT4VEvtw91OP9hdg9DA6v8qSirYAe8b0t+sq48l4IYsIsGCya+ljUW1QvF6USeOfxvr3Sw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/synthesize': 2.0.0-internal.3.3.1
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.3.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/aqueduct/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-YPbaNRk0w36HO8lPBu7ujl6Xe59Mos1kOQwIKfJj4ekXJvbjRwcogBXFq67MntWgqdwN0eBzRD3KxMKpb3qA7g==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/synthesize': 2.0.0-internal.3.3.1
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/container-runtime': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/map': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/synthesize': 2.0.0-internal.4.0.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.4.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -12782,17 +12740,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/cell/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-/Gg/SjmV/SNAmZrWxY+2yde2vcmhHOgLEE/vvVEd0au8LUKJy0NcpDImlgBdPFlZ5TImYQR4WXvTI4mT/1JBBA==}
+  /@fluidframework/cell/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-cCKhUZUbcL4MhbEGd+6AEVfDmUXlITniXIEfKqpIegIS0yYTFQmWPnsE5QbInFljR21qkSXvqf9Cp9h2g8/3+A==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -12822,39 +12779,29 @@ packages:
       events: 3.3.0
     dev: true
 
-  /@fluidframework/container-definitions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-qwZ0+nVhxjhy6nks41S/hOTXg/6LowL4Qp1WGsTQ2qJEQ7iGzNkgx0tprLtcpe4K5Ak808R0WGB5N+GuRYhF/Q==}
+  /@fluidframework/container-definitions/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-0TiU0BnfspRxf9H0Jqg7JeQh7ZbEXta5Gnt7dzRYAN0Byn9tuvvnNySiYa5/5PLF1Z8loNDm5kW4VCr6jtQ3lA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
       events: 3.3.0
     dev: true
 
-  /@fluidframework/container-definitions/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-kPGUNI4kcfGz3WlQeUIBxZF0r2MoKeDKgiW4Aa44Kt8uC7C5v4OLXif9FZZ/JxS4NUcLKHjNh78+H8PvX7ri0A==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      events: 3.3.0
-    dev: true
-
-  /@fluidframework/container-loader/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-bsFWzfqdPfyk7ldumau+Qngsk9fK+4Cd2hULUnZV9rmiYBQv3/BUL3+aSR6B6sdekvzBzOU8MWu+X68g+XNmmQ==}
+  /@fluidframework/container-loader/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-y/3coT6awpfppFc1UnaFlMWUbuGWHQKFxZtW59u+nLUybXn/7E7ytsKWN+PSpCUIChcTZShJ6dIV+Kxx8B9Plg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       abort-controller: 3.0.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -12866,43 +12813,19 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-loader/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-eq42QNDmqATStLi8yfhnkSiJr56POZJdpgVB9TdynUhjN6ca3grE120TzDiJUsZs6h5W1Bm+3y5UVOeryTtymg==}
+  /@fluidframework/container-loader/2.0.0-internal.4.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-y/3coT6awpfppFc1UnaFlMWUbuGWHQKFxZtW59u+nLUybXn/7E7ytsKWN+PSpCUIChcTZShJ6dIV+Kxx8B9Plg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0_debug@4.3.4
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      abort-controller: 3.0.0
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lodash: 4.17.21
-      url: 0.11.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/container-loader/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-eq42QNDmqATStLi8yfhnkSiJr56POZJdpgVB9TdynUhjN6ca3grE120TzDiJUsZs6h5W1Bm+3y5UVOeryTtymg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       abort-controller: 3.0.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -12925,26 +12848,15 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.3
     dev: true
 
-  /@fluidframework/container-runtime-definitions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-AsXBy6Ct4p18O9hTlx11U91c4Gbx6ZHP/v4jhUst+UG0ODWsdw+T7xhCIhNR+iC63FuIuXzK10CLHtWrSWSShQ==}
+  /@fluidframework/container-runtime-definitions/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-D9XxYMZtO7MFFLStNR99kzmSWLCQ1PnRrVRn8Lvb20DtgfaMEuJkKGkocwod7VxaS1sH0D3gsZ7ycqdli14tgg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-    dev: true
-
-  /@fluidframework/container-runtime-definitions/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-wWr+FwgrPWB2Cz/y2KSxTqqqsJN36iSyrf6o0uH/9lcJxePQro2lyk5bjbURde+oztxKUSCzOHf0xqQ3EbYvMw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
     dev: true
 
   /@fluidframework/container-runtime/2.0.0-internal.2.4.3:
@@ -12974,24 +12886,24 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-+jMECGYgs0CEa+MmkQ+8K8v7g5swxxpFY0cj9oDEVNgdUMmHL93dgUcPxi+M9O8HuDqKm+7KMU+8b9StOB6Myg==}
+  /@fluidframework/container-runtime/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-bpHGLT3YTrZbcGnnFV3N0+Gc3VDErLU0IEv7Hva/NptFtDbSSF9b+xMJS7BkEij959G317IC/+0SI4oEnf6Gxg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/garbage-collector': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -13001,51 +12913,24 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-ZTgDBS2P0ZviT8Ao2ZzTJ/7TCgE4Q/zytuz34TDQnvD8dDmcBOziH7Ca3jY1xUtEUz5om5W8E7D7eg/sJH1hKw==}
+  /@fluidframework/container-runtime/2.0.0-internal.4.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-bpHGLT3YTrZbcGnnFV3N0+Gc3VDErLU0IEv7Hva/NptFtDbSSF9b+xMJS7BkEij959G317IC/+0SI4oEnf6Gxg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/garbage-collector': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lz4js: 0.2.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/container-runtime/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-ZTgDBS2P0ZviT8Ao2ZzTJ/7TCgE4Q/zytuz34TDQnvD8dDmcBOziH7Ca3jY1xUtEUz5om5W8E7D7eg/sJH1hKw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -13067,26 +12952,14 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-KZNRvslw2GiZeP2Ig1SUYzRswCarwK25LFnNAgRJo+xhZ7A1qi4eYi3aUiQeteyxjPyFwKTRS0tfc52FuX9cpQ==}
+  /@fluidframework/container-utils/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-qPBFIpsZ5b2Va1pHNzDeFnSqQxb4dA2+ly6joworlUFUP/XI/rdA7+8NtWAaspkEnMnLM1dgp6XQzW6I5jji8Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/container-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-0qxJVxj3OHN/ejqaJvPu2bRTL6/9TqcmgIher36ufOKkiC3H6UDSTrVe3LYKDQRpNKWIGQwmzwDbCqtHT2rg+Q==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13095,43 +12968,40 @@ packages:
     resolution: {integrity: sha512-wNH5TrE69s8nmP9XCacHAdUDuBlLbWk1FJhtrM+n4fXRBMa+UzJ3JS97ZsMJQcqBrEVtsA1ioov4iaoOFyGQuA==}
     dev: true
 
-  /@fluidframework/core-interfaces/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-6dX5P+uxxv5QxZy+uIuV4QH7FQeaLvlxk2+u9qdhZI4z5CL77F3XkO/UU03h7mAOQsJ2fmi/63uYOKQxdDVFPg==}
+  /@fluidframework/core-interfaces/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-DJH+TmbthJ69Lay1iw0JxGFwmTl4k0/gUlIlurahZeGCsPcIVRf0R6PVBVD17UsvFrPnwNb8OjpU4zr5jdRFDQ==}
     dev: true
 
-  /@fluidframework/core-interfaces/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-HHNMbmPXMJ7aARNkVEIfgnTg7RfzRpWjs+S3yC8Bh6+qBdksp6ID07PyclrcjEdo7XfYAJgGlkocEVj/D1ZBcA==}
-    dev: true
-
-  /@fluidframework/counter/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-9gIvOC706DCHMRVhQ5asmnnyOJC1tLuY8xQU4Ra6eq796cmQMuEr++O+Aj2qZyRPYxlqntNtO2PT/Lg4/MQX/A==}
+  /@fluidframework/counter/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-F9EG5tbVvUhsNTr6PvXI4Kvsq4rpFr27Pv9toKlDxYyAWgdOS1XMNXCKU0h67SyTkCkwcLaLmZE4j6TCrbVf5Q==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/data-object-base/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-fCqEgSFmNroHixhVbA34FaFYXd5luAVtBPQb8k5Rv5KrDuImCdFpttg8kt/iQBIKiAiOH1YSPb57kDOcnUfedg==}
+  /@fluidframework/data-object-base/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-xq6b+Gx6VVS8hj99UK6vLlcseD6QLYsGka7m36/mTFPBxLrwStzCiwAyNLeO5/nXcsbdQabKW9ME0MrIr/Q3CQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.4.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/request-handler': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13148,26 +13018,15 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.3
     dev: true
 
-  /@fluidframework/datastore-definitions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-FDVmQu1ak8tSx+5G2mWSJgBG1eZkwR1tSLzzaKTUJbW50LjvQ1zy/rzOig9m2sYToneIeeqLZjnuKSOZQFm0mQ==}
+  /@fluidframework/datastore-definitions/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-kcwH86bdSiPmenmQFEJf5MvOwVq7yZuOkgKeirg3B4RtViwnuNxWcvnK+rYYVKJGxif78DJl7+L0q5vIUqDQMw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-    dev: true
-
-  /@fluidframework/datastore-definitions/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-JlhDIVDeax/8bdo5R0PP1WgVr0zAk1OOu4LcvHLNV6TkKqP7slvTMDqGmqY1oCFXe/VtEMXQWEUTEoxQpejKmQ==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
     dev: true
 
   /@fluidframework/datastore/2.0.0-internal.2.4.3:
@@ -13194,23 +13053,23 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-TVjht4LLXjTL6vdJLVNizH52btN14QZXgZL9PQKRoCLsqJOxWbOCyz7zOq7dAo6vpBv/AQUbECf9YL1d8eVurg==}
+  /@fluidframework/datastore/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-E7TTZWfQgWqhc0ZpJQY+hwPVRaTFknGekR68Cu8rS0ALIHia0pMoguaPH2zFUZmUL9xvcun2mB23XbVujTClfg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/garbage-collector': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       lodash: 4.17.21
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -13218,23 +13077,23 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-EOvi9DuJvDXJanAJIJLreQUlkhqOAAt1ag46+oqUoaxc+h/A/1s1NxPETEhiQ4VdLKGPyVWolHaHy+o9qnBNSw==}
+  /@fluidframework/datastore/2.0.0-internal.4.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-E7TTZWfQgWqhc0ZpJQY+hwPVRaTFknGekR68Cu8rS0ALIHia0pMoguaPH2zFUZmUL9xvcun2mB23XbVujTClfg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/garbage-collector': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       lodash: 4.17.21
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -13242,94 +13101,56 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-EOvi9DuJvDXJanAJIJLreQUlkhqOAAt1ag46+oqUoaxc+h/A/1s1NxPETEhiQ4VdLKGPyVWolHaHy+o9qnBNSw==}
+  /@fluidframework/dds-interceptions/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-I4+/FjmW3lH4p64k6ggGkE+Qi8GAkLEuGBPeKogDXc3mR+yD9ybc3R2f+CzvhdwUzthI3v3lozk8kn0d2s19RQ==}
     dependencies:
-      '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      lodash: 4.17.21
-      uuid: 8.3.2
+      '@fluidframework/map': 2.0.0-internal.4.0.0
+      '@fluidframework/merge-tree': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/sequence': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/dds-interceptions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-SvIY/J9FNiQGXY31WWvW+vc6Pwoec6dBV+frwuh55+a0Y2kQL+SF6BqOrVBG9MzmY85FYZJUIiNDooGUbANhnw==}
+  /@fluidframework/debugger/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-9rFMR4F/D9+In2q+p67AiUAuCx28hdUy66st/+OF/dP0Y3hdVbqm3dOwL7goy0OG5QC432CNtQn74rw+epGvVg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/sequence': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/debugger/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-2C+zFZTx+nwSAZ34pJ7XXvj92y2fApnIYurRqTTHn0NuzbYAd99ovyASjPMFuOmAyCATHk4G4wQ6UECJNMuSkA==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/replay-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/replay-driver': 2.0.0-internal.4.0.0
       jsonschema: 1.4.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-xPH31GtvDo4qLU4o/F0GYv8iwVWTmTYEJF279XZzbWpSNzh/kTAHD7ALeNFuE9cAZht3p1Ypi1wVJ0FPR5IiRg==}
+  /@fluidframework/driver-base/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-jXM5VoJYjwbGIS26USSuCoklf5ms09znJNY7A4VjrIOjBL9RYcyeXHRMi1Hsbqlw9IVIx1BepLgLxpwi/lCTkg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-mamE7COu0PKrGKJocnLsJGb7kgs3jPaDPIMqCagmGXbrPNE1CSp3SvNQGPZ7DpaXVmmdF/VrD7G03iGz48uFzw==}
+  /@fluidframework/driver-base/2.0.0-internal.4.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-jXM5VoJYjwbGIS26USSuCoklf5ms09znJNY7A4VjrIOjBL9RYcyeXHRMi1Hsbqlw9IVIx1BepLgLxpwi/lCTkg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/driver-base/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-mamE7COu0PKrGKJocnLsJGb7kgs3jPaDPIMqCagmGXbrPNE1CSp3SvNQGPZ7DpaXVmmdF/VrD7G03iGz48uFzw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13343,19 +13164,11 @@ packages:
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
-  /@fluidframework/driver-definitions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-dw08xt+k6/FZ70P1cBh2N6aiglWxbkehcVoPlDSrafnmZ+jYiA68ql8SBj7hbxnPtN+G9zy+baCqN3ah9tqyEA==}
+  /@fluidframework/driver-definitions/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-w7y1LWPHYydjt3KI7XY3k0TV8nkujQSRdMEd1QostF5yg5ooG40iXS56qs0qbs7TW33Eoe29SEoV2+iR7icKEw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-    dev: true
-
-  /@fluidframework/driver-definitions/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-Xw5+RGJN+iNIUR012EWLZao2KziXR5TzKhvanOsHqXkZulDjzwWa74ALaxyfvOmgSkaHIDpDx3gvChKjgBfikg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
@@ -13378,17 +13191,17 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-tZgy1yoTTmeZkPDErRaTV5bd9X7Rte8WX1fq/X4nIowBVPQfTCVTTiPk4Tn4yFfD4SJGTrs5efJ6mpDNmQlKZQ==}
+  /@fluidframework/driver-utils/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-OWdJ7vP5xGJir8KiB5HmeFD+pgOX7QyGuxY3vYblBTznRZ/4Pb+AxkqIbvm70Fpeq65eRmE2p0ErzrKX1EAYWw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/gitresources': 0.1038.4000
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       axios: 0.26.1
       url: 0.11.0
       uuid: 8.3.2
@@ -13397,36 +13210,17 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-xelVnKDo5U7VzvPdPo2iaICZXZniODVVdlF4nvlc6egWQpd1PFR8GXdGLbswMnsSfmdmiiL+4G1PpTDRXJesiw==}
+  /@fluidframework/driver-utils/2.0.0-internal.4.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-OWdJ7vP5xGJir8KiB5HmeFD+pgOX7QyGuxY3vYblBTznRZ/4Pb+AxkqIbvm70Fpeq65eRmE2p0ErzrKX1EAYWw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/gitresources': 0.1038.4000
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      axios: 0.26.1
-      url: 0.11.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/driver-utils/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-xelVnKDo5U7VzvPdPo2iaICZXZniODVVdlF4nvlc6egWQpd1PFR8GXdGLbswMnsSfmdmiiL+4G1PpTDRXJesiw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/gitresources': 0.1038.4000
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       axios: 0.26.1_debug@4.3.4
       url: 0.11.0
       uuid: 8.3.2
@@ -13435,12 +13229,12 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-web-cache/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-x38jxmQF4btBMX3oFvZcYQuk8gm7btN+UE4/E/Sr/a1ByRXxBLELUDA1sNKRdJ8lyN/s4WXtrvcS9HD+UtbcJQ==}
+  /@fluidframework/driver-web-cache/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-2YeNzDY8AXOwdKusInHlOiyNpUUGPR8KPyuEzKOQggm+byPuL4mwW+Lk9jQCRBBZq2iKK1ze2U7YN6M5RRdlrQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -13472,33 +13266,33 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/file-driver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-9ZCP9VjvxcJXi07KJlrf7VvkFsVf4Tlf/KBX0g+GRyoBxyp7F55vNtEzO9s5Jsu8v+a+ZV/S4sITZR0TfJ0A6A==}
+  /@fluidframework/file-driver/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-AlTbEmfu6x3whMpDpj2H8z+GGuHBkn7THhyT3U1FbjZjrP9UWzh8MBi3u5XwdSd0Wr8FGquQzDZmS0IErhFF7Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/replay-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/replay-driver': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/fluid-runner/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-xWUIaNfEHNv8Nl72z7ESqJE1nPO3IiS3CeTpgTlRD5KZunkj45LBEDTKW1gW3U0zG+Ud1pU7Jeq2l/EnsNlXmw==}
+  /@fluidframework/fluid-runner/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-rutPrIWEV5fD0gMZkiONvPWDhi4kOoSFriUJBDpimtlF6aYA5x5Bv0Uj0vC3mGDe38jhtbpSi0pAEIE8Mq+u3A==}
     hasBin: true
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1
+      '@fluidframework/aqueduct': 2.0.0-internal.4.0.0
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       json2csv: 5.0.7
       yargs: 13.2.2
     transitivePeerDependencies:
@@ -13509,41 +13303,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/fluid-static/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-0OesqwiGz9ctRDdZWlKyODFYY+cag8eHdDDBwDGeXZWu89n7yE8lvm2o2z/xycmuRpCJ2twJFRDMINk1rHNIug==}
+  /@fluidframework/fluid-static/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-zSYKRK7fg0bHV0hj/Hj5HIq1/7m94d8ElRADIAPRvL1sUVwNAIC7dRP99Xl3n0zw4osRZ9Jzu1sv2VzZnSlrVw==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1
+      '@fluidframework/aqueduct': 2.0.0-internal.4.0.0
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.4.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/fluid-static/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-BM6cvHEu0B4Dv4p+b0LkKb142Ta+e5eK/pQ9vodDIa7tQTQL2HaXuopJcxSLKTlQ9tJ5jdUB08shinwF+73Aww==}
-    dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/request-handler': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13558,22 +13332,13 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.3
     dev: true
 
-  /@fluidframework/garbage-collector/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-tQ/+eIsM23fJMENXncgpgSm1RG/QN6yF35KtHNvkNGgJxzFP5j6g670tqoI68hssfNkSH33BLicQrTkxGVQwJw==}
+  /@fluidframework/garbage-collector/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-igTgC0S6av3xd6ed8xI1lchqh6lPrMiVagPtnOdAfePbpVN8FB1k3foXjGi+0HXqvZgJkgLmNPw8IxSOD3+aVQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-    dev: true
-
-  /@fluidframework/garbage-collector/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-jA7+CKOu1ZLPHWvXS5OA4AgOgxOKGIB9bMnEbJ7meK7F8LFsAZrdlUgT45WTxA5qQNmOjkvieGfWJRv/gGdDxw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
     dev: true
 
   /@fluidframework/gitresources/0.1038.3000:
@@ -13582,39 +13347,39 @@ packages:
   /@fluidframework/gitresources/0.1038.4000:
     resolution: {integrity: sha512-YYHauGScTKafXUTqRvpJyYLF0T5wGYXRagZz/ymZFYmG/3AzSj0XKCv1QmkKyAw6wgHWSk/IZyKQ9bukHpPB2w==}
 
-  /@fluidframework/ink/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-ylql+kDaPtPp1GvxC2ysIcveFQrOVhhslLLHD0zwzlnIBDDjPrkZQ3++lSxRyMWKywL+ITn794/GPImC4bg1oA==}
+  /@fluidframework/ink/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-/dQChSfncobmWmp+8A/KtCj26QtuKCfQbe8fYYsVEtfkrfSaKVIzUBISiPITK2GX/WEn0Ih3ixOx65lBZiPSDg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.4.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-ctAHUgpIN8C6fcfJppeZIGlwGJ3QE2kSYkFndBERIY4Pb90P6HPy8xCXbEIZnNH0cDOXwRcT+w7aYHg+sn+V8g==}
+  /@fluidframework/local-driver/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-NJDURVf7LbMKJ2urBUP4s4mI6Nv15Fwn3k3zy1hmEImhWXGzg2pEsIHEKwz2qY4fNojy37rhkoHnpLiyO4ctcA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-base': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.4.0.0
       '@fluidframework/server-local-server': 0.1038.4000
       '@fluidframework/server-services-client': 0.1038.4000
       '@fluidframework/server-services-core': 0.1038.4000
       '@fluidframework/server-test-utils': 0.1038.4000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       events: 3.3.0
       jsrsasign: 10.7.0
       url: 0.11.0
@@ -13627,23 +13392,23 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-VD8k+ZlCp7SnbJspeTsY0XRh0j1i80dA9vsgPlfpLxenwOZuDR8jExZ+u8CQ3eWbe9REYVnzbl7yof+Yiv/IIQ==}
+  /@fluidframework/local-driver/2.0.0-internal.4.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-NJDURVf7LbMKJ2urBUP4s4mI6Nv15Fwn3k3zy1hmEImhWXGzg2pEsIHEKwz2qY4fNojy37rhkoHnpLiyO4ctcA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-base': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0_debug@4.3.4
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.4.0.0_debug@4.3.4
       '@fluidframework/server-local-server': 0.1038.4000
       '@fluidframework/server-services-client': 0.1038.4000
       '@fluidframework/server-services-core': 0.1038.4000
       '@fluidframework/server-test-utils': 0.1038.4000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       events: 3.3.0
       jsrsasign: 10.7.0
       url: 0.11.0
@@ -13656,117 +13421,69 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-VD8k+ZlCp7SnbJspeTsY0XRh0j1i80dA9vsgPlfpLxenwOZuDR8jExZ+u8CQ3eWbe9REYVnzbl7yof+Yiv/IIQ==}
+  /@fluidframework/location-redirection-utils/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-Qw9qIeJF6GYVgDFvUFaL1FpceiDu7kKbSWTMF9wHl8OqFeAKtDo5dsnJLSFXA+7XlAQ4kxvUSIVBe4mLp2ddtA==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/map/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-Cw/beHGz2ZrgijPUY4c5GF2D5e1kJKulXT1MElpuxQMvDlLhxr2Y67oHeNjHCcKwh7Dv2GcrT7PBbw/AUi4zWQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
+      '@fluidframework/container-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.4.0.0
+      path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/map/2.0.0-internal.4.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-Cw/beHGz2ZrgijPUY4c5GF2D5e1kJKulXT1MElpuxQMvDlLhxr2Y67oHeNjHCcKwh7Dv2GcrT7PBbw/AUi4zWQ==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.4.0.0_debug@4.3.4
+      path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/matrix/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-/DUU712IQ9v5itAm+UkIDkkDHgHBU661fgzp4SVJcpTc1cOXx9TR+cNgKSXdITo27BdcRNxe9wudrFMiSipd4Q==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/merge-tree': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/server-local-server': 0.1038.4000
-      '@fluidframework/server-services-client': 0.1038.4000
-      '@fluidframework/server-services-core': 0.1038.4000
-      '@fluidframework/server-test-utils': 0.1038.4000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      events: 3.3.0
-      jsrsasign: 10.7.0
-      url: 0.11.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/location-redirection-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-RZhB/NjJI2LG46I7qMlXzsRYo+vLGQPmWtFmaO2fZozIMhFZPV0NXfwxcL4BySpsc7aPkp3Tom22iD0Q5exNcw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/map/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-CZYl0nj9Zvb2ibEuRjbE62tuk1sNFV5Q/vVDmXlnbTGnbeqxcQ5nknQCcAU1FZzH1kEZibqG0/3CAZQRxWhySg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      path-browserify: 1.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/map/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-WWgLK7Px7lFJEB5I33PTztw68QRlZLxEMdiGMvGyS2v+e+qIbxoLtmdnqS+jdrcyRbjQYRIg8bfaPnDXrcjx3A==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      path-browserify: 1.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/map/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-WWgLK7Px7lFJEB5I33PTztw68QRlZLxEMdiGMvGyS2v+e+qIbxoLtmdnqS+jdrcyRbjQYRIg8bfaPnDXrcjx3A==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1_debug@4.3.4
-      path-browserify: 1.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/matrix/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-HghTmkCx3BWIWaAz4qA9Fm3V8TKGmqmq4v2jRztCnoauxRhDiPflkz4bqhEkxPpCZQodaIVJZfKiBq5z+quZ5A==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       '@tiny-calc/nano': 0.0.0-alpha.5
       events: 3.3.0
       tslib: 1.14.1
@@ -13775,91 +13492,42 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/matrix/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-UqT0kDIOxNhnB9pchRgAREJn2WS5Yi/I+a+aYUz1PENlDIPw5/l4GwUnBL994i+lnni1yfZJELbnf6bs3mmQtg==}
+  /@fluidframework/merge-tree/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-ojfOreZsylKiSILRJO5LBAaowaliCDdS8hhWbAzneioJ4sAIZ8CskNXbA5XihqUhyRfWZqzaR8h0sdKuM1sWMA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-base': 0.1038.4000
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      '@tiny-calc/nano': 0.0.0-alpha.5
-      events: 3.3.0
-      tslib: 1.14.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/merge-tree/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-cazYDLeIXz86trBbCNVhiMnOffD9+QChuWKfa+H/USykXjCPfs/jQIoNbAaDeLyI8jrsfGb4YyCL2ZZmgYmyWg==}
+  /@fluidframework/mocha-test-setup/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-vD3VoPvK9NyYzgCZtj79Ez8GrkknNUzF47YaX8paOIv1XWiQM+mV9Hk9KejBP0/9S1fVnrfyRU3NYAiduQTLjA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/merge-tree/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-KoQ/V2BeS/Fs7P/n5llyOboX9ZJ3FdFpbGCkyjaMKPlhGxIoxjD2m7qKriIerrULMuIaO3PDn43cd6N3dQxo2g==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/mocha-test-setup/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-LZMcnGk1ccVak3NOsLaM1emUNIS6+Un3Ivdweo0uz8GF5WJSgeDTLxthjwX3GO6OQ7xiUpMk0OLXyAeguBjmCg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.4.0.0
       mocha: 10.2.0
     dev: true
 
-  /@fluidframework/mocha-test-setup/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-shdZZSxDquzdwFkWquw7bCCzR/QkBTs3xdW+RD99KW5cDQvGeNK/RFva426VA7le2QM46xexdQzNlW8TFD4QTg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
-      mocha: 10.2.0
-    dev: true
-
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-GshBGwxZwbt2HjUVfRTInLxGcT9feybg3iJXVNcSBsEsv2lBavxPdSQEzXUmY8sYcKSj6f98ZBFEUgvtLuhrTw==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-RsFSLPFAq0ra9A4t0JcMeOWNCdge1tSH2PVzhc06rPFLZIjbi881epicSNaIisTxh2cBZdr7rfA40KVjFSdFzA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       node-fetch: 2.6.9
     transitivePeerDependencies:
       - debug
@@ -13867,15 +13535,15 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-JwweD3mRWnLo0sF8i0TDXhOHUFNYxrOBy9GOtxHlEdWVLkjvyVg0FBxoXWw4BoMtMdKhjKTWcHAY83fRtFW6Nw==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.4.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-RsFSLPFAq0ra9A4t0JcMeOWNCdge1tSH2PVzhc06rPFLZIjbi881epicSNaIisTxh2cBZdr7rfA40KVjFSdFzA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       node-fetch: 2.6.9
     transitivePeerDependencies:
       - debug
@@ -13883,49 +13551,27 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-JwweD3mRWnLo0sF8i0TDXhOHUFNYxrOBy9GOtxHlEdWVLkjvyVg0FBxoXWw4BoMtMdKhjKTWcHAY83fRtFW6Nw==}
+  /@fluidframework/odsp-driver-definitions/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-X8LM9B3EacY4whBe1mRaMcbQh2gdws+4z8UQ3KK+zi70HFoXUqhG0aiCvGIBGarHnNq+lIPB0NuVgW6VFp4efg==}
+    dependencies:
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+    dev: true
+
+  /@fluidframework/odsp-driver/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-nd3KoblLx69WNKI8G4TLrtEpd6o6I22oh+ezZ6zBDctuOX6iwqJ30goFrp1+nsC74+P61CH8HrKgcf96L4N9ZQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      node-fetch: 2.6.9
-    transitivePeerDependencies:
-      - debug
-      - encoding
-      - supports-color
-    dev: true
-
-  /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-S2ojncuUUXmznSdHJdPk1JTQiVHGisyNvBJ3/Q6ZlwwTBAxg2Lge/3IxOSpqaZJCwzuWNzxXoXRSEmtdcW+u2w==}
-    dependencies:
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-    dev: true
-
-  /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-H5CANR8BkOsRDT3F/1w+O9tnQVJnPfZyxdLuXM4TQ/TupQ1W0imIyAbNcCtzorO3af/CPsv7N+RaObC6yht/cg==}
-    dependencies:
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-    dev: true
-
-  /@fluidframework/odsp-driver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-ell+1uDdrsAvDX/c9sowlrvwzeMYYg7S+EWrPyomjKSyU3SKBjoXFzPXyWWl0eXEx0fokefmNROrorpBff11ew==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-base': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/gitresources': 0.1038.4000
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       abort-controller: 3.0.0
       node-fetch: 2.6.9
       socket.io-client: 4.6.1
@@ -13938,25 +13584,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/odsp-driver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-gFA9ecSo1f4MIn9uGOpHyKOafErs0rVDWoQQwyVU+yuF+/dD7Xa6LfKAbVSdfmK2LINlgTyfMqg3esUD8MQp7w==}
+  /@fluidframework/odsp-urlresolver/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-UWirt8YY/zHrilbN1CaEnG12ooxLh/U5/MWcXfOM+nKyDOp55ScaO6Zi+OnnxinfFw0fgZffj8F1QRSzPf+1iQ==}
     dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/gitresources': 0.1038.4000
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      abort-controller: 3.0.0
-      node-fetch: 2.6.9
-      socket.io-client: 4.6.1
-      uuid: 8.3.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.4.0.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -13965,46 +13599,16 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/odsp-urlresolver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-nipuppWvjBzcyHNVac/+ApOM1GyIfgreV3BShmseogY6/E92R0gjtl3btfPwk0LUxsEaZhCcWfRIJ5HJjc7IXg==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/odsp-urlresolver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-1zsN7qVTZrJE4Gfn67MlNpGbmOsJtGp8zrzGQst7zTuaEqRVp3kJ+VTv9yqWB6fg0xSCbnDGuk6L8wqhSRzC0g==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/ordered-collection/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-44oSz5XqCOVs9WHaY2gFaw9r/WmldVL++Wq1O3655dcZTdAm79XtSk5Bj2m/0gAxUBmYm/pxKBXGEXcJHzg3TQ==}
+  /@fluidframework/ordered-collection/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-kWgONixskFl25H19G1my/ZaNKqqMh59BhZVabI5Jh5V1OQKD/tmfKId7X9hv3Ox/jZb/yg+OqxobKSad9keiHw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.4.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -14034,101 +13638,60 @@ packages:
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
 
-  /@fluidframework/register-collection/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-rFBMkXx+sxpGrOhjS08soiPoKFjU2ADU0DMyQweo3mqx70RmS6CsKvuohfjL0PnWeY32SCgJ35MYUeypVfRqOQ==}
+  /@fluidframework/register-collection/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-RFpT8mvhC2qIuNrbJ3My8d0cLYu36zN8lsdJbDn6R0VPKffOppiwYurawqCl8jc9nCK036U9lfKZ/7AuMuGkJw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/register-collection/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-0si80lawOnCLrWXxHdwV+fMuZp6QZwgJRANYd9WcLwWEYbuWr1/OjsS66gwAWOnngp8bfAlWRhrp18knvvtjAw==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/replay-driver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-mS7oI16b2+SrfsTmuEx5w9+wROIavR5nMlCRWLS1PK1KzDeJ4HwH8xDa6DPe7rYP6PfYyLSryPrCNmNmitHOEg==}
+  /@fluidframework/replay-driver/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-R0mZhut+K0a0kKiuh7cE1vdVIgZKmG4Rzu4/Y+lYnyWxHWzxxDU8tdJ6grt1z85dEk99p7n/el5hNbCmEqIZWA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/replay-driver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-nRrYeAevWpikXtgLml3oi3NajMqj3Qm1+CNs7llTUdVWhbJC0F9wSqTdbuYDgAEhZ4pFzJ2s/tSkbnnh8cf6Uw==}
+  /@fluidframework/request-handler/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-x8ewEfrsS7KlKFCojnBpsbLmGXrS4FDfWXSc2kOiPY3/yjwbXbSQjG0/OoWkJuV9H4TWoIxflRKY1MJRb8aQWg==}
+    dependencies:
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/routerlicious-driver/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-hMW7aL/kziAdYl5d7FwB3mJ0q4vJ58zOJQk4JXa/O++llBPMtf/pUfDJDj4q3wLSCx7Y75LvQvuqoss45XYmQQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/request-handler/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-Ibo63Q8Tx5f/9RG0k9/XGK7naoMphyLGjmYmVP6GEfF7P9QwXKJ1rdXNL+LvtfN8uSHuWmNygZ2YWnjhq+X4bQ==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/request-handler/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-8GckLkahngAznLpMedJk8Qo1IWhXjl2BhfA+8dKCOXeEn5IdgzdYupjeN3CMjCydERK3nfyRRSiv0pp0ipG4lA==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/routerlicious-driver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-gLLONsTz1trnW1wtCQtXhPyYdy+qQNcI4wNs+ZfPviWKKFwG8LAd9o6lX6VTB7f6CXani3q3USffFvrxKQDhPA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-base': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/gitresources': 0.1038.4000
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
       '@fluidframework/server-services-client': 0.1038.4000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       cross-fetch: 3.1.5
       json-stringify-safe: 5.0.1
       querystring: 0.2.1
@@ -14143,19 +13706,19 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-blOaZmEQAzTh6ajJ856IK2foyRJykzy1Tq0O78iVS0jCo46hQNejKvRw0+NA/xlYIv05xKWNTsfmrkTXXHsMmw==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.4.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-hMW7aL/kziAdYl5d7FwB3mJ0q4vJ58zOJQk4JXa/O++llBPMtf/pUfDJDj4q3wLSCx7Y75LvQvuqoss45XYmQQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-base': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0_debug@4.3.4
       '@fluidframework/gitresources': 0.1038.4000
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
       '@fluidframework/server-services-client': 0.1038.4000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       cross-fetch: 3.1.5
       json-stringify-safe: 5.0.1
       querystring: 0.2.1
@@ -14170,50 +13733,12 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-blOaZmEQAzTh6ajJ856IK2foyRJykzy1Tq0O78iVS0jCo46hQNejKvRw0+NA/xlYIv05xKWNTsfmrkTXXHsMmw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/gitresources': 0.1038.4000
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/server-services-client': 0.1038.4000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      cross-fetch: 3.1.5
-      json-stringify-safe: 5.0.1
-      querystring: 0.2.1
-      socket.io-client: 4.6.1
-      url-parse: 1.5.10
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-ol2F4Ux7sRq40JS3D6BUUfd/yqTGjhNaw3AMWm2HfeQ/hizFNAckvLdeqxFzJg//3bEGtueaQ1CfUFUPJebIsw==}
+  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-/sSh1NPdUtC0i83IihK4/BNgkr4/xDxIlObnD1jZbnRRp8u6Xfpj7hypK4uu5FaznYXJOXiTDd9asFub8L1p/g==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      nconf: 0.12.0
-      url: 0.11.0
-    dev: true
-
-  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-JE/8oIpAHfSmtCbsdQvVbTnd5J2o5f/vWeXeXQ9w1pK42Z70Pt5IVfcjhIRHBR6xaThlbM/xDawqJSeET+qKhg==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
       nconf: 0.12.0
       url: 0.11.0
@@ -14230,25 +13755,14 @@ packages:
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
-  /@fluidframework/runtime-definitions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-l28uA04tYt9c28yo0kexz7cw0sgwVkce0ruLfvpE6gHtxG/mnbJO6NzokBTL5TDdF6pVukzMhUBzSTRT3RcYHw==}
+  /@fluidframework/runtime-definitions/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-RvfimKkGluIH1mweSzEpmoVe59wjnuWzsQWYtumL54P4fF8DP3teoQZmzThbp2gGB9DiPMl+i7yRZ3xvYjUEAQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-    dev: true
-
-  /@fluidframework/runtime-definitions/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-H7lY1krb27M76qRuoPi7hI2dyEuQVHzYdPd430SyI7WHqh4Q1vrU5FrNF8VHgeN8x7Ol60jNiWJ8LyRf6OKSKA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
@@ -14270,78 +13784,38 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/runtime-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-EG9kLvnEERriEoKQJAq6gBfzQK7gk412zFjiTaYSvVN6pzY+xNB3OXnxjmRMOuYOkOu9N03dAuoAZ4Mu0TMU7Q==}
+  /@fluidframework/runtime-utils/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-sK0jgCoKsk39zcZHvJyvCkRu25yDBKwN3IxRocdx9z1kel1ZilXR9kzpmZdJ8okWDNYC/1deWTBR5rHPjODOmA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/runtime-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-+LVuXcvVuuxky2v8+QvkRWNJUpHl0DZ0DhmtfrQSTKGx74NFWQDFhWoyuT3EqJd9ULcvHwF5ZuoKpaw7qBtx9A==}
+  /@fluidframework/sequence/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-DT4QS+VC5q59jGnVQNKdzfrd8a8pJNOknIOn58ibrrQtWi2nLzP+Ex3FBTO9uz6LjZtRIk+PKvsvS7x1pBiDgA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-base': 0.1038.4000
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/merge-tree': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/sequence/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-I6UCsATCKKGfftrSnEOHs4JtZfAmIezO3V34IB6G416ykiOn9iSrzj3gpfiHG3tFFGwOzREODYR4DeMmtDn3bA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/sequence/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-33aAJY1KiQXQYCrZrxU4LuQaRNwRhSyH8GnQ8q0bmp3wkok8WL1YGcb/vJSNKg5MfYce8OB+jaERG9xC9OwkIg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -14715,105 +14189,80 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/shared-object-base/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-n9aSMWNx+s12WDkfxJVle2BWr9glvQSfNxVl5ZUSji6fcP8TRfBEhZl8oblqJVpMjTLuoYbS25rfegZPam3bmg==}
+  /@fluidframework/shared-object-base/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-HjG/Zgq384XIr8O+/Drm8i4ei5iEPFy5e/d9u1YLUzO6+lfTtVknGrivY+czuL4JS+EXdE/QQBAaA3iWrgAWgw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.4.0.0
+      '@fluidframework/container-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-object-base/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-FMjPUhfPiIbykOI+I12gOgAPq6rLCB8oQOaVfT2+cYz0EuOEQ1OCFq3dGAvcyFSyt6nQZFPErqb7zRLM2eS6yQ==}
+  /@fluidframework/shared-object-base/2.0.0-internal.4.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-HjG/Zgq384XIr8O+/Drm8i4ei5iEPFy5e/d9u1YLUzO6+lfTtVknGrivY+czuL4JS+EXdE/QQBAaA3iWrgAWgw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-runtime': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/container-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-object-base/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-FMjPUhfPiIbykOI+I12gOgAPq6rLCB8oQOaVfT2+cYz0EuOEQ1OCFq3dGAvcyFSyt6nQZFPErqb7zRLM2eS6yQ==}
+  /@fluidframework/shared-summary-block/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-7I256x+PyUgN33PD4agsWCC1XEsfW4KsKA8wbZbykIQp3/p3jm7O5GAYNMdM4Yr7VbCg/t0WLqwZ6kCnXsCW3Q==}
     dependencies:
-      '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      uuid: 8.3.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.4.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-summary-block/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-xNKeEUKtFSj/wTOkGKNmV/C6nOBDHxd3Q7aGeiLEaKEFASDGYvXOahpb2KkWcjLQ7YlzG9sx9j5iHbyKpEE37Q==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
+  /@fluidframework/synthesize/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-E+KyYj44KoXSnYNHjcdaj932dktxdZjlnQp0lYx6Iw/IEwF7zDNFpWNjnrrG8mWeceqL7oov13vInjwwJjty1g==}
     dev: true
 
-  /@fluidframework/synthesize/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-lJbTdNe2vl/zpawe5i3MnFcslaBQLxMLWs8S+miFTGL5GkVeisFZ34D+q8Cm7EMTb0/Kv6z90kMEfs8LCQDsOg==}
-    dev: true
-
-  /@fluidframework/synthesize/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-LzOUUCMoD69n+qH50DOw2WlMQ/viOPAxe0KFcRVVPftwqqStABx2hBzVm06811+0nCVPDfsnFvwwIkdupzTK6A==}
-    dev: true
-
-  /@fluidframework/task-manager/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-W0LGdGvFff0+T0UD/94NI3TZKcK13nHOsL98yHC5w2bGn0Up7yJmOfo82zAGe0XGSVu2lZ0SWLkmlLfE4POFRg==}
+  /@fluidframework/task-manager/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-B9yVGKUa8dVoN/HTtpswW5vfyfGlsu76Qfwk0yHiDsd24nQ+Qj86gWzCN0sJbCWVjANoNoeu56pQkPZ3yThdLg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.4.0.0
       events: 3.3.0
     transitivePeerDependencies:
       - debug
@@ -14832,8 +14281,8 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/telemetry-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-+h+r/mSNsEUAoqmMtcm6ETb+LAohD92TJWnPrE1r0VM4pgbSry1DBWKwohnIkYOFdgW4Nh4mAMU8MMzZOWB3BQ==}
+  /@fluidframework/telemetry-utils/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-Moda9ooGEPKRyYj9z7YceGdlIwaP63xKvb39JZZIguweGqGPJmmDhFqdrIbF3eoDAwfiytbUo03hI5qlJxWeFQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
@@ -14844,23 +14293,11 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/telemetry-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-IbJe5y9hno1k7C/ZrJsaCuefGXtrwYh1Ro8d0nY2XaZbPCD0u6nYzDhKY/UtyUfq5wC8mCMHx/JgzGzkekhd8w==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      debug: 4.3.4
-      events: 3.3.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/test-client-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-WylamsOD6oCcOq6sYhU1woplNW/YKyABnjjAOCIyRnrraDDaZEe9PDVGGaomNXuicLGu3oASxHfKBC8vqAGLVA==}
+  /@fluidframework/test-client-utils/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-97Ml5+f7aDgObAtUmzbd3nDSgWJx8HOmAdG/QTMsyuWJ4rNQ7JmaBtECfXQNrPPSklddF8mUpQBmmzhCufNybg==}
     dependencies:
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.4.0.0
       sillyname: 0.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -14871,56 +14308,31 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-client-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-xoQbJ0/kTXbAHobFKblydSDSmrsRJg6cRmg2MsbZAABFd28mh5ez8WYcng2OQgZGGPjh6mSULjSOlYVvnyfSzw==}
-    dependencies:
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1
-      sillyname: 0.1.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/test-driver-definitions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-ZFuLpORr7mlb5s9XZBym3irazL8N270PNymK1nx/jqDHNvPL4z+j2syUoQ21dJLl3JEyxfQmdC80SF8XvXi3cg==}
+  /@fluidframework/test-driver-definitions/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-EIg/XhoftzVDB/FYzIxoRTYUxGM+mpSf/UV2xdoCYf5AlaWGIuXsqLRBThdHlRVQMENbNtDRr95puRbvgU/pGQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
       uuid: 8.3.2
     dev: true
 
-  /@fluidframework/test-driver-definitions/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-wmLxVq2MkY/UF7As3U0bjXY+QUNsJGa9jjCqTnBMKqQxlHU5Yyp+9VgKtC168krDx/ej8Ycvbfh03hHFHcN/Ow==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      uuid: 8.3.2
-    dev: true
-
-  /@fluidframework/test-runtime-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-rrulWN8F0h11R1KQJ7q8IUxueTIB5279VpLYjIf5mbuT6dxw397MvtTYxux/6m0R8538aKHtab0159+mSKAx/w==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-K7YYt3hAFbrmCC4m7sCQNopxpAx9WnLKuXSesJ660+RhlE6S06GDJoOlA41rqhUcIknGbZUMhid/TdtrxoRijA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       axios: 0.26.1
       events: 3.3.0
       jsrsasign: 10.7.0
@@ -14933,48 +14345,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-1rv5Lad8A/3eoOUKs3iiLX5FchZfbovSYH9RRt0Fp+KOVHycwVRAci7kDlECuPKm9+ai0BWSSZXNSdwgMhbxKA==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.4.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-K7YYt3hAFbrmCC4m7sCQNopxpAx9WnLKuXSesJ660+RhlE6S06GDJoOlA41rqhUcIknGbZUMhid/TdtrxoRijA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      axios: 0.26.1
-      events: 3.3.0
-      jsrsasign: 10.7.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/test-runtime-utils/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-1rv5Lad8A/3eoOUKs3iiLX5FchZfbovSYH9RRt0Fp+KOVHycwVRAci7kDlECuPKm9+ai0BWSSZXNSdwgMhbxKA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
       axios: 0.26.1_debug@4.3.4
       events: 3.3.0
       jsrsasign: 10.7.0
@@ -14992,32 +14377,31 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/test-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-1r+Gu0j690iBD0K9kQg+p3Nz30zmElC8lS0nQ2qR+pfjvhO8Mi0noyxm3ChnrQknP6+h9mmghrXXaRwIPtTuQQ==}
+  /@fluidframework/test-utils/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-stGyTUqsq4dDiOuRcnTFpIEN0Blk3nWLjW2cJo1cIcq7pX3EOLaXY71vr0EP9iOJi4/IGIXeM/u70DqRVO4VQw==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1_debug@4.3.4
+      '@fluidframework/aqueduct': 2.0.0-internal.4.0.0_debug@4.3.4
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/local-driver': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/map': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/mocha-test-setup': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/container-runtime': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/datastore': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/local-driver': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/map': 2.0.0-internal.4.0.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.4.0.0
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.4.0.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.4.0.0_debug@4.3.4
       best-random: 1.0.3
       debug: 4.3.4
       uuid: 8.3.2
@@ -15028,8 +14412,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-client/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-9g/HnsT3nUMLEP3QRBb7EatnBZOqcQ2vK6HcaOiiwOZG7RyMV5H6bpBRr+EusNjHsTbozNDXOvcYeCyRfCHoFg==}
+  /@fluidframework/tinylicious-client/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-Drq42XlZ7IEJZWJOgTtyRQYUksPd1ADXhab3/zsdkqIPHYgLBJUaP1htzDoVA+DktExOLVNUjP1P4C7cLeTdig==}
     peerDependencies:
       fluid-framework: '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
     peerDependenciesMeta:
@@ -15038,16 +14422,16 @@ packages:
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/fluid-static': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/container-loader': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/fluid-static': 2.0.0-internal.4.0.0
+      '@fluidframework/map': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/tinylicious-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.4.0.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.4.0.0
+      '@fluidframework/tinylicious-driver': 2.0.0-internal.4.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -15057,14 +14441,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-driver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-ObO4ONwwpAEtANqNFCWyw5xZrF56AYlMARcuqZMb8TjmrLl373IDm4G8T2+QMQ1Ij5zp6tV8PsTNvnQoXuG7fg==}
+  /@fluidframework/tinylicious-driver/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-B3bzj38QO5cga2NT/CjA2iQ6XA3R/R5rrs5j13O8bGwM/HcynKIdLJajjBS8VeWVrn3SoSLBimPwDOiI340ijg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.4.0.0
+      '@fluidframework/driver-utils': 2.0.0-internal.4.0.0
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.4.0.0
       '@fluidframework/server-services-client': 0.1038.4000
       jsrsasign: 10.7.0
       uuid: 8.3.2
@@ -15076,30 +14460,11 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-driver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-QzTKXFnvJ9VC0UcIRTI3w6sYxomRFoNqo4DuyNjYYGRbOt8kLL6zVRm9bw8cQTx5CQyOPXdBC7fefndTmFX6jA==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/server-services-client': 0.1038.4000
-      jsrsasign: 10.7.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/tool-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-WRvLSGzx3pU5Npo1n1xyjW4iUi3HYkyMAEFi/E2/pSQ4Q/C5fRVt3aQ1pd5CGUQjgkqiKBwNduh82Ib83Hj8dQ==}
+  /@fluidframework/tool-utils/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-caJuV/lS9+EYC4tOe321/tAZAVSggNSBiZjJiYdiKWwav+FcSjL7tua+LCAOYMuLZ6VyHnVLho9Sq7hnLxFAxg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1_debug@4.3.4
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.4.0.0_debug@4.3.4
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
       async-mutex: 0.3.2
@@ -15111,73 +14476,32 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/tool-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-SX4uwiWSIluVGgmqvCz0NE/V49pbF0CVkAKo4pfRCT0j37hKqbn6WiYsZ5KtsajFMSiX38RQMcUZDmm2yi7m5Q==}
+  /@fluidframework/undo-redo/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-sdgqLXtDKnlgJvWh8Btyp2issOqGzy0h6nAyaWVEykP49K6b2SQ5WrB+jqDqGCYgaqox4fCaUBbmEV6NKj85cw==}
     dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      async-mutex: 0.3.2
-      debug: 4.3.4
-      jwt-decode: 2.2.0
-      proper-lockfile: 4.1.2
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: true
-
-  /@fluidframework/undo-redo/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-WjV1sRNEy+ilXvjJFiZyDg3Sx4d9+hDefjYbMMkNqaSxBZm9M0S/KMucx1VYdX2jRYeTm/LpMgozPVMis3tjnw==}
-    dependencies:
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/matrix': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/sequence': 2.0.0-internal.3.3.1
+      '@fluidframework/map': 2.0.0-internal.4.0.0
+      '@fluidframework/matrix': 2.0.0-internal.4.0.0
+      '@fluidframework/merge-tree': 2.0.0-internal.4.0.0
+      '@fluidframework/sequence': 2.0.0-internal.4.0.0
       events: 3.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/view-adapters/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-PYDZ25qm6KrpeDxzG6KQ3c9K8trpq17lWstBjHnKe6IcuuKF9xacj8jZtdniP0pNuHjmW7SJeP9nS/xIQzefiA==}
+  /@fluidframework/view-adapters/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-F2EELRrxCH6YwDBw62Eokj8bfLXy7BQINzh/sJ9zei5MkD/9VXNfiXp53yn9x8sGsidwSLXAui9VNKp0/Wvgxg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.4.0.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
-  /@fluidframework/view-adapters/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-0DP8kokVHt+RqnODAa5DSGY0YbxwhJg6ET8eyeP7i/n/5ocTDHnlbfPng/HHg0gq8CsETL0lwByQx3GwcWkFwA==}
+  /@fluidframework/view-interfaces/2.0.0-internal.4.0.0:
+    resolution: {integrity: sha512-d6qNjvYE+lJ/NzbNJiD+WvJ7fWYnlFsjZ2Wmca+9xSpTBqzqRWaAV3uh9PaB0X7QZZHX2+oAeOVCHyJgE4m1ZA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.3.1
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-    dev: true
-
-  /@fluidframework/view-interfaces/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-kwMOGl/stYyRiiL0+C7RwKLQewQHNghEVAD1HyJspDZ42fHA27SUOFfleCU6bz+lmZv+CRgNiXZynzFI1s//IA==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-    dev: true
-
-  /@fluidframework/view-interfaces/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-bho8Heaeac84WeCid3yuhzkImqCxH+ABGbJk09PG+YKSal/PTK6nnDz+dm69lIpRqpb1xh7mNF9NqBUUnSJ7nA==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-    dev: true
-
-  /@fluidframework/web-code-loader/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-LMBuFaKn8oZfEvOaBVFXqI9esyPISJaoVCTiRaOiWOAl5xrzcfazZpGKUrKaZ7H8QDN4+2R6I/mxnVFvhCMe6g==}
-    dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      isomorphic-fetch: 3.0.0
-    transitivePeerDependencies:
-      - encoding
+      '@fluidframework/core-interfaces': 2.0.0-internal.4.0.0
     dev: true
 
   /@gar/promisify/1.1.3:


### PR DESCRIPTION
Updated type tests on the 4.0 release branch by doing the following:

1. Manually disables type testing for end-to-end-tests and remove previous version dependency.
2. Ran `flub typetests -g client --reset --previous --normalize` to prepare the packages.
3. Ran `pnpm i` to install new dependencies.
4. Ran `pnpm typetests:gen` to regenerate type tests.
5. Ran a full build to verify changes.