### PR TITLE
Add tests for rollback involving multiple types and instances of DDSs

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
@@ -134,7 +134,6 @@ describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
 
 		assert.equal(changedEventData[2], 2);
 
-		// rollback
 		assert(
 			changedEventData[3] instanceof SequenceDeltaEvent,
 			`Unexpected event type - ${typeof changedEventData[3]}`,
@@ -145,6 +144,7 @@ describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
 
 		assert.equal(changedEventData[5], undefined);
 
+		// rollback
 		assert.equal(changedEventData[6], 2);
 
 		assert.equal(changedEventData[7].key, "key1");
@@ -208,7 +208,6 @@ describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
 
 		assert.equal(changedEventData[3], 2);
 
-		// rollback
 		assert.equal(changedEventData[4].key, "key1");
 		assert.equal(changedEventData[4].previousValue, 0);
 
@@ -226,6 +225,7 @@ describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
 
 		assert.equal(changedEventData[8], undefined);
 
+		// rollback
 		assert.equal(changedEventData[9], 5);
 
 		// segments are split up at some point - reason for multiple events
@@ -297,7 +297,6 @@ describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
 			`Unexpected event type - ${typeof changedEventData[2]}`,
 		);
 
-		// rollback
 		assert.equal(changedEventData[3].key, "key");
 		assert.equal(changedEventData[3].previousValue, 1);
 
@@ -311,6 +310,7 @@ describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
 			`Unexpected event type - ${typeof changedEventData[5]}`,
 		);
 
+		// rollback
 		assert(
 			changedEventData[6] instanceof SequenceDeltaEvent,
 			`Unexpected event type - ${typeof changedEventData[6]}`,
@@ -365,7 +365,6 @@ describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
 		assert.equal(changedEventData[1].key, "key");
 		assert.equal(changedEventData[1].previousValue, undefined);
 
-		// rollback
 		assert.equal(changedEventData[2].key, "key");
 		assert.equal(changedEventData[2].previousValue, 1);
 
@@ -374,6 +373,7 @@ describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
 			`Unexpected event type - ${typeof changedEventData[3]}`,
 		);
 
+		// rollback - inner orderSequentially call
 		assert(
 			changedEventData[4] instanceof SequenceDeltaEvent,
 			`Unexpected event type - ${typeof changedEventData[4]}`,
@@ -382,6 +382,7 @@ describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
 		assert.equal(changedEventData[5].key, "key");
 		assert.equal(changedEventData[5].previousValue, 0);
 
+		// rollback - outer orderSequentially call
 		assert.equal(changedEventData[6].key, "key");
 		assert.equal(changedEventData[6].previousValue, undefined);
 

--- a/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
@@ -25,19 +25,11 @@ const stringId = "sharedStringKey";
 const dirId = "sharedDirKey";
 const cellId = "cellKey";
 const mapId = "mapKey";
-const string2Id = "sharedString2Key";
-const dir2Id = "sharedDir2Key";
-const cell2Id = "cell2Key";
-const map2Id = "map2Key";
 const registry: ChannelFactoryRegistry = [
 	[stringId, SharedString.getFactory()],
 	[dirId, SharedDirectory.getFactory()],
 	[cellId, SharedCell.getFactory()],
 	[mapId, SharedMap.getFactory()],
-	[string2Id, SharedString.getFactory()],
-	[dir2Id, SharedDirectory.getFactory()],
-	[cell2Id, SharedCell.getFactory()],
-	[map2Id, SharedMap.getFactory()],
 ];
 const testContainerConfig: ITestContainerConfig = {
 	fluidDataObjectType: DataObjectFactoryType.Test,
@@ -56,12 +48,7 @@ describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
 	let sharedDir: SharedDirectory;
 	let sharedCell: SharedCell;
 	let sharedMap: SharedMap;
-	let string2: SharedString;
-	let dir2: SharedDirectory;
-	let cell2: SharedCell;
-	let map2: SharedMap;
 	let changedEventData: IValueChanged[];
-	let changedData2: IValueChanged[];
 	let containerRuntime: ContainerRuntime;
 	let error: Error | undefined;
 
@@ -85,10 +72,6 @@ describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
 		sharedDir = await dataObject.getSharedObject<SharedDirectory>(dirId);
 		sharedCell = await dataObject.getSharedObject<SharedCell>(cellId);
 		sharedMap = await dataObject.getSharedObject<SharedMap>(mapId);
-		string2 = await dataObject.getSharedObject<SharedString>(string2Id);
-		dir2 = await dataObject.getSharedObject<SharedDirectory>(dir2Id);
-		cell2 = await dataObject.getSharedObject<SharedCell>(cell2Id);
-		map2 = await dataObject.getSharedObject<SharedMap>(map2Id);
 
 		containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
 		changedEventData = [];
@@ -104,31 +87,20 @@ describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
 		sharedMap.on("valueChanged", (value) => {
 			changedEventData.push(value);
 		});
-		changedData2 = [];
-		dir2.on("valueChanged", (changed, _local, _target) => {
-			changedData2.push(changed);
-		});
-		cell2.on("valueChanged", (value) => {
-			changedData2.push(value);
-		});
-		cell2.on("delete", (value) => {
-			changedData2.push(value);
-		});
-		map2.on("valueChanged", (value) => {
-			changedData2.push(value);
-		});
 	});
 
