### PR TITLE
docs(r11s-internal-cluster): Update deployment configuration for r11s AKS cluster

### DIFF
--- a/server/routerlicious/kubernetes/nginx/README.md
+++ b/server/routerlicious/kubernetes/nginx/README.md
@@ -66,7 +66,7 @@ helm upgrade --install --set controller.image.registry=<registry> \
 	--set controller.image.tag=<optional-tag> \
 	--set controller.image.digest=<optional-digest> \
 	$HELM_RELEASE_NAME $HELM_CHART_NAME --version $HELM_CHART_VERSION --repo $HELM_CHART_REPO -f $VALUES_FILE --namespace $K8S_NAMESPACE --create-namespace
-
+```
 
 The output will include a command that you can use to check the status of the `Service` object, something similar to this:
 

--- a/server/routerlicious/kubernetes/nginx/README.md
+++ b/server/routerlicious/kubernetes/nginx/README.md
@@ -30,7 +30,8 @@ The deployed certificates for the CI environments are (`<namespace>/<name>`):
 
 ## Deploy Helm chart for the ingress controller
 
-**NOTE**: This will work for an rbac-enabled cluster. A non-rbac cluster will require non-trivial changes to these steps.
+**NOTE**: This will work for an rbac-enabled cluster.
+A non-rbac cluster will require non-trivial changes to these steps.
 
 First, define variables that depend on the environment.
 
@@ -50,12 +51,15 @@ HELM_RELEASE_NAME=ingress-controller-prod
 VALUES_FILE=values-prod.yaml
 ```
 
