### PR TITLE
feat(client-debugger): Improve devtools initialization

### DIFF
--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/background/BackgroundScript.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/background/BackgroundScript.ts
@@ -111,6 +111,24 @@ chrome.runtime.onConnect.addListener((devtoolsPort: chrome.runtime.Port): void =
 						devtoolsPort.disconnect();
 						tabConnection = undefined;
 					});
+
+					console.log(
+						formatBackgroundScriptMessageForLogging(
+							"Informing DevTools script that tab connection is ready.",
+						),
+					);
+
+					// Send acknowledgement to Devtools Script
+					const ackMessage: DevToolsInitAcknowledgement = {
+						source: extensionMessageSource,
+						type: devToolsInitAcknowledgementType,
+						data: undefined,
+					};
+					postMessageToPort(
+						ackMessage,
+						devtoolsPort,
+						backgroundScriptMessageLoggingOptions,
+					);
 				},
 				(error) => {
 					console.error(
@@ -129,20 +147,12 @@ chrome.runtime.onConnect.addListener((devtoolsPort: chrome.runtime.Port): void =
 				);
 				tabConnection?.disconnect();
 			});
-
-			// Send acknowledgement to Devtools Script
-			const ackMessage: DevToolsInitAcknowledgement = {
-				source: extensionMessageSource,
-				type: devToolsInitAcknowledgementType,
-				data: undefined,
-			};
-			postMessageToPort(ackMessage, devtoolsPort, backgroundScriptMessageLoggingOptions);
 		} else {
 			// Relay message from the Devtools Script to the tab (Content script)
 			if (tabConnection === undefined) {
-				console.warn(
+				console.error(
 					formatBackgroundScriptMessageForLogging(
-						`Tab connection has not been initialized. Cannot relay message:`,
+						`Message received from DevTools port before tab connection has finished initializing. Message won't be relayed:`,
 					),
 					message,
 				);

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/devtools/BackgroundConnection.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/devtools/BackgroundConnection.ts
@@ -59,7 +59,15 @@ export class BackgroundConnection
 	 */
 	private readonly backgroundServiceConnection: TypedPortConnection;
 
-	public constructor() {
+	public static async Initialize(): Promise<BackgroundConnection> {
+		const connection = new BackgroundConnection();
+		await new Promise((resolve) => {
+			connection.once("tabConnected", resolve);
+		});
+		return connection;
+	}
+
+	private constructor() {
 		super();
 
 		console.log(formatDevtoolsScriptMessageForLogging("Connecting to Background script..."));
@@ -122,9 +130,9 @@ export class BackgroundConnection
 		// Handle init-acknowledgment message from background service
 		if (message.type === devToolsInitAcknowledgementType) {
 			console.log(
-				formatDevtoolsScriptMessageForLogging("Background initialization acknowledged."),
+				formatDevtoolsScriptMessageForLogging("Background initialization complete."),
 			);
-			return true;
+			return this.emit("tabConnected");
 		} else {
 			// Forward incoming message onto subscribers.
 			// TODO: validate source

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/devtools/BackgroundConnection.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/devtools/BackgroundConnection.ts
@@ -38,10 +38,10 @@ import {
  *
  * TODO: This implementation is brittle in a number of ways, which should be addressed before we publish the extension:
  *
- * 1. After establishing the connection with the background service, we send the initialization message that informs
- * the background script of the devtools extension / tab relationship. If that message fails to be processed for any
- * reason, subsequent messages sent from the devtools script will not be correctly forwarded. We should utilize a proper
- * handshake mechanism for the initialization process, and any other critical messages.
+ * 1. There's no timeout or fallback logic if the initial handshake with the Background Service does not succeed; the
+ * call to BackgroundConnection.Initialize() will just hang forever. This at least ensures that the DevTools script
+ * won't be able to send messages that would fail to be relayed to the Content Script, but results in bad UX in the case
+ * where the Background Service fails to connect with the application tab for some reason.
  *
  * 2. We don't currently recover if the background service is disconnected for any reason. Generally speaking, the
  * background script's lifetime should outlive the devtools script, but there may be cases where the connection is


### PR DESCRIPTION
## Description

Wait to render the debugger UI in the DevTools until the connection with the background script has been successfully established, to prevent issues with messages failing to be relayed.

Currently includes the changes from #14809 as well; after we merge that I'll rebase this branch so only the relevant changes (`BackgroundScript.ts`, `BackgroundConnection.ts`, `RootView.tsx` in the client-debugger-chrome-extension package) are here.