-	it("Should rollback simple edits on multiple strings in order", () => {
-		sharedString.insertText(0, "abcd");
-		string2.insertText(0, "12345");
-		sharedString.insertText(2, "123");
-		string2.insertText(2, "abc");
+	it("Should rollback simple edits on multiple DDS types", () => {
+		sharedString.insertText(0, "abcde");
+		sharedMap.set("key1", 0);
+		sharedDir.set("key2", 1);
+		sharedCell.set(2);
 		try {
 			containerRuntime.orderSequentially(() => {
-				sharedString.removeRange(1, 3);
-				string2.removeRange(4, 6);
-				throw new Error("callback failure");
+				sharedString.removeRange(0, 5);
+				sharedMap.delete("key1");
+				sharedDir.delete("key2");
+				sharedCell.delete();
+				throw new Error(errorMessage);
 			});
 		} catch (err) {
 			error = err as Error;
@@ -136,25 +108,58 @@ describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
 
 		assert.notEqual(error, undefined, "No error");
 		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false);
-		assert.equal(sharedString.getText(), "ab123cd");
-		assert.equal(string2.getText(), "12abc345");
+		assert.equal(containerRuntime.disposed, false, "Container disposed");
+		assert.equal(sharedString.getText(), "abcde");
+		assert.equal(sharedMap.size, 1);
+		assert.equal(sharedMap.has("key1"), true);
+		assert.equal(sharedMap.get("key1"), 0);
+		assert.equal(sharedDir.size, 1);
+		assert.equal(sharedDir.has("key2"), true);
+		assert.equal(sharedDir.get("key2"), 1);
+		assert.equal(sharedCell.get(), 2);
+
+		assert.equal(changedEventData.length, 9);
+		assert.equal(changedEventData[0].key, "key1");
+		assert.equal(changedEventData[0].previousValue, undefined);
+
+		assert.equal(changedEventData[1].key, "key2");
+		assert.equal(changedEventData[1].previousValue, undefined);
+
+		assert.equal(changedEventData[2], 2);
+
+		// rollback
+		assert.equal(changedEventData[3].key, "key1");
+		assert.equal(changedEventData[3].previousValue, 0);
+
+		assert.equal(changedEventData[4].key, "key2");
+		assert.equal(changedEventData[4].previousValue, 1);
+
+		assert.equal(changedEventData[5], undefined);
+
+		assert.equal(changedEventData[6], 2);
+
+		assert.equal(changedEventData[7].key, "key2");
+		assert.equal(changedEventData[7].previousValue, undefined);
+
+		assert.equal(changedEventData[8].key, "key1");
+		assert.equal(changedEventData[8].previousValue, undefined);
 	});
 
-	it("Should rollback complex edits on multiple strings in the correct order", () => {
-		sharedString.insertText(0, "abcd");
-		string2.insertText(0, "12345");
-		sharedString.removeRange(2, 4);
-		string2.removeRange(2, 3);
-		string2.insertText(2, "abc");
-		sharedString.insertText(2, "123");
-		string2.annotateRange(1, 5, { foo: "bar" });
-		sharedString.annotateRange(1, 4, { foo: "bar" });
+	it("Should rollback complex edits on multiple DDS types", () => {
+		sharedString.insertText(0, "abcde");
+		sharedMap.set("key1", 0);
+		sharedString.annotateRange(2, 5, { foo: "old" });
+		sharedDir.set("key2", 1);
+		sharedCell.set(2);
 		try {
 			containerRuntime.orderSequentially(() => {
-				sharedString.removeRange(1, 3);
-				string2.removeRange(4, 6);
-				throw new Error("callback failure");
+				sharedMap.set("key1", 3);
+				sharedString.annotateRange(0, 3, { foo: "new" });
+				sharedDir.delete("key2");
+				sharedCell.set(5);
+				sharedString.removeRange(0, 5);
+				sharedCell.delete();
+				throw new Error(errorMessage);
 			});
 		} catch (err) {
 			error = err as Error;
@@ -162,326 +167,52 @@ describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
 
 		assert.notEqual(error, undefined, "No error");
 		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false);
-		assert.equal(sharedString.getText(), "ab123");
-		assert.equal(string2.getText(), "12abc45");
+		assert.equal(containerRuntime.disposed, false, "Container disposed");
+		assert.equal(sharedString.getText(), "abcde");
 		for (let i = 0; i < sharedString.getText().length; i++) {
 			const props = sharedString.getPropertiesAtPosition(i);
-			if (i >= 1 && i < 4) {
-				assert.equal(props?.foo, "bar");
+			if (i >= 2 && i < 5) {
+				assert.equal(props?.foo, "old");
 			} else {
 				assert(props === undefined || props.foo === undefined);
 			}
 		}
-		for (let i = 0; i < string2.getText().length; i++) {
-			const props = string2.getPropertiesAtPosition(i);
-			if (i >= 1 && i < 5) {
-				assert.equal(props?.foo, "bar");
-			} else {
-				assert(props === undefined || props.foo === undefined);
-			}
-		}
-	});
-
-	it("Should rollback string and directory edits in the correct order", () => {
-		sharedString.insertText(0, "abcd");
-		sharedDir.set("key", 1);
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedDir.set("key", 0);
-				sharedString.insertText(2, "123");
-				throw new Error(errorMessage);
-			});
-		} catch (err) {
-			error = err as Error;
-		}
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false, "Container disposed");
-		assert.equal(sharedString.getText(), "abcd");
-		assert.equal(sharedDir.size, 1);
-		assert.equal(sharedDir.has("key"), true);
-		assert.equal(sharedDir.get("key"), 1);
-		assert.equal(changedEventData.length, 3);
-		assert.equal(changedEventData[0].key, "key");
-		assert.equal(changedEventData[0].previousValue, undefined);
-		assert.equal(changedEventData[1].key, "key");
-		assert.equal(changedEventData[1].previousValue, 1);
-		// rollback
-		assert.equal(changedEventData[2].key, "key");
-		assert.equal(changedEventData[2].previousValue, 0);
-	});
-
-	it("Should rollback string and cell edits in the correct order", () => {
-		sharedString.insertText(0, "abcd");
-		sharedCell.set("old");
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedString.removeRange(1, 2);
-				sharedCell.set("new");
-				sharedString.insertText(0, "123");
-				throw new Error(errorMessage);
-			});
-		} catch (err) {
-			error = err as Error;
-		}
-
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false);
-		assert.equal(sharedString.getText(), "abcd");
-		assert.equal(sharedCell.get(), "old");
-		assert.equal(changedEventData.length, 3);
-		assert.equal(changedEventData[0], "old");
-		// rollback
-		assert.equal(changedEventData[1], "new");
-		assert.equal(changedEventData[2], "old");
-	});
-
-	it("Should rollback string and map edits in the correct order", () => {
-		sharedString.insertText(0, "abcd");
-		sharedMap.set("key", 1);
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedMap.set("key", 0);
-				sharedString.insertText(2, "123");
-				sharedMap.delete("key");
-				sharedString.removeRange(0, 2);
-				throw new Error(errorMessage);
-			});
-		} catch (err) {
-			error = err as Error;
-		}
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false, "Container disposed");
-		assert.equal(sharedString.getText(), "abcd");
-		assert.equal(sharedMap.has("key"), true);
 		assert.equal(sharedMap.size, 1);
