### PR TITLE
Remove back compat code for very old channel attach messages

### DIFF
--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -11,7 +11,6 @@ import {
 	IChannel,
 	IChannelAttributes,
 	IFluidDataStoreRuntime,
-	IChannelFactory,
 } from "@fluidframework/datastore-definitions";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { readAndParse } from "@fluidframework/driver-utils";
@@ -192,62 +191,45 @@ export class RemoteChannelContext implements IChannelContext {
 			);
 		}
 
-		let factory: IChannelFactory | undefined;
-		// this is a backward compatibility case where
-		// the attach message doesn't include
-		// the attributes. Since old attach messages
-		// will not have attributes we need to keep
-		// this as long as we support old attach messages
-		if (attributes === undefined) {
-			if (this.attachMessageType === undefined) {
-				// TODO: dataStoreId may require a different tag from PackageData #7488
-				throw new DataCorruptionError("channelTypeNotAvailable", {
-					channelId: {
-						value: this.id,
-						tag: TelemetryDataTag.CodeArtifact,
-					},
-					dataStoreId: {
-						value: this.dataStoreContext.id,
-						tag: TelemetryDataTag.CodeArtifact,
-					},
-					dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
-				});
-			}
-			factory = this.registry.get(this.attachMessageType);
-			if (factory === undefined) {
-				// TODO: dataStoreId may require a different tag from PackageData #7488
-				throw new DataCorruptionError("channelFactoryNotRegisteredForAttachMessageType", {
-					channelId: {
-						value: this.id,
-						tag: TelemetryDataTag.CodeArtifact,
-					},
-					dataStoreId: {
-						value: this.dataStoreContext.id,
-						tag: TelemetryDataTag.CodeArtifact,
-					},
-					dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
-					channelFactoryType: this.attachMessageType,
-				});
-			}
-			attributes = factory.attributes;
-		} else {
-			factory = this.registry.get(attributes.type);
-			if (factory === undefined) {
-				// TODO: dataStoreId may require a different tag from PackageData #7488
-				throw new DataCorruptionError("channelFactoryNotRegisteredForGivenType", {
-					channelId: {
-						value: this.id,
-						tag: TelemetryDataTag.CodeArtifact,
-					},
-					dataStoreId: {
-						value: this.dataStoreContext.id,
-						tag: TelemetryDataTag.CodeArtifact,
-					},
-					dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
-					channelFactoryType: attributes.type,
-				});
-			}
+		// This is a backward compatibility case where the attach message doesn't include attributes. They must
+		// include attach message type.
+		// Since old attach messages will not have attributes, we need to keep this as long as we support old attach
+		// messages.
+		const channelFactoryType = attributes ? attributes.type : this.attachMessageType;
+		if (channelFactoryType === undefined) {
+			throw new DataCorruptionError("channelTypeNotAvailable", {
+				channelId: {
+					value: this.id,
+					tag: TelemetryDataTag.CodeArtifact,
+				},
+				dataStoreId: {
+					value: this.dataStoreContext.id,
+					tag: TelemetryDataTag.CodeArtifact,
+				},
+				dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
+				channelFactoryType: this.attachMessageType,
+			});
 		}
+		const factory = this.registry.get(channelFactoryType);
+		if (factory === undefined) {
+			// TODO: dataStoreId may require a different tag from PackageData #7488
+			throw new DataCorruptionError("channelFactoryNotRegisteredForGivenType", {
+				channelId: {
+					value: this.id,
+					tag: TelemetryDataTag.CodeArtifact,
+				},
+				dataStoreId: {
+					value: this.dataStoreContext.id,
+					tag: TelemetryDataTag.CodeArtifact,
+				},
+				dataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
+				channelFactoryType,
+			});
+		}
+
+		// This is a backward compatibility case where the attach message doesn't include attributes. Get the attributes
+		// from the factory.
+		attributes = attributes ?? factory.attributes;
 
 		// Compare snapshot version to collaborative object version
 		if (


### PR DESCRIPTION
The back-compat code when loading remote channel contexts [here](https://github.com/agarwal-navin/FluidFramework/blob/394ea61469b7c57151c0a655a09d6d0cd4a45430/packages/runtime/datastore/src/remoteChannelContext.ts#L201) has been removed. They were added ~3 years ago by [this PR](https://github.com/microsoft/FluidFramework/pull/1486). There are no hits in telemetry for any of the errors in the back compat code.
If there are very old documents out there that may have old attach messages without attributes, they are not going to work anyway, so throwing an assert should be fine because it makes the code cleaner.

[AB#4008](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4008)