### PR TITLE
Simplify SharedTree indexes

### DIFF
--- a/packages/dds/tree/src/feature-libraries/README.md
+++ b/packages/dds/tree/src/feature-libraries/README.md
@@ -14,7 +14,7 @@ Some important libraries in here:
 -   Families of changes/edits which can be applies for various field kinds
 -   `ChangeRebaser` implementations for these change families
 -   Implementations of Forest (Currently just [object-forest](./object-forest/README.md)).
--   `Index` implementations, including [schemaIndex](./schemaIndex.ts), [editManagerIndex](./editManagerIndex.ts) and [forestIndex](./forestIndex.ts).
+-   `Index` summarizers, including [schemaSummarizer](./schemaSummarizer.ts), and [forestSummarizer](./forestSummarizer.ts).
 
 ## Future Plans
 

--- a/packages/dds/tree/src/feature-libraries/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forestSummarizer.ts
@@ -27,13 +27,10 @@ import {
 	moveToDetachedField,
 } from "../core";
 import {
-	Index,
-	SummaryElement,
+	IndexSummarizer,
 	SummaryElementParser,
 	SummaryElementStringifier,
-	IndexEvents,
 } from "../shared-tree-core";
-import { ISubscribable } from "../events";
 import { jsonableTreeFromCursor, singleTextCursor } from "./treeTextCursor";
 
 /**
@@ -42,18 +39,10 @@ import { jsonableTreeFromCursor, singleTextCursor } from "./treeTextCursor";
 const treeBlobKey = "ForestTree";
 
 /**
- * Index which provides an editable forest for the current state for the document.
- *
- * Maintains part of the document in memory, but can fetch more on demand.
- *
- * TODO: support for partial checkouts.
- *
- * Used to capture snapshots of document for summaries.
+ * Provides methods for summarizing and loading a forest.
  */
