### PR TITLE
Fix signal error event in case we reconnect and we miss the first signal

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1945,12 +1945,13 @@ export class ContainerRuntime
 					clientSignalSequenceNumber: envelope.clientSignalSequenceNumber,
 				});
 			} else if (
-				this.consecutiveReconnects === 0 &&
 				envelope.clientSignalSequenceNumber ===
-					this._perfSignalData.trackingSignalSequenceNumber
+				this._perfSignalData.trackingSignalSequenceNumber
 			) {
 				// only logging for the first connection and the trackingSignalSequenceNUmber.
-				this.sendSignalTelemetryEvent(envelope.clientSignalSequenceNumber);
+				if (this.consecutiveReconnects === 0) {
+					this.sendSignalTelemetryEvent(envelope.clientSignalSequenceNumber);
+				}
 				this._perfSignalData.trackingSignalSequenceNumber = undefined;
 			}
 		}


### PR DESCRIPTION

## Description

Fix regression caused by [Download snapshot with handle before throwing "Fetched snapshot is older than the received ack" by NicholasCouri · Pull Request #14225 · microsoft/FluidFramework · GitHub](https://github.com/microsoft/FluidFramework/pull/14225)  in which, if we reconnect, we will send the SendError Logic. 
WIll work on adding a new test to prevent this error from happening again. 