### PR TITLE
Add attribution to experimental map

### DIFF
--- a/api-report/attributable-map.api.md
+++ b/api-report/attributable-map.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AttributionKey } from '@fluidframework/runtime-definitions';
 import { IChannelAttributes } from '@fluidframework/datastore-definitions';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IChannelServices } from '@fluidframework/datastore-definitions';
@@ -20,20 +21,69 @@ import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { SharedObject } from '@fluidframework/shared-object-base';
 
 // @public
+export class AttributableMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
+    [Symbol.iterator](): IterableIterator<[string, any]>;
+    readonly [Symbol.toStringTag]: string;
+    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
+    // @internal (undocumented)
+    protected applyStashedOp(content: unknown): unknown;
+    clear(): void;
+    static create(runtime: IFluidDataStoreRuntime, id?: string): AttributableMap;
+    delete(key: string): boolean;
+    entries(): IterableIterator<[string, any]>;
+    forEach(callbackFn: (value: any, key: string, map: Map<string, any>) => void): void;
+    get<T = any>(key: string): T | undefined;
+    getAllAttribution(): Map<string, AttributionKey> | undefined;
+    getAttribution(key: string): AttributionKey | undefined;
+    static getFactory(): IChannelFactory;
+    has(key: string): boolean;
+    keys(): IterableIterator<string>;
+    // @internal (undocumented)
+    protected loadCore(storage: IChannelStorageService): Promise<void>;
+    // @internal (undocumented)
+    protected onDisconnect(): void;
+    // @internal (undocumented)
+    protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
+    // @internal (undocumented)
+    protected reSubmitCore(content: unknown, localOpMetadata: unknown): void;
+    // @internal (undocumented)
+    protected rollback(content: unknown, localOpMetadata: unknown): void;
+    set(key: string, value: unknown): this;
+    get size(): number;
+    // @internal (undocumented)
+    protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+    values(): IterableIterator<any>;
+}
+
+// @public
 export interface ILocalValue {
-    makeSerialized(serializer: IFluidSerializer, bind: IFluidHandle): ISerializedValue;
+    makeSerialized(serializer: IFluidSerializer, bind: IFluidHandle, attribution?: AttributionKey | number): ISerializedValue;
     readonly type: string;
     readonly value: any;
 }
 
+// @public
+export interface IMapAttributionOptions {
+    // (undocumented)
+    track?: boolean;
+}
+
+// @public
+export interface IMapOptions {
+    // (undocumented)
+    attribution?: IMapAttributionOptions;
+}
+
 // @public @deprecated
 export interface ISerializableValue {
+    attribution?: AttributionKey | number;
     type: string;
     value: any;
 }
 
 // @public
 export interface ISerializedValue {
+    attribution?: string;
     type: string;
     value: string | undefined;
 }
