### PR TITLE
build: Update type tests for 3.4 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 		"tsc": "lerna run tsc --stream",
 		"tsc:fast": "fluid-build  --root . -s tsc",
 		"typetests:gen": "pnpm -r typetests:gen",
-		"typetests:prepare": "flub generate typetests --prepare --releaseGroup client --pin",
+		"typetests:prepare": "flub typetests -g client --reset --previous --normalize",
 		"watch": "concurrently \"npm run watch:tsc\" \"npm run watch:esnext\" \"npm run watch:webpack\"",
 		"watch:esnext": "lerna run --parallel build:esnext -- --watch",
 		"watch:tsc": "lerna run --parallel tsc -- --watch",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -51,7 +51,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.3.2.0",
+		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/events": "^3.0.0",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -44,7 +44,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.3.2.0",
+		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/node": "^14.18.38",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -47,7 +47,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.3.2.0",
+		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -75,7 +75,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.3.2.0",
+		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -74,7 +74,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.3.2.0",
+		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.3.2.0",
+		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.3.4.1",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.3.2.0",
+		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.3.4.1",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/map/src/test/types/validateMapPrevious.generated.ts
+++ b/packages/dds/map/src/test/types/validateMapPrevious.generated.ts
@@ -40,6 +40,30 @@ use_old_ClassDeclaration_DirectoryFactory(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ICreateInfo": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ICreateInfo():
+    TypeOnly<old.ICreateInfo>;
+declare function use_current_InterfaceDeclaration_ICreateInfo(
+    use: TypeOnly<current.ICreateInfo>);
+use_current_InterfaceDeclaration_ICreateInfo(
+    get_old_InterfaceDeclaration_ICreateInfo());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ICreateInfo": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ICreateInfo():
+    TypeOnly<current.ICreateInfo>;
+declare function use_old_InterfaceDeclaration_ICreateInfo(
+    use: TypeOnly<old.ICreateInfo>);
+use_old_InterfaceDeclaration_ICreateInfo(
+    get_current_InterfaceDeclaration_ICreateInfo());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IDirectory": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IDirectory():

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -86,7 +86,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.3.2.0",
+		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.3.4.1",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.3.2.0",
+		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.3.4.1",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-pairwise-generator": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.3.2.0",
+		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.3.4.1",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.3.2.0",
+		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.3.4.1",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -92,7 +92,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/gitresources": "^0.1038.4000",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.3.2.0",
+		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.3.4.1",
 		"@fluidframework/server-services-client": "^0.1038.4000",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.3.2.0",
+		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.3.4.1",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.3.2.0",
+		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.3.4.1",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.3.2.0",
+		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.3.4.1",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -46,7 +46,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.3.2.0",
+		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -47,7 +47,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.3.2.0",
+		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/node": "^14.18.38",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -48,7 +48,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.3.2.0",
+		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/jest": "22.2.3",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -47,7 +47,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.3.2.0",
+		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/node": "^14.18.38",
 		"concurrently": "^7.6.0",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -47,7 +47,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.13.0",
-		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.3.2.0",
+		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.3.4.1",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -87,7 +87,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.3.2.0",
+		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.3.4.1",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/jsrsasign": "^8.0.8",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -45,7 +45,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.3.2.0",
+		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.3.4.1",
 		"@fluidframework/protocol-definitions": "^1.1.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.3.2.0",
+		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -50,7 +50,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.3.2.0",
+		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.3.4.1",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
 		"concurrently": "^7.6.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -48,7 +48,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.3.2.0",
+		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.3.2.0",
+		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -52,7 +52,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.3.2.0",
+		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.3.4.1",
 		"@types/mocha": "^9.1.1",
 		"@types/nconf": "^0.10.0",
 		"@types/node": "^14.18.38",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -53,7 +53,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-tools": "^0.2.3074",
-		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.3.2.0",
+		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.3.4.1",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -70,7 +70,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.13.0",
-		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.3.2.0",
+		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.3.4.1",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -84,7 +84,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.13.0",
-		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.3.2.0",
+		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.3.4.1",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -79,7 +79,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.3.2.0",
+		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -73,7 +73,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.3.2.0",
+		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -79,7 +79,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.3.2.0",
+		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.3.4.1",
 		"@fluidframework/map": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/sequence": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",

--- a/packages/framework/oldest-client-observer/package.json
+++ b/packages/framework/oldest-client-observer/package.json
@@ -85,7 +85,7 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {},
-		"disabled": true
+		"disabled": true,
+		"broken": {}
 	}
 }

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -74,7 +74,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.3.2.0",
+		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.3.4.1",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/diff": "^3.5.1",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -72,7 +72,7 @@
 		"@fluidframework/datastore": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.3.2.0",
+		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/framework/test-client-utils/package.json
+++ b/packages/framework/test-client-utils/package.json
@@ -49,7 +49,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/test-client-utils-previous": "npm:@fluidframework/test-client-utils@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/uuid": "^8.3.0",
 		"concurrently": "^7.6.0",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -64,7 +64,7 @@
 		"@fluidframework/container-runtime-definitions": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/test-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.3.2.0",
+		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.3.2.0",
+		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/diff": "^3.5.1",
 		"@types/events": "^3.0.0",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -48,7 +48,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.3.2.0",
+		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -45,7 +45,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.3.2.0",
+		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -84,7 +84,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.3.2.0",
+		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-loader-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",

