### PR TITLE
Deprecate last function in @fluidframework/garbage-collector

### DIFF
--- a/.changeset/thirty-ravens-serve.md
+++ b/.changeset/thirty-ravens-serve.md
@@ -1,15 +1,17 @@
 ---
-"@fluidframework/runtime-definitions": minor
-"@fluidframework/test-end-to-end-tests": minor
+"@fluid-internal/tree": minor
 "@fluidframework/container-runtime": minor
+"@fluidframework/datastore": minor
 "@fluidframework/garbage-collector": minor
 "@fluidframework/runtime-utils": minor
-"@fluidframework/datastore": minor
+"@fluidframework/test-end-to-end-tests": minor
 ---
 
-garbage-collector and related items deprecated
+@fluidframework/garbage-collector deprecated
 
-The following functions, interfaces, and types currently available in `@fluidframework/garbage-collector` are internal implementation details and have been deprecated for public use. They will be removed in an upcoming release.
+The `@fluidframework/garbage-collector` package is deprecated with the following functions, interfaces, and types in it.
+These are internal implementation details and have been deprecated for public use. They will be removed in an upcoming
+release.
 
 -   `cloneGCData`
 -   `concatGarbageCollectionData`
@@ -23,3 +25,4 @@ The following functions, interfaces, and types currently available in `@fluidfra
 -   `trimLeadingSlashes`
 -   `trimTrailingSlashes`
 -   `unpackChildNodesGCDetails`
+-   `unpackChildNodesUsedRoutes`

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -19,14 +19,14 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 
 ## 2.0.0-internal.4.1.0 Upcoming changes
 
--   [garbage-collector and related items deprecated](#garbage-collector-and-related-items-deprecated)
+-   [@fluidframework/garbage-collector deprecated](#@fluidframework/garbage-collector-deprecated)
 -   [GC interfaces removed from runtime-definitions](#gc-interfaces-removed-from-runtime-definitions)
 -   [ensureSynchronizedWithTimeout deprecated in LoaderContainerTracker](#ensuresynchronizedwithtimeout-deprecated-in-loadercontainertracker)
 -   [Op compression is enabled by default](#op-compression-is-enabled-by-default)
 
-### garbage-collector and related items deprecated
+### @fluidframework/garbage-collector deprecated
 
-The following functions, interfaces, and types currently available in `@fluidframework/garbage-collector` are internal implementation details and have been deprecated for public use. They will be removed in an upcoming release.
+The `@fluidframework/garbage-collector` package is deprecated with the following functions, interfaces, and types in it. These are internal implementation details and have been deprecated for public use. They will be removed in an upcoming release.
 
 -   `runGarbageCollection`
 -   `trimLeadingAndTrailingSlashes`
@@ -34,6 +34,7 @@ The following functions, interfaces, and types currently available in `@fluidfra
 -   `trimTrailingSlashes`
 -   `cloneGCData`
 -   `unpackChildNodesGCDetails`
+-   `unpackChildNodesUsedRoutes`
 -   `removeRouteFromAllNodes`
 -   `concatGarbageCollectionStates`
 -   `concatGarbageCollectionData`

--- a/api-report/garbage-collector.api.md
+++ b/api-report/garbage-collector.api.md
@@ -70,7 +70,7 @@ export function trimTrailingSlashes(str: string): string;
 // @public @deprecated
 export function unpackChildNodesGCDetails(gcDetails: IGarbageCollectionDetailsBase): Map<string, IGarbageCollectionDetailsBase>;
 
-// @public
+// @public @deprecated
 export function unpackChildNodesUsedRoutes(usedRoutes: string[]): Map<string, string[]>;
 
 // (No @packageDocumentation comment for this package)

