### PR TITLE
Refactoring sharedtree fuzz edit generator to produce transaction ops

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -49,10 +49,28 @@ export interface FuzzSetPayload {
 	value: number;
 }
 
-export type FuzzChange = FuzzInsert | FuzzDelete | FuzzSetPayload;
+export type FuzzChange =
+	| FuzzInsert
+	| FuzzDelete
+	| FuzzSetPayload
+	| TransactionStartOp
+	| TransactionAbortOp
+	| TransactionCommitOp;
 
 export interface Synchronize {
 	type: "synchronize";
+}
+
+export interface TransactionStartOp {
+	fuzzType: "transactionStart";
+}
+
+export interface TransactionCommitOp {
+	fuzzType: "transactionCommit";
+}
+
+export interface TransactionAbortOp {
+	fuzzType: "transactionAbort";
 }
 
 export interface FuzzTestState extends BaseFuzzTestState {
@@ -69,7 +87,26 @@ export interface NodeRangePath {
 	count: number;
 }
 
-export const makeEditGenerator = (): AsyncGenerator<Operation, FuzzTestState> => {
+export interface EditGeneratorOpWeights {
+	insert: number;
+	delete: number;
+	setPayload: number;
+	start: number;
+	commit: number;
+	abort: number;
+}
+const defaultEditGeneratorOpWeights = {
+	insert: 5,
+	delete: 1,
+	setPayload: 1,
+	start: 3,
+	commit: 1,
+	abort: 1,
+};
+
+export const makeEditGenerator = (
+	opWeights: EditGeneratorOpWeights = defaultEditGeneratorOpWeights,
+): AsyncGenerator<Operation, FuzzTestState> => {
 	type EditState = FuzzTestState & TreeContext;
 	async function insertGenerator(state: EditState): Promise<FuzzInsert> {
 		const trees = state.testTreeProvider.trees;
@@ -115,19 +152,62 @@ export const makeEditGenerator = (): AsyncGenerator<Operation, FuzzTestState> =>
 		};
 	}
 
+	async function transactionStartGenerator(state: EditState): Promise<TransactionStartOp> {
+		return {
+			fuzzType: "transactionStart",
+		};
+	}
+
+	async function transactionCommitGenerator(state: EditState): Promise<TransactionCommitOp> {
+		return {
+			fuzzType: "transactionCommit",
+		};
+	}
+
+	async function transactionAbortGenerator(state: EditState): Promise<TransactionAbortOp> {
+		return {
+			fuzzType: "transactionAbort",
+		};
+	}
+
 	const baseEditGenerator = createWeightedAsyncGenerator<FuzzChange, EditState>([
-		[insertGenerator, 5],
+		[
+			insertGenerator,
+			opWeights.insert,
+			({ testTreeProvider, treeIndex }) =>
+				transactionsInProgress(testTreeProvider.trees[treeIndex]),
+		],
 		[
 			deleteGenerator,
-			1,
+			opWeights.delete,
 			({ testTreeProvider, treeIndex }) =>
-				containsAtLeastOneNode(testTreeProvider.trees[treeIndex]),
+				containsAtLeastOneNode(testTreeProvider.trees[treeIndex]) &&
+				transactionsInProgress(testTreeProvider.trees[treeIndex]),
 		],
 		[
 			setPayloadGenerator,
-			1,
+			opWeights.setPayload,
 			({ testTreeProvider, treeIndex }) =>
-				containsAtLeastOneNode(testTreeProvider.trees[treeIndex]),
+				containsAtLeastOneNode(testTreeProvider.trees[treeIndex]) &&
+				transactionsInProgress(testTreeProvider.trees[treeIndex]),
+		],
+		[
+			transactionStartGenerator,
+			opWeights.start,
+			({ testTreeProvider, treeIndex }) =>
+				!transactionsInProgress(testTreeProvider.trees[treeIndex]),
+		],
+		[
+			transactionCommitGenerator,
+			opWeights.commit,
+			({ testTreeProvider, treeIndex }) =>
+				transactionsInProgress(testTreeProvider.trees[treeIndex]),
+		],
+		[
+			transactionAbortGenerator,
+			opWeights.abort,
+			({ testTreeProvider, treeIndex }) =>
+				transactionsInProgress(testTreeProvider.trees[treeIndex]),
 		],
 	]);
 
@@ -148,9 +228,11 @@ export const makeEditGenerator = (): AsyncGenerator<Operation, FuzzTestState> =>
 	};
 };
 
