### PR TITLE
Limit the max batch size sent to db from scriptorium

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -39,6 +39,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 	private readonly clientFacadeRetryEnabled: boolean;
 	private readonly telemetryEnabled: boolean;
 	private pendingMetric: Lumber<LumberEventName.ScriptoriumProcessBatch> | undefined;
+	private readonly maxDbBatchSize: number;
 
 	constructor(
 		private readonly opCollection: ICollection<any>,
@@ -47,6 +48,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 	) {
 		this.clientFacadeRetryEnabled = isRetryEnabled(this.opCollection);
 		this.telemetryEnabled = this.providerConfig?.enableTelemetry;
+		this.maxDbBatchSize = this.providerConfig?.maxDbBatchSize ?? 1000;
 	}
 
 	public handler(message: IQueuedMessage) {
@@ -142,8 +144,20 @@ export class ScriptoriumLambda implements IPartitionLambda {
 
 		// Process all the batches + checkpoint
 		for (const [, messages] of this.current) {
-			const processP = this.processMongoCore(messages, metric?.id);
-			allProcessed.push(processP);
+			if (this.maxDbBatchSize > 0 && messages.length > this.maxDbBatchSize) { // cap the max batch size sent to mongo db
+				let startIndex = 0;
+				while(startIndex < messages.length) {
+					const endIndex = startIndex + this.maxDbBatchSize;
+					const messagesBatch = messages.slice(startIndex, endIndex);
+					startIndex = endIndex;
+
+					const processP = this.processMongoCore(messagesBatch, metric?.id);
+					allProcessed.push(processP);
+				}
+			} else {
+				const processP = this.processMongoCore(messages, metric?.id);
+				allProcessed.push(processP);
+			}
 		}
 
 		Promise.all(allProcessed).then(

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -269,7 +269,8 @@
 		"groupId": "scriptorium",
 		"checkpointBatchSize": 1,
 		"checkpointTimeIntervalMsec": 1000,
-		"enableTelemetry": true
+		"enableTelemetry": true,
+		"maxDbBatchSize": 1000
 	},
 	"copier": {
 		"topic": "rawdeltas",

--- a/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
@@ -36,6 +36,7 @@ export async function create(
 	const deletionIntervalMs = config.get("mongo:deletionIntervalMs") as number;
 
 	const enableTelemetry = (config.get("scriptorium:enableTelemetry") as boolean) ?? false;
+	const maxDbBatchSize = config.get("scriptorium:maxDbBatchSize") as number;
 
 	// Database connection for global db if enabled
 	const factory = await services.getDbFactory(config);
@@ -100,5 +101,5 @@ export async function create(
 		},
 	);
 
-	return new ScriptoriumLambdaFactory(operationsDbManager, opCollection, { enableTelemetry });
+	return new ScriptoriumLambdaFactory(operationsDbManager, opCollection, { enableTelemetry, maxDbBatchSize });
 }


### PR DESCRIPTION
## Description

When client sends messages/ops really quickly, scriptorium creates really large batches of messages for db insert, which leads to db timeout exception and then scriptorium restarts.

This ultimately causes multiple issues like high latency in writing the ops, duplicate ops in case of timeouts and retries, high kafka lag in reading messages.

This PR adds a limit (1000) to the max batch size that can be sent to db. This will help reduce timeouts and all the above issues caused by it.

## Reviewer Guidance

The default value of maxDbBatchSize is 1000 based on the guidance [here](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/optimize-write-performance#tune-for-the-optimal-batch-size-and-thread-count), but I made it configurable in case we need to modify it for particular clusters, or in case we need to disable it (maxDbBatchSize value should be 0 to disable it).