--- a/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
+++ b/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
@@ -376,6 +376,30 @@ use_old_ClassDeclaration_RelativeLoader(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_requestResolvedObjectFromContainer": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_requestResolvedObjectFromContainer():
+    TypeOnly<typeof old.requestResolvedObjectFromContainer>;
+declare function use_current_FunctionDeclaration_requestResolvedObjectFromContainer(
+    use: TypeOnly<typeof current.requestResolvedObjectFromContainer>);
+use_current_FunctionDeclaration_requestResolvedObjectFromContainer(
+    get_old_FunctionDeclaration_requestResolvedObjectFromContainer());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_requestResolvedObjectFromContainer": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_requestResolvedObjectFromContainer():
+    TypeOnly<typeof current.requestResolvedObjectFromContainer>;
+declare function use_old_FunctionDeclaration_requestResolvedObjectFromContainer(
+    use: TypeOnly<typeof old.requestResolvedObjectFromContainer>);
+use_old_FunctionDeclaration_requestResolvedObjectFromContainer(
+    get_current_FunctionDeclaration_requestResolvedObjectFromContainer());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "FunctionDeclaration_waitContainerToCatchUp": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_waitContainerToCatchUp():

--- a/packages/loader/container-utils/package.json
+++ b/packages/loader/container-utils/package.json
@@ -73,7 +73,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/container-utils-previous": "npm:@fluidframework/container-utils@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",

--- a/packages/loader/container-utils/src/test/types/validateContainerUtilsPrevious.generated.ts
+++ b/packages/loader/container-utils/src/test/types/validateContainerUtilsPrevious.generated.ts
@@ -88,6 +88,30 @@ use_old_ClassDeclaration_DataProcessingError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_DeltaManagerProxyBase": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_DeltaManagerProxyBase():
+    TypeOnly<old.DeltaManagerProxyBase>;
+declare function use_current_ClassDeclaration_DeltaManagerProxyBase(
+    use: TypeOnly<current.DeltaManagerProxyBase>);
+use_current_ClassDeclaration_DeltaManagerProxyBase(
+    get_old_ClassDeclaration_DeltaManagerProxyBase());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_DeltaManagerProxyBase": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_DeltaManagerProxyBase():
+    TypeOnly<current.DeltaManagerProxyBase>;
+declare function use_old_ClassDeclaration_DeltaManagerProxyBase(
+    use: TypeOnly<old.DeltaManagerProxyBase>);
+use_old_ClassDeclaration_DeltaManagerProxyBase(
+    get_current_ClassDeclaration_DeltaManagerProxyBase());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_GenericError": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_GenericError():

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -78,7 +78,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",

--- a/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.generated.ts
+++ b/packages/loader/driver-utils/src/test/types/validateDriverUtilsPrevious.generated.ts
@@ -88,6 +88,30 @@ use_old_ClassDeclaration_BlobCacheStorageService(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_CombinedAppAndProtocolSummary": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_CombinedAppAndProtocolSummary():
+    TypeOnly<old.CombinedAppAndProtocolSummary>;
+declare function use_current_InterfaceDeclaration_CombinedAppAndProtocolSummary(
+    use: TypeOnly<current.CombinedAppAndProtocolSummary>);
+use_current_InterfaceDeclaration_CombinedAppAndProtocolSummary(
+    get_old_InterfaceDeclaration_CombinedAppAndProtocolSummary());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_CombinedAppAndProtocolSummary": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_CombinedAppAndProtocolSummary():
+    TypeOnly<current.CombinedAppAndProtocolSummary>;
+declare function use_old_InterfaceDeclaration_CombinedAppAndProtocolSummary(
+    use: TypeOnly<old.CombinedAppAndProtocolSummary>);
+use_old_InterfaceDeclaration_CombinedAppAndProtocolSummary(
+    get_current_InterfaceDeclaration_CombinedAppAndProtocolSummary());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_DeltaStreamConnectionForbiddenError": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_DeltaStreamConnectionForbiddenError():
@@ -1092,6 +1116,30 @@ declare function use_old_VariableDeclaration_getRetryDelaySecondsFromError(
     use: TypeOnly<typeof old.getRetryDelaySecondsFromError>);
 use_old_VariableDeclaration_getRetryDelaySecondsFromError(
     get_current_VariableDeclaration_getRetryDelaySecondsFromError());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_isCombinedAppAndProtocolSummary": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_isCombinedAppAndProtocolSummary():
+    TypeOnly<typeof old.isCombinedAppAndProtocolSummary>;
+declare function use_current_FunctionDeclaration_isCombinedAppAndProtocolSummary(
+    use: TypeOnly<typeof current.isCombinedAppAndProtocolSummary>);
+use_current_FunctionDeclaration_isCombinedAppAndProtocolSummary(
+    get_old_FunctionDeclaration_isCombinedAppAndProtocolSummary());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_isCombinedAppAndProtocolSummary": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_isCombinedAppAndProtocolSummary():
+    TypeOnly<typeof current.isCombinedAppAndProtocolSummary>;
+declare function use_old_FunctionDeclaration_isCombinedAppAndProtocolSummary(
+    use: TypeOnly<typeof old.isCombinedAppAndProtocolSummary>);
+use_old_FunctionDeclaration_isCombinedAppAndProtocolSummary(
+    get_current_FunctionDeclaration_isCombinedAppAndProtocolSummary());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -73,7 +73,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.3.4.1",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -43,7 +43,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/test-loader-utils-previous": "npm:@fluidframework/test-loader-utils@2.0.0-internal.3.4.1",
 		"concurrently": "^7.6.0",
 		"eslint": "~8.6.0",
 		"prettier": "~2.6.2",

--- a/packages/loader/web-code-loader/package.json
+++ b/packages/loader/web-code-loader/package.json
@@ -46,7 +46,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/protocol-definitions": "^1.1.0",
-		"@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@2.0.0-internal.3.2.0",
+		"@fluidframework/web-code-loader-previous": "npm:@fluidframework/web-code-loader@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/isomorphic-fetch": "^0.0.35",
 		"concurrently": "^7.6.0",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -45,7 +45,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.3.2.0",
+		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -87,7 +87,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.3.2.0",
+		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -45,7 +45,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.3.2.0",
+		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -84,7 +84,7 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
-		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.3.2.0",
+		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.3.4.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@2.0.0-internal.3.2.0",
+		"@fluidframework/garbage-collector-previous": "npm:@fluidframework/garbage-collector@2.0.0-internal.3.4.1",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/events": "^3.0.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -46,7 +46,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.3.2.0",
+		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"concurrently": "^7.6.0",
 		"copyfiles": "^2.4.1",
@@ -56,10 +56,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"TypeAliasDeclaration_AttributionKey": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -83,7 +83,6 @@ declare function get_current_TypeAliasDeclaration_AttributionKey():
 declare function use_old_TypeAliasDeclaration_AttributionKey(
     use: TypeOnly<old.AttributionKey>);
 use_old_TypeAliasDeclaration_AttributionKey(
-    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_AttributionKey());
 
 /*
@@ -1045,6 +1044,30 @@ declare function use_old_TypeAliasDeclaration_InboundAttachMessage(
     use: TypeOnly<old.InboundAttachMessage>);
 use_old_TypeAliasDeclaration_InboundAttachMessage(
     get_current_TypeAliasDeclaration_InboundAttachMessage());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_LocalAttributionKey": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_LocalAttributionKey():
+    TypeOnly<old.LocalAttributionKey>;
+declare function use_current_InterfaceDeclaration_LocalAttributionKey(
+    use: TypeOnly<current.LocalAttributionKey>);
+use_current_InterfaceDeclaration_LocalAttributionKey(
+    get_old_InterfaceDeclaration_LocalAttributionKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_LocalAttributionKey": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_LocalAttributionKey():
+    TypeOnly<current.LocalAttributionKey>;
+declare function use_old_InterfaceDeclaration_LocalAttributionKey(
+    use: TypeOnly<old.LocalAttributionKey>);
+use_old_InterfaceDeclaration_LocalAttributionKey(
+    get_current_InterfaceDeclaration_LocalAttributionKey());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -81,7 +81,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -66,7 +66,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.3.2.0",
+		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -69,7 +69,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.3.2.0",
+		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"concurrently": "^7.6.0",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -84,7 +84,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@2.0.0-internal.3.2.0",
+		"@fluidframework/test-drivers-previous": "npm:@fluidframework/test-drivers@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -128,7 +128,6 @@
 		"@fluid-tools/build-cli": "^0.13.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-end-to-end-tests-previous": "npm:@fluidframework/test-end-to-end-tests@2.0.0-internal.3.2.0",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^14.18.38",
@@ -142,6 +141,7 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
+		"disabled": true,
 		"broken": {}
 	}
 }

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -76,7 +76,7 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {},
-		"disabled": true
+		"disabled": true,
+		"broken": {}
 	}
 }

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -89,7 +89,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/debug": "^4.1.5",
 		"@types/diff": "^3.5.1",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -93,7 +93,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/test-version-utils-previous": "npm:@fluidframework/test-version-utils@2.0.0-internal.3.4.1",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^14.18.38",

--- a/packages/test/test-version-utils/src/test/types/validateTestVersionUtilsPrevious.generated.ts
+++ b/packages/test/test-version-utils/src/test/types/validateTestVersionUtilsPrevious.generated.ts
@@ -16,6 +16,30 @@ type TypeOnly<T> = {
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_BenchmarkType": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_BenchmarkType():
+    TypeOnly<old.BenchmarkType>;
+declare function use_current_TypeAliasDeclaration_BenchmarkType(
+    use: TypeOnly<current.BenchmarkType>);
+use_current_TypeAliasDeclaration_BenchmarkType(
+    get_old_TypeAliasDeclaration_BenchmarkType());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_BenchmarkType": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_BenchmarkType():
+    TypeOnly<current.BenchmarkType>;
+declare function use_old_TypeAliasDeclaration_BenchmarkType(
+    use: TypeOnly<old.BenchmarkType>);
+use_old_TypeAliasDeclaration_BenchmarkType(
+    get_current_TypeAliasDeclaration_BenchmarkType());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "TypeAliasDeclaration_DescribeCompat": {"forwardCompat": false}
 */
 declare function get_old_TypeAliasDeclaration_DescribeCompat():
@@ -60,6 +84,54 @@ declare function use_old_TypeAliasDeclaration_DescribeCompatSuite(
     use: TypeOnly<old.DescribeCompatSuite>);
 use_old_TypeAliasDeclaration_DescribeCompatSuite(
     get_current_TypeAliasDeclaration_DescribeCompatSuite());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_DescribeE2EDocInfo": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_DescribeE2EDocInfo():
+    TypeOnly<old.DescribeE2EDocInfo>;
+declare function use_current_InterfaceDeclaration_DescribeE2EDocInfo(
+    use: TypeOnly<current.DescribeE2EDocInfo>);
+use_current_InterfaceDeclaration_DescribeE2EDocInfo(
+    get_old_InterfaceDeclaration_DescribeE2EDocInfo());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_DescribeE2EDocInfo": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_DescribeE2EDocInfo():
+    TypeOnly<current.DescribeE2EDocInfo>;
+declare function use_old_InterfaceDeclaration_DescribeE2EDocInfo(
+    use: TypeOnly<old.DescribeE2EDocInfo>);
+use_old_InterfaceDeclaration_DescribeE2EDocInfo(
+    get_current_InterfaceDeclaration_DescribeE2EDocInfo());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_DocumentType": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_DocumentType():
+    TypeOnly<old.DocumentType>;
+declare function use_current_TypeAliasDeclaration_DocumentType(
+    use: TypeOnly<current.DocumentType>);
+use_current_TypeAliasDeclaration_DocumentType(
+    get_old_TypeAliasDeclaration_DocumentType());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_DocumentType": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_DocumentType():
+    TypeOnly<current.DocumentType>;
+declare function use_old_TypeAliasDeclaration_DocumentType(
+    use: TypeOnly<old.DocumentType>);
+use_old_TypeAliasDeclaration_DocumentType(
+    get_current_TypeAliasDeclaration_DocumentType());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -180,6 +252,102 @@ declare function use_old_VariableDeclaration_TestDataObjectType(
     use: TypeOnly<typeof old.TestDataObjectType>);
 use_old_VariableDeclaration_TestDataObjectType(
     get_current_VariableDeclaration_TestDataObjectType());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_describeE2EDocRun": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_describeE2EDocRun():
+    TypeOnly<typeof old.describeE2EDocRun>;
+declare function use_current_VariableDeclaration_describeE2EDocRun(
+    use: TypeOnly<typeof current.describeE2EDocRun>);
+use_current_VariableDeclaration_describeE2EDocRun(
+    get_old_VariableDeclaration_describeE2EDocRun());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_describeE2EDocRun": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_describeE2EDocRun():
+    TypeOnly<typeof current.describeE2EDocRun>;
+declare function use_old_VariableDeclaration_describeE2EDocRun(
+    use: TypeOnly<typeof old.describeE2EDocRun>);
+use_old_VariableDeclaration_describeE2EDocRun(
+    get_current_VariableDeclaration_describeE2EDocRun());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_describeE2EDocs": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_describeE2EDocs():
+    TypeOnly<typeof old.describeE2EDocs>;
+declare function use_current_VariableDeclaration_describeE2EDocs(
+    use: TypeOnly<typeof current.describeE2EDocs>);
+use_current_VariableDeclaration_describeE2EDocs(
+    get_old_VariableDeclaration_describeE2EDocs());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_describeE2EDocs": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_describeE2EDocs():
+    TypeOnly<typeof current.describeE2EDocs>;
+declare function use_old_VariableDeclaration_describeE2EDocs(
+    use: TypeOnly<typeof old.describeE2EDocs>);
+use_old_VariableDeclaration_describeE2EDocs(
+    get_current_VariableDeclaration_describeE2EDocs());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_describeE2EDocsMemory": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_describeE2EDocsMemory():
+    TypeOnly<typeof old.describeE2EDocsMemory>;
+declare function use_current_VariableDeclaration_describeE2EDocsMemory(
+    use: TypeOnly<typeof current.describeE2EDocsMemory>);
+use_current_VariableDeclaration_describeE2EDocsMemory(
+    get_old_VariableDeclaration_describeE2EDocsMemory());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_describeE2EDocsMemory": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_describeE2EDocsMemory():
+    TypeOnly<typeof current.describeE2EDocsMemory>;
+declare function use_old_VariableDeclaration_describeE2EDocsMemory(
+    use: TypeOnly<typeof old.describeE2EDocsMemory>);
+use_old_VariableDeclaration_describeE2EDocsMemory(
+    get_current_VariableDeclaration_describeE2EDocsMemory());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_describeE2EDocsRuntime": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_describeE2EDocsRuntime():
+    TypeOnly<typeof old.describeE2EDocsRuntime>;
+declare function use_current_VariableDeclaration_describeE2EDocsRuntime(
+    use: TypeOnly<typeof current.describeE2EDocsRuntime>);
+use_current_VariableDeclaration_describeE2EDocsRuntime(
+    get_old_VariableDeclaration_describeE2EDocsRuntime());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_describeE2EDocsRuntime": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_describeE2EDocsRuntime():
+    TypeOnly<typeof current.describeE2EDocsRuntime>;
+declare function use_old_VariableDeclaration_describeE2EDocsRuntime(
+    use: TypeOnly<typeof old.describeE2EDocsRuntime>);
+use_old_VariableDeclaration_describeE2EDocsRuntime(
+    get_current_VariableDeclaration_describeE2EDocsRuntime());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -324,6 +492,30 @@ declare function use_old_FunctionDeclaration_getContainerRuntimeApi(
     use: TypeOnly<typeof old.getContainerRuntimeApi>);
 use_old_FunctionDeclaration_getContainerRuntimeApi(
     get_current_FunctionDeclaration_getContainerRuntimeApi());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_getCurrentBenchmarkType": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_getCurrentBenchmarkType():
+    TypeOnly<typeof old.getCurrentBenchmarkType>;
+declare function use_current_VariableDeclaration_getCurrentBenchmarkType(
+    use: TypeOnly<typeof current.getCurrentBenchmarkType>);
+use_current_VariableDeclaration_getCurrentBenchmarkType(
+    get_old_VariableDeclaration_getCurrentBenchmarkType());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_getCurrentBenchmarkType": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_getCurrentBenchmarkType():
+    TypeOnly<typeof current.getCurrentBenchmarkType>;
+declare function use_old_VariableDeclaration_getCurrentBenchmarkType(
+    use: TypeOnly<typeof old.getCurrentBenchmarkType>);
+use_old_VariableDeclaration_getCurrentBenchmarkType(
+    get_current_VariableDeclaration_getCurrentBenchmarkType());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -51,7 +51,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.13.0",
-		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.3.2.0",
+		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.3.4.1",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@types/node": "^14.18.38",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.3.2.0",
+		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.3.4.1",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -95,7 +95,7 @@
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.13.0",
-		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.3.2.0",
+		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.3.4.1",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.3.4.1",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
 		"@types/node-fetch": "^2.5.10",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/debug": "^4.1.5",
 		"@types/events": "^3.0.0",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-tools": "^0.13.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": ">=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0",
-		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.3.2.0",
+		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.3.4.1",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@types/debug": "^4.1.5",
 		"@types/jwt-decode": "^2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4699,7 +4699,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
-      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.3.2.0
+      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.3.4.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -4723,7 +4723,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
-      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.3.2.0
+      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4
       '@types/events': 3.0.0
@@ -4739,7 +4739,7 @@ importers:
       '@fluid-tools/build-cli': ^0.13.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
-      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@microsoft/api-extractor': ^7.34.4
       '@types/node': ^14.18.38
@@ -4753,7 +4753,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.3.2.0
+      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/node': 14.18.38
@@ -4815,7 +4815,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.3.2.0
+      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@microsoft/api-extractor': ^7.34.4
@@ -4833,7 +4833,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
-      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.3.2.0
+      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4
       concurrently: 7.6.0
@@ -4849,7 +4849,7 @@ importers:
       '@fluid-tools/build-cli': ^0.13.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
-      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.3.2.0
+      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.3.4.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -4885,7 +4885,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.3.2.0
+      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -4909,7 +4909,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.3.2.0
+      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.3.4.1
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -4942,7 +4942,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.3.2.0
+      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -4969,7 +4969,7 @@ importers:
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.3.2.0
+      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -5001,7 +5001,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.3.2.0
+      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4
@@ -5031,7 +5031,7 @@ importers:
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.3.2.0
+      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -5072,7 +5072,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.3.2.0
+      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
@@ -5101,7 +5101,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.3.2.0
+      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.3.4.1
       '@fluidframework/merge-tree': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.4000
@@ -5154,7 +5154,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.3.2.0
+      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
@@ -5190,7 +5190,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.3.2.0
+      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -5233,7 +5233,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.3.2.0
+      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-pairwise-generator': link:../../test/test-pairwise-generator
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -5264,7 +5264,7 @@ importers:
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.3.2.0
+      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.3.4.1
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -5299,7 +5299,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.3.2.0
+      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.3.4.1
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
@@ -5388,7 +5388,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.4000
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.3.2.0
+      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.3.4.1
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/shared-object-base': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -5419,7 +5419,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.3.2.0
+      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.3.4.1
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
@@ -5455,7 +5455,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.3.2.0
+      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.3.4.1
       '@fluidframework/server-services-client': ^0.1038.4000
       '@fluidframework/shared-object-base': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -5501,7 +5501,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/gitresources': 0.1038.4000
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.3.2.0
+      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.3.4.1
       '@fluidframework/server-services-client': 0.1038.4000
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
@@ -5539,7 +5539,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.3.4.1
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.34.4
@@ -5578,7 +5578,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.3.2.0
+      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.3.4.1
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/benchmark': 2.1.2
@@ -5610,7 +5610,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/shared-object-base': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.3.2.0
+      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.3.4.1
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/benchmark': ^2.1.0
@@ -5640,7 +5640,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.3.2.0
+      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.3.4.1
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/benchmark': 2.1.2
@@ -5677,7 +5677,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/shared-object-base': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.3.2.0
+      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.3.4.1
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -5714,7 +5714,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.3.2.0
+      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.3.4.1
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
@@ -5864,7 +5864,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.3.2.0
+      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.3.4.1
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -5892,7 +5892,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.3.2.0
+      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
@@ -5912,7 +5912,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.3.2.0
+      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.3.4.1
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -5938,7 +5938,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.3.2.0
+      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/node': 14.18.38
@@ -5956,7 +5956,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
-      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.3.2.0
+      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -5981,7 +5981,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.3.2.0
+      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/jest': 22.2.3
@@ -6005,7 +6005,7 @@ importers:
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.3.2.0
+      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.3.4.1
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/replay-driver': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.34.4
@@ -6028,7 +6028,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.3.2.0
+      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/node': 14.18.38
       concurrently: 7.6.0
@@ -6041,7 +6041,7 @@ importers:
   packages/drivers/fluidapp-odsp-urlResolver:
     specifiers:
       '@fluid-tools/build-cli': ^0.13.0
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.3.2.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.3.4.1
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-utils': ^1.1.1
@@ -6068,7 +6068,7 @@ importers:
       '@fluidframework/odsp-driver-definitions': link:../odsp-driver-definitions
     devDependencies:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.2.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.4.1
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -6095,7 +6095,7 @@ importers:
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.3.2.0
+      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.4000
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -6146,7 +6146,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.3.2.0
+      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/jsrsasign': 8.0.13
@@ -6178,7 +6178,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-doclib-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.3.4.1
       '@fluidframework/protocol-base': ^0.1038.4000
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -6225,7 +6225,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -6250,7 +6250,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.3.4.1
       '@fluidframework/protocol-definitions': ^1.1.0
       '@microsoft/api-extractor': ^7.34.4
       concurrently: ^7.6.0
@@ -6267,7 +6267,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.2.0
+      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.4.1
       '@fluidframework/protocol-definitions': 1.1.0
       '@microsoft/api-extractor': 7.34.4
       concurrently: 7.6.0
@@ -6289,7 +6289,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.3.2.0
+      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.3.4.1
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
       concurrently: ^7.6.0
@@ -6310,7 +6310,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.3.2.0
+      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.3.4.1
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
       concurrently: 7.6.0
@@ -6332,7 +6332,7 @@ importers:
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.3.2.0
+      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.3.4.1
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -6358,7 +6358,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.3.2.0
+      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -6387,7 +6387,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.4000
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.3.2.0
+      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.3.4.1
       '@fluidframework/server-services-client': ^0.1038.4000
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.34.4
@@ -6438,7 +6438,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.3.2.0
+      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -6470,7 +6470,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.3.2.0
+      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.3.4.1
       '@types/mocha': ^9.1.1
       '@types/nconf': ^0.10.0
       '@types/node': ^14.18.38
@@ -6497,7 +6497,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.2.0
+      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.4.1
       '@types/mocha': 9.1.1
       '@types/nconf': 0.10.3
       '@types/node': 14.18.38
@@ -6524,7 +6524,7 @@ importers:
       '@fluidframework/routerlicious-driver': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/server-services-client': ^0.1038.4000
       '@fluidframework/test-tools': ^0.2.3074
-      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.3.2.0
+      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.3.4.1
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
@@ -6554,7 +6554,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-tools': 0.2.3074
-      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.3.2.0
+      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.3.4.1
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -6570,7 +6570,7 @@ importers:
   packages/framework/agent-scheduler:
     specifiers:
       '@fluid-tools/build-cli': ^0.13.0
-      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.3.2.0
+      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.3.4.1
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
@@ -6612,7 +6612,7 @@ importers:
       uuid: 8.3.2
     devDependencies:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
-      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.3.2.0
+      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.3.4.1
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -6629,7 +6629,7 @@ importers:
   packages/framework/aqueduct:
     specifiers:
       '@fluid-tools/build-cli': ^0.13.0
-      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.3.2.0
+      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.3.4.1
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
@@ -6681,7 +6681,7 @@ importers:
       uuid: 8.3.2
     devDependencies:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
-      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.3.2.0
+      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.3.4.1
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -6783,7 +6783,7 @@ importers:
       '@fluidframework/container-runtime': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/container-runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.3.2.0
+      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.3.4.1
       '@fluidframework/datastore': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -6820,7 +6820,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.3.2.0
+      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
@@ -6841,7 +6841,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-utils': ^1.1.1
-      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.3.2.0
+      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/merge-tree': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -6875,7 +6875,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.3.2.0
+      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -6955,7 +6955,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.3.2.0
+      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.3.4.1
       '@fluidframework/map': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -6993,7 +6993,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.3.2.0
+      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.3.4.1
       '@fluidframework/map': link:../../dds/map
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/sequence': link:../../dds/sequence
@@ -7073,7 +7073,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.3.2.0
+      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.3.4.1
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -7105,7 +7105,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.3.2.0
+      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.3.4.1
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/diff': 3.5.5
@@ -7133,7 +7133,7 @@ importers:
       '@fluidframework/datastore': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.3.2.0
+      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.3.4.1
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
@@ -7154,7 +7154,7 @@ importers:
       '@fluidframework/datastore': link:../../runtime/datastore
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.3.2.0
+      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -7175,7 +7175,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/test-client-utils-previous': npm:@fluidframework/test-client-utils@2.0.0-internal.3.2.0
+      '@fluidframework/test-client-utils-previous': npm:@fluidframework/test-client-utils@2.0.0-internal.3.4.1
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/uuid': ^8.3.0
@@ -7197,7 +7197,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-client-utils-previous': /@fluidframework/test-client-utils/2.0.0-internal.3.2.0
+      '@fluidframework/test-client-utils-previous': /@fluidframework/test-client-utils/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4
       '@types/uuid': 8.3.4
       concurrently: 7.6.0
@@ -7228,7 +7228,7 @@ importers:
       '@fluidframework/routerlicious-driver': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/test-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.3.2.0
+      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.3.4.1
       '@fluidframework/tinylicious-driver': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -7266,7 +7266,7 @@ importers:
       '@fluidframework/container-runtime-definitions': link:../../runtime/container-runtime-definitions
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/test-utils': link:../../test/test-utils
-      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.3.2.0
+      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -7292,7 +7292,7 @@ importers:
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/sequence': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.3.2.0
+      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.3.4.1
       '@microsoft/api-extractor': ^7.34.4
       '@types/diff': ^3.5.1
       '@types/events': ^3.0.0
@@ -7324,7 +7324,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.3.2.0
+      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/diff': 3.5.5
       '@types/events': 3.0.0
@@ -7350,7 +7350,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.3.2.0
+      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.3.4.1
       '@fluidframework/view-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/react': ^17.0.44
@@ -7373,7 +7373,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.3.2.0
+      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
@@ -7391,7 +7391,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.3.2.0
+      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.3.4.1
       '@microsoft/api-extractor': ^7.34.4
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -7408,7 +7408,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.3.2.0
+      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
@@ -7427,7 +7427,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.3.2.0
+      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.3.4.1
       '@fluidframework/container-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -7482,7 +7482,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.3.2.0
+      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-loader-utils': link:../test-loader-utils
@@ -7512,7 +7512,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/container-utils-previous': npm:@fluidframework/container-utils@2.0.0-internal.3.2.0
+      '@fluidframework/container-utils-previous': npm:@fluidframework/container-utils@2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
@@ -7540,7 +7540,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/container-utils-previous': /@fluidframework/container-utils/2.0.0-internal.3.2.0
+      '@fluidframework/container-utils-previous': /@fluidframework/container-utils/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -7566,7 +7566,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.3.2.0
+      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/gitresources': ^0.1038.4000
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -7607,7 +7607,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.3.2.0
+      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
@@ -7635,7 +7635,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.3.2.0
+      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -7661,7 +7661,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.3.2.0
+      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
@@ -7688,7 +7688,7 @@ importers:
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/test-loader-utils-previous': npm:@fluidframework/test-loader-utils@2.0.0-internal.3.2.0
+      '@fluidframework/test-loader-utils-previous': npm:@fluidframework/test-loader-utils@2.0.0-internal.3.4.1
       concurrently: ^7.6.0
       eslint: ~8.6.0
       prettier: ~2.6.2
@@ -7705,7 +7705,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-loader-utils-previous': /@fluidframework/test-loader-utils/2.0.0-internal.3.2.0
+      '@fluidframework/test-loader-utils-previous': /@fluidframework/test-loader-utils/2.0.0-internal.3.4.1
       concurrently: 7.6.0
       eslint: 8.6.0
       prettier: 2.6.2
@@ -7721,7 +7721,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/web-code-loader-previous': npm:@fluidframework/web-code-loader@2.0.0-internal.3.2.0
+      '@fluidframework/web-code-loader-previous': npm:@fluidframework/web-code-loader@2.0.0-internal.3.4.1
       '@microsoft/api-extractor': ^7.34.4
       '@types/isomorphic-fetch': ^0.0.35
       concurrently: ^7.6.0
@@ -7743,7 +7743,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/web-code-loader-previous': /@fluidframework/web-code-loader/2.0.0-internal.3.2.0
+      '@fluidframework/web-code-loader-previous': /@fluidframework/web-code-loader/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4
       '@types/isomorphic-fetch': 0.0.35
       concurrently: 7.6.0
@@ -7764,7 +7764,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/container-runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.3.4.1
       '@fluidframework/container-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -7823,7 +7823,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
-      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -7851,7 +7851,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.3.4.1
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -7875,7 +7875,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
-      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.3.2.0
+      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4
       concurrently: 7.6.0
@@ -7896,7 +7896,7 @@ importers:
       '@fluidframework/container-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/datastore-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.3.2.0
+      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.3.4.1
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
@@ -7944,7 +7944,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
-      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.3.2.0
+      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -7971,7 +7971,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/container-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -7993,7 +7993,7 @@ importers:
       '@fluid-tools/build-cli': 0.13.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
-      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.3.2.0
+      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.3.4.1
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@microsoft/api-extractor': 7.34.4
       concurrently: 7.6.0
@@ -8011,7 +8011,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/garbage-collector-previous': npm:@fluidframework/garbage-collector@2.0.0-internal.3.2.0
+      '@fluidframework/garbage-collector-previous': npm:@fluidframework/garbage-collector@2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -8038,7 +8038,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/garbage-collector-previous': /@fluidframework/garbage-collector/2.0.0-internal.3.2.0
+      '@fluidframework/garbage-collector-previous': /@fluidframework/garbage-collector/2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/events': 3.0.0
@@ -8066,7 +8066,7 @@ importers:
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.3.2.0
+      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.3.4.1
       '@microsoft/api-extractor': ^7.34.4
       concurrently: ^7.6.0
       copyfiles: ^2.4.1
@@ -8086,7 +8086,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.3.2.0
+      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4
       concurrently: 7.6.0
       copyfiles: 2.4.1
@@ -8112,7 +8112,7 @@ importers:
       '@fluidframework/protocol-base': ^0.1038.4000
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.3.2.0
+      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.3.4.1
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -8146,7 +8146,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.3.2.0
+      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -8180,7 +8180,7 @@ importers:
       '@fluidframework/runtime-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.3.2.0
+      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.3.4.1
       '@microsoft/api-extractor': ^7.34.4
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
@@ -8219,7 +8219,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.3.2.0
+      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
@@ -8417,7 +8417,7 @@ importers:
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.3.2.0
+      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.3.4.1
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
@@ -8439,7 +8439,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.3.2.0
+      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -8622,7 +8622,7 @@ importers:
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/test-driver-definitions-previous': npm:@fluidframework/test-driver-definitions@2.0.0-internal.3.2.0
+      '@fluidframework/test-driver-definitions-previous': npm:@fluidframework/test-driver-definitions@2.0.0-internal.3.4.1
       '@microsoft/api-extractor': ^7.34.4
       '@types/mocha': ^9.1.1
       concurrently: ^7.6.0
@@ -8645,7 +8645,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.3.2.0
+      '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4
       '@types/mocha': 9.1.1
       concurrently: 7.6.0
@@ -8676,7 +8676,7 @@ importers:
       '@fluidframework/routerlicious-driver': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/server-local-server': ^0.1038.4000
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-drivers-previous': npm:@fluidframework/test-drivers@2.0.0-internal.3.2.0
+      '@fluidframework/test-drivers-previous': npm:@fluidframework/test-drivers@2.0.0-internal.3.4.1
       '@fluidframework/test-pairwise-generator': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/tinylicious-driver': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -8721,7 +8721,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-drivers-previous': /@fluidframework/test-drivers/2.0.0-internal.3.2.0
+      '@fluidframework/test-drivers-previous': /@fluidframework/test-drivers/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -8776,7 +8776,6 @@ importers:
       '@fluidframework/shared-object-base': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-end-to-end-tests-previous': npm:@fluidframework/test-end-to-end-tests@2.0.0-internal.3.2.0
       '@fluidframework/test-loader-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/test-pairwise-generator': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -8858,7 +8857,6 @@ importers:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-end-to-end-tests-previous': /@fluidframework/test-end-to-end-tests/2.0.0-internal.3.2.0
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
       '@types/node': 14.18.38
@@ -9110,7 +9108,7 @@ importers:
       '@fluidframework/runtime-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.3.2.0
+      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.3.4.1
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/diff': ^3.5.1
@@ -9161,7 +9159,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.3.2.0
+      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/debug': 4.1.7
       '@types/diff': 3.5.5
@@ -9214,7 +9212,7 @@ importers:
       '@fluidframework/test-driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/test-drivers': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/test-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/test-version-utils-previous': npm:@fluidframework/test-version-utils@2.0.0-internal.3.2.0
+      '@fluidframework/test-version-utils-previous': npm:@fluidframework/test-version-utils@2.0.0-internal.3.4.1
       '@types/mocha': ^9.1.1
       '@types/nock': ^9.3.0
       '@types/node': ^14.18.38
@@ -9272,7 +9270,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_gcaeyjp6ykwlupauelnobztche
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@fluidframework/test-version-utils-previous': /@fluidframework/test-version-utils/2.0.0-internal.3.2.0
+      '@fluidframework/test-version-utils-previous': /@fluidframework/test-version-utils/2.0.0-internal.3.4.1
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
       '@types/node': 14.18.38
@@ -9580,7 +9578,7 @@ importers:
   packages/tools/fetch-tool:
     specifiers:
       '@fluid-tools/build-cli': ^0.13.0
-      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.3.2.0
+      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.3.4.1
       '@fluid-tools/fluidapp-odsp-urlresolver': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/common-utils': ^1.1.1
@@ -9628,7 +9626,7 @@ importers:
       '@fluidframework/tool-utils': link:../../utils/tool-utils
     devDependencies:
       '@fluid-tools/build-cli': 0.13.0_@types+node@14.18.38
-      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.3.2.0
+      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.3.4.1
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@types/node': 14.18.38
@@ -9650,7 +9648,7 @@ importers:
       '@fluidframework/core-interfaces': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.3.2.0
+      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
@@ -9685,7 +9683,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.3.2.0
+      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.3.4.1
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
@@ -9789,7 +9787,7 @@ importers:
   packages/tools/webpack-fluid-loader:
     specifiers:
       '@fluid-tools/build-cli': ^0.13.0
-      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.3.2.0
+      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.3.4.1
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.13.0
       '@fluidframework/common-utils': ^1.1.1
@@ -9870,7 +9868,7 @@ importers:
       webpack-dev-server: 4.6.0_stkfwfapuzpz4fwxpm6s7uwghy
     devDependencies:
       '@fluid-tools/build-cli': 0.13.0_gcaeyjp6ykwlupauelnobztche
-      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.3.2.0_stkfwfapuzpz4fwxpm6s7uwghy
+      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.3.4.1_stkfwfapuzpz4fwxpm6s7uwghy
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.13.0_gcaeyjp6ykwlupauelnobztche
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
@@ -9904,7 +9902,7 @@ importers:
       '@fluidframework/driver-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.3.2.0
+      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.3.4.1
       '@fluidframework/odsp-driver-definitions': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/telemetry-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@types/mocha': ^9.1.1
@@ -9933,7 +9931,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.2.0
+      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.4.1
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
       '@types/node-fetch': 2.6.2
@@ -9955,7 +9953,7 @@ importers:
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/mocha-test-setup': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
-      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.3.4.1
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/events': ^3.0.0
@@ -9987,7 +9985,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.3.2.0
+      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/debug': 4.1.7
       '@types/events': 3.0.0
@@ -10016,7 +10014,7 @@ importers:
       '@fluidframework/odsp-doclib-utils': '>=2.0.0-internal.3.4.2 <2.0.0-internal.4.0.0'
       '@fluidframework/protocol-base': ^0.1038.4000
       '@fluidframework/protocol-definitions': ^1.1.0
-      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.3.2.0
+      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.3.4.1
       '@microsoft/api-extractor': ^7.34.4
       '@types/debug': ^4.1.5
       '@types/jwt-decode': ^2.2.1
@@ -10050,7 +10048,7 @@ importers:
       '@fluidframework/build-tools': 0.13.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.3.2.0
+      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.3.4.1
       '@microsoft/api-extractor': 7.34.4_@types+node@14.18.38
       '@types/debug': 4.1.7
       '@types/jwt-decode': 2.2.1
@@ -12185,35 +12183,35 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@fluid-experimental/attributor/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-bqiKxr8xsGWJNQNu7iZ+NQyQUypSDUOm168jbfxpIFO6GB1iOvRL5W5pSu7zujJF9Fc2Ya+2y3qAID+WdkA8xQ==}
+  /@fluid-experimental/attributor/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-71bRXpKqvwqAUXL1A7RlbS27nHXH2BL0Iyfom1D+vF88P8CT52+37jzHdk2yjTlXCQkUdtEAEvhcdxZHpBx4nw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       lz4js: 0.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/sequence-deprecated/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-ukjtDCF0RTYDwCH0IYCU14ae8yLPU5T5a8/a66hckFcV8tKChvpG/CEA1Dk0XyNrWql8wkK9KtCXv9fTzmJWDw==}
+  /@fluid-experimental/sequence-deprecated/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-Uff/P9LX2gufhFcc2zcvl7GvSQBZF84d2r7ESxivMgs9yNY+2g94hziaCg81ynnyK4ZCXnhph5ZW0RRzHsWNlA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/sequence': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/merge-tree': 2.0.0-internal.3.4.2
+      '@fluidframework/sequence': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -12235,15 +12233,6 @@ packages:
     transitivePeerDependencies:
       - debug
       - supports-color
