### PR TITLE
ci: Use corepack to control package manager versions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,8 +26,8 @@
 
 	// Invoke 'nvm' to install our preferred version of node, per the '.nvmrc' file
 	// located at the root of the ${workspaceFolder}.
-	// Also install pnpm as it is now required to install all packages
-	"postCreateCommand": ". /usr/local/share/nvm/nvm.sh; nvm install; npm i -g pnpm@7",
+	// Also run corepack enable to allow node to download and use the right version of pnpm.
+	"postCreateCommand": ". /usr/local/share/nvm/nvm.sh; nvm install",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
 	// Invoke 'nvm' to install our preferred version of node, per the '.nvmrc' file
 	// located at the root of the ${workspaceFolder}.
 	// Also run corepack enable to allow node to download and use the right version of pnpm.
-	"postCreateCommand": ". /usr/local/share/nvm/nvm.sh; nvm install",
+	"postCreateCommand": ". /usr/local/share/nvm/nvm.sh; nvm install; corepack enable",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ cd FluidFramework
 Run the following to build the client packages:
 
 ```shell
-npm i -g pnpm
+corepack enable
 pnpm install
 npm run build:fast
 ```

--- a/azure/package.json
+++ b/azure/package.json
@@ -106,7 +106,7 @@
 			"release/azure/*": "patch"
 		}
 	},
