### PR TITLE
build: Pin pnpm version in dockerfiles

### DIFF
--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -25,7 +25,7 @@ COPY scripts/*.* ./scripts/
 COPY packages/gitrest/package*.json packages/gitrest/
 COPY packages/gitrest-base/package*.json packages/gitrest-base/
 
-RUN npm install --global pnpm
+RUN npm install --global pnpm@7.30.5
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' accout so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -28,7 +28,7 @@ COPY scripts/*.* ./scripts/
 COPY packages/historian/package.json packages/historian/
 COPY packages/historian-base/package.json packages/historian-base/
 
-RUN npm install --global pnpm
+RUN npm install --global pnpm@7.30.5
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' accout so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -50,7 +50,7 @@ COPY packages/services-utils/package*.json packages/services-utils/
 COPY packages/test-utils/package*.json packages/test-utils/
 COPY packages/protocol-base/package*.json packages/protocol-base/
 
-RUN npm install --global pnpm
+RUN npm install --global pnpm@7.30.5
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' accout so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files


### PR DESCRIPTION
Related to #14815.

This change pins the pnpm version installed in Docker images to 7.30.5, the same version we use elsewhere in the CI pipeline.