### PR TITLE
isDeletePending should check the parents delete too

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -743,29 +743,31 @@ export class SharedDirectory
 	}
 
 	/**
-	 * This checks if there is pending delete op for local delete for a subdirectory.
+	 * This checks if there is pending delete op for local delete for a any subdir in the relative path.
 	 * @param relativePath - path of sub directory.
 	 * @returns - true if there is pending delete.
 	 */
 	private isSubDirectoryDeletePending(relativePath: string): boolean {
-		const parentSubDir = this.getParentDirectory(relativePath);
-		const index = relativePath.lastIndexOf(posix.sep);
-		const dirName = relativePath.substring(index + 1);
-		return !!parentSubDir?.isSubDirectoryDeletePending(dirName);
-	}
-
-	/**
-	 * Gets the parent directory of a sub directory.
-	 * @param relativePath - path of sub directory of which parent needs to be find out.
-	 */
-	private getParentDirectory(relativePath: string): SubDirectory | undefined {
 		const absolutePath = this.makeAbsolute(relativePath);
 		if (absolutePath === posix.sep) {
-			return undefined;
+			return false;
 		}
-		const index = absolutePath.lastIndexOf(posix.sep);
-		const parentAbsPath = absolutePath.substring(0, index);
-		return this.getWorkingDirectory(parentAbsPath) as SubDirectory;
+		let currentParent = this.root;
+		const nodeList = absolutePath.split(posix.sep);
+		let start = 1;
+		while (start < nodeList.length) {
+			const subDirName = nodeList[start];
+			if (currentParent.isSubDirectoryDeletePending(subDirName)) {
+				return true;
+			}
+			const newParent = currentParent.getSubDirectory(subDirName) as SubDirectory;
+			if (newParent === undefined) {
+				return true;
+			}
+			currentParent = newParent;
+			start += 1;
+		}
+		return false;
 	}
 
 	/**
@@ -780,8 +782,8 @@ export class SharedDirectory
 				localOpMetadata,
 			) => {
 				const subdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
-				// If there is pending delete op for this subDirectory, then don't apply the this op as we are going
-				// to delete this subDirectory.
+				// If there is pending delete op for any parent of this subdirectory, then don't apply the this op
+				// as we are going to delete this subDirectory.
 				if (subdir && !this.isSubDirectoryDeletePending(op.path)) {
 					subdir.processClearMessage(msg, op, local, localOpMetadata);
 				}
@@ -807,8 +809,8 @@ export class SharedDirectory
 				localOpMetadata,
 			) => {
 				const subdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
-				// If there is pending delete op for this subDirectory, then don't apply the this op as we are going
-				// to delete this subDirectory.
+				// If there is pending delete op for any parent of this subdirectory, then don't apply the this op
+				// as we are going to delete this subDirectory.
 				if (subdir && !this.isSubDirectoryDeletePending(op.path)) {
 					subdir.processDeleteMessage(msg, op, local, localOpMetadata);
 				}
@@ -836,8 +838,8 @@ export class SharedDirectory
 				localOpMetadata,
 			) => {
 				const subdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
-				// If there is pending delete op for this subDirectory, then don't apply the this op as we are going
-				// to delete this subDirectory.
+				// If there is pending delete op for any parent of this subdirectory, then don't apply the this op
+				// as we are going to delete this subDirectory.
 				if (subdir && !this.isSubDirectoryDeletePending(op.path)) {
 					const context = local ? undefined : this.makeLocal(op.key, op.path, op.value);
 					subdir.processSetMessage(msg, op, context, local, localOpMetadata);
@@ -866,7 +868,9 @@ export class SharedDirectory
 				localOpMetadata,
 			) => {
 				const parentSubdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
-				if (parentSubdir) {
+				// If there is pending delete op for any parent of this subdirectory, then don't apply the this op
+				// as we are going to delete this subDirectory.
+				if (parentSubdir && !this.isSubDirectoryDeletePending(op.path)) {
 					parentSubdir.processCreateSubDirectoryMessage(msg, op, local, localOpMetadata);
 				}
 			},
@@ -895,7 +899,9 @@ export class SharedDirectory
 				localOpMetadata,
 			) => {
 				const parentSubdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
-				if (parentSubdir) {
+				// If there is pending delete op for any parent of this subdirectory, then don't apply the this op
+				// as we are going to delete this subDirectory.
+				if (parentSubdir && !this.isSubDirectoryDeletePending(op.path)) {
 					parentSubdir.processDeleteSubDirectoryMessage(msg, op, local, localOpMetadata);
 				}
 			},

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -781,7 +781,7 @@ export class SharedDirectory
 				localOpMetadata,
 			) => {
 				const subdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
-				// If there is pending delete op for any parent of this subdirectory, then don't apply the this op
+				// If there is pending delete op for any subDirectory in the op.path, then don't apply the this op
 				// as we are going to delete this subDirectory.
 				if (subdir && !this.isSubDirectoryDeletePending(op.path)) {
 					subdir.processClearMessage(msg, op, local, localOpMetadata);
@@ -808,7 +808,7 @@ export class SharedDirectory
 				localOpMetadata,
 			) => {
 				const subdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
-				// If there is pending delete op for any parent of this subdirectory, then don't apply the this op
+				// If there is pending delete op for any subDirectory in the op.path, then don't apply the this op
 				// as we are going to delete this subDirectory.
 				if (subdir && !this.isSubDirectoryDeletePending(op.path)) {
 					subdir.processDeleteMessage(msg, op, local, localOpMetadata);
@@ -837,7 +837,7 @@ export class SharedDirectory
 				localOpMetadata,
 			) => {
 				const subdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
-				// If there is pending delete op for any parent of this subdirectory, then don't apply the this op
+				// If there is pending delete op for any subDirectory in the op.path, then don't apply the this op
 				// as we are going to delete this subDirectory.
 				if (subdir && !this.isSubDirectoryDeletePending(op.path)) {
 					const context = local ? undefined : this.makeLocal(op.key, op.path, op.value);
@@ -867,7 +867,7 @@ export class SharedDirectory
 				localOpMetadata,
 			) => {
 				const parentSubdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
-				// If there is pending delete op for any parent of this subdirectory, then don't apply the this op
+				// If there is pending delete op for any subDirectory in the op.path, then don't apply the this op
 				// as we are going to delete this subDirectory.
 				if (parentSubdir && !this.isSubDirectoryDeletePending(op.path)) {
 					parentSubdir.processCreateSubDirectoryMessage(msg, op, local, localOpMetadata);
@@ -898,7 +898,7 @@ export class SharedDirectory
 				localOpMetadata,
 			) => {
 				const parentSubdir = this.getWorkingDirectory(op.path) as SubDirectory | undefined;
-				// If there is pending delete op for any parent of this subdirectory, then don't apply the this op
+				// If there is pending delete op for any subDirectory in the op.path, then don't apply the this op
 				// as we are going to delete this subDirectory.
 				if (parentSubdir && !this.isSubDirectoryDeletePending(op.path)) {
 					parentSubdir.processDeleteSubDirectoryMessage(msg, op, local, localOpMetadata);

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -760,11 +760,10 @@ export class SharedDirectory
 			if (currentParent.isSubDirectoryDeletePending(subDirName)) {
 				return true;
 			}
-			const newParent = currentParent.getSubDirectory(subDirName) as SubDirectory;
-			if (newParent === undefined) {
+			currentParent = currentParent.getSubDirectory(subDirName) as SubDirectory;
+			if (currentParent === undefined) {
 				return true;
 			}
-			currentParent = newParent;
 			start += 1;
 		}
 		return false;

--- a/packages/dds/map/src/test/mocha/directory.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.spec.ts
@@ -1184,7 +1184,7 @@ describe("Directory", () => {
 				);
 			});
 
-			it("Directories should ensure eventual consistency using LWW approach 1", async () => {
+			it("Directories should ensure eventual consistency using LWW approach 1: Test 1", async () => {
 				const root1SubDir = directory1.createSubDirectory("testSubDir");
 				root1SubDir.set("key1", "testValue1");
 
@@ -1194,9 +1194,6 @@ describe("Directory", () => {
 				directory2.createSubDirectory("testSubDir");
 
 				// After the above scenario, the consistent state using LWW would be to have testSubDir with 1 key.
-				// Right now what happens is directory B just ignores the delete Op from directory 1 because its own
-				// create is not acked and it ends up ignoring the delete op. So directory 2 ends up having 2 keys
-				// instead of one.
 				containerRuntimeFactory.processAllMessages();
 				const directory1SubDir = directory1.getSubDirectory("testSubDir");
 				const directory2SubDir = directory2.getSubDirectory("testSubDir");
@@ -1218,7 +1215,7 @@ describe("Directory", () => {
 				);
 			});
 
-			it("Directories should ensure eventual consistency using LWW approach 1", async () => {
+			it("Directories should ensure eventual consistency using LWW approach 1: Test 2", async () => {
 				const root1SubDir = directory1.createSubDirectory("testSubDir");
 				directory2.createSubDirectory("testSubDir");
 
@@ -1227,9 +1224,6 @@ describe("Directory", () => {
 				directory2.createSubDirectory("testSubDir");
 
 				// After the above scenario, the consistent state using LWW would be to have testSubDir with 0 keys.
-				// Right now what happens is directory B just sees the set Op from directory 1 and set the key while
-				// directory A sees delete and create sub directory op from B and eventually have a sub directory
-				// testSubDir with 0 keys. So the state of directory 2 ends up wrong.
 				containerRuntimeFactory.processAllMessages();
 				const directory1SubDir = directory1.getSubDirectory("testSubDir");
 				const directory2SubDir = directory2.getSubDirectory("testSubDir");


### PR DESCRIPTION
## Description

Following up on PR: https://github.com/microsoft/FluidFramework/pull/14226
Seems like there was a bug where sudir.isSubDirectoryDeletePending should check in parent chain whether delete is pending or not and not just the immediate parent.