### PR TITLE
Performance Benchmark: Create stages for local, odsp and frs instead of having a single one

### DIFF
--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -384,10 +384,10 @@ stages:
             artifactName: 'perf-test-outputs_memory-usage'
           condition: succeededOrFailed()
 
-  - ${{ each stage in parameters.endpoints }}:
+  - ${{ each endpoint in parameters.endpoints }}:
 
-    - stage: perf_e2e_tests_${{ stage }}
-      displayName: Perf e2e tests_${{ stage }}
+    - stage: perf_e2e_tests_${{ endpoint }}
+      displayName: Perf e2e tests - ${{ endpoint }}
       dependsOn: []
       variables:
         # The following two paths are defined by the npm scripts invocations in @fluid-internal/test-end-to-end-tests
@@ -471,7 +471,7 @@ stages:
           # Doing this with separate ADO steps is not easy.
           # This step reports failure if either of the test runs reports failure.
           - task: Bash@3
-            displayName: Run tests ${{ stage }}
+            displayName: Run tests ${{ endpoint }}
             inputs:
               targetType: 'inline'
               workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}
@@ -479,29 +479,29 @@ stages:
 
                 # Run execution time tests
                 echo "FLUID_ENDPOINTNAME = $FLUID_ENDPOINTNAME"
-                if [[ '${{ stage }}' == 'local' ]]; then
+                if [[ '${{ endpoint }}' == 'local' ]]; then
                   npm run test:benchmark:report;
                 else
-                  npm run test:benchmark:report:${{ stage }};
+                  npm run test:benchmark:report:${{ endpoint }};
                 fi
                 executionTimeTestsExitCode=$?;
 
                 echo "FLUID_ENDPOINTNAME = $FLUID_ENDPOINTNAME"
                 # Run memory tests
-                if [[ '${{ stage }}' == 'local' ]]; then
+                if [[ '${{ endpoint }}' == 'local' ]]; then
                   npm run test:memory-profiling:report;
                 else
-                  npm run test:memory-profiling:report:${{ stage }};
+                  npm run test:memory-profiling:report:${{ endpoint }};
                 fi
 
                 memoryTestsExitCode=$?;
 
                 if [[ $executionTimeTestsExitCode -ne 0 ]]; then
-                  echo "##vso[task.logissue type=error]Exit code for runtime tests execution = $executionTimeTestsExitCode ${{ stage }}"
+                  echo "##vso[task.logissue type=error]Exit code for runtime tests execution = $executionTimeTestsExitCode ${{ endpoint }}"
                 fi
 
                 if [[ $memoryTestsExitCode -ne 0 ]]; then
-                  echo "##vso[task.logissue type=error]Exit code for memory tests execution = $memoryTestsExitCode ${{ stage }}"
+                  echo "##vso[task.logissue type=error]Exit code for memory tests execution = $memoryTestsExitCode ${{ endpoint }}"
                 fi
 
                 if [[ $executionTimeTestsExitCode -ne 0 ]] || [[ $memoryTestsExitCode -ne 0 ]]; then
@@ -510,41 +510,43 @@ stages:
             env:
               FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
               FLUID_BUILD_ID: $(Build.BuildId)
+              FLUID_ENDPOINTNAME: ${{ endpoint }}
               login__microsoft__clientId: $(login-microsoft-clientId)
               login__microsoft__secret: $(login-microsoft-secret)
-              login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
-              fluid__test__driver__frs: $(automation-fluid-test-driver-frs-stress-test)
-              FLUID_ENDPOINTNAME: ${{ stage }}
+              ${{ if eq( endpoint, 'odsp' ) }}: 
+                login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
+              ${{ if eq( endpoint, 'frs' ) }}: 
+                fluid__test__driver__frs: $(automation-fluid-test-driver-frs-stress-test)
 
           - task: Bash@3
-            displayName: Write measurements to Aria/Kusto - execution time ${{ stage }}
+            displayName: Write measurements to Aria/Kusto - execution time ${{ endpoint }}
             condition: succeededOrFailed()
             inputs:
               targetType: 'inline'
               workingDirectory: $(toolAbsolutePath)
               script: |
-                echo "Writing the following performance tests results to Aria/Kusto - ${{ stage }}"
+                echo "Writing the following performance tests results to Aria/Kusto - ${{ endpoint }}"
                 ls -la ${{ variables.executionTimeTestOutputFolder }};
                 node --require @ff-internal/aria-logger bin/run --handlerModule $(toolAbsolutePath)/dist/handlers/executionTimeTestHandler.js --dir ${{ variables.executionTimeTestOutputFolder }};
             env:
-              FLUID_ENDPOINTNAME: ${{ stage }}
+              FLUID_ENDPOINTNAME: ${{ endpoint }}
 
           - task: Bash@3
-            displayName: Write measurements to Aria/Kusto - memory usage ${{ stage }}
+            displayName: Write measurements to Aria/Kusto - memory usage ${{ endpoint }}
             condition: succeededOrFailed()
             inputs:
               targetType: 'inline'
               workingDirectory: $(toolAbsolutePath)
               script: |
-                echo "Writing the following performance tests results to Aria/Kusto - ${{ stage }}"
+                echo "Writing the following performance tests results to Aria/Kusto - ${{ endpoint }}"
                 ls -la ${{ variables.memoryUsageTestOutputFolder }};
                 node --require @ff-internal/aria-logger bin/run --handlerModule $(toolAbsolutePath)/dist/handlers/memoryUsageTestHandler.js --dir ${{ variables.memoryUsageTestOutputFolder }};
             env:
-              FLUID_ENDPOINTNAME: ${{ stage }}
+              FLUID_ENDPOINTNAME: ${{ endpoint }}
 
           - task: Bash@3
             displayName: Send Execution Time Perf Benchmark Measurements to Azure App Insights
-            condition: eq('${{ stage }}', 'local')
+            condition: eq('${{ endpoint }}', 'local')
             inputs:
               targetType: 'inline'
               workingDirectory: $(toolAbsolutePath)
@@ -555,11 +557,11 @@ stages:
             env:
               BUILD_ID: $(Build.BuildId)
               BRANCH_NAME: $(Build.SourceBranchName)
-              FLUID_ENDPOINTNAME: ${{ stage }}
+              FLUID_ENDPOINTNAME: ${{ endpoint }}
 
           - task: Bash@3
             displayName: Send Memory Usage Perf Benchmark Measurements to Azure App Insights
-            condition: eq('${{ stage }}', 'local')
+            condition: eq('${{ endpoint }}', 'local')
             inputs:
               targetType: 'inline'
               workingDirectory: $(toolAbsolutePath)
@@ -570,25 +572,25 @@ stages:
             env:
               BUILD_ID: $(Build.BuildId)
               BRANCH_NAME: $(Build.SourceBranchName)
-              FLUID_ENDPOINTNAME: ${{ stage }}
+              FLUID_ENDPOINTNAME: ${{ endpoint }}
 
           - task: PublishPipelineArtifact@1
             displayName: Publish Artifact - E2E perf tests output - execution time {{ $stage }}
-            condition: and(succeededOrFailed(), eq('${{ stage }}', 'local'))
+            condition: succeededOrFailed()
 
             inputs:
               targetPath: '${{ variables.executionTimeTestOutputFolder }}'
-              artifactName: 'perf-test-outputs-e2e_execution-time'
+              artifactName: 'perf-test-outputs-e2e_execution-time-${{ endpoint }}'
 
           - task: PublishPipelineArtifact@1
             displayName: Publish Artifact - E2E perf tests output - memory usage {{ $stage }}
-            condition: and(succeededOrFailed(), eq('${{ stage }}', 'local'))
+            condition: succeededOrFailed()
             inputs:
               targetPath: '${{ variables.memoryUsageTestOutputFolder }}'
-              artifactName: 'perf-test-outputs-e2e_memory-usage'
+              artifactName: 'perf-test-outputs-e2e_memory-usage-${{ endpoint }}'
 
           - task: Bash@3
-            displayName: Remove Output Folders from local server run ${{ stage }}
+            displayName: Remove Output Folders from local server run ${{ endpoint }}
             inputs:
               targetType: 'inline'
               workingDirectory: $(toolAbsolutePath)

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -38,6 +38,14 @@ parameters:
     - "@fluid-experimental/tree"
     - "@fluidframework/merge-tree"
 
+# Performance e2e tests
+- name: endpoints
+  type: object
+  default:
+  - "local"
+  - "odsp"
+  - "frs"
+
 variables:
   # We use 'chalk' to colorize output, which auto-detects color support in the
   # running terminal.  The log output shown in Azure DevOps job runs only has
@@ -376,351 +384,218 @@ stages:
             artifactName: 'perf-test-outputs_memory-usage'
           condition: succeededOrFailed()
 
