### PR TITLE
fix: Message type string

### DIFF
--- a/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidClientDebugger.ts
@@ -348,7 +348,7 @@ export class FluidClientDebugger
 		visualizations: Record<string, RootHandleNode> | undefined,
 	): void => {
 		postMessagesToWindow(this.messageLoggingOptions, {
-			type: "ROOT_DATA_VISUALIZATION",
+			type: "ROOT_DATA_VISUALIZATIONS",
 			data: {
 				visualizations,
 			},


### PR DESCRIPTION
The message "type" string being posted was incorrect.

In a subsequent PR, I plan to refactor our existing typing pattern to use constants so we don't run this risk in the future,