### PR TITLE
New protocol definition signal source enum

### DIFF
--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -90,6 +90,13 @@ export enum SignalType {
 	ClientLeave = "leave",
 }
 
+export enum SignalSource {
+	/**
+	 * System signal sent to indicate a new client has joined the collaboration.
+	 */
+	External = "external",
+}
+
 /**
  * Messages to track latency trace
  */

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -92,7 +92,7 @@ export enum SignalType {
 
 export enum SignalSource {
 	/**
-	 * System signal sent to indicate a new client has joined the collaboration.
+	 * Signal sent by server on behald of external caller (through brodcast-signal service endpoint).
 	 */
 	External = "external",
 }


### PR DESCRIPTION
Prototype SignalSource to enable signal routing for external-data example usecase.