-export function makeOpGenerator(): AsyncGenerator<Operation, FuzzTestState> {
+export function makeOpGenerator(
+	editOpWeights: EditGeneratorOpWeights = defaultEditGeneratorOpWeights,
+): AsyncGenerator<Operation, FuzzTestState> {
 	const opWeights: AsyncWeights<Operation, FuzzTestState> = [
-		[makeEditGenerator(), 3],
+		[makeEditGenerator(editOpWeights), 3],
 		[{ type: "synchronize" }, 1],
 	];
 	return createWeightedAsyncGenerator(opWeights);
@@ -269,4 +351,8 @@ function containsAtLeastOneNode(tree: ISharedTree): boolean {
 	const firstNode = cursor.firstNode();
 	cursor.free();
 	return firstNode;
+}
+
+function transactionsInProgress(tree: ISharedTree) {
+	return tree.transaction.inProgress();
 }

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -88,12 +88,12 @@ export interface NodeRangePath {
 }
 
 export interface EditGeneratorOpWeights {
-	insert: number;
-	delete: number;
-	setPayload: number;
-	start: number;
-	commit: number;
-	abort: number;
+	insert?: number;
+	delete?: number;
+	setPayload?: number;
+	start?: number;
+	commit?: number;
+	abort?: number;
 }
 const defaultEditGeneratorOpWeights = {
 	insert: 5,
@@ -171,41 +171,29 @@ export const makeEditGenerator = (
 	}
 
 	const baseEditGenerator = createWeightedAsyncGenerator<FuzzChange, EditState>([
-		[
-			insertGenerator,
-			opWeights.insert,
-			({ testTreeProvider, treeIndex }) =>
-				transactionsInProgress(testTreeProvider.trees[treeIndex]),
-		],
+		[insertGenerator, opWeights.insert ?? 0],
 		[
 			deleteGenerator,
-			opWeights.delete,
+			opWeights.delete ?? 0,
 			({ testTreeProvider, treeIndex }) =>
-				containsAtLeastOneNode(testTreeProvider.trees[treeIndex]) &&
-				transactionsInProgress(testTreeProvider.trees[treeIndex]),
+				containsAtLeastOneNode(testTreeProvider.trees[treeIndex]),
 		],
 		[
 			setPayloadGenerator,
-			opWeights.setPayload,
+			opWeights.setPayload ?? 0,
 			({ testTreeProvider, treeIndex }) =>
-				containsAtLeastOneNode(testTreeProvider.trees[treeIndex]) &&
-				transactionsInProgress(testTreeProvider.trees[treeIndex]),
+				containsAtLeastOneNode(testTreeProvider.trees[treeIndex]),
 		],
-		[
-			transactionStartGenerator,
-			opWeights.start,
-			({ testTreeProvider, treeIndex }) =>
-				!transactionsInProgress(testTreeProvider.trees[treeIndex]),
-		],
+		[transactionStartGenerator, opWeights.start ?? 0],
 		[
 			transactionCommitGenerator,
-			opWeights.commit,
+			opWeights.commit ?? 0,
 			({ testTreeProvider, treeIndex }) =>
 				transactionsInProgress(testTreeProvider.trees[treeIndex]),
 		],
 		[
 			transactionAbortGenerator,
-			opWeights.abort,
+			opWeights.abort ?? 0,
 			({ testTreeProvider, treeIndex }) =>
 				transactionsInProgress(testTreeProvider.trees[treeIndex]),
 		],

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzUtils.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzUtils.ts
@@ -12,10 +12,12 @@ import {
 import { JsonableTree, fieldSchema, SchemaData, rootFieldKey } from "../../../core";
 import { FieldKinds, namedTreeSchema } from "../../../feature-libraries";
 import { brand } from "../../../util";
-import { FuzzTestState, Operation } from "./fuzzEditGenerators";
+import { FuzzTestState, Operation, EditGeneratorOpWeights } from "./fuzzEditGenerators";
 
 export function runFuzzBatch(
-	opGenerator: () => AsyncGenerator<Operation, FuzzTestState>,
+	opGenerator: (
+		editGeneratorOpWeights?: EditGeneratorOpWeights,
+	) => AsyncGenerator<Operation, FuzzTestState>,
 	fuzzActions: (
 		generatorFactory: AsyncGenerator<Operation, FuzzTestState>,
 		seed: number,
@@ -24,11 +26,12 @@ export function runFuzzBatch(
 	opsPerRun: number,
 	runsPerBatch: number,
 	random: IRandom,
+	editGeneratorOpWeights?: EditGeneratorOpWeights,
 ): void {
 	const seed = random.integer(1, 1000000);
 	for (let i = 0; i < runsPerBatch; i++) {
 		const runSeed = seed + i;
-		const generatorFactory = () => take(opsPerRun, opGenerator());
+		const generatorFactory = () => take(opsPerRun, opGenerator(editGeneratorOpWeights));
 		const saveInfo: SaveInfo = {
 			saveOnFailure: false, // Change to true to save failing runs.
 			saveOnSuccess: false, // Change to true to save successful runs.

--- a/packages/dds/tree/src/test/shared-tree/fuzz/targetedFuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/targetedFuzz.spec.ts
@@ -49,6 +49,9 @@ export async function performFuzzActionsAbort(
 		testTreeProvider: provider,
 		numberOfEdits: 0,
 	};
+
+	provider.trees[0].transaction.start();
+
 	const finalState = await performFuzzActionsAsync(
 		generator,
 		fuzzReducer,
@@ -57,10 +60,9 @@ export async function performFuzzActionsAbort(
 	);
 
 	// aborts any transactions that may still be in progress
-	for (const currentTree of provider.trees) {
-		if (currentTree.transaction.inProgress()) {
-			currentTree.transaction.abort();
-		}
+	const finalTree = provider.trees[0];
+	if (finalTree.transaction.inProgress()) {
+		finalTree.transaction.abort();
 	}
 	validateTree(provider.trees[0], [initialTreeState]);
 
@@ -92,14 +94,9 @@ describe("Fuzz - Targeted", () => {
 	const runsPerBatch = 20;
 	const opsPerRun = 20;
 	const editGeneratorOpWeights: EditGeneratorOpWeights = {
-		insert: 5,
-		delete: 1,
 		setPayload: 1,
-		start: 3,
-		commit: 0,
-		abort: 1,
 	};
-	describe.skip("Anchors are unaffected by aborted transaction", () => {
+	describe("Anchors are unaffected by aborted transaction", () => {
 		runFuzzBatch(
 			makeOpGenerator,
 			performFuzzActionsAbort,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/targetedFuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/targetedFuzz.spec.ts
@@ -61,9 +61,7 @@ export async function performFuzzActionsAbort(
 
 	// aborts any transactions that may still be in progress
 	const finalTree = provider.trees[0];
-	if (finalTree.transaction.inProgress()) {
-		finalTree.transaction.abort();
-	}
+	finalTree.transaction.abort();
 	validateTree(provider.trees[0], [initialTreeState]);
 
 	// validate anchor

--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevelFuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevelFuzz.spec.ts
@@ -61,8 +61,6 @@ describe("Fuzz - Top-Level", () => {
 	const runsPerBatch = 20;
 	const opsPerRun = 20;
 	const editGeneratorOpWeights: EditGeneratorOpWeights = {
-		insert: 5,
-		delete: 1,
 		setPayload: 1,
 		start: 3,
 		commit: 1,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevelFuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevelFuzz.spec.ts
@@ -9,7 +9,12 @@ import {
 	SaveInfo,
 } from "@fluid-internal/stochastic-test-utils";
 import { TestTreeProvider, SummarizeType, initializeTestTree } from "../../utils";
-import { FuzzTestState, makeOpGenerator, Operation } from "./fuzzEditGenerators";
+import {
+	FuzzTestState,
+	makeOpGenerator,
+	Operation,
+	EditGeneratorOpWeights,
+} from "./fuzzEditGenerators";
 import { checkTreesAreSynchronized, fuzzReducer } from "./fuzzEditReducers";
 import { initialTreeState, runFuzzBatch, testSchema } from "./fuzzUtils";
 
@@ -55,11 +60,26 @@ describe("Fuzz - Top-Level", () => {
 	const random = makeRandom(0);
 	const runsPerBatch = 20;
 	const opsPerRun = 20;
+	const editGeneratorOpWeights: EditGeneratorOpWeights = {
+		insert: 5,
+		delete: 1,
+		setPayload: 1,
+		start: 3,
+		commit: 1,
+		abort: 1,
+	};
 	/**
 	 * This test suite is meant exercise all public APIs of SharedTree together, as well as all service-oriented
 	 * operations (such as summarization and stashed ops).
 	 */
 	describe.skip("Everything", () => {
-		runFuzzBatch(makeOpGenerator, performFuzzActions, opsPerRun, runsPerBatch, random);
+		runFuzzBatch(
+			makeOpGenerator,
+			performFuzzActions,
+			opsPerRun,
+			runsPerBatch,
+			random,
+			editGeneratorOpWeights,
+		);
 	});
 });

--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevelFuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevelFuzz.spec.ts
@@ -62,15 +62,12 @@ describe("Fuzz - Top-Level", () => {
 	const opsPerRun = 20;
 	const editGeneratorOpWeights: EditGeneratorOpWeights = {
 		setPayload: 1,
-		start: 3,
-		commit: 1,
-		abort: 1,
 	};
 	/**
 	 * This test suite is meant exercise all public APIs of SharedTree together, as well as all service-oriented
 	 * operations (such as summarization and stashed ops).
 	 */
-	describe.skip("Everything", () => {
+	describe("Everything", () => {
 		runFuzzBatch(
 			makeOpGenerator,
 			performFuzzActions,


### PR DESCRIPTION
## Description

This PR refactors the sharedTree fuzz edit generator to generate transaction related ops (e.g. tree.transaction.start(), tree.transaction.commit(), tree.transaction.abort()), for simpler reducer functions.