-    dev: true
-
-  /@fluid-tools/benchmark/0.45.112032:
-    resolution: {integrity: sha512-mCZgefqxqEWiWNRb9SpUDb2xW+vt/tjx5wLAMG1fOPTEUSMMBwT/baIuDF9EURYq8MbysWLfZsuw5cE7zFYxMg==}
-    dependencies:
-      benchmark: 2.1.4
-      chai: 4.3.7
-      easy-table: 1.2.0
-      mocha: 10.2.0
     dev: true
 
   /@fluid-tools/benchmark/0.46.133527:
@@ -12395,27 +12384,28 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/fetch-tool/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-cx7ImmVbVPAeu1AAlW/7wNXSQCqtetjKDFkyJuWgAwT4T5ii5UiOfcmARImV/E8OqX9YXkDWrQJUurwn1g0Vbw==}
+  /@fluid-tools/fetch-tool/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-YdVA8iQAygLd342fcc9d1JdhCb9rt2Ob27YJaeV9ysRkIlQ1teh6jOYUYONUbFDE+5FWVQaD5Y0+eEp9IBFyrQ==}
     hasBin: true
     dependencies:
-      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.3.3.1
+      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.3.4.2
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-urlresolver': 2.0.0-internal.3.3.1
+      '@fluidframework/container-runtime': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-urlresolver': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-client-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/tool-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/test-client-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/tool-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -12424,14 +12414,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-a0R5L2LZ74yvVnHPXI8eyqvfVisiSlZGs9QjZdSdH2CVwidpcfO7VJAJkhidf2cvKf6UcZDA4VvUJThD6zjEcA==}
+  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-srnlI/UrX3vDJdjpw3r5QauYriHATLTZ3PMQuTlfL2ROftRRAdNFAq3vlh5Nw/z1nyXoiCkVQYyQ/8WhhDc/IQ==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -12440,14 +12430,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-J7F3QjWVy+naY/TI0ovNFZRaGaIdBFqEJeQRrpNh62D0Mu4itF8PK3TONMNyYaBdgJYqmXoxAVKDL0tJ9lOg8w==}
+  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-28YgMOVfdFwCvBlGA7ofaApWQVHBwCm4hE3boMbC0cAVL6l2l/IhWJXczYz745OCyl4307OJJNJnNdEk6dD+hw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -12474,30 +12464,30 @@ packages:
       - supports-color
     dev: true
 
