### PR TITLE
Add canary stage to FRS stress tests runs

### DIFF
--- a/api-report/test-driver-definitions.api.md
+++ b/api-report/test-driver-definitions.api.md
@@ -35,7 +35,7 @@ export interface ITestDriver {
 export type OdspEndpoint = "odsp" | "odsp-df";
 
 // @public (undocumented)
-export type RouterliciousEndpoint = "frs" | "r11s" | "docker";
+export type RouterliciousEndpoint = "frs" | "frs-canary" | "r11s" | "docker";
 
 // @public (undocumented)
 export type TestDriverTypes = "tinylicious" | "t9s" | "routerlicious" | "r11s" | "odsp" | "local";

--- a/api-report/test-driver-definitions.api.md
+++ b/api-report/test-driver-definitions.api.md
@@ -35,7 +35,7 @@ export interface ITestDriver {
 export type OdspEndpoint = "odsp" | "odsp-df";
 
 // @public (undocumented)
-export type RouterliciousEndpoint = "frs" | "frs-canary" | "r11s" | "docker";
+export type RouterliciousEndpoint = "frs" | "frsCanary" | "r11s" | "docker";
 
 // @public (undocumented)
 export type TestDriverTypes = "tinylicious" | "t9s" | "routerlicious" | "r11s" | "odsp" | "local";

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -83,8 +83,12 @@
 	},
 	"typeValidation": {
 		"broken": {
-			"TypeAliasDeclaration_DriverEndpoint": {"backCompat": false},
-			"TypeAliasDeclaration_RouterliciousEndpoint": {"backCompat": false}
+			"TypeAliasDeclaration_DriverEndpoint": {
+				"backCompat": false
+			},
+			"TypeAliasDeclaration_RouterliciousEndpoint": {
+				"backCompat": false
+			}
 		}
 	}
 }

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -82,6 +82,9 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"TypeAliasDeclaration_DriverEndpoint": {"backCompat": false},
+			"TypeAliasDeclaration_RouterliciousEndpoint": {"backCompat": false}
+		}
 	}
 }

