### PR TITLE
Perf benchmark E2E tests: Exclude 5 and 10 Mb Map from AFR runs

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/LoadDocument.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/LoadDocument.all.spec.ts
@@ -29,6 +29,16 @@ describeE2EDocRun("Load Document", (getTestObjectProvider, getDocumentInfo) => {
 		});
 		await documentWrapper.initializeDocument();
 	});
+
+	beforeEach(async function () {
+		const docData = getDocumentInfo();
+		if (
+			docData.supportedEndpoints &&
+			!docData.supportedEndpoints?.includes(provider.driver.type)
+		) {
+			this.skip();
+		}
+	});
 	/**
 	 * The PerformanceTestWrapper class includes 2 functionalities:
 	 * 1) Store any objects that should not be garbage collected during the benchmark execution (specific for memory tests).

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarizationDocument.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarizationDocument.all.spec.ts
@@ -35,6 +35,15 @@ describeE2EDocRun(scenarioTitle, (getTestObjectProvider, getDocumentInfo) => {
 		await documentWrapper.summarize();
 	});
 
+	beforeEach(async function () {
+		const docData = getDocumentInfo();
+		if (
+			docData.supportedEndpoints &&
+			!docData.supportedEndpoints?.includes(provider.driver.type)
+		) {
+			this.skip();
+		}
+	});
 	/**
 	 * The PerformanceTestWrapper class includes 2 functionalities:
 	 * 1) Store any objects that should not be garbage collected during the benchmark execution (specific for memory tests).

--- a/packages/test/test-version-utils/src/describeE2eDocs.ts
+++ b/packages/test/test-version-utils/src/describeE2eDocs.ts
@@ -4,6 +4,7 @@
  */
 
 import { ChildLogger } from "@fluidframework/telemetry-utils";
+import { TestDriverTypes } from "@fluidframework/test-driver-definitions";
 import {
 	getUnexpectedLogErrorException,
 	ITestObjectProvider,
@@ -33,11 +34,13 @@ const E2EDefaultDocumentTypes: DescribeE2EDocInfo[] = [
 		testTitle: "10Mb Map",
 		documentType: "LargeDocumentMap",
 		minSampleCount: 2,
+		supportedEndpoints: ["local", "odsp"],
 	},
 	{
 		testTitle: "5Mb Map",
 		documentType: "MediumDocumentMap",
 		minSampleCount: 2,
+		supportedEndpoints: ["local", "odsp"],
 	},
 	{
 		testTitle: "250 DataStores - 750 DDSs",
@@ -57,6 +60,7 @@ export type BenchmarkTypeDescription = "Runtime benchmarks" | "Memory benchmarks
 export interface DescribeE2EDocInfo {
 	testTitle: string;
 	documentType: DocumentType | string | undefined;
+	supportedEndpoints?: TestDriverTypes[];
 	/**
 	 * Minimum number of iterations when running performance tests against the document.
 	 */


### PR DESCRIPTION

## Description

There are bugs on AFR in which the large Map documents fail to summarize intermittently. In order to continue with the addition of AFR to the suite, we are skipping the Map tests when running against AFR. 

