### PR TITLE
Discussion draft for alternative SharedTree emit & collect eventing functionality

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -659,6 +659,7 @@ export interface IEditableForest extends IForestSubscription {
 // @alpha
 export interface IEmitter<E extends Events<E>> {
     emit<K extends keyof Events<E>>(eventName: K, ...args: Parameters<E[K]>): void;
+    emitAndCollect<K extends keyof Events<E>>(eventName: K, ...args: Parameters<E[K]>): ReturnType<E[K]>[];
 }
 
 // @alpha


### PR DESCRIPTION
## Description
Enhancement to the `SharedTree` event library which adds experimental ability to collect the execution  results of the registered listeners.

The requirements for the feature are based on the @DLehenbauer & @CraigMacomber implementation ideas for the [SharedTree DataBinder story](https://github.com/microsoft/FluidFramework/issues/14293#issuecomment-1485928510). 

The new feature introduces no regressions to the existing functionality.

## Observation
One of the core motivations for event-based integration is the promise of components decoupling. The added functionality reverses conceptually this benefit and can have negative consequences in many areas where event-based integration shines: independent component evolution and deployment, scalability, etc.

It's important to use this pattern judiciously and consider the trade-offs. Proper warnings are added to the relevant documentation sections.

## Reviewer Guidance
New tests, covering the consumption of listener results, added. All `SharedTree` yield green results.
The `eventEmitter.spec.ts` covers also the compilation validation of the `emitAndCollect` return type in case of inheritance and composition usage.
