### PR TITLE
[GC stress] Log a console error when the runner fails

### DIFF
--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -148,9 +148,13 @@ async function main() {
 		);
 	} catch (e) {
 		logger.sendErrorEvent({ eventName: "runnerFailed" }, e);
+		console.log(`xxxxxxxxx Runner failed. Error: ${JSON.stringify(e)}`);
 	} finally {
 		if (testFailed) {
 			result = -2;
+		}
+		if (result === -1) {
+			console.log(`xxxxxxxxx Test failed`);
 		}
 		await safeExit(result, url, runId);
 	}


### PR DESCRIPTION
There aren instances where the test runner fails because of reasons other that unexpected GC errors. Adding a console log when that happens to be able to understand why it happens.
Most likely it's one of the steps outisde the `while` loop in [this function](https://github.com/agarwal-navin/FluidFramework/blob/6df0eb3e23fa49c3dee12d02a7bd591dca0c03e8/packages/test/test-service-load/src/runner.ts#L213).

## Reviewer guidance
This is for an experimental stress test in test/gc-stress branch. This is not in the main FF branch and does not affect its stress test.