-		assert.equal(sharedMap.get("key"), 1);
-		assert.equal(changedEventData.length, 5);
-		assert.equal(changedEventData[0].key, "key");
-		assert.equal(changedEventData[0].previousValue, undefined);
-		assert.equal(changedEventData[1].key, "key");
-		assert.equal(changedEventData[1].previousValue, 1);
-		// rollback
-		assert.equal(changedEventData[2].key, "key");
-		assert.equal(changedEventData[2].previousValue, 0);
-		assert.equal(changedEventData[3].previousValue, undefined);
-		assert.equal(changedEventData[4].previousValue, 0);
-	});
-
-	it("Should rollback edits in the correct order: string + 2 directories", () => {
-		sharedDir.set("key", 1);
-		sharedString.insertText(0, "abcd");
-		dir2.set("key", 2);
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedString.insertText(2, "123");
-				dir2.delete("key");
-				sharedDir.set("key", 0);
-				throw new Error(errorMessage);
-			});
-		} catch (err) {
-			error = err as Error;
-		}
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false, "Container disposed");
-		assert.equal(sharedString.getText(), "abcd");
+		assert.equal(sharedMap.has("key1"), true);
+		assert.equal(sharedMap.get("key1"), 0);
 		assert.equal(sharedDir.size, 1);
