### PR TITLE
Fix doOverRanges

### DIFF
--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -162,7 +162,7 @@ export function doOverRanges<T extends ProvidesGrowthFunc>(
 		if (selections.length === rangeEntries.length) {
 			const selectionsObj = {};
 			for (const [key, value] of selections) {
-				selections[key] = value;
+				selectionsObj[key] = value;
 			}
 			const description = selections.map(([key, value]) => `${key}:${value}`).join("_");
 			doAction(selectionsObj as PickFromRanges<T>, description);


### PR DESCRIPTION
## Description
Fix bug in doOverRanges where we were setting the range values on the incorrect object, which was leading to all range values being undefined.