### PR TITLE
build fix: add 'copyfiles' dep to 'local-driver'

### DIFF
--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -95,6 +95,7 @@
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
 		"concurrently": "^7.6.0",
+		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.6.0",
 		"mocha": "^10.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6563,6 +6563,7 @@ importers:
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
       concurrently: ^7.6.0
+      copyfiles: ^2.4.1
       cross-env: ^7.0.3
       eslint: ~8.6.0
       events: ^3.1.0
@@ -6609,6 +6610,7 @@ importers:
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
       concurrently: 7.6.0
+      copyfiles: 2.4.1
       cross-env: 7.0.3
       eslint: 8.6.0
       mocha: 10.2.0
@@ -22619,7 +22621,7 @@ packages:
   /axios/0.21.4_debug@4.3.2:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2_debug@4.3.2
     transitivePeerDependencies:
       - debug
 
@@ -28012,6 +28014,17 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  /follow-redirects/1.15.2_debug@4.3.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.2
 
   /follow-redirects/1.15.2_debug@4.3.4:
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}


### PR DESCRIPTION
'local-driver' failed to build in a fresh codespace due to the missing dev dependency on 'copyfiles'