### PR TITLE
feat(client-debugger): Add the ability for applications to supply custom DDS visualizers

### DIFF
--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -13,6 +13,7 @@ import { IDisposable } from '@fluidframework/common-definitions';
 import { IEvent } from '@fluidframework/common-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
+import { ISharedObject } from '@fluidframework/shared-object-base';
 import { ITelemetryBaseEvent } from '@fluidframework/common-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ITelemetryLoggerPropertyBags } from '@fluidframework/telemetry-utils';
@@ -162,6 +163,7 @@ export interface FluidClientDebuggerProps {
     containerData?: Record<string, IFluidLoadable>;
     containerId: string;
     containerNickname?: string;
+    dataVisualizers?: Record<string, VisualizeSharedObject>;
 }
 
 // @internal @sealed
@@ -407,6 +409,12 @@ export interface ValueNodeBase extends VisualNodeBase {
 
 // @public
 export type VisualChildNode = VisualTreeNode | VisualValueNode | FluidHandleNode | UnknownObjectNode;
+
+// @public
+export type VisualizeChildData = (data: unknown) => Promise<VisualChildNode>;
+
+// @public
+export type VisualizeSharedObject = (sharedObject: ISharedObject, visualizeChildData: VisualizeChildData) => Promise<FluidObjectNode>;
 
 // @public
 export type VisualNode = VisualTreeNode | VisualValueNode | FluidHandleNode | FluidObjectTreeNode | FluidObjectValueNode | FluidUnknownObjectNode | UnknownObjectNode;

--- a/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
@@ -398,11 +398,13 @@ export class FluidClientDebugger
 		this._connectionStateLog = [];
 		this._audienceChangeLog = [];
 
-		// TODO: accept custom visualizers.
 		this.dataVisualizer =
 			props.containerData === undefined
 				? undefined
-				: new DataVisualizerGraph(props.containerData, defaultVisualizers);
+				: new DataVisualizerGraph(props.containerData, {
+						...defaultVisualizers,
+						...props.dataVisualizers, // User-specified visualizers take precedence over system defaults
+				  });
 		this.dataVisualizer?.on("update", this.dataUpdateHandler);
 
 		// Bind Container events required for change-logging

--- a/packages/tools/client-debugger/client-debugger/src/Registry.ts
+++ b/packages/tools/client-debugger/client-debugger/src/Registry.ts
@@ -17,6 +17,7 @@ import {
 	postMessagesToWindow,
 	RegistryChangeMessage,
 } from "./messaging";
+import { VisualizeSharedObject } from "./data-visualization";
 
 // TODOs:
 // - Clear registry on `window.beforeunload`, to ensure we do not hold onto stale resources.
@@ -73,6 +74,19 @@ export interface FluidClientDebuggerProps {
 	 * debugger instances.
 	 */
 	containerNickname?: string;
+
+	/**
+	 * (optional) Configurations for generating visual representations of
+	 * {@link @fluidframework/shared-object-base#ISharedObject}s under {@link FluidClientDebuggerProps.containerData}.
+	 *
+	 * @remarks
+	 *
+	 * If not specified, then only `SharedObject` types natively known by the system will be visualized, and using
+	 * default visualization implementations.
+	 *
+	 * Provided visualizer configurations will be used in place of system defaults if specified.
+	 */
+	dataVisualizers?: Record<string, VisualizeSharedObject>;
 }
 
 /**

--- a/packages/tools/client-debugger/client-debugger/src/Registry.ts
+++ b/packages/tools/client-debugger/client-debugger/src/Registry.ts
@@ -84,7 +84,7 @@ export interface FluidClientDebuggerProps {
 	 * If not specified, then only `SharedObject` types natively known by the system will be visualized, and using
 	 * default visualization implementations.
 	 *
-	 * Provided visualizer configurations will be used in place of system defaults if specified.
+	 * If a visualizer configuration is specified for a shared object type that has a default visualizer, the custom one will be used.
 	 */
 	dataVisualizers?: Record<string, VisualizeSharedObject>;
 }

--- a/packages/tools/client-debugger/client-debugger/src/data-visualization/DataVisualization.ts
+++ b/packages/tools/client-debugger/client-debugger/src/data-visualization/DataVisualization.ts
@@ -48,6 +48,8 @@ export type SharedObjectType = string;
  * @param visualizeChildData - Callback to render child content of the shared object.
  *
  * @returns A visual tree representation of the provided `sharedObject`.
+ *
+ * @public
  */
 export type VisualizeSharedObject = (
 	sharedObject: ISharedObject,
@@ -67,6 +69,8 @@ export type VisualizeSharedObject = (
  * - A handle to another Fluid object
  *
  * @returns A visual tree representation of the input `data`.
+ *
+ * @public
  */
 export type VisualizeChildData = (data: unknown) => Promise<VisualChildNode>;
 

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -64,6 +64,8 @@ export {
 	VisualNodeKind,
 	VisualTreeNode,
 	VisualValueNode,
+	VisualizeChildData,
+	VisualizeSharedObject,
 	UnknownObjectNode,
 } from "./data-visualization";
 export { IFluidClientDebugger, IFluidClientDebuggerEvents } from "./IFluidClientDebugger";


### PR DESCRIPTION
Applications may now specify custom DDS visualizers at debugger initialization. These can be used to...
1. Supply visualizers for custom DDSs / any not natively known to the debugger
2. Supply custom overrides for default visualizers bundled with the system