### PR TITLE
Add sharedTree fuzz test for aborting transaction with multiple edits

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -27,6 +27,23 @@ export const fuzzReducer: {
 	},
 };
 
+export const fuzzReducerAbortMultipleOps: {
+	[K in Operation["type"]]: AsyncReducer<Extract<Operation, { type: K }>, FuzzTestState>;
+} = {
+	edit: async (state, operation) => {
+		const { index, contents } = operation;
+		const tree = state.testTreeProvider.trees[index];
+		applyFuzzChangeAbortMultipleOps(tree, contents);
+		return state;
+	},
+	synchronize: async (state) => {
+		const { testTreeProvider } = state;
+		await testTreeProvider.ensureSynchronized();
+		checkTreesAreSynchronized(testTreeProvider);
+		return state;
+	},
+};
+
 export function checkTreesAreSynchronized(provider: ITestTreeProvider) {
 	const lastTree = toJsonableTree(provider.trees[provider.trees.length - 1]);
 	for (let i = 0; i < provider.trees.length - 1; i++) {
@@ -69,6 +86,33 @@ function applyFuzzChange(
 				return transactionResult;
 			});
 			break;
+		default:
+			fail("Invalid edit.");
+	}
+}
+
+function applyFuzzChangeAbortMultipleOps(tree: ISharedTree, contents: FuzzChange): void {
+	switch (contents.fuzzType) {
+		case "insert": {
+			const field = tree.editor.sequenceField(contents.parent, contents.field);
+			field.insert(
+				contents.index,
+				singleTextCursor({ type: brand("Test"), value: contents.value }),
+			);
+			break;
+		}
+		case "delete": {
+			const field = tree.editor.sequenceField(
+				contents.firstNode?.parent,
+				contents.firstNode?.parentField,
+			);
+			field.delete(contents.firstNode?.parentIndex, contents.count);
+			break;
+		}
+		case "setPayload": {
+			tree.editor.setValue(contents.path, contents.value);
+			break;
+		}
 		default:
 			fail("Invalid edit.");
 	}


### PR DESCRIPTION
## Description

This PR adds testing for aborting a transaction with multiple edits in the sharedTree fuzz test

## Reviewer Guidance

### Questions
1. This PR adds an additional reducer `fuzzEditReducerAbortMultipleOps` to the `fuzzEditReducer.ts` file. Should this be combined into the existing `fuzzReducer`, where it takes in the type of `applyFuzzChange` function that should be used instead?
