### PR TITLE
ci: Only run azure pipeline on older release branches

### DIFF
--- a/tools/pipelines/build-azure.yml
+++ b/tools/pipelines/build-azure.yml
@@ -35,7 +35,10 @@ trigger:
   branches:
     include:
     - lts
-    - release/*
+    - release/v2int/1*
+    - release/v2int/2*
+    - release/v2int/3*
+    - release/v2int/4.0
   paths:
     include:
     - azure
@@ -60,7 +63,10 @@ pr:
   branches:
     include:
     - lts
-    - release/*
+    - release/v2int/1*
+    - release/v2int/2*
+    - release/v2int/3*
+    - release/v2int/4.0
   paths:
     include:
     - azure

--- a/tools/pipelines/build-azure.yml
+++ b/tools/pipelines/build-azure.yml
@@ -35,6 +35,7 @@ trigger:
   branches:
     include:
     - lts
+    - release/azure/*
     - release/v2int/1*
     - release/v2int/2*
     - release/v2int/3*
@@ -63,6 +64,7 @@ pr:
   branches:
     include:
     - lts
+    - release/azure/*
     - release/v2int/1*
     - release/v2int/2*
     - release/v2int/3*


### PR DESCRIPTION
The azure release group was combined with client for the internal 4.1 release. This change updates the pipeline to only run for changes to release branches before 4.1.

Fixes [AB#4016](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4016).