### PR TITLE
tree: Replace SchemaAware.ApiMode.Normalized with Editable

### DIFF
--- a/experimental/examples/bubblebench/editable-shared-tree/src/appState.ts
+++ b/experimental/examples/bubblebench/editable-shared-tree/src/appState.ts
@@ -3,12 +3,11 @@
  * Licensed under the MIT License.
  */
 import { IAppState, makeBubble, randomColor } from "@fluid-example/bubblebench-common";
-import { brand, FieldKey } from "@fluid-internal/tree";
+import { cursorFromContextualData } from "@fluid-internal/tree";
 import { ClientWrapper } from "./client";
-import { ClientsField, Client, FlexClient, FlexBubble } from "./schema";
+import { ClientsField, FlexClient, FlexBubble, rootAppStateSchema } from "./schema";
 
 export class AppState implements IAppState {
-	static clientsFieldKey: FieldKey = brand("clients");
 	readonly localClient: ClientWrapper;
 
 	constructor(
@@ -17,9 +16,14 @@ export class AppState implements IAppState {
 		public height: number,
 		numBubbles: number,
 	) {
-		clientsSequence[clientsSequence.length] = this.createInitialClientNode(
-			numBubbles,
-		) as Client;
+		clientsSequence.insertNodes(
+			clientsSequence.length,
+			cursorFromContextualData(
+				clientsSequence.context.schema,
+				rootAppStateSchema.types,
+				this.createInitialClientNode(numBubbles),
+			),
+		);
 		this.localClient = new ClientWrapper(clientsSequence[clientsSequence.length - 1]);
 
 		console.log(

--- a/experimental/examples/bubblebench/editable-shared-tree/src/bubblebench.ts
+++ b/experimental/examples/bubblebench/editable-shared-tree/src/bubblebench.ts
@@ -2,7 +2,14 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { fail, ISharedTree, SharedTreeFactory } from "@fluid-internal/tree";
+import {
+	AllowedUpdateType,
+	fail,
+	ISharedTree,
+	ISharedTreeView,
+	schematizeView,
+	SharedTreeFactory,
+} from "@fluid-internal/tree";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { AppState } from "./appState";
@@ -16,28 +23,30 @@ export class Bubblebench extends DataObject {
 		return "@fluid-example/bubblebench-sharedtree";
 	}
 
-	private _tree: ISharedTree | undefined;
+	private view: ISharedTreeView | undefined;
 	private _appState: AppState | undefined;
 
 	protected async initializingFirstTime() {
-		this._tree = this.runtime.createChannel(
+		const tree = this.runtime.createChannel(
 			/* id: */ undefined,
 			new SharedTreeFactory().type,
 		) as ISharedTree;
 
-		this.initializeTree(this.tree);
+		this.initializeTree(tree);
 
-		this.root.set(treeKey, this.tree.handle);
+		this.root.set(treeKey, tree.handle);
 	}
 
 	protected async initializingFromExisting() {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		this._tree = await this.root.get<IFluidHandle<ISharedTree>>(treeKey)!.get();
+		const tree = await this.root.get<IFluidHandle<ISharedTree>>(treeKey)!.get();
+		this.initializeTree(tree);
 	}
 
 	protected async hasInitialized() {
 		this._appState = new AppState(
-			this.tree.root as ClientsField,
+			// TODO: make schematizeView strongly type root and remove this cast
+			this.tree.root as unknown as ClientsField,
 			/* stageWidth: */ 640,
 			/* stageHeight: */ 480,
 			/* numBubbles: */ 1,
@@ -63,20 +72,23 @@ export class Bubblebench extends DataObject {
 	}
 
 	/**
-	 * Initialize the schema of the shared tree to that of the Bubblebench AppState
-	 * and inserts a node with the initial AppState as the root of the tree.
+	 * Initialize the schema of the shared tree to that of the Bubblebench AppState.
 	 * @param tree - ISharedTree
 	 */
 	initializeTree(tree: ISharedTree) {
-		tree.storedSchema.update(appSchemaData);
+		this.view = schematizeView(tree, {
+			allowedSchemaModifications: AllowedUpdateType.None,
+			initialTree: [],
+			schema: appSchemaData,
+		});
 	}
 
 	/**
 	 * Get the SharedTree.
 	 * Cannot be accessed until after initialization has complected.
 	 */
-	private get tree(): ISharedTree {
-		return this._tree ?? fail("not initialized");
+	private get tree(): ISharedTreeView {
+		return this.view ?? fail("not initialized");
 	}
 
 	/**

--- a/experimental/examples/bubblebench/editable-shared-tree/src/client.ts
+++ b/experimental/examples/bubblebench/editable-shared-tree/src/client.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { IClient } from "@fluid-example/bubblebench-common";
-import { EditableField } from "@fluid-internal/tree";
+import { cursorFromContextualData } from "@fluid-internal/tree";
 import { BubbleWrapper } from "./bubble";
 import { Client, FlexBubble } from "./schema";
 
@@ -33,8 +33,12 @@ export class ClientWrapper implements IClient {
 	}
 
 	public increaseBubbles(bubble: FlexBubble) {
-		const bubbles: EditableField = this.clientTreeProxy.bubbles;
-		bubbles[bubbles.length] = bubble;
+		const bubbles = this.clientTreeProxy.bubbles;
+		// TODO: better API
+		bubbles.insertNodes(
+			bubbles.length,
+			cursorFromContextualData(bubbles.context.schema, bubbles.fieldSchema.types, bubble),
+		);
 	}
 
 	public decreaseBubbles() {

--- a/experimental/examples/bubblebench/editable-shared-tree/src/schema.ts
+++ b/experimental/examples/bubblebench/editable-shared-tree/src/schema.ts
@@ -2,15 +2,14 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+/* eslint-disable @typescript-eslint/no-empty-interface */
 
 import {
-	EditableTree,
 	FieldKinds,
 	rootFieldKey,
 	ValueSchema,
 	TypedSchema,
 	SchemaAware,
-	EditableField,
 } from "@fluid-internal/tree";
 
 // Aliases for conciseness
@@ -50,24 +49,20 @@ export const appSchemaData = SchemaAware.typedSchemaData(
 
 type Typed<
 	TSchema extends TypedSchema.LabeledTreeSchema,
-	TMode extends SchemaAware.ApiMode = SchemaAware.ApiMode.Normalized,
+	TMode extends SchemaAware.ApiMode = SchemaAware.ApiMode.Editable,
 > = SchemaAware.NodeDataFor<typeof appSchemaData, TMode, TSchema>;
 
-// TODO: Generate this from schema automatically instead of hand coding it.
-export type Bubble = EditableTree & NormalizedBubble;
+export type Bubble = Typed<typeof bubbleSchema>;
+export type Client = Typed<typeof clientSchema>;
 
-export type NormalizedBubble = Typed<typeof bubbleSchema>;
-export type NormalizedClient = Typed<typeof clientSchema>;
+export type FlexBubble = Typed<typeof bubbleSchema, SchemaAware.ApiMode.Simple>;
+export type FlexClient = Typed<typeof clientSchema, SchemaAware.ApiMode.Simple>;
 
-export type FlexBubble = Typed<typeof bubbleSchema, SchemaAware.ApiMode.Flexible>;
-export type FlexClient = Typed<typeof clientSchema, SchemaAware.ApiMode.Flexible>;
-
-// TODO: Generate this from schema automatically instead of hand coding it.
-export type Client = EditableTree & {
-	clientId: string;
-	color: string;
-	bubbles: EditableField & Bubble[];
-};
-
-// TODO: Generate this from schema automatically instead of hand coding it.
-export type ClientsField = EditableField & Client[];
+// TODO: experiment with this interface pattern. Maybe it makes better intellisense and errors?
+// TODO: Intellisense is pretty bad here if not using interface.
+export interface ClientsField
+	extends SchemaAware.TypedField<
+		typeof appSchemaData,
+		SchemaAware.ApiMode.Editable,
+		typeof rootAppStateSchema
+	> {}

--- a/experimental/examples/tree-sample/tree-react-api/src/test/schema/appSchema.ts
+++ b/experimental/examples/tree-sample/tree-react-api/src/test/schema/appSchema.ts
@@ -18,6 +18,6 @@ export const appSchemaData = SchemaAware.typedSchemaData(
 
 export type Inventory = SchemaAware.NodeDataFor<
 	typeof appSchemaData,
-	SchemaAware.ApiMode.Normalized,
+	SchemaAware.ApiMode.Editable,
 	typeof inventorySchema
 >;

--- a/packages/dds/tree/src/feature-libraries/contextuallyTyped.ts
+++ b/packages/dds/tree/src/feature-libraries/contextuallyTyped.ts
@@ -327,6 +327,7 @@ function shallowCompatibilityTest(
  * Construct a tree from ContextuallyTypedNodeData.
  *
  * TODO: this should probably be refactored into a `try` function which either returns a Cursor or a SchemaError with a path to the error.
+ * @alpha
  */
 export function cursorFromContextualData(
 	schemaData: SchemaDataAndPolicy,

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeContext.ts
@@ -21,7 +21,7 @@ import {
 import { ISubscribable } from "../../events";
 import { DefaultEditBuilder } from "../defaultChangeFamily";
 import { singleMapTreeCursor } from "../mapTreeCursor";
-import { applyFieldTypesFromContext, ContextuallyTypedNodeData } from "../contextuallyTyped";
+import { applyFieldTypesFromContext, ContextuallyTypedFieldData } from "../contextuallyTyped";
 import { EditableField, UnwrappedEditableField } from "./editableTreeTypes";
 import { makeField, unwrappedField } from "./editableField";
 import { ProxyTarget } from "./ProxyTarget";
@@ -63,7 +63,7 @@ export interface EditableTreeContext extends ISubscribable<ForestEvents> {
 	 */
 	get root(): EditableField;
 
-	set root(data: ContextuallyTypedNodeData | undefined);
+	set root(data: ContextuallyTypedFieldData);
 
 	/**
 	 * Gets or sets the root field of the tree.
@@ -76,7 +76,7 @@ export interface EditableTreeContext extends ISubscribable<ForestEvents> {
 	 */
 	get unwrappedRoot(): UnwrappedEditableField;
 
-	set unwrappedRoot(data: ContextuallyTypedNodeData | undefined);
+	set unwrappedRoot(data: ContextuallyTypedFieldData);
 
 	/**
 	 * Schema used within this context.
@@ -165,7 +165,7 @@ export class ProxyContext implements EditableTreeContext {
 		return this.getRoot(true);
 	}
 
-	public set unwrappedRoot(value: ContextuallyTypedNodeData | undefined) {
+	public set unwrappedRoot(value: ContextuallyTypedFieldData) {
 		// Note that an implementation of `set root` might change in the future,
 		// see a comment in there regarding the `replaceNodes` and `replaceField` semantics.
 		// This setter might want to keep the `replaceNodes` semantics for the cases when the root is unwrapped,
@@ -179,7 +179,7 @@ export class ProxyContext implements EditableTreeContext {
 		return this.getRoot(false);
 	}
 
-	public set root(value: ContextuallyTypedNodeData | undefined) {
+	public set root(value: ContextuallyTypedFieldData) {
 		const rootField = this.getRoot(false);
 		const mapTrees = applyFieldTypesFromContext(this.schema, rootField.fieldSchema, value);
 		const cursors = mapTrees.map(singleMapTreeCursor);

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeTypes.ts
@@ -13,7 +13,6 @@ import {
 } from "../../core";
 import {
 	PrimitiveValue,
-	ContextuallyTypedNodeData,
 	MarkedArrayLike,
 	ContextuallyTypedNodeDataObject,
 	typeNameSymbol,
@@ -114,6 +113,10 @@ export interface EditableTreeEvents {
  *
  * The tree can be edited either by using its symbol-based "toolbox" (e.g. {@link createField})
  * or using a simple assignment operator (see `EditableTreeContext.unwrappedRoot` for more details).
+ *
+ * When iterating, reads all fields at once before the iteration starts to get a "snapshot" of this node.
+ * It might be inefficient regarding resources, but avoids situations
+ * when the fields are getting changed while iterating.
  * @alpha
  */
 export interface EditableTree extends Iterable<EditableField>, ContextuallyTypedNodeDataObject {
@@ -172,14 +175,6 @@ export interface EditableTree extends Iterable<EditableField>, ContextuallyTyped
 	 */
 	// TODO: update docs for concurrently deleting the field.
 	[key: FieldKey]: UnwrappedEditableField;
-
-	/**
-	 * Gets an iterator iterating over the fields of this node.
-	 * It reads all fields at once before the iteration starts to get a "snapshot" of this node.
-	 * It might be inefficient regarding resources, but avoids situations
-	 * when the fields are getting changed while iterating.
-	 */
-	[Symbol.iterator](): IterableIterator<EditableField>;
 
 	/**
 	 * Creates a new field at this node.
@@ -270,7 +265,7 @@ export type UnwrappedEditableField = UnwrappedEditableTree | undefined | Editabl
  * @alpha
  */
 export interface EditableField
-	// Here, the `UnwrappedEditableTree | ContextuallyTypedNodeData` union is used
+	// Here, the `UnwrappedEditableTree | ContextuallyTypedNodeData` is is used
 	// due to a lacking support for variant accessors for index signatures in TypeScript,
 	// see https://github.com/microsoft/TypeScript/issues/43826.
 	// Otherwise it would be better to have a setter accepting the `ContextuallyTypedNodeData`
@@ -280,7 +275,7 @@ export interface EditableField
 	// - "returns `UnwrappedEditableTree` when accessing the nodes by their indices" and
 	// - "can also accept `ContextuallyTypedNodeData` when setting the nodes by their indices".
 	// TODO: replace the numeric indexed access with getters and setters if possible.
-	extends MarkedArrayLike<UnwrappedEditableTree | ContextuallyTypedNodeData> {
+	extends MarkedArrayLike<UnwrappedEditableTree> {
 	/**
 	 * The `FieldSchema` of this field.
 	 */

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -152,3 +152,13 @@ export const FieldKinds: {
 	readonly optional: FieldKind<FieldEditor<any>, Multiplicity.Optional>;
 	readonly sequence: FieldKind<FieldEditor<any>, Multiplicity.Sequence>;
 } = FieldKindsOriginal;
+
+export {
+	UntypedField,
+	UntypedTree,
+	UntypedTreeContext,
+	UntypedTreeCore,
+	UnwrappedUntypedField,
+	UnwrappedUntypedTree,
+	UntypedTreeOrPrimitive,
+} from "./unknownTree";

--- a/packages/dds/tree/src/feature-libraries/schema-aware/README.md
+++ b/packages/dds/tree/src/feature-libraries/schema-aware/README.md
@@ -15,3 +15,8 @@ TODO:
     - Support extra local fields.
     - Support extra global fields (including in a way that is compatible with use in a library that does not have global schema knowledge).
     - Measure compiler performance, and ensure its good enough and we have a way to track it.
+
+TODO2:
+
+-   Explicit primitive schema and primary fields in schema objects.
+-   Schema sanity check somewhere (when building schema data): runtime error on missing schema types, fields, anything thats a Never node etc. Specific Error on infinite recursion.

--- a/packages/dds/tree/src/feature-libraries/schema-aware/index.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-aware/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export { ApiMode, NodeDataFor, typedSchemaData, TypedNode } from "./schemaAware";
+export { ApiMode, NodeDataFor, typedSchemaData, TypedNode, TypedField } from "./schemaAware";
 
 // Below here are things that are used by the above, but not part of the desired API surface.
 import * as InternalTypes from "./internal";

--- a/packages/dds/tree/src/feature-libraries/schema-aware/internal.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-aware/internal.ts
@@ -13,6 +13,10 @@ export {
 	ApplyMultiplicity,
 	ValueFieldTreeFromSchema,
 	FlexibleObject,
+	EditableSequenceField,
+	TypedField,
 } from "./schemaAware";
 
 export { NamesFromSchema, ValuesOf, TypedValue, PrimitiveValueSchema } from "./schemaAwareUtil";
+
+export { UntypedSequenceField } from "./partlyTyped";

--- a/packages/dds/tree/src/feature-libraries/schema-aware/partlyTyped.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-aware/partlyTyped.ts
@@ -1,0 +1,73 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { FieldKey, FieldSchema, ITreeCursor } from "../../core";
+import { FieldEditor, FieldKind, Multiplicity } from "../modular-schema";
+import { UntypedField, UntypedTree, UntypedTreeContext } from "../unknownTree";
+
+/**
+ * A sequence field in an {@link UntypedTree}.
+ *
+ * TODO:
+ * insertNodes and replaceNodes should be made more strongly typed (and moved elsewhere)
+ * and/or and API supporting more strongly typed data should be added (elsewhere).
+ * @alpha
+ */
+export interface UntypedSequenceField extends UntypedField {
+	/**
+	 * The `FieldSchema` of this field.
+	 */
+	readonly fieldSchema: FieldSchema & {
+		readonly kind: FieldKind<FieldEditor<any>, Multiplicity.Sequence>;
+	};
+
+	/**
+	 * The `FieldKey` of this field.
+	 */
+	readonly fieldKey: FieldKey;
+
+	/**
+	 * The node which has this field on it under `fieldKey`.
+	 * `undefined` iff this field is a detached field.
+	 */
+	readonly parent?: UntypedTree;
+
+	/**
+	 * A common context of a "forest" of EditableTrees.
+	 */
+	readonly context: UntypedTreeContext;
+
+	/**
+	 * Gets a node of this field by its index without unwrapping.
+	 * Note that the node must exists at the given index.
+	 */
+	getNode(index: number): UntypedTree;
+
+	/**
+	 * Inserts new nodes into this field.
+	 */
+	insertNodes(index: number, newContent: ITreeCursor | ITreeCursor[]): void;
+
+	/**
+	 * Sequentially deletes the nodes from this field.
+	 *
+	 * @param index - the index of the first node to be deleted. It must be in a range of existing node indices.
+	 * @param count - the number of nodes to be deleted. If not provided, deletes all nodes
+	 * starting from the index and up to the length of the field.
+	 */
+	deleteNodes(index: number, count?: number): void;
+
+	/**
+	 * Sequentially replaces the nodes of this field.
+	 *
+	 * @param index - the index of the first node to be replaced. It must be in a range of existing node indices.
+	 * @param count - the number of nodes to be replaced. If not provided, replaces all nodes
+	 * starting from the index and up to the length of the field.
+	 *
+	 * Note that, if multiple clients concurrently call replace on a sequence field,
+	 * all the insertions will be preserved.
+	 */
+	replaceNodes(index: number, newContent: ITreeCursor | ITreeCursor[], count?: number): void;
+}

--- a/packages/dds/tree/src/feature-libraries/schema-aware/schemaAware.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-aware/schemaAware.ts
@@ -4,7 +4,7 @@
  */
 
 import { GlobalFieldKey, SchemaDataAndPolicy, TreeSchemaIdentifier, ValueSchema } from "../../core";
-import { typeNameSymbol, valueSymbol } from "../contextuallyTyped";
+import { MarkedArrayLike, typeNameSymbol, valueSymbol } from "../contextuallyTyped";
 import {
 	FullSchemaPolicy,
 	Multiplicity,
@@ -13,7 +13,9 @@ import {
 	ViewSchemaCollection,
 } from "../modular-schema";
 import { defaultSchemaPolicy } from "../defaultSchema";
+import { UntypedField, UntypedTreeCore } from "../unknownTree";
 import { NamesFromSchema, PrimitiveValueSchema, TypedValue, ValuesOf } from "./schemaAwareUtil";
+import { UntypedSequenceField } from "./partlyTyped";
 
 /**
  * Schema aware API for a specific Schema.
@@ -68,13 +70,19 @@ export const enum ApiMode {
 	 * - Does not do primary field inlining.
 	 * - Primitive node handling might not match.
 	 */
-	Normalized,
+	Editable,
 	/**
 	 * Always use full node objects for everything.
 	 *
 	 * Fields are still shaped based on their multiplicity.
 	 */
 	Wrapped,
+	/**
+	 * Simplified version of Flexible.
+	 *
+	 * Primitive values are always unwrapped.
+	 */
+	Simple,
 }
 
 /**
@@ -90,7 +98,7 @@ export type CollectOptions<
 	[ApiMode.Flexible]: Record<string, never> extends TTypedFields
 		? TypedValue<TValueSchema> | FlexibleObject<TValueSchema, TName>
 		: FlexibleObject<TValueSchema, TName> & TypedSchema.AllowOptionalNotFlattened<TTypedFields>;
-	[ApiMode.Normalized]: [Record<string, never>, TValueSchema] extends [
+	[ApiMode.Editable]: [Record<string, never>, TValueSchema] extends [
 		TTypedFields,
 		PrimitiveValueSchema,
 	]
@@ -100,11 +108,15 @@ export type CollectOptions<
 					[typeNameSymbol]: TName & TreeSchemaIdentifier;
 				} & ValueFieldTreeFromSchema<TValueSchema> &
 					TTypedFields
-		  >;
+		  > &
+				UntypedTreeCore;
 	[ApiMode.Wrapped]: {
 		[typeNameSymbol]: TName;
 		[valueSymbol]: TypedValue<TValueSchema>;
 	} & TTypedFields;
+	[ApiMode.Simple]: Record<string, never> extends TTypedFields
+		? TypedValue<TValueSchema>
+		: FlexibleObject<TValueSchema, TName> & TypedSchema.AllowOptionalNotFlattened<TTypedFields>;
 }[Mode];
 
 /**
@@ -132,23 +144,51 @@ export type TypedFields<
 	TFields extends { [key: string]: TypedSchema.FieldSchemaTypeInfo },
 > = [
 	{
-		[key in keyof TFields]: ApplyMultiplicity<
-			TFields[key]["kind"]["multiplicity"],
-			TypeSetToTypedTrees<TMap, Mode, TFields[key]["types"]>
-		>;
+		[key in keyof TFields]: TypedField<TMap, Mode, TFields[key]>;
 	},
+][TypedSchema._dummy];
+
+/**
+ * `FieldSchemaTypeInfo` to `TypedTree`
+ * @alpha
+ */
+export type TypedField<
+	TMap extends TypedSchemaData,
+	Mode extends ApiMode,
+	TField extends TypedSchema.FieldSchemaTypeInfo,
+> = [
+	ApplyMultiplicity<
+		TField["kind"]["multiplicity"],
+		TypeSetToTypedTrees<TMap, Mode, TField["types"]>,
+		Mode
+	>,
 ][TypedSchema._dummy];
 
 /**
  * Adjusts the API for a field based on its Multiplicity.
  * @alpha
  */
-export type ApplyMultiplicity<TMultiplicity extends Multiplicity, TypedChild> = {
+export type ApplyMultiplicity<
+	TMultiplicity extends Multiplicity,
+	TypedChild,
+	Mode extends ApiMode,
+> = {
 	[Multiplicity.Forbidden]: undefined;
 	[Multiplicity.Optional]: undefined | TypedChild;
-	[Multiplicity.Sequence]: TypedChild[];
+	[Multiplicity.Sequence]: Mode extends ApiMode.Editable
+		? EditableSequenceField<TypedChild>
+		: TypedChild[];
 	[Multiplicity.Value]: TypedChild;
 }[TMultiplicity];
+
+// TODO: add strong typed `getNode`.
+export type EditableField<TypedChild> = UntypedField & MarkedArrayLike<TypedChild>;
+
+// TODO: add strong typed `getNode`.
+/**
+ * @alpha
+ */
+export type EditableSequenceField<TypedChild> = UntypedSequenceField & MarkedArrayLike<TypedChild>;
 
 /**
  * Takes in `types?: unknown | TypedSchema.NameSet` and returns a TypedTree union.

--- a/packages/dds/tree/src/feature-libraries/unknownTree.ts
+++ b/packages/dds/tree/src/feature-libraries/unknownTree.ts
@@ -1,0 +1,220 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	Value,
+	FieldKey,
+	FieldSchema,
+	TreeSchemaIdentifier,
+	TreeSchema,
+	ForestEvents,
+	SchemaDataAndPolicy,
+} from "../core";
+import { ISubscribable } from "../events";
+import { requireAssignableTo } from "../util";
+import { PrimitiveValue, MarkedArrayLike, typeNameSymbol, valueSymbol } from "./contextuallyTyped";
+import {
+	EditableField,
+	EditableTree,
+	EditableTreeEvents,
+	contextSymbol,
+	getField,
+	on,
+	parentField,
+	typeSymbol,
+} from "./editable-tree";
+
+/**
+ * This file provides an API for working with trees which is type safe even when schema is not known.
+ * This means no editing is allowed.
+ *
+ * Schema aware APIs for working with trees should superset this, while sub-setting EditableTree.
+ *
+ * TODO:
+ * This API should replace EditableTree as the default public API for tree access.
+ * SchemaAware builds on this, adding editing and type safe APIs which can be accessed via SchematizeView.
+ * Once this is finished, the unsafe EditableTree types can be removed (or converted to package internal documentation for the proxies).
+ */
+
+/**
+ * A tree of an unknown type.
+ * This only includes operations that are safe to do without knowing the schema for the tree, so it does not include any editing.
+ *
+ * TODO: document how to downcast to more specific types for schema aware reading and editing APIs.
+ *
+ * @alpha
+ */
+export interface UntypedTree extends UntypedTreeCore {
+	/**
+	 * The name of the node type.
+	 */
+	readonly [typeNameSymbol]: TreeSchemaIdentifier;
+
+	/**
+	 * Value stored on this node.
+	 *
+	 * Set the value using the simple assignment operator (`=`).
+	 * Concurrently setting the value will follow the "last-write-wins" semantics.
+	 */
+	readonly [valueSymbol]: Value;
+
+	/**
+	 * Fields of this node, indexed by their field keys.
+	 *
+	 * This API exposes content in a way depending on the {@link Multiplicity} of the {@link FieldKind}.
+	 * Sequences (including empty ones) are always exposed as {@link UntypedField}s,
+	 * and everything else is either a single UntypedTree or undefined depending on if it's empty.
+	 */
+	readonly [key: FieldKey]: UnwrappedUntypedField;
+}
+
+/**
+ * Subset of {@link UntypedTree} which does not get narrowed based on schema.
+ *
+ * TODO:
+ * getField should be made schema aware and moved to `UntypedTree`.
+ * @alpha
+ */
+export interface UntypedTreeCore extends Iterable<UntypedField> {
+	/**
+	 * The type of the node.
+	 * If this node is well-formed, it must follow this schema.
+	 */
+	readonly [typeSymbol]: TreeSchema;
+
+	/**
+	 * A common context of a "forest" of EditableTrees.
+	 */
+	readonly [contextSymbol]: UntypedTreeContext;
+
+	/**
+	 * Gets the field of this node by its key without unwrapping.
+	 */
+	[getField](fieldKey: FieldKey): UntypedField;
+
+	/**
+	 * The field this tree is in, and the index within that field.
+	 */
+	readonly [parentField]: { readonly parent: UntypedField; readonly index: number };
+
+	/**
+	 * {@inheritDoc ISubscribable#on}
+	 */
+	[on]<K extends keyof EditableTreeEvents>(
+		eventName: K,
+		listener: EditableTreeEvents[K],
+	): () => void;
+}
+
+/**
+ * UntypedTree,
+ * but with any type that `isPrimitive` unwrapped into the value if that value is a {@link PrimitiveValue}.
+ * @alpha
+ */
+export type UntypedTreeOrPrimitive = UntypedTree | PrimitiveValue;
+
+/**
+ * UntypedTree, but with these cases of unwrapping:
+ * - primitives are unwrapped. See {@link UntypedTreeOrPrimitive}.
+ * - nodes with PrimaryField (see `getPrimaryField`) are unwrapped to {@link UntypedField}s.
+ * - fields are unwrapped based on their schema's multiplicity. See {@link UnwrappedUntypedField}.
+ * @alpha
+ */
+export type UnwrappedUntypedTree = UntypedTreeOrPrimitive | UntypedField;
+
+/**
+ * Unwrapped field.
+ * Non-sequence multiplicities are unwrapped to the child tree or `undefined` if there is none.
+ * Sequence multiplicities are handled with {@link UntypedField}.
+ * See {@link UnwrappedUntypedTree} for how the children themselves are unwrapped.
+ * @alpha
+ */
+export type UnwrappedUntypedField = UnwrappedUntypedTree | undefined | UntypedField;
+
+/**
+ * A field of an {@link UntypedTree} as an array-like sequence of unwrapped nodes (see {@link UnwrappedUntypedTree}).
+ * @alpha
+ */
+export interface UntypedField extends MarkedArrayLike<UnwrappedUntypedTree> {
+	/**
+	 * The `FieldSchema` of this field.
+	 */
+	readonly fieldSchema: FieldSchema;
+
+	/**
+	 * The `FieldKey` of this field.
+	 */
+	readonly fieldKey: FieldKey;
+
+	/**
+	 * The node which has this field on it under `fieldKey`.
+	 * `undefined` iff this field is a detached field.
+	 */
+	readonly parent?: UntypedTree;
+
+	/**
+	 * A common context of a "forest" of EditableTrees.
+	 */
+	readonly context: UntypedTreeContext;
+
+	/**
+	 * Gets a node of this field by its index without unwrapping.
+	 * Note that the node must exists at the given index.
+	 */
+	getNode(index: number): UntypedTree;
+}
+
+/**
+ * A common context of a "forest" of UntypedTrees.
+ * @alpha
+ */
+export interface UntypedTreeContext extends ISubscribable<ForestEvents> {
+	/**
+	 * Gets the root field of the tree.
+	 */
+	readonly root: UntypedField;
+
+	/**
+	 * Gets the root field of the tree.
+	 *
+	 * See {@link UnwrappedEditableField} for what is unwrapped.
+	 */
+	readonly unwrappedRoot: UnwrappedUntypedField;
+
+	/**
+	 * Schema used within this context.
+	 * All data must conform to these schema.
+	 *
+	 * The root's schema is tracked under {@link rootFieldKey}.
+	 */
+	readonly schema: SchemaDataAndPolicy;
+
+	/**
+	 * Call before editing.
+	 *
+	 * Note that after performing edits, EditableTrees for nodes that no longer exist are invalid to use.
+	 * TODO: maybe add an API to check if a specific EditableTree still exists,
+	 * and only make use other than that invalid.
+	 */
+	prepareForEdit(): void;
+
+	/**
+	 * Call to free resources.
+	 * It is invalid to use the context after this.
+	 */
+	free(): void;
+
+	/**
+	 * Release any cursors and anchors held by EditableTrees created in this context.
+	 * The EditableTrees are invalid to use after this, but the context may still be used
+	 * to create new trees starting from the root.
+	 */
+	clear(): void;
+}
+
+{
+	type _check1 = requireAssignableTo<EditableTree, UntypedTree>;
+	type _check2 = requireAssignableTo<EditableField, UntypedField>;
+}

--- a/packages/dds/tree/src/feature-libraries/unknownTree.ts
+++ b/packages/dds/tree/src/feature-libraries/unknownTree.ts
@@ -54,9 +54,6 @@ export interface UntypedTree extends UntypedTreeCore {
 
 	/**
 	 * Value stored on this node.
-	 *
-	 * Set the value using the simple assignment operator (`=`).
-	 * Concurrently setting the value will follow the "last-write-wins" semantics.
 	 */
 	readonly [valueSymbol]: Value;
 

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -227,6 +227,14 @@ export {
 	ContextuallyTypedFieldData,
 	TreeViewSchema,
 	FieldViewSchema,
+	cursorFromContextualData,
+	UntypedField,
+	UntypedTree,
+	UntypedTreeContext,
+	UntypedTreeCore,
+	UnwrappedUntypedField,
+	UnwrappedUntypedTree,
+	UntypedTreeOrPrimitive,
 } from "./feature-libraries";
 
 export {

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
@@ -195,7 +195,7 @@ describe("editable-tree: editing", () => {
 				[typeNameSymbol]: complexPhoneSchema.name,
 				prefix: "+1",
 				number: "2345",
-			};
+			} as unknown as ComplexPhone;
 		}
 
 		const globalPhonesKey: FieldKey = globalFieldSymbolSequencePhones;

--- a/packages/dds/tree/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
@@ -10,6 +10,7 @@ import {
 	TypedSchemaData,
 	typedSchemaData,
 	TypedNode,
+	EditableField,
 	/* eslint-disable-next-line import/no-internal-modules */
 } from "../../../feature-libraries/schema-aware/schemaAware";
 
@@ -23,6 +24,7 @@ import {
 	TypedSchema,
 	ContextuallyTypedNodeDataObject,
 	FieldViewSchema,
+	UntypedTreeCore,
 } from "../../../feature-libraries";
 import {
 	FlattenKeys,
@@ -162,7 +164,7 @@ const nError1: NumberTree = { [typeNameSymbol]: ballSchema.name, [valueSymbol]: 
 
 interface TypeBuilder<TSchema extends TypedSchema.LabeledTreeSchema> {
 	a: NodeDataFor<typeof schemaData, ApiMode.Flexible, TSchema>;
-	b: NodeDataFor<typeof schemaData, ApiMode.Normalized, TSchema>;
+	b: NodeDataFor<typeof schemaData, ApiMode.Editable, TSchema>;
 	c: NodeDataFor<typeof schemaData, ApiMode.Wrapped, TSchema>;
 }
 
@@ -198,7 +200,7 @@ interface FlexBall {
 	size?: FlexNumber | undefined;
 }
 
-interface NormalizedBall {
+interface EditableBall extends UntypedTreeCore {
 	[typeNameSymbol]: typeof ballSchema.name;
 	x: number;
 	y: number;
@@ -222,7 +224,7 @@ type WrappedBall = {
 	type XB = F["b"];
 	type XC = F["c"];
 	type _check1 = requireTrue<areSafelyAssignable<XA, FlexBall>>;
-	type _check2 = requireTrue<areSafelyAssignable<XB, NormalizedBall>>;
+	type _check2 = requireTrue<areSafelyAssignable<XB, EditableBall>>;
 	type _check3 = requireTrue<areSafelyAssignable<XC, WrappedBall>>;
 }
 
@@ -238,11 +240,11 @@ type WrappedBall = {
 		children: (FlexBall | FlexBox)[];
 	}
 	type _check1 = requireTrue<areSafelyAssignable<XA, FlexBox>>;
-	interface NormalizedBox {
+	interface NormalizedBox extends UntypedTreeCore {
 		[typeNameSymbol]: typeof boxSchema.name;
-		children: (NormalizedBall | NormalizedBox)[];
+		children: EditableField<EditableBall | NormalizedBox>;
 	}
-	type _check2 = requireTrue<areSafelyAssignable<XB, NormalizedBox>>;
+	type _check2 = requireAssignableTo<XB, NormalizedBox>;
 
 	{
 		const child: XA = {
@@ -256,24 +258,6 @@ type WrappedBall = {
 					[typeNameSymbol]: "ball",
 					x: 1,
 					y: { [typeNameSymbol]: "number", [valueSymbol]: 2 },
-				},
-			],
-		};
-	}
-
-	{
-		const child: XB = {
-			[typeNameSymbol]: boxSchema.name,
-			children: [],
-		};
-		const parent: XB = {
-			[typeNameSymbol]: boxSchema.name,
-			children: [
-				child,
-				{
-					[typeNameSymbol]: ballSchema.name,
-					x: 1,
-					y: 2,
 				},
 			],
 		};

--- a/packages/dds/tree/src/test/feature-libraries/schema-aware/schemaComplex.ts
+++ b/packages/dds/tree/src/test/feature-libraries/schema-aware/schemaComplex.ts
@@ -37,13 +37,13 @@ export const appSchemaData = SchemaAware.typedSchemaData(
 // Schema aware types
 export type StringTask = SchemaAware.NodeDataFor<
 	typeof appSchemaData,
-	SchemaAware.ApiMode.Normalized,
+	SchemaAware.ApiMode.Editable,
 	typeof stringTaskSchema
 >;
 
 export type ListTask = SchemaAware.NodeDataFor<
 	typeof appSchemaData,
-	SchemaAware.ApiMode.Normalized,
+	SchemaAware.ApiMode.Editable,
 	typeof listTaskSchema
 >;
 

--- a/packages/dds/tree/src/test/feature-libraries/schema-aware/schemaSimple.ts
+++ b/packages/dds/tree/src/test/feature-libraries/schema-aware/schemaSimple.ts
@@ -39,24 +39,18 @@ export const appSchemaData = SchemaAware.typedSchemaData(
 // Schema aware types
 export type Number = SchemaAware.NodeDataFor<
 	typeof appSchemaData,
-	SchemaAware.ApiMode.Normalized,
+	SchemaAware.ApiMode.Editable,
 	typeof numberSchema
 >;
 
 export type Point = SchemaAware.NodeDataFor<
 	typeof appSchemaData,
-	SchemaAware.ApiMode.Normalized,
+	SchemaAware.ApiMode.Editable,
 	typeof pointSchema
 >;
 
 // Example Use
 {
-	const point: Point = {
-		[typeNameSymbol]: pointSchema.name,
-		x: 1,
-		y: 2,
-	};
-
 	function dotProduct(a: Point, b: Point): number {
 		return a.x * b.x + a.y * b.y;
 	}


### PR DESCRIPTION
## Description

Replace SchemaAware.ApiMode.Normalized with Editable, and make the API actually subset editableTree.

Add SchemaAware.ApiMode.Simple which is a bit cleaner for intelisense than Flexible for literals.

This is part of a larger effort to obsolete the non-schema aware EditableTree API types, and replace them with UnknownTree for non-schema aware readers, and SchemaAware's Editable Mode for editors (and not export a non-schema aware editing API).

## Breaking Changes

`SchemaAware.ApiMode.Normalized` has been removed. Users of it can most likely want to use `SchemaAware.ApiMode.Editable` instead.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

