### PR TITLE
Fix for deleted nodes changes not considered when doing incremental summary of GC data

### DIFF
--- a/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
@@ -19,6 +19,8 @@ import { getGCDataFromSnapshot, generateSortedGCState, getGCVersion } from "./gc
 import { IGarbageCollectionSnapshotData, IGarbageCollectionState } from "./gcSummaryDefinitions";
 import { IGarbageCollectorConfigs } from ".";
 
+export const gcStateBlobKey = `${gcBlobPrefix}_root`;
+
 /**
  * The GC data that is tracked for a summary.
  */
@@ -162,7 +164,8 @@ export class GCSummaryStateTracker {
 			// If nothing changed since last summary, send a summary handle for the entire GC data.
 			if (
 				this.latestSummaryData.serializedGCState === serializedGCState &&
-				this.latestSummaryData.serializedTombstones === serializedTombstones
+				this.latestSummaryData.serializedTombstones === serializedTombstones &&
+				this.latestSummaryData.serializedDeletedNodes === serializedDeletedNodes
 			) {
 				const stats = mergeStats();
 				stats.handleNodeCount++;
@@ -209,7 +212,6 @@ export class GCSummaryStateTracker {
 		serializedDeletedNodes: string | undefined,
 		trackState: boolean,
 	): ISummaryTreeWithStats {
-		const gcStateBlobKey = `${gcBlobPrefix}_root`;
 		const builder = new SummaryTreeBuilder();
 
 		// If the GC state hasn't changed, write a summary handle, else write a summary blob for it.

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -53,7 +53,11 @@ export {
 	IGarbageCollectionState,
 	IGarbageCollectionSummaryDetailsLegacy,
 } from "./gcSummaryDefinitions";
-export { GCSummaryStateTracker, IGCSummaryTrackingData } from "./gcSummaryStateTracker";
+export {
+	gcStateBlobKey,
+	GCSummaryStateTracker,
+	IGCSummaryTrackingData,
+} from "./gcSummaryStateTracker";
 export {
 	skipClosureForXDaysKey,
 	closuresMapLocalStorageKey,

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -4,7 +4,15 @@
  */
 
 import { strict as assert } from "assert";
-import { GCSummaryStateTracker, GCVersion } from "../../gc";
+import { SummaryType } from "@fluidframework/protocol-definitions";
+import { gcDeletedBlobKey, gcTombstoneBlobKey } from "@fluidframework/runtime-definitions";
+import {
+	currentGCVersion,
+	gcStateBlobKey,
+	GCSummaryStateTracker,
+	GCVersion,
+	IGarbageCollectionState,
+} from "../../gc";
 
 type GCSummaryStateTrackerWithPrivates = Omit<GCSummaryStateTracker, "latestSummaryGCVersion"> & {
 	latestSummaryGCVersion: GCVersion;
@@ -69,6 +77,142 @@ describe("Garbage Collection Tests", () => {
 					tracker.doesSummaryStateNeedReset,
 					true,
 					"Should need reset: Persisted GC Version is not old",
+				);
+			});
+		});
+
+		/**
+		 * These tests validate that the GC data is written in summary incrementally. Basically, only parts of the GC
+		 * data that has changed since the last successful summary is re-written, rest is written as SummaryHandle.
+		 */
+		describe("Incremental summary of GC data", () => {
+			const nodes = ["node1", "node2", "node3"];
+			const initialGCState: IGarbageCollectionState = {
+				gcNodes: {
+					"/": { outboundRoutes: [] },
+					[nodes[0]]: { outboundRoutes: [] },
+					[nodes[1]]: { outboundRoutes: [] },
+				},
+			};
+			const initialTombstones: string[] = [nodes[0], nodes[1]];
+			const initialDeletedNodes: Set<string> = new Set([nodes[1]]);
+			let summaryStateTracker: GCSummaryStateTracker;
+
+			beforeEach(async () => {
+				// Creates a summary state tracker and initialize it.
+				summaryStateTracker = new GCSummaryStateTracker(
+					{
+						shouldRunGC: true,
+						tombstoneMode: true,
+						gcVersionInBaseSnapshot: currentGCVersion,
+						gcVersionInEffect: currentGCVersion,
+					},
+					false,
+				);
+
+				summaryStateTracker.initializeBaseState({
+					gcState: initialGCState,
+					tombstones: initialTombstones,
+					deletedNodes: Array.from(initialDeletedNodes),
+				});
+			});
+
+			it("does incremental summary when nothing changes", async () => {
+				// Summarize with the same GC state, tombstone state and deleted nodes as in the initial state.
+				// The GC data should be summarized as a summary handle.
+				const summary = summaryStateTracker.summarize(
+					false /* fullTree */,
+					true /* trackState */,
+					initialGCState,
+					initialDeletedNodes,
+					initialTombstones,
+				);
+				assert(
+					summary?.summary.type === SummaryType.Handle,
+					"GC summary should be a handle",
+				);
+			});
+
+			it("does incremental summary when only GC state changes", async () => {
+				// Summarize with the same tombstone state and deleted nodes but different GC state as in the initial.
+				// state. The GC state should be summarized as a summary handle.
+				const newGCState: IGarbageCollectionState = {
+					gcNodes: {
+						...initialGCState.gcNodes,
+						[nodes[2]]: { outboundRoutes: [] },
+					},
+				};
+				const summary = summaryStateTracker.summarize(
+					false /* fullTree */,
+					true /* trackState */,
+					newGCState,
+					initialDeletedNodes,
+					initialTombstones,
+				);
+				assert(summary?.summary.type === SummaryType.Tree, "GC summary should be a tree");
+				assert(
+					summary.summary.tree[gcStateBlobKey].type === SummaryType.Blob,
+					"GC state should be written as a blob",
+				);
+				assert(
+					summary.summary.tree[gcTombstoneBlobKey].type === SummaryType.Handle,
+					"Tombstone state should be written as handle",
+				);
+				assert(
+					summary.summary.tree[gcDeletedBlobKey].type === SummaryType.Handle,
+					"Deleted nodes should be written as handle",
+				);
+			});
+
+			it("does incremental summary when only tombstone state changes", async () => {
+				// Summarize with the same GC state and deleted nodes but different tombstone state as in the initial.
+				// state. The tombstone state should be summarized as a summary handle.
+				const newTombstones: string[] = Array.from([...initialTombstones, nodes[2]]);
+				const summary = summaryStateTracker.summarize(
+					false /* fullTree */,
+					true /* trackState */,
+					initialGCState,
+					initialDeletedNodes,
+					newTombstones,
+				);
+				assert(summary?.summary.type === SummaryType.Tree, "GC summary should be a tree");
+				assert(
+					summary.summary.tree[gcStateBlobKey].type === SummaryType.Handle,
+					"GC state should be written as handle",
+				);
+				assert(
+					summary.summary.tree[gcTombstoneBlobKey].type === SummaryType.Blob,
+					"Tombstone state should be written as a blob",
+				);
+				assert(
+					summary.summary.tree[gcDeletedBlobKey].type === SummaryType.Handle,
+					"Deleted nodes should be written as handle",
+				);
+			});
+
+			it("does incremental summary when only deleted nodes change", async () => {
+				// Summarize with the same GC state and tombstone state but different deleted nodes as in the initial.
+				// state. The deleted nodes should be summarized as a summary handle.
+				const newDeletedNodes: Set<string> = new Set(...initialDeletedNodes, nodes[2]);
+				const summary = summaryStateTracker.summarize(
+					false /* fullTree */,
+					true /* trackState */,
+					initialGCState,
+					newDeletedNodes,
+					initialTombstones,
+				);
+				assert(summary?.summary.type === SummaryType.Tree, "GC summary should be a tree");
+				assert(
+					summary.summary.tree[gcStateBlobKey].type === SummaryType.Handle,
+					"GC state should be written as handle",
+				);
+				assert(
+					summary.summary.tree[gcTombstoneBlobKey].type === SummaryType.Handle,
+					"Tombstone state should be written as handle",
+				);
+				assert(
+					summary.summary.tree[gcDeletedBlobKey].type === SummaryType.Blob,
+					"Deleted nodes should be written as a blob",
 				);
 			});
 		});


### PR DESCRIPTION
## Bug
If the only change in GC data is deleted nodes, the GC data is written as a handle and the changes to deleted nodes will be lost. The issue is the following code which does not compare deleted nodes across summaries:
```
    // If nothing changed since last summary, send a summary handle for the entire GC data.
    if (
        this.latestSummaryData.serializedGCState === serializedGCState &&
        this.latestSummaryData.serializedTombstones === serializedTombstones
    ) {
        const stats = mergeStats();
        stats.handleNodeCount++;
        return {
            summary: {
                type: SummaryType.Handle,
                handle: `/${gcTreeKey}`,
                handleType: SummaryType.Tree,
            },
            stats,
        };
    }

```
 Since sweep is not enabled yet, deleted nodes are not written so this should not be a problem yet. 

## Fix
The fix is to compare deleted nodes across summaries as well in the above piece of code. Also, added unit tests for incremental summaries.

[AB#3903](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3903)