### PR TITLE
Test remove undo that moves an interval

### DIFF
--- a/packages/dds/sequence/src/test/intervalCollection.snapshot.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.snapshot.spec.ts
@@ -18,35 +18,7 @@ import {
 	IntervalType,
 	SequenceInterval,
 } from "../intervalCollection";
-
-const assertIntervals = (
-	sharedString: SharedString,
-	intervalCollection: IntervalCollection<SequenceInterval>,
-	expected: readonly { start: number; end: number }[],
-	validateOverlapping: boolean = true,
-) => {
-	const actual = Array.from(intervalCollection);
-	if (validateOverlapping && sharedString.getLength() > 0) {
-		const overlapping = intervalCollection.findOverlappingIntervals(
-			0,
-			sharedString.getLength() - 1,
-		);
-		assert.deepEqual(actual, overlapping, "Interval search returned inconsistent results");
-	}
-	assert.strictEqual(
-		actual.length,
-		expected.length,
-		`findOverlappingIntervals() must return the expected number of intervals`,
-	);
-
-	const actualPos = actual.map((interval) => {
-		assert(interval);
-		const start = sharedString.localReferencePositionToPosition(interval.start);
-		const end = sharedString.localReferencePositionToPosition(interval.end);
-		return { start, end };
-	});
-	assert.deepEqual(actualPos, expected, "intervals are not as expected");
-};
+import { assertIntervals } from "./intervalUtils";
 
 async function loadSharedString(
 	containerRuntimeFactory: MockContainerRuntimeFactory,

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -17,35 +17,7 @@ import {
 import { SharedString } from "../sharedString";
 import { SharedStringFactory } from "../sequenceFactory";
 import { IntervalCollection, IntervalType, SequenceInterval } from "../intervalCollection";
-
-const assertIntervals = (
-	sharedString: SharedString,
-	intervalCollection: IntervalCollection<SequenceInterval>,
-	expected: readonly { start: number; end: number }[],
-	validateOverlapping: boolean = true,
-) => {
-	const actual = Array.from(intervalCollection);
-	if (validateOverlapping && sharedString.getLength() > 0) {
-		const overlapping = intervalCollection.findOverlappingIntervals(
-			0,
-			sharedString.getLength() - 1,
-		);
-		assert.deepEqual(actual, overlapping, "Interval search returned inconsistent results");
-	}
-	assert.strictEqual(
-		actual.length,
-		expected.length,
-		`findOverlappingIntervals() must return the expected number of intervals`,
-	);
-
-	const actualPos = actual.map((interval) => {
-		assert(interval);
-		const start = sharedString.localReferencePositionToPosition(interval.start);
-		const end = sharedString.localReferencePositionToPosition(interval.end);
-		return { start, end };
-	});
-	assert.deepEqual(actualPos, expected, "intervals are not as expected");
-};
+import { assertIntervals } from "./intervalUtils";
 
 function assertIntervalEquals(
 	string: SharedString,

--- a/packages/dds/sequence/src/test/intervalCollection.undoRedo.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.undoRedo.spec.ts
@@ -1,0 +1,165 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import {
+	MockContainerRuntimeFactory,
+	MockFluidDataStoreRuntime,
+	MockStorage,
+} from "@fluidframework/test-runtime-utils";
+import {
+	appendToMergeTreeDeltaRevertibles,
+	MergeTreeDeltaRevertible,
+	revertMergeTreeDeltaRevertibles,
+} from "@fluidframework/merge-tree";
+import { SharedString } from "../sharedString";
+import { IntervalCollection, IntervalType, SequenceInterval } from "../intervalCollection";
+import { SharedStringFactory } from "../sequenceFactory";
+
+const assertIntervals = (
+	sharedString: SharedString,
+	intervalCollection: IntervalCollection<SequenceInterval>,
+	expected: readonly { start: number; end: number }[],
+	validateOverlapping: boolean = true,
+) => {
+	const actual = Array.from(intervalCollection);
+	if (validateOverlapping && sharedString.getLength() > 0) {
+		const overlapping = intervalCollection.findOverlappingIntervals(
+			0,
+			sharedString.getLength() - 1,
+		);
+		assert.deepEqual(actual, overlapping, "Interval search returned inconsistent results");
+	}
+	assert.strictEqual(
+		actual.length,
+		expected.length,
+		`findOverlappingIntervals() must return the expected number of intervals`,
+	);
+
+	const actualPos = actual.map((interval) => {
+		assert(interval);
+		const start = sharedString.localReferencePositionToPosition(interval.start);
+		const end = sharedString.localReferencePositionToPosition(interval.end);
+		return { start, end };
+	});
+	assert.deepEqual(actualPos, expected, "intervals are not as expected");
+};
+
+function assertIntervalEquals(
+	string: SharedString,
+	interval: SequenceInterval | undefined,
+	endpoints: { start: number; end: number },
+): void {
+	assert(interval);
+	assert.equal(
+		string.localReferencePositionToPosition(interval.start),
+		endpoints.start,
+		"mismatched start",
+	);
+	assert.equal(
+		string.localReferencePositionToPosition(interval.end),
+		endpoints.end,
+		"mismatched end",
+	);
+}
+
+describe.only("Undo/redo for interval collection operations", () => {
+	let sharedString: SharedString;
+	let dataStoreRuntime1: MockFluidDataStoreRuntime;
+	// not sure if i need the factory if im only using one sharedstring
+	let containerRuntimeFactory: MockContainerRuntimeFactory;
+	let collection: IntervalCollection<SequenceInterval>;
+	let revertibles: MergeTreeDeltaRevertible[];
+
+	beforeEach(() => {
+		dataStoreRuntime1 = new MockFluidDataStoreRuntime({ clientId: "1" });
+		sharedString = new SharedString(
+			dataStoreRuntime1,
+			"shared-string-1",
+			SharedStringFactory.Attributes,
+		);
+
+		// unclear if this is needed
+		containerRuntimeFactory = new MockContainerRuntimeFactory();
+
+		// Connect the first SharedString.
+		dataStoreRuntime1.local = false;
+		const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
+		const services1 = {
+			deltaConnection: containerRuntime1.createDeltaConnection(),
+			objectStorage: new MockStorage(),
+		};
+		sharedString.initializeLocal();
+		sharedString.connect(services1);
+		collection = sharedString.getIntervalCollection("test");
+		revertibles = [];
+	});
+
+	it("has an interval contained within the deleted range", () => {
+		sharedString.insertText(0, "hello world, this is me");
+
+		sharedString.on("sequenceDelta", (op) => {
+			appendToMergeTreeDeltaRevertibles(sharedString, op.deltaArgs, revertibles);
+		});
+
+		collection.add(6, 11, IntervalType.SlideOnRemove);
+
+		sharedString.removeRange(5, 11);
+
+		revertMergeTreeDeltaRevertibles(sharedString, revertibles.splice(0));
+
+		assert.equal(sharedString.getText(), "hello world, this is me");
+		assertIntervals(sharedString, collection, [{ start: 6, end: 11 }]);
+	});
+	it("has an interval with the same range as the deleted text", () => {
+		sharedString.insertText(0, "hello world, this is me");
+
+		sharedString.on("sequenceDelta", (op) => {
+			appendToMergeTreeDeltaRevertibles(sharedString, op.deltaArgs, revertibles);
+		});
+
+		collection.add(0, 12, IntervalType.SlideOnRemove);
+
+		sharedString.removeRange(0, 13);
+
+		revertMergeTreeDeltaRevertibles(sharedString, revertibles.splice(0));
+
+		assert.equal(sharedString.getText(), "hello world, this is me");
+		assertIntervals(sharedString, collection, [{ start: 0, end: 13 }]);
+	});
+	it("has an interval starting point within the deleted range", () => {
+		sharedString.insertText(0, "hello world, this is me");
+
+		sharedString.on("sequenceDelta", (op) => {
+			appendToMergeTreeDeltaRevertibles(sharedString, op.deltaArgs, revertibles);
+		});
+
+		collection.add(8, 16, IntervalType.SlideOnRemove);
+
+		sharedString.removeRange(5, 11);
+
+		revertMergeTreeDeltaRevertibles(sharedString, revertibles.splice(0));
+
+		assert.equal(sharedString.getText(), "hello world, this is me");
+		assertIntervals(sharedString, collection, [{ start: 8, end: 16 }]);
+	});
+	it("has an interval ending point within the deleted range", () => {
+		sharedString.insertText(0, "hello world, this is me");
+
+		sharedString.on("sequenceDelta", (op) => {
+			appendToMergeTreeDeltaRevertibles(sharedString, op.deltaArgs, revertibles);
+		});
+
+		collection.add(2, 8, IntervalType.SlideOnRemove);
+
+		sharedString.removeRange(5, 11);
+
+		revertMergeTreeDeltaRevertibles(sharedString, revertibles.splice(0));
+
+		assert.equal(sharedString.getText(), "hello world, this is me");
+		assertIntervals(sharedString, collection, [{ start: 2, end: 8 }]);
+	});
+});

--- a/packages/dds/sequence/src/test/intervalCollection.undoRedo.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.undoRedo.spec.ts
@@ -18,58 +18,11 @@ import {
 import { SharedString } from "../sharedString";
 import { IntervalCollection, IntervalType, SequenceInterval } from "../intervalCollection";
 import { SharedStringFactory } from "../sequenceFactory";
-
-const assertIntervals = (
-	sharedString: SharedString,
-	intervalCollection: IntervalCollection<SequenceInterval>,
-	expected: readonly { start: number; end: number }[],
-	validateOverlapping: boolean = true,
-) => {
-	const actual = Array.from(intervalCollection);
-	if (validateOverlapping && sharedString.getLength() > 0) {
-		const overlapping = intervalCollection.findOverlappingIntervals(
-			0,
-			sharedString.getLength() - 1,
-		);
-		assert.deepEqual(actual, overlapping, "Interval search returned inconsistent results");
-	}
-	assert.strictEqual(
-		actual.length,
-		expected.length,
-		`findOverlappingIntervals() must return the expected number of intervals`,
-	);
-
-	const actualPos = actual.map((interval) => {
-		assert(interval);
-		const start = sharedString.localReferencePositionToPosition(interval.start);
-		const end = sharedString.localReferencePositionToPosition(interval.end);
-		return { start, end };
-	});
-	assert.deepEqual(actualPos, expected, "intervals are not as expected");
-};
-
-function assertIntervalEquals(
-	string: SharedString,
-	interval: SequenceInterval | undefined,
-	endpoints: { start: number; end: number },
-): void {
-	assert(interval);
-	assert.equal(
-		string.localReferencePositionToPosition(interval.start),
-		endpoints.start,
-		"mismatched start",
-	);
-	assert.equal(
-		string.localReferencePositionToPosition(interval.end),
-		endpoints.end,
-		"mismatched end",
-	);
-}
+import { assertIntervals } from "./intervalUtils";
 
 describe("Undo/redo for interval collection operations", () => {
 	let sharedString: SharedString;
 	let dataStoreRuntime1: MockFluidDataStoreRuntime;
-	// not sure if i need the factory if im only using one sharedstring
 	let containerRuntimeFactory: MockContainerRuntimeFactory;
 	let collection: IntervalCollection<SequenceInterval>;
 	let revertibles: MergeTreeDeltaRevertible[];
@@ -82,7 +35,6 @@ describe("Undo/redo for interval collection operations", () => {
 			SharedStringFactory.Attributes,
 		);
 
-		// unclear if this is needed
 		containerRuntimeFactory = new MockContainerRuntimeFactory();
 
 		// Connect the first SharedString.
@@ -99,67 +51,68 @@ describe("Undo/redo for interval collection operations", () => {
 	});
 
 	it("has an interval contained within the deleted range", () => {
-		sharedString.insertText(0, "hello world, this is me");
+		sharedString.insertText(0, "hello world");
 
 		sharedString.on("sequenceDelta", (op) => {
 			appendToMergeTreeDeltaRevertibles(sharedString, op.deltaArgs, revertibles);
 		});
 
-		collection.add(6, 11, IntervalType.SlideOnRemove);
+		collection.add(2, 4, IntervalType.SlideOnRemove);
+		assertIntervals(sharedString, collection, [{ start: 2, end: 4 }]);
 
-		sharedString.removeRange(5, 11);
+		sharedString.removeRange(0, 6);
 
 		revertMergeTreeDeltaRevertibles(sharedString, revertibles.splice(0));
 
-		assert.equal(sharedString.getText(), "hello world, this is me");
-		assertIntervals(sharedString, collection, [{ start: 6, end: 11 }]);
+		assert.equal(sharedString.getText(), "hello world");
+		assertIntervals(sharedString, collection, [{ start: 2, end: 4 }]);
 	});
 	it("has an interval with the same range as the deleted text", () => {
-		sharedString.insertText(0, "hello world, this is me");
+		sharedString.insertText(0, "hello world");
 
 		sharedString.on("sequenceDelta", (op) => {
 			appendToMergeTreeDeltaRevertibles(sharedString, op.deltaArgs, revertibles);
 		});
 
-		collection.add(0, 12, IntervalType.SlideOnRemove);
+		collection.add(0, 5, IntervalType.SlideOnRemove);
 
-		sharedString.removeRange(0, 13);
+		sharedString.removeRange(0, 6);
 
 		revertMergeTreeDeltaRevertibles(sharedString, revertibles.splice(0));
 
-		assert.equal(sharedString.getText(), "hello world, this is me");
-		assertIntervals(sharedString, collection, [{ start: 0, end: 13 }]);
+		assert.equal(sharedString.getText(), "hello world");
+		assertIntervals(sharedString, collection, [{ start: 0, end: 5 }]);
 	});
 	it("has an interval starting point within the deleted range", () => {
-		sharedString.insertText(0, "hello world, this is me");
+		sharedString.insertText(0, "hello world");
 
 		sharedString.on("sequenceDelta", (op) => {
 			appendToMergeTreeDeltaRevertibles(sharedString, op.deltaArgs, revertibles);
 		});
 
-		collection.add(8, 16, IntervalType.SlideOnRemove);
+		collection.add(5, 9, IntervalType.SlideOnRemove);
 
-		sharedString.removeRange(5, 11);
+		sharedString.removeRange(2, 7);
 
 		revertMergeTreeDeltaRevertibles(sharedString, revertibles.splice(0));
 
-		assert.equal(sharedString.getText(), "hello world, this is me");
-		assertIntervals(sharedString, collection, [{ start: 8, end: 16 }]);
+		assert.equal(sharedString.getText(), "hello world");
+		assertIntervals(sharedString, collection, [{ start: 5, end: 9 }]);
 	});
 	it("has an interval ending point within the deleted range", () => {
-		sharedString.insertText(0, "hello world, this is me");
+		sharedString.insertText(0, "hello world");
 
 		sharedString.on("sequenceDelta", (op) => {
 			appendToMergeTreeDeltaRevertibles(sharedString, op.deltaArgs, revertibles);
 		});
 
-		collection.add(2, 8, IntervalType.SlideOnRemove);
+		collection.add(0, 4, IntervalType.SlideOnRemove);
 
-		sharedString.removeRange(5, 11);
+		sharedString.removeRange(2, 7);
 
 		revertMergeTreeDeltaRevertibles(sharedString, revertibles.splice(0));
 
-		assert.equal(sharedString.getText(), "hello world, this is me");
-		assertIntervals(sharedString, collection, [{ start: 2, end: 8 }]);
+		assert.equal(sharedString.getText(), "hello world");
+		assertIntervals(sharedString, collection, [{ start: 0, end: 4 }]);
 	});
 });

--- a/packages/dds/sequence/src/test/intervalCollection.undoRedo.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.undoRedo.spec.ts
@@ -66,7 +66,7 @@ describe("Undo/redo for interval collection operations", () => {
 		assert.equal(sharedString.getText(), "hello world");
 		assertIntervals(sharedString, collection, [{ start: 6, end: 6 /* start: 2, end: 4 */ }]);
 	});
-	it("has an interval with the same range as the deleted text", () => {
+	it("has an interval with both endpoints contained within the deleted range", () => {
 		sharedString.insertText(0, "hello world");
 
 		sharedString.on("sequenceDelta", (op) => {
@@ -82,7 +82,7 @@ describe("Undo/redo for interval collection operations", () => {
 		assert.equal(sharedString.getText(), "hello world");
 		assertIntervals(sharedString, collection, [{ start: 6, end: 6 /* start: 0, end: 5 */ }]);
 	});
-	it("has an interval starting point within the deleted range", () => {
+	it("has an interval with one endpoint within the deleted range", () => {
 		sharedString.insertText(0, "hello world");
 
 		sharedString.on("sequenceDelta", (op) => {
@@ -97,22 +97,6 @@ describe("Undo/redo for interval collection operations", () => {
 
 		assert.equal(sharedString.getText(), "hello world");
 		assertIntervals(sharedString, collection, [{ /* start: 5 */ start: 7, end: 9 }]);
-	});
-	it("has an interval ending point within the deleted range", () => {
-		sharedString.insertText(0, "hello world");
-
-		sharedString.on("sequenceDelta", (op) => {
-			appendToMergeTreeDeltaRevertibles(sharedString, op.deltaArgs, revertibles);
-		});
-
-		collection.add(0, 4, IntervalType.SlideOnRemove);
-
-		sharedString.removeRange(2, 7);
-
-		revertMergeTreeDeltaRevertibles(sharedString, revertibles.splice(0));
-
-		assert.equal(sharedString.getText(), "hello world");
-		assertIntervals(sharedString, collection, [{ start: 0, end: 7 /* end: 4 */ }]);
 	});
 	it("restores an interval after two removes", () => {
 		sharedString.insertText(0, "hello world");

--- a/packages/dds/sequence/src/test/intervalCollection.undoRedo.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.undoRedo.spec.ts
@@ -20,6 +20,9 @@ import { IntervalCollection, IntervalType, SequenceInterval } from "../intervalC
 import { SharedStringFactory } from "../sequenceFactory";
 import { assertIntervals } from "./intervalUtils";
 
+// The code being tested currently does the wrong behavior. Currently,
+// the tests validate the bug and should be updated when the implementation
+// is fixed.
 describe("Undo/redo for interval collection operations", () => {
 	let sharedString: SharedString;
 	let dataStoreRuntime1: MockFluidDataStoreRuntime;
@@ -73,7 +76,7 @@ describe("Undo/redo for interval collection operations", () => {
 			appendToMergeTreeDeltaRevertibles(sharedString, op.deltaArgs, revertibles);
 		});
 
-		collection.add(0, 5, IntervalType.SlideOnRemove);
+		collection.add(0, 6, IntervalType.SlideOnRemove);
 
 		sharedString.removeRange(0, 6);
 

--- a/packages/dds/sequence/src/test/intervalCollection.undoRedo.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.undoRedo.spec.ts
@@ -66,7 +66,7 @@ function assertIntervalEquals(
 	);
 }
 
-describe.only("Undo/redo for interval collection operations", () => {
+describe("Undo/redo for interval collection operations", () => {
 	let sharedString: SharedString;
 	let dataStoreRuntime1: MockFluidDataStoreRuntime;
 	// not sure if i need the factory if im only using one sharedstring

--- a/packages/dds/sequence/src/test/intervalUtils.ts
+++ b/packages/dds/sequence/src/test/intervalUtils.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "assert";
 import { MockContainerRuntimeForReconnection } from "@fluidframework/test-runtime-utils";
 import { SharedString } from "../sharedString";
+import { IntervalCollection, SequenceInterval } from "../intervalCollection";
 
 export interface Client {
 	sharedString: SharedString;
@@ -80,3 +81,32 @@ export function assertEquivalentSharedStrings(a: SharedString, b: SharedString) 
 		}
 	}
 }
+
+export const assertIntervals = (
+	sharedString: SharedString,
+	intervalCollection: IntervalCollection<SequenceInterval>,
+	expected: readonly { start: number; end: number }[],
+	validateOverlapping: boolean = true,
+) => {
+	const actual = Array.from(intervalCollection);
+	if (validateOverlapping && sharedString.getLength() > 0) {
+		const overlapping = intervalCollection.findOverlappingIntervals(
+			0,
+			sharedString.getLength() - 1,
+		);
+		assert.deepEqual(actual, overlapping, "Interval search returned inconsistent results");
+	}
+	assert.strictEqual(
+		actual.length,
+		expected.length,
+		`findOverlappingIntervals() must return the expected number of intervals`,
+	);
+
+	const actualPos = actual.map((interval) => {
+		assert(interval);
+		const start = sharedString.localReferencePositionToPosition(interval.start);
+		const end = sharedString.localReferencePositionToPosition(interval.end);
+		return { start, end };
+	});
+	assert.deepEqual(actualPos, expected, "intervals are not as expected");
+};


### PR DESCRIPTION
Prior to the [SharedInterval undo/redo work](https://dev.azure.com/fluidframework/internal/_workitems/edit/3578), intervals would not return to their original positions after an action that modifies the interval is undone. These tests are meant to test that functionality once it is implemented. Currently, an interval modified in this way will move to the endpoint of the removed range once the remove is undone, instead of returning to the position at which it was added. Because of this, the added tests currently fail.

[AB#3914](https://dev.azure.com/fluidframework/internal/_workitems/edit/3914)