### PR TITLE
refactor(client-debugger): Rename logger type and filename to use "devtools" nomenclature

### DIFF
--- a/packages/tools/client-debugger/client-debugger-view/src/test/app/App.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/test/app/App.tsx
@@ -20,7 +20,7 @@ import { SharedString } from "@fluidframework/sequence";
 
 import { CollaborativeTextArea, SharedStringHelper } from "@fluid-experimental/react-inputs";
 import {
-	FluidDebuggerLogger,
+	FluidDevtoolsLogger,
 	IFluidDevtools,
 	initializeFluidDevtools,
 } from "@fluid-tools/client-debugger";
@@ -236,7 +236,7 @@ const appViewPaneStackStyles = mergeStyles({
  */
 export function App(): React.ReactElement {
 	// Initialize the Fluid Debugger logger
-	const logger = React.useMemo(() => FluidDebuggerLogger.create(), []);
+	const logger = React.useMemo(() => FluidDevtoolsLogger.create(), []);
 
 	// Initialize devtools
 	const devtools = React.useMemo(() => initializeFluidDevtools(), []);

--- a/packages/tools/client-debugger/client-debugger-view/src/test/app/App.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/test/app/App.tsx
@@ -20,7 +20,7 @@ import { SharedString } from "@fluidframework/sequence";
 
 import { CollaborativeTextArea, SharedStringHelper } from "@fluid-experimental/react-inputs";
 import {
-	FluidDevtoolsLogger,
+	DevtoolsLogger,
 	IFluidDevtools,
 	initializeFluidDevtools,
 } from "@fluid-tools/client-debugger";
@@ -236,7 +236,7 @@ const appViewPaneStackStyles = mergeStyles({
  */
 export function App(): React.ReactElement {
 	// Initialize the Fluid Debugger logger
-	const logger = React.useMemo(() => FluidDevtoolsLogger.create(), []);
+	const logger = React.useMemo(() => DevtoolsLogger.create(), []);
 
 	// Initialize devtools
 	const devtools = React.useMemo(() => initializeFluidDevtools(), []);

--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -189,13 +189,6 @@ export namespace DisconnectContainer {
     export type MessageData = HasContainerId;
 }
 
-// @internal @sealed
-export class FluidDebuggerLogger extends TelemetryLogger {
-    static create(namespace?: string, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
-    static mixinLogger(namespace?: string, baseLogger?: ITelemetryBaseLogger, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
-    send(event: ITelemetryBaseEvent): void;
-}
-
 // @internal
 export class FluidDevtools extends TypedEventEmitter<FluidDevtoolsEvents> implements IFluidDevtools {
     constructor(props?: FluidDevtoolsProps);
@@ -217,6 +210,13 @@ export interface FluidDevtoolsEvents extends IEvent {
     (event: "containerDevtoolsClosed", listener: (containerId: string) => void): void;
     // @eventProperty
     (event: "devtoolsDisposed", listener: () => void): void;
+}
+
+// @internal @sealed
+export class FluidDevtoolsLogger extends TelemetryLogger {
+    static create(namespace?: string, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
+    static mixinLogger(namespace?: string, baseLogger?: ITelemetryBaseLogger, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
+    send(event: ITelemetryBaseEvent): void;
 }
 
 // @public

--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -176,6 +176,13 @@ export namespace DataVisualization {
     }
 }
 
+// @internal @sealed
+export class DevtoolsLogger extends TelemetryLogger {
+    static create(namespace?: string, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
+    static mixinLogger(namespace?: string, baseLogger?: ITelemetryBaseLogger, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
+    send(event: ITelemetryBaseEvent): void;
+}
+
 // @public
 export const devtoolsMessageSource: string;
 
@@ -210,13 +217,6 @@ export interface FluidDevtoolsEvents extends IEvent {
     (event: "containerDevtoolsClosed", listener: (containerId: string) => void): void;
     // @eventProperty
     (event: "devtoolsDisposed", listener: () => void): void;
-}
-
-// @internal @sealed
-export class FluidDevtoolsLogger extends TelemetryLogger {
-    static create(namespace?: string, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
-    static mixinLogger(namespace?: string, baseLogger?: ITelemetryBaseLogger, properties?: ITelemetryLoggerPropertyBags): TelemetryLogger;
-    send(event: ITelemetryBaseEvent): void;
 }
 
 // @public

--- a/packages/tools/client-debugger/client-debugger/src/DevtoolsLogger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/DevtoolsLogger.ts
@@ -43,7 +43,7 @@ import { ITimestampedTelemetryEvent } from "./TelemetryMetadata";
  * @sealed
  * @internal
  */
-export class FluidDevtoolsLogger extends TelemetryLogger {
+export class DevtoolsLogger extends TelemetryLogger {
 	/**
 	 * Accumulated data for Telemetry logs.
 	 */
@@ -99,7 +99,7 @@ export class FluidDevtoolsLogger extends TelemetryLogger {
 		namespace?: string,
 		properties?: ITelemetryLoggerPropertyBags,
 	): TelemetryLogger {
-		return new FluidDevtoolsLogger(namespace, properties);
+		return new DevtoolsLogger(namespace, properties);
 	}
 
 	/**
@@ -115,12 +115,12 @@ export class FluidDevtoolsLogger extends TelemetryLogger {
 		properties?: ITelemetryLoggerPropertyBags,
 	): TelemetryLogger {
 		if (!baseLogger) {
-			return FluidDevtoolsLogger.create(namespace, properties);
+			return DevtoolsLogger.create(namespace, properties);
 		}
 
 		const multiSinkLogger = new MultiSinkLogger(undefined, properties);
 		multiSinkLogger.addLogger(
-			FluidDevtoolsLogger.create(namespace, this.tryGetBaseLoggerProps(baseLogger)),
+			DevtoolsLogger.create(namespace, this.tryGetBaseLoggerProps(baseLogger)),
 		);
 		multiSinkLogger.addLogger(ChildLogger.create(baseLogger, namespace));
 

--- a/packages/tools/client-debugger/client-debugger/src/DevtoolsLogger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/DevtoolsLogger.ts
@@ -43,21 +43,21 @@ import { ITimestampedTelemetryEvent } from "./TelemetryMetadata";
  * @sealed
  * @internal
  */
-export class FluidDebuggerLogger extends TelemetryLogger {
+export class FluidDevtoolsLogger extends TelemetryLogger {
 	/**
 	 * Accumulated data for Telemetry logs.
 	 */
 	private readonly _telemetryLog: ITimestampedTelemetryEvent[];
 
 	/**
-	 * Message logging options used by the debugger.
+	 * Message logging options used by the logger.
 	 */
 	private readonly messageLoggingOptions: MessageLoggingOptions = {
-		context: `FluidClientDebuggerLogger`,
+		context: `FluidDevtoolsLogger`,
 	};
 
 	/**
-	 * Handlers for inbound messages related to the debugger.
+	 * Handlers for inbound messages related to the logger.
 	 */
 	private readonly inboundMessageHandlers: InboundHandlers = {
 		[GetTelemetryHistory.MessageType]: (untypedMessage) => {
@@ -76,7 +76,7 @@ export class FluidDebuggerLogger extends TelemetryLogger {
 	};
 
 	/**
-	 * Posts a list of {@link IDevtoolsMessage} to the window (globalThis). It will be send
+	 * Posts a list of {@link TelemetryHistory.Message} to the window (globalThis). It will be send
 	 * when requesting all the telemetry history/log since logger created.
 	 */
 	private readonly postLogHistory = (): void => {
@@ -99,7 +99,7 @@ export class FluidDebuggerLogger extends TelemetryLogger {
 		namespace?: string,
 		properties?: ITelemetryLoggerPropertyBags,
 	): TelemetryLogger {
-		return new FluidDebuggerLogger(namespace, properties);
+		return new FluidDevtoolsLogger(namespace, properties);
 	}
 
 	/**
@@ -115,12 +115,12 @@ export class FluidDebuggerLogger extends TelemetryLogger {
 		properties?: ITelemetryLoggerPropertyBags,
 	): TelemetryLogger {
 		if (!baseLogger) {
-			return FluidDebuggerLogger.create(namespace, properties);
+			return FluidDevtoolsLogger.create(namespace, properties);
 		}
 
 		const multiSinkLogger = new MultiSinkLogger(undefined, properties);
 		multiSinkLogger.addLogger(
-			FluidDebuggerLogger.create(namespace, this.tryGetBaseLoggerProps(baseLogger)),
+			FluidDevtoolsLogger.create(namespace, this.tryGetBaseLoggerProps(baseLogger)),
 		);
 		multiSinkLogger.addLogger(ChildLogger.create(baseLogger, namespace));
 
@@ -146,7 +146,7 @@ export class FluidDebuggerLogger extends TelemetryLogger {
 	}
 
 	/**
-	 * Post a telemetry event to the window (globalThis object).
+	 * Post a {@link TelemetryEvent.Message} to the window (globalThis object).
 	 *
 	 * @param event - the event to send
 	 */

--- a/packages/tools/client-debugger/client-debugger/src/DevtoolsLogger.ts
+++ b/packages/tools/client-debugger/client-debugger/src/DevtoolsLogger.ts
@@ -76,8 +76,8 @@ export class DevtoolsLogger extends TelemetryLogger {
 	};
 
 	/**
-	 * Posts a list of {@link TelemetryHistory.Message} to the window (globalThis). It will be send
-	 * when requesting all the telemetry history/log since logger created.
+	 * Posts a {@link TelemetryHistory.Message} to the window (globalThis) containing the complete history of
+	 * telemetry events.
 	 */
 	private readonly postLogHistory = (): void => {
 		postMessagesToWindow(
@@ -146,9 +146,9 @@ export class DevtoolsLogger extends TelemetryLogger {
 	}
 
 	/**
-	 * Post a {@link TelemetryEvent.Message} to the window (globalThis object).
+	 * Post a {@link TelemetryEvent.Message} to the window (globalThis) for the provided telemetry event.
 	 *
-	 * @param event - the event to send
+	 * @param event - The telemetry event to send.
 	 */
 	public send(event: ITelemetryBaseEvent): void {
 		// TODO: ability to disable the logger so this becomes a no-op

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -71,7 +71,7 @@ export {
 } from "./data-visualization";
 export { ContainerDevtoolsEvents, IContainerDevtools } from "./IContainerDevtools";
 export { FluidDevtoolsEvents, IFluidDevtools } from "./IFluidDevtools";
-export { FluidDevtoolsLogger } from "./DevtoolsLogger";
+export { DevtoolsLogger } from "./DevtoolsLogger";
 export { FluidDevtools, FluidDevtoolsProps, initializeFluidDevtools } from "./FluidDevtools";
 export {
 	AudienceChangeLogEntry,

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -71,7 +71,7 @@ export {
 } from "./data-visualization";
 export { ContainerDevtoolsEvents, IContainerDevtools } from "./IContainerDevtools";
 export { FluidDevtoolsEvents, IFluidDevtools } from "./IFluidDevtools";
-export { FluidDebuggerLogger } from "./FluidDebuggerLogger";
+export { FluidDevtoolsLogger } from "./DevtoolsLogger";
 export { FluidDevtools, FluidDevtoolsProps, initializeFluidDevtools } from "./FluidDevtools";
 export {
 	AudienceChangeLogEntry,


### PR DESCRIPTION
Also update comments to remove lingering "debugger" nomenclature.