### PR TITLE
Tree: Support allocation of blocks of IDs in changesets

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -631,8 +631,8 @@ interface HasModifications<TTree = ProtoNode> {
     readonly setValue?: Value;
 }
 
-// @alpha (undocumented)
-export type IdAllocator = () => ChangesetLocalId;
+// @alpha
+export type IdAllocator = (count?: number) => ChangesetLocalId;
 
 // @alpha
 export interface IDefaultEditBuilder {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -219,9 +219,11 @@ export type NodeChangeEncoder = (change: NodeChangeset) => JsonCompatibleReadOnl
 export type NodeChangeDecoder = (change: JsonCompatibleReadOnly) => NodeChangeset;
 
 /**
+ * Allocates a block of `count` consecutive IDs and returns the first ID in the block.
+ * For convenience can be called with no parameters to allocate a single ID.
  * @alpha
  */
-export type IdAllocator = () => ChangesetLocalId;
+export type IdAllocator = (count?: number) => ChangesetLocalId;
 
 /**
  * Changeset for a subtree rooted at a specific node.

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -41,7 +41,9 @@ import {
 	CrossFieldManager,
 	CrossFieldQuerySet,
 	CrossFieldTarget,
+	IdAllocationState,
 	idAllocatorFromMaxId,
+	idAllocatorFromState,
 } from "./crossFieldQueries";
 import {
 	FieldChangeHandler,
@@ -135,15 +137,10 @@ export class ModularChangeFamily
 	}
 
 	public compose(changes: TaggedChange<ModularChangeset>[]): ModularChangeset {
-		let maxId = -1;
-		const revInfos: RevisionInfo[] = [];
-		for (const taggedChange of changes) {
-			const change = taggedChange.change;
-			maxId = Math.max(change.maxId ?? -1, maxId);
-			revInfos.push(...revisionInfoFromTaggedChange(taggedChange));
-		}
+		const { revInfos, maxId } = getRevInfoFromTaggedChanges(changes);
 		const revisionMetadata: RevisionMetadataSource = revisionMetadataSourceFromInfo(revInfos);
-		const genId: IdAllocator = () => brand(++maxId);
+		const idState: IdAllocationState = { maxId };
+		const genId: IdAllocator = idAllocatorFromState(idState);
 		const crossFieldTable = newCrossFieldTable<ComposeData>();
 
 		const changesWithoutConstraintViolations = changes.filter(
@@ -182,7 +179,7 @@ export class ModularChangeFamily
 			crossFieldTable.invalidatedFields.size === 0,
 			0x59b /* Should not need more than one amend pass. */,
 		);
-		return makeModularChangeset(composedFields, maxId, revInfos);
+		return makeModularChangeset(composedFields, idState.maxId, revInfos);
 	}
 
 	private composeFieldMaps(
@@ -310,8 +307,8 @@ export class ModularChangeFamily
 		isRollback: boolean,
 		repairStore?: ReadonlyRepairDataStore,
 	): ModularChangeset {
-		let maxId = change.change.maxId ?? -1;
-		const genId: IdAllocator = () => brand(++maxId);
+		const idState: IdAllocationState = { maxId: brand(change.change.maxId ?? -1) };
+		const genId: IdAllocator = idAllocatorFromState(idState);
 		const crossFieldTable = newCrossFieldTable<InvertData>();
 		const resolvedRepairStore = repairStore ?? dummyRepairDataStore;
 
@@ -350,7 +347,7 @@ export class ModularChangeFamily
 		const revInfo = change.change.revisions;
 		return makeModularChangeset(
 			invertedFields,
-			maxId,
+			idState.maxId,
 			revInfo === undefined
 				? undefined
 				: (isRollback
@@ -463,8 +460,9 @@ export class ModularChangeFamily
 		change: ModularChangeset,
 		over: TaggedChange<ModularChangeset>,
 	): ModularChangeset {
-		let maxId = Math.max(change.maxId ?? -1, over.change.maxId ?? -1);
-		const genId: IdAllocator = () => brand(++maxId);
+		const maxId = Math.max(change.maxId ?? -1, over.change.maxId ?? -1);
+		const idState: IdAllocationState = { maxId: brand(maxId) };
+		const genId: IdAllocator = idAllocatorFromState(idState);
 		const crossFieldTable: RebaseTable = {
 			...newCrossFieldTable<FieldChange>(),
 			baseMapToRebased: new Map(),
@@ -491,7 +489,7 @@ export class ModularChangeFamily
 
 		const rebasedChangeset = makeModularChangeset(
 			rebasedFields,
-			maxId,
+			idState.maxId,
 			change.revisions,
 			constraintState.violationCount,
 		);
@@ -524,8 +522,8 @@ export class ModularChangeFamily
 			0x5b4 /* Should not change constraint violation count during amend pass */,
 		);
 
-		if (maxId >= 0) {
-			rebasedChangeset.maxId = brand(maxId);
+		if (idState.maxId >= 0) {
+			rebasedChangeset.maxId = brand(idState.maxId);
 		}
 		return rebasedChangeset;
 	}
@@ -1248,6 +1246,21 @@ export interface EditDescription {
 	field: FieldKey;
 	fieldKind: FieldKindIdentifier;
 	change: FieldChangeset;
+}
+
+function getRevInfoFromTaggedChanges(changes: TaggedChange<ModularChangeset>[]): {
+	revInfos: RevisionInfo[];
+	maxId: ChangesetLocalId;
+} {
+	let maxId = -1;
+	const revInfos: RevisionInfo[] = [];
+	for (const taggedChange of changes) {
+		const change = taggedChange.change;
+		maxId = Math.max(change.maxId ?? -1, maxId);
+		revInfos.push(...revisionInfoFromTaggedChange(taggedChange));
+	}
+
+	return { maxId: brand(maxId), revInfos };
 }
 
 function revisionInfoFromTaggedChange(


### PR DESCRIPTION
Changed the signature of the `IdAllocator` for `ChangesetLocalId`s to optionally take a number of consecutive IDs to be allocated. This will be used in an upcoming PR to efficiently assign an ID to each node created by an insert mark in a sequence field.