### PR TITLE
docs (protocol-definitions): Update documentation for MessageType.Operation 

### DIFF
--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -53,7 +53,7 @@ export enum MessageType {
 	SummaryNack = "summaryNack",
 
 	/**
-	 * Channel operation (op).
+	 * Operation (op) produced by container runtime.
 	 */
 	Operation = "op",
 


### PR DESCRIPTION
# Description
Updating the documentation for MessageType.Operation as the prior description referred to a retired concept.

# Reviewer Guidance
It might make sense to go over all the Op docs in this file and see if we can update them as well if it's needed.