### PR TITLE
tree: Fix some contextual type bugs

### DIFF
--- a/packages/dds/tree/src/feature-libraries/contextuallyTyped.ts
+++ b/packages/dds/tree/src/feature-libraries/contextuallyTyped.ts
@@ -30,6 +30,7 @@ import {
 import { fieldKinds } from "./defaultFieldKinds";
 import { FieldKind, Multiplicity } from "./modular-schema";
 import { singleMapTreeCursor } from "./mapTreeCursor";
+import { isPrimitive } from "./editable-tree";
 
 /**
  * This library defines a tree data format that can infer its types from context.
@@ -92,29 +93,6 @@ export function allowsValue(schema: ValueSchema, nodeValue: Value): boolean {
 	}
 }
 
-export function allowsPrimitiveValueType(nodeValue: Value, schema: TreeSchema): boolean {
-	if (!isPrimitiveValue(nodeValue)) {
-		return false;
-	}
-	switch (schema.value) {
-		case ValueSchema.String:
-			return typeof nodeValue === "string";
-		case ValueSchema.Number:
-			return typeof nodeValue === "number";
-		case ValueSchema.Boolean:
-			return typeof nodeValue === "boolean";
-		default:
-			return false;
-	}
-}
-
-export function assertPrimitiveValueType(nodeValue: Value, schema: TreeSchema): void {
-	assert(
-		allowsPrimitiveValueType(nodeValue, schema),
-		0x4d3 /* unsupported schema for provided primitive */,
-	);
-}
-
 /**
  * @returns the key and the schema of the primary field out of the given tree schema.
  *
@@ -127,7 +105,7 @@ export function getPrimaryField(
 	// TODO: have a better mechanism for this. See note on EmptyKey.
 	const field = schema.localFields.get(EmptyKey);
 	if (field === undefined) {
-		return field;
+		return undefined;
 	}
 	return { key: EmptyKey, schema: field };
 }
@@ -307,7 +285,7 @@ export interface ContextuallyTypedNodeDataObject {
 }
 
 /**
- * Checks if data is schema-compatible.
+ * Checks if data might be schema-compatible.
  *
  * @returns false if `data` is incompatible with `type` based on a cheap/shallow check.
  *
@@ -320,7 +298,7 @@ function shallowCompatibilityTest(
 ): boolean {
 	const schema = lookupTreeSchema(schemaData, type);
 	if (isPrimitiveValue(data)) {
-		return allowsPrimitiveValueType(data, schema);
+		return isPrimitive(schema) && allowsValue(schema.value, data);
 	}
 	if (isArrayLike(data)) {
 		const primary = getPrimaryField(schema);
@@ -334,6 +312,14 @@ function shallowCompatibilityTest(
 	}
 	// For now, consider all not explicitly typed objects shallow compatible.
 	// This will require explicit differentiation in polymorphic cases rather than automatic structural differentiation.
+
+	// Special case primitive schema to to not be compatible with data with local fields.
+	if (isPrimitive(schema)) {
+		if (fieldKeysFromData(data).length > 0) {
+			return false;
+		}
+	}
+
 	return true;
 }
 
@@ -395,7 +381,13 @@ export function applyTypesFromContext(
 	const type = possibleTypes[0];
 	const schema = lookupTreeSchema(schemaData, type);
 	if (isPrimitiveValue(data)) {
-		assertPrimitiveValueType(data, schema);
+		// This check avoids returning an out of schema node
+		// in the case where schema permits the value, but has required fields.
+		assert(isPrimitive(schema), "Schema must be primitive when providing a primitive value");
+		assert(
+			allowsValue(schema.value, data),
+			0x4d3 /* unsupported schema for provided primitive */,
+		);
 		return { value: data, type, fields: new Map() };
 	} else if (isArrayLike(data)) {
 		const primary = getPrimaryField(schema);
@@ -404,20 +396,17 @@ export function applyTypesFromContext(
 			0x4d6 /* array data reported comparable with the schema without a primary field */,
 		);
 		const children = applyFieldTypesFromContext(schemaData, primary.schema, data);
-		const value = allowsValue(schema.value, data) ? data : undefined;
-		return { value, type, fields: new Map([[primary.key, children]]) };
+		return { value: undefined, type, fields: new Map([[primary.key, children]]) };
 	} else {
 		const fields: Map<FieldKey, MapTree[]> = new Map(
-			Reflect.ownKeys(data)
-				.filter((key) => typeof key === "string" || symbolIsFieldKey(key))
-				.map((key) => {
-					const childKey: FieldKey = brand(key);
-					const childSchema = getFieldSchema(childKey, schemaData, schema);
-					return [
-						childKey,
-						applyFieldTypesFromContext(schemaData, childSchema, data[childKey]),
-					];
-				}),
+			fieldKeysFromData(data).map((key) => {
+				const childKey: FieldKey = brand(key);
+				const childSchema = getFieldSchema(childKey, schemaData, schema);
+				return [
+					childKey,
+					applyFieldTypesFromContext(schemaData, childSchema, data[childKey]),
+				];
+			}),
 		);
 		const value = data[valueSymbol];
 		assert(
@@ -426,6 +415,13 @@ export function applyTypesFromContext(
 		);
 		return { value, type, fields };
 	}
+}
+
+function fieldKeysFromData(data: ContextuallyTypedNodeDataObject): FieldKey[] {
+	const keys: (string | symbol)[] = Reflect.ownKeys(data).filter(
+		(key) => typeof key === "string" || symbolIsFieldKey(key),
+	);
+	return keys as FieldKey[];
 }
 
 /**

--- a/packages/dds/tree/src/feature-libraries/contextuallyTyped.ts
+++ b/packages/dds/tree/src/feature-libraries/contextuallyTyped.ts
@@ -313,7 +313,7 @@ function shallowCompatibilityTest(
 	// For now, consider all not explicitly typed objects shallow compatible.
 	// This will require explicit differentiation in polymorphic cases rather than automatic structural differentiation.
 
-	// Special case primitive schema to to not be compatible with data with local fields.
+	// Special case primitive schema to not be compatible with data with local fields.
 	if (isPrimitive(schema)) {
 		if (fieldKeysFromData(data).length > 0) {
 			return false;

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
@@ -29,11 +29,8 @@ import { singleMapTreeCursor } from "../mapTreeCursor";
 import {
 	getFieldKind,
 	getFieldSchema,
-	isPrimitiveValue,
-	assertPrimitiveValueType,
 	ContextuallyTypedNodeData,
 	applyFieldTypesFromContext,
-	getPossibleTypes,
 	typeNameSymbol,
 	valueSymbol,
 	allowsValue,
@@ -246,7 +243,10 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 		}
 	}
 
-	public replaceField(fieldKey: FieldKey, newContent: ITreeCursor | ITreeCursor[]): void {
+	public replaceField(
+		fieldKey: FieldKey,
+		newContent: undefined | ITreeCursor | ITreeCursor[],
+	): void {
 		const fieldKind = this.lookupFieldKind(fieldKey);
 		const path = this.anchorNode;
 		switch (fieldKind.multiplicity) {
@@ -259,6 +259,10 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 				break;
 			}
 			case Multiplicity.Sequence: {
+				assert(
+					Array.isArray(newContent),
+					"It is invalid to replace the sequence field with a non array value.",
+				);
 				const length = this.fieldLength(fieldKey);
 				/**
 				 * `replaceNodes` has different merge semantics than the `replaceField` would ideally offer:
@@ -274,6 +278,10 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 				assert(
 					!Array.isArray(newContent),
 					0x4ce /* It is invalid to replace the value field using the array data. */,
