### PR TITLE
ReferenceSequenceNumberMismatch errors

### DIFF
--- a/experimental/dds/tree/src/test/utilities/TestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/TestUtilities.ts
@@ -352,7 +352,10 @@ export async function setUpLocalServerTestSharedTree(
 
 		return provider.createLoader([[defaultCodeDetails, fluidEntryPoint]], {
 			options: { maxClientLeaveWaitTime: 1000 },
-			configProvider: configProvider({ 'Fluid.Container.enableOfflineLoad': true }),
+			configProvider: configProvider({
+				'Fluid.Container.enableOfflineLoad': true,
+				'Fluid.ContainerRuntime.DisablePartialFlush': true,
+			}),
 		});
 	}
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1278,6 +1278,7 @@ export class ContainerRuntime
 			},
 			logger: this.mc.logger,
 			groupingManager: opGroupingManager,
+			getProcessedClientSequenceNumber: () => this._processedClientSequenceNumber,
 		});
 
 		this.context.quorum.on("removeMember", (clientId: string) => {
@@ -1847,6 +1848,8 @@ export class ContainerRuntime
 		}
 	}
 
+	private _processedClientSequenceNumber: number | undefined;
+
 	private processCore(
 		message: ISequencedDocumentMessage,
 		local: boolean,
@@ -1856,6 +1859,8 @@ export class ContainerRuntime
 		// the beginning and end. This allows it to emit appropriate events and/or pause the processing of new
 		// messages once a batch has been fully processed.
 		this.scheduleManager.beforeOpProcessing(message);
+
+		this._processedClientSequenceNumber = message.clientSequenceNumber;
 
 		try {
 			let localOpMetadata: unknown;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1278,7 +1278,10 @@ export class ContainerRuntime
 			},
 			logger: this.mc.logger,
 			groupingManager: opGroupingManager,
-			getProcessedClientSequenceNumber: () => this._processedClientSequenceNumber,
+			getCurrentSequenceNumbers: () => ({
+				referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
+				clientSequenceNumber: this._processedClientSequenceNumber,
+			}),
 		});
 
 		this.context.quorum.on("removeMember", (clientId: string) => {

--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -38,9 +38,11 @@ export class BatchManager {
 			: this.pendingBatch[this.pendingBatch.length - 1].referenceSequenceNumber;
 	}
 
+	public clientSequenceNumber: number | undefined;
+
 	constructor(public readonly options: IBatchManagerOptions) {}
 
-	public push(message: BatchMessage): boolean {
+	public push(message: BatchMessage, currentClientSequenceNumber?: number): boolean {
 		const contentSize = this.batchContentSize + (message.contents?.length ?? 0);
 		const opCount = this.pendingBatch.length;
 
@@ -68,6 +70,10 @@ export class BatchManager {
 			return false;
 		}
 
+		if (this.pendingBatch.length === 0) {
+			this.clientSequenceNumber = currentClientSequenceNumber;
+		}
+
 		this.batchContentSize = contentSize;
 		this.pendingBatch.push(message);
 		return true;
@@ -86,6 +92,7 @@ export class BatchManager {
 
 		this.pendingBatch = [];
 		this.batchContentSize = 0;
+		this.clientSequenceNumber = undefined;
 
 		return addBatchMetadata(batch);
 	}

--- a/packages/runtime/container-runtime/src/opLifecycle/index.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export { BatchManager, estimateSocketSize } from "./batchManager";
+export { BatchManager, estimateSocketSize, BatchSequenceNumbers } from "./batchManager";
 export {
 	BatchMessage,
 	IBatch,

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -101,6 +101,10 @@ export class Outbox {
 		}
 
 		if (++this.mismatchedOpsReported <= this.maxMismatchedOpsToReport) {
+			// Increase the stack trace limit temporarily, so as to debug better in case it occurs.
+			const originalStackTraceLimit = (Error as any).stackTraceLimit;
+			(Error as any).stackTraceLimit = 50;
+
 			this.mc.logger.sendTelemetryEvent(
 				{
 					category: this.params.config.disablePartialFlush ? "error" : "generic",
@@ -111,6 +115,8 @@ export class Outbox {
 				},
 				new UsageError("Submission of an out of order message"),
 			);
+
+			(Error as any).stackTraceLimit = originalStackTraceLimit;
 		}
 
 		if (!this.params.config.disablePartialFlush) {

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -101,8 +101,9 @@ export class Outbox {
 		}
 
 		if (++this.mismatchedOpsReported <= this.maxMismatchedOpsToReport) {
-			this.mc.logger.sendErrorEvent(
+			this.mc.logger.sendTelemetryEvent(
 				{
+					category: this.params.config.disablePartialFlush ? "error" : "generic",
 					eventName: "ReferenceSequenceNumberMismatch",
 					mainReferenceSequenceNumber: mainBatchReference,
 					attachReferenceSequenceNumber: attachFlowBatchReference,

--- a/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
@@ -174,7 +174,7 @@ describe("BatchManager", () => {
 		assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 1 }), true);
 		assert.equal(batchManager.push({ ...smallMessage(), referenceSequenceNumber: 2 }), true);
 
-		assert.equal(batchManager.referenceSequenceNumber, 2);
+		assert.equal(batchManager.sequenceNumbers.referenceSequenceNumber, 2);
 	});
 
 	it("Batch size estimates", () => {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -201,6 +201,7 @@ describe("Outbox", () => {
 			},
 			logger: mockLogger,
 			groupingManager: new OpGroupingManager(false),
+			getProcessedClientSequenceNumber: () => undefined,
 		});
 
 	beforeEach(() => {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -690,7 +690,6 @@ describe("Outbox", () => {
 		mockLogger.assertMatch([
 			{
 				eventName: "Outbox:ReferenceSequenceNumberMismatch",
-				category: "error",
 			},
 		]);
 	});
@@ -746,7 +745,6 @@ describe("Outbox", () => {
 			mockLogger.assertMatch([
 				{
 					eventName: "Outbox:ReferenceSequenceNumberMismatch",
-					category: "error",
 				},
 			]);
 		});
@@ -795,7 +793,6 @@ describe("Outbox", () => {
 		mockLogger.assertMatch([
 			{
 				eventName: "Outbox:ReferenceSequenceNumberMismatch",
-				category: "error",
 			},
 		]);
 	});
@@ -817,7 +814,6 @@ describe("Outbox", () => {
 		mockLogger.assertMatch(
 			new Array(3).fill({
 				eventName: "Outbox:ReferenceSequenceNumberMismatch",
-				category: "error",
 			}),
 		);
 	});


### PR DESCRIPTION
# [AB#4004](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4004)

[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

Downgrade `"ReferenceSequenceNumberMismatch"` event to `"generic"` when we don't flush on a reference sequence number mismatch.
Also, increase the stack limit to help determine where these ops are coming from.