### PR TITLE
Fix debug logger on error output in tests

### DIFF
--- a/packages/utils/telemetry-utils/src/debugLogger.ts
+++ b/packages/utils/telemetry-utils/src/debugLogger.ts
@@ -17,6 +17,9 @@ import {
 	ITelemetryLoggerPropertyBags,
 } from "./logger";
 
+// Capture console.error early so that we can still get the built-in one even if it has been replaced
+const consoleErrorFn = console.error.bind(console);
+
 /**
  * Implementation of debug logger
  */
@@ -35,7 +38,7 @@ export class DebugLogger extends TelemetryLogger {
 		const debug = registerDebug(namespace);
 
 		const debugErr = registerDebug(namespace);
-		debugErr.log = console.error.bind(console);
+		debugErr.log = consoleErrorFn;
 		debugErr.enabled = true;
 
 		return new DebugLogger(debug, debugErr, properties);


### PR DESCRIPTION
`DebugLogger` create a bound function of `console.error` to log error.   In our e2e tests, we overwritten the function to do nothing so we don't create noise in tests.     However, that also means that depending on when the `DebugLogger` is created, the debug output will not be output to the console even if the debug namespace is enabled.

The change is to check if the namespace is enabled, and use the default logger it is enabled. 