### PR TITLE
[GC stress]: Extend summarizer cache expiry timeout to 5 mins

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -39,7 +39,7 @@ import { FlushResult } from "./odspDocumentDeltaConnection";
 import { pkgVersion as driverVersion } from "./packageVersion";
 import { OdspDocumentStorageServiceBase } from "./odspDocumentStorageServiceBase";
 
-export const defaultSummarizerCacheExpiryTimeout: number = 60 * 1000; // 60 seconds.
+export const defaultSummarizerCacheExpiryTimeout: number = 5 * 60 * 1000; // 5 mins.
 
 // An implementation of Promise.race that gives you the winner of the promise race
 async function promiseRaceWithWinner<T>(


### PR DESCRIPTION
Extending the summarizer cache expiry timeout to 5 mins. This means that the summarizer will load from cache more often. This is important because this flow is a major source of bugs in GC data. When summarizer loads from a cached snapshot and has to update state from a newer snapshot, the summary / GC state has to be updated and this flow has known to have bugs. This change will potentially repro existing or new bugs.
We are also considering making big changes to this flow to address these bugs - let's get them reproing in the stress tests and then see them fixed.

## Reviewer guidance
This is for an experimental stress test in test/gc-stress branch. This is not in the main FF branch and does not affect its stress test.

[AB#3963](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3963)