+				);
+				assert(
+					newContent !== undefined,
+					"It is invalid to replace a value field with undefined",
 				);
 				this.context.setValueField(path, fieldKey, newContent);
 				break;
@@ -366,24 +374,6 @@ const nodeProxyHandler: AdaptingProxyHandler<NodeProxyTarget, EditableTree> = {
 			const fieldKey: FieldKey = brand(key);
 			const fieldSchema = target.getFieldSchema(fieldKey);
 			const multiplicity = target.lookupFieldKind(fieldKey).multiplicity;
-			if (target.has(fieldKey) && isPrimitiveValue(value)) {
-				assert(
-					multiplicity === Multiplicity.Value || multiplicity === Multiplicity.Optional,
-					0x4cf /* single value provided for an unsupported field */,
-				);
-				const possibleTypes = getPossibleTypes(
-					target.context.schema,
-					fieldSchema.types,
-					value,
-				);
-				if (possibleTypes.length > 1) {
-					const field = target.getField(fieldKey);
-					const node = field.getNode(0);
-					assertPrimitiveValueType(value, node[typeSymbol]);
-					node[valueSymbol] = value;
-					return true;
-				}
-			}
 			const content = applyFieldTypesFromContext(target.context.schema, fieldSchema, value);
 			const cursors = content.map(singleMapTreeCursor);
 			// This unconditionally uses `replaceField`, which differs from `createField`
@@ -393,13 +383,13 @@ const nodeProxyHandler: AdaptingProxyHandler<NodeProxyTarget, EditableTree> = {
 			// Since `insertNodes` and `replaceNodes` have same merge semantics with `replaceNodes`
 			// being a bit more general purpose function, it's ok to just use that.
 			if (multiplicity !== Multiplicity.Sequence) {
-				target.replaceField(fieldKey, cursors[0]);
+				assert(cursors.length <= 1, "more than one top level node in non-sequence filed");
+				target.replaceField(fieldKey, cursors.length === 0 ? undefined : cursors[0]);
 			} else {
 				target.replaceField(fieldKey, cursors);
 			}
 			return true;
-		}
-		if (key === valueSymbol) {
+		} else if (key === valueSymbol) {
 			target.value = value;
 			return true;
 		}

--- a/packages/dds/tree/src/feature-libraries/editable-tree/utilities.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/utilities.ts
@@ -4,11 +4,13 @@
  */
 
 import { TreeSchema, ValueSchema } from "../../core";
+import { forbidden } from "../defaultFieldKinds";
 
 /**
  * @returns true iff `schema` trees should default to being viewed as just their value when possible.
  *
- * Note that this may return true for some types which can not be unwrapped to just their value,
+ * @remarks
+ * This may return true for some types which EditableTree does not unwrap to just their value,
  * since EditableTree avoids ever unwrapping primitives that are objects
  * so users checking for primitives by type won't be broken.
  * Checking for this object case is done elsewhere.
@@ -20,7 +22,9 @@ export function isPrimitive(schema: TreeSchema): boolean {
 	return (
 		schema.value !== ValueSchema.Nothing &&
 		schema.localFields.size === 0 &&
-		schema.globalFields.size === 0
+		schema.globalFields.size === 0 &&
+		schema.extraGlobalFields === false &&
+		schema.extraLocalFields.kind.identifier === forbidden.identifier
 	);
 }
 

--- a/packages/dds/tree/src/test/feature-libraries/contextuallyTyped.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/contextuallyTyped.spec.ts
@@ -1,0 +1,61 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { ValueSchema } from "../../core";
+import { isPrimitiveValue } from "../../feature-libraries";
+// Allow importing from this specific file which is being tested:
+/* eslint-disable-next-line import/no-internal-modules */
+import { allowsValue } from "../../feature-libraries/contextuallyTyped";
+
+describe("ContextuallyTyped", () => {
+	it("isPrimitiveValue", () => {
+		assert(isPrimitiveValue(0));
+		assert(isPrimitiveValue(0.001));
+		assert(isPrimitiveValue(NaN));
+		assert(isPrimitiveValue(true));
+		assert(isPrimitiveValue(false));
+		assert(isPrimitiveValue(""));
+		assert(!isPrimitiveValue({}));
+		assert(!isPrimitiveValue(undefined));
+		assert(!isPrimitiveValue(null));
+		assert(!isPrimitiveValue([]));
+	});
+
+	it("allowsValue", () => {
+		assert(allowsValue(ValueSchema.Serializable, undefined));
+		assert(!allowsValue(ValueSchema.Boolean, undefined));
+		assert(allowsValue(ValueSchema.Nothing, undefined));
+		assert(!allowsValue(ValueSchema.String, undefined));
+		assert(!allowsValue(ValueSchema.Number, undefined));
+
+		assert(allowsValue(ValueSchema.Serializable, false));
+		assert(allowsValue(ValueSchema.Boolean, false));
+		assert(!allowsValue(ValueSchema.Nothing, false));
+		assert(!allowsValue(ValueSchema.String, false));
+		assert(!allowsValue(ValueSchema.Number, false));
+
+		assert(allowsValue(ValueSchema.Serializable, 5));
+		assert(!allowsValue(ValueSchema.Boolean, 5));
+		assert(!allowsValue(ValueSchema.Nothing, 5));
+		assert(!allowsValue(ValueSchema.String, 5));
+		assert(allowsValue(ValueSchema.Number, 5));
+
+		assert(allowsValue(ValueSchema.Serializable, ""));
+		assert(!allowsValue(ValueSchema.Boolean, ""));
+		assert(!allowsValue(ValueSchema.Nothing, ""));
+		assert(allowsValue(ValueSchema.String, ""));
+		assert(!allowsValue(ValueSchema.Number, ""));
+
+		assert(allowsValue(ValueSchema.Serializable, {}));
+		assert(!allowsValue(ValueSchema.Boolean, {}));
+		assert(!allowsValue(ValueSchema.Nothing, {}));
+		assert(!allowsValue(ValueSchema.String, {}));
+		assert(!allowsValue(ValueSchema.Number, {}));
+	});
+
+	// TODO: more tests
+});

--- a/packages/dds/tree/src/test/feature-libraries/defaultFieldKinds.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/defaultFieldKinds.spec.ts
@@ -36,14 +36,14 @@ import { assertMarkListEqual, fakeTaggedRepair as fakeRepair } from "../utils";
 
 const nodeSchema = TypedSchema.tree("Node", {
 	value: ValueSchema.String,
-	local: { foo: TypedSchema.field(FieldKinds.value, "Node") },
+	local: { foo: TypedSchema.field(FieldKinds.optional, "Node") },
 });
 
 const schemaData = SchemaAware.typedSchemaData([], nodeSchema);
 
 const tree1ContextuallyTyped: ContextuallyTypedNodeDataObject = {
 	[valueSymbol]: "value1",
-	foo: "value3",
+	foo: { [valueSymbol]: "value3" },
 };
 
 // TODO: This file is mainly working with in memory representations.

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
@@ -51,7 +51,6 @@ import {
 	float64Schema,
 	Phones,
 	phonesSchema,
-	decimalSchema,
 	personJsonableTree,
 } from "./mockData";
 
@@ -127,19 +126,21 @@ describe("editable-tree: editing", () => {
 		// polymorphic field supports:
 		// - Float64 schema (number-based)
 		// - Int32 schema (number-based)
-		// - Decimal schema (string-based)
 		// - String schema
 		maybePerson.salary = {
 			[valueSymbol]: "100.1",
-			[typeNameSymbol]: decimalSchema.name,
+			[typeNameSymbol]: stringSchema.name,
 		};
-		// basic primitive data type does match the current node type
+		// unambiguous type
 		maybePerson.salary = "not ok";
-		// basic primitive data type does not match the current node type
+		// ambiguous type since there are multiple options which are numbers:
 		assert.throws(
 			() => (maybePerson.salary = 99.99),
-			(e) => validateAssertionError(e, "unsupported schema for provided primitive"),
-			"Expected exception was not thrown",
+			(e) =>
+				validateAssertionError(
+					e,
+					"data compatible with more than one type allowed by the schema",
+				),
 		);
 		// explicit typing
 		maybePerson.salary = {

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/mockData.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/mockData.ts
@@ -45,10 +45,6 @@ export const stringSchema = TypedSchema.tree("String", {
 	value: ValueSchema.String,
 });
 
-export const decimalSchema = TypedSchema.tree("Decimal", {
-	value: ValueSchema.String,
-});
-
 export const int32Schema = TypedSchema.tree("Int32", {
 	value: ValueSchema.Number,
 });
@@ -116,13 +112,7 @@ export const personSchema = TypedSchema.tree("Test:Person-1.0.0", {
 		name: TypedSchema.field(FieldKinds.value, stringSchema),
 		age: TypedSchema.field(FieldKinds.optional, int32Schema),
 		adult: TypedSchema.field(FieldKinds.optional, boolSchema),
-		salary: TypedSchema.field(
-			FieldKinds.optional,
-			float64Schema,
-			int32Schema,
-			stringSchema,
-			decimalSchema,
-		),
+		salary: TypedSchema.field(FieldKinds.optional, float64Schema, int32Schema, stringSchema),
 		friends: TypedSchema.field(FieldKinds.optional, mapStringSchema),
 		address: TypedSchema.field(FieldKinds.optional, addressSchema),
 	},
@@ -156,7 +146,6 @@ export const treeSchema = [
 	addressSchema,
 	mapStringSchema,
 	personSchema,
-	decimalSchema,
 ] as const;
 
 export const fullSchemaData = SchemaAware.typedSchemaData(

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/utilities.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/utilities.spec.ts
@@ -9,7 +9,6 @@ import {
 	defaultSchemaPolicy,
 	FieldKinds,
 	Multiplicity,
-	isPrimitiveValue,
 	getPrimaryField,
 	getFieldKind,
 	getFieldSchema,
@@ -44,21 +43,8 @@ describe("editable-tree utilities", () => {
 	it("isPrimitive", () => {
 		assert(isPrimitive(int32Schema));
 		assert(isPrimitive(stringSchema));
-		assert(isPrimitive(mapStringSchema));
+		assert(!isPrimitive(mapStringSchema));
 		assert(!isPrimitive(optionalChildSchema));
-	});
-
-	it("isPrimitiveValue", () => {
-		assert(isPrimitiveValue(0));
-		assert(isPrimitiveValue(0.001));
-		assert(isPrimitiveValue(NaN));
-		assert(isPrimitiveValue(true));
-		assert(isPrimitiveValue(false));
-		assert(isPrimitiveValue(""));
-		assert(!isPrimitiveValue({}));
-		assert(!isPrimitiveValue(undefined));
-		assert(!isPrimitiveValue(null));
-		assert(!isPrimitiveValue([]));
 	});
 
 	it("field utils", () => {


### PR DESCRIPTION
## Description

Fixes a few issues with contextual type handlining and editing.
Makes assignment in editable tree no longer depend on the type of the data being assigned over, but just depend on the type of the field being assigned into.
Allow contextually typed node data to disambiguate objects with fields from primitives (which can't have fields) implicitly.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).