-	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2",
 	"pnpm": {
 		"peerDependencyRules": {
 			"ignoreMissing": [

--- a/azure/package.json
+++ b/azure/package.json
@@ -106,6 +106,7 @@
 			"release/azure/*": "patch"
 		}
 	},
+	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
 	"pnpm": {
 		"peerDependencyRules": {
 			"ignoreMissing": [

--- a/azure/packages/external-controller/README.md
+++ b/azure/packages/external-controller/README.md
@@ -20,10 +20,10 @@ bind to the data in the container.
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/app-integration-external-controller`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/app-integration-external-controller`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/azure/packages/external-controller/README.md
+++ b/azure/packages/external-controller/README.md
@@ -10,21 +10,20 @@ This implementation demonstrates plugging that Container into a standalone appli
 [Tinylicious](/server/tinylicious), so there are a few extra steps to get started. We bring our own view that we will
 bind to the data in the container.
 
-<!-- AUTO-GENERATED-CONTENT:START (GET_STARTED) -->
+<!-- AUTO-GENERATED-CONTENT:START (README_EXAMPLE_GETTING_STARTED_SECTION:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
-
-<!-- This section is automatically generated. To update it, make the appropriate changes to docs/md-magic.config.js or the embedded content, then run 'npm run build:md-magic' in the docs folder. -->
+<!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
 
 ## Getting Started
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/app-integration-external-controller`
-1. Run `npm start` from this directory (azure/packages/external-controller) and open <http://localhost:8080> in a web browser to see the app running.
+1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -99,7 +99,7 @@
 	"engines": {
 		"node": ">=14.17.0"
 	},
-	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2",
 	"pnpm": {
 		"peerDependencyRules": {
 			"allowedVersions": {

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -99,7 +99,7 @@
 	"engines": {
 		"node": ">=14.17.0"
 	},
-	"packageManager": "pnpm@7.30.5",
+	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7basdfasdf24db2ebeasdfasdf553f808b95adb55b5330f",
 	"pnpm": {
 		"peerDependencyRules": {
 			"allowedVersions": {

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -99,7 +99,7 @@
 	"engines": {
 		"node": ">=14.17.0"
 	},
-	"packageManager": "pnpm@7.14.2",
+	"packageManager": "pnpm@7.30.5",
 	"pnpm": {
 		"peerDependencyRules": {
 			"allowedVersions": {

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -99,7 +99,7 @@
 	"engines": {
 		"node": ">=14.17.0"
 	},
-	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7basdfasdf24db2ebeasdfasdf553f808b95adb55b5330f",
+	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
 	"pnpm": {
 		"peerDependencyRules": {
 			"allowedVersions": {

--- a/common/build/build-common/package.json
+++ b/common/build/build-common/package.json
@@ -23,5 +23,6 @@
 	},
 	"devDependencies": {
 		"prettier": "~2.6.2"
-	}
+	},
+	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f"
 }

--- a/common/build/build-common/package.json
+++ b/common/build/build-common/package.json
@@ -24,5 +24,5 @@
 	"devDependencies": {
 		"prettier": "~2.6.2"
 	},
-	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f"
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2"
 }

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -53,5 +53,5 @@
 		"sort-json": "^2.0.1",
 		"typescript": "~4.5.5"
 	},
-	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f"
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2"
 }

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -52,5 +52,6 @@
 		"prettier": "~2.6.2",
 		"sort-json": "^2.0.1",
 		"typescript": "~4.5.5"
-	}
+	},
+	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f"
 }

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -63,6 +63,7 @@
 			"release/**": "patch"
 		}
 	},
+	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
 	"typeValidation": {
 		"broken": {}
 	}

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -63,7 +63,7 @@
 			"release/**": "patch"
 		}
 	},
-	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2",
 	"typeValidation": {
 		"broken": {}
 	}

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -134,6 +134,7 @@
 		"outputDirectory": "nyc",
 		"outputName": "jest-junit-report.xml"
 	},
+	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
 	"typeValidation": {
 		"broken": {}
 	}

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -134,7 +134,7 @@
 		"outputDirectory": "nyc",
 		"outputName": "jest-junit-report.xml"
 	},
-	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2",
 	"typeValidation": {
 		"broken": {}
 	}

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -66,6 +66,7 @@
 			"release/**": "patch"
 		}
 	},
+	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
 	"typeValidation": {
 		"broken": {}
 	}

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -66,7 +66,7 @@
 			"release/**": "patch"
 		}
 	},
-	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2",
 	"typeValidation": {
 		"broken": {}
 	}

--- a/examples/apps/collaborative-textarea/README.md
+++ b/examples/apps/collaborative-textarea/README.md
@@ -12,7 +12,7 @@ component to launch a basic collaborative HTML `<textarea>`
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/collaborative-textarea`

--- a/examples/apps/collaborative-textarea/README.md
+++ b/examples/apps/collaborative-textarea/README.md
@@ -13,11 +13,11 @@ component to launch a basic collaborative HTML `<textarea>`
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/collaborative-textarea`
+      `pnpm run build:fast --nolint @fluid-example/collaborative-textarea`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious).
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/apps/contact-collection/README.md
+++ b/examples/apps/contact-collection/README.md
@@ -25,11 +25,11 @@ For another example of this pattern, consider the `SharedDirectory` DDS. The `ge
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/contact-collection`
+      `pnpm run build:fast --nolint @fluid-example/contact-collection`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious).
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/apps/contact-collection/README.md
+++ b/examples/apps/contact-collection/README.md
@@ -24,7 +24,7 @@ For another example of this pattern, consider the `SharedDirectory` DDS. The `ge
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/contact-collection`

--- a/examples/apps/data-object-grid/README.md
+++ b/examples/apps/data-object-grid/README.md
@@ -12,11 +12,11 @@
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/data-object-grid`
+      `pnpm run build:fast --nolint @fluid-example/data-object-grid`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious).
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/apps/data-object-grid/README.md
+++ b/examples/apps/data-object-grid/README.md
@@ -11,7 +11,7 @@
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/data-object-grid`

--- a/examples/apps/odspsnapshotfetch-perftestapp/README.md
+++ b/examples/apps/odspsnapshotfetch-perftestapp/README.md
@@ -12,10 +12,10 @@ A simple app to fetch and compare same file in json and binary format.
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/odspsnapshotfetch-perftestapp`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/odspsnapshotfetch-perftestapp`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/apps/odspsnapshotfetch-perftestapp/README.md
+++ b/examples/apps/odspsnapshotfetch-perftestapp/README.md
@@ -11,7 +11,7 @@ A simple app to fetch and compare same file in json and binary format.
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/odspsnapshotfetch-perftestapp`

--- a/examples/apps/view-framework-sampler/README.md
+++ b/examples/apps/view-framework-sampler/README.md
@@ -12,11 +12,11 @@
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/view-framework-sampler`
+      `pnpm run build:fast --nolint @fluid-example/view-framework-sampler`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious).
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/apps/view-framework-sampler/README.md
+++ b/examples/apps/view-framework-sampler/README.md
@@ -11,7 +11,7 @@
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/view-framework-sampler`

--- a/examples/data-objects/canvas/README.md
+++ b/examples/data-objects/canvas/README.md
@@ -12,10 +12,10 @@
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/canvas`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/canvas`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/canvas/README.md
+++ b/examples/data-objects/canvas/README.md
@@ -11,7 +11,7 @@
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/canvas`

--- a/examples/data-objects/clicker/README.md
+++ b/examples/data-objects/clicker/README.md
@@ -17,7 +17,7 @@ There is another experimental implementation of Clicker using a WiP Fluid React 
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/clicker`

--- a/examples/data-objects/clicker/README.md
+++ b/examples/data-objects/clicker/README.md
@@ -18,10 +18,10 @@ There is another experimental implementation of Clicker using a WiP Fluid React 
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/clicker`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/clicker`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/codemirror/README.md
+++ b/examples/data-objects/codemirror/README.md
@@ -12,7 +12,7 @@ and enable real-time coauthoring using the Fluid Framework.
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/codemirror`

--- a/examples/data-objects/codemirror/README.md
+++ b/examples/data-objects/codemirror/README.md
@@ -13,10 +13,10 @@ and enable real-time coauthoring using the Fluid Framework.
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/codemirror`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/codemirror`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/diceroller/README.md
+++ b/examples/data-objects/diceroller/README.md
@@ -14,10 +14,10 @@ defined in main.tsx.
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/diceroller`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/diceroller`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/diceroller/README.md
+++ b/examples/data-objects/diceroller/README.md
@@ -13,7 +13,7 @@ defined in main.tsx.
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/diceroller`

--- a/examples/data-objects/monaco/README.md
+++ b/examples/data-objects/monaco/README.md
@@ -12,7 +12,7 @@ and enable real-time coauthoring using the Fluid Framework.
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/monaco`

--- a/examples/data-objects/monaco/README.md
+++ b/examples/data-objects/monaco/README.md
@@ -13,10 +13,10 @@ and enable real-time coauthoring using the Fluid Framework.
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/monaco`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/monaco`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/multiview/container/README.md
+++ b/examples/data-objects/multiview/container/README.md
@@ -11,7 +11,7 @@ The container package is an example of how a container author might pick and cho
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/multiview-container`

--- a/examples/data-objects/multiview/container/README.md
+++ b/examples/data-objects/multiview/container/README.md
@@ -12,10 +12,10 @@ The container package is an example of how a container author might pick and cho
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/multiview-container`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/multiview-container`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/presence-tracker/README.md
+++ b/examples/data-objects/presence-tracker/README.md
@@ -15,7 +15,7 @@ This implementation visualizes the Container in a standalone application, rather
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/presence-tracker`

--- a/examples/data-objects/presence-tracker/README.md
+++ b/examples/data-objects/presence-tracker/README.md
@@ -16,11 +16,11 @@ This implementation visualizes the Container in a standalone application, rather
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/presence-tracker`
+      `pnpm run build:fast --nolint @fluid-example/presence-tracker`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious).
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/prosemirror/README.md
+++ b/examples/data-objects/prosemirror/README.md
@@ -13,10 +13,10 @@ enable real-time coauthoring using the Fluid Framework.
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/prosemirror`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/prosemirror`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/prosemirror/README.md
+++ b/examples/data-objects/prosemirror/README.md
@@ -12,7 +12,7 @@ enable real-time coauthoring using the Fluid Framework.
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/prosemirror`

--- a/examples/data-objects/shared-text/README.md
+++ b/examples/data-objects/shared-text/README.md
@@ -15,7 +15,7 @@ An experimental implementation of writing a Rich Text Editor.
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/shared-text`

--- a/examples/data-objects/shared-text/README.md
+++ b/examples/data-objects/shared-text/README.md
@@ -16,10 +16,10 @@ An experimental implementation of writing a Rich Text Editor.
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/shared-text`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/shared-text`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/smde/README.md
+++ b/examples/data-objects/smde/README.md
@@ -12,7 +12,7 @@ enable real-time coauthoring using the Fluid Framework.
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/smde`

--- a/examples/data-objects/smde/README.md
+++ b/examples/data-objects/smde/README.md
@@ -13,10 +13,10 @@ enable real-time coauthoring using the Fluid Framework.
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/smde`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/smde`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/table-view/README.md
+++ b/examples/data-objects/table-view/README.md
@@ -13,7 +13,7 @@ to the created Table Document.
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/table-view`

--- a/examples/data-objects/table-view/README.md
+++ b/examples/data-objects/table-view/README.md
@@ -14,10 +14,10 @@ to the created Table Document.
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/table-view`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/table-view`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/task-selection/README.md
+++ b/examples/data-objects/task-selection/README.md
@@ -12,11 +12,11 @@ The task selection example demonstrates a couple different ways to pick a single
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/task-selection`
+      `pnpm run build:fast --nolint @fluid-example/task-selection`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious).
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/task-selection/README.md
+++ b/examples/data-objects/task-selection/README.md
@@ -11,7 +11,7 @@ The task selection example demonstrates a couple different ways to pick a single
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/task-selection`

--- a/examples/data-objects/todo/README.md
+++ b/examples/data-objects/todo/README.md
@@ -14,10 +14,10 @@
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/todo`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/todo`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/todo/README.md
+++ b/examples/data-objects/todo/README.md
@@ -13,7 +13,7 @@
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/todo`

--- a/examples/data-objects/webflow/README.md
+++ b/examples/data-objects/webflow/README.md
@@ -12,10 +12,10 @@ WebFlow is an experimental collaborative rich text editor built on top of the Fl
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/webflow`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/webflow`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/webflow/README.md
+++ b/examples/data-objects/webflow/README.md
@@ -11,7 +11,7 @@ WebFlow is an experimental collaborative rich text editor built on top of the Fl
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/webflow`

--- a/examples/hosts/app-integration/container-views/README.md
+++ b/examples/hosts/app-integration/container-views/README.md
@@ -14,11 +14,11 @@ This implementation demonstrates plugging the container into a standalone applic
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/app-integration-container-views`
+      `pnpm run build:fast --nolint @fluid-example/app-integration-container-views`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious).
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/hosts/app-integration/container-views/README.md
+++ b/examples/hosts/app-integration/container-views/README.md
@@ -13,7 +13,7 @@ This implementation demonstrates plugging the container into a standalone applic
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/app-integration-container-views`

--- a/examples/hosts/app-integration/external-data/README.md
+++ b/examples/hosts/app-integration/external-data/README.md
@@ -111,10 +111,10 @@ DraftData - Local collaboration state between the Fluid clients is stored in a S
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/app-integration-external-data`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/app-integration-external-data`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/hosts/app-integration/external-data/README.md
+++ b/examples/hosts/app-integration/external-data/README.md
@@ -110,7 +110,7 @@ DraftData - Local collaboration state between the Fluid clients is stored in a S
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/app-integration-external-data`

--- a/examples/hosts/app-integration/external-views/README.md
+++ b/examples/hosts/app-integration/external-views/README.md
@@ -13,7 +13,7 @@ This implementation demonstrates plugging that Container into a standalone appli
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/app-integration-external-views`

--- a/examples/hosts/app-integration/external-views/README.md
+++ b/examples/hosts/app-integration/external-views/README.md
@@ -14,11 +14,11 @@ This implementation demonstrates plugging that Container into a standalone appli
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/app-integration-external-views`
+      `pnpm run build:fast --nolint @fluid-example/app-integration-external-views`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious).
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/hosts/app-integration/live-schema-upgrade/README.md
+++ b/examples/hosts/app-integration/live-schema-upgrade/README.md
@@ -37,11 +37,11 @@ There are a number of ways to handle rendering the view. In this example, we inc
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/app-integration-live-schema-upgrade`
+      `pnpm run build:fast --nolint @fluid-example/app-integration-live-schema-upgrade`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious).
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/hosts/app-integration/live-schema-upgrade/README.md
+++ b/examples/hosts/app-integration/live-schema-upgrade/README.md
@@ -36,7 +36,7 @@ There are a number of ways to handle rendering the view. In this example, we inc
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/app-integration-live-schema-upgrade`

--- a/examples/hosts/app-integration/schema-upgrade/README.md
+++ b/examples/hosts/app-integration/schema-upgrade/README.md
@@ -73,7 +73,7 @@ Similarly, the view used on a model must be compatible with that model. A view l
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/app-integration-schema-upgrade`

--- a/examples/hosts/app-integration/schema-upgrade/README.md
+++ b/examples/hosts/app-integration/schema-upgrade/README.md
@@ -74,11 +74,11 @@ Similarly, the view used on a model must be compatible with that model. A view l
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/app-integration-schema-upgrade`
+      `pnpm run build:fast --nolint @fluid-example/app-integration-schema-upgrade`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious).
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/experimental/examples/bubblebench/baseline/README.md
+++ b/experimental/examples/bubblebench/baseline/README.md
@@ -9,7 +9,7 @@
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/bubblebench-baseline`

--- a/experimental/examples/bubblebench/baseline/README.md
+++ b/experimental/examples/bubblebench/baseline/README.md
@@ -10,10 +10,10 @@
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/bubblebench-baseline`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/bubblebench-baseline`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/experimental/examples/bubblebench/ot/README.md
+++ b/experimental/examples/bubblebench/ot/README.md
@@ -10,10 +10,10 @@
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/bubblebench-ot`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/bubblebench-ot`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/experimental/examples/bubblebench/ot/README.md
+++ b/experimental/examples/bubblebench/ot/README.md
@@ -9,7 +9,7 @@
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/bubblebench-ot`

--- a/experimental/examples/bubblebench/sharedtree/README.md
+++ b/experimental/examples/bubblebench/sharedtree/README.md
@@ -10,10 +10,10 @@
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-example/bubblebench-sharedtree`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-example/bubblebench-sharedtree`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/experimental/examples/bubblebench/sharedtree/README.md
+++ b/experimental/examples/bubblebench/sharedtree/README.md
@@ -9,7 +9,7 @@
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @fluid-example/bubblebench-sharedtree`

--- a/experimental/examples/tree-sample/inventory-app/README.md
+++ b/experimental/examples/tree-sample/inventory-app/README.md
@@ -12,10 +12,10 @@ Minimal sample demonstrating use of the SharedTree API.
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-experimental/inventory-app`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @fluid-experimental/inventory-app`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/experimental/examples/tree-sample/inventory-app/README.md
+++ b/experimental/examples/tree-sample/inventory-app/README.md
@@ -2,21 +2,20 @@
 
 Minimal sample demonstrating use of the SharedTree API.
 
-<!-- AUTO-GENERATED-CONTENT:START (GET_STARTED) -->
+<!-- AUTO-GENERATED-CONTENT:START (README_EXAMPLE_GETTING_STARTED_SECTION:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
-
-<!-- This section is automatically generated. To update it, make the appropriate changes to docs/md-magic.config.js or the embedded content, then run 'npm run build:md-magic' in the docs folder. -->
+<!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
 
 ## Getting Started
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @fluid-experimental/tree-api`
-1. Run `npm start` from this directory (experimental/examples/tree-api) and open <http://localhost:8080> in a web browser to see the app running.
+      `npm run build:fast -- --nolint @fluid-experimental/inventory-app`
+1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
 		"node": ">=16.16.0",
 		"pnpm": "7"
 	},
-	"packageManager": "pnpm@7.30.5+sha1.invalidhash",
+	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
 	"pnpm": {
 		"overrides": {
 			"@types/node": "^14.18.38",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
 		"node": ">=16.16.0",
 		"pnpm": "7"
 	},
-	"packageManager": "pnpm@7.27.0",
+	"packageManager": "pnpm@7.30.5",
 	"pnpm": {
 		"overrides": {
 			"@types/node": "^14.18.38",

--- a/package.json
+++ b/package.json
@@ -152,8 +152,8 @@
 		"node": ">=16.16.0",
 		"pnpm": "7"
 	},
-	"packageManager": "pnpm@7.30.5",
-	"pnpm": {
+    "packageManager": "yarn@3.2.3+sha224.953c8233f7a92884easdfasdfee2de69a1b92d1f2ec1655e66d08071ba9a02fa",
+  "pnpm": {
 		"overrides": {
 			"@types/node": "^14.18.38",
 			"node-fetch": "^2.6.9",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
 		"node": ">=16.16.0",
 		"pnpm": "7"
 	},
-	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
+	"packageManager": "pnpm@7.30.5+sha1.invalidhash",
 	"pnpm": {
 		"overrides": {
 			"@types/node": "^14.18.38",

--- a/package.json
+++ b/package.json
@@ -152,8 +152,8 @@
 		"node": ">=16.16.0",
 		"pnpm": "7"
 	},
-    "packageManager": "yarn@3.2.3+sha224.953c8233f7a92884easdfasdfee2de69a1b92d1f2ec1655e66d08071ba9a02fa",
-  "pnpm": {
+	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
+	"pnpm": {
 		"overrides": {
 			"@types/node": "^14.18.38",
 			"node-fetch": "^2.6.9",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
 		"node": ">=16.16.0",
 		"pnpm": "7"
 	},
-	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2",
 	"pnpm": {
 		"overrides": {
 			"@types/node": "^14.18.38",

--- a/scripts/only-pnpm.cjs
+++ b/scripts/only-pnpm.cjs
@@ -9,14 +9,16 @@
  */
 
 const message = `
-╔═════════════════════════════════════════════════════════════╗
-║                                                             ║
-║   Use "pnpm install" for installation in this project.      ║
-║                                                             ║
-║   If you don't have pnpm, install it via "npm i -g pnpm@7". ║
-║   For more details, see the README.                         ║
-║                                                             ║
-╚═════════════════════════════════════════════════════════════╝
+╔══════════════════════════════════════════════════════════════════╗
+║                                                                  ║
+║   Use "pnpm install" for installation in this project.           ║
+║                                                                  ║
+║   If you don't have pnpm, enable corepack via "corepack enable". ║
+║   Then run "pnpm install" to install dependencies.               ║
+║                                                                  ║
+║   For more details, see the README.                              ║
+║                                                                  ║
+╚══════════════════════════════════════════════════════════════════╝
 `;
 
 const used_pnpm = process.env.npm_config_user_agent.startsWith(`pnpm`);

--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -25,7 +25,7 @@ COPY scripts/*.* ./scripts/
 COPY packages/gitrest/package*.json packages/gitrest/
 COPY packages/gitrest-base/package*.json packages/gitrest-base/
 
-RUN npm install --global pnpm@7.30.5
+RUN corepack enable
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' accout so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -74,6 +74,7 @@
 		"supertest": "^3.4.2",
 		"typescript": "~4.5.5"
 	},
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2",
 	"pnpm": {
 		"overrides": {
 			"qs": "^6.11.0"

--- a/server/gitrest/scripts/only-pnpm.cjs
+++ b/server/gitrest/scripts/only-pnpm.cjs
@@ -9,14 +9,16 @@
  */
 
 const message = `
-╔═════════════════════════════════════════════════════════════╗
-║                                                             ║
-║   Use "pnpm install" for installation in this project.      ║
-║                                                             ║
-║   If you don't have pnpm, install it via "npm i -g pnpm@7". ║
-║   For more details, see the README.                         ║
-║                                                             ║
-╚═════════════════════════════════════════════════════════════╝
+╔══════════════════════════════════════════════════════════════════╗
+║                                                                  ║
+║   Use "pnpm install" for installation in this project.           ║
+║                                                                  ║
+║   If you don't have pnpm, enable corepack via "corepack enable". ║
+║   Then run "pnpm install" to install dependencies.               ║
+║                                                                  ║
+║   For more details, see the README.                              ║
+║                                                                  ║
+╚══════════════════════════════════════════════════════════════════╝
 `;
 
 const used_pnpm = process.env.npm_config_user_agent.startsWith(`pnpm`);

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -28,7 +28,7 @@ COPY scripts/*.* ./scripts/
 COPY packages/historian/package.json packages/historian/
 COPY packages/historian-base/package.json packages/historian-base/
 
-RUN npm install --global pnpm@7.30.5
+RUN corepack enable
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' accout so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -79,6 +79,7 @@
 		"tslint": "^5.12.0",
 		"typescript": "~4.5.5"
 	},
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2",
 	"pnpm": {
 		"overrides": {
 			"qs": "^6.11.0",

--- a/server/historian/scripts/only-pnpm.cjs
+++ b/server/historian/scripts/only-pnpm.cjs
@@ -9,14 +9,16 @@
  */
 
 const message = `
-╔═════════════════════════════════════════════════════════════╗
-║                                                             ║
-║   Use "pnpm install" for installation in this project.      ║
-║                                                             ║
-║   If you don't have pnpm, install it via "npm i -g pnpm@7". ║
-║   For more details, see the README.                         ║
-║                                                             ║
-╚═════════════════════════════════════════════════════════════╝
+╔══════════════════════════════════════════════════════════════════╗
+║                                                                  ║
+║   Use "pnpm install" for installation in this project.           ║
+║                                                                  ║
+║   If you don't have pnpm, enable corepack via "corepack enable". ║
+║   Then run "pnpm install" to install dependencies.               ║
+║                                                                  ║
+║   For more details, see the README.                              ║
+║                                                                  ║
+╚══════════════════════════════════════════════════════════════════╝
 `;
 
 const used_pnpm = process.env.npm_config_user_agent.startsWith(`pnpm`);

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -50,7 +50,7 @@ COPY packages/services-utils/package*.json packages/services-utils/
 COPY packages/test-utils/package*.json packages/test-utils/
 COPY packages/protocol-base/package*.json packages/protocol-base/
 
-RUN npm install --global pnpm@7.30.5
+RUN corepack enable
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' accout so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -88,7 +88,7 @@
 	"engines": {
 		"node": ">=14.13.0"
 	},
-	"packageManager": "pnpm@7.30.5",
+	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
 	"pnpm": {
 		"overrides": {
 			"qs": "^6.11.0",

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -88,7 +88,7 @@
 	"engines": {
 		"node": ">=14.13.0"
 	},
-	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2",
 	"pnpm": {
 		"overrides": {
 			"qs": "^6.11.0",

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -88,7 +88,7 @@
 	"engines": {
 		"node": ">=14.13.0"
 	},
-	"packageManager": "pnpm@7.14.2",
+	"packageManager": "pnpm@7.30.5",
 	"pnpm": {
 		"overrides": {
 			"qs": "^6.11.0",

--- a/server/routerlicious/scripts/only-pnpm.cjs
+++ b/server/routerlicious/scripts/only-pnpm.cjs
@@ -9,14 +9,16 @@
  */
 
 const message = `
-╔═════════════════════════════════════════════════════════════╗
-║                                                             ║
-║   Use "pnpm install" for installation in this project.      ║
-║                                                             ║
-║   If you don't have pnpm, install it via "npm i -g pnpm@7". ║
-║   For more details, see the README.                         ║
-║                                                             ║
-╚═════════════════════════════════════════════════════════════╝
+╔══════════════════════════════════════════════════════════════════╗
+║                                                                  ║
+║   Use "pnpm install" for installation in this project.           ║
+║                                                                  ║
+║   If you don't have pnpm, enable corepack via "corepack enable". ║
+║   Then run "pnpm install" to install dependencies.               ║
+║                                                                  ║
+║   For more details, see the README.                              ║
+║                                                                  ║
+╚══════════════════════════════════════════════════════════════════╝
 `;
 
 const used_pnpm = process.env.npm_config_user_agent.startsWith(`pnpm`);

--- a/server/tinylicious/package.json
+++ b/server/tinylicious/package.json
@@ -108,6 +108,7 @@
 	"engines": {
 		"node": ">=14.0.0"
 	},
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2",
 	"pnpm": {
 		"overrides": {
 			"qs": "^6.11.0",

--- a/tools/getkeys/package.json
+++ b/tools/getkeys/package.json
@@ -36,7 +36,7 @@
 		"prettier": "~2.6.2",
 		"typescript": "~4.5.5"
 	},
-	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2",
 	"pnpm": {
 		"overrides": {
 			"qs": "^6.11.0"

--- a/tools/getkeys/package.json
+++ b/tools/getkeys/package.json
@@ -36,6 +36,7 @@
 		"prettier": "~2.6.2",
 		"typescript": "~4.5.5"
 	},
+	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f",
 	"pnpm": {
 		"overrides": {
 			"qs": "^6.11.0"

--- a/tools/markdown-magic/package.json
+++ b/tools/markdown-magic/package.json
@@ -37,5 +37,5 @@
 	"devDependencies": {
 		"prettier": "~2.6.2"
 	},
-	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f"
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2"
 }

--- a/tools/markdown-magic/package.json
+++ b/tools/markdown-magic/package.json
@@ -36,5 +36,6 @@
 	},
 	"devDependencies": {
 		"prettier": "~2.6.2"
-	}
+	},
+	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f"
 }

--- a/tools/markdown-magic/src/md-magic.config.cjs
+++ b/tools/markdown-magic/src/md-magic.config.cjs
@@ -49,10 +49,10 @@ const generateGettingStartedSection = (packageJsonPath, includeTinyliciousStep, 
 
 	const sectionBody = [];
 	sectionBody.push("You can run this example using the following steps:\n");
-	sectionBody.push("1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.");
-	sectionBody.push(`1. Run \`pnpm install\` and \`npm run build:fast -- --nolint\` from the \`FluidFramework\` root directory.
+	sectionBody.push("1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.");
+	sectionBody.push(`1. Run \`pnpm install\` and \`pnpm run build:fast --nolint\` from the \`FluidFramework\` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      \`npm run build:fast -- --nolint ${packageName}\``);
+      \`pnpm run build:fast --nolint ${packageName}\``);
 
 	if (includeTinyliciousStep) {
 		sectionBody.push(
@@ -61,7 +61,7 @@ const generateGettingStartedSection = (packageJsonPath, includeTinyliciousStep, 
 	}
 
 	sectionBody.push(
-		`1. Run \`npm start\` from this directory and open <http://localhost:8080> in a web browser to see the app running.`,
+		`1. Run \`pnpm start\` from this directory and open <http://localhost:8080> in a web browser to see the app running.`,
 	);
 
 	return formattedSectionText(

--- a/tools/markdown-magic/src/md-magic.config.cjs
+++ b/tools/markdown-magic/src/md-magic.config.cjs
@@ -49,7 +49,9 @@ const generateGettingStartedSection = (packageJsonPath, includeTinyliciousStep, 
 
 	const sectionBody = [];
 	sectionBody.push("You can run this example using the following steps:\n");
-	sectionBody.push("1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.");
+	sectionBody.push(
+		"1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.",
+	);
 	sectionBody.push(`1. Run \`pnpm install\` and \`pnpm run build:fast --nolint\` from the \`FluidFramework\` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       \`pnpm run build:fast --nolint ${packageName}\``);

--- a/tools/markdown-magic/test/example-package-readme.md
+++ b/tools/markdown-magic/test/example-package-readme.md
@@ -7,7 +7,7 @@
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @test/test-package`

--- a/tools/markdown-magic/test/example-package-readme.md
+++ b/tools/markdown-magic/test/example-package-readme.md
@@ -8,11 +8,11 @@
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @test/test-package`
+      `pnpm run build:fast --nolint @test/test-package`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious).
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 ## Scripts
 

--- a/tools/markdown-magic/test/readme-example-getting-started-section.md
+++ b/tools/markdown-magic/test/readme-example-getting-started-section.md
@@ -6,11 +6,11 @@
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @test/test-package`
+      `pnpm run build:fast --nolint @test/test-package`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious).
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 
@@ -26,10 +26,10 @@ You can run this example using the following steps:
 You can run this example using the following steps:
 
 1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
-1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
-      `npm run build:fast -- --nolint @test/test-package`
-1. Run `npm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+      `pnpm run build:fast --nolint @test/test-package`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
 
 <!-- prettier-ignore-end -->
 

--- a/tools/markdown-magic/test/readme-example-getting-started-section.md
+++ b/tools/markdown-magic/test/readme-example-getting-started-section.md
@@ -5,7 +5,7 @@
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @test/test-package`
@@ -25,7 +25,7 @@ You can run this example using the following steps:
 
 You can run this example using the following steps:
 
-1. Install [pnpm](https://pnpm.io/) by running `npm i -g pnpm@7`.
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
 1. Run `pnpm install` and `npm run build:fast -- --nolint` from the `FluidFramework` root directory.
     - For an even faster build, you can add the package name to the build command, like this:
       `npm run build:fast -- --nolint @test/test-package`

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -118,6 +118,8 @@ resources:
 stages:
 - stage: build
   displayName: 'Build website'
+  env:
+    COREPACK_DEFAULT_TO_LATEST: 0
   dependsOn: [] # run in parallel
   jobs:
     - job: debug_variables

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -202,7 +202,7 @@ stages:
           inputs:
             targetType: 'inline'
             script: |
-              npm i -g pnpm@7.30.5
+              corepack enable
               pnpm -v
               pnpm config set store-dir $(pnpmStorePath)
 

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -45,7 +45,7 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      npm i -g pnpm@7.30.5
+      corepack enable
       pnpm -v
       pnpm config set store-dir $(pnpmStorePath)
 

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -242,7 +242,7 @@ stages:
           targetType: 'inline'
           workingDirectory: ${{ parameters.buildDirectory }}
           script: |
-            npm i -g pnpm@7.30.5
+            corepack enable
             pnpm -v
             pnpm config set store-dir $(pnpmStorePath)
 

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -255,7 +255,7 @@ stages:
               targetType: 'inline'
               workingDirectory: ${{ parameters.buildDirectory }}
               script: |
-                npm i -g pnpm@7.30.5
+                corepack enable
                 pnpm -v
                 pnpm config set store-dir $(pnpmStorePath)
 

--- a/tools/pipelines/templates/include-policy-check.yml
+++ b/tools/pipelines/templates/include-policy-check.yml
@@ -41,7 +41,7 @@ stages:
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
           # Install pnpm globally
-          npm i -g pnpm@7.30.5
+          corepack enable
           pnpm -v
 
           # We only want to install the root package deps, so we set recursive-install to false

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -44,7 +44,7 @@ steps:
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
         pushd "$(Build.SourcesDirectory)/build-tools"
-        npm i -g pnpm@7.30.5
+        corepack enable
         pnpm -v
         pnpm config set store-dir $(pnpmStorePath)
         pnpm i

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -84,7 +84,7 @@ jobs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
-          npm i -g pnpm@7.30.5
+          corepack enable
           pnpm -v
           pnpm config set store-dir $(pnpmStorePath)
 

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -41,5 +41,5 @@
 		"rimraf": "^2.6.2",
 		"typescript": "~4.5.5"
 	},
-	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f"
+	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2"
 }

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -40,5 +40,6 @@
 		"prettier": "~2.6.2",
 		"rimraf": "^2.6.2",
 		"typescript": "~4.5.5"
-	}
+	},
+	"packageManager": "pnpm@7.30.5+sha1.ba4f8057ab7b24db2ebe553808b95adb55b5330f"
 }


### PR DESCRIPTION
## Description

Updates the CI pipeline and readme instructions to use [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) to install and use the correct version of pnpm. The hash of the package manager is included to improve the security of the CI pipeline. If the hashes don't match when node downloads the package manager then the CI pipeline will fail at the "install and configure pnpm" step.

Example failing CI run:

https://dev.azure.com/fluidframework/public/_build/results?buildId=146662&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=996a989a-edd9-5084-d9de-d81350de1bfc

To determine the sha512 hash, I used Linux and ran `npm view pnpm@7.30.5 dist.tarball` to get the URL of the package tarball. Then I did the following:

```shell
wget https://registry.npmjs.org/pnpm/-/pnpm-7.30.5.tgz
sha512sum pnpm-7.30.5.tgz
```