### PR TITLE
Improve join session refresh flow.

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -335,9 +335,8 @@ export class OdspDelayLoadedDeltaStream {
 					requestSocketToken,
 				).catch((error) => {
 					const canRetry = canRetryOnError(error);
-					// Only record error event in case it is non retriable.
 					if (!canRetry) {
-						this.mc.logger.sendErrorEvent(
+						this.mc.logger.sendTelemetryEvent(
 							{
 								eventName: "JoinSessionRefreshError",
 								details: JSON.stringify(props),

--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -220,7 +220,12 @@ export class OdspDelayLoadedDeltaStream {
 		await new Promise<void>((resolve, reject) => {
 			this.joinSessionRefreshTimer = setTimeout(() => {
 				getWithRetryForTokenRefresh(async (options) => {
-					await this.joinSession(requestSocketToken, options, true, clientId);
+					await this.joinSession(
+						requestSocketToken,
+						options,
+						true /* isRefreshingJoinSession */,
+						clientId,
+					);
 					resolve();
 				}).catch((error) => {
 					reject(error);

--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -138,7 +138,7 @@ export class OdspDelayLoadedDeltaStream {
 			const joinSessionPromise = this.joinSession(
 				requestWebsocketTokenFromJoinSession,
 				options,
-				false,
+				false /* isRefreshingJoinSession */,
 			);
 			const [websocketEndpoint, websocketToken] = await Promise.all([
 				joinSessionPromise.catch(annotateAndRethrowConnectionError("joinSession")),
@@ -246,7 +246,8 @@ export class OdspDelayLoadedDeltaStream {
 		// timer we should not make the call and throw error.
 		if (
 			isRefreshingJoinSession &&
-			(this.currentConnection === undefined || this.currentConnection.clientId !== clientId)
+			(this.currentConnection === undefined ||
+				(clientId !== undefined && this.currentConnection.clientId !== clientId))
 		) {
 			this.clearJoinSessionTimer();
 			throw new NonRetryableError(

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -33,6 +33,7 @@ interface IJoinSessionBody {
  * which is used when establishing websocket connection with collab session backend service.
  * @param options - Options to fetch the token.
  * @param disableJoinSessionRefresh - Whether the caller wants to disable refreshing join session periodically.
+ * @param isRefreshingJoinSession - whether call is to refresh the session before expiry.
  * @param guestDisplayName - display name used to identify guest user joining a session.
  * This is optional and used only when collab session is being joined via invite.
  */
@@ -46,6 +47,7 @@ export async function fetchJoinSession(
 	requestSocketToken: boolean,
 	options: TokenFetchOptionsEx,
 	disableJoinSessionRefresh: boolean | undefined,
+	isRefreshingJoinSession: boolean,
 	guestDisplayName?: string,
 ): Promise<ISocketStorageDiscovery> {
 	const token = await getStorageToken(options, "JoinSession");
@@ -57,6 +59,7 @@ export async function fetchJoinSession(
 		refreshedToken: options.refresh,
 		requestSocketToken,
 		...tokenRefreshProps,
+		refreshingSession: isRefreshingJoinSession,
 	};
 
 	return PerformanceEvent.timedExecAsync(


### PR DESCRIPTION
## Description

Don't call join session network call in case the current connection does not exists as this call was the refresh the current session and dispose the timer and throw error. Also record in telemetry, if the call for join session was to refresh or not.