### PR TITLE
draft: Cleanup protocol-base package

### DIFF
--- a/server/routerlicious/packages/protocol-base/src/blobs.ts
+++ b/server/routerlicious/packages/protocol-base/src/blobs.ts
@@ -35,6 +35,8 @@ export function getGitMode(value: SummaryObject): string {
 }
 
 /**
+ * @deprecated Please import the function from `@fluidframework/server-services-client`. It will be removed from server packages.
+ *
  * Take a summary object and returns its type.
  *
  * @param value - summary object
@@ -55,6 +57,9 @@ export function getGitType(value: SummaryObject): "blob" | "tree" {
 }
 
 /**
+ * @deprecated Please import the function from `@fluidframework/server-services-client` if you want to use it in server packages.
+ * `@fluidframework/protocol-base` will be moved to client release group soon.
+ *
  * Build a tree hierarchy base on a flat tree
  *
  * @param flatTree - a flat tree
@@ -97,6 +102,8 @@ export function buildHierarchy(
 }
 
 /**
+ * Only used in client packages
+ *
  * Basic implementation of a blob ITreeEntry
  */
 export class BlobTreeEntry {
@@ -120,6 +127,8 @@ export class BlobTreeEntry {
 }
 
 /**
+ * Only used in client packages
+ *
  * Basic implementation of a tree ITreeEntry
  */
 export class TreeTreeEntry {
@@ -135,6 +144,8 @@ export class TreeTreeEntry {
 }
 
 /**
+ * Only used in client packages
+ *
  * Basic implementation of an attachment ITreeEntry
  */
 export class AttachmentTreeEntry {

--- a/server/routerlicious/packages/protocol-base/src/blobs.ts
+++ b/server/routerlicious/packages/protocol-base/src/blobs.ts
@@ -15,7 +15,10 @@ import {
 	SummaryObject,
 } from "@fluidframework/protocol-definitions";
 import { unreachableCase } from "@fluidframework/common-utils";
+
 /**
+ * @deprecated Please import the function from `@fluidframework/server-services-client`. It will be removed from server packages.
+ *
  * Take a summary object and returns its git mode.
  *
  * @param value - summary object

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -43,6 +43,9 @@ export function isSystemMessage(message: ISequencedDocumentMessage) {
 	}
 }
 
+/**
+ * Only used in client packages
+ */
 export interface ILocalSequencedClient extends ISequencedClient {
 	/**
 	 * True if the client should have left the quorum, false otherwise
@@ -50,6 +53,9 @@ export interface ILocalSequencedClient extends ISequencedClient {
 	shouldHaveLeft?: boolean;
 }
 
+/**
+ * Only used in client packages
+ */
 export interface IProtocolHandler {
 	readonly quorum: IQuorum;
 	readonly attributes: IDocumentAttributes;

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -32,11 +32,15 @@ class PendingProposal implements ISequencedProposal {
 }
 
 /**
+ * NOTE: for server usage - duplicated the code in `@fluidframework/server-services-client#utils.ts`
+ *
  * Snapshot format for a QuorumClients
  */
 export type QuorumClientsSnapshot = [string, ISequencedClient][];
 
 /**
+ * NOTE: for server usage - duplicated the code in `@fluidframework/server-services-client#utils.ts`
+ *
  * Snapshot format for a QuorumProposals
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -46,6 +50,8 @@ export type QuorumProposalsSnapshot = {
 };
 
 /**
+ * NOTE: for server usage - duplicated the code in `@fluidframework/server-services-client#utils.ts`
+ *
  * Snapshot format for a Quorum
  */
 export interface IQuorumSnapshot {

--- a/server/routerlicious/packages/protocol-base/src/scribeHelper.ts
+++ b/server/routerlicious/packages/protocol-base/src/scribeHelper.ts
@@ -90,6 +90,9 @@ export function mergeAppAndProtocolTree(
 	return newTreeEntries;
 }
 
+/**
+ * @deprecated Will be removed from `@fluidframework/protocol-base` as it is part of server packages only
+ */
 export function generateServiceProtocolEntries(deli: string, scribe: string): ITreeEntry[] {
 	const serviceProtocolEntries: ITreeEntry[] = [
 		{

--- a/server/routerlicious/packages/protocol-base/src/utils.ts
+++ b/server/routerlicious/packages/protocol-base/src/utils.ts
@@ -6,6 +6,8 @@
 import { MessageType } from "@fluidframework/protocol-definitions";
 
 /**
+ * @deprecated Will be removed from `@fluidframework/protocol-base` as the usage is found only in server packages
+ *
  * Check if the string is a service message type, which includes
  * MessageType.ClientJoin, MessageType.ClientLeave, MessageType.Control,
  * MessageType.NoClient, MessageType.SummaryAck, and MessageType.SummaryNack

--- a/server/routerlicious/packages/services-client/src/gitManager.ts
+++ b/server/routerlicious/packages/services-client/src/gitManager.ts
@@ -5,7 +5,6 @@
 
 import { assert } from "@fluidframework/common-utils";
 import * as resources from "@fluidframework/gitresources";
-import { buildHierarchy } from "@fluidframework/protocol-base";
 import * as api from "@fluidframework/protocol-definitions";
 import { debug } from "./debug";
 import {
@@ -14,7 +13,7 @@ import {
 	IGitManager,
 	IHistorian,
 } from "./storage";
-import { IWholeFlatSummary, IWholeSummaryPayload, IWriteSummaryResponse } from "./storageContracts";
+import { buildGitTreeHierarchy } from "./utils";
 
 export class GitManager implements IGitManager {
 	private readonly blobCache = new Map<string, resources.IBlob>();
@@ -32,7 +31,7 @@ export class GitManager implements IGitManager {
 			this.blobCache.set(blob.sha, blob);
 		}
 
-		return buildHierarchy(header.tree);
+		return buildGitTreeHierarchy(header.tree);
 	}
 
 	public async getFullTree(sha: string): Promise<any> {

--- a/server/routerlicious/packages/services-client/src/storageUtils.ts
+++ b/server/routerlicious/packages/services-client/src/storageUtils.ts
@@ -149,7 +149,7 @@ export function convertSummaryTreeToWholeSummaryTree(
  * @param treePrefixToRemove - tree prefix to strip
  * @returns the heirarchical tree
  */
-function buildHierarchy(
+function buildSummaryTreeHierarchy(
 	flatTree: IWholeFlatSummaryTree,
 	treePrefixToRemove: string,
 ): ISnapshotTree {
@@ -206,7 +206,7 @@ export function convertWholeFlatSummaryToSnapshotTreeAndBlobs(
 	}
 	const flatSummaryTree = flatSummary.trees?.[0];
 	const sequenceNumber = flatSummaryTree?.sequenceNumber;
-	const snapshotTree = buildHierarchy(flatSummaryTree, treePrefixToRemove);
+	const snapshotTree = buildSummaryTreeHierarchy(flatSummaryTree, treePrefixToRemove);
 
 	return {
 		blobs,

--- a/server/routerlicious/packages/services-client/src/utils.ts
+++ b/server/routerlicious/packages/services-client/src/utils.ts
@@ -4,6 +4,15 @@
  */
 
 import * as resources from "@fluidframework/gitresources";
+import {
+	FileMode,
+	ISnapshotTreeEx,
+	ITreeEntry,
+	MessageType,
+	SummaryObject,
+	SummaryType,
+	TreeEntry,
+} from "@fluidframework/protocol-definitions";
 import Axios, { AxiosRequestHeaders } from "axios";
 
 export async function getOrCreateRepository(
@@ -38,3 +47,119 @@ export async function getOrCreateRepository(
  * getRandomInt is not and should not be used as part of any secure random number generation
  */
 export const getRandomInt = (range: number) => Math.floor(Math.random() * range);
+
+/**
+ * NOTE: Duplicated this function from common-utils
+ *
+ * This function can be used to assert at compile time that a given value has type never.
+ * One common usage is in the default case of a switch block,
+ * to ensure that all cases are explicitly handled.
+ */
+export function unreachableCase(_: never, message = "Unreachable Case"): never {
+	throw new Error(message);
+}
+
+/**
+ * Take a summary object and returns its type.
+ *
+ * @param value - summary object
+ * @returns the type of summary object
+ */
+export function getGitType(value: SummaryObject): "blob" | "tree" {
+	const type = value.type === SummaryType.Handle ? value.handleType : value.type;
+
+	switch (type) {
+		case SummaryType.Blob:
+		case SummaryType.Attachment:
+			return "blob";
+		case SummaryType.Tree:
+			return "tree";
+		default:
+			unreachableCase(type, `Unknown type: ${type}`);
+	}
+}
+
+/**
+ * NOTE: found a similar function in services-client#storageUtils.ts
+ *
+ * Build a tree hierarchy base on a flat tree
+ *
+ * @param flatTree - a flat tree
+ * @param blobsShaToPathCache - Map with blobs sha as keys and values as path of the blob.
+ * @param removeAppTreePrefix - Remove `.app/` from beginning of paths when present
+ * @returns the hierarchical tree
+ */
+export function buildHierarchy(
+	flatTree: resources.ITree,
+	blobsShaToPathCache: Map<string, string> = new Map<string, string>(),
+	removeAppTreePrefix = false,
+): ISnapshotTreeEx {
+	const lookup: { [path: string]: ISnapshotTreeEx } = {};
+	const root: ISnapshotTreeEx = { id: flatTree.sha, blobs: {}, trees: {} };
+	lookup[""] = root;
+
+	for (const entry of flatTree.tree) {
+		const entryPath = removeAppTreePrefix ? entry.path.replace(/^\.app\//, "") : entry.path;
+		const lastIndex = entryPath.lastIndexOf("/");
+		const entryPathDir = entryPath.slice(0, Math.max(0, lastIndex));
+		const entryPathBase = entryPath.slice(lastIndex + 1);
+
+		// The flat output is breadth-first so we can assume we see tree nodes prior to their contents
+		const node = lookup[entryPathDir];
+
+		// Add in either the blob or tree
+		if (entry.type === "tree") {
+			const newTree = { id: entry.sha, blobs: {}, commits: {}, trees: {} };
+			node.trees[decodeURIComponent(entryPathBase)] = newTree;
+			lookup[entryPath] = newTree;
+		} else if (entry.type === "blob") {
+			node.blobs[decodeURIComponent(entryPathBase)] = entry.sha;
+			blobsShaToPathCache.set(entry.sha, `/${entryPath}`);
+		} else {
+			throw new Error("Unknown entry type!!");
+		}
+	}
+
+	return root;
+}
+
+/**
+ * Check if the string is a service message type, which includes
+ * MessageType.ClientJoin, MessageType.ClientLeave, MessageType.Control,
+ * MessageType.NoClient, MessageType.SummaryAck, and MessageType.SummaryNack
+ *
+ * @param type - the type to check
+ * @returns true if it is a system message type
+ */
+export const isServiceMessageType = (type: string) =>
+	type === MessageType.ClientJoin ||
+	type === MessageType.ClientLeave ||
+	type === MessageType.Control ||
+	type === MessageType.NoClient ||
+	type === MessageType.SummaryAck ||
+	type === MessageType.SummaryNack;
+
+export function generateServiceProtocolEntries(deli: string, scribe: string): ITreeEntry[] {
+	const serviceProtocolEntries: ITreeEntry[] = [
+		{
+			mode: FileMode.File,
+			path: "deli",
+			type: TreeEntry.Blob,
+			value: {
+				contents: deli,
+				encoding: "utf-8",
+			},
+		},
+	];
+
+	serviceProtocolEntries.push({
+		mode: FileMode.File,
+		path: "scribe",
+		type: TreeEntry.Blob,
+		value: {
+			contents: scribe,
+			encoding: "utf-8",
+		},
+	});
+	return serviceProtocolEntries;
+}

--- a/server/routerlicious/packages/services-client/src/utils.ts
+++ b/server/routerlicious/packages/services-client/src/utils.ts
@@ -6,6 +6,9 @@
 import * as resources from "@fluidframework/gitresources";
 import {
 	FileMode,
+	ICommittedProposal,
+	ISequencedClient,
+	ISequencedProposal,
 	ISnapshotTreeEx,
 	ITreeEntry,
 	MessageType,
@@ -162,4 +165,46 @@ export function generateServiceProtocolEntries(deli: string, scribe: string): IT
 		},
 	});
 	return serviceProtocolEntries;
+}
+
+/**
+ * Take a summary object and returns its git mode.
+ *
+ * @param value - summary object
+ * @returns the git mode of summary object
+ */
+export function getGitMode(value: SummaryObject): string {
+	const type = value.type === SummaryType.Handle ? value.handleType : value.type;
+	switch (type) {
+		case SummaryType.Blob:
+		case SummaryType.Attachment:
+			return FileMode.File;
+		case SummaryType.Tree:
+			return FileMode.Directory;
+		default:
+			unreachableCase(type, `Unknown type: ${type}`);
+	}
+}
+
+/**
+ * Snapshot format for a QuorumClients
+ */
+export type QuorumClientsSnapshot = [string, ISequencedClient][];
+
+/**
+ * Snapshot format for a QuorumProposals
+ */
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type QuorumProposalsSnapshot = {
+	proposals: [number, ISequencedProposal, string[]][];
+	values: [string, ICommittedProposal][];
+};
+
+/**
+ * Snapshot format for a Quorum
+ */
+export interface IQuorumSnapshot {
+	members: QuorumClientsSnapshot;
+	proposals: QuorumProposalsSnapshot["proposals"];
+	values: QuorumProposalsSnapshot["values"];
 }

--- a/server/routerlicious/packages/services-client/src/utils.ts
+++ b/server/routerlicious/packages/services-client/src/utils.ts
@@ -80,7 +80,7 @@ export function getGitType(value: SummaryObject): "blob" | "tree" {
 }
 
 /**
- * NOTE: found a similar function in services-client#storageUtils.ts
+ * NOTE: Duplicated the protocol-base#buildHierarchy function. Renamed it to buildGitTreeHierarchy
  *
  * Build a tree hierarchy base on a flat tree
  *
@@ -89,7 +89,7 @@ export function getGitType(value: SummaryObject): "blob" | "tree" {
  * @param removeAppTreePrefix - Remove `.app/` from beginning of paths when present
  * @returns the hierarchical tree
  */
-export function buildHierarchy(
+export function buildGitTreeHierarchy(
 	flatTree: resources.ITree,
 	blobsShaToPathCache: Map<string, string> = new Map<string, string>(),
 	removeAppTreePrefix = false,

--- a/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
+++ b/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
@@ -26,15 +26,94 @@ import {
 	SummaryType,
 	ISnapshotTreeEx,
 	SummaryObject,
+	IDocumentAttributes,
+	FileMode,
+	TreeEntry,
+	ITree,
 } from "@fluidframework/protocol-definitions";
-import {
-	IQuorumSnapshot,
-	getQuorumTreeEntries,
-	mergeAppAndProtocolTree,
-	getGitMode,
-	getGitType,
-} from "@fluidframework/protocol-base";
+import { IQuorumSnapshot, getGitMode, getGitType } from "@fluidframework/protocol-base";
 import { gitHashFile, IsoBuffer, Uint8ArrayToString } from "@fluidframework/common-utils";
+
+export function getQuorumTreeEntries(
+	documentId: string,
+	minimumSequenceNumber: number,
+	sequenceNumber: number,
+	term: number,
+	quorumSnapshot: IQuorumSnapshot,
+): ITreeEntry[] {
+	const documentAttributes: IDocumentAttributes = {
+		minimumSequenceNumber,
+		sequenceNumber,
+		term,
+	};
+
+	const entries: ITreeEntry[] = [
+		{
+			mode: FileMode.File,
+			path: "quorumMembers",
+			type: TreeEntry.Blob,
+			value: {
+				contents: JSON.stringify(quorumSnapshot.members),
+				encoding: "utf-8",
+			},
+		},
+		{
+			mode: FileMode.File,
+			path: "quorumProposals",
+			type: TreeEntry.Blob,
+			value: {
+				contents: JSON.stringify(quorumSnapshot.proposals),
+				encoding: "utf-8",
+			},
+		},
+		{
+			mode: FileMode.File,
+			path: "quorumValues",
+			type: TreeEntry.Blob,
+			value: {
+				contents: JSON.stringify(quorumSnapshot.values),
+				encoding: "utf-8",
+			},
+		},
+		{
+			mode: FileMode.File,
+			path: "attributes",
+			type: TreeEntry.Blob,
+			value: {
+				contents: JSON.stringify(documentAttributes),
+				encoding: "utf-8",
+			},
+		},
+	];
+	return entries;
+}
+
+const isInvalidPath = (path: string) =>
+	path === ".protocol" || path === ".logTail" || path === ".serviceProtocol";
+
+export function mergeAppAndProtocolTree(
+	appSummaryTree: ITree,
+	protocolTree: ITree,
+): ICreateTreeEntry[] {
+	const newTreeEntries = appSummaryTree.tree
+		.filter((value) => !isInvalidPath(value.path))
+		.map((value) => {
+			const createTreeEntry: ICreateTreeEntry = {
+				mode: value.mode,
+				path: value.path,
+				sha: value.sha,
+				type: value.type,
+			};
+			return createTreeEntry;
+		});
+	newTreeEntries.push({
+		mode: FileMode.Directory,
+		path: ".protocol",
+		sha: protocolTree.sha,
+		type: "tree",
+	});
+	return newTreeEntries;
+}
 
 // Forked from DocumentStorage to remove to server dependencies and enable testing of other data stores.
 export class TestDocumentStorage implements IDocumentStorage {


### PR DESCRIPTION
This PR is initial effort to clean up the protocol-base package. The goal is to move protocol-base as part of client packages and decouple the client and server packages. 

The functions/interfaces are deprecated in protocol-base and moved to services-client. After the next server release, the protocol-base will be moved to client packages and the server imports will be updated. 

The class `ProtocolOpHandler` is not yet moved to services-client.