### PR TITLE
Stop logging summarizingError which is duplicate of summarize_cancel

### DIFF
--- a/packages/runtime/container-runtime/src/summary/index.ts
+++ b/packages/runtime/container-runtime/src/summary/index.ts
@@ -95,7 +95,7 @@ export {
 	WriteFluidDataStoreAttributes,
 	wrapSummaryInChannelsTree,
 } from "./summaryFormat";
-export { SummarizeReason } from "./summaryGenerator";
+export { getFailMessage, SummarizeReason } from "./summaryGenerator";
 export {
 	IConnectedEvents,
 	IConnectedState,

--- a/packages/runtime/container-runtime/src/summary/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizer.ts
@@ -264,14 +264,6 @@ export class Summarizer extends EventEmitter implements ISummarizer {
 				refSequenceNumber: this.runtime.deltaManager.initialSequenceNumber,
 				summaryTime: Date.now(),
 			} as const),
-			(errorMessage: string) => {
-				if (!this._disposed) {
-					this.logger.sendErrorEvent(
-						{ eventName: "summarizingError" },
-						createSummarizingWarning(errorMessage, true),
-					);
-				}
-			},
 			this.summaryCollection,
 			runCoordinator /* cancellationToken */,
 			(reason) => runCoordinator.stop(reason) /* stopSummarizerCallback */,

--- a/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
@@ -120,6 +120,10 @@ const summarizeErrors = {
 	disconnect: "Summary cancelled due to summarizer or main client disconnect",
 } as const;
 
+// Helper functions to report failures and return.
+export const getFailMessage = (errorCode: keyof typeof summarizeErrors) =>
+	`${errorCode}: ${summarizeErrors[errorCode]}`;
+
 export class SummarizeResultBuilder {
 	public readonly summarySubmitted = new Deferred<SummarizeResultPart<SubmitSummaryResult>>();
 	public readonly summaryOpBroadcasted = new Deferred<
@@ -171,7 +175,6 @@ export class SummaryGenerator {
 		private readonly submitSummaryCallback: (
 			options: ISubmitSummaryOptions,
 		) => Promise<SubmitSummaryResult>,
-		private readonly raiseSummarizingError: (errorMessage: string) => void,
 		private readonly successfulSummaryCallback: () => void,
 		private readonly summaryWatcher: Pick<IClientSummaryWatcher, "watchSummary">,
 		private readonly logger: ITelemetryLogger,
@@ -235,16 +238,12 @@ export class SummaryGenerator {
 			{ start: true, end: true, cancel: "generic" },
 		);
 
-		// Helper functions to report failures and return.
-		const getFailMessage = (errorCode: keyof typeof summarizeErrors) =>
-			`${errorCode}: ${summarizeErrors[errorCode]}`;
 		const fail = (
 			errorCode: keyof typeof summarizeErrors,
 			error?: any,
 			properties?: SummaryGeneratorTelemetry,
 			nackSummaryResult?: INackSummaryResult,
 		) => {
-			this.raiseSummarizingError(summarizeErrors[errorCode]);
 			// UploadSummary may fail with 429 and retryAfter - respect that
 			// Summary Nack also can have retryAfter, it's parsed below and comes as a property.
 			const retryAfterSeconds = getRetryDelaySecondsFromError(error);
@@ -257,17 +256,17 @@ export class SummaryGenerator {
 					? "generic"
 					: "error";
 
-			const message = getFailMessage(errorCode);
+			const reason = getFailMessage(errorCode);
 			summarizeEvent.cancel(
 				{
 					...properties,
-					reason: errorCode,
+					reason,
 					category,
 					retryAfterSeconds,
 				},
-				error ?? message,
+				error ?? reason,
 			); // disconnect & summaryAckTimeout do not have proper error.
-			resultsBuilder.fail(message, error, nackSummaryResult, retryAfterSeconds);
+			resultsBuilder.fail(reason, error, nackSummaryResult, retryAfterSeconds);
 		};
 
 		// Wait to generate and send summary

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -20,6 +20,7 @@ import { MockDeltaManager } from "@fluidframework/test-runtime-utils";
 import { IDeltaManager } from "@fluidframework/container-definitions";
 import { ISummaryConfiguration } from "../../containerRuntime";
 import {
+	getFailMessage,
 	neverCancelledSummaryToken,
 	RunningSummarizer,
 	SummaryCollection,
@@ -240,7 +241,6 @@ describe("Runtime", () => {
 					},
 					async (options) => {},
 					heuristicData,
-					() => {},
 					summaryCollection,
 					neverCancelledSummaryToken,
 					// stopSummarizerCallback
@@ -569,7 +569,7 @@ describe("Runtime", () => {
 							{
 								eventName: "Running:Summarize_cancel",
 								...retryProps1,
-								reason: "summaryNack",
+								reason: getFailMessage("summaryNack"),
 							},
 							{ eventName: "Running:Summarize_generate", ...retryProps2 },
 							{ eventName: "Running:Summarize_Op", ...retryProps2 },
@@ -597,7 +597,7 @@ describe("Runtime", () => {
 								{
 									eventName: "Running:Summarize_cancel",
 									...retryProps2,
-									reason: "summaryNack",
+									reason: getFailMessage("summaryNack"),
 								},
 								{ eventName: "Running:Summarize_generate", ...retryProps3 },
 								{ eventName: "Running:Summarize_Op", ...retryProps3 },
@@ -685,7 +685,7 @@ describe("Runtime", () => {
 							{
 								eventName: "Running:Summarize_cancel",
 								summarizeCount: 1,
-								reason: "summaryNack",
+								reason: getFailMessage("summaryNack"),
 							},
 							{
 								eventName: "Running:SummarizeAttemptDelay",
@@ -728,7 +728,7 @@ describe("Runtime", () => {
 								{
 									eventName: "Running:Summarize_cancel",
 									...retryProps2,
-									reason: "summaryNack",
+									reason: getFailMessage("summaryNack"),
 								},
 								{ eventName: "Running:SummarizeAttemptDelay", ...retryProps3 },
 								{ eventName: "Running:Summarize_generate", ...retryProps3 },

--- a/packages/runtime/container-runtime/src/test/summary/summaryManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/summaryManager.spec.ts
@@ -153,7 +153,6 @@ describe("Summary Manager", () => {
 				},
 				async (options) => {},
 				new SummarizeHeuristicData(0, { refSequenceNumber: 0, summaryTime: Date.now() }),
-				() => {},
 				summaryCollection,
 				neverCancelledSummaryToken,
 				// stopSummarizerCallback


### PR DESCRIPTION
Every time summarize fails, "fluid:telemetry:Summarizer:summarizingError" and "fluid:telemetry:Summarizer:Running:Summarize_cancel" are both logged. `summarize_cancel` has the real error why summarize failed. `summarizingError` just has a message which is something like "Error while generating, uploading, or submitting summary".

We have metrics tracking number of errors in tests and in prod. These errors skew the metrics by doubling the number of errors. Having one error will also make debugging easier because we only have to look at one error.

This change removes `summarizingError` and adds it message to `summarize_cancel` under reason.

[AB#4037](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4037)