-		assert.equal(sharedDir.has("key"), true);
-		assert.equal(sharedDir.get("key"), 1);
-		assert.equal(changedEventData.length, 3);
-		assert.equal(changedEventData[0].key, "key");
-		assert.equal(changedEventData[0].previousValue, undefined);
-		assert.equal(changedEventData[1].key, "key");
-		assert.equal(changedEventData[1].previousValue, 1);
-		// rollback
-		assert.equal(changedEventData[2].key, "key");
-		assert.equal(changedEventData[2].previousValue, 0);
-		// second directory
-		assert.equal(dir2.size, 1);
-		assert.equal(dir2.has("key"), true);
-		assert.equal(dir2.get("key"), 2);
-		assert.equal(changedData2.length, 3);
-		assert.equal(changedData2[0].key, "key");
-		assert.equal(changedData2[0].previousValue, undefined); // 2
-		assert.equal(changedData2[1].key, "key");
-		assert.equal(changedData2[1].previousValue, 2); // undefined
-		// second directory rollback
-		assert.equal(changedData2[2].key, "key");
-		assert.equal(changedData2[2].previousValue, undefined); // 2
-	});
-	it("Should rollback edits in the correct order: string + 2 cells", () => {
-		sharedString.insertText(0, "abcd");
-		cell2.set("val");
-		sharedCell.set("old");
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedString.removeRange(1, 2);
-				sharedCell.set("new");
-				sharedString.insertText(0, "123");
-				cell2.delete();
-				throw new Error(errorMessage);
-			});
-		} catch (err) {
-			error = err as Error;
-		}
+		assert.equal(sharedDir.has("key2"), true);
+		assert.equal(sharedDir.get("key2"), 1);
+		assert.equal(sharedCell.get(), 2);
 
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false);
-		assert.equal(sharedString.getText(), "abcd");
-		assert.equal(sharedCell.get(), "old");
-		assert.equal(changedEventData.length, 3);
-		assert.equal(changedEventData[0], "old");
-		// rollback
-		assert.equal(changedEventData[1], "new");
-		assert.equal(changedEventData[2], "old");
-		// second cell
-		assert.equal(cell2.get(), "val");
-		assert.equal(changedData2.length, 3);
-		assert.equal(changedData2[0], "val");
-		// second cell rollback
-		assert.equal(changedData2[1], undefined);
-		assert.equal(changedData2[2], "val");
-	});
-	it("Should rollback edits in the correct order: string + 2 maps", () => {
-		sharedString.insertText(0, "abcd");
-		map2.set("key", 3);
-		sharedMap.set("key", 1);
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedMap.delete("key");
-				sharedString.insertText(2, "123");
-				sharedString.removeRange(0, 2);
-				map2.set("key", 2);
-				throw new Error(errorMessage);
-			});
-		} catch (err) {
-			error = err as Error;
-		}
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false, "Container disposed");
-		assert.equal(sharedString.getText(), "abcd");
-		assert.equal(sharedMap.has("key"), true);
-		assert.equal(sharedMap.size, 1);
-		assert.equal(sharedMap.get("key"), 1);
-		assert.equal(changedEventData.length, 3);
-		assert.equal(changedEventData[0].key, "key");
+		assert.equal(changedEventData.length, 11);
+		assert.equal(changedEventData[0].key, "key1");
 		assert.equal(changedEventData[0].previousValue, undefined);
-		assert.equal(changedEventData[1].key, "key");
-		assert.equal(changedEventData[1].previousValue, 1);
+
+		assert.equal(changedEventData[1].key, "key2");
+		assert.equal(changedEventData[1].previousValue, undefined);
+
+		assert.equal(changedEventData[2], 2);
+
 		// rollback
