### PR TITLE
Improve Fluid cache perf for odsp driver

### DIFF
--- a/packages/drivers/driver-web-cache/src/FluidCache.ts
+++ b/packages/drivers/driver-web-cache/src/FluidCache.ts
@@ -226,6 +226,7 @@ export class FluidCache implements IPersistedCache {
 					cacheItemId: entry.key,
 					partitionKey: this.partitionKey,
 					createdTimeMs: currentTime,
+					lastAccessTimeMs: currentTime,
 				},
 				getKeyForCacheEntry(entry),
 			);

--- a/packages/drivers/driver-web-cache/src/FluidCacheIndexedDb.ts
+++ b/packages/drivers/driver-web-cache/src/FluidCacheIndexedDb.ts
@@ -127,6 +127,8 @@ export interface FluidCacheDBSchema extends DBSchema {
 			/**
 			 * The last time the cache entry was used.
 			 * This is initially set to the time the cache entry was created Measured as ms since unix epoch.
+			 * With the recent change, this won't be updated on read as it will not be used anywhere. Only keeping
+			 * so as to not upgrade the schema version.
 			 */
 			lastAccessTimeMs: number;
 		};

--- a/packages/drivers/driver-web-cache/src/FluidCacheIndexedDb.ts
+++ b/packages/drivers/driver-web-cache/src/FluidCacheIndexedDb.ts
@@ -13,15 +13,14 @@ import { FluidCacheErrorEvent } from "./fluidCacheTelemetry";
 export const FluidDriverCacheDBName = "fluidDriverCache";
 
 // The name of the object store within the indexed db instance that the driver will use to cache Fluid content.
-export const FluidDriverObjectStoreName = "driverStorage.V4";
+export const FluidDriverObjectStoreName = "driverStorage.V3";
 
-export const CurrentCacheVersion = 4;
+export const CurrentCacheVersion = 3;
 
 // Note that V1 and V2 were misspelled as "diver", and we need to keep using the misspelling here.
 export const oldVersionNameMapping: Partial<{ [key: number]: string }> = {
 	1: "diverStorage",
 	2: "diverStorage.V2",
-	3: "driverStorage.V3",
 };
 
 export function getKeyForCacheEntry(entry: ICacheEntry) {
@@ -57,6 +56,7 @@ export function getFluidCacheIndexedDbInstance(
 
 				const cacheObjectStore = db.createObjectStore(FluidDriverObjectStoreName);
 				cacheObjectStore.createIndex("createdTimeMs", "createdTimeMs");
+				cacheObjectStore.createIndex("lastAccessTimeMs", "lastAccessTimeMs");
 				cacheObjectStore.createIndex("partitionKey", "partitionKey");
 				cacheObjectStore.createIndex("fileId", "fileId");
 			},
@@ -123,11 +123,18 @@ export interface FluidCacheDBSchema extends DBSchema {
 			 * The time when the cache entry was put into the cache
 			 */
 			createdTimeMs: number;
+
+			/**
+			 * The last time the cache entry was used.
+			 * This is initially set to the time the cache entry was created Measured as ms since unix epoch.
+			 */
+			lastAccessTimeMs: number;
 		};
 
 		indexes: {
 			createdTimeMs: number;
 			partitionKey: string;
+			lastAccessTimeMs: number;
 			fileId: string;
 		};
 	};

--- a/packages/drivers/driver-web-cache/src/FluidCacheIndexedDb.ts
+++ b/packages/drivers/driver-web-cache/src/FluidCacheIndexedDb.ts
@@ -13,14 +13,15 @@ import { FluidCacheErrorEvent } from "./fluidCacheTelemetry";
 export const FluidDriverCacheDBName = "fluidDriverCache";
 
 // The name of the object store within the indexed db instance that the driver will use to cache Fluid content.
-export const FluidDriverObjectStoreName = "driverStorage.V3";
+export const FluidDriverObjectStoreName = "driverStorage.V4";
 
