### PR TITLE
refactor(tree): Remove count field on Delta.MoveIn

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -1002,8 +1002,6 @@ interface MoveId extends Opaque<Brand<number, "delta.MoveId">> {
 
 // @alpha
 interface MoveIn {
-    // (undocumented)
-    readonly count: number;
     readonly moveId: MoveId;
     // (undocumented)
     readonly type: typeof MarkType.MoveIn;

--- a/packages/dds/tree/src/core/tree/delta.ts
+++ b/packages/dds/tree/src/core/tree/delta.ts
@@ -222,7 +222,6 @@ export interface MoveOut<TTree = ProtoNode> extends HasModifications<TTree> {
  */
 export interface MoveIn {
 	readonly type: typeof MarkType.MoveIn;
-	readonly count: number;
 	/**
 	 * The delta should carry exactly one `MoveOut` mark with the same move ID.
 	 */

--- a/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-change-family/changeset/toDelta.ts
@@ -61,7 +61,6 @@ function convertMarkList(marks: T.MarkList): Delta.MarkList {
 				case "MoveIn": {
 					const moveMark: Delta.MoveIn = {
 						type: Delta.MarkType.MoveIn,
-						count: mark.count,
 						moveId: brandOpaque<Delta.MoveId>(mark.id),
 					};
 					out.pushContent(moveMark);

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -39,7 +39,6 @@ export function sequenceFieldToDelta<TNodeChange>(
 				case "ReturnTo": {
 					const moveMark: Delta.MoveIn = {
 						type: Delta.MarkType.MoveIn,
-						count: mark.count,
 						moveId: brandOpaque<Delta.MoveId>(mark.id),
 					};
 					out.pushContent(moveMark);

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
@@ -192,7 +192,6 @@ describe("SequenceField - toDelta", () => {
 		const moveIn: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
 			moveId: deltaMoveId,
-			count: 10,
 		};
 		const expected: Delta.MarkList = [42, moveOut, 8, moveIn];
 		const actual = toDelta(changeset);

--- a/packages/dds/tree/src/test/forestTestSuite.ts
+++ b/packages/dds/tree/src/test/forestTestSuite.ts
@@ -550,7 +550,6 @@ export function testForest(config: ForestTestConfiguration): void {
 				};
 				const moveIn: Delta.MoveIn = {
 					type: Delta.MarkType.MoveIn,
-					count: 1,
 					moveId,
 				};
 				const modify: Delta.Modify = {
@@ -770,7 +769,6 @@ export function testForest(config: ForestTestConfiguration): void {
 				};
 				const moveIn: Delta.MoveIn = {
 					type: Delta.MarkType.MoveIn,
-					count: 1,
 					moveId,
 				};
 				const modify: Delta.Modify = {

--- a/packages/dds/tree/src/test/sequence-change-family/toDelta.spec.ts
+++ b/packages/dds/tree/src/test/sequence-change-family/toDelta.spec.ts
@@ -212,7 +212,6 @@ describe("toDelta", () => {
 		const moveIn: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
 			moveId,
-			count: 10,
 		};
 		const expected: Delta.MarkList = [
 			{
@@ -256,7 +255,6 @@ describe("toDelta", () => {
 		const moveIn: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
 			moveId,
-			count: 10,
 		};
 		const expected: Delta.MarkList = [
 			{
@@ -307,7 +305,6 @@ describe("toDelta", () => {
 		const moveIn: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
 			moveId,
-			count: 10,
 		};
 		const expected: Delta.Root = new Map([
 			[

--- a/packages/dds/tree/src/test/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/tree/anchorSet.spec.ts
@@ -55,7 +55,6 @@ describe("AnchorSet", () => {
 
 		const moveIn: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
-			count: 1,
 			moveId: brand(1),
 		};
 
@@ -140,7 +139,6 @@ describe("AnchorSet", () => {
 
 		const moveIn: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
-			count: 1,
 			moveId: brand(1),
 		};
 

--- a/packages/dds/tree/src/test/tree/visit.spec.ts
+++ b/packages/dds/tree/src/test/tree/visit.spec.ts
@@ -230,7 +230,6 @@ describe("visit", () => {
 
 		const moveIn: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
-			count: 1,
 			moveId,
 		};
 
@@ -261,7 +260,6 @@ describe("visit", () => {
 
 		const moveIn: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
-			count: 2,
 			moveId,
 		};
 
@@ -307,7 +305,6 @@ describe("visit", () => {
 
 		const moveIn: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
-			count: 2,
 			moveId,
 		};
 
@@ -354,7 +351,6 @@ describe("visit", () => {
 
 		const moveIn: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
-			count: 1,
 			moveId,
 		};
 
@@ -403,7 +399,6 @@ describe("visit", () => {
 
 		const moveIn: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
-			count: 2,
 			moveId,
 		};
 
@@ -456,7 +451,6 @@ describe("visit", () => {
 
 		const moveIn: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
-			count: 2,
 			moveId,
 		};
 
@@ -501,7 +495,6 @@ describe("visit", () => {
 
 		const moveIn1: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
-			count: 1,
 			moveId: moveId1,
 		};
 
@@ -513,7 +506,6 @@ describe("visit", () => {
 
 		const moveIn2: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
-			count: 2,
 			moveId: moveId2,
 		};
 
@@ -560,7 +552,6 @@ describe("visit", () => {
 
 		const moveIn1: Delta.MoveIn = {
 			type: Delta.MarkType.MoveIn,
-			count: 1,
 			moveId: moveId1,
 		};
 


### PR DESCRIPTION
Removes the need to specify the `count` field when producing a `Delta.MoveIn` mark. The count is derived from the matching `Delta.MoveOut` mark instead.

## Motivation

This change paves the way for deltas to be able to describe operations on all the nodes in a given field, irrespective of how many nodes there may be. For example, a change may move all the nodes in field foo to field bar.

## Breaking Changes

While this is technically a breaking change since the `Delta` format is public, no consumers of SharedTree should be reading or writing this format directly.