### PR TITLE
Remove server upload time from BlobManager

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -246,7 +246,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 				this.mc.logger.sendTelemetryEvent({
 					eventName: "sendBlobAttach",
 					entryStatus: pendingEntry.status,
-					timeSinceUpload: secondsSinceUpload,
+					secondsSinceUpload,
 					minTTLInSeconds: pendingEntry.minTTLInSeconds,
 					expired,
 				});

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1228,7 +1228,6 @@ export class ContainerRuntime
 			(blobPath: string) => this.garbageCollector.isNodeDeleted(blobPath),
 			this,
 			pendingRuntimeState?.pendingAttachmentBlobs,
-			() => this.getCurrentReferenceTimestampMs(),
 		);
 
 		this.scheduleManager = new ScheduleManager(

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -76,7 +76,6 @@ class MockRuntime
 			(blobPath: string) => this.isBlobDeleted(blobPath),
 			this,
 			undefined,
-			() => undefined,
 		);
 	}
 


### PR DESCRIPTION
Splitting https://github.com/microsoft/FluidFramework/pull/15066 into 2 PRs. This one will only remove server time calculation from blobManager. I simplified some code for logging as well. 
A following PR will have the remaning changes regarding expired blobs