-export const CurrentCacheVersion = 3;
+export const CurrentCacheVersion = 4;
 
 // Note that V1 and V2 were misspelled as "diver", and we need to keep using the misspelling here.
 export const oldVersionNameMapping: Partial<{ [key: number]: string }> = {
 	1: "diverStorage",
 	2: "diverStorage.V2",
+	3: "driverStorage.V3",
 };
 
 export function getKeyForCacheEntry(entry: ICacheEntry) {
@@ -56,7 +57,6 @@ export function getFluidCacheIndexedDbInstance(
 
 				const cacheObjectStore = db.createObjectStore(FluidDriverObjectStoreName);
 				cacheObjectStore.createIndex("createdTimeMs", "createdTimeMs");
-				cacheObjectStore.createIndex("lastAccessTimeMs", "lastAccessTimeMs");
 				cacheObjectStore.createIndex("partitionKey", "partitionKey");
 				cacheObjectStore.createIndex("fileId", "fileId");
 			},
@@ -123,18 +123,11 @@ export interface FluidCacheDBSchema extends DBSchema {
 			 * The time when the cache entry was put into the cache
 			 */
 			createdTimeMs: number;
-
-			/**
-			 * The last time the cache entry was used.
-			 * This is initially set to the time the cache entry was created Measured as ms since unix epoch.
-			 */
-			lastAccessTimeMs: number;
 		};
 
 		indexes: {
 			createdTimeMs: number;
 			partitionKey: string;
-			lastAccessTimeMs: number;
 			fileId: string;
 		};
 	};

--- a/packages/drivers/driver-web-cache/src/test/FluidCache.test.ts
+++ b/packages/drivers/driver-web-cache/src/test/FluidCache.test.ts
@@ -204,6 +204,7 @@ describe("Fluid Cache tests", () => {
 			},
 			createdTimeMs: 100,
 			fileId: "myDocument",
+			lastAccessTimeMs: 100,
 			type: "snapshot",
 			partitionKey: "FAKEPARTITIONKEY",
 		});

--- a/packages/drivers/driver-web-cache/src/test/FluidCache.test.ts
+++ b/packages/drivers/driver-web-cache/src/test/FluidCache.test.ts
@@ -204,38 +204,9 @@ describe("Fluid Cache tests", () => {
 			},
 			createdTimeMs: 100,
 			fileId: "myDocument",
-			lastAccessTimeMs: 100,
 			type: "snapshot",
 			partitionKey: "FAKEPARTITIONKEY",
 		});
-
-		clearDateMock();
-	});
-
-	it("updates the last accessed time when reading a value from storage", async () => {
-		// We need to mock out the Date API to make this test work
-		const clearDateMock = setupDateMock(100);
-		const fluidCache = getFluidCache();
-
-		const cacheEntry = getMockCacheEntry("shouldUpdateLastAccessedTime");
-		const cachedItem = { dateToStore: "foo" };
-
-		await fluidCache.put(cacheEntry, cachedItem);
-
-		const db = await getFluidCacheIndexedDbInstance();
-
-		expect(
-			(await db.get(FluidDriverObjectStoreName, getKeyForCacheEntry(cacheEntry)))
-				?.lastAccessTimeMs,
-		).toBe(100);
-
-		DateMock.mockTimeMs = 800;
-		await fluidCache.get(cacheEntry);
-
-		expect(
-			(await db.get(FluidDriverObjectStoreName, getKeyForCacheEntry(cacheEntry)))
-				?.lastAccessTimeMs,
-		).toEqual(800);
 
 		clearDateMock();
 	});


### PR DESCRIPTION
## Description

1.) Stop tracking of lastAccessTime internally in Fluid driver cache as deletion/not use policy is based upon maxCacheItemAge.
It will help in saving perf and on every read we don't have to open/close db twice due to not have to do this extra transaction where we update the last Access time.
2.) Because of above, updated the version of the db too.
3.) Modified item cleaning based on maxCacheItemAge.

This is first step in solving https://dev.azure.com/fluidframework/internal/_workitems/edit/3594