### PR TITLE
Update external-controller readme

### DIFF
--- a/azure/packages/external-controller/README.md
+++ b/azure/packages/external-controller/README.md
@@ -67,8 +67,28 @@ the endpoint URL would point to the Tinylicious instance on the default values o
 
 To launch the local Tinylicious service instance, run `npm run start:tinylicious` from your terminal window.
 
-When running the live Azure Fluid Relay Instance, we would require the tenant ID and service discovery endpoint URL. We make use of
-`AzureFunctionTokenProvider` which takes in the Azure function URL and an object identifying the current user, thereby
+When running the live Azure Fluid Relay Instance, we would require the tenant ID, tenant secret and service discovery endpoint URL.
+
+We can make use of the `InsecureTokenProvider` or a custom token provider similar to `AzureFunctionTokenProvider` to run the live Azure Fluid Relay Instance.
+
+If you have access to the keyvault the tenant details can be fetched by running [this tool](../../../tools/getkeys), after which you can get the env variable `fluid__test__driver__frs` which has the required tenant details. Later, we can run the `AzureClient` with the `InsecureTokenProvider` as follows:
+
+```typescript
+const connectionConfig: AzureConnectionConfig = useAzure
+	? {
+			type: "remote",
+			tenantId: "YOUR-TENANT-ID-HERE",
+			tokenProvider: new InsecureTokenProvider("YOUR-SECRET-HERE", user),
+			endpoint: "ENTER-DISCOVERY-ENDPOINT-URL-HERE",
+	  }
+	: {
+			type: "local",
+			tokenProvider: new InsecureTokenProvider("fooBar", user),
+			endpoint: "http://localhost:7070",
+	  };
+```
+
+We make use of `AzureFunctionTokenProvider` which takes in the Azure function URL and an object identifying the current user, thereby
 making an axios `GET` request call to the Azure Function. This axios call takes in the tenant ID, documentId and
 userID/userName as optional parameters. The Azure Function is responsible for mapping the tenantId to tenant key secret
 to generate and sign the token such that the service will accept it.
@@ -94,17 +114,6 @@ const connectionConfig: AzureConnectionConfig = useAzure
 In this way, we can toggle between remote and local mode using the same config format. We make use of
 `AzureFunctionTokenProvider` for running against live Azure Fluid Relay instance since it is more secured, without exposing the tenant
 secret key in the client-side code whereas while running the service locally for development purpose, we make use of `InsecureTokenProvider`.
-
-We can also run the `AzureClient` with the `InsecureTokenProvider` as follows:
-
-```typescript
-const connectionConfig: AzureConnectionConfig = {
-	type: "remote",
-	tenantId: "YOUR-TENANT-ID-HERE",
-	tokenProvider: new InsecureTokenProvider("YOUR-SECRET-HERE", user),
-	endpoint: "ENTER-DISCOVERY-ENDPOINT-URL-HERE",
-};
-```
 
 <!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->
 

--- a/azure/packages/external-controller/README.md
+++ b/azure/packages/external-controller/README.md
@@ -67,11 +67,13 @@ the endpoint URL would point to the Tinylicious instance on the default values o
 
 To launch the local Tinylicious service instance, run `npm run start:tinylicious` from your terminal window.
 
-When running the live Azure Fluid Relay Instance, we would require the tenant ID, tenant secret and service discovery endpoint URL.
+When using a live Azure Fluid Relay instance, we need to provide the tenant ID, tenant secret and service discovery endpoint URL for our Azure Fluid Relay instance.
 
-We can make use of the `InsecureTokenProvider` or a custom token provider similar to `AzureFunctionTokenProvider` to run the live Azure Fluid Relay Instance.
+We can use the `InsecureTokenProvider` or a custom token provider similar to `AzureFunctionTokenProvider` to authorize requests to the live Azure Fluid Relay Instance.
 
-If you have access to the keyvault the tenant details can be fetched by running [this tool](../../../tools/getkeys), after which you can get the env variable `fluid__test__driver__frs` which has the required tenant details. Later, we can run the `AzureClient` with the `InsecureTokenProvider` as follows:
+**Note for Fluid developers:** You can use [this tool](../../../tools/getkeys) to retrieve test tenant details. After running getkeys, the env variable `fluid__test__driver__frs` will contain the tenant details.
+
+We can run the `AzureClient` with the `InsecureTokenProvider` with code like this:
 
 ```typescript
 const connectionConfig: AzureConnectionConfig = useAzure
@@ -88,7 +90,7 @@ const connectionConfig: AzureConnectionConfig = useAzure
 	  };
 ```
 
-We make use of `AzureFunctionTokenProvider` which takes in the Azure function URL and an object identifying the current user, thereby
+We use the `AzureFunctionTokenProvider` which takes in the Azure function URL and an object identifying the current user, thereby
 making an axios `GET` request call to the Azure Function. This axios call takes in the tenant ID, documentId and
 userID/userName as optional parameters. The Azure Function is responsible for mapping the tenantId to tenant key secret
 to generate and sign the token such that the service will accept it.


### PR DESCRIPTION
Developers can make use to `InsecureTokenProvider` to run their example against the Azure Client. This PR updates the README to add some guidelines around it.