-  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.3.2.0_stkfwfapuzpz4fwxpm6s7uwghy:
-    resolution: {integrity: sha512-6ej1DoYX6mV6rQMuxWsHAff7AypfbPKPSlL5dRc7YxSonj7yF6GJLWlyJcBaWy9+51cfC7/16ZgroOP+XWlqmA==}
+  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.3.4.1_stkfwfapuzpz4fwxpm6s7uwghy:
+    resolution: {integrity: sha512-C4u2aBxoyD6se7gCEkp3/KZLZrYqyPbV7Mmpdenj1oqCKi4JQJAWHNYX2rwPKgfZ3PXRJK36lVZHvB9mUYLjRA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/local-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-loader': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/local-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
       '@fluidframework/server-local-server': 0.1038.4000
       '@fluidframework/server-services-client': 0.1038.4000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/tool-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/view-adapters': 2.0.0-internal.3.3.1
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/web-code-loader': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/tool-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/view-adapters': 2.0.0-internal.3.4.2
+      '@fluidframework/view-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/web-code-loader': 2.0.0-internal.3.4.2
       axios: 0.26.1
       buffer: 6.0.3
       express: 4.18.2
@@ -12516,135 +12506,94 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/agent-scheduler/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-EXrrygI8QefV1XZcDd1SQaKnHiB8KIuYGt6NyJj8qAeJ0CdiPVjc34YdLyIyBY9aOkmDmqIpc9JlvH+pD4eYag==}
+  /@fluidframework/agent-scheduler/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-xnRRQQGyJnfvCelMFQYw2XMe17GdbrCUvkUHypYNsXSV8VVDVUk7sUsZVvCITYN0og/nF0AD03vG2IQjdI5NYA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/register-collection': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/map': 2.0.0-internal.3.4.2
+      '@fluidframework/register-collection': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/agent-scheduler/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-/r2cYunW9Sh5YrSO4LKOJ3dB+5AkNDjBQFh1wPM9wcSntesxMzVWVvHqESLU7EAIFJjcKN7PXa4VN3rx2f34gA==}
+  /@fluidframework/aqueduct/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-AZIB8kSLgk9mMjdBQlTXcOL2NEBbCMzPt0gs7eT0l40uGfXP4QdYwnM8wKouCDMSycivWdiFi+l6K01ECwwLWw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/register-collection': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-loader': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/map': 2.0.0-internal.3.4.2
+      '@fluidframework/request-handler': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/synthesize': 2.0.0-internal.3.4.2
+      '@fluidframework/view-interfaces': 2.0.0-internal.3.4.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-ZjX7pPuTUPt/z1rY7aENDmf37FIsCV7nnCtNx0S9EUhkKq6RvpM90u9PXHy/TGeDACKNWnD9T3LfS+yuaIcQDA==}
+  /@fluidframework/aqueduct/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-1Wcq+RvGynKSlYNtWvkrP1eYPcyCpkARu63L8br8subhVJQ5jlNXmFkkA1YJa2SzhZCPXyWf03/myOHhkxIelw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/synthesize': 2.0.0-internal.3.3.1
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-loader': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/map': 2.0.0-internal.3.4.2
+      '@fluidframework/request-handler': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/synthesize': 2.0.0-internal.3.4.2
+      '@fluidframework/view-interfaces': 2.0.0-internal.3.4.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-YPbaNRk0w36HO8lPBu7ujl6Xe59Mos1kOQwIKfJj4ekXJvbjRwcogBXFq67MntWgqdwN0eBzRD3KxMKpb3qA7g==}
+  /@fluidframework/aqueduct/2.0.0-internal.3.4.2_debug@4.3.4:
+    resolution: {integrity: sha512-1Wcq+RvGynKSlYNtWvkrP1eYPcyCpkARu63L8br8subhVJQ5jlNXmFkkA1YJa2SzhZCPXyWf03/myOHhkxIelw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/synthesize': 2.0.0-internal.3.3.1
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-loader': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/container-runtime': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/map': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/synthesize': 2.0.0-internal.3.4.2
+      '@fluidframework/view-interfaces': 2.0.0-internal.3.4.2
       uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/aqueduct/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-YPbaNRk0w36HO8lPBu7ujl6Xe59Mos1kOQwIKfJj4ekXJvbjRwcogBXFq67MntWgqdwN0eBzRD3KxMKpb3qA7g==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/synthesize': 2.0.0-internal.3.3.1
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.3.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/attributor/2.0.0-internal.3.2.2:
-    resolution: {integrity: sha512-3B+AX6HydWyfYYVIcp+hw4QLxOTbABZbdtdtmFZIq5du5xseppPWHwl0XpyHkpqjs32LWZubR8GbqcpHPLk88Q==}
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      lz4js: 0.2.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -12859,32 +12808,31 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/cell/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-/Gg/SjmV/SNAmZrWxY+2yde2vcmhHOgLEE/vvVEd0au8LUKJy0NcpDImlgBdPFlZ5TImYQR4WXvTI4mT/1JBBA==}
+  /@fluidframework/cell/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-IgVhENMp0foOlXrx110s/tRp3UrzWHvy4bTUI81mlj0Tb6NIbYahP8K2KowSVZNKHLGKy9gCzDpa4Z/SKD+8Rw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/cell/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-+b9rF8q623OcVTgd9CKCPjNHfNlrz/L2ifczXAFtTuzQkHKwoiZSHJPpw1C841JYkyQLmGGekvUmOj7O/EmjzA==}
+  /@fluidframework/cell/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-c/WYP+fxPz/06/9rk3BiGPwNZQbGA8Ji5jwStgISbB/N82SXiqV8dzU4qIyP/R8wg7xcCDMPfSgg+zPHgexLvA==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -12914,39 +12862,39 @@ packages:
       events: 3.3.0
     dev: true
 
-  /@fluidframework/container-definitions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-qwZ0+nVhxjhy6nks41S/hOTXg/6LowL4Qp1WGsTQ2qJEQ7iGzNkgx0tprLtcpe4K5Ak808R0WGB5N+GuRYhF/Q==}
+  /@fluidframework/container-definitions/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-KXSmt5cD+kvb5XLMJxLlW911E33sqN0JFEeESVR4i49PMgeClB1VjK5C97ZG4u5+yRCkINkXNhZ6xV596tvu+A==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
       events: 3.3.0
     dev: true
 
-  /@fluidframework/container-definitions/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-kPGUNI4kcfGz3WlQeUIBxZF0r2MoKeDKgiW4Aa44Kt8uC7C5v4OLXif9FZZ/JxS4NUcLKHjNh78+H8PvX7ri0A==}
+  /@fluidframework/container-definitions/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-iaUG4ysDH++AmcS1BvtqaqCiWzVbH2cT7XBnkHjnO9rokYO07YXKGUjKL7eMEqOSihwHEf7HzuYOx9J+BEAb8g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
       events: 3.3.0
     dev: true
 
-  /@fluidframework/container-loader/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-bsFWzfqdPfyk7ldumau+Qngsk9fK+4Cd2hULUnZV9rmiYBQv3/BUL3+aSR6B6sdekvzBzOU8MWu+X68g+XNmmQ==}
+  /@fluidframework/container-loader/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-nn+37pNYIZZ5RGLw0WtsTItZ1B4wKmrcpYygbf3so4nwSLMmTMcnoLtE8hwOn8F1uNCfJOBUr9eTMX+mSInGow==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       abort-controller: 3.0.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -12958,19 +12906,19 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-loader/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-eq42QNDmqATStLi8yfhnkSiJr56POZJdpgVB9TdynUhjN6ca3grE120TzDiJUsZs6h5W1Bm+3y5UVOeryTtymg==}
+  /@fluidframework/container-loader/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-dWgVkWmY7jYhMTq+XadwfSYaUBYrDLDsYMOVXCpoYFB1KsgP5rBmWAPGsVhQKsnjxQ4heB/iX+f4sWKbPrUfEQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       abort-controller: 3.0.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -12982,19 +12930,19 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-loader/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-eq42QNDmqATStLi8yfhnkSiJr56POZJdpgVB9TdynUhjN6ca3grE120TzDiJUsZs6h5W1Bm+3y5UVOeryTtymg==}
+  /@fluidframework/container-loader/2.0.0-internal.3.4.2_debug@4.3.4:
+    resolution: {integrity: sha512-dWgVkWmY7jYhMTq+XadwfSYaUBYrDLDsYMOVXCpoYFB1KsgP5rBmWAPGsVhQKsnjxQ4heB/iX+f4sWKbPrUfEQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2_debug@4.3.4
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       abort-controller: 3.0.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -13017,26 +12965,26 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.3
     dev: true
 
-  /@fluidframework/container-runtime-definitions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-AsXBy6Ct4p18O9hTlx11U91c4Gbx6ZHP/v4jhUst+UG0ODWsdw+T7xhCIhNR+iC63FuIuXzK10CLHtWrSWSShQ==}
+  /@fluidframework/container-runtime-definitions/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-PoQ0CUPlNHwf0Mhx3l/oL88XoJg7fgjQZv0oMvoIYyp2iuXF9XGWJwxcfZypDiOaY3vE8MQGGfbmRxJmUgyebA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
     dev: true
 
-  /@fluidframework/container-runtime-definitions/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-wWr+FwgrPWB2Cz/y2KSxTqqqsJN36iSyrf6o0uH/9lcJxePQro2lyk5bjbURde+oztxKUSCzOHf0xqQ3EbYvMw==}
+  /@fluidframework/container-runtime-definitions/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-5V8qezysITmqqWtg3aLRdVgh6S6UInq+6fB/fxXpFiUgqREvYJV2Z9Ykp20sDo/eaWuGPO7H9O8FE0TeKp9c3w==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
     dev: true
 
   /@fluidframework/container-runtime/2.0.0-internal.2.4.3:
@@ -13066,24 +13014,24 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-+jMECGYgs0CEa+MmkQ+8K8v7g5swxxpFY0cj9oDEVNgdUMmHL93dgUcPxi+M9O8HuDqKm+7KMU+8b9StOB6Myg==}
+  /@fluidframework/container-runtime/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-2oGJnXLnYfrMHyoXufUXQ3KhhEy/P/ham36BrpuA3/DbT50q6qHyQxfwsMlM7CBrhIrB1odYnCkwddbWb0q6jw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -13093,24 +13041,24 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-ZTgDBS2P0ZviT8Ao2ZzTJ/7TCgE4Q/zytuz34TDQnvD8dDmcBOziH7Ca3jY1xUtEUz5om5W8E7D7eg/sJH1hKw==}
+  /@fluidframework/container-runtime/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-KteiuCdVaTXLU/jA00EgF8JRsbacJqPYc9eHUtu1msgA7JOy2yi9xvz5PS9FRWcc3sdlL5MVtuG095nbEpjJHA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -13120,24 +13068,24 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-ZTgDBS2P0ZviT8Ao2ZzTJ/7TCgE4Q/zytuz34TDQnvD8dDmcBOziH7Ca3jY1xUtEUz5om5W8E7D7eg/sJH1hKw==}
+  /@fluidframework/container-runtime/2.0.0-internal.3.4.2_debug@4.3.4:
+    resolution: {integrity: sha512-KteiuCdVaTXLU/jA00EgF8JRsbacJqPYc9eHUtu1msgA7JOy2yi9xvz5PS9FRWcc3sdlL5MVtuG095nbEpjJHA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -13159,26 +13107,26 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-KZNRvslw2GiZeP2Ig1SUYzRswCarwK25LFnNAgRJo+xhZ7A1qi4eYi3aUiQeteyxjPyFwKTRS0tfc52FuX9cpQ==}
+  /@fluidframework/container-utils/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-mw7iAmhhyFsyaxeJLIO5Gl48O9l5HANc9pQOci/zOjsakIQ3G8UcxeT4oa/Zs1QvVZFNHkTfDhUHbS2wWafhjw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/container-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-0qxJVxj3OHN/ejqaJvPu2bRTL6/9TqcmgIher36ufOKkiC3H6UDSTrVe3LYKDQRpNKWIGQwmzwDbCqtHT2rg+Q==}
+  /@fluidframework/container-utils/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-uEoycZmnVeJfiOQ37fm7dolUGyAfNuX1VmF/lc3u33n4ZmN4ZJnfhjDm5w72hK6ojQv8pnrNwiJnqHM9klbUKg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13187,58 +13135,59 @@ packages:
     resolution: {integrity: sha512-wNH5TrE69s8nmP9XCacHAdUDuBlLbWk1FJhtrM+n4fXRBMa+UzJ3JS97ZsMJQcqBrEVtsA1ioov4iaoOFyGQuA==}
     dev: true
 
-  /@fluidframework/core-interfaces/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-6dX5P+uxxv5QxZy+uIuV4QH7FQeaLvlxk2+u9qdhZI4z5CL77F3XkO/UU03h7mAOQsJ2fmi/63uYOKQxdDVFPg==}
+  /@fluidframework/core-interfaces/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-hZJ8E16TbIdY4cMfAvf9e84p5VIeSr9Zhm3FRcsGSqESWbrb8Tn4XDNfAHmD7wgeehJ0ns7wCc5btsXvSPqjYg==}
     dev: true
 
-  /@fluidframework/core-interfaces/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-HHNMbmPXMJ7aARNkVEIfgnTg7RfzRpWjs+S3yC8Bh6+qBdksp6ID07PyclrcjEdo7XfYAJgGlkocEVj/D1ZBcA==}
+  /@fluidframework/core-interfaces/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-fYCxrgtfDkwqVdDSRObMbBcudxlUQU1PkNgU0JGZclmAapPmtJgG0SkwIWs4eivMvpENgXveCQg/hQsCenSrTw==}
     dev: true
 
-  /@fluidframework/counter/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-9gIvOC706DCHMRVhQ5asmnnyOJC1tLuY8xQU4Ra6eq796cmQMuEr++O+Aj2qZyRPYxlqntNtO2PT/Lg4/MQX/A==}
+  /@fluidframework/counter/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-5UcIxtWkzZ/9WKA73WbldFMZtGUTfelk3XOnRgtLr+23KEOPUM3rquNmn31mOCTEPfzt05/Vg0JAaB8IdbwsWw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/counter/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-qW9yMZv09ctWz9UTJ6YnTn3FD37At7c8Us4BGDfz9IUJrBJn2K3iMpLJvdBVKy3XvU52dgKAOLqE40KhzdcFlA==}
+  /@fluidframework/counter/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-s34DLITpFVLKD+KNtnD5OHvHWjQDQwRH5mFzkMJwZLg+kPv+Q2e/71SzK+Q3PT3sb1EwrDuxDml6KkohRcocnw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/data-object-base/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-fCqEgSFmNroHixhVbA34FaFYXd5luAVtBPQb8k5Rv5KrDuImCdFpttg8kt/iQBIKiAiOH1YSPb57kDOcnUfedg==}
+  /@fluidframework/data-object-base/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-JWPmtMMFzO93PbLBGlkd2oUo1uqt6ymkGdQX9GduZI4Q2Nq4SGhAIZkD76gO8UVIs7GCz/vhuyqOXJ1JR9hu8A==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/request-handler': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13255,26 +13204,26 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.3
     dev: true
 
-  /@fluidframework/datastore-definitions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-FDVmQu1ak8tSx+5G2mWSJgBG1eZkwR1tSLzzaKTUJbW50LjvQ1zy/rzOig9m2sYToneIeeqLZjnuKSOZQFm0mQ==}
+  /@fluidframework/datastore-definitions/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-8r/7+qgBxje3/hZXrInVSyefT466Vgk7GzqONd6eFwQ2BUK0tzF+MqqP6ghb43SJ9O4lEFDSdcpKAiJ58Nbhhw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
     dev: true
 
-  /@fluidframework/datastore-definitions/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-JlhDIVDeax/8bdo5R0PP1WgVr0zAk1OOu4LcvHLNV6TkKqP7slvTMDqGmqY1oCFXe/VtEMXQWEUTEoxQpejKmQ==}
+  /@fluidframework/datastore-definitions/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-/dsAqqd6ICkWAIV6dFkIoWFNy1H1w4x1p6XI8xYwtVKHa/Sr1RMNRRBkn9nCAlr15GqlVwPgRkFM2wgoZIMfqg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
     dev: true
 
   /@fluidframework/datastore/2.0.0-internal.2.4.3:
@@ -13301,23 +13250,23 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-TVjht4LLXjTL6vdJLVNizH52btN14QZXgZL9PQKRoCLsqJOxWbOCyz7zOq7dAo6vpBv/AQUbECf9YL1d8eVurg==}
+  /@fluidframework/datastore/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-od0wMG69jvsLZXG/tyW95q8+7iI4OaPupUxqmB1O0DcNKrIdMEuV4zFBS/+crjIrppMl+ztAecTaL+ry3MdEJg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       lodash: 4.17.21
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -13325,23 +13274,23 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-EOvi9DuJvDXJanAJIJLreQUlkhqOAAt1ag46+oqUoaxc+h/A/1s1NxPETEhiQ4VdLKGPyVWolHaHy+o9qnBNSw==}
+  /@fluidframework/datastore/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-vMc1Q5qhavCO6MddVVK8tmvKjXbTXgAUzKGybizKLyOAlRi6wutrd+SjZVMt7GCgpBonv7uNE3BmkCPbxcynOA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       lodash: 4.17.21
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -13349,23 +13298,23 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-EOvi9DuJvDXJanAJIJLreQUlkhqOAAt1ag46+oqUoaxc+h/A/1s1NxPETEhiQ4VdLKGPyVWolHaHy+o9qnBNSw==}
+  /@fluidframework/datastore/2.0.0-internal.3.4.2_debug@4.3.4:
+    resolution: {integrity: sha512-vMc1Q5qhavCO6MddVVK8tmvKjXbTXgAUzKGybizKLyOAlRi6wutrd+SjZVMt7GCgpBonv7uNE3BmkCPbxcynOA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       lodash: 4.17.21
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -13373,70 +13322,56 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/dds-interceptions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-SvIY/J9FNiQGXY31WWvW+vc6Pwoec6dBV+frwuh55+a0Y2kQL+SF6BqOrVBG9MzmY85FYZJUIiNDooGUbANhnw==}
+  /@fluidframework/dds-interceptions/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-1e0R+fnSPoEVQGFZAoflzKsc8GYignMRLnyCQtl5hW8hX2sbps1bVdjiOjfze9KvQTTzkHgbwkZ2BoX2WlkacQ==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/sequence': 2.0.0-internal.3.3.1
+      '@fluidframework/map': 2.0.0-internal.3.4.2
+      '@fluidframework/merge-tree': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/sequence': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/debugger/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-2C+zFZTx+nwSAZ34pJ7XXvj92y2fApnIYurRqTTHn0NuzbYAd99ovyASjPMFuOmAyCATHk4G4wQ6UECJNMuSkA==}
+  /@fluidframework/debugger/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-aPymJ1MotdTTtzHlBCzJCZWWIKSgfribkgYwFc9u06S5ru/8IzCe+Vcx+5+SMCGbi2Rq5SoD0l5OPoCHFPuxsw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/replay-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/replay-driver': 2.0.0-internal.3.4.2
       jsonschema: 1.4.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-xPH31GtvDo4qLU4o/F0GYv8iwVWTmTYEJF279XZzbWpSNzh/kTAHD7ALeNFuE9cAZht3p1Ypi1wVJ0FPR5IiRg==}
