### PR TITLE
Move DDS fuzz harness to test-dds-utils

### DIFF
--- a/build-tools/packages/build-tools/data/layerInfo.json
+++ b/build-tools/packages/build-tools/data/layerInfo.json
@@ -134,6 +134,7 @@
 			"Test-Utils": {
 				"dev": true,
 				"packages": [
+					"@fluid-internal/stochastic-test-utils",
 					"@fluid-internal/test-dds-utils",
 					"@fluidframework/local-driver",
 					"@fluidframework/test-runtime-utils",

--- a/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.fuzz.spec.ts
@@ -13,11 +13,11 @@ import {
 	Reducer,
 	take,
 } from "@fluid-internal/stochastic-test-utils";
+import { createDDSFuzzSuite, DDSFuzzModel, DDSFuzzTestState } from "@fluid-internal/test-dds-utils";
 import { PropertySet } from "@fluidframework/merge-tree";
 import { IntervalCollection, IntervalType, SequenceInterval } from "../intervalCollection";
 import { SharedStringFactory } from "../sequenceFactory";
 import { assertEquivalentSharedStrings } from "./intervalUtils";
-import { createDDSFuzzSuite, DDSFuzzModel, DDSFuzzTestState } from "./ddsFuzzHarness";
 
 type FuzzTestState = DDSFuzzTestState<SharedStringFactory>;
 

--- a/packages/dds/test-dds-utils/README.md
+++ b/packages/dds/test-dds-utils/README.md
@@ -32,3 +32,19 @@ The caller is responsible for the following:
 ### Examples
 
 [SharedCell](../cell/src/test/cell.spec.ts) and [SharedDirectory](../map/test/directory.spec.ts) have tests that use the gcTestRunner for validating GC data.
+
+## Eventual Consistency Fuzz Tests
+
+This package also provides a [generic harness](./src/ddsFuzzHarness.ts) for writing eventual consistency fuzz tests for a DDS.
+This model is written using [@fluid-internal/stochastic-test-utils](../../test/stochastic-test-utils/README.md).
+See documentation on `createDDSFuzzSuite` and `DDSFuzzModel` for more details.
+
+The harness currently supports testing eventual consistency of op application using Fluid's set of [mocks](../../runtime/test-runtime-utils/README.md)
+including the reconnect flow.
+
+### Future Improvements
+
+The generic aspects of this model could be improved to fuzz test correctness a few other general concerns DDS authors have:
+
+-   Summarization correctness
+-   Offline (`applyStashedOp` implementation)

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -50,7 +50,11 @@
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"dependencies": {
+		"@fluid-internal/stochastic-test-utils": ">=2.0.0-internal.4.1.0 <2.0.0-internal.5.0.0",
+		"@fluidframework/common-utils": "^1.1.1",
+		"@fluidframework/datastore-definitions": ">=2.0.0-internal.4.1.0 <2.0.0-internal.5.0.0",
 		"@fluidframework/shared-object-base": ">=2.0.0-internal.4.1.0 <2.0.0-internal.5.0.0",
+		"@fluidframework/test-runtime-utils": ">=2.0.0-internal.4.1.0 <2.0.0-internal.5.0.0",
 		"mocha": "^10.2.0"
 	},
 	"devDependencies": {

--- a/packages/dds/test-dds-utils/src/index.ts
+++ b/packages/dds/test-dds-utils/src/index.ts
@@ -4,3 +4,13 @@
  */
 
 export { IGCTestProvider, runGCTests } from "./gcTestRunner";
+export {
+	BaseOperation,
+	ChangeConnectionState,
+	Client,
+	ClientSpec,
+	createDDSFuzzSuite,
+	DDSFuzzModel,
+	DDSFuzzTestState,
+	Synchronize,
+} from "./ddsFuzzHarness";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6171,10 +6171,14 @@ importers:
 
   packages/dds/test-dds-utils:
     specifiers:
+      '@fluid-internal/stochastic-test-utils': '>=2.0.0-internal.4.1.0 <2.0.0-internal.5.0.0'
       '@fluid-tools/build-cli': ^0.13.1
       '@fluidframework/build-common': ^1.1.0
+      '@fluidframework/common-utils': ^1.1.1
+      '@fluidframework/datastore-definitions': '>=2.0.0-internal.4.1.0 <2.0.0-internal.5.0.0'
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/shared-object-base': '>=2.0.0-internal.4.1.0 <2.0.0-internal.5.0.0'
+      '@fluidframework/test-runtime-utils': '>=2.0.0-internal.4.1.0 <2.0.0-internal.5.0.0'
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
       concurrently: ^7.6.0
@@ -6184,7 +6188,11 @@ importers:
       rimraf: ^4.4.0
       typescript: ~4.5.5
     dependencies:
+      '@fluid-internal/stochastic-test-utils': link:../../test/stochastic-test-utils
+      '@fluidframework/common-utils': 1.1.1
+      '@fluidframework/datastore-definitions': link:../../runtime/datastore-definitions
       '@fluidframework/shared-object-base': link:../shared-object-base
+      '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       mocha: 10.2.0
     devDependencies:
       '@fluid-tools/build-cli': 0.13.1_@types+node@14.18.38


### PR DESCRIPTION
## Description

Moves the DDS fuzz harness extracted from the interval collection fuzz tests to `@fluid-internal/test-dds-utils`.
This package has a more strict linter configuration, so this also fixes up some linter violations.

[AB#3806](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3806)