-Then define some common variables and deploy the Helm chart. In the following commands you can omit the optional key+value pairs to use the defaults defined in the Helm Chart.
+Then define some common variables and deploy the Helm chart.
+In the following command you can omit the `--set controller.image.*` overrides to use the defaults defined in the Helm Chart.
+For the appropriate values when deploying this to the FluidFramework team's internal test cluster, refer to our internal
+documentation.
 
 ```bash
 HELM_CHART_NAME=ingress-nginx
 HELM_CHART_REPO=https://kubernetes.github.io/ingress-nginx
-HELM_CHART_VERSION=4.2.1
+HELM_CHART_VERSION=4.6.0
 
 helm upgrade --install --set controller.image.registry=<registry> \
 	--set controller.image.image=<optional-repo-name> \

--- a/server/routerlicious/kubernetes/nginx/values-ppe.yaml
+++ b/server/routerlicious/kubernetes/nginx/values-ppe.yaml
@@ -11,6 +11,17 @@ controller:
     default-ssl-certificate: default/wu2-ppe-tls-certificate
   admissionWebhooks:
     enabled: False # Disable admission webhooks endpoint to keep moving parts to a minimum as long as we don't use it
+  service:
+    annotations:
+      # This annotation is necessary for external traffic to reach the pods correctly in AKS.
+      # Without it, health probes on the automatically-created load balancer will have an incorrect path, fail because
+      # of that, and make it look like the targets of the load balancing rules are unhealthy, which results in external
+      # requests hanging instead of getting routed to the appropriate pods.
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+    # The "Local" external traffic policy ensures that the source IP of external requests to the AKS cluster isn't
+    # completely lost as they go throught network translation inside the AKS cluster in order to get to a pod.
+    # See https://learn.microsoft.com/en-us/azure/aks/concepts-network#client-source-ip-preservation for details.
+    externalTrafficPolicy: Local
 
 # Strong DH params generated with 'openssl dhparam -out dhparam.pem 4096'
 dhParam: "LS0tLS1CRUdJTiBESCBQQVJBTUVURVJTLS0tLS0KTUlJQ0NBS0NBZ0VBbk03d1NsNWNIR25HOFdiRk85NW54T21YUkIzU3l1MFFpbzJXZlFBS2tRRkRiaS9wYk9McgpXZDBjS1U1cHZrQzVKVFg1eDNwOENBT21hL1gvaWxMNC9CclFRMHFhdEhHMzdhQ0FGN3dvSUppUDZHS1lOR0l0Cms0d3krc2NOZzN0RVRxRmovQnZEM0orYU5rSUY4dFRPcHJLLzZ2SFp6Vmw3bzAxSEV1NThxRS9hS3M3SDJpRm4KUW1wNklneW5sY1RwTUtEZ0xwbk5nL2FhQmQxdkRkL245djNyeFRrU2pmT1Q1T2NoMXYwdjRVWENxejJDbGIrWgp5czk5VjJZRHRoYnVjaVpQb2FvT3NTQmhFejdEWS85dnJEa2RnRGtKbU5oT3ZjZEdhMm1KbjAydkx5NWxCaExiCmZpSXA5NHJRMUZaQzNPT2R1VkRDaldsR0FEVnJGdWZMakgrSHNwOWk1M0k4Umg2T0YzT0FkODAxU3dXWTh0aTQKOVNibFJuTU5LUlNHT04zNmxGTXEvOFhaaEx6MHNPN3pMcjlrOE9td2xDTVJmNldNdHBId2tteDFrMHRkU1l5bwpjc1R5RjVVR3hUVGYzTmFOWHJjYVc1V2RDVG5kWU45OWpKRmxRYVFUOE5VZEJMaDBSZ0d0MGJzMVlTMzJoeGgrCnRJekVBcDVPYk5BWGlpakxlR200eDhRYXE3NFZXNDBUYk1qdzlKZUtoRmdCYnlvZ290QXVjZkczWWJlVEN2c04KRXp0cXVMNCtJV3FWN1krZVFnTDFGUVIvanZVVkI2Vk00NUlhY1VKU0lJRWFodUhPVDZNbXJUN3NSOEw3YnMvcAp6Mk1TeW1BTVZaNjVtT2R2Q0d2SUtZUSswblBCT1ZURFF0N204MDl6MUppUTlMdUpUYnhSaUhNQ0FRST0KLS0tLS1FTkQgREggUEFSQU1FVEVSUy0tLS0tCg=="

--- a/server/routerlicious/kubernetes/nginx/values-ppe.yaml
+++ b/server/routerlicious/kubernetes/nginx/values-ppe.yaml
@@ -17,9 +17,10 @@ controller:
       # Without it, health probes on the automatically-created load balancer will have an incorrect path, fail because
       # of that, and make it look like the targets of the load balancing rules are unhealthy, which results in external
       # requests hanging instead of getting routed to the appropriate pods.
+      # More details at https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/#custom-load-balancer-health-probe
       service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
     # The "Local" external traffic policy ensures that the source IP of external requests to the AKS cluster isn't
-    # completely lost as they go throught network translation inside the AKS cluster in order to get to a pod.
+    # completely lost as they go through network translation inside the AKS cluster in order to get to a pod.
     # See https://learn.microsoft.com/en-us/azure/aks/concepts-network#client-source-ip-preservation for details.
     externalTrafficPolicy: Local
 

--- a/server/routerlicious/kubernetes/nginx/values-ppe.yaml
+++ b/server/routerlicious/kubernetes/nginx/values-ppe.yaml
@@ -13,7 +13,8 @@ controller:
     enabled: False # Disable admission webhooks endpoint to keep moving parts to a minimum as long as we don't use it
   service:
     annotations:
-      # This annotation is necessary for external traffic to reach the pods correctly in AKS.
+      # This annotation is necessary for external traffic to reach the pods correctly in AKS (Azure Kubernetes Service,
+      # https://learn.microsoft.com/en-us/azure/aks/).
       # Without it, health probes on the automatically-created load balancer will have an incorrect path, fail because
       # of that, and make it look like the targets of the load balancing rules are unhealthy, which results in external
       # requests hanging instead of getting routed to the appropriate pods.

--- a/server/routerlicious/kubernetes/nginx/values-prod.yaml
+++ b/server/routerlicious/kubernetes/nginx/values-prod.yaml
@@ -11,6 +11,17 @@ controller:
     default-ssl-certificate: default/wu2-tls-certificate
   admissionWebhooks:
     enabled: False # Disable admission webhooks endpoint to keep moving parts to a minimum as long as we don't use it
+  service:
+    annotations:
+      # This annotation is necessary for external traffic to reach the pods correctly in AKS.
+      # Without it, health probes on the automatically-created load balancer will have an incorrect path, fail because
+      # of that, and make it look like the targets of the load balancing rules are unhealthy, which results in external
+      # requests hanging instead of getting routed to the appropriate pods.
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+    # The "Local" external traffic policy ensures that the source IP of external requests to the AKS cluster isn't
+    # completely lost as they go throught network translation inside the AKS cluster in order to get to a pod.
+    # See https://learn.microsoft.com/en-us/azure/aks/concepts-network#client-source-ip-preservation for details.
+    externalTrafficPolicy: Local
 
 # Strong DH params generated with 'openssl dhparam -out dhparam.pem 4096'
 dhParam: "LS0tLS1CRUdJTiBESCBQQVJBTUVURVJTLS0tLS0KTUlJQ0NBS0NBZ0VBbk03d1NsNWNIR25HOFdiRk85NW54T21YUkIzU3l1MFFpbzJXZlFBS2tRRkRiaS9wYk9McgpXZDBjS1U1cHZrQzVKVFg1eDNwOENBT21hL1gvaWxMNC9CclFRMHFhdEhHMzdhQ0FGN3dvSUppUDZHS1lOR0l0Cms0d3krc2NOZzN0RVRxRmovQnZEM0orYU5rSUY4dFRPcHJLLzZ2SFp6Vmw3bzAxSEV1NThxRS9hS3M3SDJpRm4KUW1wNklneW5sY1RwTUtEZ0xwbk5nL2FhQmQxdkRkL245djNyeFRrU2pmT1Q1T2NoMXYwdjRVWENxejJDbGIrWgp5czk5VjJZRHRoYnVjaVpQb2FvT3NTQmhFejdEWS85dnJEa2RnRGtKbU5oT3ZjZEdhMm1KbjAydkx5NWxCaExiCmZpSXA5NHJRMUZaQzNPT2R1VkRDaldsR0FEVnJGdWZMakgrSHNwOWk1M0k4Umg2T0YzT0FkODAxU3dXWTh0aTQKOVNibFJuTU5LUlNHT04zNmxGTXEvOFhaaEx6MHNPN3pMcjlrOE9td2xDTVJmNldNdHBId2tteDFrMHRkU1l5bwpjc1R5RjVVR3hUVGYzTmFOWHJjYVc1V2RDVG5kWU45OWpKRmxRYVFUOE5VZEJMaDBSZ0d0MGJzMVlTMzJoeGgrCnRJekVBcDVPYk5BWGlpakxlR200eDhRYXE3NFZXNDBUYk1qdzlKZUtoRmdCYnlvZ290QXVjZkczWWJlVEN2c04KRXp0cXVMNCtJV3FWN1krZVFnTDFGUVIvanZVVkI2Vk00NUlhY1VKU0lJRWFodUhPVDZNbXJUN3NSOEw3YnMvcAp6Mk1TeW1BTVZaNjVtT2R2Q0d2SUtZUSswblBCT1ZURFF0N204MDl6MUppUTlMdUpUYnhSaUhNQ0FRST0KLS0tLS1FTkQgREggUEFSQU1FVEVSUy0tLS0tCg=="

--- a/server/routerlicious/kubernetes/nginx/values-prod.yaml
+++ b/server/routerlicious/kubernetes/nginx/values-prod.yaml
@@ -17,9 +17,10 @@ controller:
       # Without it, health probes on the automatically-created load balancer will have an incorrect path, fail because
       # of that, and make it look like the targets of the load balancing rules are unhealthy, which results in external
       # requests hanging instead of getting routed to the appropriate pods.
+      # More details at https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/#custom-load-balancer-health-probe
       service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
     # The "Local" external traffic policy ensures that the source IP of external requests to the AKS cluster isn't
-    # completely lost as they go throught network translation inside the AKS cluster in order to get to a pod.
+    # completely lost as they go through network translation inside the AKS cluster in order to get to a pod.
     # See https://learn.microsoft.com/en-us/azure/aks/concepts-network#client-source-ip-preservation for details.
     externalTrafficPolicy: Local
 

--- a/server/routerlicious/kubernetes/nginx/values-prod.yaml
+++ b/server/routerlicious/kubernetes/nginx/values-prod.yaml
@@ -13,7 +13,8 @@ controller:
     enabled: False # Disable admission webhooks endpoint to keep moving parts to a minimum as long as we don't use it
   service:
     annotations:
-      # This annotation is necessary for external traffic to reach the pods correctly in AKS.
+      # This annotation is necessary for external traffic to reach the pods correctly in AKS (Azure Kubernetes Service,
+      # https://learn.microsoft.com/en-us/azure/aks/).
       # Without it, health probes on the automatically-created load balancer will have an incorrect path, fail because
       # of that, and make it look like the targets of the load balancing rules are unhealthy, which results in external
       # requests hanging instead of getting routed to the appropriate pods.


### PR DESCRIPTION
## Description

We recently upgraded our internal AKS cluster to kubernetes v1.24.9 (2023-03-14) and the r11s end-to-end tests started failing with timeouts. Turned out there had been some changes to the Nginx Ingress Controller and AKS itself that starting with kubernetes v1.24 required explicitly setting a new annotation to make sure that the load-balancing rules created in the internal Load Balancer for the cluster (auto-managed by AKS) use the correct path (`/healthz`), the nodes in the pool are not considered unhealthy, and thus external traffic to the cluster can reach the correct pods.

I took the opportunity to upgrade to the latest version of the Helm chart (4.6.0) and the Nginx Ingress Controller (1.7.0, default for Helm chart 4.6.0).

I already upgraded the Helm release in the cluster and validated that external requests don't hang anymore.

[AB#3933](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3933)