### PR TITLE
Remove `ensureSynchronizedWithTimeout` as it does not work

### DIFF
--- a/.changeset/chilly-seas-act.md
+++ b/.changeset/chilly-seas-act.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/test-utils": major
+---
+
+ensureSynchronizedWithTimeout removed from LoaderContainerTracker
+
+`LoaderContainerTracker.ensureSynchronizedWithTimeout` has been removed, as it is equivalent to `LoaderContainerTracker.ensureSynchronized`. The `timeoutDuration` parameter from `TestObjectProvider.ensureSynchronized` has also been removed. Please configure the timeout for the test instead.

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -21,6 +21,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 
 -   [garbage-collector and related items deprecated](#garbage-collector-and-related-items-deprecated)
 -   [GC interfaces removed from runtime-definitions](#gc-interfaces-removed-from-runtime-definitions)
+-   [ensureSynchronizedWithTimeout removed from LoaderContainerTracker](#ensuresynchronizedwithtimeout-removed-from-loadercontainertracker)
 
 ### garbage-collector and related items deprecated
 
@@ -47,6 +48,10 @@ The following interfaces available in `@fluidframework/runtime-definitions` are 
 -   `IGarbageCollectionState`
 -   `IGarbageCollectionSnapshotData`
 -   `IGarbageCollectionSummaryDetailsLegacy`
+
+### ensureSynchronizedWithTimeout removed from LoaderContainerTracker
+
+`LoaderContainerTracker.ensureSynchronizedWithTimeout` has been removed, as it is equivalent to `LoaderContainerTracker.ensureSynchronized`. The `timeoutDuration` parameter from `TestObjectProvider.ensureSynchronized` has also been removed. Please configure the timeout for the test instead.
 
 # 2.0.0-internal.4.0.0
 

--- a/api-report/test-utils.api.md
+++ b/api-report/test-utils.api.md
@@ -212,7 +212,6 @@ export class LoaderContainerTracker implements IOpProcessingController {
     constructor(syncSummarizerClients?: boolean);
     add<LoaderType extends IHostLoader>(loader: LoaderType): void;
     ensureSynchronized(...containers: IContainer[]): Promise<void>;
-    ensureSynchronizedWithTimeout?(timeoutDuration: number | undefined, ...containers: IContainer[]): Promise<void>;
     pauseProcessing(...containers: IContainer[]): Promise<void>;
     processIncoming(...containers: IContainer[]): Promise<void>;
     processOutgoing(...containers: IContainer[]): Promise<void>;
@@ -311,7 +310,7 @@ export class TestObjectProvider implements ITestObjectProvider {
     // (undocumented)
     readonly driver: ITestDriver;
     // (undocumented)
-    ensureSynchronized(timeoutDuration?: number): Promise<void>;
+    ensureSynchronized(): Promise<void>;
     // (undocumented)
     loadContainer(entryPoint: fluidEntryPoint, loaderProps?: Partial<ILoaderProps>, requestHeader?: IRequestHeader): Promise<IContainer>;
     // (undocumented)

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -163,23 +163,6 @@ export class LoaderContainerTracker implements IOpProcessingController {
 	}
 
 	/**
-	 * Ensure all tracked containers are synchronized
-	 */
-	public async ensureSynchronized(...containers: IContainer[]): Promise<void> {
-		await this.processSynchronized(undefined, ...containers);
-	}
-
-	/**
-	 * Ensure all tracked containers are synchronized with a time limit
-	 */
-	public async ensureSynchronizedWithTimeout?(
-		timeoutDuration: number | undefined,
-		...containers: IContainer[]
-	) {
-		await this.processSynchronized(timeoutDuration, ...containers);
-	}
-
-	/**
 	 * Make sure all the tracked containers are synchronized.
 	 *
 	 * No isDirty (non-readonly) containers
@@ -198,10 +181,7 @@ export class LoaderContainerTracker implements IOpProcessingController {
 	 *
 	 * - Trailing NoOp is tracked and don't count as pending ops.
 	 */
-	private async processSynchronized(
-		timeoutDuration: number | undefined,
-		...containers: IContainer[]
-	) {
+	public async ensureSynchronized(...containers: IContainer[]): Promise<void> {
 		const resumed = this.resumeProcessing(...containers);
 
 		let waitingSequenceNumberSynchronized = false;

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -454,10 +454,8 @@ export class TestObjectProvider implements ITestObjectProvider {
 		this._documentCreated = false;
 	}
 
-	public async ensureSynchronized(timeoutDuration?: number): Promise<void> {
-		return this._loaderContainerTracker.ensureSynchronizedWithTimeout
-			? this._loaderContainerTracker.ensureSynchronizedWithTimeout(timeoutDuration)
-			: this._loaderContainerTracker.ensureSynchronized();
+	public async ensureSynchronized(): Promise<void> {
+		return this._loaderContainerTracker.ensureSynchronized();
 	}
 
 	public async waitContainerToCatchUp(container: IContainer) {


### PR DESCRIPTION
## Description

Behind the scenes, `ensureSynchronizedWithTimeout` works exactly like `ensureSynchronized`, so it can be removed. Deprecated with https://github.com/microsoft/FluidFramework/pull/14866