### PR TITLE
Deprecate interval collection conflict resolvers

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -45,6 +45,7 @@ and verifying that the following expectation changes won't have any effects:
 -   [ensureSynchronizedWithTimeout deprecated in LoaderContainerTracker](#ensuresynchronizedwithtimeout-deprecated-in-loadercontainertracker)
 -   [Container-loader deprecations](#Container-loader-deprecations)
 -   [Op compression is enabled by default](#op-compression-is-enabled-by-default)
+-   [IntervalConflictResolver deprecation](#intervalconflictresolver-deprecation)
 
 ### @fluidframework/garbage-collector deprecated
 
@@ -97,6 +98,12 @@ The following types in the @fluidframework/container-loader package are not used
 If the size of a batch is larger than 614kb, the ops will be compressed. After upgrading to this version, if batches exceed the size threshold, the runtime will produce a new type of op with the compression properties. To open a document which contains this type of op, the client's runtime version needs to be at least `client_v2.0.0-internal.2.3.0`. Older clients will close with assert `0x3ce` ("Runtime message of unknown type") and will not be able to open the documents until they upgrade. To minimize the risk, it is recommended to audit existing session and ensure that at least 99.9% of them are using a runtime version equal or greater than `client_v2.0.0-internal.2.3.0`, before upgrading to `2.0.0-internal.4.1.0`.
 
 More information about op compression can be found [here](./packages/runtime/container-runtime/src/opLifecycle/README.md).
+
+### IntervalConflictResolver deprecation
+
+In SharedString, interval conflict resolvers have been unused since [this change](https://github.com/microsoft/FluidFramework/pull/6407), which added support for multiple intervals at the same position.
+As such, any existing usages can be removed.
+Related APIs have been deprecated and will be removed in an upcoming release.
 
 # 2.0.0-internal.4.0.0
 

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -150,7 +150,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
     // @internal (undocumented)
     ackDelete(serializedInterval: ISerializedInterval, local: boolean, op: ISequencedDocumentMessage): void;
     add(start: number, end: number, intervalType: IntervalType, props?: PropertySet): TInterval;
-    // (undocumented)
+    // @deprecated (undocumented)
     addConflictResolver(conflictResolver: IntervalConflictResolver<TInterval>): void;
     // (undocumented)
     attachDeserializer(onDeserialize: DeserializeCallback): void;
@@ -192,7 +192,7 @@ export class IntervalCollectionIterator<TInterval extends ISerializableInterval>
     next(): IteratorResult<TInterval>;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type IntervalConflictResolver<TInterval> = (a: TInterval, b: TInterval) => TInterval;
 
 // @public

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -1956,6 +1956,13 @@ export class IntervalCollection<TInterval extends ISerializableInterval> extends
 		}
 	}
 
+	/**
+	 * @deprecated - This functionality was useful when adding two intervals at the same start/end positions resulted
+	 * in a conflict. This is no longer the case (as of PR#6407), as interval collections support multiple intervals
+	 * at the same location and gives each interval a unique id.
+	 *
+	 * As such, the conflict resolver is never invoked and unnecessary. This API will be removed in an upcoming release.
+	 */
 	public addConflictResolver(conflictResolver: IntervalConflictResolver<TInterval>): void {
 		if (!this.localCollection) {
 			throw new LoggingError("attachSequence must be called");

--- a/packages/dds/sequence/src/intervalTree.ts
+++ b/packages/dds/sequence/src/intervalTree.ts
@@ -77,6 +77,13 @@ const intervalComparer = (a: IInterval, b: IInterval) => a.compare(b);
 
 export type IntervalNode<T extends IInterval> = RBNode<T, AugmentedIntervalNode>;
 
+/**
+ * @deprecated - This functionality was useful when adding two intervals at the same start/end positions resulted
+ * in a conflict. This is no longer the case (as of PR#6407), as interval collections support multiple intervals
+ * at the same location and gives each interval a unique id.
+ *
+ * As such, conflict resolvers are never invoked and unnecessary. They will be removed in an upcoming release.
+ */
 export type IntervalConflictResolver<TInterval> = (a: TInterval, b: TInterval) => TInterval;
 
 export class IntervalTree<T extends IInterval>


### PR DESCRIPTION
## Description

Deprecates a no-longer relevant concept for future removal.
