### PR TITLE
Deprecate `ensureSynchronizedWithTimeout` as it does not work

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -21,6 +21,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 
 -   [garbage-collector and related items deprecated](#garbage-collector-and-related-items-deprecated)
 -   [GC interfaces removed from runtime-definitions](#gc-interfaces-removed-from-runtime-definitions)
+-   [ensureSynchronizedWithTimeout deprecated in LoaderContainerTracker](#ensuresynchronizedwithtimeout-deprecated-in-loadercontainertracker)
 
 ### garbage-collector and related items deprecated
 
@@ -47,6 +48,10 @@ The following interfaces available in `@fluidframework/runtime-definitions` are 
 -   `IGarbageCollectionState`
 -   `IGarbageCollectionSnapshotData`
 -   `IGarbageCollectionSummaryDetailsLegacy`
+
+### ensureSynchronizedWithTimeout deprecated in LoaderContainerTracker
+
+`LoaderContainerTracker.ensureSynchronizedWithTimeout` is deprecated as it is equivalent to `LoaderContainerTracker.ensureSynchronized` and will be removed in an upcoming release. The `timeoutDuration` parameter from `TestObjectProvider.ensureSynchronized` will also be removed. Please configure the timeout for the test instead.
 
 # 2.0.0-internal.4.0.0
 

--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -212,6 +212,8 @@ export class LoaderContainerTracker implements IOpProcessingController {
     constructor(syncSummarizerClients?: boolean);
     add<LoaderType extends IHostLoader>(loader: LoaderType): void;
     ensureSynchronized(...containers: IContainer[]): Promise<void>;
+    // @deprecated
+    ensureSynchronizedWithTimeout?(timeoutDuration: number | undefined, ...containers: IContainer[]): Promise<void>;
     pauseProcessing(...containers: IContainer[]): Promise<void>;
     processIncoming(...containers: IContainer[]): Promise<void>;
     processOutgoing(...containers: IContainer[]): Promise<void>;
@@ -310,7 +312,7 @@ export class TestObjectProvider implements ITestObjectProvider {
     // (undocumented)
     readonly driver: ITestDriver;
     // (undocumented)
-    ensureSynchronized(): Promise<void>;
+    ensureSynchronized(timeoutDuration?: number): Promise<void>;
     // (undocumented)
     loadContainer(entryPoint: fluidEntryPoint, loaderProps?: Partial<ILoaderProps>, requestHeader?: IRequestHeader): Promise<IContainer>;
     // (undocumented)

--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -212,7 +212,6 @@ export class LoaderContainerTracker implements IOpProcessingController {
     constructor(syncSummarizerClients?: boolean);
     add<LoaderType extends IHostLoader>(loader: LoaderType): void;
     ensureSynchronized(...containers: IContainer[]): Promise<void>;
-    ensureSynchronizedWithTimeout?(timeoutDuration: number | undefined, ...containers: IContainer[]): Promise<void>;
     pauseProcessing(...containers: IContainer[]): Promise<void>;
     processIncoming(...containers: IContainer[]): Promise<void>;
     processOutgoing(...containers: IContainer[]): Promise<void>;
@@ -311,7 +310,7 @@ export class TestObjectProvider implements ITestObjectProvider {
     // (undocumented)
     readonly driver: ITestDriver;
     // (undocumented)
-    ensureSynchronized(timeoutDuration?: number): Promise<void>;
+    ensureSynchronized(): Promise<void>;
     // (undocumented)
     loadContainer(entryPoint: fluidEntryPoint, loaderProps?: Partial<ILoaderProps>, requestHeader?: IRequestHeader): Promise<IContainer>;
     // (undocumented)

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -170,6 +170,18 @@ export class LoaderContainerTracker implements IOpProcessingController {
 	}
 
 	/**
+	 * Ensure all tracked containers are synchronized with a time limit
+	 *
+	 * @deprecated - this method is equivalent to @see {@link LoaderContainerTracker.ensureSynchronized}, please configure the test timeout instead
+	 */
+	public async ensureSynchronizedWithTimeout?(
+		timeoutDuration: number | undefined,
+		...containers: IContainer[]
+	) {
+		await this.processSynchronized(...containers);
+	}
+
+	/**
 	 * Make sure all the tracked containers are synchronized.
 	 *
 	 * No isDirty (non-readonly) containers

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -166,17 +166,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
 	 * Ensure all tracked containers are synchronized
 	 */
 	public async ensureSynchronized(...containers: IContainer[]): Promise<void> {
-		await this.processSynchronized(undefined, ...containers);
-	}
-
-	/**
-	 * Ensure all tracked containers are synchronized with a time limit
-	 */
-	public async ensureSynchronizedWithTimeout?(
-		timeoutDuration: number | undefined,
-		...containers: IContainer[]
-	) {
-		await this.processSynchronized(timeoutDuration, ...containers);
+		await this.processSynchronized(...containers);
 	}
 
 	/**
@@ -198,10 +188,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
 	 *
 	 * - Trailing NoOp is tracked and don't count as pending ops.
 	 */
-	private async processSynchronized(
-		timeoutDuration: number | undefined,
-		...containers: IContainer[]
-	) {
+	private async processSynchronized(...containers: IContainer[]) {
 		const resumed = this.resumeProcessing(...containers);
 
 		let waitingSequenceNumberSynchronized = false;

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -163,13 +163,6 @@ export class LoaderContainerTracker implements IOpProcessingController {
 	}
 
 	/**
-	 * Ensure all tracked containers are synchronized
-	 */
-	public async ensureSynchronized(...containers: IContainer[]): Promise<void> {
-		await this.processSynchronized(...containers);
-	}
-
-	/**
 	 * Ensure all tracked containers are synchronized with a time limit
 	 *
 	 * @deprecated - this method is equivalent to @see {@link LoaderContainerTracker.ensureSynchronized}, please configure the test timeout instead
@@ -178,7 +171,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
 		timeoutDuration: number | undefined,
 		...containers: IContainer[]
 	) {
-		await this.processSynchronized(...containers);
+		await this.ensureSynchronized(...containers);
 	}
 
 	/**
@@ -200,7 +193,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
 	 *
 	 * - Trailing NoOp is tracked and don't count as pending ops.
 	 */
-	private async processSynchronized(...containers: IContainer[]) {
+	public async ensureSynchronized(...containers: IContainer[]): Promise<void> {
 		const resumed = this.resumeProcessing(...containers);
 
 		let waitingSequenceNumberSynchronized = false;

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -454,7 +454,7 @@ export class TestObjectProvider implements ITestObjectProvider {
 		this._documentCreated = false;
 	}
 
-	public async ensureSynchronized(): Promise<void> {
+	public async ensureSynchronized(timeoutDuration?: number): Promise<void> {
 		return this._loaderContainerTracker.ensureSynchronized();
 	}
 

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -454,10 +454,8 @@ export class TestObjectProvider implements ITestObjectProvider {
 		this._documentCreated = false;
 	}
 
-	public async ensureSynchronized(timeoutDuration?: number): Promise<void> {
-		return this._loaderContainerTracker.ensureSynchronizedWithTimeout
-			? this._loaderContainerTracker.ensureSynchronizedWithTimeout(timeoutDuration)
-			: this._loaderContainerTracker.ensureSynchronized();
+	public async ensureSynchronized(): Promise<void> {
+		return this._loaderContainerTracker.ensureSynchronized();
 	}
 
 	public async waitContainerToCatchUp(container: IContainer) {


### PR DESCRIPTION
## Description

Behind the scenes, `ensureSynchronizedWithTimeout` works exactly like `ensureSynchronized`, so it can be removed.