### PR TITLE
Pass incremental context to channels

### DIFF
--- a/api-report/datastore-definitions.api.md
+++ b/api-report/datastore-definitions.api.md
@@ -18,6 +18,7 @@ import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
 import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
+import { IIncrementalContext } from '@fluidframework/runtime-definitions';
 import { ILoaderOptions } from '@fluidframework/container-definitions';
 import { IProvideFluidDataStoreRegistry } from '@fluidframework/runtime-definitions';
 import { IQuorumClients } from '@fluidframework/protocol-definitions';
@@ -37,7 +38,7 @@ export interface IChannel extends IFluidLoadable {
     isAttached(): boolean;
     // (undocumented)
     readonly owner?: string;
-    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
+    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalContext?: IIncrementalContext): Promise<ISummaryTreeWithStats>;
 }
 
 // @public

--- a/api-report/datastore-definitions.api.md
+++ b/api-report/datastore-definitions.api.md
@@ -18,7 +18,7 @@ import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
 import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
-import { IIncrementalContext } from '@fluidframework/runtime-definitions';
+import { IIncrementalSummaryContext } from '@fluidframework/runtime-definitions';
 import { ILoaderOptions } from '@fluidframework/container-definitions';
 import { IProvideFluidDataStoreRegistry } from '@fluidframework/runtime-definitions';
 import { IQuorumClients } from '@fluidframework/protocol-definitions';
@@ -38,7 +38,7 @@ export interface IChannel extends IFluidLoadable {
     isAttached(): boolean;
     // (undocumented)
     readonly owner?: string;
-    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalContext?: IIncrementalContext): Promise<ISummaryTreeWithStats>;
+    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
 }
 
 // @public

--- a/api-report/datastore-definitions.api.md
+++ b/api-report/datastore-definitions.api.md
@@ -12,13 +12,13 @@ import { IDisposable } from '@fluidframework/common-definitions';
 import { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import { IEvent } from '@fluidframework/common-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
+import { IExperimentalIncrementalSummaryContext } from '@fluidframework/runtime-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidHandleContext } from '@fluidframework/core-interfaces';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
 import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
-import { IIncrementalSummaryContext } from '@fluidframework/runtime-definitions';
 import { ILoaderOptions } from '@fluidframework/container-definitions';
 import { IProvideFluidDataStoreRegistry } from '@fluidframework/runtime-definitions';
 import { IQuorumClients } from '@fluidframework/protocol-definitions';
@@ -38,7 +38,7 @@ export interface IChannel extends IFluidLoadable {
     isAttached(): boolean;
     // (undocumented)
     readonly owner?: string;
-    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
+    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
 }
 
 // @public

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -311,13 +311,10 @@ export interface IInboundSignalMessage extends ISignalMessage {
 }
 
 // @public
-export interface IIncrementalContext {
-    // (undocumented)
-    parentPath: string;
-    // (undocumented)
-    previousSequenceNumber: number;
-    // (undocumented)
-    sequenceNumber: number;
+export interface IIncrementalSummaryContext {
+    lastAckedSummarySequenceNumber: number;
+    summaryPath: string;
+    wipSummarySequenceNumber: number;
 }
 
 // @public
@@ -455,7 +452,7 @@ export interface OpAttributionKey {
 }
 
 // @public (undocumented)
-export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext, incrementalContext?: IIncrementalContext) => Promise<ISummarizeInternalResult>;
+export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IIncrementalSummaryContext) => Promise<ISummarizeInternalResult>;
 
 // @public (undocumented)
 export const totalBlobSizePropertyName = "TotalBlobSize";

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -311,6 +311,16 @@ export interface IInboundSignalMessage extends ISignalMessage {
 }
 
 // @public
+export interface IIncrementalContext {
+    // (undocumented)
+    parentPath: string;
+    // (undocumented)
+    previousSequenceNumber: number;
+    // (undocumented)
+    sequenceNumber: number;
+}
+
+// @public
 export type InboundAttachMessage = Omit<IAttachMessage, "snapshot"> & {
     snapshot: IAttachMessage["snapshot"] | null;
 };
@@ -445,7 +455,7 @@ export interface OpAttributionKey {
 }
 
 // @public (undocumented)
-export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext) => Promise<ISummarizeInternalResult>;
+export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext, incrementalContext?: IIncrementalContext) => Promise<ISummarizeInternalResult>;
 
 // @public (undocumented)
 export const totalBlobSizePropertyName = "TotalBlobSize";

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -159,6 +159,13 @@ export interface IEnvelope {
 }
 
 // @public