@@ -77,39 +127,6 @@ export class MapFactory implements IChannelFactory {
     static readonly Type = "https://graph.microsoft.com/types/map";
     // (undocumented)
     get type(): string;
-}
-
-// @public
-export class SharedMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
-    [Symbol.iterator](): IterableIterator<[string, any]>;
-    readonly [Symbol.toStringTag]: string;
-    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
-    // @internal (undocumented)
-    protected applyStashedOp(content: unknown): unknown;
-    clear(): void;
-    static create(runtime: IFluidDataStoreRuntime, id?: string): SharedMap;
-    delete(key: string): boolean;
-    entries(): IterableIterator<[string, any]>;
-    forEach(callbackFn: (value: any, key: string, map: Map<string, any>) => void): void;
-    get<T = any>(key: string): T | undefined;
-    static getFactory(): IChannelFactory;
-    has(key: string): boolean;
-    keys(): IterableIterator<string>;
-    // @internal (undocumented)
-    protected loadCore(storage: IChannelStorageService): Promise<void>;
-    // @internal (undocumented)
-    protected onDisconnect(): void;
-    // @internal (undocumented)
-    protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
-    // @internal (undocumented)
-    protected reSubmitCore(content: unknown, localOpMetadata: unknown): void;
-    // @internal (undocumented)
-    protected rollback(content: unknown, localOpMetadata: unknown): void;
-    set(key: string, value: unknown): this;
-    get size(): number;
-    // @internal (undocumented)
-    protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
-    values(): IterableIterator<any>;
 }
 
 ```

--- a/experimental/dds/attributable-map/README.md
+++ b/experimental/dds/attributable-map/README.md
@@ -35,8 +35,8 @@ when the key becomes available.
 
 ### Attribution
 
- This experimental DDS allows for the tracking of attribution information, such as the user who made an update and the timestamp of the change. The `attributableMap` currently includes three types of attribution keys: Op-stream, detached, and local.
+This experimental DDS allows for the tracking of attribution information, such as the user who made an update and the timestamp of the change. The `attributableMap` currently includes three types of attribution keys: Op-stream, detached, and local.
 
-- The Op-stream attribution key indicates that the update of attribution information is synchronized with the processing of a map operation, and only occurs once the update is ack'd. 
-- The detached attribution key only occurs when the DDS is not attached, and can be summarized into a snapshot. 
-- The local attribution key exists when the operation has not yet been ack'd and cannot be summarized.
+-   The Op-stream attribution key indicates that the update of attribution information is synchronized with the processing of a map operation, and only occurs once the update is ack'd.
+-   The detached attribution key only occurs when the DDS is not attached, and can be summarized into a snapshot.
+-   The local attribution key exists when the operation has not yet been ack'd and cannot be summarized.

--- a/experimental/dds/attributable-map/README.md
+++ b/experimental/dds/attributable-map/README.md
@@ -4,7 +4,7 @@
 
 This experimental DDS is a fork of the SharedMap which implements attribution, the plan is to remove it and integrate those APIs into SharedMap.
 
-## SharedMap
+## AttributableMap
 
 The SharedMap distributed data structure can be used to store key-value pairs. It provides the same API for setting and
 retrieving values that JavaScript developers are accustomed to with the
@@ -33,28 +33,10 @@ when the key becomes available.
 
 `SharedMap` is an `EventEmitter`, and will emit events when other clients make modifications. You should register for these events and respond appropriately as the data is modified. `valueChanged` will be emitted in response to a `set` or `delete`, and provide the key and previous value that was stored at that key. `clear` will be emitted in response to a `clear`.
 
-## SharedDirectory and IDirectory
+### Attribution
 
-A `SharedDirectory` is a map-like DDS that additionally supports storing key/value pairs within a tree of subdirectories. This subdirectory tree can be used to give hierarchical structure to stored key/value pairs rather than storing them on a flat map. Both the `SharedDirectory` and any subdirectories are `IDirectories`.
+ This experimental DDS allows for the tracking of attribution information, such as the user who made an update and the timestamp of the change. The `attributableMap` currently includes three types of attribution keys: Op-stream, detached, and local.
 
-### Creation
-
-To create a `SharedDirectory`, call the static create method:
-
-```typescript
-const myDirectory = SharedDirectory.create(this.runtime, id);
-```
-
-### Usage
-
-The map operations on an `IDirectory` refer to the key/value pairs stored in that `IDirectory`, and function just like `SharedMap` including the same extra functionality and restrictions on keys and values. To operate on the subdirectory structure, use the corresponding subdirectory methods.
-
-#### `getWorkingDirectory()`
-
-To "navigate" the subdirectory structure, `IDirectory` provides a `getWorkingDirectory` method which takes a relative path and returns the `IDirectory` located at that path if it exists.
-
-#### Eventing
-
-`valueChanged` events additionally provide the absolute path to the subdirectory storing the value that changed.
-
-`dispose` events are fired on sub directory which is deleted. Any access to this sub directory will throw an error once it is disposed.
+- The Op-stream attribution key indicates that the update of attribution information is synchronized with the processing of a map operation, and only occurs once the update is ack'd. 
+- The detached attribution key only occurs when the DDS is not attached, and can be summarized into a snapshot. 
+- The local attribution key exists when the operation has not yet been ack'd and cannot be summarized.

--- a/experimental/dds/attributable-map/README.md
+++ b/experimental/dds/attributable-map/README.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-This experimental DDS is a fork of the SharedMap which implements attribution, the plan is to remove it and integrate those APIs into SharedMap.
+This experimental DDS is a copy of `SharedMap` which additionally tracks attribution information, such as the user who made an update and the timestamp of the change. Please refer to the description of [attributor](../../../packages/framework/attributor/README.md) for more details.
 
-## AttributableMap
+## SharedMap
 
 The SharedMap distributed data structure can be used to store key-value pairs. It provides the same API for setting and
 retrieving values that JavaScript developers are accustomed to with the
@@ -32,11 +32,3 @@ when the key becomes available.
 ### Eventing
 
 `SharedMap` is an `EventEmitter`, and will emit events when other clients make modifications. You should register for these events and respond appropriately as the data is modified. `valueChanged` will be emitted in response to a `set` or `delete`, and provide the key and previous value that was stored at that key. `clear` will be emitted in response to a `clear`.
-
-### Attribution
-
-This experimental DDS allows for the tracking of attribution information, such as the user who made an update and the timestamp of the change. The `attributableMap` currently includes three types of attribution keys: Op-stream, detached, and local.
-
--   The Op-stream attribution key indicates that the update of attribution information is synchronized with the processing of a map operation, and only occurs once the update is ack'd.
--   The detached attribution key only occurs when the DDS is not attached, and can be summarized into a snapshot.
--   The local attribution key exists when the operation has not yet been ack'd and cannot be summarized.

--- a/experimental/dds/attributable-map/src/index.ts
+++ b/experimental/dds/attributable-map/src/index.ts
@@ -8,7 +8,7 @@
  *
  * @remarks The following distributed data structures are defined in this library:
  *
- * - {@link SharedMap}
+ * - {@link AttributableMap}
  *
  * @packageDocumentation
  */
@@ -19,6 +19,8 @@ export {
 	ISharedMap,
 	ISharedMapEvents,
 	IValueChanged,
+	IMapAttributionOptions,
+	IMapOptions,
 } from "./interfaces";
 export { LocalValueMaker, ILocalValue } from "./localValues";
-export { MapFactory, SharedMap } from "./map";
+export { MapFactory, AttributableMap } from "./map";

--- a/experimental/dds/attributable-map/src/interfaces.ts
+++ b/experimental/dds/attributable-map/src/interfaces.ts
@@ -5,7 +5,7 @@
 
 import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-object-base";
 import { IEventThisPlaceHolder } from "@fluidframework/common-definitions";
-
+import { AttributionKey } from "@fluidframework/runtime-definitions";
 /**
  * Type of "valueChanged" event parameter.
  */
@@ -119,6 +119,12 @@ export interface ISerializableValue {
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	value: any;
+
+	/**
+	 * @alpha
+	 * The attribution key attached with the entry
+	 */
+	attribution?: AttributionKey | number;
 }
 
 /**
@@ -136,4 +142,31 @@ export interface ISerializedValue {
 	 * @remarks Will be undefined if the original value was undefined.
 	 */
 	value: string | undefined;
+
+	/**
+	 * @alpha
+	 * The attribution key or seq number attached with the entry
+	 */
+	attribution?: string;
+}
+
+/**
+ * Options related to attribution
+ *
+ * @alpha
+ */
+export interface IMapOptions {
+	attribution?: IMapAttributionOptions;
+}
+
+/**
+ * This enables the map to store the attribution information which can be accessed with the runtime
+ * (i.e. who creeated the content and when it was created)
+ *
+ * default: false
+ *
+ * @alpha
+ */
+export interface IMapAttributionOptions {
+	track?: boolean;
 }

--- a/experimental/dds/attributable-map/src/interfaces.ts
+++ b/experimental/dds/attributable-map/src/interfaces.ts
@@ -121,7 +121,6 @@ export interface ISerializableValue {
 	value: any;
 
 	/**
-	 * @alpha
 	 * The attribution key attached with the entry
 	 */
 	attribution?: AttributionKey | number;
@@ -144,7 +143,6 @@ export interface ISerializedValue {
 	value: string | undefined;
 
 	/**
-	 * @alpha
 	 * The attribution key or seq number attached with the entry
 	 */
 	attribution?: string;
@@ -153,7 +151,7 @@ export interface ISerializedValue {
 /**
  * Options related to attribution
  *
- * @alpha
+ * @public
  */
 export interface IMapOptions {
 	attribution?: IMapAttributionOptions;
@@ -165,7 +163,7 @@ export interface IMapOptions {
  *
  * default: false
  *
- * @alpha
+ * @public
  */
 export interface IMapAttributionOptions {
 	track?: boolean;

--- a/experimental/dds/attributable-map/src/localValues.ts
+++ b/experimental/dds/attributable-map/src/localValues.ts
@@ -11,6 +11,7 @@ import {
 	serializeHandles,
 	ValueType,
 } from "@fluidframework/shared-object-base";
+import { AttributionKey } from "@fluidframework/runtime-definitions";
 import { ISerializableValue, ISerializedValue } from "./interfaces";
 
 /**
@@ -33,9 +34,14 @@ export interface ILocalValue {
 	 * Retrieve the serialized form of the value stored within.
 	 * @param serializer - Data store runtime's serializer
 	 * @param bind - Container type's handle
+	 * @param attribution - The attribution Key of DDS
 	 * @returns The serialized form of the contained value
 	 */
-	makeSerialized(serializer: IFluidSerializer, bind: IFluidHandle): ISerializedValue;
+	makeSerialized(
+		serializer: IFluidSerializer,
+		bind: IFluidHandle,
+		attribution?: AttributionKey | number,
+	): ISerializedValue;
 }
 
 /**
@@ -80,7 +86,11 @@ export class PlainLocalValue implements ILocalValue {
 	/**
 	 * {@inheritDoc ILocalValue.makeSerialized}
 	 */
-	public makeSerialized(serializer: IFluidSerializer, bind: IFluidHandle): ISerializedValue {
+	public makeSerialized(
+		serializer: IFluidSerializer,
+		bind: IFluidHandle,
+		attribution?: AttributionKey | number,
+	): ISerializedValue {
 		// Stringify to convert to the serialized handle values - and then parse in order to create
 		// a POJO for the op
 		const value = serializeHandles(this.value, serializer, bind);
@@ -88,6 +98,7 @@ export class PlainLocalValue implements ILocalValue {
 		return {
 			type: this.type,
 			value,
+			attribution: JSON.stringify(attribution),
 		};
 	}
 }

--- a/experimental/dds/attributable-map/src/map.ts
+++ b/experimental/dds/attributable-map/src/map.ts
@@ -101,10 +101,10 @@ export class AttributableMap extends SharedObject<ISharedMapEvents> implements I
 	 * @returns Newly created shared map.
 	 *
 	 * @example
-	 * To create a `SharedMap`, call the static create method:
+	 * To create a `AttributableMap`, call the static create method:
 	 *
 	 * ```typescript
