### PR TITLE
refactor(client-debugger): Add the ability to specify explicit message types in `MessageRelay`'s `postMessage` method

### DIFF
--- a/packages/tools/client-debugger/client-debugger-view/src/Debugger.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/Debugger.tsx
@@ -106,7 +106,7 @@ export function FluidClientDebuggers(): React.ReactElement {
 
 		messageRelay.on("message", messageHandler);
 
-		messageRelay.postMessage(getContainerListMessage);
+		messageRelay.postMessage<GetContainerListMessage>(getContainerListMessage);
 
 		return (): void => {
 			messageRelay.off("message", messageHandler);

--- a/packages/tools/client-debugger/client-debugger-view/src/components/AudienceView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/AudienceView.tsx
@@ -12,6 +12,7 @@ import {
 	AudienceSummaryMessage,
 	AudienceSummaryMessageData,
 	AudienceSummaryMessageType,
+	GetAudienceMessage,
 	handleIncomingMessage,
 	HasContainerId,
 	IDebuggerMessage,
@@ -71,7 +72,7 @@ export function AudienceView(props: AudienceViewProps): React.ReactElement {
 		messageRelay.on("message", messageHandler);
 
 		// Request the current Audience State of the Container
-		messageRelay.postMessage({
+		messageRelay.postMessage<GetAudienceMessage>({
 			type: "GET_AUDIENCE",
 			data: {
 				containerId,

--- a/packages/tools/client-debugger/client-debugger-view/src/components/AudienceView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/AudienceView.tsx
@@ -13,6 +13,7 @@ import {
 	AudienceSummaryMessageData,
 	AudienceSummaryMessageType,
 	GetAudienceMessage,
+	GetAudienceMessageType,
 	handleIncomingMessage,
 	HasContainerId,
 	IDebuggerMessage,
@@ -73,7 +74,7 @@ export function AudienceView(props: AudienceViewProps): React.ReactElement {
 
 		// Request the current Audience State of the Container
 		messageRelay.postMessage<GetAudienceMessage>({
-			type: "GET_AUDIENCE",
+			type: GetAudienceMessageType,
 			data: {
 				containerId,
 			},

--- a/packages/tools/client-debugger/client-debugger-view/src/components/ContainerHistoryView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/ContainerHistoryView.tsx
@@ -15,6 +15,7 @@ import {
 	ISourcedDebuggerMessage,
 	InboundHandlers,
 	ContainerStateHistoryMessageType,
+	GetContainerStateMessage,
 } from "@fluid-tools/client-debugger";
 import { useMessageRelay } from "../MessageRelayContext";
 import { Waiting } from "./Waiting";
@@ -70,7 +71,7 @@ export function ContainerHistoryView(props: ContainerHistoryProps): React.ReactE
 		setContainerHistory(undefined);
 
 		// Request state info for the newly specified containerId
-		messageRelay.postMessage({
+		messageRelay.postMessage<GetContainerStateMessage>({
 			type: GetContainerStateMessageType,
 			data: {
 				containerId,

--- a/packages/tools/client-debugger/client-debugger-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/ContainerSummaryView.tsx
@@ -20,6 +20,10 @@ import {
 	CloseContainerMessageType,
 	GetContainerStateMessageType,
 	ContainerStateChangeMessageType,
+	GetContainerStateMessage,
+	ConnectContainerMessage,
+	DisconnectContainerMessage,
+	CloseContainerMessage,
 } from "@fluid-tools/client-debugger";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
@@ -86,7 +90,7 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 		setContainerState(undefined);
 
 		// Request state info for the newly specified containerId
-		messageRelay.postMessage({
+		messageRelay.postMessage<GetContainerStateMessage>({
 			type: GetContainerStateMessageType,
 			data: {
 				containerId,
@@ -103,7 +107,7 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 	}
 
 	function tryConnect(): void {
-		messageRelay.postMessage({
+		messageRelay.postMessage<ConnectContainerMessage>({
 			type: ConnectContainerMessageType,
 			data: {
 				containerId,
@@ -112,7 +116,7 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 	}
 
 	function forceDisconnect(): void {
-		messageRelay.postMessage({
+		messageRelay.postMessage<DisconnectContainerMessage>({
 			type: DisconnectContainerMessageType,
 			data: {
 				containerId,
@@ -122,7 +126,7 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 	}
 
 	function closeContainer(): void {
-		messageRelay.postMessage({
+		messageRelay.postMessage<CloseContainerMessage>({
 			type: CloseContainerMessageType,
 			data: {
 				containerId,

--- a/packages/tools/client-debugger/client-debugger-view/src/components/TelemetryView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/components/TelemetryView.tsx
@@ -22,6 +22,7 @@ import {
 	TelemetryEventMessageType,
 	TelemetryHistoryMessageType,
 	GetTelemetryHistoryMessageType,
+	GetTelemetryHistoryMessage,
 } from "@fluid-tools/client-debugger";
 import { useMessageRelay } from "../MessageRelayContext";
 import { Waiting } from "./Waiting";
@@ -99,7 +100,7 @@ export function TelemetryView(): React.ReactElement {
 		messageRelay.on("message", messageHandler);
 
 		// Request all log history
-		messageRelay.postMessage({
+		messageRelay.postMessage<GetTelemetryHistoryMessage>({
 			type: GetTelemetryHistoryMessageType,
 			data: undefined,
 		});

--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -365,7 +365,7 @@ export interface IFluidDevtools extends IEventProvider<FluidDevtoolsEvents>, IDi
 
 // @internal
 export interface IMessageRelay<TSend extends IDebuggerMessage = IDebuggerMessage, TReceive extends ISourcedDebuggerMessage = ISourcedDebuggerMessage> extends IEventProvider<IMessageRelayEvents<TReceive>> {
-    postMessage: (message: TSend) => void;
+    postMessage<TPost extends TSend>(message: TPost): void;
 }
 
 // @internal

--- a/packages/tools/client-debugger/client-debugger/src/messaging/MessageRelay.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/MessageRelay.ts
@@ -23,6 +23,13 @@ export interface IMessageRelayEvents<
 /**
  * Manages relaying messages between the consumer of this interface, and some external message sender/receiver.
  *
+ * @remarks
+ *
+ * To send a message **to** the external recipient, call {@link IMessageRelay.postMessage}.
+ *
+ * To be notified when a message is received **from** the external sender, subscribe to the "message" event
+ * via {@link @fluidframework/common-definitions#IEventProvider.on}.
+ *
  * @internal
  */
 export interface IMessageRelay<
@@ -32,5 +39,5 @@ export interface IMessageRelay<
 	/**
 	 * Posts the provided message to external recipient.
 	 */
-	postMessage: (message: TSend) => void;
+	postMessage<TPost extends TSend>(message: TPost): void;
 }


### PR DESCRIPTION
Affords extra type-safety when posting messages defined (untyped) inline. 

Also update usages to specify explicit type parameters.