--- a/api-report/runtime-utils.api.md
+++ b/api-report/runtime-utils.api.md
@@ -198,6 +198,9 @@ export class TelemetryContext implements ITelemetryContext {
     setMultiple(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
 }
 
+// @public
+export function unpackChildNodesUsedRoutes(usedRoutes: string[]): Map<string, string[]>;
+
 // @public (undocumented)
 export function utf8ByteLength(str: string): number;
 

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -35,6 +35,7 @@ import {
 	GCDataBuilder,
 	responseToException,
 	SummaryTreeBuilder,
+	unpackChildNodesUsedRoutes,
 } from "@fluidframework/runtime-utils";
 import {
 	ChildLogger,
@@ -47,7 +48,6 @@ import { AttachState } from "@fluidframework/container-definitions";
 import { buildSnapshotTree } from "@fluidframework/driver-utils";
 import { assert, Lazy } from "@fluidframework/common-utils";
 import { v4 as uuid } from "uuid";
-import { unpackChildNodesUsedRoutes } from "@fluidframework/garbage-collector";
 import { DataStoreContexts } from "./dataStoreContexts";
 import {
 	ContainerRuntime,

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
@@ -5,7 +5,6 @@
 
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert, LazyPromise } from "@fluidframework/common-utils";
-import { unpackChildNodesUsedRoutes } from "@fluidframework/garbage-collector";
 import { ISnapshotTree } from "@fluidframework/protocol-definitions";
 import {
 	CreateChildSummarizerNodeParam,
@@ -20,7 +19,7 @@ import {
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions";
 import { LoggingError, TelemetryDataTag } from "@fluidframework/telemetry-utils";
-import { ReadAndParseBlob } from "@fluidframework/runtime-utils";
+import { ReadAndParseBlob, unpackChildNodesUsedRoutes } from "@fluidframework/runtime-utils";
 import {
 	cloneGCData,
 	getGCDataFromSnapshot,

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -68,6 +68,7 @@ import {
 	GCDataBuilder,
 	requestFluidObject,
 	packagePathToTelemetryProperty,
+	unpackChildNodesUsedRoutes,
 } from "@fluidframework/runtime-utils";
 import {
 	IChannel,
@@ -75,7 +76,6 @@ import {
 	IFluidDataStoreRuntimeEvents,
 	IChannelFactory,
 } from "@fluidframework/datastore-definitions";
-import { unpackChildNodesUsedRoutes } from "@fluidframework/garbage-collector";
 import { v4 as uuid } from "uuid";
 import { IChannelContext, summarizeChannel } from "./channelContext";
 import {

--- a/packages/runtime/garbage-collector/README.md
+++ b/packages/runtime/garbage-collector/README.md
@@ -1,5 +1,7 @@
 # @fluidframework/garbage-collector
 
+This package has been deprecated. It's functions, interfaces and types are for internal use only and will be deleted in a future release.
+
 Garbage collector implementation for Fluid Framework.
 
 See [GitHub](https://github.com/microsoft/FluidFramework) for more details on the Fluid Framework and packages within.

--- a/packages/runtime/garbage-collector/package.json
+++ b/packages/runtime/garbage-collector/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@fluidframework/garbage-collector",
 	"version": "2.0.0-internal.4.1.0",
-	"description": "Garbage Collector implementation for Fluid",
+	"description": "Garbage Collector implementation for Fluid, @deprecated - This package is for internal use only and will be deleted in a future release.",
 	"homepage": "https://fluidframework.com",
 	"repository": {
 		"type": "git",

--- a/packages/runtime/garbage-collector/src/utils.ts
+++ b/packages/runtime/garbage-collector/src/utils.ts
@@ -136,6 +136,8 @@ export function unpackChildNodesGCDetails(gcDetails: IGarbageCollectionDetailsBa
  * Helper function that unpacks the used routes of children from a given node's used routes.
  * @param usedRoutes - The used routes of a node.
  * @returns A map of used routes of each children of the the given node.
+ *
+ * @deprecated Internal implementation detail and will no longer be exported in an upcoming release.
  */
 export function unpackChildNodesUsedRoutes(usedRoutes: string[]) {
 	// Remove the node's self used route, if any, and generate the children used routes.

--- a/packages/runtime/runtime-utils/src/index.ts
+++ b/packages/runtime/runtime-utils/src/index.ts
@@ -34,4 +34,5 @@ export {
 	TelemetryContext,
 	utf8ByteLength,
 } from "./summaryUtils";
+export { unpackChildNodesUsedRoutes } from "./unpackUsedRoutes";
 export { ReadAndParseBlob, seqFromTree } from "./utils";

--- a/packages/runtime/runtime-utils/src/unpackUsedRoutes.ts
+++ b/packages/runtime/runtime-utils/src/unpackUsedRoutes.ts
@@ -15,7 +15,7 @@ export function unpackChildNodesUsedRoutes(usedRoutes: string[]) {
 	const filteredUsedRoutes = usedRoutes.filter((route) => route !== "" && route !== "/");
 	const childUsedRoutesMap: Map<string, string[]> = new Map();
 	for (const route of filteredUsedRoutes) {
-		assert(route.startsWith("/"), 0x198 /* "Used route should always be an absolute route" */);
+		assert(route.startsWith("/"), "Used route should always be an absolute route");
 		const childId = route.split("/")[1];
 		const childUsedRoute = route.slice(childId.length + 1);
 

--- a/packages/runtime/runtime-utils/src/unpackUsedRoutes.ts
+++ b/packages/runtime/runtime-utils/src/unpackUsedRoutes.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert } from "@fluidframework/common-utils";
+
+/**
+ * Helper function that unpacks the used routes of children from a given node's used routes.
+ * @param usedRoutes - The used routes of a node.
+ * @returns A map of used routes of each children of the the given node.
+ */
+export function unpackChildNodesUsedRoutes(usedRoutes: string[]) {
+	// Remove the node's self used route, if any, and generate the children used routes.
+	const filteredUsedRoutes = usedRoutes.filter((route) => route !== "" && route !== "/");
+	const childUsedRoutesMap: Map<string, string[]> = new Map();
+	for (const route of filteredUsedRoutes) {
+		assert(route.startsWith("/"), 0x198 /* "Used route should always be an absolute route" */);
+		const childId = route.split("/")[1];
+		const childUsedRoute = route.slice(childId.length + 1);
+
+		const childUsedRoutes = childUsedRoutesMap.get(childId);
+		if (childUsedRoutes !== undefined) {
+			childUsedRoutes.push(childUsedRoute);
+		} else {
+			childUsedRoutesMap.set(childId, [childUsedRoute]);
+		}
+	}
+	return childUsedRoutesMap;
+}


### PR DESCRIPTION
Deprecated the last function `unpackChildNodesUsedRoutes` in `@fluidframework/garbage-collector`. This function has been moved to `@fluidframework/runtime-utils`.
`@fluidframework/garbage-collector` will be removed in the next major release.