### PR TITLE
refactor(client-debugger): Cleanup messaging infrastructure

### DIFF
--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/content/ContentScript.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/content/ContentScript.ts
@@ -38,8 +38,10 @@ chrome.runtime.onConnect.addListener((backgroundPort: chrome.runtime.Port) => {
 	/**
 	 * Relay messages if they conform to our expected format.
 	 */
-	function relayMessageFromPageToBackground(event: MessageEvent): void {
-		const message = event.data as Partial<ISourcedDebuggerMessage>;
+	function relayMessageFromPageToBackground(
+		event: MessageEvent<Partial<ISourcedDebuggerMessage>>,
+	): void {
+		const message = event.data;
 		// Only relay message if it is one of ours, and if the source is the window's debugger
 		// (and not a message originating from the extension).
 		if (isDebuggerMessage(message) && message.source === debuggerMessageSource) {

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/content/ContentScript.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/content/ContentScript.ts
@@ -42,6 +42,7 @@ chrome.runtime.onConnect.addListener((backgroundPort: chrome.runtime.Port) => {
 		event: MessageEvent<Partial<ISourcedDebuggerMessage>>,
 	): void {
 		const message = event.data;
+
 		// Only relay message if it is one of ours, and if the source is the window's debugger
 		// (and not a message originating from the extension).
 		if (isDebuggerMessage(message) && message.source === debuggerMessageSource) {

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/devtools/BackgroundConnection.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/devtools/BackgroundConnection.ts
@@ -4,7 +4,11 @@
  */
 
 import { TypedEventEmitter } from "@fluidframework/common-utils";
-import { ISourcedDebuggerMessage, isDebuggerMessage } from "@fluid-tools/client-debugger";
+import {
+	ISourcedDebuggerMessage,
+	isDebuggerMessage,
+	debuggerMessageSource,
+} from "@fluid-tools/client-debugger";
 
 import {
 	devToolsInitAcknowledgementType,
@@ -87,7 +91,7 @@ export class BackgroundConnection
 	}
 
 	/**
-	 * Post message to Background Script.
+	 * Post a message for the debugger to the Background Script.
 	 */
 	public postMessage(message: ISourcedDebuggerMessage): void {
 		postMessageToPort(
@@ -108,6 +112,14 @@ export class BackgroundConnection
 			return false;
 		}
 
+		// Ignore messages from unexpected sources.
+		// We receive at least one message directly from the Background script so we need to include
+		// extensionMessageSource as a valid source.
+		if (message.source !== extensionMessageSource && message.source !== debuggerMessageSource) {
+			return false;
+		}
+
+		// Handle init-acknowledgment message from background service
 		if (message.type === devToolsInitAcknowledgementType) {
 			console.log(
 				formatDevtoolsScriptMessageForLogging("Background initialization acknowledged."),

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/MessageRelayContext.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/react-components/MessageRelayContext.ts
@@ -8,12 +8,12 @@ import React from "react";
 import { IMessageRelay } from "../messaging";
 
 /**
- * Context for accessing a shared {@link IMessageRelay} for communicating messages with the webpage.
+ * Context for accessing a shared {@link @fluid-tools/client-debugger#IMessageRelay} for communicating with the webpage.
  *
  * @remarks
  *
  * Any message listening / posting should go through here, rather than directly through the
- * `window` (`globalThis`) or through the `chrome.runtime` APIs in to ensure general compatibility, regardless of
+ * `window` (`globalThis`) or through the `chrome.runtime` APIs to ensure general compatibility, regardless of
  * how the Chrome Extension is configured / what context the components are run in.
  */
 export const MessageRelayContext = React.createContext<IMessageRelay | undefined>(

--- a/packages/tools/client-debugger/client-debugger-view/src/components/TelemetryView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/TelemetryView.tsx
@@ -7,7 +7,6 @@ import React from "react";
 
 import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
 import {
-	debuggerMessageSource,
 	InboundHandlers,
 	TelemetryHistoryMessage,
 	GetTelemetryHistoryMessage,
@@ -49,7 +48,6 @@ export function TelemetryView(): React.ReactElement {
 
 		// Request all log history
 		postMessagesToWindow<GetTelemetryHistoryMessage>(undefined, {
-			source: debuggerMessageSource,
 			type: "GET_TELEMETRY_HISTORY",
 			data: undefined,
 		});

--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -33,7 +33,7 @@ export interface AudienceClientMetaData {
 }
 
 // @public
-export interface AudienceSummaryMessage extends ISourcedDebuggerMessage<AudienceSummaryMessageData> {
+export interface AudienceSummaryMessage extends IDebuggerMessage<AudienceSummaryMessageData> {
     // (undocumented)
     type: "AUDIENCE_EVENT";
 }
@@ -50,7 +50,7 @@ export interface AudienceSummaryMessageData extends HasContainerId {
 export function clearDebuggerRegistry(): void;
 
 // @public
-export interface CloseContainerMessage extends ISourcedDebuggerMessage<CloseContainerMessageData> {
+export interface CloseContainerMessage extends IDebuggerMessage<CloseContainerMessageData> {
     // (undocumented)
     type: "CLOSE_CONTAINER";
 }
@@ -62,7 +62,7 @@ export type CloseContainerMessageData = HasContainerId;
 export function closeFluidClientDebugger(containerId: string): void;
 
 // @public
-export interface ConnectContainerMessage extends ISourcedDebuggerMessage<ConnectContainerMessageData> {
+export interface ConnectContainerMessage extends IDebuggerMessage<ConnectContainerMessageData> {
     // (undocumented)
     type: "CONNECT_CONTAINER";
 }
@@ -94,7 +94,7 @@ export enum ContainerStateChangeKind {
 }
 
 // @public
-export interface ContainerStateChangeMessage extends ISourcedDebuggerMessage<ContainerStateChangeMessageData> {
+export interface ContainerStateChangeMessage extends IDebuggerMessage<ContainerStateChangeMessageData> {
     // (undocumented)
     type: "CONTAINER_STATE_CHANGE";
 }
@@ -105,7 +105,7 @@ export interface ContainerStateChangeMessageData extends HasContainerId {
 }
 
 // @public
-export interface ContainerStateHistoryMessage extends ISourcedDebuggerMessage<ContainerStateHistoryMessageData> {
+export interface ContainerStateHistoryMessage extends IDebuggerMessage<ContainerStateHistoryMessageData> {
     // (undocumented)
     type: "CONTAINER_STATE_HISTORY";
 }
@@ -147,7 +147,7 @@ export interface DebuggerRegistryEvents extends IEvent {
 }
 
 // @public
-export interface DisconnectContainerMessage extends ISourcedDebuggerMessage<DisconnectContainerMessageData> {
+export interface DisconnectContainerMessage extends IDebuggerMessage<DisconnectContainerMessageData> {
     // (undocumented)
     type: "DISCONNECT_CONTAINER";
 }
@@ -171,19 +171,19 @@ export class FluidDebuggerLogger extends TelemetryLogger {
 }
 
 // @public
-export interface GetAudienceMessage extends ISourcedDebuggerMessage<HasContainerId> {
+export interface GetAudienceMessage extends IDebuggerMessage<HasContainerId> {
     // (undocumented)
     type: "GET_AUDIENCE";
 }
 
 // @public
-export interface GetContainerListMessage extends ISourcedDebuggerMessage<undefined> {
+export interface GetContainerListMessage extends IDebuggerMessage<undefined> {
     // (undocumented)
     type: "GET_CONTAINER_LIST";
 }
 
 // @public
-export interface GetContainerStateMessage extends ISourcedDebuggerMessage<HasContainerId> {
+export interface GetContainerStateMessage extends IDebuggerMessage<HasContainerId> {
     // (undocumented)
     type: "GET_CONTAINER_STATE";
 }
@@ -201,7 +201,7 @@ export function getFluidClientDebugger(containerId: string): IFluidClientDebugge
 export function getFluidClientDebuggers(): IFluidClientDebugger[];
 
 // @public
-export interface GetTelemetryHistoryMessage extends ISourcedDebuggerMessage {
+export interface GetTelemetryHistoryMessage extends IDebuggerMessage {
     type: "GET_TELEMETRY_HISTORY";
 }
 
@@ -272,10 +272,10 @@ export interface MessageLoggingOptions {
 }
 
 // @internal
-export function postMessagesToWindow<TMessage extends ISourcedDebuggerMessage>(loggingOptions?: MessageLoggingOptions, ...messages: TMessage[]): void;
+export function postMessagesToWindow<TMessage extends IDebuggerMessage>(loggingOptions?: MessageLoggingOptions, ...messages: TMessage[]): void;
 
 // @public
-export interface RegistryChangeMessage extends ISourcedDebuggerMessage<RegistryChangeMessageData> {
+export interface RegistryChangeMessage extends IDebuggerMessage<RegistryChangeMessageData> {
     // (undocumented)
     type: "REGISTRY_CHANGE";
 }
@@ -291,7 +291,7 @@ export interface StateChangeLogEntry<TState> extends LogEntry {
 }
 
 // @public
-export interface TelemetryEventMessage extends ISourcedDebuggerMessage<TelemetryEventMessageData> {
+export interface TelemetryEventMessage extends IDebuggerMessage<TelemetryEventMessageData> {
     type: "TELEMETRY_EVENT";
 }
 
@@ -301,7 +301,7 @@ export interface TelemetryEventMessageData {
 }
 
 // @public
-export interface TelemetryHistoryMessage extends ISourcedDebuggerMessage<TelemetryEventMessageData> {
+export interface TelemetryHistoryMessage extends IDebuggerMessage<TelemetryEventMessageData> {
     type: "TELEMETRY_HISTORY";
 }
 

--- a/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
@@ -17,10 +17,10 @@ import {
 	GetAudienceMessage,
 	CloseContainerMessage,
 	ConnectContainerMessage,
-	debuggerMessageSource,
 	DisconnectContainerMessage,
 	GetContainerStateMessage,
 	handleIncomingWindowMessage,
+	IDebuggerMessage,
 	ISourcedDebuggerMessage,
 	InboundHandlers,
 	MessageLoggingOptions,
@@ -237,10 +237,9 @@ export class FluidClientDebugger
 	 * Posts a {@link ISourcedDebuggerMessage} to the window (globalThis).
 	 */
 	private readonly postContainerStateChange = (): void => {
-		postMessagesToWindow<ISourcedDebuggerMessage>(
+		postMessagesToWindow<IDebuggerMessage>(
 			this.messageLoggingOptions,
 			{
-				source: debuggerMessageSource,
 				type: "CONTAINER_STATE_CHANGE",
 				data: {
 					containerId: this.containerId,
@@ -248,7 +247,6 @@ export class FluidClientDebugger
 				},
 			},
 			{
-				source: debuggerMessageSource,
 				type: "CONTAINER_STATE_HISTORY",
 				data: {
 					containerId: this.containerId,
@@ -271,7 +269,6 @@ export class FluidClientDebugger
 		});
 
 		postMessagesToWindow<AudienceSummaryMessage>(this.messageLoggingOptions, {
-			source: debuggerMessageSource,
 			type: "AUDIENCE_EVENT",
 			data: {
 				containerId: this.containerId,

--- a/packages/tools/client-debugger/client-debugger/src/FluidDebuggerLogger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidDebuggerLogger.ts
@@ -11,7 +11,6 @@ import {
 	ITelemetryLoggerPropertyBags,
 } from "@fluidframework/telemetry-utils";
 import {
-	debuggerMessageSource,
 	handleIncomingWindowMessage,
 	IDebuggerMessage,
 	InboundHandlers,
@@ -78,7 +77,6 @@ export class FluidDebuggerLogger extends TelemetryLogger {
 	 */
 	private readonly postLogHistory = (): void => {
 		postMessagesToWindow<TelemetryHistoryMessage>(this.messageLoggingOptions, {
-			source: debuggerMessageSource,
 			type: "TELEMETRY_HISTORY",
 			data: {
 				contents: this._telemetryLog,
@@ -153,7 +151,6 @@ export class FluidDebuggerLogger extends TelemetryLogger {
 
 		const newEvent: ITelemetryBaseEvent = this.prepareEvent(event);
 		const newMessage: TelemetryEventMessage = {
-			source: debuggerMessageSource,
 			type: "TELEMETRY_EVENT",
 			data: {
 				contents: [newEvent],

--- a/packages/tools/client-debugger/client-debugger/src/Registry.ts
+++ b/packages/tools/client-debugger/client-debugger/src/Registry.ts
@@ -10,7 +10,6 @@ import { IFluidLoadable } from "@fluidframework/core-interfaces";
 import { FluidClientDebugger } from "./FluidClientDebugger";
 import { IFluidClientDebugger } from "./IFluidClientDebugger";
 import {
-	debuggerMessageSource,
 	handleIncomingWindowMessage,
 	ISourcedDebuggerMessage,
 	InboundHandlers,
@@ -142,7 +141,6 @@ export class DebuggerRegistry extends TypedEventEmitter<DebuggerRegistryEvents> 
 	 */
 	private readonly postRegistryChange = (): void => {
 		postMessagesToWindow<RegistryChangeMessage>(registryMessageLoggingOptions, {
-			source: debuggerMessageSource,
 			type: "REGISTRY_CHANGE",
 			data: {
 				containers: [...this.registeredDebuggers.values()].map((clientDebugger) => ({

--- a/packages/tools/client-debugger/client-debugger/src/messaging/AudienceMessages.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/AudienceMessages.ts
@@ -5,7 +5,7 @@
 import { IClient } from "@fluidframework/protocol-definitions";
 import { AudienceChangeLogEntry } from "../Logs";
 import { HasContainerId } from "./DebuggerMessages";
-import { ISourcedDebuggerMessage } from "./Messages";
+import { IDebuggerMessage } from "./Messages";
 
 /**
  * Metadata of clients within the Audience.
@@ -30,7 +30,7 @@ export interface AudienceClientMetaData {
  *
  * @public
  */
-export interface GetAudienceMessage extends ISourcedDebuggerMessage<HasContainerId> {
+export interface GetAudienceMessage extends IDebuggerMessage<HasContainerId> {
 	type: "GET_AUDIENCE";
 }
 
@@ -61,7 +61,6 @@ export interface AudienceSummaryMessageData extends HasContainerId {
  *
  * @public
  */
-export interface AudienceSummaryMessage
-	extends ISourcedDebuggerMessage<AudienceSummaryMessageData> {
+export interface AudienceSummaryMessage extends IDebuggerMessage<AudienceSummaryMessageData> {
 	type: "AUDIENCE_EVENT";
 }

--- a/packages/tools/client-debugger/client-debugger/src/messaging/DebuggerMessages.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/DebuggerMessages.ts
@@ -5,7 +5,7 @@
 
 import { ContainerStateMetadata } from "../ContainerMetadata";
 import { ConnectionStateChangeLogEntry } from "../Logs";
-import { ISourcedDebuggerMessage } from "./Messages";
+import { IDebuggerMessage } from "./Messages";
 
 /**
  * Base interface used in message data for events targeting a particular debugger instance via
@@ -68,7 +68,7 @@ export interface ContainerStateHistoryMessageData extends HasContainerId {
  *
  * @public
  */
-export interface GetContainerStateMessage extends ISourcedDebuggerMessage<HasContainerId> {
+export interface GetContainerStateMessage extends IDebuggerMessage<HasContainerId> {
 	type: "GET_CONTAINER_STATE";
 }
 
@@ -96,7 +96,7 @@ export interface ContainerStateChangeMessageData extends HasContainerId {
  * @public
  */
 export interface ContainerStateChangeMessage
-	extends ISourcedDebuggerMessage<ContainerStateChangeMessageData> {
+	extends IDebuggerMessage<ContainerStateChangeMessageData> {
 	type: "CONTAINER_STATE_CHANGE";
 }
 
@@ -105,8 +105,7 @@ export interface ContainerStateChangeMessage
  *
  * @public
  */
-export interface ConnectContainerMessage
-	extends ISourcedDebuggerMessage<ConnectContainerMessageData> {
+export interface ConnectContainerMessage extends IDebuggerMessage<ConnectContainerMessageData> {
 	type: "CONNECT_CONTAINER";
 }
 
@@ -116,7 +115,7 @@ export interface ConnectContainerMessage
  * @public
  */
 export interface DisconnectContainerMessage
-	extends ISourcedDebuggerMessage<DisconnectContainerMessageData> {
+	extends IDebuggerMessage<DisconnectContainerMessageData> {
 	type: "DISCONNECT_CONTAINER";
 }
 
@@ -125,7 +124,7 @@ export interface DisconnectContainerMessage
  *
  * @public
  */
-export interface CloseContainerMessage extends ISourcedDebuggerMessage<CloseContainerMessageData> {
+export interface CloseContainerMessage extends IDebuggerMessage<CloseContainerMessageData> {
 	type: "CLOSE_CONTAINER";
 }
 
@@ -135,7 +134,7 @@ export interface CloseContainerMessage extends ISourcedDebuggerMessage<CloseCont
  * @public
  */
 export interface ContainerStateHistoryMessage
-	extends ISourcedDebuggerMessage<ContainerStateHistoryMessageData> {
+	extends IDebuggerMessage<ContainerStateHistoryMessageData> {
 	type: "CONTAINER_STATE_HISTORY";
 }
 // #endregion

--- a/packages/tools/client-debugger/client-debugger/src/messaging/RegistryMessages.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/RegistryMessages.ts
@@ -4,7 +4,7 @@
  */
 
 import { ContainerMetadata } from "../ContainerMetadata";
-import { ISourcedDebuggerMessage } from "./Messages";
+import { IDebuggerMessage } from "./Messages";
 
 // #region Inbound messages
 
@@ -14,7 +14,7 @@ import { ISourcedDebuggerMessage } from "./Messages";
  *
  * @public
  */
-export interface GetContainerListMessage extends ISourcedDebuggerMessage<undefined> {
+export interface GetContainerListMessage extends IDebuggerMessage<undefined> {
 	type: "GET_CONTAINER_LIST";
 }
 
@@ -40,7 +40,7 @@ export interface RegistryChangeMessageData {
  *
  * @public
  */
-export interface RegistryChangeMessage extends ISourcedDebuggerMessage<RegistryChangeMessageData> {
+export interface RegistryChangeMessage extends IDebuggerMessage<RegistryChangeMessageData> {
 	type: "REGISTRY_CHANGE";
 }
 

--- a/packages/tools/client-debugger/client-debugger/src/messaging/TelemetryMessages.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/TelemetryMessages.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITelemetryBaseEvent } from "@fluidframework/common-definitions";
-import { ISourcedDebuggerMessage } from "./Messages";
+import { IDebuggerMessage } from "./Messages";
 
 // #region Outbound messages
 
@@ -26,7 +26,7 @@ export interface TelemetryEventMessageData {
  *
  * @public
  */
-export interface TelemetryEventMessage extends ISourcedDebuggerMessage<TelemetryEventMessageData> {
+export interface TelemetryEventMessage extends IDebuggerMessage<TelemetryEventMessageData> {
 	/**
 	 * {@inheritDoc IDebuggerMessage."type"}
 	 */
@@ -38,8 +38,7 @@ export interface TelemetryEventMessage extends ISourcedDebuggerMessage<Telemetry
  *
  * @public
  */
-export interface TelemetryHistoryMessage
-	extends ISourcedDebuggerMessage<TelemetryEventMessageData> {
+export interface TelemetryHistoryMessage extends IDebuggerMessage<TelemetryEventMessageData> {
 	/**
 	 * {@inheritDoc IDebuggerMessage."type"}
 	 */
@@ -51,7 +50,7 @@ export interface TelemetryHistoryMessage
  *
  * @public
  */
-export interface GetTelemetryHistoryMessage extends ISourcedDebuggerMessage {
+export interface GetTelemetryHistoryMessage extends IDebuggerMessage {
 	/**
 	 * {@inheritDoc IDebuggerMessage."type"}
 	 */

--- a/packages/tools/client-debugger/client-debugger/src/messaging/Utilities.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/Utilities.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { ISourcedDebuggerMessage } from "./Messages";
+import { debuggerMessageSource } from "./Constants";
+import { IDebuggerMessage, ISourcedDebuggerMessage } from "./Messages";
 
 /**
  * Posts the provided message to the window (globalThis).
@@ -16,20 +17,24 @@ import { ISourcedDebuggerMessage } from "./Messages";
  *
  * @internal
  */
-export function postMessagesToWindow<TMessage extends ISourcedDebuggerMessage>(
+export function postMessagesToWindow<TMessage extends IDebuggerMessage>(
 	loggingOptions?: MessageLoggingOptions,
 	...messages: TMessage[]
 ): void {
+	const messagesWithSource: ISourcedDebuggerMessage[] = messages.map((m) => ({
+		...m,
+		source: debuggerMessageSource,
+	}));
+
 	// TODO: remove loggingOptions once things settle.
 	// If we need special logic for globalThis.postMessage maybe keep this function, but otherwise maybe remove it too.
 	if (loggingOptions !== undefined) {
 		const loggingPreamble =
 			loggingOptions?.context === undefined ? "" : `${loggingOptions.context}: `;
-		console.debug(`${loggingPreamble}Posting message to the window:`, messages);
+		console.debug(`${loggingPreamble}Posting messages to the window:`, messagesWithSource);
 	}
-
-	for (const message of messages) {
-		globalThis.postMessage?.(message, "*");
+	for (const message of messagesWithSource) {
+		globalThis.postMessage?.(message, "*"); // TODO: verify target is okay
 	}
 }
 

--- a/packages/tools/client-debugger/client-debugger/src/messaging/Utilities.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/Utilities.ts
@@ -21,8 +21,8 @@ export function postMessagesToWindow<TMessage extends IDebuggerMessage>(
 	loggingOptions?: MessageLoggingOptions,
 	...messages: TMessage[]
 ): void {
-	const messagesWithSource: ISourcedDebuggerMessage[] = messages.map((m) => ({
-		...m,
+	const messagesWithSource: ISourcedDebuggerMessage[] = messages.map((message) => ({
+		...message,
 		source: debuggerMessageSource,
 	}));
 
@@ -34,7 +34,7 @@ export function postMessagesToWindow<TMessage extends IDebuggerMessage>(
 		console.debug(`${loggingPreamble}Posting messages to the window:`, messagesWithSource);
 	}
 	for (const message of messagesWithSource) {
-		globalThis.postMessage?.(message, "*"); // TODO: verify target is okay
+		globalThis.postMessage?.(message, "*");
 	}
 }
 


### PR DESCRIPTION
## Description

Some cleanup of the messaging infrastructure for the client-debugger.

- Add missing checks for message sources from TODOs.
- FluidClientDebugger, FluidDebuggerLogger, and views in client-debugger-view and client-debugger-chrome-extension now don't set the message sources themselves; the relays/piping that transports the messages do it. This means most places that used `ISourcedDebuggerMessage` now use `IDebuggerMessage`.
