### PR TITLE
Add explicit null check to isCompressed

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
@@ -133,6 +133,7 @@ export class OpDecompressor {
 		 */
 		try {
 			if (
+				message.contents !== null &&
 				typeof message.contents === "object" &&
 				Object.keys(message.contents).length === 1 &&
 				message.contents?.packedContents !== undefined &&


### PR DESCRIPTION
## Description
This is throwing a ton when trying to debug, as the condition does not handle null, which appears to be common. Adding the null check to avoid spurious throws.