### PR TITLE
[main > release/v2int/4.0]: Improve Fluid cache perf for odsp driver (#14832)

### DIFF
--- a/packages/drivers/driver-web-cache/src/FluidCacheIndexedDb.ts
+++ b/packages/drivers/driver-web-cache/src/FluidCacheIndexedDb.ts
@@ -127,6 +127,8 @@ export interface FluidCacheDBSchema extends DBSchema {
 			/**
 			 * The last time the cache entry was used.
 			 * This is initially set to the time the cache entry was created Measured as ms since unix epoch.
+			 * With the recent change, this won't be updated on read as it will not be used anywhere. Only keeping
+			 * so as to not upgrade the schema version.
 			 */
 			lastAccessTimeMs: number;
 		};

--- a/packages/drivers/driver-web-cache/src/test/FluidCache.test.ts
+++ b/packages/drivers/driver-web-cache/src/test/FluidCache.test.ts
@@ -212,34 +212,6 @@ describe("Fluid Cache tests", () => {
 		clearDateMock();
 	});
 
-	it("updates the last accessed time when reading a value from storage", async () => {
-		// We need to mock out the Date API to make this test work
-		const clearDateMock = setupDateMock(100);
-		const fluidCache = getFluidCache();
-
-		const cacheEntry = getMockCacheEntry("shouldUpdateLastAccessedTime");
-		const cachedItem = { dateToStore: "foo" };
-
-		await fluidCache.put(cacheEntry, cachedItem);
-
-		const db = await getFluidCacheIndexedDbInstance();
-
-		expect(
-			(await db.get(FluidDriverObjectStoreName, getKeyForCacheEntry(cacheEntry)))
-				?.lastAccessTimeMs,
-		).toBe(100);
-
-		DateMock.mockTimeMs = 800;
-		await fluidCache.get(cacheEntry);
-
-		expect(
-			(await db.get(FluidDriverObjectStoreName, getKeyForCacheEntry(cacheEntry)))
-				?.lastAccessTimeMs,
-		).toEqual(800);
-
-		clearDateMock();
-	});
-
 	it("does not throw when APIs are called and the database has been upgraded by another client", async () => {
 		// Create a DB with a much newer version number to simulate an old client
 		await openDB(FluidDriverCacheDBName, 1000000);


### PR DESCRIPTION
## Description

1.) Stop tracking of lastAccessTime internally in Fluid driver cache as deletion/not use policy is based upon maxCacheItemAge. It will help in saving perf and on every read we don't have to open/close db twice due to not have to do this extra transaction where we update the last Access time.
2.) Because of above, updated the version of the db too. 3.) Modified item cleaning based on maxCacheItemAge.

This is first step in solving
https://dev.azure.com/fluidframework/internal/_workitems/edit/3594

