### PR TITLE
Fix document creation in tinylicious

### DIFF
--- a/server/tinylicious/src/services/tenantManager.ts
+++ b/server/tinylicious/src/services/tenantManager.ts
@@ -48,8 +48,9 @@ export class TinyliciousTenant implements ITenant {
 export class TenantManager implements ITenantManager {
 	constructor(private readonly url: string) {}
 
-	public async getTenantGitManager(tenantId: string, documentId: string): Promise<IGitManager> {
-		throw new Error("Method not implemented.");
+	public async getTenantGitManager(tenantId: string, _documentId: string): Promise<IGitManager> {
+		const tenant = await this.getTenant(tenantId);
+		return tenant.gitManager;
 	}
 
 	public async createTenant(tenantId?: string): Promise<ITenantConfig & { key: string }> {


### PR DESCRIPTION

## Description
Currently tinylicious fails to run sample scenarios in the [Share Live Repo](https://github.com/microsoft/live-share-sdk)
2 interesting commits: 
a) [Update deps (minor) on server release group in tinylicious (#14586) · microsoft/FluidFramework@12b3f4c (github.com)](https://github.com/microsoft/FluidFramework/commit/12b3f4cb0dc832bcbf708a01214c33303a560588#diff-18fce4d66a0b908f502bc635b1c1377557fd7ec4f8d9df8dcaa4d9c261158ca9)) 

Throws when  getTenantGitManager is invoked. 

2) [Separate api for getting tenant gitManager. (#14290) · microsoft/FluidFramework@d368f26 (github.com)](https://github.com/microsoft/FluidFramework/commit/d368f26923fb0379b00451d68b990b4c8e53a9b2#diff-deeaa88a2f939b81094f7412e1482709a59c4c47850a5c379c92aef0b78d70d5)) 
Moved the call when creating the document from getTenant to getTenantGitManager and I'm not sure if it applies to tinylicious but it is consumed by it.

This PR is trying to revert the current behavior by keeping changes #2  and not throwing on #1  

Repro steps: 
a) Clone https://github.com/microsoft/live-share-sdk

b) Follow instructions from the Readme to install  (I had to also install vite as it was failing without it)

c) Simply try to run one of the samples (I'm using samples\javascript\03.live-canvas-demo\) http://localhost:3000/