### PR TITLE
fix(tinylicious): Remove preinstall script

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -85,6 +85,7 @@ module.exports = {
 			"@fluidframework/eslint-config-fluid",
 			"@fluidframework/protocol-definitions",
 			"@fluidframework/test-tools",
+      "tinylicious",
 		],
 	},
 

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -85,7 +85,7 @@ module.exports = {
 			"@fluidframework/eslint-config-fluid",
 			"@fluidframework/protocol-definitions",
 			"@fluidframework/test-tools",
-      "tinylicious",
+			"tinylicious",
 		],
 	},
 

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -25,7 +25,6 @@
 		"eslint": "eslint --format stylish src",
 		"eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
 		"format": "npm run prettier:fix",
-		"preinstall": "node ../../scripts/only-pnpm.cjs",
 		"lint": "npm run prettier && npm run eslint",
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
 		"prettier": "prettier --check . --ignore-path ../../.prettierignore",


### PR DESCRIPTION
Remove pnpm preinstall script since tinylicious is a published package.