### PR TITLE
Allow SharedTree branches to live after merge

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -770,7 +770,6 @@ export interface ISharedTree extends ISharedObject, ISharedTreeView {
 
 // @alpha
 export interface ISharedTreeFork extends ISharedTreeView {
-    isMerged(): boolean;
     merge(): void;
     pull(): void;
 }

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -225,15 +225,8 @@ export interface ISharedTreeFork extends ISharedTreeView {
 	 * Apply all the changes on this view to the base view from which it was forked.
 	 * If the base view has new changes since this view last pulled (or was forked),
 	 * then this view's changes will be rebased over those first.
-	 * After the merge completes, this view may no longer be forked or mutated.
 	 */
 	merge(): void;
-
-	/**
-	 * Whether or not this view has been merged into its base view via `merge()`.
-	 * If it has, then it may no longer be forked or mutated.
-	 */
-	isMerged(): boolean;
 }
 
 /**
@@ -481,10 +474,6 @@ export class SharedTreeFork implements ISharedTreeFork {
 
 	public merge(): void {
 		this.branch.merge();
-	}
-
-	public isMerged(): boolean {
-		return this.branch.isMerged();
 	}
 
 	public get root(): UnwrappedEditableField {

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -1306,52 +1306,37 @@ describe("SharedTree", () => {
 			cursor.clear();
 		});
 
-		it("are disposed after merging", async () => {
+		it("can be mutated after merging", async () => {
 			const provider = await TestTreeProvider.create(1);
 			const [tree] = provider.trees;
-			const viewA = tree.fork();
-			const viewB = viewA.fork();
-			const viewC = viewB.fork();
-			assert.equal(viewA.isMerged(), false);
-			assert.equal(viewB.isMerged(), false);
-			assert.equal(viewC.isMerged(), false);
-			viewA.merge();
-			assert.equal(viewA.isMerged(), true);
-			assert.equal(viewB.isMerged(), true);
-			assert.equal(viewC.isMerged(), true);
+			const baseView = tree.fork();
+			pushTestValue(baseView, "A");
+			baseView.merge();
+			pushTestValue(baseView, "B");
+			assert.deepEqual([...getTestValues(tree)].reverse(), ["A"]);
+			assert.deepEqual([...getTestValues(baseView)].reverse(), ["A", "B"]);
+			baseView.merge();
+			assert.deepEqual([...getTestValues(tree)].reverse(), ["A", "B"]);
 		});
 
-		it("can be read after disposal", async () => {
+		it("can pull after merging", async () => {
+			const provider = await TestTreeProvider.create(1);
+			const [tree] = provider.trees;
+			const baseView = tree.fork();
+			pushTestValue(baseView, "A");
+			baseView.merge();
+			pushTestValue(tree, "B");
+			baseView.pull();
+			assert.deepEqual([...getTestValues(baseView)].reverse(), ["A", "B"]);
+		});
+
+		it("can be read after merging", async () => {
 			const provider = await TestTreeProvider.create(1);
 			const [tree] = provider.trees;
 			pushTestValue(tree, "root");
 			const view = tree.fork();
 			view.merge();
 			assert.equal(peekTestValue(view), "root");
-		});
-
-		it("cannot be mutated after disposal", async () => {
-			const provider = await TestTreeProvider.create(1);
-			const [tree] = provider.trees;
-			const view = tree.fork();
-			view.merge();
-			const expectedError = "Branch is already merged";
-			assert.throws(
-				() => view.pull(),
-				(e) => validateAssertionError(e, expectedError),
-			);
-			assert.throws(
-				() => view.fork(),
-				(e) => validateAssertionError(e, expectedError),
-			);
-			assert.throws(
-				() => view.merge(),
-				(e) => validateAssertionError(e, expectedError),
-			);
-			assert.throws(
-				() => pushTestValue(view, "unused"),
-				(e) => validateAssertionError(e, expectedError),
-			);
 		});
 
 		it("properly fork the tree schema", async () => {


### PR DESCRIPTION
## Description

This removes the constraint that branches and view forks may not be modified after their first merge. Pull and Merge APIs will soon undergo significant changes, but in the meantime, removing this restriction will allow some tests to be improved and refactored.

## Breaking Changes

SharedTreeFork no longer exposes `isMerged()`.
