### PR TITLE
[r11s] Moving some utility functions to shared packages

### DIFF
--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -83,6 +83,9 @@ export function getNextHash(message: ISequencedDocumentMessage, lastHash: string
 // @public (undocumented)
 export function getOrCreateRepository(endpoint: string, owner: string, repository: string, headers?: AxiosRequestHeaders): Promise<void>;
 
+// @public
+export const getRandomInt: (range: number) => number;
+
 // @public (undocumented)
 export function getRandomName(connector?: string, capitalize?: boolean): string;
 

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -17,6 +17,7 @@ import {
 import {
 	canSummarize,
 	canWrite,
+	getRandomInt,
 	isNetworkError,
 	NetworkError,
 	validateTokenClaims,
@@ -38,7 +39,6 @@ import {
 	createNackMessage,
 	createRoomLeaveMessage,
 	generateClientId,
-	getRandomInt,
 	ConnectionCountLogger,
 } from "../utils";
 

--- a/server/routerlicious/packages/lambdas/src/index.ts
+++ b/server/routerlicious/packages/lambdas/src/index.ts
@@ -37,7 +37,6 @@ export {
 	createRoomLeaveMessage,
 	createSessionMetric,
 	generateClientId,
-	getRandomInt,
 	isDocumentSessionValid,
 	isDocumentValid,
 	logCommonSessionEndMetrics,

--- a/server/routerlicious/packages/lambdas/src/utils/index.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/index.ts
@@ -9,7 +9,6 @@ export {
 	createRoomLeaveMessage,
 } from "./messageGenerator";
 export { NoOpLambda } from "./noOpLambda";
-export { getRandomInt } from "./random";
 export { createSessionMetric, logCommonSessionEndMetrics } from "./telemetryHelper";
 export { isDocumentSessionValid, isDocumentValid } from "./validateDocument";
 export { CheckpointReason, ICheckpoint } from "./checkpointHelper";

--- a/server/routerlicious/packages/lambdas/src/utils/random.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/random.ts
@@ -1,9 +1,0 @@
-/*!
- * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
- * Licensed under the MIT License.
- */
-
-/**
- * getRandomInt is not and should not be used as part of any secure random number generation
- */
-export const getRandomInt = (range: number) => Math.floor(Math.random() * range);

--- a/server/routerlicious/packages/services-client/src/index.ts
+++ b/server/routerlicious/packages/services-client/src/index.ts
@@ -65,5 +65,5 @@ export {
 	convertWholeFlatSummaryToSnapshotTreeAndBlobs,
 } from "./storageUtils";
 export { SummaryTreeUploadManager } from "./summaryTreeUploadManager";
-export { getOrCreateRepository } from "./utils";
+export { getOrCreateRepository, getRandomInt } from "./utils";
 export { WholeSummaryUploadManager } from "./wholeSummaryUploadManager";

--- a/server/routerlicious/packages/services-client/src/utils.ts
+++ b/server/routerlicious/packages/services-client/src/utils.ts
@@ -33,3 +33,8 @@ export async function getOrCreateRepository(
 		await Axios.post(`${endpoint}/${owner}/repos`, createParams, { headers });
 	}
 }
+
+/**
+ * getRandomInt is not and should not be used as part of any secure random number generation
+ */
+export const getRandomInt = (range: number) => Math.floor(Math.random() * range);

--- a/server/routerlicious/packages/services-utils/src/executeApiWithMetric.ts
+++ b/server/routerlicious/packages/services-utils/src/executeApiWithMetric.ts
@@ -1,0 +1,32 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { getRandomInt } from "@fluidframework/server-services-client";
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
+
+export async function executeApiWithMetric<U>(
+	api: () => Promise<U>,
+	metricName: string,
+	apiName: string,
+	metricEnabled: boolean,
+	samplingPeriod?: number,
+	telemetryProperties?: Record<string, any>,
+): Promise<U> {
+	// If generating a metric is not enabled, we just execute the API.
+	// We also do the same if sampling tells us to skip the metric for
+	// this instance (when a sampling period is provided).
+	if (!metricEnabled || (samplingPeriod && getRandomInt(samplingPeriod) !== 0)) {
+		return api();
+	}
+	const metric = Lumberjack.newLumberMetric(metricName, telemetryProperties);
+	try {
+		const result = await api();
+		metric.success(`${metricName}: ${apiName} success`);
+		return result;
+	} catch (error: any) {
+		metric.error(`${metricName}: ${apiName} error`, error);
+		throw error;
+	}
+}

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -22,6 +22,7 @@ export { parseBoolean } from "./conversion";
 export { deleteSummarizedOps } from "./deleteSummarizedOps";
 export { getHostIp } from "./dns";
 export { FluidServiceError, FluidServiceErrorCode } from "./errorUtils";
+export { executeApiWithMetric } from "./executeApiWithMetric";
 export { executeOnInterval, ScheduledJob } from "./executeOnInterval";
 export { choose, getRandomName } from "./generateNames";
 export { configureLogging, IWinstonConfig } from "./logger";


### PR DESCRIPTION
## Description

Moving some utility functions around, to shared packages, so it is easier to reuse them throughout the project and also AFR.
- Moving `executeApiWithMetric`, originally implemented in the `gitrest-base` package, to `services-utils`, which will allow reusing this utility function without the need to import `gitrest-base` and all its dependencies, like `nodegit`. The logic of the function is also extended: this PR adds sampling capabilities to `executeApiWithMetric()` allowing us to capture API metrics without concerns of overloading the service due to very frequent metric collection and emission
- Moving `getRandomInt` to `services-client` package, so that it can be reused by `executeApiWithMetric` as well. `services-client` is is isomorphic (therefore can be used by Alfred's lambda/index.ts, where `getRandomInt` was originally used) and is also already referenced in `services-utils`, so no further dependendencies are needed there.


## Breaking Changes

None.