### PR TITLE
Weight ops for last summary

### DIFF
--- a/packages/runtime/container-runtime/src/summary/summarizerHeuristics.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerHeuristics.ts
@@ -157,16 +157,21 @@ export class SummarizeHeuristicRunner implements ISummarizeHeuristicRunner {
 	}
 
 	public shouldRunLastSummary(): boolean {
-		const opsSinceLastAck = this.opsSinceLastAck;
+		const weightedOpsSinceLastAck = getWeightedNumberOfOps(
+			this.heuristicData.numRuntimeOps,
+			this.heuristicData.numNonRuntimeOps,
+			this.configuration.runtimeOpWeight,
+			this.configuration.nonRuntimeOpWeight,
+		);
 		const minOpsForLastSummaryAttempt = this.configuration.minOpsForLastSummaryAttempt;
 
 		this.logger.sendTelemetryEvent({
 			eventName: "ShouldRunLastSummary",
-			opsSinceLastAck,
+			weightedOpsSinceLastAck,
 			minOpsForLastSummaryAttempt,
 		});
 
-		return opsSinceLastAck >= minOpsForLastSummaryAttempt;
+		return weightedOpsSinceLastAck >= minOpsForLastSummaryAttempt;
 	}
 
 	public dispose() {

--- a/packages/runtime/container-runtime/src/test/summary/summarizerHeuristics.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/summarizerHeuristics.spec.ts
@@ -235,7 +235,7 @@ describe("Runtime", () => {
 				initialize({ minOpsForLastSummaryAttempt, runtimeOpWeight: 1.0 });
 
 				data.numRuntimeOps = minOpsForLastSummaryAttempt;
-				assert(runner.shouldRunLastSummary() === true, "should run on close");
+				assert.strictEqual(runner.shouldRunLastSummary(), true, "should run on close");
 			});
 
 			it("Should not summarize on close if insufficient outstanding ops", () => {
@@ -243,7 +243,25 @@ describe("Runtime", () => {
 				initialize({ minOpsForLastSummaryAttempt, runtimeOpWeight: 1.0 });
 
 				data.numRuntimeOps = minOpsForLastSummaryAttempt - 1;
-				assert(runner.shouldRunLastSummary() === false, "should not run on close");
+				assert.strictEqual(runner.shouldRunLastSummary(), false, "should not run on close");
+			});
+
+			it("Should summarize on close weights ops properly", () => {
+				const minOpsForLastSummaryAttempt = 2;
+				initialize({
+					minOpsForLastSummaryAttempt,
+					runtimeOpWeight: 0.1,
+					nonRuntimeOpWeight: 1.1,
+				});
+
+				data.numRuntimeOps += 8;
+				assert.strictEqual(runner.shouldRunLastSummary(), false, "should not run yet");
+
+				data.numNonRuntimeOps += 1;
+				assert.strictEqual(runner.shouldRunLastSummary(), false, "should not run yet");
+
+				data.numRuntimeOps += 1;
+				assert.strictEqual(runner.shouldRunLastSummary(), true, "should run");
 			});
 
 			it("Should not run idle timer after dispose", () => {

--- a/packages/runtime/container-runtime/src/test/summary/summarizerHeuristics.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/summarizerHeuristics.spec.ts
@@ -231,20 +231,18 @@ describe("Runtime", () => {
 			});
 
 			it("Should summarize on close if enough outstanding ops", () => {
-				const lastSummary = 1000;
 				const minOpsForLastSummaryAttempt = 10;
-				initialize({ refSequenceNumber: lastSummary, minOpsForLastSummaryAttempt });
+				initialize({ minOpsForLastSummaryAttempt, runtimeOpWeight: 1.0 });
 
-				data.lastOpSequenceNumber = lastSummary + minOpsForLastSummaryAttempt + 1;
+				data.numRuntimeOps = minOpsForLastSummaryAttempt;
 				assert(runner.shouldRunLastSummary() === true, "should run on close");
 			});
 
 			it("Should not summarize on close if insufficient outstanding ops", () => {
-				const lastSummary = 1000;
 				const minOpsForLastSummaryAttempt = 10;
-				initialize({ refSequenceNumber: lastSummary, minOpsForLastSummaryAttempt });
+				initialize({ minOpsForLastSummaryAttempt, runtimeOpWeight: 1.0 });
 
-				data.lastOpSequenceNumber = lastSummary + minOpsForLastSummaryAttempt - 1;
+				data.numRuntimeOps = minOpsForLastSummaryAttempt - 1;
 				assert(runner.shouldRunLastSummary() === false, "should not run on close");
 			});
 


### PR DESCRIPTION
# [AB#3089](https://dev.azure.com/fluidframework/internal/_workitems/edit/3089)

[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

There was a change in regular summary heuristics that weight runtime and non-runtime ops differently.

`shouldRunLastSummary` should also do something similar so that it doesn't end up summarizing too often which might be the case today. There were some changes relatively recently where `minOpsForLastSummaryAttempt` was changed to 10 and system ops might be contributing to this.