### PR TITLE
Fix external controller 

### DIFF
--- a/azure/packages/external-controller/README.md
+++ b/azure/packages/external-controller/README.md
@@ -95,6 +95,17 @@ In this way, we can toggle between remote and local mode using the same config f
 `AzureFunctionTokenProvider` for running against live Azure Fluid Relay instance since it is more secured, without exposing the tenant
 secret key in the client-side code whereas while running the service locally for development purpose, we make use of `InsecureTokenProvider`.
 
+We can also run the `AzureClient` with the `InsecureTokenProvider` as follows:
+
+```typescript
+const connectionConfig: AzureConnectionConfig = {
+	type: "remote",
+	tenantId: "YOUR-TENANT-ID-HERE",
+	tokenProvider: new InsecureTokenProvider("YOUR-SECRET-HERE", user),
+	endpoint: "ENTER-DISCOVERY-ENDPOINT-URL-HERE",
+};
+```
+
 <!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->
 
 <!-- prettier-ignore-start -->

--- a/azure/packages/external-controller/package.json
+++ b/azure/packages/external-controller/package.json
@@ -30,7 +30,7 @@
 		"prettier": "prettier --check . --ignore-path ../../../.prettierignore",
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"start": "npm run start:tinylicious",
-		"start:azure": "webpack serve --define process.env.FLUID_CLIENT='\"azure\"'",
+		"start:azure": "webpack serve --env FLUID_CLIENT=azure",
 		"start:client": "webpack serve",
 		"start:client:test": "webpack serve --config webpack.test.js",
 		"start:tinylicious": "start-server-and-test tinylicious 7070 start:client",

--- a/azure/packages/external-controller/webpack.config.js
+++ b/azure/packages/external-controller/webpack.config.js
@@ -10,6 +10,7 @@ const webpack = require("webpack");
 
 module.exports = (env) => {
 	const isProduction = env?.production;
+	const fluidClient = env?.FLUID_CLIENT || "";
 
 	return merge(
 		{
@@ -40,6 +41,9 @@ module.exports = (env) => {
 				libraryTarget: "umd",
 			},
 			plugins: [
+				new webpack.DefinePlugin({
+					"process.env.FLUID_CLIENT": JSON.stringify(fluidClient),
+				}),
 				new webpack.ProvidePlugin({
 					process: "process/browser",
 				}),


### PR DESCRIPTION
The external controller example part was not picking up the `azure` env variable. This PR fixes the issue. The example is running across both azure-client and tinylicious.

