### PR TITLE
Patch to sample IdCompressor telemetry events

### DIFF
--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -88,7 +88,7 @@ import { SharedTreeEncoder_0_0_2, SharedTreeEncoder_0_1_1 } from './SharedTreeEn
 import { revert } from './HistoryEditFactory';
 import { BuildNode, BuildTreeNode, Change, ChangeType } from './ChangeTypes';
 import { TransactionInternal } from './TransactionInternal';
-import { IdCompressor, createSessionId } from './id-compressor';
+import { IdCompressor, createSessionId, createThrottledIdCompressorLogger } from './id-compressor';
 import { convertEditIds } from './IdConversion';
 import { MutableStringInterner } from './StringInterner';
 import { nilUuid } from './UuidUtilities';
@@ -545,7 +545,12 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 		);
 
 		const attributionId = (options as SharedTreeOptions<WriteFormat.v0_1_1>).attributionId;
-		this.idCompressor = new IdCompressor(createSessionId(), reservedIdCount, attributionId, this.logger);
+		this.idCompressor = new IdCompressor(
+			createSessionId(),
+			reservedIdCount,
+			attributionId,
+			createThrottledIdCompressorLogger(this.logger, 0.05)
+		);
 		this.editLogSize = options.inMemoryHistorySize;
 		this.editEvictionFrequency = options.inMemoryHistorySize;
 		const { editLog, cachingLogViewer } = this.initializeNewEditLogFromSummary(

--- a/experimental/dds/tree/src/id-compressor/Logger.ts
+++ b/experimental/dds/tree/src/id-compressor/Logger.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ITelemetryLogger } from '@fluidframework/common-definitions';
+import { TelemetryNullLogger } from '@fluidframework/telemetry-utils';
+
+/**
+ * Because the IdCompressor emits so much telemetry, this function is used to sample
+ * based on the sessionId. Only the given percentage of sessions will emit telemetry.
+ *
+ * @param logger - The logger that will be used to send the events if sampled.
+ * @param percentage - A percentage (in decimal) of clients that should send events.
+ * @returns The original logger or the null logger that doesn't send events.
+ */
+export function createThrottledIdCompressorLogger(logger: ITelemetryLogger, percentage: number): ITelemetryLogger {
+	const sendEvents = Math.random() < percentage;
+	return sendEvents ? logger : new TelemetryNullLogger();
+}

--- a/experimental/dds/tree/src/id-compressor/index.ts
+++ b/experimental/dds/tree/src/id-compressor/index.ts
@@ -31,3 +31,4 @@ export {
 	VersionedSerializedIdCompressor,
 } from './persisted-types';
 export { createSessionId } from './NumericUuid';
+export { createThrottledIdCompressorLogger } from './Logger';


### PR DESCRIPTION
## Description

We're generating a ton of IdCompressorStatus telemetry events because some versions don't have the sampling PR (#13898). Porting here to reduce telemetry events. This should reduce our events to 5% of what's currently being emitted. 

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