-  # Performance e2e tests
-  - stage: perf_e2e_tests
-    displayName: Perf e2e tests
-    dependsOn: []
-    variables:
-      # The following two paths are defined by the npm scripts invocations in @fluid-internal/test-end-to-end-tests
-      - name: executionTimeTestOutputFolder
-        value: ${{ variables.testWorkspace }}/node_modules/@fluid-internal/test-end-to-end-tests/.timeTestsOutput
-        readonly: true
-      - name: memoryUsageTestOutputFolder
-        value: ${{ variables.testWorkspace }}/node_modules/@fluid-internal/test-end-to-end-tests/.memoryTestsOutput
-        readonly: true
-      - name: testPackage
-        value: '@fluid-internal/test-end-to-end-tests'
-        readonly: true
-      - name: escapedTestPackage
-        value: ${{ replace(replace(variables.testPackage, '@', '' ), '/', '-') }}
-        readonly: true
-    jobs:
-    - template: templates/include-test-perf-benchmarks.yml
-      parameters:
-        poolBuild: ${{ parameters.poolBuild }}
-        testWorkspace: ${{ variables.testWorkspace }}
-        customSteps:
+  - ${{ each stage in parameters.endpoints }}:
 
-        # Download test package
-        - task: DownloadPipelineArtifact@2
-          displayName: Download test package
-          inputs:
-            # It seems there's a bug and preferTriggeringPipeline is not respected.
-            # We force the behavior by explicitly specifying:
-            # - buildVersionToDownload: specific
-            # - buildId: <the id of the triggering build>
-            # preferTriggeringPipeline: true
-            source: specific
-            project: internal
-            pipeline: ${{ variables.artifactPipeline }}
-            buildVersionToDownload: specific
-            buildId: ${{ variables.artifactBuildId }}
-            artifact: pack
-            patterns: "**/${{ variables.escapedTestPackage }}-?.?.?-*.tgz"
-            path: $(Pipeline.Workspace)/client/pack
-            # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
-            # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
+    - stage: perf_e2e_tests_${{ stage }}
+      displayName: Perf e2e tests_${{ stage }}
+      dependsOn: []
+      variables:
+        # The following two paths are defined by the npm scripts invocations in @fluid-internal/test-end-to-end-tests
+        - name: executionTimeTestOutputFolder
+          value: ${{ variables.testWorkspace }}/node_modules/@fluid-internal/test-end-to-end-tests/.timeTestsOutput
+          readonly: true
+        - name: memoryUsageTestOutputFolder
+          value: ${{ variables.testWorkspace }}/node_modules/@fluid-internal/test-end-to-end-tests/.memoryTestsOutput
+          readonly: true
+        - name: testPackage
+          value: '@fluid-internal/test-end-to-end-tests'
+          readonly: true
+        - name: escapedTestPackage
+          value: ${{ replace(replace(variables.testPackage, '@', '' ), '/', '-') }}
+          readonly: true
+      jobs:
+      - template: templates/include-test-perf-benchmarks.yml
+        parameters:
+          poolBuild: ${{ parameters.poolBuild }}
+          testWorkspace: ${{ variables.testWorkspace }}
+          customSteps:
 
-        # Install e2e test package
-        - task: Bash@3
-          displayName: Install Test Package
-          inputs:
-            targetType: 'inline'
-            workingDirectory: ${{ variables.testWorkspace }}
-            script: |
-              echo "Install ${{ variables.testPackage }}"
-              TEST_PACKAGE_FILE_PATTERN=${{ variables.escapedTestPackage }}-?.?.?-*.tgz
-              TEST_PACKAGE_PATH_PATTERN=$(Pipeline.Workspace)/client/pack/scoped/$TEST_PACKAGE_FILE_PATTERN
+          # Download test package
+          - task: DownloadPipelineArtifact@2
+            displayName: Download test package
+            inputs:
+              # It seems there's a bug and preferTriggeringPipeline is not respected.
+              # We force the behavior by explicitly specifying:
+              # - buildVersionToDownload: specific
+              # - buildId: <the id of the triggering build>
+              # preferTriggeringPipeline: true
+              source: specific
+              project: internal
+              pipeline: ${{ variables.artifactPipeline }}
+              buildVersionToDownload: specific
+              buildId: ${{ variables.artifactBuildId }}
+              artifact: pack
+              patterns: "**/${{ variables.escapedTestPackage }}-?.?.?-*.tgz"
+              path: $(Pipeline.Workspace)/client/pack
+              # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
+              # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
 
