### PR TITLE
build(client-debugger): Update API-Extractor to fail build on incompatible release tags

### DIFF
--- a/packages/tools/client-debugger/client-debugger/api-extractor.json
+++ b/packages/tools/client-debugger/client-debugger/api-extractor.json
@@ -11,9 +11,15 @@
 	},
 	"messages": {
 		"extractorMessageReporting": {
+			// Require explicit release tags
 			"ae-missing-release-tag": {
 				"logLevel": "error",
-				"addToApiReportFile": false
+				"addToApiReportFile": false // Fail build rather than adding warning comment to API report
+			},
+			// TODO: Remove once base config is fixed to correctly fail build on incompatible release tags
+			"ae-incompatible-release-tags": {
+				"logLevel": "error",
+				"addToApiReportFile": false // Fail build rather than adding warning comment to API report
 			}
 		}
 	}

--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -19,7 +19,7 @@ import { ITelemetryLoggerPropertyBags } from '@fluidframework/telemetry-utils';
 import { TelemetryLogger } from '@fluidframework/telemetry-utils';
 import { TypedEventEmitter } from '@fluidframework/common-utils';
 
-// @internal
+// @public
 export interface AudienceChangeLogEntry extends LogEntry {
     changeKind: "added" | "removed";
     client: IClient;
@@ -40,7 +40,6 @@ export interface AudienceSummaryMessage extends IDebuggerMessage<AudienceSummary
 
 // @public
 export interface AudienceSummaryMessageData extends HasContainerId {
-    // Warning: (ae-incompatible-release-tags) The symbol "audienceHistory" is marked as @public, but its signature references "AudienceChangeLogEntry" which is marked as @internal
     audienceHistory: readonly AudienceChangeLogEntry[];
     audienceState: AudienceClientMetaData[];
     clientId: string | undefined;
@@ -70,9 +69,6 @@ export interface ConnectContainerMessage extends IDebuggerMessage<ConnectContain
 // @public
 export type ConnectContainerMessageData = HasContainerId;
 
-// Warning: (ae-incompatible-release-tags) The symbol "ConnectionStateChangeLogEntry" is marked as @public, but its signature references "StateChangeLogEntry" which is marked as @internal
-// Warning: (ae-incompatible-release-tags) The symbol "ConnectionStateChangeLogEntry" is marked as @public, but its signature references "ContainerStateChangeKind" which is marked as @internal
-//
 // @public
 export interface ConnectionStateChangeLogEntry extends StateChangeLogEntry<ContainerStateChangeKind> {
     clientId: string | undefined;
@@ -84,7 +80,7 @@ export interface ContainerMetadata {
     nickname?: string;
 }
 
-// @internal
+// @public
 export enum ContainerStateChangeKind {
     Attached = "attached",
     Closed = "closed",
@@ -255,7 +251,7 @@ export interface ISourcedDebuggerMessage<TData = unknown> extends IDebuggerMessa
     source: string;
 }
 
-// @internal
+// @public
 export interface LogEntry {
     timestamp: number;
 }
@@ -285,7 +281,7 @@ export interface RegistryChangeMessageData {
     containers: ContainerMetadata[];
 }
 
-// @internal
+// @public
 export interface StateChangeLogEntry<TState> extends LogEntry {
     newState: TState;
 }

--- a/packages/tools/client-debugger/client-debugger/src/Container.ts
+++ b/packages/tools/client-debugger/client-debugger/src/Container.ts
@@ -6,7 +6,7 @@
 /**
  * Kind of container state change.
  *
- * @internal
+ * @public
  */
 export enum ContainerStateChangeKind {
 	/**

--- a/packages/tools/client-debugger/client-debugger/src/Logs.ts
+++ b/packages/tools/client-debugger/client-debugger/src/Logs.ts
@@ -8,7 +8,7 @@ import { ContainerStateChangeKind } from "./Container";
 /**
  * Base interface for data logs, associating data with a timestamp at which the data was recorded by the debugger.
  *
- * @internal
+ * @public
  */
 export interface LogEntry {
 	/**
@@ -22,7 +22,7 @@ export interface LogEntry {
  *
  * @typeParam TState - The type of state being tracked.
  *
- * @internal
+ * @public
  */
 export interface StateChangeLogEntry<TState> extends LogEntry {
 	/**
@@ -55,7 +55,7 @@ export interface ConnectionStateChangeLogEntry
  * TODOs:
  * - Annotate when the client is me, even though "me" can change. This is useful context when viewing the history.
  *
- * @internal
+ * @public
  */
 export interface AudienceChangeLogEntry extends LogEntry {
 	/**


### PR DESCRIPTION
Prevents `@public` members from extending or referencing `@internal` members, etc.

This PR also fixes existing violations.