-	 * const myMap = SharedMap.create(this.runtime, id);
+	 * const myMap = AttributableMap.create(this.runtime, id);
 	 * ```
 	 */
 	public static create(runtime: IFluidDataStoreRuntime, id?: string): AttributableMap {
@@ -112,8 +112,8 @@ export class AttributableMap extends SharedObject<ISharedMapEvents> implements I
 	}
 
 	/**
-	 * Get a factory for SharedMap to register with the data store.
-	 * @returns A factory that creates SharedMaps and loads them from storage.
+	 * Get a factory for AttributableMap to register with the data store.
+	 * @returns A factory that creates AttributableMap's and loads them from storage.
 	 */
 	public static getFactory(): IChannelFactory {
 		return new MapFactory();

--- a/experimental/dds/attributable-map/src/map.ts
+++ b/experimental/dds/attributable-map/src/map.ts
@@ -11,12 +11,16 @@ import {
 	IChannelServices,
 	IChannelFactory,
 } from "@fluidframework/datastore-definitions";
-import { ISummaryTreeWithStats, ITelemetryContext } from "@fluidframework/runtime-definitions";
+import {
+	AttributionKey,
+	ISummaryTreeWithStats,
+	ITelemetryContext,
+} from "@fluidframework/runtime-definitions";
 import { readAndParse } from "@fluidframework/driver-utils";
 import { IFluidSerializer, SharedObject } from "@fluidframework/shared-object-base";
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils";
-import { ISharedMap, ISharedMapEvents } from "./interfaces";
-import { IMapDataObjectSerializable, IMapOperation, MapKernel } from "./mapKernel";
+import { ISharedMap, IMapOptions, ISharedMapEvents } from "./interfaces";
+import { IMapDataObjectSerializable, IMapOperation, AttributableMapKernel } from "./mapKernel";
 import { pkgVersion } from "./packageVersion";
 
 interface IMapSerializationFormat {
@@ -27,7 +31,7 @@ interface IMapSerializationFormat {
 const snapshotFileName = "header";
 
 /**
- * {@link @fluidframework/datastore-definitions#IChannelFactory} for {@link SharedMap}.
+ * {@link @fluidframework/datastore-definitions#IChannelFactory} for {@link AttributableMap}.
  *
  * @sealed
  */
@@ -69,7 +73,7 @@ export class MapFactory implements IChannelFactory {
 		services: IChannelServices,
 		attributes: IChannelAttributes,
 	): Promise<ISharedMap> {
-		const map = new SharedMap(id, runtime, attributes);
+		const map = new AttributableMap(id, runtime, attributes);
 		await map.load(services);
 
 		return map;
@@ -79,7 +83,7 @@ export class MapFactory implements IChannelFactory {
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.create}
 	 */
 	public create(runtime: IFluidDataStoreRuntime, id: string): ISharedMap {
-		const map = new SharedMap(id, runtime, MapFactory.Attributes);
+		const map = new AttributableMap(id, runtime, MapFactory.Attributes);
 		map.initializeLocal();
 
 		return map;
@@ -89,7 +93,7 @@ export class MapFactory implements IChannelFactory {
 /**
  * {@inheritDoc ISharedMap}
  */
-export class SharedMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
+export class AttributableMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
 	/**
 	 * Create a new shared map.
 	 * @param runtime - The data store runtime that the new shared map belongs to.
@@ -103,8 +107,8 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	 * const myMap = SharedMap.create(this.runtime, id);
 	 * ```
 	 */