+export interface IExperimentalIncrementalSummaryContext {
+    latestSummarySequenceNumber: number;
+    summaryPath: string;
+    summarySequenceNumber: number;
+}
+
+// @public
 export interface IFluidDataStoreChannel extends IFluidRouter, IDisposable {
     // (undocumented)
     applyStashedOp(content: any): Promise<unknown>;
@@ -311,13 +318,6 @@ export interface IInboundSignalMessage extends ISignalMessage {
 }
 
 // @public
-export interface IIncrementalSummaryContext {
-    lastAckedSummarySequenceNumber: number;
-    summaryPath: string;
-    wipSummarySequenceNumber: number;
-}
-
-// @public
 export type InboundAttachMessage = Omit<IAttachMessage, "snapshot"> & {
     snapshot: IAttachMessage["snapshot"] | null;
 };
@@ -452,7 +452,7 @@ export interface OpAttributionKey {
 }
 
 // @public (undocumented)
-export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IIncrementalSummaryContext) => Promise<ISummarizeInternalResult>;
+export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext) => Promise<ISummarizeInternalResult>;
 
 // @public (undocumented)
 export const totalBlobSizePropertyName = "TotalBlobSize";

--- a/api-report/shared-object-base.api.md
+++ b/api-report/shared-object-base.api.md
@@ -17,6 +17,7 @@ import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidHandleContext } from '@fluidframework/core-interfaces';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
+import { IIncrementalContext } from '@fluidframework/runtime-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
@@ -95,8 +96,8 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
     // (undocumented)
     protected get serializer(): IFluidSerializer;
     // (undocumented)
-    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
-    protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalContext?: IIncrementalContext): Promise<ISummaryTreeWithStats>;
+    protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext, incrementalContext?: IIncrementalContext): ISummaryTreeWithStats;
 }
 
 // @public

--- a/api-report/shared-object-base.api.md
+++ b/api-report/shared-object-base.api.md
@@ -17,7 +17,7 @@ import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidHandleContext } from '@fluidframework/core-interfaces';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
-import { IIncrementalContext } from '@fluidframework/runtime-definitions';
+import { IIncrementalSummaryContext } from '@fluidframework/runtime-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
@@ -96,8 +96,8 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
     // (undocumented)
     protected get serializer(): IFluidSerializer;
     // (undocumented)
-    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalContext?: IIncrementalContext): Promise<ISummaryTreeWithStats>;
-    protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext, incrementalContext?: IIncrementalContext): ISummaryTreeWithStats;
+    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
+    protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IIncrementalSummaryContext): ISummaryTreeWithStats;
 }
 
 // @public

--- a/api-report/shared-object-base.api.md
+++ b/api-report/shared-object-base.api.md
@@ -13,11 +13,11 @@ import { IChannelStorageService } from '@fluidframework/datastore-definitions';
 import { IErrorEvent } from '@fluidframework/common-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
 import { IEventThisPlaceHolder } from '@fluidframework/common-definitions';
+import { IExperimentalIncrementalSummaryContext } from '@fluidframework/runtime-definitions';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidHandleContext } from '@fluidframework/core-interfaces';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
-import { IIncrementalSummaryContext } from '@fluidframework/runtime-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
@@ -96,8 +96,8 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
     // (undocumented)
     protected get serializer(): IFluidSerializer;
     // (undocumented)
