### PR TITLE
Deprecate term member from IDocumentAttributes and ISequencedDocumentMessage

### DIFF
--- a/common/lib/protocol-definitions/CHANGELOG.md
+++ b/common/lib/protocol-definitions/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @fluidframework/protocol-definitions Changelog
+
+## [1.2.0](https://github.com/microsoft/FluidFramework/releases/tag/protocol-definitions_v1.2.0) (2023-04-05)
+
+### Deprecate term member from IDocumentAttributes and ISequencedDocumentMessage
+
+This member was related to an experimental feature that did not ship. As a result it is unused/ignored by all consumers.
+This change deprecates it, to be removed in a later release.

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -154,6 +154,7 @@ export interface ICreateBlobResponse {
 export interface IDocumentAttributes {
     minimumSequenceNumber: number;
     sequenceNumber: number;
+    // @deprecated
     term: number | undefined;
 }
 
@@ -307,6 +308,7 @@ export interface ISequencedDocumentMessage {
     referenceSequenceNumber: number;
     sequenceNumber: number;
     serverMetadata?: any;
+    // @deprecated
     term: number | undefined;
     timestamp: number;
     traces?: ITrace[];

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -222,6 +222,7 @@ export interface ISequencedDocumentMessage {
 
 	/**
 	 * The term identifier.
+	 * @deprecated 1.2.0 - Unused from a legacy feature, will be removed entirely in an upcoming release.
 	 */
 	term: number | undefined;
 

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -18,6 +18,7 @@ export interface IDocumentAttributes {
 
 	/**
 	 * Term number at which the snapshot was taken
+	 * @deprecated 1.2.0 - Unused from a legacy feature, will be removed entirely in an upcoming release.
 	 */
 	term: number | undefined;
 }


### PR DESCRIPTION
This member was related to an experimental feature that did not ship. As a result it is unused/ignored by all consumers. This change deprecates it, to be removed in a later release.