-export class ForestIndex implements Index, SummaryElement {
+export class ForestSummarizer implements IndexSummarizer {
 	public readonly key = "Forest";
-
-	public readonly summaryElement?: SummaryElement = this;
 
 	private readonly cursor: ITreeSubscriptionCursor;
 
@@ -62,7 +51,6 @@ export class ForestIndex implements Index, SummaryElement {
 
 	public constructor(
 		private readonly runtime: IFluidDataStoreRuntime,
-		events: ISubscribable<IndexEvents<unknown>>,
 		private readonly forest: IEditableForest,
 	) {
 		this.cursor = this.forest.allocateCursor();
@@ -74,9 +62,6 @@ export class ForestIndex implements Index, SummaryElement {
 			// For now we are not chunking the data, and instead put it in a single blob:
 			// TODO: use lower level API to avoid blob manager?
 			return this.runtime.uploadBlob(IsoBuffer.from(treeText));
-		});
-		events.on("newLocalState", (changeDelta) => {
-			this.forest.applyDelta(changeDelta);
 		});
 	}
 

--- a/packages/dds/tree/src/feature-libraries/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forestSummarizer.ts
@@ -26,11 +26,7 @@ import {
 	mapCursorField,
 	moveToDetachedField,
 } from "../core";
-import {
-	IndexSummarizer,
-	SummaryElementParser,
-	SummaryElementStringifier,
-} from "../shared-tree-core";
+import { Summarizable, SummaryElementParser, SummaryElementStringifier } from "../shared-tree-core";
 import { jsonableTreeFromCursor, singleTextCursor } from "./treeTextCursor";
 
 /**
@@ -41,7 +37,7 @@ const treeBlobKey = "ForestTree";
 /**
  * Provides methods for summarizing and loading a forest.
  */
-export class ForestSummarizer implements IndexSummarizer {
+export class ForestSummarizer implements Summarizable {
 	public readonly key = "Forest";
 
 	private readonly cursor: ITreeSubscriptionCursor;

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -52,10 +52,10 @@ export {
 	ContextuallyTypedFieldData,
 } from "./contextuallyTyped";
 
-export { ForestIndex } from "./forestIndex";
+export { ForestSummarizer } from "./forestSummarizer";
 export { singleMapTreeCursor, mapTreeFromCursor } from "./mapTreeCursor";
 export { buildForest } from "./object-forest";
-export { SchemaIndex, SchemaEditor } from "./schemaIndex";
+export { SchemaSummarizer, SchemaEditor } from "./schemaSummarizer";
 // This is exported because its useful for doing comparisons of schema in tests.
 export { getSchemaString } from "./schemaIndexFormat";
 export {
@@ -120,13 +120,6 @@ export {
 } from "./modular-schema";
 
 export { mapFieldMarks, mapMark, mapMarkList, populateChildModifications } from "./deltaUtils";
-
-export {
-	EditManagerIndex,
-	CommitEncoder,
-	parseSummary as loadSummary,
-	stringifySummary as encodeSummary,
-} from "./editManagerIndex";
 
 export { ForestRepairDataStore } from "./forestRepairDataStore";
 export { dummyRepairDataStore } from "./fakeRepairDataStore";

--- a/packages/dds/tree/src/feature-libraries/schemaSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/schemaSummarizer.ts
@@ -32,11 +32,7 @@ import {
 	schemaDataIsEmpty,
 	SchemaEvents,
 } from "../core";
-import {
-	IndexSummarizer,
-	SummaryElementParser,
-	SummaryElementStringifier,
-} from "../shared-tree-core";
+import { Summarizable, SummaryElementParser, SummaryElementStringifier } from "../shared-tree-core";
 import { isJsonObject, JsonCompatibleReadOnly } from "../util";
 import { getSchemaString, parseSchemaString } from "./schemaIndexFormat";
 
@@ -50,7 +46,7 @@ const schemaStringKey = "SchemaString";
 /**
  * Provides methods for summarizing and loading a schema repository.
  */
-export class SchemaSummarizer implements IndexSummarizer {
+export class SchemaSummarizer implements Summarizable {
 	public readonly key = "Schema";
 
 	private readonly schemaBlob: ICachedValue<Promise<IFluidHandle<ArrayBufferLike>>>;

--- a/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
@@ -30,12 +30,7 @@ import {
 	ChangeEncoder,
 	ChangeFamilyEditor,
 } from "../core";
-import {
-	Index,
-	SummaryElement,
-	SummaryElementParser,
-	SummaryElementStringifier,
-} from "../shared-tree-core";
+import { IndexSummarizer, SummaryElementParser, SummaryElementStringifier } from ".";
 
 /**
  * The storage key for the blob in the summary containing EditManager data
@@ -45,13 +40,9 @@ const blobKey = "Blob";
 const stringKey = "String";
 
 /**
- * Represents a local branch of a document and interprets the effect on the document of adding sequenced changes,
- * which were based on a given session's branch, to the document history
+ * Provides methods for summarizing and loading an `EditManager`
  */
-// TODO: Remove commits when they are no longer in the collab window
-// TODO: Move logic into Rebaser if possible
-export class EditManagerIndex<TChangeset> implements Index, SummaryElement {
-	public readonly summaryElement?: SummaryElement = this;
+export class EditManagerSummarizer<TChangeset> implements IndexSummarizer {
 	public readonly key = "EditManager";
 
 	private readonly editDataBlob: ICachedValue<Promise<IFluidHandle<ArrayBufferLike>>>;

--- a/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
@@ -30,7 +30,7 @@ import {
 	ChangeEncoder,
 	ChangeFamilyEditor,
 } from "../core";
-import { Summarizable, SummaryElementParser, SummaryElementStringifier } from ".";
+import { Summarizable, SummaryElementParser, SummaryElementStringifier } from "./sharedTreeCore";
 
 /**
  * The storage key for the blob in the summary containing EditManager data

--- a/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
@@ -30,7 +30,7 @@ import {
 	ChangeEncoder,
 	ChangeFamilyEditor,
 } from "../core";
-import { IndexSummarizer, SummaryElementParser, SummaryElementStringifier } from ".";
+import { Summarizable, SummaryElementParser, SummaryElementStringifier } from ".";
 
 /**
  * The storage key for the blob in the summary containing EditManager data
@@ -42,7 +42,7 @@ const stringKey = "String";
 /**
  * Provides methods for summarizing and loading an `EditManager`
  */
-export class EditManagerSummarizer<TChangeset> implements IndexSummarizer {
+export class EditManagerSummarizer<TChangeset> implements Summarizable {
 	public readonly key = "EditManager";
 
 	private readonly editDataBlob: ICachedValue<Promise<IFluidHandle<ArrayBufferLike>>>;

--- a/packages/dds/tree/src/shared-tree-core/index.ts
+++ b/packages/dds/tree/src/shared-tree-core/index.ts
@@ -8,7 +8,7 @@ export {
 	ChangeEvents,
 	ISharedTreeCoreEvents,
 	SharedTreeCore,
-	IndexSummarizer,
+	Summarizable,
 	SummaryElementParser,
 	SummaryElementStringifier,
 } from "./sharedTreeCore";
@@ -18,6 +18,6 @@ export { TransactionStack } from "./transactionStack";
 export {
 	EditManagerSummarizer,
 	CommitEncoder,
-	parseSummary as loadSummary,
-	stringifySummary as encodeSummary,
+	parseSummary,
+	stringifySummary,
 } from "./editManagerSummarizer";

--- a/packages/dds/tree/src/shared-tree-core/index.ts
+++ b/packages/dds/tree/src/shared-tree-core/index.ts
@@ -5,13 +5,19 @@
 export { SharedTreeBranch, SharedTreeBranchEvents } from "./branch";
 
 export {
-	Index,
-	IndexEvents,
+	ChangeEvents,
 	ISharedTreeCoreEvents,
 	SharedTreeCore,
-	SummaryElement,
+	IndexSummarizer,
 	SummaryElementParser,
 	SummaryElementStringifier,
 } from "./sharedTreeCore";
 
 export { TransactionStack } from "./transactionStack";
+
+export {
+	EditManagerSummarizer,
+	CommitEncoder,
+	parseSummary as loadSummary,
+	stringifySummary as encodeSummary,
+} from "./editManagerSummarizer";

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -56,7 +56,7 @@ export interface ISharedTreeCoreEvents {
 // TODO: How should the format version be determined?
 const formatVersion = 0;
 // TODO: Organize this to be adjacent to persisted types.
-const summarizablesTreekey = "indexes";
+const summarizablesTreeKey = "indexes";
 
 /**
  * Events which result from the state of the tree changing.
@@ -178,14 +178,14 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 			);
 		}
 
-		builder.addWithStats(summarizablesTreekey, summarizableBuilder.getSummaryTree());
+		builder.addWithStats(summarizablesTreeKey, summarizableBuilder.getSummaryTree());
 		return builder.getSummaryTree();
 	}
 
 	protected async loadCore(services: IChannelStorageService): Promise<void> {
 		const loadSummaries = this.summarizables.map(async (summaryElement) =>
 			summaryElement.load(
-				scopeStorageService(services, summarizablesTreekey, summaryElement.key),
+				scopeStorageService(services, summarizablesTreeKey, summaryElement.key),
 				(contents) => this.serializer.parse(contents),
 			),
 		);

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -26,8 +26,8 @@ import { SharedTreeBranch, SharedTreeCore } from "../shared-tree-core";
 import {
 	defaultSchemaPolicy,
 	EditableTreeContext,
-	ForestIndex,
-	SchemaIndex,
+	ForestSummarizer,
+	SchemaSummarizer as SchemaSummarizer,
 	DefaultChangeFamily,
 	defaultChangeFamily,
 	DefaultEditBuilder,
@@ -35,10 +35,8 @@ import {
 	getEditableTreeContext,
 	SchemaEditor,
 	DefaultChangeset,
-	EditManagerIndex,
 	buildForest,
 	ContextuallyTypedNodeData,
-	ModularChangeset,
 	IDefaultEditBuilder,
 	ForestRepairDataStore,
 } from "../feature-libraries";
@@ -211,11 +209,7 @@ export interface ISharedTree extends ISharedObject, ISharedTreeView {}
  * TODO: detail compatibility requirements.
  */
 class SharedTree
-	extends SharedTreeCore<
-		DefaultEditBuilder,
-		DefaultChangeset,
-		readonly [SchemaIndex, ForestIndex, EditManagerIndex<ModularChangeset>]
-	>
+	extends SharedTreeCore<DefaultEditBuilder, DefaultChangeset>
 	implements ISharedTree
 {
 	public readonly context: EditableTreeContext;
@@ -237,16 +231,10 @@ class SharedTree
 		const anchors = new AnchorSet();
 		const schema = new InMemoryStoredSchemaRepository(defaultSchemaPolicy);
 		const forest = buildForest(schema, anchors);
+		const schemaSummarizer = new SchemaSummarizer(runtime, schema);
+		const forestSummarizer = new ForestSummarizer(runtime, forest);
 		super(
-			(events, editManager) => {
-				const indexes = [
-					new SchemaIndex(runtime, events, schema),
-					new ForestIndex(runtime, events, forest),
-					new EditManagerIndex(runtime, editManager),
-				] as const;
-				events.on("newLocalState", () => this.events.emit("afterBatch"));
-				return indexes;
-			},
+			[schemaSummarizer, forestSummarizer],
 			defaultChangeFamily,
 			anchors,
 			id,
@@ -267,6 +255,10 @@ class SharedTree
 		};
 
 		this.context = getEditableTreeContext(forest, this.editor);
+		this.changeEvents.on("newLocalState", (changeDelta) => {
+			this.forest.applyDelta(changeDelta);
+			this.events.emit("afterBatch");
+		});
 	}
 
 	public locate(anchor: Anchor): AnchorNode | undefined {

--- a/packages/dds/tree/src/test/feature-libraries/editManagerSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editManagerSummarizer.spec.ts
@@ -7,9 +7,9 @@ import { strict as assert } from "assert";
 import { mintRevisionTag, SummaryData } from "../../core";
 import { TestChange } from "../testChange";
 import { brand } from "../../util";
-import { encodeSummary, loadSummary } from "../../shared-tree-core";
+import { parseSummary, stringifySummary } from "../../shared-tree-core";
 
-describe("EditManagerIndex", () => {
+describe("EditManagerSummarizer", () => {
 	it("roundtrip", () => {
 		const tag1 = mintRevisionTag();
 		const tag2 = mintRevisionTag();
@@ -59,10 +59,10 @@ describe("EditManagerIndex", () => {
 				],
 			]),
 		};
-		const s1 = encodeSummary(input, TestChange.encoder);
-		const output = loadSummary(s1, TestChange.encoder);
+		const s1 = stringifySummary(input, TestChange.encoder);
+		const output = parseSummary(s1, TestChange.encoder);
 		assert.deepEqual(output, input);
-		const s2 = encodeSummary(output, TestChange.encoder);
+		const s2 = stringifySummary(output, TestChange.encoder);
 		assert.equal(s1, s2);
 	});
 

--- a/packages/dds/tree/src/test/feature-libraries/editManagerSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editManagerSummarizer.spec.ts
@@ -66,6 +66,6 @@ describe("EditManagerSummarizer", () => {
 		assert.equal(s1, s2);
 	});
 
-	// TODO: testing EditManagerIndex class itself, specifically for attachment and normal summaries.
+	// TODO: testing EditManagerSummarizer class itself, specifically for attachment and normal summaries.
 	// TODO: format compatibility tests to detect breaking of existing documents.
 });

--- a/packages/dds/tree/src/test/feature-libraries/editManagerSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editManagerSummarizer.spec.ts
@@ -4,13 +4,10 @@
  */
 
 import { strict as assert } from "assert";
-
-// Allow importing from this specific file which is being tested:
-import { loadSummary, encodeSummary } from "../../feature-libraries";
-
 import { mintRevisionTag, SummaryData } from "../../core";
 import { TestChange } from "../testChange";
 import { brand } from "../../util";
+import { encodeSummary, loadSummary } from "../../shared-tree-core";
 
 describe("EditManagerIndex", () => {
 	it("roundtrip", () => {

--- a/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -20,7 +20,7 @@ import { createSingleBlobSummary } from "@fluidframework/shared-object-base";
 import {
 	ChangeEvents,
 	SharedTreeCore,
-	IndexSummarizer,
+	Summarizable,
 	SummaryElementParser,
 	SummaryElementStringifier,
 } from "../../shared-tree-core";
@@ -131,106 +131,107 @@ describe("SharedTreeCore", () => {
 		const { summary, stats } = await tree.summarize();
 		assert(summary);
 		assert(stats);
-		assert.equal(stats.treeNodeCount, 2);
-		assert.equal(stats.blobNodeCount, 0);
+		assert.equal(stats.treeNodeCount, 3);
+		assert.equal(stats.blobNodeCount, 1); // EditManager is always summarized
 		assert.equal(stats.handleNodeCount, 0);
 	});
 
-	describe("indexes", () => {
+	describe("summarizables", () => {
 		it("are loaded", async () => {
-			const index = new MockIndexSummarizer();
+			const summarizable = new MockSummarizable();
 			let loaded = false;
-			index.on("loaded", () => (loaded = true));
-			const indexes = [index] as const;
-			const tree = createTree(indexes);
-			await tree.load(new MockSharedObjectServices({}));
-			assert(loaded, "Expected index to load");
+			summarizable.on("loaded", () => (loaded = true));
+			const summarizables = [summarizable] as const;
+			const tree = createTree(summarizables);
+			const defaultSummary = await createTree([]).summarize();
+			await tree.load(MockSharedObjectServices.createFromSummary(defaultSummary.summary));
+			assert(loaded, "Expected summarizable to load");
 		});
 
 		it("load blobs", async () => {
-			const index = new MockIndexSummarizer();
+			const summarizable = new MockSummarizable();
 			let loadedBlob = false;
-			index.on("loaded", (blobContents) => {
-				if (blobContents === MockIndexSummarizer.blobContents) {
+			summarizable.on("loaded", (blobContents) => {
+				if (blobContents === MockSummarizable.blobContents) {
 					loadedBlob = true;
 				}
 			});
-			const indexes = [index] as const;
-			const tree = createTree(indexes);
+			const summarizables = [summarizable] as const;
+			const tree = createTree(summarizables);
 			const { summary } = await tree.summarize();
 			await tree.load(MockSharedObjectServices.createFromSummary(summary));
 			assert.equal(loadedBlob, true);
 		});
 
 		it("summarize synchronously", () => {
-			const indexA = new MockIndexSummarizer("Index A");
-			let summarizedIndexA = false;
-			indexA.on("summarizeAttached", () => (summarizedIndexA = true));
-			const indexB = new MockIndexSummarizer("Index B");
-			let summarizedIndexB = false;
-			indexB.on("summarizeAttached", () => (summarizedIndexB = true));
-			const indexes = [indexA, indexB] as const;
-			const tree = createTree(indexes);
+			const summarizableA = new MockSummarizable("summarizable A");
+			let summarizedA = false;
+			summarizableA.on("summarizeAttached", () => (summarizedA = true));
+			const summarizableB = new MockSummarizable("summarizable B");
+			let summarizedB = false;
+			summarizableB.on("summarizeAttached", () => (summarizedB = true));
+			const summarizables = [summarizableA, summarizableB] as const;
+			const tree = createTree(summarizables);
 			const { summary, stats } = tree.getAttachSummary();
-			assert(summarizedIndexA, "Expected Index A to summarize");
-			assert(summarizedIndexB, "Expected Index B to summarize");
-			const indexSummaryTree = summary.tree.indexes;
+			assert(summarizedA, "Expected summarizable A to summarize");
+			assert(summarizedB, "Expected summarizable B to summarize");
+			const summarizableTree = summary.tree.indexes;
 			assert(
-				isSummaryTree(indexSummaryTree),
-				"Expected index subtree to be present in summary",
+				isSummaryTree(summarizableTree),
+				"Expected summarizable subtree to be present in summary",
 			);
 			assert.equal(
-				Object.entries(indexSummaryTree.tree).length,
-				indexes.length,
-				"Expected both indexes to be present in the index subtree of the summary",
+				Object.entries(summarizableTree.tree).length - 1, // EditManager is always summarized
+				summarizables.length,
+				"Expected both summaries to be present in the summarizable",
 			);
 
 			assert.equal(
 				stats.treeNodeCount,
-				4,
+				5,
 				"Expected summary stats to correctly count tree nodes",
 			);
 		});
 
 		// TODO: Enable once SharedTreeCore properly implements async summaries
 		it.skip("summarize asynchronously", async () => {
-			const indexA = new MockIndexSummarizer("Index A");
-			let summarizedIndexA = false;
-			indexA.on("summarizeAsync", () => (summarizedIndexA = true));
-			const indexB = new MockIndexSummarizer("Index B");
-			let summarizedIndexB = false;
-			indexB.on("summarizeAsync", () => (summarizedIndexB = true));
-			const indexes = [indexA, indexB];
-			const tree = createTree(indexes);
+			const summarizableA = new MockSummarizable("summarizable A");
+			let summarizedA = false;
+			summarizableA.on("summarizeAsync", () => (summarizedA = true));
+			const summarizableB = new MockSummarizable("summarizable B");
+			let summarizedB = false;
+			summarizableB.on("summarizeAsync", () => (summarizedB = true));
+			const summarizables = [summarizableA, summarizableB];
+			const tree = createTree(summarizables);
 			const { summary, stats } = await tree.summarize();
-			assert(summarizedIndexA, "Expected Index A to summarize");
-			assert(summarizedIndexB, "Expected Index B to summarize");
-			const indexSummaryTree = summary.tree.indexes;
+			assert(summarizedA, "Expected summarizable A to summarize");
+			assert(summarizedB, "Expected summarizable B to summarize");
+			const summarizableTree = summary.tree.indexes;
 			assert(
-				isSummaryTree(indexSummaryTree),
-				"Expected index subtree to be present in summary",
+				isSummaryTree(summarizableTree),
+				"Expected summarizable subtree to be present in summary",
 			);
 			assert.equal(
-				Object.entries(indexSummaryTree.tree).length,
-				indexes.length,
-				"Expected both indexes to be present in the index subtree of the summary",
+				Object.entries(summarizableTree.tree).length,
+				summarizables.length,
+				"Expected both summaries to be present in the summary",
 			);
 
 			assert.equal(
 				stats.treeNodeCount,
-				indexes.length + 1,
+				summarizables.length + 1,
 				"Expected summary stats to correctly count tree nodes",
 			);
 		});
 
 		it("are asked for GC", () => {
-			const index = new MockIndexSummarizer("Index");
+			const summarizable = new MockSummarizable("summarizable");
 			let requestedGC = false;
-			index.on("gcRequested", () => (requestedGC = true));
-			const indexes = [index] as const;
-			const tree = createTree(indexes);
+			summarizable.on("gcRequested", () => (requestedGC = true));
+			const summarizables = [summarizable] as const;
+			const tree = createTree(summarizables);
 			tree.getGCData();
-			assert(requestedGC, "Expected SharedTree to ask index for GC");
+			assert(requestedGC, "Expected SharedTree to ask summarizable for GC");
 		});
 	});
 
@@ -238,7 +239,7 @@ describe("SharedTreeCore", () => {
 		return summaryObject.type === SummaryType.Tree;
 	}
 
-	function createTree<TIndexes extends readonly IndexSummarizer[]>(
+	function createTree<TIndexes extends readonly Summarizable[]>(
 		indexes: TIndexes,
 	): SharedTreeCore<DefaultEditBuilder, DefaultChangeset> {
 		const runtime = new MockFluidDataStoreRuntime();
@@ -258,19 +259,19 @@ describe("SharedTreeCore", () => {
 		);
 	}
 
-	interface MockIndexSummarizerEvents extends IEvent {
+	interface MockSummarizableEvents extends IEvent {
 		(event: "loaded", listener: (blobContents?: string) => void): void;
 		(event: "summarize" | "summarizeAttached" | "summarizeAsync" | "gcRequested"): void;
 	}
 
-	class MockIndexSummarizer
-		extends TypedEventEmitter<MockIndexSummarizerEvents>
-		implements IndexSummarizer
+	class MockSummarizable
+		extends TypedEventEmitter<MockSummarizableEvents>
+		implements Summarizable
 	{
 		public static readonly blobKey = "MockIndexBlobKey";
 		public static readonly blobContents = "MockIndexBlobContent";
 
-		public constructor(public readonly key = "MockIndexSummarizer") {
+		public constructor(public readonly key = "MockIndexsummarizable") {
 			super();
 		}
 
@@ -278,8 +279,8 @@ describe("SharedTreeCore", () => {
 			services: IChannelStorageService,
 			parse: SummaryElementParser,
 		): Promise<void> {
-			if (await services.contains(MockIndexSummarizer.blobKey)) {
-				const blob = await services.readBlob(MockIndexSummarizer.blobKey);
+			if (await services.contains(MockSummarizable.blobKey)) {
+				const blob = await services.readBlob(MockSummarizable.blobKey);
 				const blobContents = parse(IsoBuffer.from(blob).toString());
 				this.emit("loaded", blobContents);
 			} else {
@@ -310,8 +311,8 @@ describe("SharedTreeCore", () => {
 		private summarizeCore(stringify: SummaryElementStringifier): ISummaryTreeWithStats {
 			this.emit("summarize");
 			return createSingleBlobSummary(
-				MockIndexSummarizer.blobKey,
-				stringify(MockIndexSummarizer.blobContents),
+				MockSummarizable.blobKey,
+				stringify(MockSummarizable.blobContents),
 			);
 		}
 


### PR DESCRIPTION
## Description

This PR strips away much of the "index" types/code in order to simplify the relationship between SharedTreeCore and SharedTree. It is not clear exactly what an index is or what an index's requirements are at this time, and the current and planned features that are considered "index-like" differ in enough ways that there is not much obvious value in trying to conform them to a common interface or pattern. After this PR, the process for organizing and exposing indexes is simply "have SharedTree do it however it wants". In the future, we may want to create an index abstraction to help guide external implementers to make their own indexes, but it isn't clear at this time the best way to do that so for now we can just keep things simple.

* Removed generic index parameter from SharedTreeCore
* Replaced *Index classes with *Summarizer classes. They are now only responsible for summarizing their respective state; they do not do any event registration.
* Simplified the way that SharedTrees provide their summarizers to SharedTreeCore.
* IndexEvents are now "ChangeEvents" and are available to subclasses of SharedTreeCore.
* EditManagerSummarizer is a concern of SharedTreeCore, so it has been moved to shared-tree-core rather than being awkwardly injected in by SharedTree.