### PR TITLE
Fix bot config to merge PRs in next

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -700,40 +700,26 @@
       "subCapability": "AutoMerge",
       "version": "1.0",
       "config": {
-        "taskName": "Automatically merge pull requests ",
+        "taskName": "Squash PRs in next",
         "label": "msftbot: merge-next",
-        "silentMode": false,
         "minMinutesOpen": "5",
-        "deleteBranches": true,
-        "allowAutoMergeInstructionsWithoutLabel": true,
-        "enforceDMPAsStatus": true,
-        "removeLabelOnPush": false,
-        "usePrDescriptionAsCommitMessage": true,
-        "requireAllStatuses": false,
-        "conditionalMergeTypes": [
-          {
-            "mergeType": "merge",
-            "condition": {
-              "placeholder": "labels",
-              "operator": "contains",
-              "label_name": "do-not-squash-merge"
-            }
-          },
-          {
-            "mergeType": "merge",
-            "condition": {
-              "placeholder": "labels",
-              "operator": "contains",
-              "label_name": "main-next-integrate"
-            }
-          }
-        ],
         "mergeType": "squash",
-        "requireSpecificCheckRuns": false,
-        "requireSpecificCheckRunsList": []
-      },
-      "disabled": false
+        "deleteBranches": true
+      }
     },
+    {
+      "taskType": "trigger",
+      "capabilityId": "AutoMerge",
+      "subCapability": "AutoMerge",
+      "version": "1.0",
+      "config": {
+        "taskName": "Merge PRs in next",
+        "label": "main-next-integrate",
+        "minMinutesOpen": "5",
+        "mergeType": "merge",
+        "deleteBranches": true
+      }
+    }
     {
       "taskType": "trigger",
       "capabilityId": "IssueResponder",

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -709,19 +709,6 @@
     },
     {
       "taskType": "trigger",
-      "capabilityId": "AutoMerge",
-      "subCapability": "AutoMerge",
-      "version": "1.0",
-      "config": {
-        "taskName": "Merge PRs in next",
-        "label": "main-next-integrate",
-        "minMinutesOpen": "5",
-        "mergeType": "merge",
-        "deleteBranches": true
-      }
-    },
-    {
-      "taskType": "trigger",
       "capabilityId": "IssueResponder",
       "subCapability": "IssuesOnlyResponder",
       "version": "1.0",

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -719,7 +719,7 @@
         "mergeType": "merge",
         "deleteBranches": true
       }
-    }
+    },
     {
       "taskType": "trigger",
       "capabilityId": "IssueResponder",


### PR DESCRIPTION
This PR is intended to fix the merge bot used for merging PRs in next. 

There are two auto-merge task added: 

If the label -- `msftbot: merge-next` is added, the bot would `squash-merge` the PR in next