### PR TITLE
Correctly document interval endpoints as exclusive

### DIFF
--- a/docs/content/docs/data-structures/sequences.md
+++ b/docs/content/docs/data-structures/sequences.md
@@ -342,8 +342,8 @@ The following example illustrates these properties and highlights the major APIs
 
 const comments = sharedString.getIntervalCollection("comments");
 const comment = comments.add(
-	3,
-	7, // (inclusive range): references "world"
+	3, // (inclusive)
+	8, // (exclusive): references "world"
 	IntervalType.SlideOnRemove,
 	{
 		creator: "my-user-id",
@@ -352,7 +352,7 @@ const comment = comments.add(
 );
 //   content: hi world!
 // positions: 012345678
-//   comment:    [   ]
+//   comment:    [    )
 
 // Interval collection supports iterating over all intervals via Symbol.iterator or `.map()`:
 const allIntervalsInCollection = Array.from(comments);
@@ -361,14 +361,14 @@ const allProperties = comments.map((comment) => comment.properties);
 const intervalsOverlappingFirstHalf = comments.findOverlappingIntervals(0, 4);
 
 // Interval endpoints are LocalReferencePositions, so all APIs in the above section can be used:
-const startPosition = sharedString.localReferencePositionToPosition(comment.start);
-const endPosition = sharedString.localReferencePositionToPosition(comment.end);
+const startPosition = sharedString.localReferencePositionToPosition(comment.start); // returns 3
+const endPosition = sharedString.localReferencePositionToPosition(comment.end); // returns 8: note this is exclusive!
 
 // Intervals can be modified:
 comments.change(comment.getIntervalId(), 0, 1);
 //   content: hi world!
 // positions: 012345678
-//   comment: []
+//   comment: [)
 
 // their properties can be changed:
 comments.changeProperties(comment.getIntervalId(), { status: "resolved" });

--- a/packages/dds/sequence/README.md
+++ b/packages/dds/sequence/README.md
@@ -328,8 +328,8 @@ The following example illustrates these properties and highlights the major APIs
 
 const comments = sharedString.getIntervalCollection("comments");
 const comment = comments.add(
-	3,
-	7, // (inclusive range): references "world"
+	3, // (inclusive)
+	8, // (exclusive): references "world"
 	IntervalType.SlideOnRemove,
 	{
 		creator: "my-user-id",
@@ -338,7 +338,7 @@ const comment = comments.add(
 );
 //   content: hi world!
 // positions: 012345678
-//   comment:    [   ]
+//   comment:    [    )
 
 // Interval collection supports iterating over all intervals via Symbol.iterator or `.map()`:
 const allIntervalsInCollection = Array.from(comments);
@@ -347,14 +347,14 @@ const allProperties = comments.map((comment) => comment.properties);
 const intervalsOverlappingFirstHalf = comments.findOverlappingIntervals(0, 4);
 
 // Interval endpoints are LocalReferencePositions, so all APIs in the above section can be used:
-const startPosition = sharedString.localReferencePositionToPosition(comment.start);
-const endPosition = sharedString.localReferencePositionToPosition(comment.end);
+const startPosition = sharedString.localReferencePositionToPosition(comment.start); // returns 3
+const endPosition = sharedString.localReferencePositionToPosition(comment.end); // returns 8: note this is exclusive!
 
 // Intervals can be modified:
 comments.change(comment.getIntervalId(), 0, 1);
 //   content: hi world!
 // positions: 012345678
-//   comment: []
+//   comment: [)
 
 // their properties can be changed:
 comments.changeProperties(comment.getIntervalId(), { status: "resolved" });

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -78,9 +78,9 @@ export interface ISerializedInterval {
 	 * At the time of writing, it's not plumbed through to the reconnect/rebase code, however, which does need it.
 	 */
 	sequenceNumber: number;
-	/** Start position of the interval (inclusive) */
+	/** Start position of the interval */
 	start: number;
-	/** End position of the interval (inclusive) */
+	/** End position of the interval */
 	end: number;
 	/** Interval type to create */
 	intervalType: IntervalType;
@@ -400,6 +400,22 @@ export class Interval implements ISerializableInterval {
  * Interval impelmentation whose ends are associated with positions in a mutatable sequence.
  * As such, when content is inserted into the middle of the interval, the interval expands to
  * include that content.
+ *
+ * @remarks - The endpoint's position should be treated exclusively to get reasonable behavior--i.e.
+ * an interval referring to "hello" in "hello world" should have a start position of 0 and an end
+ * position of 5.
+ *
+ * To see why, consider what happens if "llo wor" is removed from the string to make "held".
+ * The interval's startpoint remains on the "h" (it isn't altered), but the interval's endpoint
+ * slides forward to the next unremoved position, which is the "l" in "held".
+ * Users would generally expect the interval to now refer to "he" (as it is the subset of content
+ * remaining after the removal), hence the "l" should be excluded.
+ * If the interval endpoint was treated inclusively, the interval would now refer to "hel", which
+ * is undesirable.
+ *
+ * Since the end of an interval is treated exclusively but cannot be greater than or equal to the
+ * length of the associated sequence, application models which leverage interval collections should
+ * consider inserting a marker at the end of the sequence to represent the end of the content.
  */
 export class SequenceInterval implements ISerializableInterval {
 	/**
@@ -593,7 +609,6 @@ export class SequenceInterval implements ISerializableInterval {
 
 	/**
 	 * @returns whether this interval overlaps two numerical positions.
-	 * @remarks - this is currently strict overlap, which doesn't align with the endpoint treatment of`.overlaps()`
 	 */
 	public overlapsPos(bstart: number, bend: number) {
 		const startPos = this.client.localReferencePositionToPosition(this.start);
@@ -953,7 +968,7 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
 
 	/**
 	 * @returns an array of all intervals contained in this collection that overlap the range
-	 * `[startPosition, endPosition]`.
+	 * `[startPosition, endPosition)`.
 	 */
 	public findOverlappingIntervals(startPosition: number, endPosition: number) {
 		if (endPosition < startPosition || this.intervalTree.intervals.isEmpty()) {
@@ -1634,11 +1649,13 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 
 	/**
 	 * Creates a new interval and add it to the collection.
-	 * @param start - interval start position
-	 * @param end - interval end position
+	 * @param start - interval start position (inclusive)
+	 * @param end - interval end position (exclusive)
 	 * @param intervalType - type of the interval. All intervals are SlideOnRemove. Intervals may not be Transient.
 	 * @param props - properties of the interval
 	 * @returns - the created interval
+	 * @remarks - See documentation on {@link SequenceInterval} for comments on interval endpoint semantics: there are subtleties
+	 * with how the current half-open behavior is represented.
 	 */
 	public add(
 		start: number,

--- a/packages/dds/sequence/src/intervalTree.ts
+++ b/packages/dds/sequence/src/intervalTree.ts
@@ -61,7 +61,7 @@ export interface IInterval {
 	): IInterval | undefined;
 	/**
 	 * @returns whether this interval overlaps with `b`.
-	 * Since intervals are inclusive, this includes cases where endpoints are equal.
+	 * Intervals are considered to overlap if their intersection is non-empty.
 	 */
 	overlaps(b: IInterval): boolean;
 	/**


### PR DESCRIPTION
## Description

I previously documented interval endpoints as being inclusive on both ends. Though the end endpoint is *placed* directly on the character position, this yields behavior consistent with half-open intervals.

This PR updates documentation in the README/public API surface to be more in-line with how we currently recommend its usage, and calls out some gotchas (like the fact that in its current form, applications using intervals probably want to add an "end of string" marker to their SharedString)

Note: the upcoming interval stickiness feature will likely change some of the recommendations here (perhaps including APIs we expose, hopefully in a way that simplifies them). But best to fix it up for now to recommend best practices for people using it.
