### PR TITLE
Increase timeout for memory tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/.mocharc.memory.js
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/.mocharc.memory.js
@@ -24,6 +24,6 @@ const newConfig = {
 		"dist/test/benchmark/**/*.all.spec.js",
 		"--perfMode",
 	],
-	"timeout": "120000", // depending on the test and the size of the E2E document, the timeout might not be enough. To address it, let's first try to decrease the number of iterations (minSampleCount).
+	"timeout": "360000", // depending on the test and the size of the E2E document, the timeout might not be enough. To address it, let's first try to decrease the number of iterations (minSampleCount).
 };
 module.exports = newConfig;


### PR DESCRIPTION
## Description

Increment the timeout for memory tests as some of the perf e2e tests are taking longer when running against ODSP 