--- a/packages/test/test-driver-definitions/src/interfaces.ts
+++ b/packages/test/test-driver-definitions/src/interfaces.ts
@@ -12,7 +12,7 @@ import {
 
 export type TestDriverTypes = "tinylicious" | "t9s" | "routerlicious" | "r11s" | "odsp" | "local";
 
-export type RouterliciousEndpoint = "frs" | "frs-canary" | "r11s" | "docker";
+export type RouterliciousEndpoint = "frs" | "frsCanary" | "r11s" | "docker";
 
 export type OdspEndpoint = "odsp" | "odsp-df";
 

--- a/packages/test/test-driver-definitions/src/interfaces.ts
+++ b/packages/test/test-driver-definitions/src/interfaces.ts
@@ -12,7 +12,7 @@ import {
 
 export type TestDriverTypes = "tinylicious" | "t9s" | "routerlicious" | "r11s" | "odsp" | "local";
 
-export type RouterliciousEndpoint = "frs" | "r11s" | "docker";
+export type RouterliciousEndpoint = "frs" | "frs-canary" | "r11s" | "docker";
 
 export type OdspEndpoint = "odsp" | "odsp-df";
 

--- a/packages/test/test-driver-definitions/src/test/types/validateTestDriverDefinitionsPrevious.generated.ts
+++ b/packages/test/test-driver-definitions/src/test/types/validateTestDriverDefinitionsPrevious.generated.ts
@@ -35,6 +35,7 @@ declare function get_current_TypeAliasDeclaration_DriverEndpoint():
 declare function use_old_TypeAliasDeclaration_DriverEndpoint(
     use: TypeOnly<old.DriverEndpoint>);
 use_old_TypeAliasDeclaration_DriverEndpoint(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_DriverEndpoint());
 
 /*
@@ -131,6 +132,7 @@ declare function get_current_TypeAliasDeclaration_RouterliciousEndpoint():
 declare function use_old_TypeAliasDeclaration_RouterliciousEndpoint(
     use: TypeOnly<old.RouterliciousEndpoint>);
 use_old_TypeAliasDeclaration_RouterliciousEndpoint(
+    // @ts-expect-error compatibility expected to be broken
     get_current_TypeAliasDeclaration_RouterliciousEndpoint());
 
 /*

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -114,6 +114,7 @@ export function assertRouterliciousEndpoint(
 	if (
 		endpoint === undefined ||
 		endpoint === "frs" ||
+		endpoint === "frs-canary" ||
 		endpoint === "r11s" ||
 		endpoint === "docker"
 	) {

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -114,7 +114,7 @@ export function assertRouterliciousEndpoint(
 	if (
 		endpoint === undefined ||
 		endpoint === "frs" ||
-		endpoint === "frs-canary" ||
+		endpoint === "frsCanary" ||
 		endpoint === "r11s" ||
 		endpoint === "docker"
 	) {

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -37,6 +37,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"start": "node ./dist/nodeStressTest.js",
 		"start:frs": "node ./dist/nodeStressTest.js --driver routerlicious --driverEndpoint frs --profile ci_frs",
+		"start:frs:canary": "node ./dist/nodeStressTest.js --driver routerlicious --driverEndpoint frs-canary --profile ci_frs",
 		"start:mini": "node ./dist/nodeStressTest.js  --profile mini",
 		"start:odsp": "node ./dist/nodeStressTest.js --driver odsp",
 		"start:odspdf": "node ./dist/nodeStressTest.js --driver odsp --driverEndpoint odsp-df",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -37,7 +37,7 @@
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"start": "node ./dist/nodeStressTest.js",
 		"start:frs": "node ./dist/nodeStressTest.js --driver routerlicious --driverEndpoint frs --profile ci_frs",
-		"start:frs:canary": "node ./dist/nodeStressTest.js --driver routerlicious --driverEndpoint frs-canary --profile ci_frs",
+		"start:frs:canary": "node ./dist/nodeStressTest.js --driver routerlicious --driverEndpoint frsCanary --profile ci_frs",
 		"start:mini": "node ./dist/nodeStressTest.js  --profile mini",
 		"start:odsp": "node ./dist/nodeStressTest.js --driver odsp",
 		"start:odspdf": "node ./dist/nodeStressTest.js --driver odsp --driverEndpoint odsp-df",

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -140,5 +140,5 @@ stages:
         timeoutInMinutes: 120
         testCommand: start:frs:canary
         env:
-          fluid__test__driver__frs-canary: $(automation-fluid-driver-frs-canary-stress-test)
+          fluid__test__driver__frsCanary: $(automation-fluid-driver-frs-canary-stress-test)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -129,7 +129,7 @@ stages:
     dependsOn: []
     # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
     variables:
-    - group: stress-frs-canary-lock
+    - group: stress-frs-canary
     jobs:
     - template: templates/include-test-real-service.yml
       parameters:

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -129,7 +129,7 @@ stages:
     dependsOn: []
     # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
     variables:
-    - group: stress-frs-canary-lock
+    - group: stress-frs-lock
     jobs:
     - template: templates/include-test-real-service.yml
       parameters:
@@ -138,7 +138,7 @@ stages:
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 120
-        testCommand: start:frs:canary
+        testCommand: start:frs
         env:
           fluid__test__driver__frs__canary: $(automation-fluid-test-frs-canary-stress-test)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -123,3 +123,22 @@ stages:
         env:
           fluid__test__driver__frs: $(automation-fluid-test-driver-frs-stress-test)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+  # stress tests canary
+  - stage:
+    displayName: Stress tests - canary
+    dependsOn: []
+    # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
+    variables:
+    - group: stress-canary-lock
+    jobs:
+    - template: templates/include-test-real-service.yml
+      parameters:
+        poolBuild: Large
+        testPackage: ${{ variables.testPackage }}
+        testWorkspace: ${{ variables.testWorkspace }}
+        artifactBuildId: $(resources.pipeline.client.runID)
+        timeoutInMinutes: 120
+        testCommand: start:canary
+        env:
+          fluid__test__driver__canary: $(automation-fluid-test-canary-stress-test)
+          FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -140,5 +140,5 @@ stages:
         timeoutInMinutes: 120
         testCommand: start:frs
         env:
-          fluid__test__driver__frs: $(automation-fluid-test-driver-frs-canary-stress-test)
+          fluid__test__driver__frs: $(automation-fluid-test-driver-frs-canary)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -140,5 +140,5 @@ stages:
         timeoutInMinutes: 120
         testCommand: start:frs:canary
         env:
-          fluid__test__driver__frs: $(automation-fluid-driver-frs-canary-stress-test)
+          fluid__test__driver__frs-canary: $(automation-fluid-driver-frs-canary-stress-test)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -123,13 +123,13 @@ stages:
         env:
           fluid__test__driver__frs: $(automation-fluid-test-driver-frs-stress-test)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-  # stress tests canary
+  # stress tests frs canary
   - stage:
-    displayName: Stress tests - canary
+    displayName: Stress tests - frs canary
     dependsOn: []
     # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
     variables:
-    - group: stress-canary-lock
+    - group: stress-frs-canary-lock
     jobs:
     - template: templates/include-test-real-service.yml
       parameters:
@@ -138,7 +138,7 @@ stages:
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 120
-        testCommand: start:canary
+        testCommand: start:frs:canary
         env:
-          fluid__test__driver__canary: $(automation-fluid-test-canary-stress-test)
+          fluid__test__driver__frs__canary: $(automation-fluid-test-frs-canary-stress-test)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -140,5 +140,5 @@ stages:
         timeoutInMinutes: 120
         testCommand: start:frs
         env:
-          fluid__test__driver__frs: $(automation-fluid-test-driver-frs-canary-stress)
+          fluid__test__driver__frs: $(automation-fluid-driver-frs-canary-stress-test)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -12,7 +12,7 @@ resources:
   pipelines:
   - pipeline: client   # Name of the pipeline resource
     source: Build - client packages
-    branch: test/CanaryTest # Default branch for manual/scheduled triggers if none is selected
+    branch: main # Default branch for manual/scheduled triggers if none is selected
     trigger:
       branches:
       - release/*

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -129,7 +129,7 @@ stages:
     dependsOn: []
     # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
     variables:
-    - group: stress-frs-lock
+    - group: stress-frs-canary-lock
     jobs:
     - template: templates/include-test-real-service.yml
       parameters:

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -12,7 +12,7 @@ resources:
   pipelines:
   - pipeline: client   # Name of the pipeline resource
     source: Build - client packages
-    branch: main # Default branch for manual/scheduled triggers if none is selected
+    branch: test/CanaryTest # Default branch for manual/scheduled triggers if none is selected
     trigger:
       branches:
       - release/*

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -140,5 +140,5 @@ stages:
         timeoutInMinutes: 120
         testCommand: start:frs:canary
         env:
-          fluid__test__driver__frs-canary: $(automation-fluid-driver-frs-canary-stress-test)
+          fluid__test__driver__frs: $(automation-fluid-driver-frs-canary-stress-test)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -140,5 +140,5 @@ stages:
         timeoutInMinutes: 120
         testCommand: start:frs
         env:
-          fluid__test__driver__frs: $(automation-fluid-test-driver-frs-canary)
+          fluid__test__driver__frs: $(automation-fluid-test-driver-frs-canary-stress)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -140,5 +140,5 @@ stages:
         timeoutInMinutes: 120
         testCommand: start:frs
         env:
-          fluid__test__driver__frs__canary: $(automation-fluid-test-frs-canary-stress-test)
+          fluid__test__driver__frs: $(automation-fluid-test-frs-canary-stress-test)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -140,5 +140,5 @@ stages:
         timeoutInMinutes: 120
         testCommand: start:frs
         env:
-          fluid__test__driver__frs: $(automation-fluid-test-frs-canary-stress-test)
+          fluid__test__driver__frs: $(automation-fluid-test-driver-frs-canary-stress-test)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -138,7 +138,7 @@ stages:
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 120
-        testCommand: start:frs
+        testCommand: start:frs:canary
         env:
           fluid__test__driver__frs: $(automation-fluid-driver-frs-canary-stress-test)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject


### PR DESCRIPTION
Currently, the FRS stress test runs against the prod tenants and service endpoint. We want to add a new canary state to our stress test which is basically an endpoint where FRS deploys their code before it goes to production. 

Acceptance criteria:
- The new tenant secrets and service endpoint is added to the key-vault
- The FRS stress test succeeds after adding this new canary endpoint.