### PR TITLE
Change `TestObjectProvider.loadContainer` default to use delayed load mode

### DIFF
--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -3,7 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { IContainer, IHostLoader, IFluidCodeDetails } from "@fluidframework/container-definitions";
+import {
+	IContainer,
+	IHostLoader,
+	IFluidCodeDetails,
+	LoaderHeader,
+} from "@fluidframework/container-definitions";
 import {
 	ITelemetryGenericEvent,
 	ITelemetryBaseLogger,
@@ -377,10 +382,37 @@ export class TestObjectProvider implements ITestObjectProvider {
 		requestHeader?: IRequestHeader,
 	): Promise<IContainer> {
 		const loader = this.createLoader([[defaultCodeDetails, entryPoint]], loaderProps);
-		return loader.resolve({
+
+		// Once ADO#3889 is done to switch default connection mode to "read" on load, we don't need
+		// to load "delayed" across the board. Remove the following code.
+		const delayConnection =
+			requestHeader === undefined || requestHeader[LoaderHeader.reconnect] !== false;
+		const headers: IRequestHeader = delayConnection
+			? {
+					[LoaderHeader.loadMode]: { deltaConnection: "delayed" },
+					...requestHeader,
+			  }
+			: requestHeader;
+
+		const container = await loader.resolve({
 			url: await this.driver.createContainerUrl(this.documentId),
-			headers: requestHeader,
+			headers,
 		});
+
+		// Once ADO#3889 is done to switch default connection mode to "read" on load, we don't need
+		// to load "delayed" across the board. Remove the following code.
+
+		if (delayConnection) {
+			// Older version might have the connect function, but that also means that delayed doesn't work
+			if ((container as any).connect !== undefined) {
+				container.connect();
+			} else {
+				// back compat
+				(container as any).resume();
+			}
+		}
+
+		return container;
 	}
 
 	/**

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -401,10 +401,10 @@ export class TestObjectProvider implements ITestObjectProvider {
 
 		// Once ADO#3889 is done to switch default connection mode to "read" on load, we don't need
 		// to load "delayed" across the board. Remove the following code.
-
 		if (delayConnection) {
-			// Older version might have the connect function, but that also means that delayed doesn't work
-			if ((container as any).connect !== undefined) {
+			// Older version may not have connect, use resume instead.
+			const maybeContainer = container as Partial<IContainer>;
+			if (maybeContainer.connect !== undefined) {
 				container.connect();
 			} else {
 				// back compat


### PR DESCRIPTION
Currently when loading a container, the default for the initial connection is "write" mode. However, if delayed load mode is used, the initial connection mode is "read".  We don't have test coverage when the container is loaded as "read" by default.

This PR fixes [AB#3900](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3900). It will partially make our e2e test to cover delayed mode because of the default connection mode behavior. This is part one of the work that will cover tests that use `TestObjectProvider.loadContainer`.  A future PR for the next work item [AB#3904](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3904) and [AB#3901](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3901) will track the rest.

The change add the `loadMode.deltaConnection = "delayed"` to the header, if the caller doesn't specify and `loadMode` header.  The exception is that if the test asked for `reconnect: false` in the header, we can't use delayed load mode, because the `connect` call implicitly assumes we want to reset the reconnection mode to enabled, which is a possible API gap. 

The only tests that needed to be fixed are `AgentScheduler` tests, where it tries to use the call to register a task to generate an 'op' and force it to switch to write mode. However, the op is not generated if the task already exists.  The fix is to generate different name every time `forceWrite` is called.

The change is also been tested with targeting ODSP, and no additional unique failures compare to baseline in the `main` branch.