### PR TITLE
fix(container-runtime): Remove incorrect assert

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1289,12 +1289,6 @@ export class ContainerRuntime
 			);
 
 			if (this.context.clientDetails.type === summarizerClientType) {
-				// ContainerRuntime handles the entryPoint for summarizer clients on its own; we shouldn't receive
-				// an initializeEntryPoint for that case.
-				assert(
-					initializeEntryPoint === undefined,
-					0x5be /* Summarizer clients cannot have a custom entryPoint */,
-				);
 				this._summarizer = new Summarizer(
 					this /* ISummarizerRuntime */,
 					() => this.summaryConfiguration,


### PR DESCRIPTION
## Description

Fixes a bug by removing an assert added in #14681 that shouldn't have been there in the first place. The assert makes it so the new entryPoint functionality for Container which is intended to replace the request pattern _cannot be used_, because it causes the instantiation of the summarizer container to fail every time if an entryPoint-initialization function is provided to the ContainerRuntime. Since the ContainerRuntime that gets instantiated for both interactive and summarizer containers is created by the same factory, we cannot expect that in the summarizer case the `initializeEntryPoint` constructor parameter will be undefined while in the interactive case it is not.

I'm working on tests to prevent a regression here, but wanted to get the fix in ASAP.