+  /@fluidframework/driver-base/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-Vyl4PChqCbCb7zU6bf+izk2il1abpUs4i7J+YkbjNMLBkMpteGmevI9u2VM6K6A7aP118X1hiVjyQyCVuBw8yA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-mamE7COu0PKrGKJocnLsJGb7kgs3jPaDPIMqCagmGXbrPNE1CSp3SvNQGPZ7DpaXVmmdF/VrD7G03iGz48uFzw==}
+  /@fluidframework/driver-base/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-jYzWlfzCtwhlAfDVoq0VhV+mECQSXn+PlJvPwHX9B/mIal7UhAlKh33BFUjqppsSlrsmvTMIoZvfl2Z0V/+GEA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/driver-base/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-mamE7COu0PKrGKJocnLsJGb7kgs3jPaDPIMqCagmGXbrPNE1CSp3SvNQGPZ7DpaXVmmdF/VrD7G03iGz48uFzw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13450,19 +13385,19 @@ packages:
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
-  /@fluidframework/driver-definitions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-dw08xt+k6/FZ70P1cBh2N6aiglWxbkehcVoPlDSrafnmZ+jYiA68ql8SBj7hbxnPtN+G9zy+baCqN3ah9tqyEA==}
+  /@fluidframework/driver-definitions/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-XAbCR+wKsYn3+SrWAh3QWekBgv0glkjq2O7Ss+PBBonqwGXcqcujOSw9tMfBuQqCdJLbnVap9G//MRR2zmUKFA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
-  /@fluidframework/driver-definitions/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-Xw5+RGJN+iNIUR012EWLZao2KziXR5TzKhvanOsHqXkZulDjzwWa74ALaxyfvOmgSkaHIDpDx3gvChKjgBfikg==}
+  /@fluidframework/driver-definitions/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-8R8GA/6IVwUotqjm4KQU5rwkwN8tmZK0x1z6LQVjl4OZN9D95O39KoBtu85w5b11KbPybo29Cyho1YhSYIIP/A==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
@@ -13485,17 +13420,17 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-tZgy1yoTTmeZkPDErRaTV5bd9X7Rte8WX1fq/X4nIowBVPQfTCVTTiPk4Tn4yFfD4SJGTrs5efJ6mpDNmQlKZQ==}
+  /@fluidframework/driver-utils/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-8YYdwbINCYaH3skUT/mzHK12zDgP4LcLJwSTGcWKQmOVQsqpuHNMV006K6/16BrXM72stGAb1dDrW9+nVJROHw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/gitresources': 0.1038.4000
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       axios: 0.26.1
       url: 0.11.0
       uuid: 8.3.2
@@ -13504,17 +13439,17 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-xelVnKDo5U7VzvPdPo2iaICZXZniODVVdlF4nvlc6egWQpd1PFR8GXdGLbswMnsSfmdmiiL+4G1PpTDRXJesiw==}
+  /@fluidframework/driver-utils/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-940Oy4AIfFyxS009etGTjTbM68zY90WZBoxUWou2OGaiOUib+R8s+4yHP8ZyCDi4awLt/63TYklJ02gkGK2pcw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/gitresources': 0.1038.4000
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       axios: 0.26.1
       url: 0.11.0
       uuid: 8.3.2
@@ -13523,17 +13458,17 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-xelVnKDo5U7VzvPdPo2iaICZXZniODVVdlF4nvlc6egWQpd1PFR8GXdGLbswMnsSfmdmiiL+4G1PpTDRXJesiw==}
+  /@fluidframework/driver-utils/2.0.0-internal.3.4.2_debug@4.3.4:
+    resolution: {integrity: sha512-940Oy4AIfFyxS009etGTjTbM68zY90WZBoxUWou2OGaiOUib+R8s+4yHP8ZyCDi4awLt/63TYklJ02gkGK2pcw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/gitresources': 0.1038.4000
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       axios: 0.26.1_debug@4.3.4
       url: 0.11.0
       uuid: 8.3.2
@@ -13542,12 +13477,12 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-web-cache/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-x38jxmQF4btBMX3oFvZcYQuk8gm7btN+UE4/E/Sr/a1ByRXxBLELUDA1sNKRdJ8lyN/s4WXtrvcS9HD+UtbcJQ==}
+  /@fluidframework/driver-web-cache/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-EDvKB2IzUw/LAk3vzSkUd1vz66ZvLRZ2icbc1GF6dVj8gA/dJiFYTEN7u8Q9oYLsxJTrVqm3jPl/5U/H5CKgpw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -13579,33 +13514,33 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/file-driver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-9ZCP9VjvxcJXi07KJlrf7VvkFsVf4Tlf/KBX0g+GRyoBxyp7F55vNtEzO9s5Jsu8v+a+ZV/S4sITZR0TfJ0A6A==}
+  /@fluidframework/file-driver/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-uEEmgbDcmHEIc5T+AhElDClLrulXb83ZM/A0KMK6Tcnj1gBi0G2A6T62q8pjfFYtCDu0hxLqT5PO1HYxbtH/xg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/replay-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/replay-driver': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/fluid-runner/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-xWUIaNfEHNv8Nl72z7ESqJE1nPO3IiS3CeTpgTlRD5KZunkj45LBEDTKW1gW3U0zG+Ud1pU7Jeq2l/EnsNlXmw==}
+  /@fluidframework/fluid-runner/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-RVrNUAVZkELB4e2AspiIbFQKDrc+ZZEblb1mzZuyDGPZn7Tzmk913DGJ3U0F2Ww02GOgrvuVYcI6dKcOUS314Q==}
     hasBin: true
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1
+      '@fluidframework/aqueduct': 2.0.0-internal.3.4.2
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-loader': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       json2csv: 5.0.7
       yargs: 13.2.2
     transitivePeerDependencies:
@@ -13616,41 +13551,41 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/fluid-static/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-0OesqwiGz9ctRDdZWlKyODFYY+cag8eHdDDBwDGeXZWu89n7yE8lvm2o2z/xycmuRpCJ2twJFRDMINk1rHNIug==}
+  /@fluidframework/fluid-static/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-Km9+839RP00FN8EBwqN3NpscoNxjZIQgu6L7hx7lh7l738nYlHXKrMhvrdSYzynOQtof10UW/s3l6Zw64trF3Q==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1
+      '@fluidframework/aqueduct': 2.0.0-internal.3.4.2
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-loader': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/request-handler': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/fluid-static/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-BM6cvHEu0B4Dv4p+b0LkKb142Ta+e5eK/pQ9vodDIa7tQTQL2HaXuopJcxSLKTlQ9tJ5jdUB08shinwF+73Aww==}
+  /@fluidframework/fluid-static/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-huZNq/dGmEEjoEoqyjfzswoov02LnDAlG0G7D4WYJLl5Q8y4uW1CXC1lubRo8/lFf44QXMUVMy07xy6MX59+wA==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1
+      '@fluidframework/aqueduct': 2.0.0-internal.3.4.2
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-loader': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/request-handler': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13665,22 +13600,22 @@ packages:
       '@fluidframework/runtime-definitions': 2.0.0-internal.2.4.3
     dev: true
 
-  /@fluidframework/garbage-collector/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-tQ/+eIsM23fJMENXncgpgSm1RG/QN6yF35KtHNvkNGgJxzFP5j6g670tqoI68hssfNkSH33BLicQrTkxGVQwJw==}
+  /@fluidframework/garbage-collector/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-UfXePoklqSvj3766zMUBkHq77K1PNHNMiQXBcPPj7hIvvwGljaDv0Kx44WoOnEqoHLX+nd9WVJhnk3fHAcQOUQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
     dev: true
 
-  /@fluidframework/garbage-collector/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-jA7+CKOu1ZLPHWvXS5OA4AgOgxOKGIB9bMnEbJ7meK7F8LFsAZrdlUgT45WTxA5qQNmOjkvieGfWJRv/gGdDxw==}
+  /@fluidframework/garbage-collector/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-/KtqGw0Dp5rMXlr3FghN14TV63n9QZI98vIDp4HkHcVchMRMvyMF9y/iw0lX48F+JU6ViMy1R1eBCyqSssx85g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
     dev: true
 
   /@fluidframework/gitresources/0.1038.3000:
@@ -13689,55 +13624,55 @@ packages:
   /@fluidframework/gitresources/0.1038.4000:
     resolution: {integrity: sha512-YYHauGScTKafXUTqRvpJyYLF0T5wGYXRagZz/ymZFYmG/3AzSj0XKCv1QmkKyAw6wgHWSk/IZyKQ9bukHpPB2w==}
 
-  /@fluidframework/ink/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-ylql+kDaPtPp1GvxC2ysIcveFQrOVhhslLLHD0zwzlnIBDDjPrkZQ3++lSxRyMWKywL+ITn794/GPImC4bg1oA==}
+  /@fluidframework/ink/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-x09MYO5/Dc8K8TQXYLYwp+6my9RIeNfn0i225IpaGwLCaO0Fuw0mN0Qv0MklgCtrRlPqzpaAIGawcCkbVPdh+A==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/ink/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-xCY1hxqDUlXfw5M2FdDjWafBi/D023PoZ+C/W73OSCmAcPifUOy0jacgb92758X06IByZwycpcFQ2dq69HLiXA==}
+  /@fluidframework/ink/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-23xc3MnAFWdTQlOw3gpzUcfBOJZzhWVimbSmGg0Gi8XXAOIt3u/5qJKswk7tFCPpOPEIaJIP6uZACJ4NPS94/w==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-ctAHUgpIN8C6fcfJppeZIGlwGJ3QE2kSYkFndBERIY4Pb90P6HPy8xCXbEIZnNH0cDOXwRcT+w7aYHg+sn+V8g==}
+  /@fluidframework/local-driver/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-Uzhz9WRrAy2vTZHs8fdoy8jPGNdr3kalcjpBdfKPn9P9sSGAbNB4PtDiRQ/M1Axl7Ky1hLLIk7/BarFPForQIg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-base': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.4.2
       '@fluidframework/server-local-server': 0.1038.4000
       '@fluidframework/server-services-client': 0.1038.4000
       '@fluidframework/server-services-core': 0.1038.4000
       '@fluidframework/server-test-utils': 0.1038.4000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       events: 3.3.0
       jsrsasign: 10.7.0
       url: 0.11.0
@@ -13750,23 +13685,23 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-VD8k+ZlCp7SnbJspeTsY0XRh0j1i80dA9vsgPlfpLxenwOZuDR8jExZ+u8CQ3eWbe9REYVnzbl7yof+Yiv/IIQ==}
+  /@fluidframework/local-driver/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-4TSJyegzwvbK8/Gj0q2NcfvphTcB1kWSCJlsDQlSDfCvlHU7hC9zOBhKRGFH80Q7GwBeSDtB0a4VxuzQdgUZOw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-base': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.4.2
       '@fluidframework/server-local-server': 0.1038.4000
       '@fluidframework/server-services-client': 0.1038.4000
       '@fluidframework/server-services-core': 0.1038.4000
       '@fluidframework/server-test-utils': 0.1038.4000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       events: 3.3.0
       jsrsasign: 10.7.0
       url: 0.11.0
@@ -13779,117 +13714,88 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-VD8k+ZlCp7SnbJspeTsY0XRh0j1i80dA9vsgPlfpLxenwOZuDR8jExZ+u8CQ3eWbe9REYVnzbl7yof+Yiv/IIQ==}
+  /@fluidframework/location-redirection-utils/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-q00i6qXcZu3YPwDZsariBC+BQt0ud+GZ7TTWeKRxjoa3OoEJ5LXt8hDJ0500HMIpWUK21cM03NQvqATFeb2sSg==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@fluidframework/map/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-Ac2JgL2mpwQkUIqxDw2QQDUYxPcYV6TRpmLmgHtJ2G/b8X6j+p6GgMRqu6kN/J99uFT405bWKPZ2cAv+90Fuvw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
+      path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/map/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-2rX2XwurQ6VEnpIei1mplOlZLMxyssJ9iOGcFWlHexy3RMbeZ/1kTP5xVu3golI08ouEjxyFDOmEhfP0bths3w==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
+      path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/map/2.0.0-internal.3.4.2_debug@4.3.4:
+    resolution: {integrity: sha512-2rX2XwurQ6VEnpIei1mplOlZLMxyssJ9iOGcFWlHexy3RMbeZ/1kTP5xVu3golI08ouEjxyFDOmEhfP0bths3w==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/protocol-definitions': 1.1.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2_debug@4.3.4
+      path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: true
+
+  /@fluidframework/matrix/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-dDOJrsN73gxasXB0EicolX+hRTykDhwIZwKe2B0fIcUwtbzlNrcO/faeSYU6L8sLFMQ5s1ndNVftCTRGNOjS7A==}
+    dependencies:
+      '@fluidframework/common-definitions': 0.20.1
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/merge-tree': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/server-local-server': 0.1038.4000
-      '@fluidframework/server-services-client': 0.1038.4000
-      '@fluidframework/server-services-core': 0.1038.4000
-      '@fluidframework/server-test-utils': 0.1038.4000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      events: 3.3.0
-      jsrsasign: 10.7.0
-      url: 0.11.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/location-redirection-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-RZhB/NjJI2LG46I7qMlXzsRYo+vLGQPmWtFmaO2fZozIMhFZPV0NXfwxcL4BySpsc7aPkp3Tom22iD0Q5exNcw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/map/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-CZYl0nj9Zvb2ibEuRjbE62tuk1sNFV5Q/vVDmXlnbTGnbeqxcQ5nknQCcAU1FZzH1kEZibqG0/3CAZQRxWhySg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      path-browserify: 1.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/map/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-WWgLK7Px7lFJEB5I33PTztw68QRlZLxEMdiGMvGyS2v+e+qIbxoLtmdnqS+jdrcyRbjQYRIg8bfaPnDXrcjx3A==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      path-browserify: 1.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/map/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-WWgLK7Px7lFJEB5I33PTztw68QRlZLxEMdiGMvGyS2v+e+qIbxoLtmdnqS+jdrcyRbjQYRIg8bfaPnDXrcjx3A==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1_debug@4.3.4
-      path-browserify: 1.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/matrix/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-HghTmkCx3BWIWaAz4qA9Fm3V8TKGmqmq4v2jRztCnoauxRhDiPflkz4bqhEkxPpCZQodaIVJZfKiBq5z+quZ5A==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       '@tiny-calc/nano': 0.0.0-alpha.5
       events: 3.3.0
       tslib: 1.14.1
@@ -13898,20 +13804,20 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/matrix/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-UqT0kDIOxNhnB9pchRgAREJn2WS5Yi/I+a+aYUz1PENlDIPw5/l4GwUnBL994i+lnni1yfZJELbnf6bs3mmQtg==}
+  /@fluidframework/matrix/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-uUfk34hshMN6YkOEa1652UlHl/9CGq6Yb8jZg2gO910LEXmRiyZT3yRpOivAvNbfI/J8WhImlwmK5STprgPCcg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/merge-tree': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       '@tiny-calc/nano': 0.0.0-alpha.5
       events: 3.3.0
       tslib: 1.14.1
