### PR TITLE
Fix alfred ERR_SERVER_NOT_RUNNING during shutdown

### DIFF
--- a/server/routerlicious/packages/services-shared/src/webServer.ts
+++ b/server/routerlicious/packages/services-shared/src/webServer.ts
@@ -18,7 +18,6 @@ export class HttpServer implements core.IHttpServer {
 	constructor(private readonly server: http.Server) {}
 
 	public async close(): Promise<void> {
-		console.log("yunho: httpServer close called");
 		await util.promisify(((callback) => this.server.close(callback)) as any)();
 	}
 

--- a/server/routerlicious/packages/services-shared/src/webServer.ts
+++ b/server/routerlicious/packages/services-shared/src/webServer.ts
@@ -18,6 +18,7 @@ export class HttpServer implements core.IHttpServer {
 	constructor(private readonly server: http.Server) {}
 
 	public async close(): Promise<void> {
+		console.log("yunho: httpServer close called");
 		await util.promisify(((callback) => this.server.close(callback)) as any)();
 	}
 
@@ -41,10 +42,9 @@ export class WebServer implements core.IWebServer {
 	 * Closes the web server
 	 */
 	public async close(): Promise<void> {
-		await Promise.all([
-			this.httpServer.close(),
-			this.webSocketServer ? this.webSocketServer.close() : Promise.resolve(),
-		]);
+		// Since httpServer is reused in webSocketServer, only need to shutdown webSocketServer.
+		await (this.webSocketServer ? this.webSocketServer.close() : this.httpServer.close());
+
 	}
 }
 


### PR DESCRIPTION
Alfred has websocket sever and http server and websocket server reuse the http server. During shutdown, it shuts down both servers and triggers an error: ERR_SERVER_NOT_RUNNING. It is because the http server is shut down twice, once in http server and 2nd time in web socket server.
Change the logic to shutdown only websocket server if exists.