### PR TITLE
Augment EditableTree (SharedTree) events

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -382,7 +382,8 @@ export interface EditableTreeContext extends ISubscribable<ForestEvents> {
 
 // @alpha
 export interface EditableTreeEvents {
-    changing(): void;
+    changing(upPath: UpPath, value: Value): void;
+    subtreeChanging(upPath: UpPath): void;
 }
 
 // @alpha

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
@@ -316,10 +316,7 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 	): () => void {
 		switch (eventName) {
 			case "changing": {
-				const unsubscribeFromValueChange = this.anchorNode.on(
-					"valueChanging",
-					(anchorNode: AnchorNode, value: Value) => listener(anchorNode, value),
-				);
+				const unsubscribeFromValueChange = this.anchorNode.on("valueChanging", listener);
 				const unsubscribeFromChildrenChange = this.anchorNode.on(
 					"childrenChanging",
 					(anchorNode: AnchorNode) => listener(anchorNode, undefined),
@@ -332,13 +329,9 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 			case "subtreeChanging": {
 				const unsubscribeFromSubtreeChange = this.anchorNode.on(
 					"subtreeChanging",
-					(anchorNode: AnchorNode) => {
-						return (listener as EditableTreeEvents["subtreeChanging"])(anchorNode);
-					},
+					(anchorNode: AnchorNode) => listener(anchorNode, undefined),
 				);
-				return () => {
-					unsubscribeFromSubtreeChange();
-				};
+				return unsubscribeFromSubtreeChange;
 			}
 			default:
 				unreachableCase(eventName);

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/common-utils";
+import { assert, unreachableCase } from "@fluidframework/common-utils";
 import {
 	Value,
 	Anchor,
@@ -314,15 +314,35 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 		eventName: K,
 		listener: EditableTreeEvents[K],
 	): () => void {
-		assert(eventName === "changing", 0x5b3 /* unexpected eventName */);
-		const unsubscribeFromValueChange = this.anchorNode.on("valueChanging", () => listener());
-		const unsubscribeFromChildrenChange = this.anchorNode.on("childrenChanging", () =>
-			listener(),
-		);
-		return () => {
-			unsubscribeFromValueChange();
-			unsubscribeFromChildrenChange();
-		};
+		switch (eventName) {
+			case "changing": {
+				const unsubscribeFromValueChange = this.anchorNode.on(
+					"valueChanging",
+					(anchorNode: AnchorNode, value: Value) => listener(anchorNode, value),
+				);
+				const unsubscribeFromChildrenChange = this.anchorNode.on(
+					"childrenChanging",
+					(anchorNode: AnchorNode) => listener(anchorNode, undefined),
+				);
+				return () => {
+					unsubscribeFromValueChange();
+					unsubscribeFromChildrenChange();
+				};
+			}
+			case "subtreeChanging": {
+				const unsubscribeFromSubtreeChange = this.anchorNode.on(
+					"subtreeChanging",
+					(anchorNode: AnchorNode) => {
+						return (listener as EditableTreeEvents["subtreeChanging"])(anchorNode);
+					},
+				);
+				return () => {
+					unsubscribeFromSubtreeChange();
+				};
+			}
+			default:
+				unreachableCase(eventName);
+		}
 	}
 }
 

--- a/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/editable-tree/editableTreeTypes.ts
@@ -10,6 +10,7 @@ import {
 	TreeSchemaIdentifier,
 	TreeSchema,
 	ITreeCursor,
+	UpPath,
 } from "../../core";
 import {
 	PrimitiveValue,
@@ -76,7 +77,7 @@ export const contextSymbol: unique symbol = Symbol("editable-tree:context");
 export const on: unique symbol = Symbol("editable-tree:on");
 
 /**
- * Events for {@link EditableTree}.
+ * A collection of events that can be raised by an {@link EditableTree}.
  * These events are triggered while the internal data structures are being updated.
  * Thus these events must not trigger reading of the anchorSet or forest.
  *
@@ -90,11 +91,20 @@ export const on: unique symbol = Symbol("editable-tree:on");
  */
 export interface EditableTreeEvents {
 	/**
-	 * A specific EditableTree node is changing.
+	 * Raised when a specific EditableTree node is changing.
 	 * This includes its values and fields.
-	 * Note that this is shallow: it does not include changes to the values of nodes it its fields for example.
+	 * @param upPath - the path corresponding to the location of the node being changed, upward.
+	 * @param value - the new value stored in the node.
 	 */
-	changing(): void;
+	changing(upPath: UpPath, value: Value): void;
+
+	/**
+	 * Raised when something in the tree is changing, including this node and its descendants.
+	 * This event is called on every parent (transitively) when a change is occurring.
+	 * Includes changes to this node itself.
+	 * @param upPath - the path corresponding to the location of the node being changed, upward.
+	 */
+	subtreeChanging(upPath: UpPath): void;
 }
 
 /**

--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.events.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.events.spec.ts
@@ -1,0 +1,115 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { strict as assert } from "assert";
+
+import {
+	Value,
+	FieldKey,
+	rootFieldKeySymbol,
+	UpPath,
+	AnchorEvents,
+	AnchorNode,
+	IEditableForest,
+} from "../../../core";
+import { brand } from "../../../util";
+import { getField, on } from "../../../feature-libraries";
+
+import { IEmitter } from "../../../events";
+import {
+	fullSchemaData,
+	personData,
+	getReadonlyEditableTreeContext,
+	setupForest,
+} from "./mockData";
+
+const fieldAddress: FieldKey = brand("address");
+
+describe("editable-tree: event subscription", () => {
+	it("consumes children changing events with correct args", () => {
+		const { address, forest } = retrieveAddressNode();
+		const log: UpPath[] = [];
+		const unsubscribeChanging = address[on]("changing", (upPath: UpPath) => {
+			log.push(upPath);
+		});
+		const { emitter, node } = accessEmitters(
+			forest,
+			[rootFieldKeySymbol, 0],
+			[fieldAddress, 0],
+		);
+		emitter.emit("childrenChanging", node);
+		unsubscribeChanging();
+		emitter.emit("childrenChanging", node);
+		assert.deepEqual(log, [node]);
+	});
+
+	it("consumes value changing events with correct args", () => {
+		const { address, forest } = retrieveAddressNode();
+		const log: Map<Value, UpPath> = new Map();
+		const unsubscribeChanging = address[on]("changing", (upPath: UpPath, value: Value) => {
+			log.set(value, upPath);
+		});
+		const { emitter, node } = accessEmitters(
+			forest,
+			[rootFieldKeySymbol, 0],
+			[fieldAddress, 0],
+		);
+		emitter.emit("valueChanging", node, 122);
+		unsubscribeChanging();
+		emitter.emit("valueChanging", node, 123);
+		assert.deepEqual(log, new Map([[122, node]]));
+	});
+
+	it("consumes subtree changing events with correct args", () => {
+		const { address, forest } = retrieveAddressNode();
+		const log: UpPath[] = [];
+		const unsubscribeChanging = address[on]("subtreeChanging", (upPath: UpPath) => {
+			log.push(upPath);
+		});
+		const { emitter, node } = accessEmitters(
+			forest,
+			[rootFieldKeySymbol, 0],
+			[fieldAddress, 0],
+		);
+		emitter.emit("subtreeChanging", node);
+		unsubscribeChanging();
+		emitter.emit("subtreeChanging", node);
+		assert.deepEqual(log, [node]);
+	});
+});
+
+interface PathNode extends AnchorNode {
+	events: IEmitter<AnchorEvents>;
+}
+
+type PathStep = [FieldKey, number];
+
+function makePath(...steps: [PathStep, ...PathStep[]]): UpPath {
+	assert(steps.length > 0, "Path cannot be empty");
+	return steps.reduce(
+		(path: UpPath | undefined, step: PathStep) => ({
+			parent: path,
+			parentField: step[0],
+			parentIndex: step[1],
+		}),
+		undefined,
+	) as UpPath;
+}
+
+function accessEmitters(forest: IEditableForest, ...steps: [PathStep, ...PathStep[]]) {
+	const upPath = makePath(...steps);
+	const anchor = forest.anchors.track(upPath);
+	const node = forest.anchors.locate(anchor) ?? assert.fail();
+	const pathNode = node as PathNode;
+	const emitter: IEmitter<AnchorEvents> = pathNode.events;
+	return { emitter, node };
+}
+
+function retrieveAddressNode() {
+	const forest = setupForest(fullSchemaData, personData);
+	const context = getReadonlyEditableTreeContext(forest);
+	const root = context.root.getNode(0);
+	const address = root[getField](fieldAddress).getNode(0);
+	return { address, forest };
+}

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -642,8 +642,8 @@ describe("SharedTree", () => {
 			const root = tree1.context.root.getNode(0);
 
 			const log: string[] = [];
-			const unsubscribe = root[on]("changing", (upPath, value) =>
-				log.push(`change-${String(upPath.parentField)}-${upPath.parentIndex}-${value}`),
+			const unsubscribe = root[on]("changing", (upPath, val) =>
+				log.push(`change-${String(upPath.parentField)}-${upPath.parentIndex}-${val}`),
 			);
 			const unsubscribeSubtree = root[on]("subtreeChanging", (upPath) =>
 				log.push(`subtree-${String(upPath.parentField)}-${upPath.parentIndex}`),


### PR DESCRIPTION

## Description

Incremental delivery towards SharedTree data binding support. See complete [story](https://github.com/microsoft/FluidFramework/issues/14293).

Current enhancements
- Propagates `changing` event details
- Introduces additional `subtreeChanging` event

The new feature introduces no regressions to the existing functionality.

@CraigMacomber @DLehenbauer 


