### PR TITLE
feat: Decrease sample rate for ddsOpProcessing and ddsEventCallbacks telemetry events

### DIFF
--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -138,7 +138,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
 				category: "performance",
 			},
 			this.logger,
-			this.mc.config.getNumber("Fluid.SharedObject.OpProcessingTelemetrySampling") ?? 100,
+			this.mc.config.getNumber("Fluid.SharedObject.OpProcessingTelemetrySampling") ?? 1000,
 			true,
 			new Map<string, ITelemetryProperties>([
 				["local", { localOp: true }],
@@ -151,7 +151,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
 				category: "performance",
 			},
 			this.logger,
-			this.mc.config.getNumber("Fluid.SharedObject.DdsCallbacksTelemetrySampling") ?? 100,
+			this.mc.config.getNumber("Fluid.SharedObject.DdsCallbacksTelemetrySampling") ?? 1000,
 			true,
 		);
 


### PR DESCRIPTION
## Description

Update the sampling rate for the `fluid:telemetry:FluidDataStoreRuntime:ddsOpProcessing` and `fluid:telemetry:FluidDataStoreRuntime:ddsEventCallbacks` events from 1 in 100 to 1 in 1000. Based on current telemetry volume we see in Kusto, we can still get good measurements while reducing the number of events that need to be generated, transmitted, stored, etc.

[AB#3148](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3148)