-		assert.equal(changedEventData[2].key, "key");
-		assert.equal(changedEventData[2].previousValue, undefined);
-		// second map
-		assert.equal(map2.has("key"), true);
-		assert.equal(map2.size, 1);
-		assert.equal(map2.get("key"), 3);
-		assert.equal(changedData2.length, 3);
-		assert.equal(changedData2[0].key, "key");
-		assert.equal(changedData2[0].previousValue, undefined);
-		assert.equal(changedData2[1].key, "key");
-		assert.equal(changedData2[1].previousValue, 3);
-		// second map rollback
-		assert.equal(changedData2[2].key, "key");
-		assert.equal(changedData2[2].previousValue, 2);
-	});
-	it("Should rollback edits in the correct order: 2 strings + directory", () => {
-		string2.insertText(0, "12345");
-		sharedDir.set("key", 1);
-		sharedString.insertText(0, "abcd");
-		string2.removeRange(0, 2);
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedString.insertText(2, "123");
-				sharedDir.delete("key");
-				string2.removeRange(0, 2);
-				throw new Error(errorMessage);
-			});
-		} catch (err) {
-			error = err as Error;
-		}
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false, "Container disposed");
-		assert.equal(sharedString.getText(), "abcd");
-		assert.equal(sharedDir.size, 1);
-		assert.equal(sharedDir.has("key"), true);
-		assert.equal(sharedDir.get("key"), 1);
-		assert.equal(changedEventData.length, 3);
-		assert.equal(changedEventData[0].key, "key");
-		assert.equal(changedEventData[0].previousValue, undefined);
-		assert.equal(changedEventData[1].key, "key");
-		assert.equal(changedEventData[1].previousValue, 1);
-		// rollback
-		assert.equal(changedEventData[2].key, "key");
-		assert.equal(changedEventData[2].previousValue, undefined);
-		// second string
-		assert.equal(string2.getText(), "345");
-	});
-	it("Should rollback edits in the correct order: 2 strings + cell", () => {
-		string2.insertText(0, "12345");
-		sharedCell.set("val");
-		sharedString.insertText(0, "abcd");
-		string2.removeRange(0, 2);
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedString.insertText(2, "123");
-				sharedCell.delete();
-				string2.removeRange(0, 2);
-				throw new Error(errorMessage);
-			});
-		} catch (err) {
-			error = err as Error;
-		}
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false, "Container disposed");
-		assert.equal(sharedString.getText(), "abcd");
-		assert.equal(sharedCell.get(), "val");
-		assert.equal(changedEventData.length, 3);
-		assert.equal(changedEventData[0], "val");
-		assert.equal(changedEventData[1], undefined);
-		// rollback
-		assert.equal(changedEventData[2], "val");
-		// second string
-		assert.equal(string2.getText(), "345");
-	});
-	it("Should rollback edits in the correct order: 2 strings + map", () => {
-		string2.insertText(0, "12345");
-		sharedMap.set("key", 1);
-		sharedString.insertText(0, "abcd");
-		string2.removeRange(0, 2);
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedString.insertText(2, "123");
-				sharedMap.delete("key");
-				string2.removeRange(0, 2);
-				throw new Error(errorMessage);
-			});
-		} catch (err) {
-			error = err as Error;
-		}
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false, "Container disposed");
-		assert.equal(sharedString.getText(), "abcd");
-		assert.equal(sharedMap.size, 1);
-		assert.equal(sharedMap.has("key"), true);
-		assert.equal(sharedMap.get("key"), 1);
-		assert.equal(changedEventData.length, 3);
-		assert.equal(changedEventData[0].key, "key");
-		assert.equal(changedEventData[0].previousValue, undefined);
-		assert.equal(changedEventData[1].key, "key");
-		assert.equal(changedEventData[1].previousValue, 1);
-		// rollback
-		assert.equal(changedEventData[2].key, "key");
-		assert.equal(changedEventData[2].previousValue, undefined);
-		// second string
-		assert.equal(string2.getText(), "345");
+		assert.equal(changedEventData[3].key, "key1");
+		assert.equal(changedEventData[3].previousValue, 0);
+
+		assert.equal(changedEventData[4].key, "key2");
+		assert.equal(changedEventData[4].previousValue, 1);
+
+		assert.equal(changedEventData[5], 5);
+
+		assert.equal(changedEventData[6], undefined);
+
+		assert.equal(changedEventData[7], 5);
+
+		assert.equal(changedEventData[8], 2);
+
+		assert.equal(changedEventData[9].key, "key2");
+		assert.equal(changedEventData[9].previousValue, undefined);
+
+		assert.equal(changedEventData[10].key, "key1");
+		assert.equal(changedEventData[10].previousValue, 3);
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
@@ -1,0 +1,487 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { requestFluidObject } from "@fluidframework/runtime-utils";
+import { SharedString } from "@fluidframework/sequence";
+import {
+	ITestObjectProvider,
+	ITestContainerConfig,
+	DataObjectFactoryType,
+	ChannelFactoryRegistry,
+	ITestFluidObject,
+} from "@fluidframework/test-utils";
+import { describeNoCompat } from "@fluid-internal/test-version-utils";
+import { IContainer } from "@fluidframework/container-definitions";
+import { ContainerRuntime } from "@fluidframework/container-runtime";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
+import { IValueChanged, SharedDirectory, SharedMap } from "@fluidframework/map";
+import { SharedCell } from "@fluidframework/cell";
+
+const stringId = "sharedStringKey";
+const dirId = "sharedDirKey";
+const cellId = "cellKey";
+const mapId = "mapKey";
+const string2Id = "sharedString2Key";
+const dir2Id = "sharedDir2Key";
+const cell2Id = "cell2Key";
+const map2Id = "map2Key";
+const registry: ChannelFactoryRegistry = [
+	[stringId, SharedString.getFactory()],
+	[dirId, SharedDirectory.getFactory()],
+	[cellId, SharedCell.getFactory()],
+	[mapId, SharedMap.getFactory()],
+	[string2Id, SharedString.getFactory()],
+	[dir2Id, SharedDirectory.getFactory()],
+	[cell2Id, SharedCell.getFactory()],
+	[map2Id, SharedMap.getFactory()],
+];
+const testContainerConfig: ITestContainerConfig = {
+	fluidDataObjectType: DataObjectFactoryType.Test,
+	registry,
+};
+
+describeNoCompat("Multiple DDS orderSequentially", (getTestObjectProvider) => {
+	let provider: ITestObjectProvider;
+	beforeEach(() => {
+		provider = getTestObjectProvider();
+	});
+
+	let container: IContainer;
+	let dataObject: ITestFluidObject;
+	let sharedString: SharedString;
+	let sharedDir: SharedDirectory;
+	let sharedCell: SharedCell;
+	let sharedMap: SharedMap;
+	let string2: SharedString;
+	let dir2: SharedDirectory;
+	let cell2: SharedCell;
+	let map2: SharedMap;
+	let changedEventData: IValueChanged[];
+	let changedData2: IValueChanged[];
+	let containerRuntime: ContainerRuntime;
+	let error: Error | undefined;
+
+	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+		getRawConfig: (name: string): ConfigTypes => settings[name],
+	});
+	const errorMessage = "callback failure";
+
+	beforeEach(async () => {
+		const configWithFeatureGates = {
+			...testContainerConfig,
+			loaderProps: {
+				configProvider: configProvider({
+					"Fluid.ContainerRuntime.EnableRollback": true,
+				}),
+			},
+		};
+		container = await provider.makeTestContainer(configWithFeatureGates);
+		dataObject = await requestFluidObject<ITestFluidObject>(container, "default");
+		sharedString = await dataObject.getSharedObject<SharedString>(stringId);
+		sharedDir = await dataObject.getSharedObject<SharedDirectory>(dirId);
+		sharedCell = await dataObject.getSharedObject<SharedCell>(cellId);
+		sharedMap = await dataObject.getSharedObject<SharedMap>(mapId);
+		string2 = await dataObject.getSharedObject<SharedString>(string2Id);
+		dir2 = await dataObject.getSharedObject<SharedDirectory>(dir2Id);
+		cell2 = await dataObject.getSharedObject<SharedCell>(cell2Id);
+		map2 = await dataObject.getSharedObject<SharedMap>(map2Id);
+
+		containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
+		changedEventData = [];
+		sharedDir.on("valueChanged", (changed, _local, _target) => {
+			changedEventData.push(changed);
+		});
+		sharedCell.on("valueChanged", (value) => {
+			changedEventData.push(value);
+		});
+		sharedCell.on("delete", (value) => {
+			changedEventData.push(value);
+		});
+		sharedMap.on("valueChanged", (value) => {
+			changedEventData.push(value);
+		});
+		changedData2 = [];
+		dir2.on("valueChanged", (changed, _local, _target) => {
+			changedData2.push(changed);
+		});
+		cell2.on("valueChanged", (value) => {
+			changedData2.push(value);
+		});
+		cell2.on("delete", (value) => {
+			changedData2.push(value);
+		});
+		map2.on("valueChanged", (value) => {
+			changedData2.push(value);
+		});
+	});
+
+	it("Should rollback simple edits on multiple strings in order", () => {
+		sharedString.insertText(0, "abcd");
+		string2.insertText(0, "12345");
+		sharedString.insertText(2, "123");
+		string2.insertText(2, "abc");
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedString.removeRange(1, 3);
+				string2.removeRange(4, 6);
+				throw new Error("callback failure");
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false);
+		assert.equal(sharedString.getText(), "ab123cd");
+		assert.equal(string2.getText(), "12abc345");
+	});
+
+	it("Should rollback complex edits on multiple strings in the correct order", () => {
+		sharedString.insertText(0, "abcd");
+		string2.insertText(0, "12345");
+		sharedString.removeRange(2, 4);
+		string2.removeRange(2, 3);
+		string2.insertText(2, "abc");
+		sharedString.insertText(2, "123");
+		string2.annotateRange(1, 5, { foo: "bar" });
+		sharedString.annotateRange(1, 4, { foo: "bar" });
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedString.removeRange(1, 3);
+				string2.removeRange(4, 6);
+				throw new Error("callback failure");
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false);
+		assert.equal(sharedString.getText(), "ab123");
+		assert.equal(string2.getText(), "12abc45");
+		for (let i = 0; i < sharedString.getText().length; i++) {
+			const props = sharedString.getPropertiesAtPosition(i);
+			if (i >= 1 && i < 4) {
+				assert.equal(props?.foo, "bar");
+			} else {
+				assert(props === undefined || props.foo === undefined);
+			}
+		}
+		for (let i = 0; i < string2.getText().length; i++) {
+			const props = string2.getPropertiesAtPosition(i);
+			if (i >= 1 && i < 5) {
+				assert.equal(props?.foo, "bar");
+			} else {
+				assert(props === undefined || props.foo === undefined);
+			}
+		}
+	});
+
+	it("Should rollback string and directory edits in the correct order", () => {
+		sharedString.insertText(0, "abcd");
+		sharedDir.set("key", 1);
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedDir.set("key", 0);
+				sharedString.insertText(2, "123");
+				throw new Error(errorMessage);
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false, "Container disposed");
+		assert.equal(sharedString.getText(), "abcd");
+		assert.equal(sharedDir.size, 1);
+		assert.equal(sharedDir.has("key"), true);
+		assert.equal(sharedDir.get("key"), 1);
+		assert.equal(changedEventData.length, 3);
+		assert.equal(changedEventData[0].key, "key");
+		assert.equal(changedEventData[0].previousValue, undefined);
+		assert.equal(changedEventData[1].key, "key");
+		assert.equal(changedEventData[1].previousValue, 1);
+		// rollback
+		assert.equal(changedEventData[2].key, "key");
+		assert.equal(changedEventData[2].previousValue, 0);
+	});
+
+	it("Should rollback string and cell edits in the correct order", () => {
+		sharedString.insertText(0, "abcd");
+		sharedCell.set("old");
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedString.removeRange(1, 2);
+				sharedCell.set("new");
+				sharedString.insertText(0, "123");
+				throw new Error(errorMessage);
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false);
+		assert.equal(sharedString.getText(), "abcd");
+		assert.equal(sharedCell.get(), "old");
+		assert.equal(changedEventData.length, 3);
+		assert.equal(changedEventData[0], "old");
+		// rollback
+		assert.equal(changedEventData[1], "new");
+		assert.equal(changedEventData[2], "old");
+	});
+
+	it("Should rollback string and map edits in the correct order", () => {
+		sharedString.insertText(0, "abcd");
+		sharedMap.set("key", 1);
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedMap.set("key", 0);
+				sharedString.insertText(2, "123");
+				sharedMap.delete("key");
+				sharedString.removeRange(0, 2);
+				throw new Error(errorMessage);
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false, "Container disposed");
+		assert.equal(sharedString.getText(), "abcd");
+		assert.equal(sharedMap.has("key"), true);
+		assert.equal(sharedMap.size, 1);
+		assert.equal(sharedMap.get("key"), 1);
+		assert.equal(changedEventData.length, 5);
+		assert.equal(changedEventData[0].key, "key");
+		assert.equal(changedEventData[0].previousValue, undefined);
+		assert.equal(changedEventData[1].key, "key");
+		assert.equal(changedEventData[1].previousValue, 1);
+		// rollback
+		assert.equal(changedEventData[2].key, "key");
+		assert.equal(changedEventData[2].previousValue, 0);
+		assert.equal(changedEventData[3].previousValue, undefined);
+		assert.equal(changedEventData[4].previousValue, 0);
+	});
+
+	it("Should rollback edits in the correct order: string + 2 directories", () => {
+		sharedDir.set("key", 1);
+		sharedString.insertText(0, "abcd");
+		dir2.set("key", 2);
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedString.insertText(2, "123");
+				dir2.delete("key");
+				sharedDir.set("key", 0);
+				throw new Error(errorMessage);
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false, "Container disposed");
+		assert.equal(sharedString.getText(), "abcd");
+		assert.equal(sharedDir.size, 1);
+		assert.equal(sharedDir.has("key"), true);
+		assert.equal(sharedDir.get("key"), 1);
+		assert.equal(changedEventData.length, 3);
+		assert.equal(changedEventData[0].key, "key");
+		assert.equal(changedEventData[0].previousValue, undefined);
+		assert.equal(changedEventData[1].key, "key");
+		assert.equal(changedEventData[1].previousValue, 1);
+		// rollback
+		assert.equal(changedEventData[2].key, "key");
+		assert.equal(changedEventData[2].previousValue, 0);
+		// second directory
+		assert.equal(dir2.size, 1);
+		assert.equal(dir2.has("key"), true);
+		assert.equal(dir2.get("key"), 2);
+		assert.equal(changedData2.length, 3);
+		assert.equal(changedData2[0].key, "key");
+		assert.equal(changedData2[0].previousValue, undefined); // 2
+		assert.equal(changedData2[1].key, "key");
+		assert.equal(changedData2[1].previousValue, 2); // undefined
+		// second directory rollback
+		assert.equal(changedData2[2].key, "key");
+		assert.equal(changedData2[2].previousValue, undefined); // 2
+	});
+	it("Should rollback edits in the correct order: string + 2 cells", () => {
+		sharedString.insertText(0, "abcd");
+		cell2.set("val");
+		sharedCell.set("old");
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedString.removeRange(1, 2);
+				sharedCell.set("new");
+				sharedString.insertText(0, "123");
+				cell2.delete();
+				throw new Error(errorMessage);
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false);
+		assert.equal(sharedString.getText(), "abcd");
+		assert.equal(sharedCell.get(), "old");
+		assert.equal(changedEventData.length, 3);
+		assert.equal(changedEventData[0], "old");
+		// rollback
+		assert.equal(changedEventData[1], "new");
+		assert.equal(changedEventData[2], "old");
+		// second cell
+		assert.equal(cell2.get(), "val");
+		assert.equal(changedData2.length, 3);
+		assert.equal(changedData2[0], "val");
+		// second cell rollback
+		assert.equal(changedData2[1], undefined);
+		assert.equal(changedData2[2], "val");
+	});
+	it("Should rollback edits in the correct order: string + 2 maps", () => {
+		sharedString.insertText(0, "abcd");
+		map2.set("key", 3);
+		sharedMap.set("key", 1);
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedMap.delete("key");
+				sharedString.insertText(2, "123");
+				sharedString.removeRange(0, 2);
+				map2.set("key", 2);
+				throw new Error(errorMessage);
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false, "Container disposed");
+		assert.equal(sharedString.getText(), "abcd");
+		assert.equal(sharedMap.has("key"), true);
+		assert.equal(sharedMap.size, 1);
+		assert.equal(sharedMap.get("key"), 1);
+		assert.equal(changedEventData.length, 3);
+		assert.equal(changedEventData[0].key, "key");
+		assert.equal(changedEventData[0].previousValue, undefined);
+		assert.equal(changedEventData[1].key, "key");
+		assert.equal(changedEventData[1].previousValue, 1);
+		// rollback
+		assert.equal(changedEventData[2].key, "key");
+		assert.equal(changedEventData[2].previousValue, undefined);
+		// second map
+		assert.equal(map2.has("key"), true);
+		assert.equal(map2.size, 1);
+		assert.equal(map2.get("key"), 3);
+		assert.equal(changedData2.length, 3);
+		assert.equal(changedData2[0].key, "key");
+		assert.equal(changedData2[0].previousValue, undefined);
+		assert.equal(changedData2[1].key, "key");
+		assert.equal(changedData2[1].previousValue, 3);
+		// second map rollback
+		assert.equal(changedData2[2].key, "key");
+		assert.equal(changedData2[2].previousValue, 2);
+	});
+	it("Should rollback edits in the correct order: 2 strings + directory", () => {
+		string2.insertText(0, "12345");
+		sharedDir.set("key", 1);
+		sharedString.insertText(0, "abcd");
+		string2.removeRange(0, 2);
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedString.insertText(2, "123");
+				sharedDir.delete("key");
+				string2.removeRange(0, 2);
+				throw new Error(errorMessage);
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false, "Container disposed");
+		assert.equal(sharedString.getText(), "abcd");
+		assert.equal(sharedDir.size, 1);
+		assert.equal(sharedDir.has("key"), true);
+		assert.equal(sharedDir.get("key"), 1);
+		assert.equal(changedEventData.length, 3);
+		assert.equal(changedEventData[0].key, "key");
+		assert.equal(changedEventData[0].previousValue, undefined);
+		assert.equal(changedEventData[1].key, "key");
+		assert.equal(changedEventData[1].previousValue, 1);
+		// rollback
+		assert.equal(changedEventData[2].key, "key");
+		assert.equal(changedEventData[2].previousValue, undefined);
+		// second string
+		assert.equal(string2.getText(), "345");
+	});
+	it("Should rollback edits in the correct order: 2 strings + cell", () => {
+		string2.insertText(0, "12345");
+		sharedCell.set("val");
+		sharedString.insertText(0, "abcd");
+		string2.removeRange(0, 2);
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedString.insertText(2, "123");
+				sharedCell.delete();
+				string2.removeRange(0, 2);
+				throw new Error(errorMessage);
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false, "Container disposed");
+		assert.equal(sharedString.getText(), "abcd");
+		assert.equal(sharedCell.get(), "val");
+		assert.equal(changedEventData.length, 3);
+		assert.equal(changedEventData[0], "val");
+		assert.equal(changedEventData[1], undefined);
+		// rollback
+		assert.equal(changedEventData[2], "val");
+		// second string
+		assert.equal(string2.getText(), "345");
+	});
+	it("Should rollback edits in the correct order: 2 strings + map", () => {
+		string2.insertText(0, "12345");
+		sharedMap.set("key", 1);
+		sharedString.insertText(0, "abcd");
+		string2.removeRange(0, 2);
+		try {
+			containerRuntime.orderSequentially(() => {
+				sharedString.insertText(2, "123");
+				sharedMap.delete("key");
+				string2.removeRange(0, 2);
+				throw new Error(errorMessage);
+			});
+		} catch (err) {
+			error = err as Error;
+		}
+		assert.notEqual(error, undefined, "No error");
+		assert.equal(error?.message, errorMessage, "Unexpected error message");
+		assert.equal(containerRuntime.disposed, false, "Container disposed");
+		assert.equal(sharedString.getText(), "abcd");
+		assert.equal(sharedMap.size, 1);
+		assert.equal(sharedMap.has("key"), true);
+		assert.equal(sharedMap.get("key"), 1);
+		assert.equal(changedEventData.length, 3);
+		assert.equal(changedEventData[0].key, "key");
+		assert.equal(changedEventData[0].previousValue, undefined);
+		assert.equal(changedEventData[1].key, "key");
+		assert.equal(changedEventData[1].previousValue, 1);
+		// rollback
+		assert.equal(changedEventData[2].key, "key");
+		assert.equal(changedEventData[2].previousValue, undefined);
+		// second string
+		assert.equal(string2.getText(), "345");
+	});
+});


### PR DESCRIPTION
Testing to ensure that orderSequentially can keep operations in order when multiple DDSs of both the same and different types are involved (for example, 2 SharedStrings or a SharedString and a SharedMap). The tests vary in the type and number of DDS instances, as well as in the complexity of the ops performed. 

[AB#3777](https://dev.azure.com/fluidframework/internal/_workitems/edit/3777)