-              echo $TEST_PACKAGE_FILE_PATTERN
-              echo $TEST_PACKAGE_PATH_PATTERN
+          # Install e2e test package
+          - task: Bash@3
+            displayName: Install Test Package
+            inputs:
+              targetType: 'inline'
+              workingDirectory: ${{ variables.testWorkspace }}
+              script: |
+                echo "Install ${{ variables.testPackage }}"
+                TEST_PACKAGE_FILE_PATTERN=${{ variables.escapedTestPackage }}-?.?.?-*.tgz
+                TEST_PACKAGE_PATH_PATTERN=$(Pipeline.Workspace)/client/pack/scoped/$TEST_PACKAGE_FILE_PATTERN
 
-              echo `ls -1 $TEST_PACKAGE_PATH_PATTERN | wc -l`
-              echo `ls $TEST_PACKAGE_PATH_PATTERN`
+                echo $TEST_PACKAGE_FILE_PATTERN
+                echo $TEST_PACKAGE_PATH_PATTERN
 
-              if [[ `ls -1 $TEST_PACKAGE_PATH_PATTERN | wc -l` -eq 1 ]]; then
-                TEST_PACKAGE_TGZ=`ls $TEST_PACKAGE_PATH_PATTERN`
-              else
-                ls -1 $TEST_PACKAGE_PATH_PATTERN
-                echo "##vso[task.logissue type=error]Test package '${{ variables.testPackage }}' not found, or there are more then one found"
-                exit -1
-              fi
+                echo `ls -1 $TEST_PACKAGE_PATH_PATTERN | wc -l`
+                echo `ls $TEST_PACKAGE_PATH_PATTERN`
 
-              npm install $TEST_PACKAGE_TGZ
+                if [[ `ls -1 $TEST_PACKAGE_PATH_PATTERN | wc -l` -eq 1 ]]; then
+                  TEST_PACKAGE_TGZ=`ls $TEST_PACKAGE_PATH_PATTERN`
+                else
+                  ls -1 $TEST_PACKAGE_PATH_PATTERN
+                  echo "##vso[task.logissue type=error]Test package '${{ variables.testPackage }}' not found, or there are more then one found"
+                  exit -1
+                fi
 
-        - task: Bash@3
-          displayName: Prepare test package to run tests
-          inputs:
-            targetType: 'inline'
-            workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}
-            script: |
-              cp ${{ variables.testWorkspace }}/.npmrc . ;
-              npm i ;
+                npm install $TEST_PACKAGE_TGZ
 
-        # We run both types of tests in the same bash step so we can make sure to run the second set even if the first
-        # one fails.
-        # Doing this with separate ADO steps is not easy.
-        # This step reports failure if either of the test runs reports failure.
-        - task: Bash@3
-          displayName: Run tests
-          inputs:
-            targetType: 'inline'
-            workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}
-            script: |
+          - task: Bash@3
+            displayName: Prepare test package to run tests
+            inputs:
+              targetType: 'inline'
+              workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}
+              script: |
+                cp ${{ variables.testWorkspace }}/.npmrc . ;
+                npm i ;
 
-              # Run execution time tests
-              npm run test:benchmark:report;
-              executionTimeTestsExitCode=$?;
+          # We run both types of tests in the same bash step so we can make sure to run the second set even if the first
+          # one fails.
+          # Doing this with separate ADO steps is not easy.
+          # This step reports failure if either of the test runs reports failure.
+          - task: Bash@3
+            displayName: Run tests ${{ stage }}
+            inputs:
+              targetType: 'inline'
+              workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}
+              script: |
 
-              # Run memory tests
-              npm run test:memory-profiling:report;
-              memoryTestsExitCode=$?;
+                # Run execution time tests
+                echo "FLUID_ENDPOINTNAME = $FLUID_ENDPOINTNAME"
+                if [[ '${{ stage }}' == 'local' ]]; then
+                  npm run test:benchmark:report;
+                else
+                  npm run test:benchmark:report:${{ stage }};
+                fi
+                executionTimeTestsExitCode=$?;
 
-              if [[ $executionTimeTestsExitCode -ne 0 ]]; then
-                echo "##vso[task.logissue type=error]Exit code for runtime tests execution = $executionTimeTestsExitCode"
-              fi
+                echo "FLUID_ENDPOINTNAME = $FLUID_ENDPOINTNAME"
+                # Run memory tests
+                if [[ '${{ stage }}' == 'local' ]]; then
+                  npm run test:memory-profiling:report;
+                else
+                  npm run test:memory-profiling:report:${{ stage }};
+                fi
 
