### PR TITLE
Upgrading typescript transpile target to ES2020 in build-common

### DIFF
--- a/common/build/build-common/ts-common-config.json
+++ b/common/build/build-common/ts-common-config.json
@@ -1,7 +1,7 @@
 {
 	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {
-		"target": "es2017",
+		"target": "ES2020",
 		"declaration": true,
 		"declarationMap": true,
 		"esModuleInterop": true,
@@ -15,6 +15,6 @@
 		"types": [],
 		"strict": true,
 		"pretty": true,
-		"lib": ["ES2017", "ES2018.Promise", "DOM", "DOM.Iterable"]
+		"lib": ["DOM", "DOM.Iterable"]
 	}
 }


### PR DESCRIPTION
## Description

Upgrading typescript target to ES2020 in build-common. After this, I will upgrade the packages depending on this to new version of build common where the target is ES2020.

This change is made so as to decrease the bundle size across packages. More info in the work item:
https://dev.azure.com/fluidframework/internal/_workitems/edit/2772