@@ -13920,69 +13826,61 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/merge-tree/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-cazYDLeIXz86trBbCNVhiMnOffD9+QChuWKfa+H/USykXjCPfs/jQIoNbAaDeLyI8jrsfGb4YyCL2ZZmgYmyWg==}
+  /@fluidframework/merge-tree/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-947FarYl9g13aqX+37N0gogUowml9tlJIxUvP4ZBd7hfVcR5MVYPNpniO6Fy7bjLFuV00M4S03WE9acm58NDVg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/merge-tree/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-KoQ/V2BeS/Fs7P/n5llyOboX9ZJ3FdFpbGCkyjaMKPlhGxIoxjD2m7qKriIerrULMuIaO3PDn43cd6N3dQxo2g==}
+  /@fluidframework/merge-tree/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-KlFlfpI3ImB558qX8Krm5ZyaxaEIgEGTCYvpbSPa2YvIe0Uyl0DjZ11HZWebpeaKrwNAuCdhYola28BSGboQvw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/mocha-test-setup/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-LZMcnGk1ccVak3NOsLaM1emUNIS6+Un3Ivdweo0uz8GF5WJSgeDTLxthjwX3GO6OQ7xiUpMk0OLXyAeguBjmCg==}
+  /@fluidframework/mocha-test-setup/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-PUEY1AhebkS1e1/LK5FWEHuO6XmdkAZi88lu+IdkG2WeB+MYBVPCDipV5upeqfkedIla65ldM8+UQPFIOwIDvA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.4.2
       mocha: 10.2.0
     dev: true
 
-  /@fluidframework/mocha-test-setup/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-shdZZSxDquzdwFkWquw7bCCzR/QkBTs3xdW+RD99KW5cDQvGeNK/RFva426VA7le2QM46xexdQzNlW8TFD4QTg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
-      mocha: 10.2.0
-    dev: true
-
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-GshBGwxZwbt2HjUVfRTInLxGcT9feybg3iJXVNcSBsEsv2lBavxPdSQEzXUmY8sYcKSj6f98ZBFEUgvtLuhrTw==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-07NM0ElUE32e/OqePvxxMDoldQ4hA79baD2k1JkMQddlcpKjwBVeY1aYOFVud/Wm5Lk/8GBc6X+My/ldTb8GEQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       node-fetch: 2.6.9
     transitivePeerDependencies:
       - debug
@@ -13990,15 +13888,15 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-JwweD3mRWnLo0sF8i0TDXhOHUFNYxrOBy9GOtxHlEdWVLkjvyVg0FBxoXWw4BoMtMdKhjKTWcHAY83fRtFW6Nw==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-ByEU7SFUdaWN7idtseUXteAqaCCHBI18BsT5+UYWyEmGjuo/mAqBnAlsGMEm2RxkJpxiPRYmgllxtjChxks6yA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       node-fetch: 2.6.9
     transitivePeerDependencies:
       - debug
@@ -14006,15 +13904,15 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-JwweD3mRWnLo0sF8i0TDXhOHUFNYxrOBy9GOtxHlEdWVLkjvyVg0FBxoXWw4BoMtMdKhjKTWcHAY83fRtFW6Nw==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.3.4.2_debug@4.3.4:
+    resolution: {integrity: sha512-ByEU7SFUdaWN7idtseUXteAqaCCHBI18BsT5+UYWyEmGjuo/mAqBnAlsGMEm2RxkJpxiPRYmgllxtjChxks6yA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       node-fetch: 2.6.9
     transitivePeerDependencies:
       - debug
@@ -14022,33 +13920,33 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-S2ojncuUUXmznSdHJdPk1JTQiVHGisyNvBJ3/Q6ZlwwTBAxg2Lge/3IxOSpqaZJCwzuWNzxXoXRSEmtdcW+u2w==}
+  /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-mZidnD3fs1L7MUjdgq5wspZhkJHU868gIYu0XcYr+31IsL+1pkgDwCA9vxq6AtaEuBob1JBBrmMa2vM9823g5g==}
     dependencies:
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
     dev: true
 
-  /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-H5CANR8BkOsRDT3F/1w+O9tnQVJnPfZyxdLuXM4TQ/TupQ1W0imIyAbNcCtzorO3af/CPsv7N+RaObC6yht/cg==}
+  /@fluidframework/odsp-driver-definitions/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-kZgvSRS439804gN91lYbMKJbBXr+gho0dsl/yGv3GSIkkC0MyGOxJbUFnyS7CmzZ+3jG16i/O/XHGyvzMancKg==}
     dependencies:
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
     dev: true
 
-  /@fluidframework/odsp-driver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-ell+1uDdrsAvDX/c9sowlrvwzeMYYg7S+EWrPyomjKSyU3SKBjoXFzPXyWWl0eXEx0fokefmNROrorpBff11ew==}
+  /@fluidframework/odsp-driver/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-Rhf7pG+OFodCWYv6M01i6y5coipjCyC8uJg7GOkVavPC1JbuhpBva6XG+hMpcu7If3mYB3bBRwaBk3H6266oLw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-base': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/gitresources': 0.1038.4000
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       abort-controller: 3.0.0
       node-fetch: 2.6.9
       socket.io-client: 4.6.1
@@ -14061,21 +13959,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/odsp-driver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-gFA9ecSo1f4MIn9uGOpHyKOafErs0rVDWoQQwyVU+yuF+/dD7Xa6LfKAbVSdfmK2LINlgTyfMqg3esUD8MQp7w==}
+  /@fluidframework/odsp-driver/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-Fbd92KrXr9fjde/T2eYL+xPaZzJG+5fxrKGCp333X8jVZBZtJExlYnO8gWj/SpyzZdUUHddUyv+r58zVSZ5jcA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-base': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/gitresources': 0.1038.4000
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       abort-controller: 3.0.0
       node-fetch: 2.6.9
       socket.io-client: 4.6.1
@@ -14088,13 +13986,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/odsp-urlresolver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-nipuppWvjBzcyHNVac/+ApOM1GyIfgreV3BShmseogY6/E92R0gjtl3btfPwk0LUxsEaZhCcWfRIJ5HJjc7IXg==}
+  /@fluidframework/odsp-urlresolver/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-cB9j83i0xrKBpAuka4xdwlGZ/DUR9Uw+xkOgdGj8RYk6P105laclNrZnIKtA5Zf6Vz9R8oQ7EJFQURhtxiWCJw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -14103,13 +14001,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/odsp-urlresolver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-1zsN7qVTZrJE4Gfn67MlNpGbmOsJtGp8zrzGQst7zTuaEqRVp3kJ+VTv9yqWB6fg0xSCbnDGuk6L8wqhSRzC0g==}
+  /@fluidframework/odsp-urlresolver/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-Dh538PKdNLWMZ7hHoeg3s6/UaS4Of//A1+n9Vl4OHz4IqJGklIAFvEhE67hd3J5gGzggbBfjbKzKvJiEq8rCAg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -14118,32 +14016,32 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/ordered-collection/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-44oSz5XqCOVs9WHaY2gFaw9r/WmldVL++Wq1O3655dcZTdAm79XtSk5Bj2m/0gAxUBmYm/pxKBXGEXcJHzg3TQ==}
+  /@fluidframework/ordered-collection/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-U0OgXx28TVyc6uMEEWFWz3AZmMgJyeihBePG+Db1rfkiUmKFfRLLLM8rpe3VAZdTSTTB7Wp+zA+/CJNzgR1N5g==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/ordered-collection/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-LsgtthNWES+C2q/JvoD6grpk/dffiJDs4RFXQQDp/lJ129X1N2yR8S/kdqfeAK5Q30OmBETG/5uDtRoxJ3+xMQ==}
+  /@fluidframework/ordered-collection/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-CFbribu1gtCTUE76LAL497egiup1J0daRynDEaLlflmcbOhGKOZVimPxJ3yOuv7otiieiSQOFR/QzEb+cdcrwg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -14173,101 +14071,101 @@ packages:
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
 
-  /@fluidframework/register-collection/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-rFBMkXx+sxpGrOhjS08soiPoKFjU2ADU0DMyQweo3mqx70RmS6CsKvuohfjL0PnWeY32SCgJ35MYUeypVfRqOQ==}
+  /@fluidframework/register-collection/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-2sREk63sRklHsKEvLiBpmxcqBV8LuUcJA07h+hQrjawCsJQDFfPe4TzD1btJNf8dvyxpDDv/LvL9TcQop3isUg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/register-collection/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-0si80lawOnCLrWXxHdwV+fMuZp6QZwgJRANYd9WcLwWEYbuWr1/OjsS66gwAWOnngp8bfAlWRhrp18knvvtjAw==}
+  /@fluidframework/register-collection/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-V0wGRniwyodkOKvZsTxcsu+Ds6pIr4zuaQY384/3PnMXKjwNDtiijFsqKDu6lpgk/7v50YZy1gNNQBZrtW3UOg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/replay-driver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-mS7oI16b2+SrfsTmuEx5w9+wROIavR5nMlCRWLS1PK1KzDeJ4HwH8xDa6DPe7rYP6PfYyLSryPrCNmNmitHOEg==}
+  /@fluidframework/replay-driver/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-NlHAIHr45rrWJOCiFLTnVD6tFzU12iDMd80z0VrkloaHO/iAXT3HkjLVOPU+4jLnycB4FWy4Qe2h6NZ/XpXc6w==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/replay-driver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-nRrYeAevWpikXtgLml3oi3NajMqj3Qm1+CNs7llTUdVWhbJC0F9wSqTdbuYDgAEhZ4pFzJ2s/tSkbnnh8cf6Uw==}
+  /@fluidframework/replay-driver/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-bWkBBZGtMo+NOk5BU7ePkz7Vkq3IIOxeTnNROWKT51i9hXRvdKlcGY27s/Ox8rKYuC49SD720eziBrJ339QCHA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/request-handler/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-Ibo63Q8Tx5f/9RG0k9/XGK7naoMphyLGjmYmVP6GEfF7P9QwXKJ1rdXNL+LvtfN8uSHuWmNygZ2YWnjhq+X4bQ==}
+  /@fluidframework/request-handler/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-ATjRCHgiLK3cloqOsPFVyNW0HnOGNMh98MdqbNs2Pln/pBvZK9fPFvPt2NIUXRPQ/Yusoixr/gTPU02gDk1/Yg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/request-handler/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-8GckLkahngAznLpMedJk8Qo1IWhXjl2BhfA+8dKCOXeEn5IdgzdYupjeN3CMjCydERK3nfyRRSiv0pp0ipG4lA==}
+  /@fluidframework/request-handler/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-dLAhErRB4pm6D1fEGdmgjOlHp2ylQ30NCkNflfBGQMJMpqnpCpnblh4XnUDsObvaWso6E7ONEBtaC1usoFvgfQ==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-gLLONsTz1trnW1wtCQtXhPyYdy+qQNcI4wNs+ZfPviWKKFwG8LAd9o6lX6VTB7f6CXani3q3USffFvrxKQDhPA==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-2S0zrU+8tMjg79XUkxgsOIBCL9omg2HDBvv3u/KrdsNJIAi73zYsxKfxrptmHKC/09vfUyQQRMO6KCSqOPkNTw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-base': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/gitresources': 0.1038.4000
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
       '@fluidframework/server-services-client': 0.1038.4000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       cross-fetch: 3.1.5
       json-stringify-safe: 5.0.1
       querystring: 0.2.1
@@ -14282,19 +14180,19 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-blOaZmEQAzTh6ajJ856IK2foyRJykzy1Tq0O78iVS0jCo46hQNejKvRw0+NA/xlYIv05xKWNTsfmrkTXXHsMmw==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-rBgpTqfzhC9FuXa3MgqyuFC90c+Ldg+NEkOso6dN4UkVGoSb8WDyWnhLRiA+aXKG2JVO6QrEZ48HOVH+cgHJ0g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-base': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/gitresources': 0.1038.4000
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
       '@fluidframework/server-services-client': 0.1038.4000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       cross-fetch: 3.1.5
       json-stringify-safe: 5.0.1
       querystring: 0.2.1
@@ -14309,50 +14207,23 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-blOaZmEQAzTh6ajJ856IK2foyRJykzy1Tq0O78iVS0jCo46hQNejKvRw0+NA/xlYIv05xKWNTsfmrkTXXHsMmw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-base': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/gitresources': 0.1038.4000
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/server-services-client': 0.1038.4000
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      cross-fetch: 3.1.5
-      json-stringify-safe: 5.0.1
-      querystring: 0.2.1
-      socket.io-client: 4.6.1
-      url-parse: 1.5.10
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-ol2F4Ux7sRq40JS3D6BUUfd/yqTGjhNaw3AMWm2HfeQ/hizFNAckvLdeqxFzJg//3bEGtueaQ1CfUFUPJebIsw==}
+  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-yHpnrHSf79alMux/j8PY3kENjI5RJOauJc6C02Dmuey7g7+LJE5ZXERC18RmUp/R6wuaruHotrJJ/jdSTk46wQ==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
       nconf: 0.12.0
       url: 0.11.0
     dev: true
 
-  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-JE/8oIpAHfSmtCbsdQvVbTnd5J2o5f/vWeXeXQ9w1pK42Z70Pt5IVfcjhIRHBR6xaThlbM/xDawqJSeET+qKhg==}
+  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-lN4n54yAtQ89TDJHjXY41MVNV/c0QxGhNC+drwwJhEHFomCHNrx2YEqzExtKdUo93VDRu9YC8Vnf0LEzM4lIqw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
       nconf: 0.12.0
       url: 0.11.0
@@ -14369,25 +14240,25 @@ packages:
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
-  /@fluidframework/runtime-definitions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-l28uA04tYt9c28yo0kexz7cw0sgwVkce0ruLfvpE6gHtxG/mnbJO6NzokBTL5TDdF6pVukzMhUBzSTRT3RcYHw==}
+  /@fluidframework/runtime-definitions/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-2WNuNC5KbO5i8uUC2yLTEvQcPQh/cLyrCt4ZexNCuyCSgfDrkNv9VndHJVkmyBhB310A72P2YAPC7G6HR7DV9Q==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
-  /@fluidframework/runtime-definitions/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-H7lY1krb27M76qRuoPi7hI2dyEuQVHzYdPd430SyI7WHqh4Q1vrU5FrNF8VHgeN8x7Ol60jNiWJ8LyRf6OKSKA==}
+  /@fluidframework/runtime-definitions/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-3Jq1MfElRdSBb7rpOihRf5JqzdBzxhc8JFpe0NLeBFLvnFbEOFwgQMY36ykf9veIozjPmOcsz/JBVM5OeO0A5A==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
     dev: true
 
@@ -14409,78 +14280,78 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/runtime-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-EG9kLvnEERriEoKQJAq6gBfzQK7gk412zFjiTaYSvVN6pzY+xNB3OXnxjmRMOuYOkOu9N03dAuoAZ4Mu0TMU7Q==}
+  /@fluidframework/runtime-utils/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-4/kPEMsi3B4WjJcb6E+8qxt4mhGi3JN7qpOUeRYR3l4G51uBI5XQpZPEKCDaKk33nmo20P08wTayLpbJtPM5RA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/runtime-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-+LVuXcvVuuxky2v8+QvkRWNJUpHl0DZ0DhmtfrQSTKGx74NFWQDFhWoyuT3EqJd9ULcvHwF5ZuoKpaw7qBtx9A==}
+  /@fluidframework/runtime-utils/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-wmgicVK1VjWBkRCe6Rnc51MqDmvxLLRPEpECDdzOfkcZv/4TBB9QBuay7DvDWFLGESWvcMR8aYhJP3qDzxPVjw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/garbage-collector': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/sequence/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-I6UCsATCKKGfftrSnEOHs4JtZfAmIezO3V34IB6G416ykiOn9iSrzj3gpfiHG3tFFGwOzREODYR4DeMmtDn3bA==}
+  /@fluidframework/sequence/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-f0vLaR41dXdsl3lQg9XI1aaFHKEyO/nr6YgFAP83KCDkZqi7axjnbZ9vTWhi8wsCKAbY6rGQ/xSdyoXEd1yGMg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/merge-tree': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/sequence/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-33aAJY1KiQXQYCrZrxU4LuQaRNwRhSyH8GnQ8q0bmp3wkok8WL1YGcb/vJSNKg5MfYce8OB+jaERG9xC9OwkIg==}
+  /@fluidframework/sequence/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-ciiCHqA5ctr0Bzg8PprBlrjRFq2qiN25WAY8OFdO8uzKS3GtwXHNiL9VtdJVmwFKrYQ46l+jsorA0uxV3xwF6g==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/merge-tree': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
@@ -14529,36 +14400,6 @@ packages:
     transitivePeerDependencies:
       - debug
       - supports-color