-              if [[ $memoryTestsExitCode -ne 0 ]]; then
-                echo "##vso[task.logissue type=error]Exit code for memory tests execution = $memoryTestsExitCode"
-              fi
+                memoryTestsExitCode=$?;
 
-              if [[ $executionTimeTestsExitCode -ne 0 ]] || [[ $memoryTestsExitCode -ne 0 ]]; then
-                exit 1;
-              fi
-          env:
-            FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-            FLUID_BUILD_ID: $(Build.BuildId)
+                if [[ $executionTimeTestsExitCode -ne 0 ]]; then
+                  echo "##vso[task.logissue type=error]Exit code for runtime tests execution = $executionTimeTestsExitCode ${{ stage }}"
+                fi
 
-        - task: Bash@3
-          displayName: Write measurements to Aria/Kusto - execution time local
-          condition: succeededOrFailed()
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(toolAbsolutePath)
-            script: |
-              echo "Writing the following performance tests results to Aria/Kusto - local"
-              ls -la ${{ variables.executionTimeTestOutputFolder }};
-              node --require @ff-internal/aria-logger bin/run --handlerModule $(toolAbsolutePath)/dist/handlers/executionTimeTestHandler.js --dir ${{ variables.executionTimeTestOutputFolder }};
-          env:
-            FLUID_ENDPOINTNAME: "local"
+                if [[ $memoryTestsExitCode -ne 0 ]]; then
+                  echo "##vso[task.logissue type=error]Exit code for memory tests execution = $memoryTestsExitCode ${{ stage }}"
+                fi
 
-        - task: Bash@3
-          displayName: Write measurements to Aria/Kusto - memory usage local
-          condition: succeededOrFailed()
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(toolAbsolutePath)
-            script: |
-              echo "Writing the following performance tests results to Aria/Kusto - local"
-              ls -la ${{ variables.memoryUsageTestOutputFolder }};
-              node --require @ff-internal/aria-logger bin/run --handlerModule $(toolAbsolutePath)/dist/handlers/memoryUsageTestHandler.js --dir ${{ variables.memoryUsageTestOutputFolder }};
-          env:
-            FLUID_ENDPOINTNAME: "local"
+                if [[ $executionTimeTestsExitCode -ne 0 ]] || [[ $memoryTestsExitCode -ne 0 ]]; then
+                  exit 1;
+                fi
+            env:
+              FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
+              FLUID_BUILD_ID: $(Build.BuildId)
+              login__microsoft__clientId: $(login-microsoft-clientId)
+              login__microsoft__secret: $(login-microsoft-secret)
+              login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
+              fluid__test__driver__frs: $(automation-fluid-test-driver-frs-stress-test)
+              FLUID_ENDPOINTNAME: ${{ stage }}
 
-        - task: Bash@3
-          displayName: Send Execution Time Perf Benchmark Measurements to Azure App Insights
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(toolAbsolutePath)
-            script: |
-              echo "Writing execution time performance benchmark output to Azure App Insights..."
-              ls -laR ${{ variables.executionTimeTestOutputFolder }};
-              node bin/run appInsights --handlerModule $(toolAbsolutePath)/dist/handlers/appInsightsExecutionTimeTestHandler.js --dir '${{ variables.executionTimeTestOutputFolder }}' --connectionString '$(fluid-interal-app-insights-connection-string)';
-          env:
-            BUILD_ID: $(Build.BuildId)
-            BRANCH_NAME: $(Build.SourceBranchName)
-            FLUID_ENDPOINTNAME: "local"
+          - task: Bash@3
+            displayName: Write measurements to Aria/Kusto - execution time ${{ stage }}
+            condition: succeededOrFailed()
+            inputs:
+              targetType: 'inline'
+              workingDirectory: $(toolAbsolutePath)
+              script: |
+                echo "Writing the following performance tests results to Aria/Kusto - ${{ stage }}"
+                ls -la ${{ variables.executionTimeTestOutputFolder }};
+                node --require @ff-internal/aria-logger bin/run --handlerModule $(toolAbsolutePath)/dist/handlers/executionTimeTestHandler.js --dir ${{ variables.executionTimeTestOutputFolder }};
+            env:
+              FLUID_ENDPOINTNAME: ${{ stage }}
 
