### PR TITLE
disable failure logging step in test-real-service pipeline

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -353,8 +353,8 @@ jobs:
         condition: succeededOrFailed()
 
       # Log Test Failures
-      - template: include-log-test-failures.yml
-        parameters:
-          buildDirectory: ${{ variables.testPackageDir }}
+      # - template: include-log-test-failures.yml
+      #   parameters:
+      #     buildDirectory: ${{ variables.testPackageDir }}
 
       - ${{ parameters.additionalSteps }}


### PR DESCRIPTION
Disable logging step in test-real-service pipeline due to bug where the pipeline is unable to access the "scripts" folder in the root directory.