-	public static create(runtime: IFluidDataStoreRuntime, id?: string): SharedMap {
-		return runtime.createChannel(id, MapFactory.Type) as SharedMap;
+	public static create(runtime: IFluidDataStoreRuntime, id?: string): AttributableMap {
+		return runtime.createChannel(id, MapFactory.Type) as AttributableMap;
 	}
 
 	/**
@@ -118,15 +122,15 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	/**
 	 * String representation for the class.
 	 */
-	public readonly [Symbol.toStringTag]: string = "SharedMap";
+	public readonly [Symbol.toStringTag]: string = "AttributableMap";
 
 	/**
 	 * MapKernel which manages actual map operations.
 	 */
-	private readonly kernel: MapKernel;
+	private readonly kernel: AttributableMapKernel;
 
 	/**
-	 * Do not call the constructor. Instead, you should use the {@link SharedMap.create | create method}.
+	 * Do not call the constructor. Instead, you should use the {@link AttributableMap.create | create method}.
 	 *
 	 * @param id - String identifier.
 	 * @param runtime - Data store runtime.
@@ -138,12 +142,13 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 		attributes: IChannelAttributes,
 	) {
 		super(id, runtime, attributes, "fluid_map_");
-		this.kernel = new MapKernel(
+		this.kernel = new AttributableMapKernel(
 			this.serializer,
 			this.handle,
 			(op, localOpMetadata) => this.submitLocalMessage(op, localOpMetadata),
 			() => this.isAttached(),
 			this,
+			runtime.options as IMapOptions,
 		);
 	}
 
@@ -246,6 +251,23 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	}
 
 	/**
+	 * Get the attribution of one entry through its key
+	 * @param key - Key to track
+	 * @returns The attribution of related entry
+	 */
+	public getAttribution(key: string): AttributionKey | undefined {
+		return this.kernel.getAttribution(key);
+	}
+
+	/**
+	 * Get all attribution of the map
+	 * @returns All attribution in the map
+	 */
+	public getAllAttribution(): Map<string, AttributionKey> | undefined {
+		return this.kernel.getAllAttribution();
+	}
+
+	/**
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.summarizeCore}
 	 * @internal
 	 */
@@ -281,7 +303,11 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 		//    loads all blobs at once and partitioning schema has no impact on that process.
 		for (const key of Object.keys(data)) {
 			const value = data[key];
-			if (value.value && value.value.length >= MinValueSizeSeparateSnapshotBlob) {
+			if (
+				value.value &&
+				value.value.length + (value.attribution?.length ?? 0) >=
+					MinValueSizeSeparateSnapshotBlob
+			) {
 				const blobName = `blob${counter}`;
 				counter++;
 				blobs.push(blobName);
@@ -289,6 +315,10 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 					[key]: {
 						type: value.type,
 						value: JSON.parse(value.value) as unknown,
+						attribution:
+							value.attribution === undefined
+								? undefined
+								: JSON.parse(value.attribution),
 					},
 				};
 				builder.addBlob(blobName, JSON.stringify(content));
@@ -296,6 +326,9 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 				currentSize += value.type.length + 21; // Approximation cost of property header
 				if (value.value) {
 					currentSize += value.value.length;
+				}
+				if (value.attribution) {
+					currentSize += value.attribution.length;
 				}
 
 				if (currentSize > MaxSnapshotBlobSize) {
@@ -312,6 +345,8 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 						value.value === undefined
 							? undefined
 							: (JSON.parse(value.value) as unknown),
+					attribution:
+						value.attribution === undefined ? undefined : JSON.parse(value.attribution),
 				};
 			}
 		}
@@ -377,11 +412,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 		localOpMetadata: unknown,
 	): void {
 		if (message.type === MessageType.Operation) {
-			this.kernel.tryProcessMessage(
-				message.contents as IMapOperation,
-				local,
-				localOpMetadata,
-			);
+			this.kernel.tryProcessMessage(message, local, localOpMetadata);
 		}
 	}
 

--- a/experimental/dds/attributable-map/src/mapKernel.ts
+++ b/experimental/dds/attributable-map/src/mapKernel.ts
@@ -6,7 +6,9 @@
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { IFluidSerializer, ValueType } from "@fluidframework/shared-object-base";
 import { assert, TypedEventEmitter } from "@fluidframework/common-utils";