-        - task: Bash@3
-          displayName: Send Memory Usage Perf Benchmark Measurements to Azure App Insights
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(toolAbsolutePath)
-            script: |
-              echo "Writing memory usage performance benchmark output to Azure App Insights..."
-              ls -laR ${{ variables.memoryUsageTestOutputFolder }};
-              node bin/run appInsights --handlerModule $(toolAbsolutePath)/dist/handlers/appInsightsMemoryUsageTestHandler.js --dir '${{ variables.memoryUsageTestOutputFolder }}' --connectionString '$(fluid-interal-app-insights-connection-string)';
-          env:
-            BUILD_ID: $(Build.BuildId)
-            BRANCH_NAME: $(Build.SourceBranchName)
-            FLUID_ENDPOINTNAME: "local"
+          - task: Bash@3
+            displayName: Write measurements to Aria/Kusto - memory usage ${{ stage }}
+            condition: succeededOrFailed()
+            inputs:
+              targetType: 'inline'
+              workingDirectory: $(toolAbsolutePath)
+              script: |
+                echo "Writing the following performance tests results to Aria/Kusto - ${{ stage }}"
+                ls -la ${{ variables.memoryUsageTestOutputFolder }};
+                node --require @ff-internal/aria-logger bin/run --handlerModule $(toolAbsolutePath)/dist/handlers/memoryUsageTestHandler.js --dir ${{ variables.memoryUsageTestOutputFolder }};
+            env:
+              FLUID_ENDPOINTNAME: ${{ stage }}
 
-        - task: Bash@3
-          displayName: Remove Output Folders from local server run
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(toolAbsolutePath)
-            script: |
-              ls -laR ${{ variables.executionTimeTestOutputFolder }};
-              echo "Cleanup  ${{ variables.executionTimeTestOutputFolder }}"
-              rm -rf ${{ variables.executionTimeTestOutputFolder }};
-              ls -laR ${{ variables.memoryUsageTestOutputFolder }};
-              echo "Cleanup  ${{ variables.memoryUsageTestOutputFolder }}"
-              rm -rf ${{ variables.memoryUsageTestOutputFolder }};
+          - task: Bash@3
+            displayName: Send Execution Time Perf Benchmark Measurements to Azure App Insights
+            condition: eq('${{ stage }}', 'local')
+            inputs:
+              targetType: 'inline'
+              workingDirectory: $(toolAbsolutePath)
+              script: |
+                echo "Writing execution time performance benchmark output to Azure App Insights..."
+                ls -laR ${{ variables.executionTimeTestOutputFolder }};
+                node bin/run appInsights --handlerModule $(toolAbsolutePath)/dist/handlers/appInsightsExecutionTimeTestHandler.js --dir '${{ variables.executionTimeTestOutputFolder }}' --connectionString '$(fluid-interal-app-insights-connection-string)';
+            env:
+              BUILD_ID: $(Build.BuildId)
+              BRANCH_NAME: $(Build.SourceBranchName)
+              FLUID_ENDPOINTNAME: ${{ stage }}
 
-        - task: Bash@3
-          displayName: Run tests ODSP
-          inputs:
-            targetType: 'inline'
-            workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}
-            script: |
-              echo "FLUID_TEST_LOGGER_PKG_PATH= ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger"
-              echo "FLUID_BUILD_ID $(Build.BuildId)"
+          - task: Bash@3
+            displayName: Send Memory Usage Perf Benchmark Measurements to Azure App Insights
+            condition: eq('${{ stage }}', 'local')
+            inputs:
+              targetType: 'inline'
+              workingDirectory: $(toolAbsolutePath)
+              script: |
+                echo "Writing memory usage performance benchmark output to Azure App Insights..."
+                ls -laR ${{ variables.memoryUsageTestOutputFolder }};
+                node bin/run appInsights --handlerModule $(toolAbsolutePath)/dist/handlers/appInsightsMemoryUsageTestHandler.js --dir '${{ variables.memoryUsageTestOutputFolder }}' --connectionString '$(fluid-interal-app-insights-connection-string)';
+            env:
+              BUILD_ID: $(Build.BuildId)
+              BRANCH_NAME: $(Build.SourceBranchName)
+              FLUID_ENDPOINTNAME: ${{ stage }}
 
-              # Run execution time tests
-              echo "FLUID_ENDPOINTNAME = odsp"
-              npm run test:benchmark:report:odsp;
-              executionTimeTestsExitCodeOdsp=$?;
+          - task: PublishPipelineArtifact@1
+            displayName: Publish Artifact - E2E perf tests output - execution time {{ $stage }}
+            condition: and(succeededOrFailed(), eq('${{ stage }}', 'local'))
 
