### PR TITLE
[Port v2int 3.1] Add setMulitple to ITelemetryContext

### DIFF
--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -426,6 +426,7 @@ export interface ITelemetryContext {
     get(prefix: string, property: string): TelemetryEventPropertyType;
     serialize(): string;
     set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
+    setAll(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
 }
 
 // @public

--- a/api-report/runtime-definitions.api.md
+++ b/api-report/runtime-definitions.api.md
@@ -426,7 +426,7 @@ export interface ITelemetryContext {
     get(prefix: string, property: string): TelemetryEventPropertyType;
     serialize(): string;
     set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
-    setAll(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
+    setMultiple(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
 }
 
 // @public

--- a/api-report/runtime-utils.api.md
+++ b/api-report/runtime-utils.api.md
@@ -230,7 +230,7 @@ export class TelemetryContext implements ITelemetryContext {
     // (undocumented)
     set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
     // (undocumented)
-    setAll(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
+    setMultiple(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
 }
 
 // @public (undocumented)

--- a/api-report/runtime-utils.api.md
+++ b/api-report/runtime-utils.api.md
@@ -229,6 +229,8 @@ export class TelemetryContext implements ITelemetryContext {
     serialize(): string;
     // (undocumented)
     set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
+    // (undocumented)
+    setAll(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
 }
 
 // @public (undocumented)

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -61,6 +61,10 @@
 		"previousVersionStyle": "~previousMinor",
 		"baselineRange": ">=2.0.0-internal.3.0.0 <2.0.0-internal.3.1.0",
 		"baselineVersion": "2.0.0-internal.3.0.1",
-		"broken": {}
+		"broken": {
+			"InterfaceDeclaration_ITelemetryContext": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -326,6 +326,18 @@ export interface ITelemetryContext {
 	set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
 
 	/**
+	 * Sets a set of values for telemetry data being tracked.
+	 * @param prefix - unique prefix to tag this data with (ex: "fluid:summarize:")
+	 * @param property - property name of the telemetry data being tracked (ex: "Options")
+	 * @param values - A set of values to attribute to this summary telemetry data.
+	 */
+	setAll(
+		prefix: string,
+		property: string,
+		values: Record<string, TelemetryEventPropertyType>,
+	): void;
+
+	/**
 	 * Get the telemetry data being tracked
 	 * @param prefix - unique prefix for this data (ex: "fluid:map:")
 	 * @param property - property name of the telemetry data being tracked (ex: "DirectoryCount")

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -326,12 +326,12 @@ export interface ITelemetryContext {
 	set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
 
 	/**
-	 * Sets a set of values for telemetry data being tracked.
+	 * Sets multiple values for telemetry data being tracked.
 	 * @param prefix - unique prefix to tag this data with (ex: "fluid:summarize:")
 	 * @param property - property name of the telemetry data being tracked (ex: "Options")
 	 * @param values - A set of values to attribute to this summary telemetry data.
 	 */
-	setAll(
+	setMultiple(
 		prefix: string,
 		property: string,
 		values: Record<string, TelemetryEventPropertyType>,

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -1103,6 +1103,7 @@ declare function get_old_InterfaceDeclaration_ITelemetryContext():
 declare function use_current_InterfaceDeclaration_ITelemetryContext(
     use: TypeOnly<current.ITelemetryContext>);
 use_current_InterfaceDeclaration_ITelemetryContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ITelemetryContext());
 
 /*

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -106,6 +106,9 @@
 			"TypeAliasDeclaration_RefreshSummaryResult": {
 				"forwardCompat": false,
 				"backCompat": false
+			},
+			"ClassDeclaration_TelemetryContext": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -357,6 +357,20 @@ export class TelemetryContext implements ITelemetryContext {
 	}
 
 	/**
+	 * {@inheritDoc @fluidframework/runtime-definitions#ITelemetryContext.setAll}
+	 */
+	setAll(
+		prefix: string,
+		property: string,
+		values: Record<string, TelemetryEventPropertyType>,
+	): void {
+		// Set the values individually so that they are logged as a flat list along with other properties.
+		for (const key of Object.keys(values)) {
+			this.set(prefix, `${property}_${key}`, values[key]);
+		}
+	}
+
+	/**
 	 * {@inheritDoc @fluidframework/runtime-definitions#ITelemetryContext.get}
 	 */
 	get(prefix: string, property: string): TelemetryEventPropertyType {

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -357,9 +357,9 @@ export class TelemetryContext implements ITelemetryContext {
 	}
 
 	/**
-	 * {@inheritDoc @fluidframework/runtime-definitions#ITelemetryContext.setAll}
+	 * {@inheritDoc @fluidframework/runtime-definitions#ITelemetryContext.setMultiple}
 	 */
-	setAll(
+	setMultiple(
 		prefix: string,
 		property: string,
 		values: Record<string, TelemetryEventPropertyType>,

--- a/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
@@ -327,13 +327,19 @@ describe("Summary Utils", () => {
 			telemetryContext.set("pre2_", "prop1", "10");
 			telemetryContext.set("pre2_", "prop2", true);
 			telemetryContext.set("pre1_", "prop2", undefined);
+			telemetryContext.setAll("pre3_", "obj1", { prop1: "1", prop2: 2, prop3: true });
 
-			const obj = JSON.parse(telemetryContext.serialize());
+			const serialized = telemetryContext.serialize();
+
+			const obj = JSON.parse(serialized);
 
 			assert.strictEqual(obj.pre1_prop1, 10);
 			assert.strictEqual(obj.pre1_prop2, undefined);
 			assert.strictEqual(obj.pre2_prop1, "10");
 			assert.strictEqual(obj.pre2_prop2, true);
+			assert.strictEqual(obj.pre3_obj1_prop1, "1");
+			assert.strictEqual(obj.pre3_obj1_prop2, 2);
+			assert.strictEqual(obj.pre3_obj1_prop3, true);
 		});
 	});
 });

--- a/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
@@ -327,7 +327,7 @@ describe("Summary Utils", () => {
 			telemetryContext.set("pre2_", "prop1", "10");
 			telemetryContext.set("pre2_", "prop2", true);
 			telemetryContext.set("pre1_", "prop2", undefined);
-			telemetryContext.setAll("pre3_", "obj1", { prop1: "1", prop2: 2, prop3: true });
+			telemetryContext.setMultiple("pre3_", "obj1", { prop1: "1", prop2: 2, prop3: true });
 
 			const serialized = telemetryContext.serialize();
 

--- a/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
@@ -817,6 +817,7 @@ declare function get_old_ClassDeclaration_TelemetryContext():
 declare function use_current_ClassDeclaration_TelemetryContext(
     use: TypeOnly<current.TelemetryContext>);
 use_current_ClassDeclaration_TelemetryContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TelemetryContext());
 
 /*


### PR DESCRIPTION
Porting ITelemetryContext changes from the following changes:
- https://github.com/microsoft/FluidFramework/pull/14070 that adds `setAll` method to `ITelemetryContext`.
- https://github.com/microsoft/FluidFramework/pull/14154 that renames `setAll` to `setMultiple`.