### PR TITLE
refactor: Better typing of PackageJson

### DIFF
--- a/build-tools/packages/build-cli/src/commands/info.ts
+++ b/build-tools/packages/build-cli/src/commands/info.ts
@@ -40,7 +40,7 @@ export default class InfoCommand extends BaseCommand<typeof InfoCommand> {
 
 		// Filter out private packages
 		if (!flags.private) {
-			packages = packages.filter((p) => !p.packageJson.private);
+			packages = packages.filter((p) => !(p.packageJson.private ?? false));
 		}
 
 		const data: (string | MonoRepoKind | undefined)[][] = [
@@ -50,7 +50,7 @@ export default class InfoCommand extends BaseCommand<typeof InfoCommand> {
 			data.push([
 				pkg.monoRepo?.kind ?? "n/a",
 				pkg.name,
-				pkg.packageJson.private ? "-private-" : "",
+				(pkg.packageJson.private ?? false) ? "-private-" : "",
 				pkg.monoRepo ? pkg.monoRepo.version : pkg.version,
 			]);
 		}

--- a/build-tools/packages/build-cli/src/commands/info.ts
+++ b/build-tools/packages/build-cli/src/commands/info.ts
@@ -40,7 +40,7 @@ export default class InfoCommand extends BaseCommand<typeof InfoCommand> {
 
 		// Filter out private packages
 		if (!flags.private) {
-			packages = packages.filter((p) => !(p.packageJson.private ?? false));
+			packages = packages.filter((p) => p.packageJson.private !== true);
 		}
 
 		const data: (string | MonoRepoKind | undefined)[][] = [
@@ -51,7 +51,7 @@ export default class InfoCommand extends BaseCommand<typeof InfoCommand> {
 				pkg.monoRepo?.kind ?? "n/a",
 				pkg.name,
 				pkg.packageJson.private ?? false ? "-private-" : "",
-				pkg.monoRepo ? pkg.monoRepo.version : pkg.version,
+				pkg.monoRepo === undefined ? pkg.version : pkg.monoRepo.version,
 			]);
 		}
 

--- a/build-tools/packages/build-cli/src/commands/info.ts
+++ b/build-tools/packages/build-cli/src/commands/info.ts
@@ -50,7 +50,7 @@ export default class InfoCommand extends BaseCommand<typeof InfoCommand> {
 			data.push([
 				pkg.monoRepo?.kind ?? "n/a",
 				pkg.name,
-				(pkg.packageJson.private ?? false) ? "-private-" : "",
+				pkg.packageJson.private ?? false ? "-private-" : "",
 				pkg.monoRepo ? pkg.monoRepo.version : pkg.version,
 			]);
 		}

--- a/build-tools/packages/build-cli/src/lib/bump.ts
+++ b/build-tools/packages/build-cli/src/lib/bump.ts
@@ -101,7 +101,8 @@ export async function bumpPackageDependencies(
 				const dependencies = dev
 					? pkg.packageJson.devDependencies
 					: pkg.packageJson.dependencies;
-				const verString = dependencies[name];
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				const verString = dependencies[name]!;
 				const depIsPrerelease = (semver.minVersion(verString)?.prerelease?.length ?? 0) > 0;
 
 				const depNewRangeOrBumpType = dep.rangeOrBumpType;
@@ -161,13 +162,9 @@ export async function bumpReleaseGroup(
 	let workingDir: string;
 
 	if (releaseGroupOrPackage instanceof MonoRepo) {
-		workingDir = releaseGroupOrPackage.repoPath;
+		workingDir = context.gitRepo.resolvedRoot;
 		name = releaseGroupOrPackage.kind;
-		cmd = `npx --no-install lerna version ${
-			translatedVersion.version
-		} --no-push --no-git-tag-version -y${
-			exactDependencyType === "" ? " --exact" : ""
-		} && npm run build:genver`;
+		cmd = `flub exec -g ${name} -- "npm version '${translatedVersion.version}' && npm run build:genver"`;
 	} else {
 		workingDir = releaseGroupOrPackage.directory;
 		name = releaseGroupOrPackage.name;

--- a/build-tools/packages/build-cli/src/lib/bump.ts
+++ b/build-tools/packages/build-cli/src/lib/bump.ts
@@ -164,7 +164,11 @@ export async function bumpReleaseGroup(
 	if (releaseGroupOrPackage instanceof MonoRepo) {
 		workingDir = context.gitRepo.resolvedRoot;
 		name = releaseGroupOrPackage.kind;
-		cmd = `flub exec -g ${name} -- "npm version '${translatedVersion.version}' && npm run build:genver"`;
+		cmd = `npx --no-install lerna version ${
+			translatedVersion.version
+		} --no-push --no-git-tag-version -y${
+			exactDependencyType === "" ? " --exact" : ""
+		} && npm run build:genver`;
 	} else {
 		workingDir = releaseGroupOrPackage.directory;
 		name = releaseGroupOrPackage.name;

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -80,6 +80,7 @@
 		"shelljs": "^0.8.4",
 		"sort-package-json": "1.54.0",
 		"ts-morph": "^17.0.1",
+    "type-fest": "^2.19.0",
 		"yaml": "^2.1.2"
 	},
 	"devDependencies": {

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -80,7 +80,7 @@
 		"shelljs": "^0.8.4",
 		"sort-package-json": "1.54.0",
 		"ts-morph": "^17.0.1",
-    "type-fest": "^2.19.0",
+		"type-fest": "^2.19.0",
 		"yaml": "^2.1.2"
 	},
 	"devDependencies": {

--- a/build-tools/packages/build-tools/src/bumpVersion/bumpDependencies.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/bumpDependencies.ts
@@ -139,7 +139,7 @@ export function getReleasedPrereleaseDependencies(context: Context) {
 	const bumpPackageMap = new Map<string, { pkg: Package; rangeSpec: string }>();
 	for (const pkg of context.repo.packages.packages) {
 		for (const dep of pkg.combinedDependencies) {
-			if (semver.prerelease(dep.version) !== null) {
+			if (dep.version !== undefined && semver.prerelease(dep.version) !== null) {
 				const depPackage = context.fullPackageMap.get(dep.name);
 				// The prerelease dependence doesn't match the live version, assume that it is released already
 				if (depPackage && !prereleaseSatisfies(depPackage.version, dep.version)) {
@@ -200,12 +200,12 @@ export async function bumpPackageDependencies(
 		if (dep && !MonoRepo.isSame(dep.pkg.monoRepo, pkg.monoRepo)) {
 			const depVersion = dep.rangeSpec;
 			const dependencies = dev
-				? pkg.packageJson.devDependencies
-				: pkg.packageJson.dependencies;
+				? pkg.packageJson.devDependencies!
+				: pkg.packageJson.dependencies!;
 			if (
 				release
-					? dependencies[name].startsWith(`${depVersion}-`)
-					: dependencies[name] !== depVersion
+					? dependencies?.[name]?.startsWith(`${depVersion}-`)
+					: dependencies?.[name] !== depVersion
 			) {
 				if (changedVersion) {
 					changedVersion.add(dep.pkg, depVersion);

--- a/build-tools/packages/build-tools/src/bumpVersion/context.ts
+++ b/build-tools/packages/build-tools/src/bumpVersion/context.ts
@@ -97,7 +97,7 @@ export class Context {
 					"Attempted to collect server info on a Fluid repo with no server directory",
 				);
 			}
-			processMonoRepo(this.repo.monoRepos.get(repoKind)!);
+			processMonoRepo(this.repo.releaseGroups.get(repoKind)!);
 		} else {
 			const pkg = this.fullPackageMap.get(releaseGroup);
 			if (!pkg) {
@@ -128,22 +128,12 @@ export class Context {
 						// Just verify that the two package has the same version and the dependency has the same version
 						if (pkg.version !== depBuildPackage.version) {
 							fatal(
-								`Inconsistent package version within ${
-									pkg.monoRepo!.kind
-								} monorepo\n   ${pkg.name}@${pkg.version}\n  ${dep}@${
-									depBuildPackage.version
-								}`,
+								`Inconsistent package version within ${pkg.monoRepo?.kind} monorepo\n   ${pkg.name}@${pkg.version}\n  ${dep}@${depBuildPackage.version}`,
 							);
 						}
 						if (version !== `^${depBuildPackage.version}`) {
 							fatal(
-								`Inconsistent version dependency within ${
-									pkg.monoRepo!.kind
-								} monorepo in ${
-									pkg.name
-								}\n  actual: ${dep}@${version}\n  expected: ${dep}@^${
-									depBuildPackage.version
-								}`,
+								`Inconsistent version dependency within ${pkg.monoRepo?.kind} monorepo in ${pkg.name}\n  actual: ${dep}@${version}\n  expected: ${dep}@^${depBuildPackage.version}`,
 							);
 						}
 						continue;

--- a/build-tools/packages/build-tools/src/common/monoRepo.ts
+++ b/build-tools/packages/build-tools/src/common/monoRepo.ts
@@ -148,7 +148,11 @@ export class MonoRepo {
 			for (const dir of this._packageJson.workspaces as string[]) {
 				this.packages.push(...Packages.loadGlob(dir, kind, ignoredDirs, this));
 			}
-			this.workspaceGlobs = this._packageJson.workspaces;
+      if(this._packageJson.workspaces instanceof Array) {
+        this.workspaceGlobs = this._packageJson.workspaces;
+      } else {
+        fatal(`workspaces field in ${this.repoPath} is not an array.`);
+      }
 			return;
 		}
 		fatal(

--- a/build-tools/packages/build-tools/src/common/monoRepo.ts
+++ b/build-tools/packages/build-tools/src/common/monoRepo.ts
@@ -148,11 +148,11 @@ export class MonoRepo {
 			for (const dir of this._packageJson.workspaces as string[]) {
 				this.packages.push(...Packages.loadGlob(dir, kind, ignoredDirs, this));
 			}
-      if(this._packageJson.workspaces instanceof Array) {
-        this.workspaceGlobs = this._packageJson.workspaces;
-      } else {
-        fatal(`workspaces field in ${this.repoPath} is not an array.`);
-      }
+			if (this._packageJson.workspaces instanceof Array) {
+				this.workspaceGlobs = this._packageJson.workspaces;
+			} else {
+				fatal(`workspaces field in ${this.repoPath} is not an array.`);
+			}
 			return;
 		}
 		fatal(

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -101,8 +101,7 @@ export class Package {
 	}
 
 	public get name(): string {
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return this.packageJson.name!;
+		return this.packageJson.name;
 	}
 
 	public get nameColored(): string {
@@ -110,8 +109,7 @@ export class Package {
 	}
 
 	public get version(): string {
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return this.packageJson.version!;
+		return this.packageJson.version;
 	}
 
 	public get fluidBuildConfig(): IFluidBuildConfig | undefined {
@@ -146,12 +144,21 @@ export class Package {
 		return Object.keys(this.packageJson.dependencies ?? {});
 	}
 
-	public get combinedDependencies() {
+	public get combinedDependencies(): Generator<
+		{
+			name: string;
+			version: string;
+			dev: boolean;
+		},
+		void
+	> {
 		const it = function* (packageJson: PackageJson) {
 			for (const item in packageJson.dependencies) {
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				yield { name: item, version: packageJson.dependencies[item]!, dev: false };
 			}
 			for (const item in packageJson.devDependencies) {
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				yield { name: item, version: packageJson.devDependencies[item]!, dev: true };
 			}
 		};

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -36,23 +36,22 @@ export type ScriptDependencies = { [key: string]: string[] };
  * A type representing fluid-build-specific config that may be in package.json.
  */
 type FluidPackageJson = {
-  /**
-   * nyc config
-   */
-  nyc?: any;
-  
-  /**
-   * type compatibility test configuration. This only takes effect when set in the package.json of a package. Setting
-   * it at the root of the repo or release group has no effect.
-   */
-  typeValidation?: ITypeValidationConfig;
+	/**
+	 * nyc config
+	 */
+	nyc?: any;
 
-  /**
-   * fluid-build config. Some properties only apply when set in the root or release group root package.json.
-   */
-  fluidBuild?: IFluidBuildConfig;
+	/**
+	 * type compatibility test configuration. This only takes effect when set in the package.json of a package. Setting
+	 * it at the root of the repo or release group has no effect.
+	 */
+	typeValidation?: ITypeValidationConfig;
 
-}
+	/**
+	 * fluid-build config. Some properties only apply when set in the root or release group root package.json.
+	 */
+	fluidBuild?: IFluidBuildConfig;
+};
 
 /**
  * A type representing all known fields in package.json, including fluid-build-specific config.

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -11,6 +11,8 @@ import { sync as globSync, hasMagic } from "glob";
 import * as path from "path";
 import sortPackageJson from "sort-package-json";
 
+import type { PackageJson as StandardPackageJson, SetRequired } from "type-fest";
+
 import { options } from "../fluidBuild/options";
 import { type IFluidBuildConfig, type ITypeValidationConfig } from "./fluidRepo";
 import { defaultLogger } from "./logging";
@@ -30,56 +32,26 @@ import {
 const { info, verbose, errorLog: error } = defaultLogger;
 export type ScriptDependencies = { [key: string]: string[] };
 
-interface IPerson {
-	name: string;
-	email: string;
-	url: string;
-}
+export type PackageJson = SetRequired<
+	StandardPackageJson & {
+		/**
+		 * type compatibility test configuration. This only takes effect when set in the package.json of a package. Setting
+		 * it at the root of the repo or release group has no effect.
+		 */
+		typeValidation?: ITypeValidationConfig;
 
-/**
- * A type representing all relevant fields in package.json, including fluid-build-specific config.
- */
-export interface PackageJson {
-	name: string;
-	version: string;
-	private: boolean;
-	description: string;
-	keywords: string[];
-	homepage: string;
-	bugs: { url: string; email: string };
-	license: string;
-	author: IPerson | string;
-	contributors: IPerson[];
-	files: string[];
-	main: string;
-	// Same as main but for browser based clients (check if webpack supports this)
-	browser: string;
-	bin: { [key: string]: string };
-	man: string | string[];
-	repository: string | { type: string; url: string; directory?: string };
-	scripts: { [key: string]: string | undefined };
-	config: { [key: string]: string };
-	dependencies: { [key: string]: string };
-	devDependencies: { [key: string]: string };
-	peerDependencies: { [key: string]: string };
-	bundledDependencies: { [key: string]: string };
-	optionalDependencies: { [key: string]: string };
-	engines: { node: string; npm: string };
-	os: string[];
-	cpu: string[];
-	/**
-	 * type compatibility test configuration. This only takes effect when set in the package.json of a package. Setting
-	 * it at the root of the repo or release group has no effect.
-	 */
-	typeValidation?: ITypeValidationConfig;
+		/**
+		 * fluid-build config. Some properties only apply when set in the root or release group root package.json.
+		 */
+		fluidBuild?: IFluidBuildConfig;
 
-	/**
-	 * fluid-build config. Some properties only apply when set in the root or release group root package.json.
-	 */
-	fluidBuild?: IFluidBuildConfig;
-
-	[key: string]: any;
-}
+		/**
+		 * nyc config
+		 */
+		nyc?: any;
+	},
+	"name" | "dependencies" | "devDependencies" | "scripts" | "version"
+>;
 
 export class Package {
 	private static packageCount: number = 0;
@@ -101,16 +73,17 @@ export class Package {
 		chalk.default.whiteBright,
 	];
 
-	public get packageJson(): PackageJson {
-		return this._packageJson;
-	}
+	private _packageJson: PackageJson;
 	private readonly packageId = Package.packageCount++;
 	private _matched: boolean = false;
 	private _markForBuild: boolean = false;
 
-	private _packageJson: PackageJson;
 	private _indent: string;
 	public readonly packageManager: PackageManager;
+	public get packageJson(): PackageJson {
+		return this._packageJson;
+	}
+
 	constructor(
 		private readonly packageJsonFileName: string,
 		public readonly group: string,
@@ -128,7 +101,8 @@ export class Package {
 	}
 
 	public get name(): string {
-		return this.packageJson.name;
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		return this.packageJson.name!;
 	}
 
 	public get nameColored(): string {
@@ -136,11 +110,12 @@ export class Package {
 	}
 
 	public get version(): string {
-		return this.packageJson.version;
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		return this.packageJson.version!;
 	}
 
 	public get fluidBuildConfig(): IFluidBuildConfig | undefined {
-		return this._packageJson.fluidBuild;
+		return this.packageJson.fluidBuild;
 	}
 
 	public get isPublished(): boolean {
@@ -174,10 +149,10 @@ export class Package {
 	public get combinedDependencies() {
 		const it = function* (packageJson: PackageJson) {
 			for (const item in packageJson.dependencies) {
-				yield { name: item, version: packageJson.dependencies[item], dev: false };
+				yield { name: item, version: packageJson.dependencies[item]!, dev: false };
 			}
 			for (const item in packageJson.devDependencies) {
-				yield { name: item, version: packageJson.devDependencies[item], dev: true };
+				yield { name: item, version: packageJson.devDependencies[item]!, dev: true };
 			}
 		};
 		return it(this.packageJson);

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -32,24 +32,36 @@ import {
 const { info, verbose, errorLog: error } = defaultLogger;
 export type ScriptDependencies = { [key: string]: string[] };
 
+/**
+ * A type representing fluid-build-specific config that may be in package.json.
+ */
+type FluidPackageJson = {
+  /**
+   * nyc config
+   */
+  nyc?: any;
+  
+  /**
+   * type compatibility test configuration. This only takes effect when set in the package.json of a package. Setting
+   * it at the root of the repo or release group has no effect.
+   */
+  typeValidation?: ITypeValidationConfig;
+
+  /**
+   * fluid-build config. Some properties only apply when set in the root or release group root package.json.
+   */
+  fluidBuild?: IFluidBuildConfig;
+
+}
+
+/**
+ * A type representing all known fields in package.json, including fluid-build-specific config.
+ *
+ * By default all fields are optional, but we require that the name, dependencies, devDependencies, scripts, and version
+ * all be defined.
+ */
 export type PackageJson = SetRequired<
-	StandardPackageJson & {
-		/**
-		 * type compatibility test configuration. This only takes effect when set in the package.json of a package. Setting
-		 * it at the root of the repo or release group has no effect.
-		 */
-		typeValidation?: ITypeValidationConfig;
-
-		/**
-		 * fluid-build config. Some properties only apply when set in the root or release group root package.json.
-		 */
-		fluidBuild?: IFluidBuildConfig;
-
-		/**
-		 * nyc config
-		 */
-		nyc?: any;
-	},
+	StandardPackageJson & FluidPackageJson,
 	"name" | "dependencies" | "devDependencies" | "scripts" | "version"
 >;
 

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -218,7 +218,8 @@ export class BuildGraph {
 			for (const { name, version } of node.pkg.combinedDependencies) {
 				const child = this.buildPackages.get(name);
 				if (child) {
-					if (semver.satisfies(child.pkg.version, version)) {
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					if (semver.satisfies(child.pkg.version, version!)) {
 						if (depFilter(child.pkg)) {
 							verbose(
 								`Package dependency: ${node.pkg.nameColored} => ${child.pkg.nameColored}`,

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidPackageCheck.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidPackageCheck.ts
@@ -255,7 +255,7 @@ export class FluidPackageCheck {
 			if (this.ensureTestDevDependency(pkg, fix, "nyc")) {
 				fixed = true;
 			}
-			if (pkg.packageJson.nyc) {
+			if (pkg.packageJson.nyc !== undefined && pkg.packageJson.nyc !== null) {
 				if (pkg.packageJson.nyc["exclude-after-remap"] !== false) {
 					this.logWarn(pkg, `nyc.exclude-after-remap need to be false`, fix);
 					if (fix) {
@@ -954,8 +954,8 @@ export class FluidPackageCheck {
 			}
 			for (const depPackage of Object.keys(scriptDep)) {
 				if (
-					!pkg.packageJson.dependencies[depPackage] &&
-					!pkg.packageJson.devDependencies[depPackage]
+					!pkg.packageJson.dependencies?.[depPackage] &&
+					!pkg.packageJson.devDependencies?.[depPackage]
 				) {
 					this.logWarn(
 						pkg,

--- a/build-tools/packages/build-tools/src/fluidBuild/npmDepChecker.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/npmDepChecker.ts
@@ -45,7 +45,7 @@ export class NpmDepChecker {
 
 	constructor(private readonly pkg: Package, private readonly checkFiles: string[]) {
 		if (checkFiles.length !== 0) {
-			for (const name of Object.keys(pkg.packageJson.dependencies)) {
+			for (const name of Object.keys(pkg.packageJson.dependencies!)) {
 				if (this.ignored.indexOf(name) !== -1) {
 					continue;
 				}
@@ -107,13 +107,13 @@ export class NpmDepChecker {
 			} else if (!depCheckRecord.found) {
 				if (this.dev.indexOf(name) != -1) {
 					console.warn(`${this.pkg.nameColored}: warning: misplaced dependency ${name}`);
-					this.pkg.packageJson.devDependencies[name] =
-						this.pkg.packageJson.dependencies[name];
+					this.pkg.packageJson.devDependencies![name] =
+						this.pkg.packageJson.dependencies?.[name];
 				} else {
 					console.warn(`${this.pkg.nameColored}: warning: unused dependency ${name}`);
 				}
 				changed = true;
-				delete this.pkg.packageJson.dependencies[name];
+				delete this.pkg.packageJson.dependencies?.[name];
 			}
 		}
 		changed = this.depcheckTypes() || changed;

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/npmPackages.ts
@@ -493,16 +493,16 @@ export const handlers: Handler[] = [
 			const manifest = getFluidBuildConfig(root);
 			const tildeDependencies = getTildeDependencies(manifest);
 			if (dependencies !== undefined) {
-				for (const [dep, ver] of Object.entries(json.dependencies)) {
-					if (tildeDependencies.includes(dep) && !ver.startsWith("~")) {
+				for (const [dep, ver] of Object.entries(dependencies)) {
+					if (tildeDependencies.includes(dep) && !ver?.startsWith("~")) {
 						ret.push(`Dependencies on ${dep} must use tilde (~) dependencies.`);
 					}
 				}
 			}
 
 			if (devDependencies !== undefined) {
-				for (const [dep, ver] of Object.entries(json.devDependencies)) {
-					if (tildeDependencies.includes(dep) && !ver.startsWith("~")) {
+				for (const [dep, ver] of Object.entries(devDependencies)) {
+					if (tildeDependencies.includes(dep) && !ver?.startsWith("~")) {
 						ret.push(`devDependencies on ${dep} must use tilde (~) dependencies.`);
 					}
 				}
@@ -610,12 +610,12 @@ export const handlers: Handler[] = [
 						hasPrettierScriptResolver ||
 						hasPrettierFixScriptResolver
 					) {
-						const formatScript = json.scripts.format?.includes("lerna");
-						const prettierScript = json.scripts.prettier?.includes("--ignore-path");
+						const formatScript = json.scripts?.format?.includes("lerna");
+						const prettierScript = json.scripts?.prettier?.includes("--ignore-path");
 						const prettierFixScript =
-							json.scripts["prettier:fix"]?.includes("--ignore-path");
+							json.scripts?.["prettier:fix"]?.includes("--ignore-path");
 
-						if (!formatScript) {
+						if (json.scripts !== undefined && !formatScript) {
 							json.scripts.format = "npm run prettier:fix";
 
 							if (!prettierScript) {

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -249,6 +249,7 @@ importers:
       shelljs: ^0.8.4
       sort-package-json: 1.54.0
       ts-morph: ^17.0.1
+      type-fest: ^2.19.0
       typescript: ~4.5.5
       yaml: ^2.1.2
     dependencies:
@@ -279,6 +280,7 @@ importers:
       shelljs: 0.8.5
       sort-package-json: 1.54.0
       ts-morph: 17.0.1
+      type-fest: 2.19.0
       yaml: 2.1.2
     devDependencies:
       '@fluidframework/build-common': 1.1.0
@@ -521,21 +523,21 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/types': 7.19.3
+      '@babel/types': 7.21.4
     dev: true
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.3
+      '@babel/types': 7.21.4
     dev: true
 
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.3
+      '@babel/types': 7.21.4
     dev: true
 
   /@babel/helper-module-transforms/7.19.0:
@@ -558,18 +560,23 @@ packages:
     resolution: {integrity: sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.3
+      '@babel/types': 7.21.4
     dev: true
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.3
+      '@babel/types': 7.21.4
     dev: true
 
   /@babel/helper-string-parser/7.18.10:
     resolution: {integrity: sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-string-parser/7.19.4:
+    resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -649,6 +656,15 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.18.10
+      '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
+    dev: true
+
+  /@babel/types/7.21.4:
+    resolution: {integrity: sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
     dev: true
@@ -796,15 +812,15 @@ packages:
       '@commitlint/execute-rule': 17.4.0
       '@commitlint/resolve-extends': 17.4.4
       '@commitlint/types': 17.4.4
-      '@types/node': 18.15.3
+      '@types/node': 14.18.38
       chalk: 4.1.2
       cosmiconfig: 8.0.0
-      cosmiconfig-typescript-loader: 4.2.0_o5d5d5qrhzipaz5nmkhyrkswza
+      cosmiconfig-typescript-loader: 4.2.0_zo3euwvvvvu26bmxcgw7aumvsq
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1_cbfmry4sbbh4vatmdrsmatfg5a
+      ts-node: 10.9.1_kgu2r2x7tb2u27tq6ztvb54vzu
       typescript: 4.9.5
     transitivePeerDependencies:
       - '@swc/core'
@@ -2986,11 +3002,6 @@ packages:
   /@types/node/15.14.9:
     resolution: {integrity: sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==}
 
-  /@types/node/18.15.3:
-    resolution: {integrity: sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==}
-    dev: true
-    optional: true
-
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
 
@@ -3050,7 +3061,7 @@ packages:
     resolution: {integrity: sha512-4UqPv+2567NhMQuMLdKAyK4yzrfCqwaTt6bLhHEs8PFcxbHILsrxaY63n4wgE/BRLDWDQeI+WcTmkXKExh9hQg==}
     dependencies:
       '@types/expect': 1.20.4
-      '@types/node': 15.14.9
+      '@types/node': 14.18.38
 
   /@typescript-eslint/eslint-plugin/4.33.0_4m7ogdpa3eknlttnvur5iofgmi:
     resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==}
@@ -4901,7 +4912,7 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /cosmiconfig-typescript-loader/4.2.0_o5d5d5qrhzipaz5nmkhyrkswza:
+  /cosmiconfig-typescript-loader/4.2.0_zo3euwvvvvu26bmxcgw7aumvsq:
     resolution: {integrity: sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -4910,9 +4921,9 @@ packages:
       ts-node: '>=10'
       typescript: '>=3'
     dependencies:
-      '@types/node': 18.15.3
+      '@types/node': 14.18.38
       cosmiconfig: 8.0.0
-      ts-node: 10.9.1_cbfmry4sbbh4vatmdrsmatfg5a
+      ts-node: 10.9.1_kgu2r2x7tb2u27tq6ztvb54vzu
       typescript: 4.9.5
     dev: true
     optional: true
@@ -6750,7 +6761,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.5
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
@@ -11218,38 +11229,6 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
-
-  /ts-node/10.9.1_cbfmry4sbbh4vatmdrsmatfg5a:
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 18.15.3
-      acorn: 8.8.0
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
-    optional: true
 
   /ts-node/10.9.1_kgu2r2x7tb2u27tq6ztvb54vzu:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}

--- a/build-tools/pnpm-workspace.yaml
+++ b/build-tools/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
 packages:
-  - "packages/*"
+  - "packages/**"

--- a/build-tools/pnpm-workspace.yaml
+++ b/build-tools/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
 packages:
-  - "packages/**"
+  - "packages/*"


### PR DESCRIPTION
I noticed that we lacked some type safety around our package.json types, so I updated the PackageJson type we use throughout build-tools to extend the PackageJson type from [type-fest](https://github.com/sindresorhus/type-fest/blob/main/source/package-json.d.ts). This gets us a bit better type safety and some better uses of TypeScript types like Record.