-              # Run memory tests
-              echo "FLUID_ENDPOINTNAME = odsp"
-              npm run test:memory-profiling:report:odsp;
-              memoryTestsExitCodeOdsp=$?;
+            inputs:
+              targetPath: '${{ variables.executionTimeTestOutputFolder }}'
+              artifactName: 'perf-test-outputs-e2e_execution-time'
 
-              if [[ $executionTimeTestsExitCodeOdsp -ne 0 ]]; then
-                echo "##vso[task.logissue type=error]Exit code for runtime tests execution Odsp= $executionTimeTestsExitCodeOdsp"
-              fi
+          - task: PublishPipelineArtifact@1
+            displayName: Publish Artifact - E2E perf tests output - memory usage {{ $stage }}
+            condition: and(succeededOrFailed(), eq('${{ stage }}', 'local'))
+            inputs:
+              targetPath: '${{ variables.memoryUsageTestOutputFolder }}'
+              artifactName: 'perf-test-outputs-e2e_memory-usage'
 
-              if [[ $memoryTestsExitCodeOdsp -ne 0 ]]; then
-                echo "##vso[task.logissue type=error]Exit code for memory tests execution Odsp = $memoryTestsExitCodeOdsp"
-              fi
-
-              if [[ $executionTimeTestsExitCodeOdsp -ne 0 ]] ||  [[ $memoryTestsExitCodeOdsp -ne 0 ]]; then
-                exit 1;
-              fi
-          env:
-            login__microsoft__clientId: $(login-microsoft-clientId)
-            login__microsoft__secret: $(login-microsoft-secret)
-            login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
-            FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-            FLUID_BUILD_ID: $(Build.BuildId)
-            FLUID_ENDPOINTNAME: odsp
-
-        - task: Bash@3
-          displayName: Write measurements to Aria/Kusto - execution time odsp
-          condition: succeededOrFailed()
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(toolAbsolutePath)
-            script: |
-              echo "Writing the following performance tests results to Aria/Kusto - ODSP"
-              ls -la ${{ variables.executionTimeTestOutputFolder }};
-              node --require @ff-internal/aria-logger bin/run --handlerModule $(toolAbsolutePath)/dist/handlers/executionTimeTestHandler.js --dir ${{ variables.executionTimeTestOutputFolder }};
-          env:
-            FLUID_ENDPOINTNAME: "odsp"
-
-        - task: Bash@3
-          displayName: Write measurements to Aria/Kusto - memory usage odsp
-          condition: succeededOrFailed()
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(toolAbsolutePath)
-            script: |
-              echo "Writing the following performance tests results to Aria/Kusto - ODSP"
-              ls -la ${{ variables.memoryUsageTestOutputFolder }};
-              node --require @ff-internal/aria-logger bin/run --handlerModule $(toolAbsolutePath)/dist/handlers/memoryUsageTestHandler.js --dir ${{ variables.memoryUsageTestOutputFolder }};
-          env:
-            FLUID_ENDPOINTNAME: "odsp"
-
-        - task: PublishPipelineArtifact@1
-          displayName: Publish Artifact - E2E perf tests output - execution time odsp
-          condition: succeededOrFailed()
-          inputs:
-            targetPath: '${{ variables.executionTimeTestOutputFolder }}'
-            artifactName: 'perf-test-outputs-e2e_execution-time'
-
-        - task: PublishPipelineArtifact@1
-          displayName: Publish Artifact - E2E perf tests output - memory usage odsp
-          condition: succeededOrFailed()
-          inputs:
-            targetPath: '${{ variables.memoryUsageTestOutputFolder }}'
-            artifactName: 'perf-test-outputs-e2e_memory-usage'
-
-        - task: Bash@3
-          displayName: Remove Output Folders from ODSP run
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(toolAbsolutePath)
-            script: |
-              ls -laR ${{ variables.executionTimeTestOutputFolder }};
-              echo "Cleanup  ${{ variables.executionTimeTestOutputFolder }}"
-              rm -rf ${{ variables.executionTimeTestOutputFolder }};
-              ls -laR ${{ variables.memoryUsageTestOutputFolder }};
-              echo "Cleanup  ${{ variables.memoryUsageTestOutputFolder }}"
-              rm -rf ${{ variables.memoryUsageTestOutputFolder }};
-
-        - task: Bash@3
-          displayName: Run tests FRS
-          inputs:
-            targetType: 'inline'
-            workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}
-            script: |
-              echo "FLUID_TEST_LOGGER_PKG_PATH= ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger"
-              echo "FLUID_BUILD_ID $(Build.BuildId)"
-
-              # Run execution time tests
-              echo "FLUID_ENDPOINTNAME = $FLUID_ENDPOINTNAME"
-              npm run test:benchmark:report:frs;
-              executionTimeTestsExitCodeFrs=$?;
-
-              # Run memory tests
-              echo "FLUID_ENDPOINTNAME = $FLUID_ENDPOINTNAME"
-              npm run test:memory-profiling:report:frs;
-              memoryTestsExitCodeFrs=$?;
-
-              if [[ $executionTimeTestsExitCodeFrs -ne 0 ]]; then
-                echo "##vso[task.logissue type=error]Exit code for runtime tests execution Frs= $executionTimeTestsExitCodeFrs"
-              fi
-
-              if [[ $memoryTestsExitCodeFrs -ne 0 ]]; then
-                echo "##vso[task.logissue type=error]Exit code for memory tests execution Frs = $memoryTestsExitCodeFrs"
-              fi
-
-              if [[ $executionTimeTestsExitCodeFrs -ne 0 ]] ||  [[ $memoryTestsExitCodeFrs -ne 0 ]]; then
-                exit 1;
-              fi
-          env:
-            fluid__test__driver__frs: $(automation-fluid-test-driver-frs-stress-test)
-            FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-            FLUID_BUILD_ID: $(Build.BuildId)
-            FLUID_ENDPOINTNAME: frs
-
-        - task: Bash@3
-          displayName: Write measurements to Aria/Kusto - execution time frs
-          condition: succeededOrFailed()
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(toolAbsolutePath)
-            script: |
-              echo "Writing the following performance tests results to Aria/Kusto - FRS"
-              ls -la ${{ variables.executionTimeTestOutputFolder }};
-              node --require @ff-internal/aria-logger bin/run --handlerModule $(toolAbsolutePath)/dist/handlers/executionTimeTestHandler.js --dir ${{ variables.executionTimeTestOutputFolder }};
-          env:
-            FLUID_ENDPOINTNAME: "frs"
-
-        - task: Bash@3
-          displayName: Write measurements to Aria/Kusto - memory usage frs
-          condition: succeededOrFailed()
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(toolAbsolutePath)
-            script: |
-              echo "Writing the following performance tests results to Aria/Kusto - FRS"
-              ls -la ${{ variables.memoryUsageTestOutputFolder }};
-              node --require @ff-internal/aria-logger bin/run --handlerModule $(toolAbsolutePath)/dist/handlers/memoryUsageTestHandler.js --dir ${{ variables.memoryUsageTestOutputFolder }};
-          env:
-            FLUID_ENDPOINTNAME: "frs"
-
-        - task: Bash@3
-          displayName: Remove Output Folders after FRS run
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(toolAbsolutePath)
-            script: |
-              ls -laR ${{ variables.executionTimeTestOutputFolder }};
-              echo "Cleanup  ${{ variables.executionTimeTestOutputFolder }}"
-              rm -rf ${{ variables.executionTimeTestOutputFolder }};
-              ls -laR ${{ variables.memoryUsageTestOutputFolder }};
-              echo "Cleanup  ${{ variables.memoryUsageTestOutputFolder }}"
-              rm -rf ${{ variables.memoryUsageTestOutputFolder }};
-
+          - task: Bash@3
+            displayName: Remove Output Folders from local server run ${{ stage }}
+            inputs:
+              targetType: 'inline'
+              workingDirectory: $(toolAbsolutePath)
+              script: |
+                ls -laR ${{ variables.executionTimeTestOutputFolder }};
+                echo "Cleanup  ${{ variables.executionTimeTestOutputFolder }}"
+                rm -rf ${{ variables.executionTimeTestOutputFolder }};
+                ls -laR ${{ variables.memoryUsageTestOutputFolder }};
+                echo "Cleanup  ${{ variables.memoryUsageTestOutputFolder }}"
+                rm -rf ${{ variables.memoryUsageTestOutputFolder }};


### PR DESCRIPTION

## Description

The idea is to simplify the performance benchmark pipeline to make use of a loop to iterate through the newly created stages: local, odsp and frs. That should make the flow much easier to understand.