### PR TITLE
The latest pnpm (@8) does not work with Node 14. pnpm@7 works with Node 14 to 18

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -202,7 +202,7 @@ stages:
           inputs:
             targetType: 'inline'
             script: |
-              npm i -g pnpm
+              npm i -g pnpm@7
               pnpm config set store-dir $(pnpmStorePath)
 
         - task: Bash@3

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -45,7 +45,7 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      npm i -g pnpm
+      npm i -g pnpm@7
       pnpm config set store-dir $(pnpmStorePath)
 
 - task: Bash@3

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -242,7 +242,7 @@ stages:
           targetType: 'inline'
           workingDirectory: ${{ parameters.buildDirectory }}
           script: |
-            npm i -g pnpm
+            npm i -g pnpm@7
             pnpm config set store-dir $(pnpmStorePath)
 
     # Set version

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -255,7 +255,7 @@ stages:
               targetType: 'inline'
               workingDirectory: ${{ parameters.buildDirectory }}
               script: |
-                npm i -g pnpm
+                npm i -g pnpm@7
                 pnpm config set store-dir $(pnpmStorePath)
 
         - task: Bash@3

--- a/tools/pipelines/templates/include-policy-check.yml
+++ b/tools/pipelines/templates/include-policy-check.yml
@@ -41,7 +41,7 @@ stages:
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
           # Install pnpm globally
-          npm i -g pnpm
+          npm i -g pnpm@7
 
           # We only want to install the root package deps, so we set recursive-install to false
           pnpm config set recursive-install false

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -44,7 +44,7 @@ steps:
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
         pushd "$(Build.SourcesDirectory)/build-tools"
-        npm i -g pnpm
+        npm i -g pnpm@7
         pnpm config set store-dir $(pnpmStorePath)
         pnpm i
         pnpm build:compile

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -84,7 +84,7 @@ jobs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
-          npm i -g pnpm
+          npm i -g pnpm@7
           pnpm config set store-dir $(pnpmStorePath)
 
     - task: Bash@3


### PR DESCRIPTION
## Description

pnpm@8 is not compatible with node 14, which is used by older release branches.

```
ERROR: This version of pnpm requires at least Node.js v16.4
The current version of Node.js is v14.21.3
Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.
```