-import { ISerializableValue, ISerializedValue, ISharedMapEvents } from "./interfaces";
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { AttributionKey } from "@fluidframework/runtime-definitions";
+import { IMapOptions, ISerializableValue, ISerializedValue, ISharedMapEvents } from "./interfaces";
 import {
 	IMapSetOperation,
 	IMapDeleteOperation,
@@ -23,12 +25,16 @@ import { ILocalValue, LocalValueMaker, makeSerializable } from "./localValues";
 interface IMapMessageHandler {
 	/**
 	 * Apply the given operation.
-	 * @param op - The map operation to apply
+	 * @param message - The message to process
 	 * @param local - Whether the message originated from the local client
 	 * @param localOpMetadata - For local client messages, this is the metadata that was submitted with the message.
 	 * For messages from a remote client, this will be undefined.
 	 */
-	process(op: IMapOperation, local: boolean, localOpMetadata: MapLocalOpMetadata): void;
+	process(
+		message: ISequencedDocumentMessage,
+		local: boolean,
+		localOpMetadata: MapLocalOpMetadata,
+	): void;
 
 	/**
 	 * Communicate the operation to remote clients.
@@ -127,7 +133,7 @@ function createKeyLocalOpMetadata(
 /**
  * A SharedMap is a map-like distributed data structure.
  */
-export class MapKernel {
+export class AttributableMapKernel {
 	/**
 	 * The number of key/value pairs stored in the map.
 	 */
@@ -165,6 +171,8 @@ export class MapKernel {
 	 */
 	private readonly localValueMaker: LocalValueMaker;
 
+	private attribution: Map<string, AttributionKey> | undefined;
+
 	/**
 	 * Create a new shared map kernel.
 	 * @param serializer - The serializer to serialize / parse handles
@@ -180,9 +188,13 @@ export class MapKernel {
 		private readonly submitMessage: (op: unknown, localOpMetadata: unknown) => void,
 		private readonly isAttached: () => boolean,
 		private readonly eventEmitter: TypedEventEmitter<ISharedMapEvents>,
+		private readonly options?: IMapOptions,
 	) {
 		this.localValueMaker = new LocalValueMaker(serializer);
 		this.messageHandlers = this.getMessageHandlers();
+		if (options?.attribution?.track) {
+			this.attribution = new Map();
+		}
 	}
 
 	/**
@@ -294,8 +306,9 @@ export class MapKernel {
 		const localValue = this.localValueMaker.fromInMemory(value);
 		const serializableValue = makeSerializable(localValue, this.serializer, this.handle);
 
-		// Set the value locally.
+		// Set the value and attribution locally.
 		const previousValue = this.setCore(key, localValue, true);
+		this.setAttribution(key);
 
 		// If we are not attached, don't submit the op.
 		if (!this.isAttached()) {
@@ -318,6 +331,7 @@ export class MapKernel {
 	public delete(key: string): boolean {
 		// Delete the key locally first.
 		const previousValue = this.deleteCore(key, true);
+		this.setAttribution(key);
 
 		// If we are not attached, don't submit the op.
 		if (!this.isAttached()) {
@@ -354,6 +368,44 @@ export class MapKernel {
 	}
 
 	/**
+	 * Get the attribution about the target key
+	 * @param key - Key to track
+	 * @returns The Attribution Key if the attribution tracking is enabled and key exists, otherwise undefined
+	 */
+	public getAttribution(key: string): AttributionKey | undefined {
+		return this.attribution?.get(key);
+	}
+
+	/**
+	 * Get the whole attribution table
+	 * @returns The attribution table if the attribution tracking is enabled, otherwise undefined
+	 */
+
+	public getAllAttribution(): Map<string, AttributionKey> | undefined {
+		return this.attribution;
+	}
+
+	private setAttribution(key: string, message?: ISequencedDocumentMessage): void {
+		if (this.options?.attribution?.track) {
+			if (message) {
+				this.attribution?.set(key, { type: "op", seq: message.sequenceNumber });
+			} else {
+				if (this.isAttached()) {
+					this.attribution?.set(key, { type: "local" });
+				} else {
+					this.attribution?.set(key, { type: "detached", id: 0 });
+				}
+			}
+		}
+	}
+
+	private clearAttribution(): void {
+		if (this.options?.attribution?.track) {
+			this.attribution?.clear();
+		}
+	}
+
+	/**
 	 * Serializes the data stored in the shared map to a JSON string
 	 * @param serializer - The serializer to use to serialize handles in its values.
 	 * @returns A JSON string containing serialized map data
@@ -361,7 +413,18 @@ export class MapKernel {
 	public getSerializedStorage(serializer: IFluidSerializer): IMapDataObjectSerialized {
 		const serializableMapData: IMapDataObjectSerialized = {};
 		for (const [key, localValue] of this.data.entries()) {
-			serializableMapData[key] = localValue.makeSerialized(serializer, this.handle);
+			const attribution = this.options?.attribution?.track
+				? this.attribution?.get(key)
+				: undefined;
+			serializableMapData[key] = localValue.makeSerialized(
+				serializer,
+				this.handle,
+				attribution && attribution?.type !== "local"
+					? attribution.type === "op"
+						? attribution.seq
+						: attribution
+					: undefined,
+			);
 		}
 		return serializableMapData;
 	}
@@ -380,7 +443,7 @@ export class MapKernel {
 
 	/**
 	 * Populate the kernel with the given map data.
-	 * @param data - A JSON string containing serialized map data
+	 * @param json - A JSON string containing serialized map data
 	 */
 	public populateFromSerializable(json: IMapDataObjectSerializable): void {
 		for (const [key, serializable] of Object.entries(json)) {
@@ -390,6 +453,18 @@ export class MapKernel {
 			};
 
 			this.data.set(localValue.key, localValue.value);
+			if (serializable.attribution) {
+				// create the attribution table once there exists attribution key in the loaded content
+				this.attribution ??= new Map();
+				if (typeof serializable.attribution === "number") {
+					this.attribution.set(localValue.key, {
+						type: "op",
+						seq: serializable.attribution,
+					});
+				} else {
+					this.attribution.set(localValue.key, serializable.attribution);
+				}
+			}
 		}
 	}
 
@@ -424,18 +499,23 @@ export class MapKernel {
 
 	/**
 	 * Process the given op if a handler is registered.
-	 * @param op - The message to process
+	 * @param message - The message to process
 	 * @param local - Whether the message originated from the local client
 	 * @param localOpMetadata - For local client messages, this is the metadata that was submitted with the message.
 	 * For messages from a remote client, this will be undefined.
 	 * @returns True if the operation was processed, false otherwise.
 	 */
-	public tryProcessMessage(op: IMapOperation, local: boolean, localOpMetadata: unknown): boolean {
+	public tryProcessMessage(
+		message: ISequencedDocumentMessage,
+		local: boolean,
+		localOpMetadata: unknown,
+	): boolean {
+		const op: IMapOperation = message.contents;
 		const handler = this.messageHandlers.get(op.type);
 		if (handler === undefined) {
 			return false;
 		}
-		handler.process(op, local, localOpMetadata as MapLocalOpMetadata);
+		handler.process(message, local, localOpMetadata as MapLocalOpMetadata);
 		return true;
 	}
 
@@ -580,17 +660,18 @@ export class MapKernel {
 	/**
 	 * If our local operations that have not yet been ack'd will eventually overwrite an incoming operation, we should
 	 * not process the incoming operation.
-	 * @param op - Operation to check
+	 * @param message - Message to process
 	 * @param local - Whether the message originated from the local client
 	 * @param localOpMetadata - For local client messages, this is the metadata that was submitted with the message.
 	 * For messages from a remote client, this will be undefined.
 	 * @returns True if the operation should be processed, false otherwise
 	 */
 	private needProcessKeyOperation(
-		op: IMapKeyOperation,
+		message: ISequencedDocumentMessage,
 		local: boolean,
 		localOpMetadata: MapLocalOpMetadata,
 	): boolean {
+		const op: IMapKeyOperation = message.contents;
 		if (this.pendingClearMessageIds.length > 0) {
 			if (local) {
 				assert(
@@ -623,6 +704,7 @@ export class MapKernel {
 				if (pendingMessageIds.length === 0) {
 					this.pendingKeys.delete(op.key);
 				}
+				this.setAttribution(op.key, message);
 			}
 			return false;
 		}
@@ -638,7 +720,7 @@ export class MapKernel {
 	private getMessageHandlers(): Map<string, IMapMessageHandler> {
 		const messageHandlers = new Map<string, IMapMessageHandler>();
 		messageHandlers.set("clear", {
-			process: (op: IMapClearOperation, local, localOpMetadata) => {
+			process: (message: ISequencedDocumentMessage, local, localOpMetadata) => {
 				if (local) {
 					assert(
 						isClearLocalOpMetadata(localOpMetadata),
@@ -649,12 +731,14 @@ export class MapKernel {
 						pendingClearMessageId === localOpMetadata.pendingMessageId,
 						0x2fb /* pendingMessageId does not match */,
 					);
+					this.clearAttribution();
 					return;
 				}
 				if (this.pendingKeys.size > 0) {
 					this.clearExceptPendingKeys();
 					return;
 				}
+				this.clearAttribution();
 				this.clearCore(local);
 			},
 			submit: (op: IMapClearOperation, localOpMetadata: IMapClearLocalOpMetadata) => {
@@ -678,10 +762,12 @@ export class MapKernel {
 			},
 		});
 		messageHandlers.set("delete", {
-			process: (op: IMapDeleteOperation, local, localOpMetadata) => {
-				if (!this.needProcessKeyOperation(op, local, localOpMetadata)) {
+			process: (message: ISequencedDocumentMessage, local, localOpMetadata) => {
+				const op: IMapDeleteOperation = message.contents;
+				if (!this.needProcessKeyOperation(message, local, localOpMetadata)) {
 					return;
 				}
+				this.setAttribution(op.key, message);
 				this.deleteCore(op.key, local);
 			},
 			submit: (op: IMapDeleteOperation, localOpMetadata: MapKeyLocalOpMetadata) => {
@@ -694,12 +780,14 @@ export class MapKernel {
 			},
 		});
 		messageHandlers.set("set", {
-			process: (op: IMapSetOperation, local, localOpMetadata) => {
-				if (!this.needProcessKeyOperation(op, local, localOpMetadata)) {
+			process: (message: ISequencedDocumentMessage, local, localOpMetadata) => {
+				const op: IMapSetOperation = message.contents;
+				if (!this.needProcessKeyOperation(message, local, localOpMetadata)) {
 					return;
 				}
 
 				// needProcessKeyOperation should have returned false if local is true
+				this.setAttribution(op.key, message);
 				const context = this.makeLocal(op.key, op.value);
 				this.setCore(op.key, context, local);
 			},

--- a/experimental/dds/attributable-map/src/mapKernel.ts
+++ b/experimental/dds/attributable-map/src/mapKernel.ts
@@ -422,10 +422,16 @@ export class AttributableMapKernel {
 			const attribution = this.options?.attribution?.track
 				? this.attribution?.get(key)
 				: undefined;
+
+			assert(
+				!attribution || attribution.type !== "local",
+				"The attribution for summarization should not be local type",
+			);
+
 			serializableMapData[key] = localValue.makeSerialized(
 				serializer,
 				this.handle,
-				attribution && attribution?.type !== "local"
+				attribution
 					? attribution.type === "op"
 						? attribution.seq
 						: attribution

--- a/experimental/dds/attributable-map/src/mapKernel.ts
+++ b/experimental/dds/attributable-map/src/mapKernel.ts
@@ -131,7 +131,7 @@ function createKeyLocalOpMetadata(
 }
 
 /**
- * A SharedMap is a map-like distributed data structure.
+ * An AttributableMap is a map-like distributed data structure.
  */
 export class AttributableMapKernel {
 	/**
@@ -174,7 +174,7 @@ export class AttributableMapKernel {
 	private attribution: Map<string, AttributionKey> | undefined;
 
 	/**
-	 * Create a new shared map kernel.
+	 * Create a new attributable-map kernel.
 	 * @param serializer - The serializer to serialize / parse handles
 	 * @param handle - The handle of the shared object using the kernel
 	 * @param submitMessage - A callback to submit a message through the shared object

--- a/experimental/dds/attributable-map/src/test/memory/map.spec.ts
+++ b/experimental/dds/attributable-map/src/test/memory/map.spec.ts
@@ -5,10 +5,14 @@
 
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { benchmarkMemory, IMemoryTestObject } from "@fluid-tools/benchmark";
-import { MapFactory, SharedMap } from "../../map";
+import { MapFactory, AttributableMap } from "../../map";
 
-function createLocalMap(id: string): SharedMap {
-	const map = new SharedMap(id, new MockFluidDataStoreRuntime(), MapFactory.Attributes);
+function createLocalMap(id: string): AttributableMap {
+	const map: AttributableMap = new AttributableMap(
+		id,
+		new MockFluidDataStoreRuntime(),
+		MapFactory.Attributes,
+	);
 	return map;
 }
 
@@ -36,7 +40,7 @@ describe("SharedMap memory usage", () => {
 			public readonly title = "Create empty map";
 			public readonly minSampleCount = 500;
 
-			private map: SharedMap = createLocalMap("testMap");
+			private map: AttributableMap = createLocalMap("testMap");
 
 			public async run(): Promise<void> {
 				this.map = createLocalMap("testMap");
@@ -50,7 +54,7 @@ describe("SharedMap memory usage", () => {
 		benchmarkMemory(
 			new (class implements IMemoryTestObject {
 				public readonly title = `Add ${x} integers to a local map`;
-				private map: SharedMap = createLocalMap("testMap");
+				private map: AttributableMap = createLocalMap("testMap");
 
 				public async run(): Promise<void> {
 					for (let i = 0; i < x; i++) {
@@ -67,7 +71,7 @@ describe("SharedMap memory usage", () => {
 		benchmarkMemory(
 			new (class implements IMemoryTestObject {
 				public readonly title = `Add ${x} integers to a local map, clear it`;
-				private map: SharedMap = createLocalMap("testMap");
+				private map: AttributableMap = createLocalMap("testMap");
 
 				public async run(): Promise<void> {
 					for (let i = 0; i < x; i++) {

--- a/experimental/dds/attributable-map/src/test/mocha/map.spec.ts
+++ b/experimental/dds/attributable-map/src/test/mocha/map.spec.ts
@@ -447,17 +447,14 @@ describe("Map", () => {
 				map.set("key1", 1);
 				map.set("key2", 2);
 
-				let attribution1 = map.getAttribution("key1");
-				let attribution2 = map.getAttribution("key2");
-
-				assert.equal(
-					attribution1?.type,
-					"detached",
+				assert.deepEqual(
+					map.getAttribution("key1"),
+					{ type: "detached", id: 0 },
 					"the first entry should have detached attribution",
 				);
-				assert.equal(
-					attribution2?.type,
-					"detached",
+				assert.deepEqual(
+					map.getAttribution("key2"),
+					{ type: "detached", id: 0 },
 					"the second entry should have detached attribution",
 				);
 
@@ -472,17 +469,14 @@ describe("Map", () => {
 				);
 				await map2.load(services);
 
-				attribution1 = map2.getAttribution("key1");
-				attribution2 = map2.getAttribution("key2");
-
-				assert.equal(
-					attribution1?.type,
-					"detached",
+				assert.deepEqual(
+					map2.getAttribution("key1"),
+					{ type: "detached", id: 0 },
 					"the first entry of the loaded map should have detached attribution",
 				);
-				assert.equal(
-					attribution2?.type,
-					"detached",
+				assert.deepEqual(
+					map2.getAttribution("key2"),
+					{ type: "detached", id: 0 },
 					"the second entry of the loaded map should have detached attribution",
 				);
 			});
@@ -853,86 +847,71 @@ describe("Map", () => {
 
 				containerRuntimeFactory.processSomeMessages(1);
 
-				let attribution1 = map1.getAttribution("key1");
-				let attribution2 = map1.getAttribution("key2");
-				let attribution3 = map2.getAttribution("key1");
-				let attribution4 = map2.getAttribution("key2");
-
-				assert.equal(
-					attribution1?.type === "op" && attribution1?.seq,
-					1,
+				assert.deepEqual(
+					map1.getAttribution("key1"),
+					{ type: "op", seq: 1 },
 					"the first entry of map1 should have correct op-based attribution",
 				);
-				assert.equal(
-					attribution2?.type,
-					"local",
+				assert.deepEqual(
+					map1.getAttribution("key2"),
+					{ type: "local" },
 					"the second entry of map1 should have valid local attribution",
 				);
-				assert.equal(
-					attribution3?.type,
-					"local",
+				assert.deepEqual(
+					map2.getAttribution("key1"),
+					{ type: "local" },
 					"the first entry of map2 should have valid local attribution",
 				);
 				assert.equal(
-					attribution4,
+					map2.getAttribution("key2"),
 					undefined,
 					"the second entry of map2 should not have valid attribution",
 				);
 
 				containerRuntimeFactory.processSomeMessages(2);
 
-				attribution1 = map1.getAttribution("key1");
-				attribution2 = map1.getAttribution("key2");
-				attribution3 = map2.getAttribution("key1");
-				attribution4 = map2.getAttribution("key2");
-
-				assert.equal(
-					attribution1?.type === "op" && attribution1?.seq,
-					3,
+				assert.deepEqual(
+					map1.getAttribution("key1"),
+					{ type: "op", seq: 3 },
 					"the first entry of map1 should have correct op-based attribution",
 				);
-				assert.equal(
-					attribution2?.type === "op" && attribution2?.seq,
-					2,
-					"the second entry of map1 should have correct op-based local attribution",
+				assert.deepEqual(
+					map1.getAttribution("key2"),
+					{ type: "op", seq: 2 },
+					"the second entry of map1 should have correct op-based attribution",
 				);
-				assert.equal(
-					attribution3?.type === "op" && attribution3?.seq,
-					3,
+				assert.deepEqual(
+					map2.getAttribution("key1"),
+					{ type: "op", seq: 3 },
 					"the first entry of map2 should have correct op-based attribution",
 				);
-				assert.equal(
-					attribution4?.type === "op" && attribution4?.seq,
-					2,
-					"the second entry of map2 should have correct op-based local attribution",
+				assert.deepEqual(
+					map2.getAttribution("key2"),
+					{ type: "op", seq: 2 },
+					"the second entry of map2 should have correct op-based attribution",
 				);
 
 				// Delete an entry and check the attribution
 				map1.delete("key2");
 				containerRuntimeFactory.processSomeMessages(1);
 
-				attribution1 = map1.getAttribution("key1");
-				attribution2 = map1.getAttribution("key2");
-				attribution3 = map2.getAttribution("key1");
-				attribution4 = map2.getAttribution("key2");
-
-				assert.equal(
-					attribution1?.type === "op" && attribution1?.seq,
-					3,
+				assert.deepEqual(
+					map1.getAttribution("key1"),
+					{ type: "op", seq: 3 },
 					"the first entry of map1 should have correct op-based attribution",
 				);
 				assert.equal(
-					attribution2,
+					map1.getAttribution("key2"),
 					undefined,
 					"the attribution of second entry of map1 should be removed",
 				);
-				assert.equal(
-					attribution3?.type === "op" && attribution3?.seq,
-					3,
+				assert.deepEqual(
+					map2.getAttribution("key1"),
+					{ type: "op", seq: 3 },
 					"the first entry of map2 should have correct op-based attribution",
 				);
 				assert.equal(
-					attribution4,
+					map2.getAttribution("key2"),
 					undefined,
 					"the attribution of second entry of map2 should be removed",
 				);
@@ -976,18 +955,15 @@ describe("Map", () => {
 				);
 				await map3.load(service);
 
-				const attribution1 = map3.getAttribution("key1");
-				const attribution2 = map3.getAttribution("key2");
-
-				assert.equal(
-					attribution1?.type === "op" && attribution1?.seq,
-					3,
+				assert.deepEqual(
+					map3.getAttribution("key1"),
+					{ type: "op", seq: 3 },
 					"The loaded map should have valid op-based attribution for the first entry",
 				);
 
-				assert.equal(
-					attribution2?.type === "op" && attribution2?.seq,
-					2,
+				assert.deepEqual(
+					map3.getAttribution("key2"),
+					{ type: "op", seq: 2 },
 					"The loaded map should have valid op-based attribution for the second entry",
 				);
 			});

--- a/experimental/dds/attributable-map/src/test/mocha/map.spec.ts
+++ b/experimental/dds/attributable-map/src/test/mocha/map.spec.ts
@@ -961,11 +961,12 @@ describe("Map", () => {
 
 			it("Can retrieve proper attribution information after summarization/loading", async () => {
 				map1.set("key1", 1);
-				map2.set("key1", 2);
+				map2.set("key2", 2);
+				map2.set("key1", 3);
 
-				containerRuntimeFactory.processSomeMessages(1);
+				containerRuntimeFactory.processAllMessages();
 
-				const service1 = MockSharedObjectServices.createFromSummary(
+				const service = MockSharedObjectServices.createFromSummary(
 					map1.getAttachSummary().summary,
 				);
 				const map3 = new AttributableMap(
@@ -973,32 +974,21 @@ describe("Map", () => {
 					new MockFluidDataStoreRuntime(),
 					MapFactory.Attributes,
 				);
-				await map3.load(service1);
+				await map3.load(service);
 
 				const attribution1 = map3.getAttribution("key1");
+				const attribution2 = map3.getAttribution("key2");
 
 				assert.equal(
 					attribution1?.type === "op" && attribution1?.seq,
-					1,
+					3,
 					"The loaded map should have valid op-based attribution for the first entry",
 				);
 
-				const service2 = MockSharedObjectServices.createFromSummary(
-					map2.getAttachSummary().summary,
-				);
-				const map4 = new AttributableMap(
-					"map4",
-					new MockFluidDataStoreRuntime(),
-					MapFactory.Attributes,
-				);
-				await map4.load(service2);
-
-				const attribution2 = map4.getAttribution("key1");
-
 				assert.equal(
-					attribution2,
-					undefined,
-					"The loaded map should not have local attribution",
+					attribution2?.type === "op" && attribution2?.seq,
+					2,
+					"The loaded map should have valid op-based attribution for the second entry",
 				);
 			});
 		});

--- a/experimental/dds/attributable-map/src/test/mocha/map.spec.ts
+++ b/experimental/dds/attributable-map/src/test/mocha/map.spec.ts
@@ -846,11 +846,10 @@ describe("Map", () => {
 				map2 = createConnectedMap("map2", containerRuntimeFactory, options);
 			});
 
-			it("Can retrieve proper attribution information with some normal operations", () => {
+			it("Can retrieve proper attribution information with set/delete key operations", () => {
 				map1.set("key1", 1);
 				map1.set("key2", 2);
 				map2.set("key1", 3);
-				map1.delete("key2");
 
 				containerRuntimeFactory.processSomeMessages(1);
 
@@ -908,6 +907,8 @@ describe("Map", () => {
 					"the second entry of map2 should have correct op-based local attribution",
 				);
 
+				// Delete an entry and check the attribution
+				map1.delete("key2");
 				containerRuntimeFactory.processSomeMessages(1);
 
 				attribution1 = map1.getAttribution("key1");
@@ -921,9 +922,9 @@ describe("Map", () => {
 					"the first entry of map1 should have correct op-based attribution",
 				);
 				assert.equal(
-					attribution2?.type === "op" && attribution2?.seq,
-					4,
-					"the second entry of map1 should have correct op-based local attribution",
+					attribution2,
+					undefined,
+					"the attribution of second entry of map1 should be removed",
 				);
 				assert.equal(
 					attribution3?.type === "op" && attribution3?.seq,
@@ -931,9 +932,9 @@ describe("Map", () => {
 					"the first entry of map2 should have correct op-based attribution",
 				);
 				assert.equal(
-					attribution4?.type === "op" && attribution4?.seq,
-					4,
-					"the second entry of map2 should have correct op-based local attribution",
+					attribution4,
+					undefined,
+					"the attribution of second entry of map2 should be removed",
 				);
 			});
 

--- a/experimental/dds/attributable-map/src/test/mocha/reconnection.spec.ts
+++ b/experimental/dds/attributable-map/src/test/mocha/reconnection.spec.ts
@@ -10,15 +10,15 @@ import {
 	MockContainerRuntimeForReconnection,
 	MockStorage,
 } from "@fluidframework/test-runtime-utils";
-import { MapFactory, SharedMap } from "../../map";
+import { MapFactory, AttributableMap } from "../../map";
 
 describe("Reconnection", () => {
 	describe("SharedMap", () => {
 		let containerRuntimeFactory: MockContainerRuntimeFactoryForReconnection;
 		let containerRuntime1: MockContainerRuntimeForReconnection;
 		let containerRuntime2: MockContainerRuntimeForReconnection;
-		let map1: SharedMap;
-		let map2: SharedMap;
+		let map1: AttributableMap;
+		let map2: AttributableMap;
 
 		beforeEach(async () => {
 			containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
@@ -30,7 +30,7 @@ describe("Reconnection", () => {
 				deltaConnection: containerRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
-			map1 = new SharedMap("shared-map-1", dataStoreRuntime1, MapFactory.Attributes);
+			map1 = new AttributableMap("shared-map-1", dataStoreRuntime1, MapFactory.Attributes);
 			map1.connect(services1);
 
 			// Create the second SharedMap.
@@ -40,7 +40,7 @@ describe("Reconnection", () => {
 				deltaConnection: containerRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
-			map2 = new SharedMap("shared-map-2", dataStoreRuntime2, MapFactory.Attributes);
+			map2 = new AttributableMap("shared-map-2", dataStoreRuntime2, MapFactory.Attributes);
 			map2.connect(services2);
 		});
 


### PR DESCRIPTION
## Description

As a follow-up of the https://github.com/microsoft/FluidFramework/pull/13989, this PR includes the integration of the original SharedMap and its attribution-related API, along with the creation of a new experimental DDS named `attributableMap`. This experimental DDS allows for the tracking of attribution information, such as the user who made an update and the timestamp of the change. The `attributableMap` currently includes three types of attribution keys: Op-stream, detached, and local.

- The Op-stream attribution key indicates that the update of attribution information is synchronized with the processing of a map operation, and only occurs once the update is ack'd. 
- The detached attribution key only occurs when the DDS is not attached, and can be summarized into a snapshot. 
- The local attribution key exists when the operation has not yet been ack'd and cannot be summarized.

### Work breakdown

- Attribution API implementation: eddd6892502fd6234425417b58faecbbdae41cb3
- Mocha test suites: 3ca07e3da0334179fd59772e9acb9e5dd49c4747
- API document: 7976aa8fab0ea313b3ac0c61eb861485e7bd73be and b6631ef3715fadb47911e20a938b1cb62a4c3581

### PR Checklist

-   [X] I have updated the documentation accordingly.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] My code follows the code style of this project.
-   [X] I ran the lint checks which produced no new errors nor warnings for my changes.
-   [X] I have checked to ensure there aren't other open Pull Requests for the same update/change.

### Does this introduce a breaking change?

-   [ ] Yes
-   [X] No
