### PR TITLE
EditableTree: expose editable tree context for fields and nodes

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -211,6 +211,9 @@ type CollectOptions<Mode extends ApiMode, TTypedFields, TValueSchema extends Val
 }[Mode];
 
 // @alpha
+export const contextSymbol: unique symbol;
+
+// @alpha
 export type ContextuallyTypedFieldData = ContextuallyTypedNodeData | undefined;
 
 // @alpha
@@ -335,6 +338,7 @@ type _dummy = 0;
 // @alpha
 export interface EditableField extends MarkedArrayLike<UnwrappedEditableTree | ContextuallyTypedNodeData> {
     readonly [proxyTargetSymbol]: object;
+    readonly context: EditableTreeContext;
     deleteNodes(index: number, count?: number): void;
     readonly fieldKey: FieldKey;
     readonly fieldSchema: FieldSchema;
@@ -346,6 +350,7 @@ export interface EditableField extends MarkedArrayLike<UnwrappedEditableTree | C
 
 // @alpha
 export interface EditableTree extends Iterable<EditableField>, ContextuallyTypedNodeDataObject {
+    readonly [contextSymbol]: EditableTreeContext;
     [createField](fieldKey: FieldKey, newContent: ITreeCursor | ITreeCursor[]): void;
     [getField](fieldKey: FieldKey): EditableField;
     // (undocumented)

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableField.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableField.ts
@@ -234,6 +234,7 @@ const editableFieldPropertySetWithoutLength = new Set<string>([
 	"fieldSchema",
 	"primaryType",
 	"parent",
+	"context",
 ]);
 /**
  * The set of `EditableField` properties exposed by `fieldProxyHandler`.

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
@@ -52,6 +52,7 @@ import {
 	proxyTargetSymbol,
 	replaceField,
 	typeSymbol,
+	contextSymbol,
 } from "./editableTreeTypes";
 import { makeField, unwrappedField } from "./editableField";
 import { ProxyTarget } from "./ProxyTarget";
@@ -347,6 +348,8 @@ const nodeProxyHandler: AdaptingProxyHandler<NodeProxyTarget, EditableTree> = {
 				return target.replaceField.bind(target);
 			case parentField:
 				return target.parentField;
+			case contextSymbol:
+				return target.context;
 			case on:
 				return target.on.bind(target);
 			default:
@@ -426,6 +429,7 @@ const nodeProxyHandler: AdaptingProxyHandler<NodeProxyTarget, EditableTree> = {
 			case replaceField:
 			case parentField:
 			case on:
+			case contextSymbol:
 				return true;
 			case valueSymbol:
 				// Could do `target.value !== ValueSchema.Nothing`
@@ -514,6 +518,13 @@ const nodeProxyHandler: AdaptingProxyHandler<NodeProxyTarget, EditableTree> = {
 					configurable: true,
 					enumerable: false,
 					value: target.parentField,
+					writable: false,
+				};
+			case contextSymbol:
+				return {
+					configurable: true,
+					enumerable: false,
+					value: target.context,
 					writable: false,
 				};
 			case on:

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeTypes.ts
@@ -19,6 +19,7 @@ import {
 	typeNameSymbol,
 	valueSymbol,
 } from "../contextuallyTyped";
+import { EditableTreeContext } from "./editableTreeContext";
 
 /**
  * A symbol for extracting target from {@link EditableTree} proxies.
@@ -60,6 +61,13 @@ export const replaceField: unique symbol = Symbol("editable-tree:replaceField()"
  * @alpha
  */
 export const parentField: unique symbol = Symbol("editable-tree:parentField()");
+
+/**
+ * A symbol to get a common context of a "forest" of EditableTrees
+ * in contexts where string keys are already in use for fields.
+ * @alpha
+ */
+export const contextSymbol: unique symbol = Symbol("editable-tree:context");
 
 /**
  * A symbol for subscribing to events.
@@ -134,6 +142,11 @@ export interface EditableTree extends Iterable<EditableField>, ContextuallyTyped
 	 * but the presence of this symbol can be used to separate EditableTrees from other types.
 	 */
 	readonly [proxyTargetSymbol]: object;
+
+	/**
+	 * A common context of a "forest" of EditableTrees.
+	 */
+	readonly [contextSymbol]: EditableTreeContext;
 
 	/**
 	 * Gets the field of this node by its key without unwrapping.
@@ -283,6 +296,11 @@ export interface EditableField
 	 * `undefined` iff this field is a detached field.
 	 */
 	readonly parent?: EditableTree;
+
+	/**
+	 * A common context of a "forest" of EditableTrees.
+	 */
+	readonly context: EditableTreeContext;
 
 	/**
 	 * Stores the target for the proxy which implements reading and writing for this sequence field.

--- a/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/index.ts
@@ -17,6 +17,7 @@ export {
 	parentField,
 	EditableTreeEvents,
 	on,
+	contextSymbol,
 } from "./editableTreeTypes";
 
 export { isEditableField } from "./editableField";

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -31,6 +31,7 @@ export {
 	parentField,
 	EditableTreeEvents,
 	on,
+	contextSymbol,
 } from "./editable-tree";
 
 export {

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -193,6 +193,7 @@ export {
 	getField,
 	createField,
 	replaceField,
+	contextSymbol,
 	ContextuallyTypedNodeDataObject,
 	ContextuallyTypedNodeData,
 	MarkedArrayLike,

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.spec.ts
@@ -40,6 +40,7 @@ import {
 	SchemaAware,
 	TypedSchema,
 	parentField,
+	contextSymbol,
 } from "../../../feature-libraries";
 
 import {
@@ -47,6 +48,11 @@ import {
 	// Allow importing from this specific file which is being tested:
 	/* eslint-disable-next-line import/no-internal-modules */
 } from "../../../feature-libraries/editable-tree/editableTree";
+import {
+	ProxyContext,
+	// Allow importing from this specific file which is being tested:
+	/* eslint-disable-next-line import/no-internal-modules */
+} from "../../../feature-libraries/editable-tree/editableTreeContext";
 
 import {
 	fullSchemaData,
@@ -210,6 +216,18 @@ describe("editable-tree: read-only", () => {
 			};
 			assert.deepEqual(descriptor, expected);
 		}
+
+		{
+			const descriptor = Object.getOwnPropertyDescriptor(nameNode, contextSymbol);
+			assert(descriptor?.value instanceof ProxyContext);
+			const expected = {
+				configurable: true,
+				enumerable: false,
+				value: proxy[contextSymbol],
+				writable: false,
+			};
+			assert.deepEqual(descriptor, expected);
+		}
 	});
 
 	it("`typeSymbol` and `typeNameSymbol` work as expected", () => {
@@ -267,6 +285,7 @@ describe("editable-tree: read-only", () => {
 		assert(typeSymbol in personProxy);
 		assert(typeNameSymbol in personProxy);
 		assert(getField in personProxy);
+		assert(contextSymbol in personProxy);
 		// Check fields show up:
 		assert("age" in personProxy);
 		assert.equal(EmptyKey in personProxy, false);
@@ -600,6 +619,7 @@ describe("editable-tree: read-only", () => {
 			"fieldSchema",
 			"primaryType",
 			"parent",
+			"context",
 		]);
 		const act = [...proxy.address.phones].map(
 			(phone: UnwrappedEditableTree): Value | object => {


### PR DESCRIPTION
## Description

Allows to access `EditableTreeContext` at fields/nodes of the tree while traversing in cases, where it might be inconvenient to forward the context through the code starting from an instance of the SharedTree.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).