### PR TITLE
Improve Time to Debug for Debug Current Mocha Test

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -308,8 +308,6 @@
 				"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha.cmd"
 			},
 			"sourceMaps": true,
-			"stopOnEntry": false,
-			"pauseForSourceMap": false,
 			"program": "${file}",
 			"args": [
 				// "--fgrep",               // Uncomment to filter by test case name
@@ -319,8 +317,7 @@
 			],
 			"cwd": "${fileDirname}",
 			"skipFiles": ["<node_internals>/**", "**/node_modules/**"],
-			"resolveSourceMapLocations": ["${workspaceFolder}/**/dist/**", "!**/node_modules/**"],
-			"outFiles": ["${workspaceFolder}/**/dist/**/*.js", "!**/node_modules/**"],
+			"outFiles": ["${workspaceFolder}/**/dist/**/*.js"],
 			"preLaunchTask": "Build Current Tests",
 			"internalConsoleOptions": "openOnSessionStart"
 		},


### PR DESCRIPTION
## Description
Simplify our Lauch.json configuration for Debug Current Mocha Test. This has improved time to debug, and doesn't seem to introduce any new issues. The previous config was put together to work around out of memory issues hit in the vs code debugger which don't appear to occur anymore. This change also seems to be inline with the current guidance for debugging typescript in the vs code documentation: https://code.visualstudio.com/docs/typescript/typescript-debugging