### PR TITLE
Tree: Add IDs to sequence inserts

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -983,7 +983,7 @@ export class ModularEditBuilder extends ProgressiveEditBuilderBase<ModularChange
     // (undocumented)
     exitTransaction(): void;
     // (undocumented)
-    generateId(): ChangesetLocalId;
+    generateId(count?: number): ChangesetLocalId;
     // (undocumented)
     setValue(path: UpPath, value: Value): void;
     submitChange(path: UpPath | undefined, field: FieldKey, fieldKind: FieldKindIdentifier, change: FieldChangeset, maxId?: ChangesetLocalId): void;

--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -631,8 +631,8 @@ interface HasModifications<TTree = ProtoNode> {
     readonly setValue?: Value;
 }
 
-// @alpha (undocumented)
-export type IdAllocator = () => ChangesetLocalId;
+// @alpha
+export type IdAllocator = (count?: number) => ChangesetLocalId;
 
 // @alpha
 export interface IDefaultEditBuilder {

--- a/packages/dds/tree/src/feature-libraries/defaultChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultChangeFamily.ts
@@ -212,7 +212,11 @@ export class DefaultEditBuilder
 		return {
 			insert: (index: number, newContent: ITreeCursor | ITreeCursor[]): void => {
 				const change: FieldChangeset = brand(
-					sequence.changeHandler.editor.insert(index, newContent),
+					sequence.changeHandler.editor.insert(
+						index,
+						newContent,
+						this.modularBuilder.generateId(),
+					),
 				);
 				this.modularBuilder.submitChange(parent, field, sequence.identifier, change);
 			},

--- a/packages/dds/tree/src/feature-libraries/defaultChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/defaultChangeFamily.ts
@@ -215,7 +215,9 @@ export class DefaultEditBuilder
 					sequence.changeHandler.editor.insert(
 						index,
 						newContent,
-						this.modularBuilder.generateId(),
+						this.modularBuilder.generateId(
+							Array.isArray(newContent) ? newContent.length : 1,
+						),
 					),
 				);
 				this.modularBuilder.submitChange(parent, field, sequence.identifier, change);

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
@@ -260,7 +260,10 @@ export class ProxyContext implements EditableTreeContext {
 	): void {
 		const field = this.editor.sequenceField(path, fieldKey);
 		field.delete(index, count);
-		field.insert(index, newContent);
+
+		if (!Array.isArray(newContent) || newContent.length > 0) {
+			field.insert(index, newContent);
+		}
 	}
 
 	public on<K extends keyof ForestEvents>(eventName: K, listener: ForestEvents[K]): () => void {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -219,9 +219,11 @@ export type NodeChangeEncoder = (change: NodeChangeset) => JsonCompatibleReadOnl
 export type NodeChangeDecoder = (change: JsonCompatibleReadOnly) => NodeChangeset;
 
 /**
+ * Allocates a block of `count` consecutive IDs and returns the first ID in the block.
+ * For convenience can be called with no parameters to allocate a single ID.
  * @alpha
  */
-export type IdAllocator = () => ChangesetLocalId;
+export type IdAllocator = (count?: number) => ChangesetLocalId;
 
 /**
  * Changeset for a subtree rooted at a specific node.

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -41,7 +41,9 @@ import {
 	CrossFieldManager,
 	CrossFieldQuerySet,
 	CrossFieldTarget,
+	IdAllocationState,
 	idAllocatorFromMaxId,
+	idAllocatorFromState,
 } from "./crossFieldQueries";
 import {
 	FieldChangeHandler,
@@ -135,15 +137,10 @@ export class ModularChangeFamily
 	}
 
 	public compose(changes: TaggedChange<ModularChangeset>[]): ModularChangeset {
-		let maxId = -1;
-		const revInfos: RevisionInfo[] = [];
-		for (const taggedChange of changes) {
-			const change = taggedChange.change;
-			maxId = Math.max(change.maxId ?? -1, maxId);
-			revInfos.push(...revisionInfoFromTaggedChange(taggedChange));
-		}
+		const { revInfos, maxId } = getRevInfoFromTaggedChanges(changes);
 		const revisionMetadata: RevisionMetadataSource = revisionMetadataSourceFromInfo(revInfos);
-		const genId: IdAllocator = () => brand(++maxId);
+		const idState: IdAllocationState = { maxId };
+		const genId: IdAllocator = idAllocatorFromState(idState);
 		const crossFieldTable = newCrossFieldTable<ComposeData>();
 
 		const changesWithoutConstraintViolations = changes.filter(
@@ -182,7 +179,7 @@ export class ModularChangeFamily
 			crossFieldTable.invalidatedFields.size === 0,
 			0x59b /* Should not need more than one amend pass. */,
 		);
-		return makeModularChangeset(composedFields, maxId, revInfos);
+		return makeModularChangeset(composedFields, idState.maxId, revInfos);
 	}
 
 	private composeFieldMaps(
@@ -310,8 +307,8 @@ export class ModularChangeFamily
 		isRollback: boolean,
 		repairStore?: ReadonlyRepairDataStore,
 	): ModularChangeset {
-		let maxId = change.change.maxId ?? -1;
-		const genId: IdAllocator = () => brand(++maxId);
+		const idState: IdAllocationState = { maxId: brand(change.change.maxId ?? -1) };
+		const genId: IdAllocator = idAllocatorFromState(idState);
 		const crossFieldTable = newCrossFieldTable<InvertData>();
 		const resolvedRepairStore = repairStore ?? dummyRepairDataStore;
 
@@ -350,7 +347,7 @@ export class ModularChangeFamily
 		const revInfo = change.change.revisions;
 		return makeModularChangeset(
 			invertedFields,
-			maxId,
+			idState.maxId,
 			revInfo === undefined
 				? undefined
 				: (isRollback
@@ -463,8 +460,9 @@ export class ModularChangeFamily
 		change: ModularChangeset,
 		over: TaggedChange<ModularChangeset>,
 	): ModularChangeset {
-		let maxId = Math.max(change.maxId ?? -1, over.change.maxId ?? -1);
-		const genId: IdAllocator = () => brand(++maxId);
+		const maxId = Math.max(change.maxId ?? -1, over.change.maxId ?? -1);
+		const idState: IdAllocationState = { maxId: brand(maxId) };
+		const genId: IdAllocator = idAllocatorFromState(idState);
 		const crossFieldTable: RebaseTable = {
 			...newCrossFieldTable<FieldChange>(),
 			baseMapToRebased: new Map(),
@@ -491,7 +489,7 @@ export class ModularChangeFamily
 
 		const rebasedChangeset = makeModularChangeset(
 			rebasedFields,
-			maxId,
+			idState.maxId,
 			change.revisions,
 			constraintState.violationCount,
 		);
@@ -524,8 +522,8 @@ export class ModularChangeFamily
 			0x5b4 /* Should not change constraint violation count during amend pass */,
 		);
 
-		if (maxId >= 0) {
-			rebasedChangeset.maxId = brand(maxId);
+		if (idState.maxId >= 0) {
+			rebasedChangeset.maxId = brand(idState.maxId);
 		}
 		return rebasedChangeset;
 	}
@@ -1248,6 +1246,21 @@ export interface EditDescription {
 	field: FieldKey;
 	fieldKind: FieldKindIdentifier;
 	change: FieldChangeset;
+}
+
+function getRevInfoFromTaggedChanges(changes: TaggedChange<ModularChangeset>[]): {
+	revInfos: RevisionInfo[];
+	maxId: ChangesetLocalId;
+} {
+	let maxId = -1;
+	const revInfos: RevisionInfo[] = [];
+	for (const taggedChange of changes) {
+		const change = taggedChange.change;
+		maxId = Math.max(change.maxId ?? -1, maxId);
+		revInfos.push(...revisionInfoFromTaggedChange(taggedChange));
+	}
+
+	return { maxId: brand(maxId), revInfos };
 }
 
 function revisionInfoFromTaggedChange(

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -1175,8 +1175,8 @@ export class ModularEditBuilder
 		this.applyChange(composedChange);
 	}
 
-	public generateId(): ChangesetLocalId {
-		return this.idAllocator();
+	public generateId(count?: number): ChangesetLocalId {
+		return this.idAllocator(count);
 	}
 
 	private buildChangeMap(

--- a/packages/dds/tree/src/feature-libraries/sequence-field/format.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/format.ts
@@ -127,6 +127,7 @@ export interface Insert<TNodeChange = NodeChangeType>
 		HasChanges<TNodeChange> {
 	type: "Insert";
 	content: ProtoNode[];
+	id: ChangesetLocalId;
 }
 
 export interface MoveIn extends HasMoveId, HasPlaceFields, HasRevisionTag, CanConflict {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/format.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/format.ts
@@ -127,6 +127,11 @@ export interface Insert<TNodeChange = NodeChangeType>
 		HasChanges<TNodeChange> {
 	type: "Insert";
 	content: ProtoNode[];
+
+	/**
+	 * The first ID in a block associated with the nodes being inserted.
+	 * The node `content[i]` is associated with `id + i`.
+	 */
 	id: ChangesetLocalId;
 }
 

--- a/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -520,7 +520,11 @@ export function splitMarkOnOutput<T, TMark extends OutputSpanningMark<T>>(
 		case "Insert":
 			return [
 				{ ...markObj, content: markObj.content.slice(0, length) },
-				{ ...markObj, content: markObj.content.slice(length) },
+				{
+					...markObj,
+					content: markObj.content.slice(length),
+					id: (markObj.id as number) + length,
+				},
 			];
 		case "MoveIn":
 		case "ReturnTo": {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -11,7 +11,11 @@ import { Changeset, Mark, MoveId, NodeChangeType, Reattach } from "./format";
 import { MarkListFactory } from "./markListFactory";
 
 export interface SequenceFieldEditor extends FieldEditor<Changeset> {
-	insert(index: number, cursor: ITreeCursor | ITreeCursor[]): Changeset<never>;
+	insert(
+		index: number,
+		cursor: ITreeCursor | ITreeCursor[],
+		id: ChangesetLocalId,
+	): Changeset<never>;
 	delete(index: number, count: number): Changeset<never>;
 	revive(
 		index: number,
@@ -49,12 +53,17 @@ export const sequenceFieldEditor = {
 		index: number,
 		change: TNodeChange,
 	): Changeset<TNodeChange> => markAtIndex(index, { type: "Modify", changes: change }),
-	insert: (index: number, cursors: ITreeCursor | ITreeCursor[]): Changeset<never> =>
+	insert: (
+		index: number,
+		cursors: ITreeCursor | ITreeCursor[],
+		id: ChangesetLocalId,
+	): Changeset<never> =>
 		markAtIndex(index, {
 			type: "Insert",
 			content: Array.isArray(cursors)
 				? cursors.map(jsonableTreeFromCursor)
 				: [jsonableTreeFromCursor(cursors)],
+			id,
 		}),
 	delete: (index: number, count: number): Changeset<never> =>
 		count === 0 ? [] : markAtIndex(index, { type: "Delete", count }),

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -404,7 +404,10 @@ export function tryExtendMark<T>(
 	switch (type) {
 		case "Insert": {
 			const lhsInsert = lhs as Insert;
-			if (isEqualPlace(lhsInsert, rhs)) {
+			if (
+				isEqualPlace(lhsInsert, rhs) &&
+				(lhsInsert.id as number) + lhsInsert.content.length === rhs.id
+			) {
 				lhsInsert.content.push(...rhs.content);
 				return true;
 			}

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.spec.ts
@@ -11,7 +11,7 @@ import {
 	TreeSchemaIdentifier,
 	mintRevisionTag,
 } from "../../../core";
-import { RevisionInfo, SequenceField as SF } from "../../../feature-libraries";
+import { ChangesetLocalId, RevisionInfo, SequenceField as SF } from "../../../feature-libraries";
 import { brand } from "../../../util";
 import { TestChange } from "../../testChange";
 import { fakeTaggedRepair as fakeRepair } from "../../utils";
@@ -29,6 +29,8 @@ const revInfos: RevisionInfo[] = [
 	{ revision: tag3 },
 	{ revision: tag4 },
 ];
+
+const defaultInsertId: ChangesetLocalId = brand(0);
 
 describe("SequenceField - Compose", () => {
 	describe("associativity of triplets", () => {
@@ -85,8 +87,9 @@ describe("SequenceField - Compose", () => {
 				type: "Insert",
 				content: [{ type, value: 0 }],
 				changes: TestChange.mint([], 42),
+				id: brand(0),
 			},
-			{ type: "Insert", content: [{ type, value: 1 }] },
+			{ type: "Insert", content: [{ type, value: 1 }], id: brand(1) },
 		];
 		const actual = compose([makeAnonChange(insert), makeAnonChange(modify)]);
 		assert.deepEqual(actual, expected);
@@ -105,6 +108,7 @@ describe("SequenceField - Compose", () => {
 				revision: tag1,
 				content: [{ type, value: 1 }],
 				changes: childChangeA,
+				id: defaultInsertId,
 			},
 		];
 		const modify = Change.modify(0, childChangeB);
@@ -114,6 +118,7 @@ describe("SequenceField - Compose", () => {
 				revision: tag1,
 				content: [{ type, value: 1 }],
 				changes: childChangeAB,
+				id: defaultInsertId,
 			},
 		];
 		const actual = compose([tagChange(insert, tag1), tagChange(modify, tag2)]);
@@ -221,10 +226,13 @@ describe("SequenceField - Compose", () => {
 		const expected: SF.Changeset = [
 			{
 				type: "Insert",
-				content: [
-					{ type, value: 1 },
-					{ type, value: 3 },
-				],
+				content: [{ type, value: 1 }],
+				id: brand(1),
+			},
+			{
+				type: "Insert",
+				content: [{ type, value: 3 }],
+				id: brand(3),
 			},
 		];
 		assert.deepEqual(actual, expected);
@@ -237,11 +245,18 @@ describe("SequenceField - Compose", () => {
 		const expected: SF.Changeset = [
 			{
 				type: "Insert",
-				content: [
-					{ type, value: 2 },
-					{ type, value: 1 },
-					{ type, value: 3 },
-				],
+				content: [{ type, value: 2 }],
+				id: brand(2),
+			},
+			{
+				type: "Insert",
+				content: [{ type, value: 1 }],
+				id: brand(1),
+			},
+			{
+				type: "Insert",
+				content: [{ type, value: 3 }],
+				id: brand(3),
 			},
 		];
 		assert.deepEqual(actual, expected);
@@ -256,6 +271,7 @@ describe("SequenceField - Compose", () => {
 					{ type, value: 1 },
 					{ type, value: 2 },
 				],
+				id: brand(1),
 			},
 			{
 				type: "Insert",
@@ -264,6 +280,7 @@ describe("SequenceField - Compose", () => {
 					{ type, value: 3 },
 					{ type, value: 4 },
 				],
+				id: brand(3),
 			},
 			{
 				type: "Insert",
@@ -272,6 +289,7 @@ describe("SequenceField - Compose", () => {
 					{ type, value: 5 },
 					{ type, value: 6 },
 				],
+				id: brand(5),
 			},
 		];
 		const deletion = Change.delete(1, 4);
@@ -280,10 +298,14 @@ describe("SequenceField - Compose", () => {
 			{
 				type: "Insert",
 				revision: tag1,
-				content: [
-					{ type, value: 1 },
-					{ type, value: 6 },
-				],
+				content: [{ type, value: 1 }],
+				id: brand(1),
+			},
+			{
+				type: "Insert",
+				revision: tag1,
+				content: [{ type, value: 6 }],
+				id: brand(6),
 			},
 		];
 		assert.deepEqual(actual, expected);
@@ -298,6 +320,7 @@ describe("SequenceField - Compose", () => {
 					{ type, value: 1 },
 					{ type, value: 2 },
 				],
+				id: brand(1),
 			},
 			{
 				type: "Insert",
@@ -306,6 +329,7 @@ describe("SequenceField - Compose", () => {
 					{ type, value: 3 },
 					{ type, value: 4 },
 				],
+				id: brand(3),
 			},
 			{
 				type: "Insert",
@@ -314,15 +338,18 @@ describe("SequenceField - Compose", () => {
 					{ type, value: 5 },
 					{ type, value: 6 },
 				],
+				id: brand(5),
 			},
 		];
 		const move = Change.move(1, 4, 0);
 		const actual = shallowCompose([makeAnonChange(insert), makeAnonChange(move)], revInfos);
+
 		const expected: SF.Changeset = [
 			{
 				type: "Insert",
 				revision: tag1,
 				content: [{ type, value: 2 }],
+				id: brand(2),
 			},
 			{
 				type: "Insert",
@@ -331,15 +358,25 @@ describe("SequenceField - Compose", () => {
 					{ type, value: 3 },
 					{ type, value: 4 },
 				],
+				id: brand(3),
 			},
 			{
 				type: "Insert",
 				revision: tag1,
-				content: [
-					{ type, value: 5 },
-					{ type, value: 1 },
-					{ type, value: 6 },
-				],
+				content: [{ type, value: 5 }],
+				id: brand(5),
+			},
+			{
+				type: "Insert",
+				revision: tag1,
+				content: [{ type, value: 1 }],
+				id: brand(1),
+			},
+			{
+				type: "Insert",
+				revision: tag1,
+				content: [{ type, value: 6 }],
+				id: brand(6),
 			},
 		];
 		assert.deepEqual(actual, expected);
@@ -428,7 +465,7 @@ describe("SequenceField - Compose", () => {
 		const modify = Change.modify(0, { valueChange: { value: 1 } });
 		const insert = Change.insert(0, 1, 2);
 		const expected: SF.Changeset = [
-			{ type: "Insert", content: [{ type, value: 2 }] },
+			{ type: "Insert", content: [{ type, value: 2 }], id: brand(2) },
 			{
 				type: "Modify",
 				changes: { valueChange: { value: 1 } },
@@ -443,7 +480,7 @@ describe("SequenceField - Compose", () => {
 		const insert = Change.insert(0, 1, 2);
 		// TODO: test with merge-right policy as well
 		const expected: SF.Changeset = [
-			{ type: "Insert", revision: tag2, content: [{ type, value: 2 }] },
+			{ type: "Insert", revision: tag2, content: [{ type, value: 2 }], id: brand(2) },
 			{ type: "Delete", revision: tag1, count: 3 },
 		];
 		const actual = shallowCompose([tagChange(deletion, tag1), tagChange(insert, tag2)]);
@@ -455,7 +492,7 @@ describe("SequenceField - Compose", () => {
 		const insert = Change.insert(0, 1, 2);
 		// TODO: test with merge-right policy as well
 		const expected: SF.Changeset = [
-			{ type: "Insert", content: [{ type, value: 2 }] },
+			{ type: "Insert", content: [{ type, value: 2 }], id: brand(2) },
 			{
 				type: "Revive",
 				content: fakeRepair(tag1, 0, 5),
@@ -470,7 +507,7 @@ describe("SequenceField - Compose", () => {
 
 	it("insert ○ insert", () => {
 		const insertA: SF.Changeset = [
-			{ type: "Insert", revision: tag1, content: [{ type, value: 1 }] },
+			{ type: "Insert", revision: tag1, content: [{ type, value: 1 }], id: brand(1) },
 			2,
 			{
 				type: "Insert",
@@ -479,21 +516,23 @@ describe("SequenceField - Compose", () => {
 					{ type, value: 2 },
 					{ type, value: 3 },
 				],
+				id: brand(2),
 			},
 		];
+
 		const insertB: SF.Changeset = [
-			{ type: "Insert", revision: tag3, content: [{ type, value: 3 }] },
+			{ type: "Insert", revision: tag3, content: [{ type, value: 4 }], id: brand(4) },
 			4,
-			{ type: "Insert", revision: tag4, content: [{ type, value: 4 }] },
+			{ type: "Insert", revision: tag4, content: [{ type, value: 5 }], id: brand(5) },
 		];
 		const actual = shallowCompose([makeAnonChange(insertA), makeAnonChange(insertB)], revInfos);
 		const expected: SF.Changeset = [
-			{ type: "Insert", revision: tag3, content: [{ type, value: 3 }] },
-			{ type: "Insert", revision: tag1, content: [{ type, value: 1 }] },
+			{ type: "Insert", revision: tag3, content: [{ type, value: 4 }], id: brand(4) },
+			{ type: "Insert", revision: tag1, content: [{ type, value: 1 }], id: brand(1) },
 			2,
-			{ type: "Insert", revision: tag2, content: [{ type, value: 2 }] },
-			{ type: "Insert", revision: tag4, content: [{ type, value: 4 }] },
-			{ type: "Insert", revision: tag2, content: [{ type, value: 3 }] },
+			{ type: "Insert", revision: tag2, content: [{ type, value: 2 }], id: brand(2) },
+			{ type: "Insert", revision: tag4, content: [{ type, value: 5 }], id: brand(5) },
+			{ type: "Insert", revision: tag2, content: [{ type, value: 3 }], id: brand(3) },
 		];
 		assert.deepEqual(actual, expected);
 	});
@@ -724,7 +763,7 @@ describe("SequenceField - Compose", () => {
 
 	it("insert ○ revive", () => {
 		const insert: SF.Changeset = [
-			{ type: "Insert", revision: tag1, content: [{ type, value: 1 }] },
+			{ type: "Insert", revision: tag1, content: [{ type, value: 1 }], id: brand(1) },
 			2,
 			{
 				type: "Insert",
@@ -733,6 +772,7 @@ describe("SequenceField - Compose", () => {
 					{ type, value: 2 },
 					{ type, value: 3 },
 				],
+				id: brand(2),
 			},
 		];
 		const revive: SF.Changeset = [
@@ -764,9 +804,9 @@ describe("SequenceField - Compose", () => {
 				detachedBy: tag1,
 				detachIndex: 0,
 			},
-			{ type: "Insert", revision: tag1, content: [{ type, value: 1 }] },
+			{ type: "Insert", revision: tag1, content: [{ type, value: 1 }], id: brand(1) },
 			2,
-			{ type: "Insert", revision: tag2, content: [{ type, value: 2 }] },
+			{ type: "Insert", revision: tag2, content: [{ type, value: 2 }], id: brand(2) },
 			{
 				type: "Revive",
 				revision: tag4,
@@ -775,7 +815,7 @@ describe("SequenceField - Compose", () => {
 				detachedBy: tag1,
 				detachIndex: 0,
 			},
-			{ type: "Insert", revision: tag2, content: [{ type, value: 3 }] },
+			{ type: "Insert", revision: tag2, content: [{ type, value: 3 }], id: brand(3) },
 		];
 		assert.deepEqual(actual, expected);
 	});

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { mintRevisionTag, RevisionTag, TreeSchemaIdentifier } from "../../../core";
-import { NodeChangeset, SequenceField as SF } from "../../../feature-libraries";
+import { ChangesetLocalId, NodeChangeset, SequenceField as SF } from "../../../feature-libraries";
 import { brand } from "../../../util";
 import { fakeTaggedRepair as fakeRepair } from "../../utils";
 
@@ -45,9 +45,11 @@ describe("SequenceField - MarkListFactory", () => {
 	});
 
 	it("Can merge consecutive inserts", () => {
+		const id1: ChangesetLocalId = brand(1);
+		const id2: ChangesetLocalId = brand(2);
 		const factory = new SF.MarkListFactory();
-		const insert1: SF.Insert = { type: "Insert", content: [{ type, value: 1 }] };
-		const insert2: SF.Insert = { type: "Insert", content: [{ type, value: 2 }] };
+		const insert1: SF.Insert = { type: "Insert", content: [{ type, value: 1 }], id: id1 };
+		const insert2: SF.Insert = { type: "Insert", content: [{ type, value: 2 }], id: id2 };
 		factory.pushContent(insert1);
 		factory.pushContent(insert2);
 		assert.deepStrictEqual(factory.list, [
@@ -57,6 +59,7 @@ describe("SequenceField - MarkListFactory", () => {
 					{ type, value: 1 },
 					{ type, value: 2 },
 				],
+				id: id1,
 			},
 		]);
 	});

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/randomChangeGenerator.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/randomChangeGenerator.ts
@@ -7,6 +7,7 @@ import { makeRandom } from "@fluid-internal/stochastic-test-utils";
 import { unreachableCase } from "@fluidframework/common-utils";
 import { singleTextCursor, SequenceField as SF, NodeChangeset } from "../../../feature-libraries";
 import { jsonNumber } from "../../../domains";
+import { brand } from "../../../util";
 
 enum Operation {
 	EditChild = 0,
@@ -40,6 +41,7 @@ export function generateRandomChange(
 					type: jsonNumber.name,
 					value: random.integer(0, Number.MAX_SAFE_INTEGER),
 				}),
+				brand(0),
 			);
 		case Operation.Delete:
 			return builder.delete(random.integer(0, maxIndex), random.integer(1, 10));

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldEditor.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldEditor.spec.ts
@@ -5,9 +5,16 @@
 
 import { strict as assert } from "assert";
 import { jsonString } from "../../../domains";
-import { NodeChangeset, SequenceField as SF, singleTextCursor } from "../../../feature-libraries";
+import {
+	ChangesetLocalId,
+	NodeChangeset,
+	SequenceField as SF,
+	singleTextCursor,
+} from "../../../feature-libraries";
+import { brand } from "../../../util";
 import { deepFreeze } from "../../utils";
 
+const id: ChangesetLocalId = brand(0);
 const nodeX = { type: jsonString.name, value: "X" };
 const nodeY = { type: jsonString.name, value: "Y" };
 const content = [singleTextCursor(nodeX), singleTextCursor(nodeY)];
@@ -23,14 +30,14 @@ describe("SequenceField - Editor", () => {
 	});
 
 	it("insert one node", () => {
-		const actual = SF.sequenceFieldEditor.insert(42, content[0]);
-		const expected: SF.Changeset = [42, { type: "Insert", content: [nodeX] }];
+		const actual = SF.sequenceFieldEditor.insert(42, content[0], id);
+		const expected: SF.Changeset = [42, { type: "Insert", content: [nodeX], id }];
 		assert.deepEqual(actual, expected);
 	});
 
 	it("insert multiple nodes", () => {
-		const actual = SF.sequenceFieldEditor.insert(42, content);
-		const expected: SF.Changeset = [42, { type: "Insert", content: [nodeX, nodeY] }];
+		const actual = SF.sequenceFieldEditor.insert(42, content, id);
+		const expected: SF.Changeset = [42, { type: "Insert", content: [nodeX, nodeY], id }];
 		assert.deepEqual(actual, expected);
 	});
 

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
@@ -283,6 +283,7 @@ describe("SequenceField - toDelta", () => {
 				type: "Insert",
 				content,
 				changes: nodeChange,
+				id: brand(0),
 			},
 		];
 		const nestedMoveDelta = new Map([

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -46,12 +46,17 @@ function createInsertChangeset(
 	index: number,
 	size: number,
 	startingValue: number = 0,
+	id?: ChangesetLocalId,
 ): SF.Changeset<never> {
 	const content = [];
 	while (content.length < size) {
 		content.push({ type, value: startingValue + content.length });
 	}
-	return SF.sequenceFieldEditor.insert(index, content.map(singleTextCursor));
+	return SF.sequenceFieldEditor.insert(
+		index,
+		content.map(singleTextCursor),
+		id ?? brand(startingValue),
+	);
 }
 
 function createDeleteChangeset(startIndex: number, size: number): SF.Changeset<never> {

--- a/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
@@ -290,12 +290,12 @@ const MAX_SUCCESSFUL_OP_BYTE_SIZES = {
 	INSERT: {
 		INDIVIDUAL: {
 			nodeCounts: {
-				"100": 9000,
+				"100": 8900,
 			},
 		},
 		SINGLE: {
 			nodeCounts: {
-				"100": 9700,
+				"100": 9600,
 			},
 		},
 	},


### PR DESCRIPTION
Assigns a `ChangesetLocalId` to each node created by an insert mark in a sequence field. These IDs will be used in future work as a way to stably identify the inserted nodes even when the insert is rolled back due to rebasing the branch which contains the insert.