-    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
-    protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IIncrementalSummaryContext): ISummaryTreeWithStats;
+    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
+    protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): ISummaryTreeWithStats;
 }
 
 // @public

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -21,7 +21,7 @@ import {
 	ITelemetryContext,
 	blobCountPropertyName,
 	totalBlobSizePropertyName,
-	IIncrementalContext,
+	IIncrementalSummaryContext,
 } from "@fluidframework/runtime-definitions";
 import {
 	ChildLogger,
@@ -657,9 +657,13 @@ export abstract class SharedObject<
 		fullTree: boolean = false,
 		trackState: boolean = false,
 		telemetryContext?: ITelemetryContext,
-		incrementalContext?: IIncrementalContext,
+		incrementalSummaryContext?: IIncrementalSummaryContext,
 	): Promise<ISummaryTreeWithStats> {
-		const result = this.summarizeCore(this.serializer, telemetryContext, incrementalContext);
+		const result = this.summarizeCore(
+			this.serializer,
+			telemetryContext,
+			incrementalSummaryContext,
+		);
 		this.incrementTelemetryMetric(
 			blobCountPropertyName,
 			result.stats.blobNodeCount,
@@ -724,7 +728,7 @@ export abstract class SharedObject<
 	protected abstract summarizeCore(
 		serializer: IFluidSerializer,
 		telemetryContext?: ITelemetryContext,
-		incrementalContext?: IIncrementalContext,
+		incrementalSummaryContext?: IIncrementalSummaryContext,
 	): ISummaryTreeWithStats;
 
 	private incrementTelemetryMetric(

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -21,6 +21,7 @@ import {
 	ITelemetryContext,
 	blobCountPropertyName,
 	totalBlobSizePropertyName,
+	IIncrementalContext,
 } from "@fluidframework/runtime-definitions";
 import {
 	ChildLogger,
@@ -656,8 +657,13 @@ export abstract class SharedObject<
 		fullTree: boolean = false,
 		trackState: boolean = false,
 		telemetryContext?: ITelemetryContext,
+		incrementalContext?: IIncrementalContext,
 	): Promise<ISummaryTreeWithStats> {
-		const result = this.summarizeCore(this.serializer, telemetryContext);
+		assert(
+			incrementalContext !== undefined,
+			"SummarizerNode should always be passing incrementalContext to channel",
+		);
+		const result = this.summarizeCore(this.serializer, telemetryContext, incrementalContext);
 		this.incrementTelemetryMetric(
 			blobCountPropertyName,
 			result.stats.blobNodeCount,
@@ -722,6 +728,7 @@ export abstract class SharedObject<
 	protected abstract summarizeCore(
 		serializer: IFluidSerializer,
 		telemetryContext?: ITelemetryContext,
+		incrementalContext?: IIncrementalContext,
 	): ISummaryTreeWithStats;
 
 	private incrementTelemetryMetric(

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -21,7 +21,7 @@ import {
 	ITelemetryContext,
 	blobCountPropertyName,
 	totalBlobSizePropertyName,
-	IIncrementalSummaryContext,
+	IExperimentalIncrementalSummaryContext,
 } from "@fluidframework/runtime-definitions";
 import {
 	ChildLogger,
@@ -657,7 +657,7 @@ export abstract class SharedObject<
 		fullTree: boolean = false,
 		trackState: boolean = false,
 		telemetryContext?: ITelemetryContext,
-		incrementalSummaryContext?: IIncrementalSummaryContext,
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 	): Promise<ISummaryTreeWithStats> {
 		const result = this.summarizeCore(
 			this.serializer,
@@ -728,7 +728,7 @@ export abstract class SharedObject<
 	protected abstract summarizeCore(
 		serializer: IFluidSerializer,
 		telemetryContext?: ITelemetryContext,
-		incrementalSummaryContext?: IIncrementalSummaryContext,
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 	): ISummaryTreeWithStats;
 
 	private incrementTelemetryMetric(

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -659,10 +659,6 @@ export abstract class SharedObject<
 		telemetryContext?: ITelemetryContext,
 		incrementalContext?: IIncrementalContext,
 	): Promise<ISummaryTreeWithStats> {
-		assert(
-			incrementalContext !== undefined,
-			"SummarizerNode should always be passing incrementalContext to channel",
-		);
 		const result = this.summarizeCore(this.serializer, telemetryContext, incrementalContext);
 		this.incrementTelemetryMetric(
 			blobCountPropertyName,

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -12,7 +12,7 @@ import {
 	CreateSummarizerNodeSource,
 	SummarizeInternalFn,
 	ITelemetryContext,
-	IIncrementalSummaryContext,
+	IExperimentalIncrementalSummaryContext,
 } from "@fluidframework/runtime-definitions";
 import {
 	ISequencedDocumentMessage,
@@ -164,13 +164,14 @@ export class SummarizerNode implements IRootSummarizerNode {
 		// complains if this assert isn't done this way
 		assert(
 			this.wipReferenceSequenceNumber !== undefined,
-			"Same as assert 0x1a1 - Summarize should not be called when tracking the summary",
+			"Summarize should not be called when not tracking the summary",
 		);
-		const incrementalSummaryContext: IIncrementalSummaryContext | undefined =
+		const incrementalSummaryContext: IExperimentalIncrementalSummaryContext | undefined =
 			this._latestSummary !== undefined
 				? {
-						wipSummarySequenceNumber: this.wipReferenceSequenceNumber,
-						lastAckedSummarySequenceNumber: this._latestSummary.referenceSequenceNumber,
+						summarySequenceNumber: this.wipReferenceSequenceNumber,
+						latestSummarySequenceNumber: this._latestSummary.referenceSequenceNumber,
+						// TODO: remove summaryPath
 						summaryPath: this._latestSummary.fullPath.path,
 				  }
 				: undefined;

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -12,6 +12,7 @@ import {
 	CreateSummarizerNodeSource,
 	SummarizeInternalFn,
 	ITelemetryContext,
+	IIncrementalContext,
 } from "@fluidframework/runtime-definitions";
 import {
 	ISequencedDocumentMessage,
@@ -159,7 +160,18 @@ export class SummarizerNode implements IRootSummarizerNode {
 			}
 		}
 
-		const result = await this.summarizeInternalFn(fullTree, true, telemetryContext);
+		const incrementalContext: IIncrementalContext = {
+			sequenceNumber: this.wipReferenceSequenceNumber ?? this._changeSequenceNumber,
+			previousSequenceNumber: this._latestSummary?.referenceSequenceNumber ?? 0,
+			parentPath: this._latestSummary?.fullPath.path ?? "",
+		};
+
+		const result = await this.summarizeInternalFn(
+			fullTree,
+			true,
+			telemetryContext,
+			incrementalContext,
+		);
 		this.wipLocalPaths = { localPath: EscapedPath.create(result.id) };
 		if (result.pathPartsForChildren !== undefined) {
 			this.wipLocalPaths.additionalPath = EscapedPath.createAndConcat(

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -164,7 +164,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 		// complains if this assert isn't done this way
 		assert(
 			this.wipReferenceSequenceNumber !== undefined,
-			0x1a1 /* "summarize should not be called when not tracking the summary" */,
+			"Same as assert 0x1a1 - Summarize should not be called when tracking the summary",
 		);
 		const incrementalSummaryContext: IIncrementalSummaryContext | undefined =
 			this._latestSummary !== undefined

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
@@ -18,6 +18,7 @@ import {
 	ISummarizerNodeWithGC,
 	SummarizeInternalFn,
 	ITelemetryContext,
+	IIncrementalContext,
 } from "@fluidframework/runtime-definitions";
 import { LoggingError, TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { ReadAndParseBlob } from "@fluidframework/runtime-utils";
@@ -107,6 +108,7 @@ class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNode
 			fullTree: boolean,
 			trackState: boolean,
 			telemetryContext?: ITelemetryContext,
+			incrementalContext?: IIncrementalContext,
 		) => Promise<ISummarizeInternalResult>,
 		config: ISummarizerNodeConfigWithGC,
 		changeSequenceNumber: number,
@@ -121,8 +123,12 @@ class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNode
 	) {
 		super(
 			logger,
-			async (fullTree: boolean, _trackState: boolean, telemetryContext?: ITelemetryContext) =>
-				summarizeFn(fullTree, true /* trackState */, telemetryContext),
+			async (
+				fullTree: boolean,
+				_trackState: boolean,
+				telemetryContext?: ITelemetryContext,
+				incrementalContext?: IIncrementalContext,
+			) => summarizeFn(fullTree, true /* trackState */, telemetryContext, incrementalContext),
 			config,
 			changeSequenceNumber,
 			latestSummary,

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
@@ -18,7 +18,7 @@ import {
 	ISummarizerNodeWithGC,
 	SummarizeInternalFn,
 	ITelemetryContext,
-	IIncrementalContext,
+	IIncrementalSummaryContext,
 } from "@fluidframework/runtime-definitions";
 import { LoggingError, TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { ReadAndParseBlob } from "@fluidframework/runtime-utils";
@@ -108,7 +108,7 @@ class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNode
 			fullTree: boolean,
 			trackState: boolean,
 			telemetryContext?: ITelemetryContext,
-			incrementalContext?: IIncrementalContext,
+			incrementalSummaryContext?: IIncrementalSummaryContext,
 		) => Promise<ISummarizeInternalResult>,
 		config: ISummarizerNodeConfigWithGC,
 		changeSequenceNumber: number,
@@ -127,8 +127,14 @@ class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNode
 				fullTree: boolean,
 				_trackState: boolean,
 				telemetryContext?: ITelemetryContext,
-				incrementalContext?: IIncrementalContext,
-			) => summarizeFn(fullTree, true /* trackState */, telemetryContext, incrementalContext),
+				incrementalSummaryContext?: IIncrementalSummaryContext,
+			) =>
+				summarizeFn(
+					fullTree,
+					true /* trackState */,
+					telemetryContext,
+					incrementalSummaryContext,
+				),
 			config,
 			changeSequenceNumber,
 			latestSummary,

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
@@ -18,7 +18,7 @@ import {
 	ISummarizerNodeWithGC,
 	SummarizeInternalFn,
 	ITelemetryContext,
-	IIncrementalSummaryContext,
+	IExperimentalIncrementalSummaryContext,
 } from "@fluidframework/runtime-definitions";
 import { LoggingError, TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { ReadAndParseBlob } from "@fluidframework/runtime-utils";
@@ -108,7 +108,7 @@ class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNode
 			fullTree: boolean,
 			trackState: boolean,
 			telemetryContext?: ITelemetryContext,
-			incrementalSummaryContext?: IIncrementalSummaryContext,
+			incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 		) => Promise<ISummarizeInternalResult>,
 		config: ISummarizerNodeConfigWithGC,
 		changeSequenceNumber: number,
@@ -127,7 +127,7 @@ class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNode
 				fullTree: boolean,
 				_trackState: boolean,
 				telemetryContext?: ITelemetryContext,
-				incrementalSummaryContext?: IIncrementalSummaryContext,
+				incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 			) =>
 				summarizeFn(
 					fullTree,

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -7,7 +7,7 @@ import { IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import {
 	IGarbageCollectionData,
-	IIncrementalContext,
+	IIncrementalSummaryContext,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions";
@@ -92,7 +92,7 @@ export interface IChannel extends IFluidLoadable {
 		fullTree?: boolean,
 		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
-		incrementalContext?: IIncrementalContext,
+		incrementalSummaryContext?: IIncrementalSummaryContext,
 	): Promise<ISummaryTreeWithStats>;
 
 	/**

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -7,6 +7,7 @@ import { IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import {
 	IGarbageCollectionData,
+	IIncrementalContext,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions";
@@ -91,6 +92,7 @@ export interface IChannel extends IFluidLoadable {
 		fullTree?: boolean,
 		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
+		incrementalContext?: IIncrementalContext,
 	): Promise<ISummaryTreeWithStats>;
 
 	/**

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -7,7 +7,7 @@ import { IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import {
 	IGarbageCollectionData,
-	IIncrementalSummaryContext,
+	IExperimentalIncrementalSummaryContext,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions";
@@ -92,7 +92,7 @@ export interface IChannel extends IFluidLoadable {
 		fullTree?: boolean,
 		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
-		incrementalSummaryContext?: IIncrementalSummaryContext,
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 	): Promise<ISummaryTreeWithStats>;
 
 	/**

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -10,7 +10,7 @@ import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import {
 	IGarbageCollectionData,
-	IIncrementalContext,
+	IIncrementalSummaryContext,
 	ISummarizeResult,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
@@ -100,13 +100,13 @@ export async function summarizeChannelAsync(
 	fullTree: boolean = false,
 	trackState: boolean = false,
 	telemetryContext?: ITelemetryContext,
-	incrementalContext?: IIncrementalContext,
+	incrementalSummaryContext?: IIncrementalSummaryContext,
 ): Promise<ISummaryTreeWithStats> {
 	const summarizeResult = await channel.summarize(
 		fullTree,
 		trackState,
 		telemetryContext,
-		incrementalContext,
+		incrementalSummaryContext,
 	);
 
 	// Add the channel attributes to the returned result.

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -10,7 +10,7 @@ import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import {
 	IGarbageCollectionData,
-	IIncrementalSummaryContext,
+	IExperimentalIncrementalSummaryContext,
 	ISummarizeResult,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
@@ -100,7 +100,7 @@ export async function summarizeChannelAsync(
 	fullTree: boolean = false,
 	trackState: boolean = false,
 	telemetryContext?: ITelemetryContext,
-	incrementalSummaryContext?: IIncrementalSummaryContext,
+	incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 ): Promise<ISummaryTreeWithStats> {
 	const summarizeResult = await channel.summarize(
 		fullTree,

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -10,6 +10,7 @@ import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
 import {
 	IGarbageCollectionData,
+	IIncrementalContext,
 	ISummarizeResult,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
@@ -99,8 +100,14 @@ export async function summarizeChannelAsync(
 	fullTree: boolean = false,
 	trackState: boolean = false,
 	telemetryContext?: ITelemetryContext,
+	incrementalContext?: IIncrementalContext,
 ): Promise<ISummaryTreeWithStats> {
-	const summarizeResult = await channel.summarize(fullTree, trackState, telemetryContext);
+	const summarizeResult = await channel.summarize(
+		fullTree,
+		trackState,
+		telemetryContext,
+		incrementalContext,
+	);
 
 	// Add the channel attributes to the returned result.
 	addBlobToSummary(summarizeResult, attributesBlobKey, JSON.stringify(channel.attributes));

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -20,6 +20,7 @@ import {
 	CreateChildSummarizerNodeFn,
 	IFluidDataStoreContext,
 	IGarbageCollectionData,
+	IIncrementalContext,
 	ISummarizeInternalResult,
 	ISummarizeResult,
 	ISummarizerNodeWithGC,
@@ -84,7 +85,8 @@ export class RemoteChannelContext implements IChannelContext {
 			fullTree: boolean,
 			trackState: boolean,
 			telemetryContext?: ITelemetryContext,
-		) => this.summarizeInternal(fullTree, trackState, telemetryContext);
+			incrementalContext?: IIncrementalContext,
+		) => this.summarizeInternal(fullTree, trackState, telemetryContext, incrementalContext);
 
 		this.summarizerNode = createSummarizerNode(
 			thisSummarizeInternal,
@@ -167,6 +169,7 @@ export class RemoteChannelContext implements IChannelContext {
 		fullTree: boolean,
 		trackState: boolean,
 		telemetryContext?: ITelemetryContext,
+		incrementalContext?: IIncrementalContext,
 	): Promise<ISummarizeInternalResult> {
 		const channel = await this.getChannel();
 		const summarizeResult = await summarizeChannelAsync(
@@ -174,6 +177,7 @@ export class RemoteChannelContext implements IChannelContext {
 			fullTree,
 			trackState,
 			telemetryContext,
+			incrementalContext,
 		);
 		return { ...summarizeResult, id: this.id };
 	}

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -20,7 +20,7 @@ import {
 	CreateChildSummarizerNodeFn,
 	IFluidDataStoreContext,
 	IGarbageCollectionData,
-	IIncrementalContext,
+	IIncrementalSummaryContext,
 	ISummarizeInternalResult,
 	ISummarizeResult,
 	ISummarizerNodeWithGC,
@@ -85,8 +85,14 @@ export class RemoteChannelContext implements IChannelContext {
 			fullTree: boolean,
 			trackState: boolean,
 			telemetryContext?: ITelemetryContext,
-			incrementalContext?: IIncrementalContext,
-		) => this.summarizeInternal(fullTree, trackState, telemetryContext, incrementalContext);
+			incrementalSummaryContext?: IIncrementalSummaryContext,
+		) =>
+			this.summarizeInternal(
+				fullTree,
+				trackState,
+				telemetryContext,
+				incrementalSummaryContext,
+			);
 
 		this.summarizerNode = createSummarizerNode(
 			thisSummarizeInternal,
@@ -169,7 +175,7 @@ export class RemoteChannelContext implements IChannelContext {
 		fullTree: boolean,
 		trackState: boolean,
 		telemetryContext?: ITelemetryContext,
-		incrementalContext?: IIncrementalContext,
+		incrementalSummaryContext?: IIncrementalSummaryContext,
 	): Promise<ISummarizeInternalResult> {
 		const channel = await this.getChannel();
 		const summarizeResult = await summarizeChannelAsync(
@@ -177,7 +183,7 @@ export class RemoteChannelContext implements IChannelContext {
 			fullTree,
 			trackState,
 			telemetryContext,
-			incrementalContext,
+			incrementalSummaryContext,
 		);
 		return { ...summarizeResult, id: this.id };
 	}

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -20,7 +20,7 @@ import {
 	CreateChildSummarizerNodeFn,
 	IFluidDataStoreContext,
 	IGarbageCollectionData,
-	IIncrementalSummaryContext,
+	IExperimentalIncrementalSummaryContext,
 	ISummarizeInternalResult,
 	ISummarizeResult,
 	ISummarizerNodeWithGC,
@@ -85,7 +85,7 @@ export class RemoteChannelContext implements IChannelContext {
 			fullTree: boolean,
 			trackState: boolean,
 			telemetryContext?: ITelemetryContext,
-			incrementalSummaryContext?: IIncrementalSummaryContext,
+			incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 		) =>
 			this.summarizeInternal(
 				fullTree,
@@ -175,7 +175,7 @@ export class RemoteChannelContext implements IChannelContext {
 		fullTree: boolean,
 		trackState: boolean,
 		telemetryContext?: ITelemetryContext,
-		incrementalSummaryContext?: IIncrementalSummaryContext,
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 	): Promise<ISummarizeInternalResult> {
 		const channel = await this.getChannel();
 		const summarizeResult = await summarizeChannelAsync(

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -56,7 +56,7 @@ export {
 	IGarbageCollectionSnapshotData,
 	IGarbageCollectionState,
 	IGarbageCollectionSummaryDetailsLegacy,
-	IIncrementalSummaryContext,
+	IExperimentalIncrementalSummaryContext,
 	ISummarizeInternalResult,
 	ISummarizeResult,
 	ISummarizerNode,

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -56,7 +56,7 @@ export {
 	IGarbageCollectionSnapshotData,
 	IGarbageCollectionState,
 	IGarbageCollectionSummaryDetailsLegacy,
-	IIncrementalContext,
+	IIncrementalSummaryContext,
 	ISummarizeInternalResult,
 	ISummarizeResult,
 	ISummarizerNode,

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -56,6 +56,7 @@ export {
 	IGarbageCollectionSnapshotData,
 	IGarbageCollectionState,
 	IGarbageCollectionSummaryDetailsLegacy,
+	IIncrementalContext,
 	ISummarizeInternalResult,
 	ISummarizeResult,
 	ISummarizerNode,

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -126,17 +126,28 @@ export interface IGarbageCollectionSnapshotData {
 /**
  * Contains the necessary information to allow DDSes to do incremental summaries
  */
-export interface IIncrementalContext {
-	sequenceNumber: number;
-	previousSequenceNumber: number;
-	parentPath: string;
+export interface IIncrementalSummaryContext {
+	/**
+	 * The sequence number of the summary generated that will be sent to the server.
+	 */
+	wipSummarySequenceNumber: number;
+	/**
+	 * The sequence number of the most recent summary that was acknowledged by the server.
+	 */
+	lastAckedSummarySequenceNumber: number;
+	/**
+	 * The path to the runtime/datastore/dds that is used to generate summary handles
+	 * Note: Summary handles are nodes of the summary tree that point to previous parts of the last successful summary
+	 * instead of being a blob or tree node
+	 */
+	summaryPath: string;
 }
 
 export type SummarizeInternalFn = (
 	fullTree: boolean,
 	trackState: boolean,
 	telemetryContext?: ITelemetryContext,
-	incrementalContext?: IIncrementalContext,
+	incrementalSummaryContext?: IIncrementalSummaryContext,
 ) => Promise<ISummarizeInternalResult>;
 
 export interface ISummarizerNodeConfig {

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -124,6 +124,7 @@ export interface IGarbageCollectionSnapshotData {
 }
 
 /**
+ * @experimental - Can be deleted/changed at any time
  * Contains the necessary information to allow DDSes to do incremental summaries
  */
 export interface IIncrementalSummaryContext {

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -127,20 +127,26 @@ export interface IGarbageCollectionSnapshotData {
  * @experimental - Can be deleted/changed at any time
  * Contains the necessary information to allow DDSes to do incremental summaries
  */
-export interface IIncrementalSummaryContext {
+export interface IExperimentalIncrementalSummaryContext {
 	/**
 	 * The sequence number of the summary generated that will be sent to the server.
 	 */
-	wipSummarySequenceNumber: number;
+	summarySequenceNumber: number;
 	/**
 	 * The sequence number of the most recent summary that was acknowledged by the server.
 	 */
-	lastAckedSummarySequenceNumber: number;
+	latestSummarySequenceNumber: number;
 	/**
 	 * The path to the runtime/datastore/dds that is used to generate summary handles
 	 * Note: Summary handles are nodes of the summary tree that point to previous parts of the last successful summary
 	 * instead of being a blob or tree node
+	 *
+	 * This path contains the id of the data store and dds which should not be leaked to layers below them. Ideally,
+	 * a layer should not know its own id. This is important for channel unification work and there has been a lot of
+	 * work to remove these kinds of leakages. Some still exist, which have to be fixed but we should not be adding
+	 * more dependencies.
 	 */
+	// TODO: remove summaryPath
 	summaryPath: string;
 }
 
@@ -148,7 +154,7 @@ export type SummarizeInternalFn = (
 	fullTree: boolean,
 	trackState: boolean,
 	telemetryContext?: ITelemetryContext,
-	incrementalSummaryContext?: IIncrementalSummaryContext,
+	incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 ) => Promise<ISummarizeInternalResult>;
 
 export interface ISummarizerNodeConfig {

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -123,10 +123,20 @@ export interface IGarbageCollectionSnapshotData {
 	deletedNodes: string[] | undefined;
 }
 
+/**
+ * Contains the necessary information to allow DDSes to do incremental summaries
+ */
+export interface IIncrementalContext {
+	sequenceNumber: number;
+	previousSequenceNumber: number;
+	parentPath: string;
+}
+
 export type SummarizeInternalFn = (
 	fullTree: boolean,
 	trackState: boolean,
 	telemetryContext?: ITelemetryContext,
+	incrementalContext?: IIncrementalContext,
 ) => Promise<ISummarizeInternalResult>;
 
 export interface ISummarizerNodeConfig {

--- a/packages/test/test-end-to-end-tests/src/test/incrementalSummaryContext.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/incrementalSummaryContext.spec.ts
@@ -1,0 +1,243 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
+import { IContainer } from "@fluidframework/container-definitions";
+import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
+import { IRequest } from "@fluidframework/core-interfaces";
+import {
+	IContainerRuntimeBase,
+	IIncrementalSummaryContext,
+	ISummaryTreeWithStats,
+	ITelemetryContext,
+} from "@fluidframework/runtime-definitions";
+import { requestFluidObject, SummaryTreeBuilder } from "@fluidframework/runtime-utils";
+import {
+	ITestFluidObject,
+	ITestObjectProvider,
+	TestFluidObjectFactory,
+	createSummarizerFromFactory,
+	summarizeNow,
+} from "@fluidframework/test-utils";
+import { describeNoCompat, getContainerRuntimeApi } from "@fluid-internal/test-version-utils";
+import { IFluidSerializer, SharedObject } from "@fluidframework/shared-object-base";
+import {
+	IChannelAttributes,
+	IChannelFactory,
+	IChannelServices,
+	IChannelStorageService,
+	IFluidDataStoreRuntime,
+} from "@fluidframework/datastore-definitions";
+import {
+	ISequencedDocumentMessage,
+	MessageType,
+	SummaryType,
+} from "@fluidframework/protocol-definitions";
+import { readAndParse } from "@fluidframework/driver-utils";
+import { pkgVersion } from "../packageVersion";
+
+// mark as experimental
+class TestSharedObjectFactory implements IChannelFactory {
+	public static readonly Type = "https://graph.microsoft.com/types/test-shared-object";
+
+	public static readonly Attributes: IChannelAttributes = {
+		type: TestSharedObjectFactory.Type,
+		snapshotFormatVersion: "0.1",
+		packageVersion: pkgVersion,
+	};
+
+	public get type(): string {
+		return TestSharedObjectFactory.Type;
+	}
+
+	public get attributes(): IChannelAttributes {
+		return TestSharedObjectFactory.Attributes;
+	}
+
+	public async load(
+		runtime: IFluidDataStoreRuntime,
+		id: string,
+		services: IChannelServices,
+		attributes: IChannelAttributes,
+	): Promise<TestSharedObject> {
+		const sharedObject = new TestSharedObject(id, runtime, attributes, "TestSharedObject");
+		await sharedObject.load(services);
+		return sharedObject;
+	}
+
+	/**
+	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.create}
+	 */
+	public create(document: IFluidDataStoreRuntime, id: string): TestSharedObject {
+		return new TestSharedObject(id, document, this.attributes, "TestSharedObject");
+	}
+}
+
+const snapshotFileName = "header";
+interface ISnapshot {
+	blobs: string[];
+}
+
+interface IBlob {
+	value: string;
+	seqNumber: number;
+}
+
+interface IOp {
+	type: "blobStorage";
+	value: string;
+}
+class TestSharedObject extends SharedObject {
+	static getFactory(): IChannelFactory {
+		return new TestSharedObjectFactory();
+	}
+	private readonly blobMap: Map<string, IBlob> = new Map();
+
+	protected summarizeCore(
+		serializer: IFluidSerializer,
+		telemetryContext?: ITelemetryContext | undefined,
+		incrementalSummaryContext?: IIncrementalSummaryContext | undefined,
+	): ISummaryTreeWithStats {
+		const builder = new SummaryTreeBuilder();
+
+		for (const [blobName, blobContent] of this.blobMap.entries()) {
+			if (
+				incrementalSummaryContext &&
+				blobContent.seqNumber <= incrementalSummaryContext.lastAckedSummarySequenceNumber
+			) {
+				builder.addHandle(
+					blobName,
+					SummaryType.Blob,
+					`${incrementalSummaryContext.summaryPath}/${blobName}`,
+				);
+			} else {
+				builder.addBlob(blobName, JSON.stringify(blobContent));
+			}
+		}
+
+		const content: ISnapshot = {
+			blobs: Array.from(this.blobMap.keys()),
+		};
+
+		builder.addBlob(snapshotFileName, JSON.stringify(content));
+		return builder.getSummaryTree();
+	}
+	protected async loadCore(storage: IChannelStorageService): Promise<void> {
+		const content = await readAndParse<ISnapshot>(storage, snapshotFileName);
+		for (const blob of content.blobs) {
+			const blobContent = await readAndParse<IBlob>(storage, blob);
+			this.blobMap.set(blob, blobContent);
+		}
+	}
+	protected processCore(
+		message: ISequencedDocumentMessage,
+		local: boolean,
+		localOpMetadata: unknown,
+	) {
+		if (message.type === MessageType.Operation) {
+			const op = message.contents as IOp;
+			switch (op.type) {
+				case "blobStorage": {
+					const blob: IBlob = {
+						value: op.value,
+						seqNumber: message.sequenceNumber,
+					};
+					const blobName = `${this.blobMap.size}`;
+					this.blobMap.set(blobName, blob);
+					break;
+				}
+				default:
+					throw new Error("Unknown operation");
+			}
+		}
+	}
+
+	public createOp(content: string) {
+		const op: IOp = {
+			type: "blobStorage",
+			value: content,
+		};
+		this.submitLocalMessage(op);
+	}
+
+	protected onDisconnect() {}
+	protected applyStashedOp(content: any): unknown {
+		throw new Error("Method not implemented.");
+	}
+}
+
+/**
+ * Validates w
+ */
+describeNoCompat(
+	"Incremental summary context fields are properly populated",
+	(getTestObjectProvider) => {
+		let provider: ITestObjectProvider;
+		const dataObjectFactory = new TestFluidObjectFactory([
+			["abc", TestSharedObject.getFactory()],
+		]);
+		const runtimeOptions: IContainerRuntimeOptions = {
+			summaryOptions: { summaryConfigOverrides: { state: "disabled" } },
+		};
+		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
+			runtime.IFluidHandleContext.resolveHandle(request);
+		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore(
+			dataObjectFactory,
+			[[dataObjectFactory.type, Promise.resolve(dataObjectFactory)]],
+			undefined,
+			[innerRequestHandler],
+			runtimeOptions,
+		);
+
+		const createContainer = async (): Promise<IContainer> => {
+			return provider.createContainer(runtimeFactory);
+		};
+
+		async function createSummarizer(container: IContainer, summaryVersion?: string) {
+			const createSummarizerResult = await createSummarizerFromFactory(
+				provider,
+				container,
+				dataObjectFactory,
+				summaryVersion,
+				getContainerRuntimeApi(pkgVersion, pkgVersion)
+					.ContainerRuntimeFactoryWithDefaultDataStore,
+			);
+			return createSummarizerResult.summarizer;
+		}
+
+		beforeEach(async () => {
+			provider = getTestObjectProvider({ syncSummarizer: true });
+		});
+
+		it("works", async () => {
+			const container = await createContainer();
+			const datastore = await requestFluidObject<ITestFluidObject>(container, "default");
+			const dds = await datastore.getSharedObject<TestSharedObject>("abc");
+			dds.createOp("test data 1");
+			dds.createOp("test data 2");
+			dds.createOp("test data 3");
+
+			const summarizer = await createSummarizer(container);
+			await provider.ensureSynchronized();
+			await summarizeNow(summarizer);
+
+			dds.createOp("test data 4");
+			await provider.ensureSynchronized();
+			const { summaryTree } = await summarizeNow(summarizer);
+			assert(summaryTree.tree[".channels"].type === SummaryType.Tree, "expecting a tree!");
+			const dataObjectTree = summaryTree.tree[".channels"].tree[datastore.runtime.id];
+			assert(dataObjectTree.type === SummaryType.Tree, "tree!");
+			const dataObjectChannelsTree = dataObjectTree.tree[".channels"];
+			assert(dataObjectChannelsTree.type === SummaryType.Tree, "data store channels tree!");
+			const ddsTree = dataObjectChannelsTree.tree[dds.id];
+			assert(ddsTree.type === SummaryType.Tree, "dds tree!");
+			assert(ddsTree.tree["0"].type === SummaryType.Handle);
+			assert(ddsTree.tree["1"].type === SummaryType.Handle);
+			assert(ddsTree.tree["2"].type === SummaryType.Handle);
+			assert(ddsTree.tree["3"].type === SummaryType.Blob);
+		});
+	},
+);


### PR DESCRIPTION
[AB#3250](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3250)

Enable sharedObjects to incrementally summarize using previous summary sequence number, current summary sequence number, and paths.

This solution attempts to provide an incremental summary context to DDSes by passing the current summary sequence number, last acked summary sequence number and summary path of the DDS to the DDS in the summarize method from the `SummarizerNode`. The DDS can then decide with that information how to summarize.