### PR TITLE
[Port v2int 3.0] Rename TelemetryContext::SetAll to SetMultiple

### DIFF
--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -410,7 +410,7 @@ export interface ITelemetryContext {
     get(prefix: string, property: string): TelemetryEventPropertyType;
     serialize(): string;
     set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
-    setAll(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
+    setMultiple(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
 }
 
 // @public

--- a/api-report/runtime-utils.api.md
+++ b/api-report/runtime-utils.api.md
@@ -230,7 +230,7 @@ export class TelemetryContext implements ITelemetryContext {
     // (undocumented)
     set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
     // (undocumented)
-    setAll(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
+    setMultiple(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
 }
 
 // @public (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2198,7 +2198,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
 
         const telemetryContext = new TelemetryContext();
         // Add the options that are used to generate this summary to the telemetry context.
-        telemetryContext.setAll("fluid_Summarize", "Options", {
+        telemetryContext.setMultiple("fluid_Summarize", "Options", {
             fullTree,
             trackState,
             runGC,

--- a/packages/runtime/container-runtime/src/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/garbageCollection.ts
@@ -978,7 +978,7 @@ export class GarbageCollector implements IGarbageCollector {
         }
 
         // Add the options that are used to run GC to the telemetry context.
-        telemetryContext?.setAll("fluid_GC", "Options", { fullGC, runSweep: options.runSweep });
+        telemetryContext?.setMultiple("fluid_GC", "Options", { fullGC, runSweep: options.runSweep });
 
         return PerformanceEvent.timedExecAsync(logger, { eventName: "GarbageCollection" }, async (event) => {
             await this.runPreGCSteps();

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -335,7 +335,7 @@ export interface ITelemetryContext {
      * @param property - property name of the telemetry data being tracked (ex: "Options")
      * @param values - A set of values to attribute to this summary telemetry data.
      */
-    setAll(
+    setMultiple(
         prefix: string,
         property: string,
         values: Record<string, TelemetryEventPropertyType>,

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -349,9 +349,9 @@ export class TelemetryContext implements ITelemetryContext {
     }
 
     /**
-     * {@inheritDoc @fluidframework/runtime-definitions#ITelemetryContext.setAll}
+     * {@inheritDoc @fluidframework/runtime-definitions#ITelemetryContext.setMultiple}
      */
-    setAll(
+    setMultiple(
         prefix: string,
         property: string,
         values: Record<string, TelemetryEventPropertyType>,

--- a/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
@@ -284,7 +284,7 @@ describe("Summary Utils", () => {
             telemetryContext.set("pre2_", "prop1", "10");
             telemetryContext.set("pre2_", "prop2", true);
             telemetryContext.set("pre1_", "prop2", undefined);
-            telemetryContext.setAll("pre3_", "obj1", { prop1: "1", prop2: 2, prop3: true });
+            telemetryContext.setMultiple("pre3_", "obj1", { prop1: "1", prop2: 2, prop3: true });
 
             const serialized = telemetryContext.serialize();
 


### PR DESCRIPTION
Porting https://github.com/microsoft/FluidFramework/commit/fa58a173a6d52f26646d9614fce66194fa1bf11c to release/v2int/3.0 as this is a breaking change. runtime-utils version 2.0.0-internal.3.0 running with runtime-definitions version 2.0.0-internal.3.2+ will not work because this change went into 2.0.0-internal.3.2.

https://github.com/microsoft/FluidFramework/pull/14070 added a setAll method to TelemetryContext that can be used to set mutliple values to the telemety context. As per https://github.com/microsoft/FluidFramework/pull/14153#discussion_r1105039108, renaming the method to setMultiple since its more inline with what it does.