-
-  /@fluidframework/server-lambdas/0.1038.4000:
-    resolution: {integrity: sha512-uy/XrfKPSjo9RHWW6NWdEzkIiLhMZDZCNck1UyWAYiaCWNjcpQJ98Wv/HO0fpTPxGPn7CysGlX7qreXqBRkwoQ==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/gitresources': 0.1038.4000
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/server-lambdas-driver': 0.1038.4000
-      '@fluidframework/server-services-client': 0.1038.4000
-      '@fluidframework/server-services-core': 0.1038.4000
-      '@fluidframework/server-services-telemetry': 0.1038.4000
-      '@types/semver': 6.2.3
-      assert: 2.0.0
-      async: 3.2.4
-      axios: 0.26.1
-      buffer: 6.0.3
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      json-stringify-safe: 5.0.1
-      lodash: 4.17.21
-      nconf: 0.12.0
-      semver: 6.3.0
-      sha.js: 2.4.11
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
 
   /@fluidframework/server-lambdas/0.1038.4000_debug@4.3.4:
     resolution: {integrity: sha512-uy/XrfKPSjo9RHWW6NWdEzkIiLhMZDZCNck1UyWAYiaCWNjcpQJ98Wv/HO0fpTPxGPn7CysGlX7qreXqBRkwoQ==}
@@ -14884,105 +14725,105 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/shared-object-base/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-n9aSMWNx+s12WDkfxJVle2BWr9glvQSfNxVl5ZUSji6fcP8TRfBEhZl8oblqJVpMjTLuoYbS25rfegZPam3bmg==}
+  /@fluidframework/shared-object-base/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-DqZkSCSYXWQEpLUVEbPuUY/VZxAOE/N7gUNZIwmj3GnCV2X/J4rFO9SuLKotei1Hnk4I/32fVcKniuzBoJ0sGw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-object-base/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-FMjPUhfPiIbykOI+I12gOgAPq6rLCB8oQOaVfT2+cYz0EuOEQ1OCFq3dGAvcyFSyt6nQZFPErqb7zRLM2eS6yQ==}
+  /@fluidframework/shared-object-base/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-i4fEVebritfBfKuMoWXMRcFk6a3N5O7/MZZ/9BsHiYlt+fpMdxMxMR/ZrQra5P3PpCI+tPDNsX/7wPFO6el7nw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime': 2.0.0-internal.3.4.2
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-object-base/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-FMjPUhfPiIbykOI+I12gOgAPq6rLCB8oQOaVfT2+cYz0EuOEQ1OCFq3dGAvcyFSyt6nQZFPErqb7zRLM2eS6yQ==}
+  /@fluidframework/shared-object-base/2.0.0-internal.3.4.2_debug@4.3.4:
+    resolution: {integrity: sha512-i4fEVebritfBfKuMoWXMRcFk6a3N5O7/MZZ/9BsHiYlt+fpMdxMxMR/ZrQra5P3PpCI+tPDNsX/7wPFO6el7nw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/container-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-summary-block/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-xNKeEUKtFSj/wTOkGKNmV/C6nOBDHxd3Q7aGeiLEaKEFASDGYvXOahpb2KkWcjLQ7YlzG9sx9j5iHbyKpEE37Q==}
+  /@fluidframework/shared-summary-block/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-93W02bhOY1QBBFNFjrDR5vcwgK4SW2L59HhZq3De3OOJmcv/LVltwih155YcabsfpxEqRvx8gvgmuCaIWqTH9g==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/synthesize/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-lJbTdNe2vl/zpawe5i3MnFcslaBQLxMLWs8S+miFTGL5GkVeisFZ34D+q8Cm7EMTb0/Kv6z90kMEfs8LCQDsOg==}
+  /@fluidframework/synthesize/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-s8AkXLP9jfTzthktgeVbCTkxR/UGiusdtAPeWVff8nzzDTikBCmgdK3YrL4ggA5OHoeRGCmTmH4Ht8nitEX07w==}
     dev: true
 
-  /@fluidframework/synthesize/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-LzOUUCMoD69n+qH50DOw2WlMQ/viOPAxe0KFcRVVPftwqqStABx2hBzVm06811+0nCVPDfsnFvwwIkdupzTK6A==}
+  /@fluidframework/synthesize/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-z4I257PETa0/AB7w0thmvSx73XfATfDWe2XyQAhVGvLa/NnVh+UTT2/13kd3ClRg3Tutjx031oskU53iyWhr1w==}
     dev: true
 
-  /@fluidframework/task-manager/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-W0LGdGvFff0+T0UD/94NI3TZKcK13nHOsL98yHC5w2bGn0Up7yJmOfo82zAGe0XGSVu2lZ0SWLkmlLfE4POFRg==}
+  /@fluidframework/task-manager/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-Zjh8wP8fpDiQ1rMMdrbMw4Z6C3AAMcRAIUdFlBWLanGXrThgk37yLCmzqFTRKuzDca/duSNx3roehmRaxKlOBg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/shared-object-base': 2.0.0-internal.3.4.2
       events: 3.3.0
     transitivePeerDependencies:
       - debug
@@ -15001,8 +14842,8 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/telemetry-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-+h+r/mSNsEUAoqmMtcm6ETb+LAohD92TJWnPrE1r0VM4pgbSry1DBWKwohnIkYOFdgW4Nh4mAMU8MMzZOWB3BQ==}
+  /@fluidframework/telemetry-utils/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-HU8GLshDT8H7j4ip0K9+SFhBaFjhejK9qLTAYvbdzClw5JuD01OrB9nOseLvKu/AC+WIThtXBNlhfz+LtLZ9mw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
@@ -15013,8 +14854,8 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/telemetry-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-IbJe5y9hno1k7C/ZrJsaCuefGXtrwYh1Ro8d0nY2XaZbPCD0u6nYzDhKY/UtyUfq5wC8mCMHx/JgzGzkekhd8w==}
+  /@fluidframework/telemetry-utils/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-Gz/uFIyDSb5bkfzljX8vLaZrOw4FnUO0xX3g3JJq2QeHZUrgeDK8TgYrEhQ4tTc7wyzt4b8JJkhUbgyD8qH6UQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
@@ -15025,11 +14866,11 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/test-client-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-WylamsOD6oCcOq6sYhU1woplNW/YKyABnjjAOCIyRnrraDDaZEe9PDVGGaomNXuicLGu3oASxHfKBC8vqAGLVA==}
+  /@fluidframework/test-client-utils/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-GXRfqNG2120bx3zZ0gOWXwonTzo3aJsb99DhB48njA5Ncvuch16Q+mf8e+kigKyddyFfc/1Xw8cXZaNN7P+HNA==}
     dependencies:
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.4.2
       sillyname: 0.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -15040,11 +14881,11 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-client-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-xoQbJ0/kTXbAHobFKblydSDSmrsRJg6cRmg2MsbZAABFd28mh5ez8WYcng2OQgZGGPjh6mSULjSOlYVvnyfSzw==}
+  /@fluidframework/test-client-utils/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-h2kBRQaenF5zyxKZ6wGQNa2cVlOpWF+inOhzMogY7ievtFev1nBPB+lTu/vNn8uTJJIrvFXspbEc4Pw+/KlzRA==}
     dependencies:
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.4.2
       sillyname: 0.1.0
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -15055,46 +14896,46 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-driver-definitions/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-ZFuLpORr7mlb5s9XZBym3irazL8N270PNymK1nx/jqDHNvPL4z+j2syUoQ21dJLl3JEyxfQmdC80SF8XvXi3cg==}
+  /@fluidframework/test-driver-definitions/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-nPargvrRn3v3s4xUm/rHMEBcM7EskK3HxG+TixMXpuEG51ZUGmPH+SCqX5GJW9j9KQoy0sEAURMx6OnQEHa4qQ==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
       uuid: 8.3.2
     dev: true
 
-  /@fluidframework/test-driver-definitions/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-wmLxVq2MkY/UF7As3U0bjXY+QUNsJGa9jjCqTnBMKqQxlHU5Yyp+9VgKtC168krDx/ej8Ycvbfh03hHFHcN/Ow==}
+  /@fluidframework/test-driver-definitions/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-xIBsdJoyYDDCFRD8PpsG8f0ubfUvW56bHEufOiqfYav7WFmBqy+9S02pTSCdHLmRvW752WeLntRJypwTe2FA/A==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
       uuid: 8.3.2
     dev: true
 
-  /@fluidframework/test-drivers/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-Ai8sjFFhINr2bzPh56IohVZ86O2F4vqqhbJHAz4xidKsFTSpmD+guhp0ogHVITumCEV94nkacQeN+LgKvSkIog==}
+  /@fluidframework/test-drivers/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-rt2GlSwLlFEz6gZUzk7gMwHogd6N7eDfkOY8RG8uoILeAt7f2aClz56ryELDoHZeTFTw7kQKVuMw62oVTMphYw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/local-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-urlresolver': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/local-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-urlresolver': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.4.2
       '@fluidframework/server-local-server': 0.1038.4000
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/test-pairwise-generator': 2.0.0-internal.3.3.1
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/tinylicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/tool-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/test-pairwise-generator': 2.0.0-internal.3.4.2
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/tinylicious-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/tool-utils': 2.0.0-internal.3.4.2
       axios: 0.26.1
       semver: 7.3.8
       uuid: 8.3.2
@@ -15106,26 +14947,26 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-drivers/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-WvWE9F94xQdSpe6KwMFGLSvKLnBCjG9g6oIYal/7xV/INblm/iyN2QsCNqijLqg1Z3zrDNDXtBk9NdgGJMa9FQ==}
+  /@fluidframework/test-drivers/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-SWI1YIBGUb4QvCft2KExxGRatV7KFBEx8MsqG7j9ALIT+7UUEirt32Mb8ozKgoSAIw7ahLxXXU27P5AUZEBQXw==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/local-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-urlresolver': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/local-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/odsp-urlresolver': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.4.2
       '@fluidframework/server-local-server': 0.1038.4000
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/test-pairwise-generator': 2.0.0-internal.3.3.1
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/tinylicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/tool-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/test-pairwise-generator': 2.0.0-internal.3.4.2
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/tinylicious-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/tool-utils': 2.0.0-internal.3.4.2
       axios: 0.26.1
       semver: 7.3.8
       uuid: 8.3.2
@@ -15137,117 +14978,40 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-end-to-end-tests/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-/Altf290r34gFVvGkO+foP1KuhaMiO5T+CXdkDNskyqTEAoUM72Tb5RMkbX1z/bqO7egEFCZ1efe5Y8oI2PwOw==}
-    dependencies:
-      '@fluid-experimental/sequence-deprecated': 2.0.0-internal.3.3.1
-      '@fluid-tools/benchmark': 0.45.112032
-      '@fluidframework/agent-scheduler': 2.0.0-internal.3.3.1
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1
-      '@fluidframework/attributor': 2.0.0-internal.3.2.2
-      '@fluidframework/cell': 2.0.0-internal.3.3.1
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/counter': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/garbage-collector': 2.0.0-internal.3.3.1
-      '@fluidframework/ink': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/matrix': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/mocha-test-setup': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/ordered-collection': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/register-collection': 2.0.0-internal.3.3.1
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/sequence': 2.0.0-internal.3.3.1
-      '@fluidframework/shared-object-base': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/test-loader-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-pairwise-generator': 2.0.0-internal.3.3.1
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-version-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/undo-redo': 2.0.0-internal.3.3.1
-      cross-env: 7.0.3
-      mocha: 10.2.0
-      semver: 7.3.8
-      sinon: 7.5.0
-      start-server-and-test: 1.14.0
-      tinylicious: 0.5.0
-      url: 0.11.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/test-loader-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-Xp5Oc7Tx/GAX68DcupvMRWkpKS72hn1dnE7diI98hu8Iw6wmvdZQznJRV4HcMTDfOD/y7wFwAZ/OB8Q+LUgdMw==}
+  /@fluidframework/test-loader-utils/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-GFJ2cN33oOGaUS8eMcQLTyoj5cMt7I4LOjcuj9lCIIgYA+DfeUlF3etI/lIepo3shQaeWU8TL8QLvILwXVZ0CA==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/test-loader-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-tbUEXnNoExtUVLUrXiDOPsrveuzRKm9MxYv1RJCvKWXXshMOf+/7+x2eZ5dFq5gIW6/zOGitDSW/RcR0zzIYkg==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/test-pairwise-generator/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-VPU/qtTDqZxRdav+TW/Anx6KHHu3HWEVSrcfQx9ZXEg5n5m8dVdNQ6dmNqa4rZGexQ4aEoxG6ojK2p6tqerbCw==}
+  /@fluidframework/test-pairwise-generator/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-NTdeRUnYBHG2ttx8+PRPdM0U9ieEBq7MfehO47LbASxe/zOk8N/UldrVnY5UuvcAe2TU4IE3lAp5BCo2xAvLJg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
       random-js: 1.0.8
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-rrulWN8F0h11R1KQJ7q8IUxueTIB5279VpLYjIf5mbuT6dxw397MvtTYxux/6m0R8538aKHtab0159+mSKAx/w==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-6SQ8RJiVE3mELS71oKvJXcHwRsY4q7pp8JmCJppVmfc9v//6PG2U4hg6QWLnKyWjTRvSwTmAeCgj8/2AvbMYHg==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      axios: 0.26.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       events: 3.3.0
       jsrsasign: 10.7.0
       uuid: 8.3.2
@@ -15259,49 +15023,20 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-1rv5Lad8A/3eoOUKs3iiLX5FchZfbovSYH9RRt0Fp+KOVHycwVRAci7kDlECuPKm9+ai0BWSSZXNSdwgMhbxKA==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-0Tzv6kG6htcLXZabC1dnmULTbSK8S9hnvi8Gaiz0kWtZlwpPTCvl43PuIWtxTbSyZiR9O22wYKG/dZFcDCS0Jw==}
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      axios: 0.26.1
-      events: 3.3.0
-      jsrsasign: 10.7.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/test-runtime-utils/2.0.0-internal.3.3.1_debug@4.3.4:
-    resolution: {integrity: sha512-1rv5Lad8A/3eoOUKs3iiLX5FchZfbovSYH9RRt0Fp+KOVHycwVRAci7kDlECuPKm9+ai0BWSSZXNSdwgMhbxKA==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      axios: 0.26.1_debug@4.3.4
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
       events: 3.3.0
       jsrsasign: 10.7.0
       uuid: 8.3.2
@@ -15318,107 +15053,93 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/test-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-1r+Gu0j690iBD0K9kQg+p3Nz30zmElC8lS0nQ2qR+pfjvhO8Mi0noyxm3ChnrQknP6+h9mmghrXXaRwIPtTuQQ==}
+  /@fluidframework/test-utils/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-YWtm057aYWkS8TZBP9CnX1nY6DvxQ4g/QG5u0/DML+eBY6JVbHyio0ix6uc0MXh1aePmWP6ucyApbaWuLyIluw==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1_debug@4.3.4
+      '@fluidframework/aqueduct': 2.0.0-internal.3.4.2_debug@4.3.4
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/local-driver': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/map': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/mocha-test-setup': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-loader': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/container-runtime': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/map': 2.0.0-internal.3.4.2_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.4.2
       best-random: 1.0.3
       debug: 4.3.4
       uuid: 8.3.2
     transitivePeerDependencies:
-      - bufferutil
-      - encoding
       - supports-color
-      - utf-8-validate
     dev: true
 
-  /@fluidframework/test-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-fEiGaxrQFYPAwQ82HWM2smKnsUvYHomz3c1U35S5t8agfwvKtFNz6c+e055YRsqd0mZZeDVPR8sUOS4nT04XRg==}
+  /@fluidframework/test-utils/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-L+LnJzoNHDt0OzG7hY2zmDbsmob2xCySuBCAbjUS+fPR4RJmsONgNlIChhq8j/4VGLX2B1bWCByDmFvR4UJPzQ==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1_debug@4.3.4
+      '@fluidframework/aqueduct': 2.0.0-internal.3.4.2_debug@4.3.4
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/local-driver': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/map': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/mocha-test-setup': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-loader': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/container-runtime': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2_debug@4.3.4
+      '@fluidframework/map': 2.0.0-internal.3.4.2_debug@4.3.4
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/request-handler': 2.0.0-internal.3.3.1
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.3.3.1_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.4.2
       best-random: 1.0.3
       debug: 4.3.4
       uuid: 8.3.2
     transitivePeerDependencies:
-      - bufferutil
-      - encoding
       - supports-color
-      - utf-8-validate
     dev: true
 
-  /@fluidframework/test-version-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-InJCIkQ/Y5yBu+TPz+VhQx8mlQrmwLtBRDswrAHp3CN54D2NqjRkrLisLupITPOzYnXu7znS9b9FfjSWI0F18w==}
+  /@fluidframework/test-version-utils/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-8WCUZE0VQDAsDyIEPE3kflYiZuapniD3H12ryJ0l8d3hhRUv3XzNOgaTFldQv9OFnrC2xe0NlSGfl/0xIFIUKg==}
     dependencies:
-      '@fluid-experimental/sequence-deprecated': 2.0.0-internal.3.3.1
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1
-      '@fluidframework/attributor': 2.0.0-internal.3.2.2
-      '@fluidframework/cell': 2.0.0-internal.3.3.1
+      '@fluid-experimental/attributor': 2.0.0-internal.3.4.2
+      '@fluid-experimental/sequence-deprecated': 2.0.0-internal.3.4.2
+      '@fluidframework/aqueduct': 2.0.0-internal.3.4.2
+      '@fluidframework/cell': 2.0.0-internal.3.4.2
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/counter': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/ink': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/matrix': 2.0.0-internal.3.3.1
-      '@fluidframework/ordered-collection': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-loader': 2.0.0-internal.3.4.2
+      '@fluidframework/container-runtime': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/counter': 2.0.0-internal.3.4.2
+      '@fluidframework/datastore-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/ink': 2.0.0-internal.3.4.2
+      '@fluidframework/map': 2.0.0-internal.3.4.2
+      '@fluidframework/matrix': 2.0.0-internal.3.4.2
+      '@fluidframework/ordered-collection': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/register-collection': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/sequence': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/test-drivers': 2.0.0-internal.3.3.1
-      '@fluidframework/test-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/register-collection': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/sequence': 2.0.0-internal.3.4.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/test-drivers': 2.0.0-internal.3.4.2
+      '@fluidframework/test-utils': 2.0.0-internal.3.4.2
       nconf: 0.12.0
       proper-lockfile: 4.1.2
       semver: 7.3.8
@@ -15430,48 +15151,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-version-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-ujxUasNowOUAuvwEuyomZPyVO6EeYLPVmWQrTtUv+oVYar2vHIkX3dwjdqiPiDLLbKGZZum9Jnzq9gR76RbMUw==}
-    dependencies:
-      '@fluid-experimental/attributor': 2.0.0-internal.3.3.1
-      '@fluid-experimental/sequence-deprecated': 2.0.0-internal.3.3.1
-      '@fluidframework/aqueduct': 2.0.0-internal.3.3.1
-      '@fluidframework/cell': 2.0.0-internal.3.3.1
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/container-runtime': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/counter': 2.0.0-internal.3.3.1
-      '@fluidframework/datastore-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/ink': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/matrix': 2.0.0-internal.3.3.1
-      '@fluidframework/ordered-collection': 2.0.0-internal.3.3.1
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/register-collection': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/sequence': 2.0.0-internal.3.3.1
-      '@fluidframework/telemetry-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/test-drivers': 2.0.0-internal.3.3.1
-      '@fluidframework/test-utils': 2.0.0-internal.3.3.1
-      nconf: 0.12.0
-      proper-lockfile: 4.1.2
-      semver: 7.3.8
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/tinylicious-client/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-9g/HnsT3nUMLEP3QRBb7EatnBZOqcQ2vK6HcaOiiwOZG7RyMV5H6bpBRr+EusNjHsTbozNDXOvcYeCyRfCHoFg==}
+  /@fluidframework/tinylicious-client/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-VoOL2zhkaPaEsZ+77f8NaxdxalOKgvpjW3T8qzb3VuGMdmEah5kZPfipGfntJfxBGqOhw44HKLyXodUcW6Ptsw==}
     peerDependencies:
       fluid-framework: '>=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0'
     peerDependenciesMeta:
@@ -15480,16 +15161,16 @@ packages:
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/container-loader': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/fluid-static': 2.0.0-internal.3.3.1
-      '@fluidframework/map': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/container-loader': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/fluid-static': 2.0.0-internal.3.4.2
+      '@fluidframework/map': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
-      '@fluidframework/runtime-utils': 2.0.0-internal.3.3.1
-      '@fluidframework/tinylicious-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.4.2
+      '@fluidframework/runtime-utils': 2.0.0-internal.3.4.2
+      '@fluidframework/tinylicious-driver': 2.0.0-internal.3.4.2
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -15499,14 +15180,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-driver/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-ObO4ONwwpAEtANqNFCWyw5xZrF56AYlMARcuqZMb8TjmrLl373IDm4G8T2+QMQ1Ij5zp6tV8PsTNvnQoXuG7fg==}
+  /@fluidframework/tinylicious-driver/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-CPNi37gRH/Tfl6UDOIw/el9QyJ4KBn4YBOG72RJdCKZsWfimRWNWS0+10f64n2gKYNcIM531/6/YvYTde0fL9Q==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.4.2
       '@fluidframework/server-services-client': 0.1038.4000
       jsrsasign: 10.7.0
       uuid: 8.3.2
@@ -15518,14 +15199,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-driver/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-QzTKXFnvJ9VC0UcIRTI3w6sYxomRFoNqo4DuyNjYYGRbOt8kLL6zVRm9bw8cQTx5CQyOPXdBC7fefndTmFX6jA==}
+  /@fluidframework/tinylicious-driver/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-gQwarrqREZJl6n+kJMqIgKQkxjcgKY5d8LpdfV2Rhlb90eO1Uiu4pUGRyQGIginZ1lAkOlvYO2MzZreUXZJ6hw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/driver-utils': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/driver-utils': 2.0.0-internal.3.4.2
       '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.3.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.3.4.2
       '@fluidframework/server-services-client': 0.1038.4000
       jsrsasign: 10.7.0
       uuid: 8.3.2
@@ -15537,11 +15218,11 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tool-utils/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-WRvLSGzx3pU5Npo1n1xyjW4iUi3HYkyMAEFi/E2/pSQ4Q/C5fRVt3aQ1pd5CGUQjgkqiKBwNduh82Ib83Hj8dQ==}
+  /@fluidframework/tool-utils/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-SSYOnB5Oqi8bOxDYch8HyhE9LHUSNWcmiThgFKOyPeOO+6N9SnNRzlF60a7u1x4fCTfwLN/QoUUOJQi4LRUUZQ==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1_debug@4.3.4
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.4.2_debug@4.3.4
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
       async-mutex: 0.3.2
@@ -15553,11 +15234,11 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/tool-utils/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-SX4uwiWSIluVGgmqvCz0NE/V49pbF0CVkAKo4pfRCT0j37hKqbn6WiYsZ5KtsajFMSiX38RQMcUZDmm2yi7m5Q==}
+  /@fluidframework/tool-utils/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-g15wsxHIhR0zmrKrrewPA6oVLGd+hIIYGg4HgSvTr0lnJJI3JubSQkS8sdgocSg6u9iwITzPNhp8QIayKhVTMg==}
     dependencies:
       '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.3.1_debug@4.3.4
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.3.4.2_debug@4.3.4
       '@fluidframework/protocol-base': 0.1038.4000
       '@fluidframework/protocol-definitions': 1.1.0
       async-mutex: 0.3.2
@@ -15569,77 +15250,64 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/undo-redo/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-WjV1sRNEy+ilXvjJFiZyDg3Sx4d9+hDefjYbMMkNqaSxBZm9M0S/KMucx1VYdX2jRYeTm/LpMgozPVMis3tjnw==}
+  /@fluidframework/undo-redo/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-RUof7+2VwpsTdoz4n3qM0e8aWLi0wo3qXVEeB9nSqIGqYlq2wtj3bxCB99rubi22Kfy0Tg4N7vK4TxYr76A9Cw==}
     dependencies:
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/matrix': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/sequence': 2.0.0-internal.3.3.1
+      '@fluidframework/map': 2.0.0-internal.3.4.2
+      '@fluidframework/matrix': 2.0.0-internal.3.4.2
+      '@fluidframework/merge-tree': 2.0.0-internal.3.4.2
+      '@fluidframework/sequence': 2.0.0-internal.3.4.2
       events: 3.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/undo-redo/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-iUZH0unt1zj788sK/6kLL1O7730N3MZ96H650tbPtoXQDEUh66QDWg01eGBvKQtWYlWHx6aDeEoCcu1/LhnJiw==}
+  /@fluidframework/view-adapters/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-Clyz5huL0nnIwk/xeJtaUAQPjEdz7f0lyDhD5eNM+vRklQah6PmwBtMvaaLoTnMykS1q/KC+idt37yR6UP6U+Q==}
     dependencies:
-      '@fluidframework/map': 2.0.0-internal.3.3.1
-      '@fluidframework/matrix': 2.0.0-internal.3.3.1
-      '@fluidframework/merge-tree': 2.0.0-internal.3.3.1
-      '@fluidframework/sequence': 2.0.0-internal.3.3.1
-      events: 3.3.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/view-adapters/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-PYDZ25qm6KrpeDxzG6KQ3c9K8trpq17lWstBjHnKe6IcuuKF9xacj8jZtdniP0pNuHjmW7SJeP9nS/xIQzefiA==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/view-interfaces': 2.0.0-internal.3.4.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
-  /@fluidframework/view-adapters/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-0DP8kokVHt+RqnODAa5DSGY0YbxwhJg6ET8eyeP7i/n/5ocTDHnlbfPng/HHg0gq8CsETL0lwByQx3GwcWkFwA==}
+  /@fluidframework/view-adapters/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-OK3x6CzLkwzAHa/UHdWGqVRi0o6HrjhsauRxj6wLJhI9nI7mPmErAdzGm4j2ShnSzyQx2uW6Dn4dxxR874nFEQ==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
-      '@fluidframework/view-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
+      '@fluidframework/view-interfaces': 2.0.0-internal.3.4.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
-  /@fluidframework/view-interfaces/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-kwMOGl/stYyRiiL0+C7RwKLQewQHNghEVAD1HyJspDZ42fHA27SUOFfleCU6bz+lmZv+CRgNiXZynzFI1s//IA==}
+  /@fluidframework/view-interfaces/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-NM1o9OUZR+F6nopMQszAmRx+qYsvgghTCslVNWLbuMhBLBftTJFUko/H7TEAcfu4vqXvJFh5EG3OW/+AKhLxww==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
     dev: true
 
-  /@fluidframework/view-interfaces/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-bho8Heaeac84WeCid3yuhzkImqCxH+ABGbJk09PG+YKSal/PTK6nnDz+dm69lIpRqpb1xh7mNF9NqBUUnSJ7nA==}
+  /@fluidframework/view-interfaces/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-6xVYUn9l2YvRTN356fFqm9JStYr2Y61WRnR9Ja2Q/nTA1JaGsOCn8Qrv6v2sNw2uSssTwC8OEpXljT3dB7QC2Q==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
     dev: true
 
-  /@fluidframework/web-code-loader/2.0.0-internal.3.2.0:
-    resolution: {integrity: sha512-3cUzcac5/s9lE4n54CcyOa3dXv8i2eErGr7v+fh+9hZAkdcc/O6VxMyLz5QmDkwnE6KwC9pleuf63RSXzyaSww==}
+  /@fluidframework/web-code-loader/2.0.0-internal.3.4.1:
+    resolution: {integrity: sha512-06aXpZVhk/KrK2f1OtsPiBCHjPulE3OUweG8q5UfH5bufRd1mcBhkH5abzwhyLVVO8hBZGG6/fgI/hJbx2Xjog==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
       isomorphic-fetch: 3.0.0
     transitivePeerDependencies:
       - encoding
     dev: true
 
-  /@fluidframework/web-code-loader/2.0.0-internal.3.3.1:
-    resolution: {integrity: sha512-LMBuFaKn8oZfEvOaBVFXqI9esyPISJaoVCTiRaOiWOAl5xrzcfazZpGKUrKaZ7H8QDN4+2R6I/mxnVFvhCMe6g==}
+  /@fluidframework/web-code-loader/2.0.0-internal.3.4.2:
+    resolution: {integrity: sha512-/y0XFmcw/MDeg6TmQuDM/eP0nLQqUNcVr0DfwgFdjSxelL6K/MiSmf2mbtECfQ2xLuD4xkPDhAL1ZaK5bx2w8A==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.3.3.1
-      '@fluidframework/core-interfaces': 2.0.0-internal.3.3.1
+      '@fluidframework/container-definitions': 2.0.0-internal.3.4.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.3.4.2
       isomorphic-fetch: 3.0.0
     transitivePeerDependencies:
       - encoding
@@ -30819,24 +30487,6 @@ packages:
       sha.js: 2.4.11
       simple-get: 4.0.1
 
-  /isomorphic-git/1.22.0:
-    resolution: {integrity: sha512-ZFmfyjj28DthNDDj/aQvxeUIVCj18YGMEjatVGig8ixvUe3oGfqjS7lAbqFXxJQ928oSgmUMcKv6+wz6YMiqZA==}
-    engines: {node: '>=12'}
-    hasBin: true
-    dependencies:
-      async-lock: 1.4.0
-      clean-git-ref: 2.0.1
-      crc-32: 1.2.2
-      diff3: 0.0.3
-      ignore: 5.2.4
-      minimisted: 2.0.1
-      pako: 1.0.11
-      pify: 4.0.1
-      readable-stream: 3.6.2
-      sha.js: 2.4.11
-      simple-get: 4.0.1
-    dev: true
-
   /isomorphic-unfetch/3.1.0:
     resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
     dependencies:
@@ -39871,51 +39521,6 @@ packages:
   /tiny-warning/1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
     dev: false
-
-  /tinylicious/0.5.0:
-    resolution: {integrity: sha512-gpsLV9/Fmyc/jiFWEfj1jQYOZISCVIxemahN/c/USzunqCfLx7J6OYBvcVli6Q9n41ZXsid7Xv06gMuPav7PBg==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
-    dependencies:
-      '@fluidframework/common-utils': 1.1.1
-      '@fluidframework/gitresources': 0.1038.4000
-      '@fluidframework/protocol-base': 0.1038.4000
-      '@fluidframework/protocol-definitions': 1.1.0
-      '@fluidframework/server-lambdas': 0.1038.4000
-      '@fluidframework/server-local-server': 0.1038.4000
-      '@fluidframework/server-memory-orderer': 0.1038.4000
-      '@fluidframework/server-services-client': 0.1038.4000
-      '@fluidframework/server-services-core': 0.1038.4000
-      '@fluidframework/server-services-shared': 0.1038.3000
-      '@fluidframework/server-services-telemetry': 0.1038.4000
-      '@fluidframework/server-services-utils': 0.1038.3000
-      '@fluidframework/server-test-utils': 0.1038.4000
-      agentkeepalive: 4.3.0
-      axios: 0.26.1
-      body-parser: 1.20.2
-      charwise: 3.0.1
-      compression: 1.7.4
-      cookie-parser: 1.4.6
-      cors: 2.8.5
-      detect-port: 1.5.1
-      express: 4.18.2
-      isomorphic-git: 1.22.0
-      json-stringify-safe: 5.0.1
-      level: 8.0.0
-      level-sublevel: 6.6.4
-      lodash: 4.17.21
-      morgan: 1.10.0
-      nconf: 0.12.0
-      socket.io: 4.6.1
-      split: 1.0.1
-      uuid: 8.3.2
-      winston: 3.8.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-    dev: true
 
   /tinylicious/0.6.0:
     resolution: {integrity: sha512-xOhIuwJt4Y9vYesQHzT61piJciFwz+dQnFA52B6CSb5i3dkcLhBMxMX6VvG07zN4HjaR2Sl4HTT7I1lHRM1zBA==}


### PR DESCRIPTION
Updated type tests on the 3.4 release branch by doing the following:

1. Manually disables type testing for end-to-end-tests and remove previous version dependency.
2. Ran `flub typetests -g client --reset --previous --normalize` to prepare the packages.
3. Ran `pnpm i` to install new dependencies.
4. Ran `pnpm typetests:gen` to regenerate type tests.
5. Ran a full build to verify changes.