### PR TITLE
SharedTree: External Delta PathVisitor API  

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -33,6 +33,7 @@ export interface AnchorEvents {
     childrenChanging(anchor: AnchorNode): void;
     subtreeChanging(anchor: AnchorNode): void;
     valueChanging(anchor: AnchorNode, value: Value): void;
+    visitSubtreeChanging(anchor: AnchorNode): PathVisitor;
 }
 
 // @alpha (undocumented)
@@ -1183,6 +1184,16 @@ export interface PathRootPrefix {
     indexOffset?: number;
     parent?: UpPath | undefined;
     rootFieldOverride?: FieldKey;
+}
+
+// @alpha
+export interface PathVisitor {
+    // (undocumented)
+    onDelete(path: FieldUpPath, index: number, count: number): void;
+    // (undocumented)
+    onInsert(path: FieldUpPath, index: number, content: readonly Delta.ProtoNode[]): void;
+    // (undocumented)
+    onSetValue(path: UpPath, field: FieldKey | undefined, value: Value): void;
 }
 
 // @alpha

--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -306,6 +306,7 @@ declare namespace Delta {
     export {
         Root,
         ProtoNode,
+        ProtoNodes,
         Mark,
         MarkList,
         Skip,
@@ -1188,12 +1189,11 @@ export interface PathRootPrefix {
 
 // @alpha
 export interface PathVisitor {
-    // (undocumented)
     onDelete(path: UpPath, count: number): void;
     // (undocumented)
-    onInsert(path: UpPath, content: readonly Delta.ProtoNode[]): void;
+    onInsert(path: UpPath, content: Delta.ProtoNodes): void;
     // (undocumented)
-    onSetValue(path: UpPath, field: FieldKey | undefined, value: Value): void;
+    onSetValue(path: UpPath, value: Value): void;
 }
 
 // @alpha
@@ -1231,6 +1231,9 @@ export abstract class ProgressiveEditBuilderBase<TChange> implements Progressive
 
 // @alpha
 type ProtoNode = ITreeCursorSynchronous;
+
+// @alpha
+type ProtoNodes = readonly ProtoNode[];
 
 // @alpha
 export const proxyTargetSymbol: unique symbol;

--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -1189,9 +1189,9 @@ export interface PathRootPrefix {
 // @alpha
 export interface PathVisitor {
     // (undocumented)
-    onDelete(path: FieldUpPath, index: number, count: number): void;
+    onDelete(path: UpPath, count: number): void;
     // (undocumented)
-    onInsert(path: FieldUpPath, index: number, content: readonly Delta.ProtoNode[]): void;
+    onInsert(path: UpPath, content: readonly Delta.ProtoNode[]): void;
     // (undocumented)
     onSetValue(path: UpPath, field: FieldKey | undefined, value: Value): void;
 }

--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -64,6 +64,7 @@ export {
 	setGenericTreeField,
 	rootFieldKeySymbol,
 	DeltaVisitor,
+	PathVisitor,
 	SparseNode,
 	getDescendant,
 	compareUpPaths,

--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -580,16 +580,17 @@ export class AnchorSet implements ISubscribable<AnchorSetRootEvents> {
 				assert(parentField !== undefined, 0x3a7 /* Must be in a field to delete */);
 				maybeWithNode(
 					(p) => {
-						assert(parentField !== undefined, 0x3a7 /* Must be in a field to delete */);
 						p.events.emit("childrenChanging", p);
-						const parentFieldPath: FieldUpPath = {
-							parent: p,
-							field: parentField,
-						};
-						for (const [, visitors] of pathVisitors) {
-							visitors.forEach(({ onDelete: visitorOnDelete }) => {
-								visitorOnDelete(parentFieldPath, start, count);
-							});
+						if (parentField !== undefined) {
+							const parentFieldPath: FieldUpPath = {
+								parent: p,
+								field: parentField,
+							};
+							for (const [, visitors] of pathVisitors) {
+								visitors.forEach(({ onDelete: visitorOnDelete }) => {
+									visitorOnDelete(parentFieldPath, start, count);
+								});
+							}
 						}
 					},
 					() => this.events.emit("childrenChanging", this),
@@ -600,16 +601,17 @@ export class AnchorSet implements ISubscribable<AnchorSetRootEvents> {
 				assert(parentField !== undefined, 0x3a8 /* Must be in a field to insert */);
 				maybeWithNode(
 					(p) => {
-						assert(parentField !== undefined, 0x3a8 /* Must be in a field to insert */);
 						p.events.emit("childrenChanging", p);
-						const parentFieldPath: FieldUpPath = {
-							parent: p,
-							field: parentField,
-						};
-						for (const [, visitors] of pathVisitors) {
-							visitors.forEach(({ onInsert: visitorOnInsert }) => {
-								visitorOnInsert(parentFieldPath, start, content);
-							});
+						if (parentField !== undefined) {
+							const parentFieldPath: FieldUpPath = {
+								parent: p,
+								field: parentField,
+							};
+							for (const [, visitors] of pathVisitors) {
+								visitors.forEach(({ onInsert: visitorOnInsert }) => {
+									visitorOnInsert(parentFieldPath, start, content);
+								});
+							}
 						}
 					},
 					() => this.events.emit("childrenChanging", this),

--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -573,9 +573,9 @@ export class AnchorSet implements ISubscribable<AnchorSetRootEvents> {
 			}
 		};
 
-		 // Lookup table for path visitors collected from {@link AnchorEvents.visitSubtreeChanging} emitted events.
-		 // The key is the path of the node that the visitor is registered on. The code ensures that the path visitor visits only the appropriate subtrees
-		 // by maintaining the mapping only during time between the {@link DeltaVisitor.enterNode} and {@link DeltaVisitor.exitNode} calls for a given anchorNode.
+		// Lookup table for path visitors collected from {@link AnchorEvents.visitSubtreeChanging} emitted events.
+		// The key is the path of the node that the visitor is registered on. The code ensures that the path visitor visits only the appropriate subtrees
+		// by maintaining the mapping only during time between the {@link DeltaVisitor.enterNode} and {@link DeltaVisitor.exitNode} calls for a given anchorNode.
 		const pathVisitors: Map<PathNode, PathVisitor[]> = new Map();
 
 		const visitor: DeltaVisitor = {

--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -7,7 +7,7 @@ import { assert } from "@fluidframework/common-utils";
 import { createEmitter, ISubscribable } from "../../events";
 import { brand, Brand, fail, Invariant, Opaque, ReferenceCountedBase } from "../../util";
 import { FieldKey, EmptyKey, Delta, visitDelta, DeltaVisitor } from "../tree";
-import { FieldUpPath, UpPath } from "./pathTree";
+import { UpPath } from "./pathTree";
 import { Value } from "./types";
 import { PathVisitor } from "./visithPath";
 
@@ -582,13 +582,14 @@ export class AnchorSet implements ISubscribable<AnchorSetRootEvents> {
 					(p) => {
 						p.events.emit("childrenChanging", p);
 						if (parentField !== undefined) {
-							const parentFieldPath: FieldUpPath = {
+							const upPath: UpPath = {
 								parent: p,
-								field: parentField,
+								parentField,
+								parentIndex: start,
 							};
 							for (const [, visitors] of pathVisitors) {
 								visitors.forEach(({ onDelete: visitorOnDelete }) => {
-									visitorOnDelete(parentFieldPath, start, count);
+									visitorOnDelete(upPath, count);
 								});
 							}
 						}
@@ -603,13 +604,14 @@ export class AnchorSet implements ISubscribable<AnchorSetRootEvents> {
 					(p) => {
 						p.events.emit("childrenChanging", p);
 						if (parentField !== undefined) {
-							const parentFieldPath: FieldUpPath = {
+							const upPath: UpPath = {
 								parent: p,
-								field: parentField,
+								parentField,
+								parentIndex: start,
 							};
 							for (const [, visitors] of pathVisitors) {
 								visitors.forEach(({ onInsert: visitorOnInsert }) => {
-									visitorOnInsert(parentFieldPath, start, content);
+									visitorOnInsert(upPath, content);
 								});
 							}
 						}

--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -573,11 +573,9 @@ export class AnchorSet implements ISubscribable<AnchorSetRootEvents> {
 			}
 		};
 
-		/**
-		 * Lookup table for path visitors collected from {@link AnchorEvents.visitSubtreeChanging} emitted events.
-		 * The key is the path of the node that the visitor is registered on. The code ensures that the path visitor visits only the appropriate subtrees
-		 * by maintaining the mapping only during time between the {@link DeltaVisitor.enterNode} and {@link DeltaVisitor.exitNode} calls for a given anchorNode.
-		 */
+		 // Lookup table for path visitors collected from {@link AnchorEvents.visitSubtreeChanging} emitted events.
+		 // The key is the path of the node that the visitor is registered on. The code ensures that the path visitor visits only the appropriate subtrees
+		 // by maintaining the mapping only during time between the {@link DeltaVisitor.enterNode} and {@link DeltaVisitor.exitNode} calls for a given anchorNode.
 		const pathVisitors: Map<PathNode, PathVisitor[]> = new Map();
 
 		const visitor: DeltaVisitor = {
@@ -671,8 +669,8 @@ export class AnchorSet implements ISubscribable<AnchorSetRootEvents> {
 			exitNode: (index: number): void => {
 				assert(parent !== undefined, 0x3ac /* Must have parent node */);
 				maybeWithNode((p) => {
-					// check for clarity
-					if (pathVisitors.has(p)) pathVisitors.delete(p);
+					// Remove subtree path visitors added at this node if there are any
+					pathVisitors.delete(p);
 				});
 				parentField = parent.parentField;
 				parent = parent.parent;

--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -573,6 +573,11 @@ export class AnchorSet implements ISubscribable<AnchorSetRootEvents> {
 			}
 		};
 
+		/**
+		 * Lookup table for path visitors collected from {@link AnchorEvents.visitSubtreeChanging} emitted events.
+		 * The key is the path of the node that the visitor is registered on. The code ensures that the path visitor visits only the appropriate subtrees
+		 * by maintaining the mapping only during time between the {@link DeltaVisitor.enterNode} and {@link DeltaVisitor.exitNode} calls for a given anchorNode.
+		 */
 		const pathVisitors: Map<PathNode, PathVisitor[]> = new Map();
 
 		const visitor: DeltaVisitor = {

--- a/packages/dds/tree/src/core/tree/delta.ts
+++ b/packages/dds/tree/src/core/tree/delta.ts
@@ -134,9 +134,26 @@ export type Root<TTree = ProtoNode> = FieldMarks<TTree>;
 
 /**
  * The default representation for inserted content.
+ *
+ * TODO:
+ * Ownership and lifetime of data referenced by this cursor is unclear,
+ * so it is a poor abstraction for this use-case which needs to hold onto the data in a non-exclusive (readonly) way.
+ * Cursors can be one supported way to input data, but aren't a good storage format.
  * @alpha
  */
 export type ProtoNode = ITreeCursorSynchronous;
+
+/**
+ * The default representation a chunk (sub-sequence) of inserted content.
+ *
+ * TODO:
+ * See issue TODO with ProtoNode.
+ * Additionally, Cursors support sequences, so if using cursors, there are better ways to handle this than an array of cursors,
+ * like using a cursor over all the content (starting in fields mode).
+ * Long term something like TreeChunk should probably be used here.
+ * @alpha
+ */
+export type ProtoNodes = readonly ProtoNode[];
 
 /**
  * Represents a change being made to a part of the tree.

--- a/packages/dds/tree/src/core/tree/index.ts
+++ b/packages/dds/tree/src/core/tree/index.ts
@@ -78,6 +78,7 @@ export {
 	isLocalKey,
 } from "./types";
 export { DeltaVisitor, visitDelta } from "./visitDelta";
+export { PathVisitor } from "./visithPath";
 
 // Split this up into separate import and export for compatibility with API-Extractor.
 import * as Delta from "./delta";

--- a/packages/dds/tree/src/core/tree/visitDelta.ts
+++ b/packages/dds/tree/src/core/tree/visitDelta.ts
@@ -84,7 +84,7 @@ export function visitDelta(delta: Delta.Root, visitor: DeltaVisitor): void {
 
 export interface DeltaVisitor {
 	onDelete(index: number, count: number): void;
-	onInsert(index: number, content: readonly Delta.ProtoNode[]): void;
+	onInsert(index: number, content: Delta.ProtoNodes): void;
 	onMoveOut(index: number, count: number, id: Delta.MoveId): void;
 	onMoveIn(index: number, count: number, id: Delta.MoveId): void;
 	onSetValue(value: Value): void;

--- a/packages/dds/tree/src/core/tree/visithPath.ts
+++ b/packages/dds/tree/src/core/tree/visithPath.ts
@@ -2,9 +2,8 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-
-import { FieldUpPath, UpPath } from "./pathTree";
 import * as Delta from "./delta";
+import { UpPath } from "./pathTree";
 import { FieldKey, Value } from "./types";
 
 /**
@@ -14,7 +13,7 @@ import { FieldKey, Value } from "./types";
  * @alpha
  */
 export interface PathVisitor {
-	onDelete(path: FieldUpPath, index: number, count: number): void;
-	onInsert(path: FieldUpPath, index: number, content: readonly Delta.ProtoNode[]): void;
+	onDelete(path: UpPath, count: number): void;
+	onInsert(path: UpPath, content: readonly Delta.ProtoNode[]): void;
 	onSetValue(path: UpPath, field: FieldKey | undefined, value: Value): void;
 }

--- a/packages/dds/tree/src/core/tree/visithPath.ts
+++ b/packages/dds/tree/src/core/tree/visithPath.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { FieldUpPath, UpPath } from "./pathTree";
+import * as Delta from "./delta";
+import { FieldKey, Value } from "./types";
+
+/**
+ * Delta visitor for the path tree.
+ *
+ * TODO: additional callbacks
+ * @alpha
+ */
+export interface PathVisitor {
+	onDelete(path: FieldUpPath, index: number, count: number): void;
+	onInsert(path: FieldUpPath, index: number, content: readonly Delta.ProtoNode[]): void;
+	onSetValue(path: UpPath, field: FieldKey | undefined, value: Value): void;
+}

--- a/packages/dds/tree/src/core/tree/visithPath.ts
+++ b/packages/dds/tree/src/core/tree/visithPath.ts
@@ -4,7 +4,7 @@
  */
 import * as Delta from "./delta";
 import { UpPath } from "./pathTree";
-import { FieldKey, Value } from "./types";
+import { Value } from "./types";
 
 /**
  * Delta visitor for the path tree.
@@ -13,7 +13,22 @@ import { FieldKey, Value } from "./types";
  * @alpha
  */
 export interface PathVisitor {
+	/**
+	 * A sequence of nodes of length `count` is being deleted starting with `path`.
+	 * Called when these nodes are no longer parented under their previous parent, and do not have a new parent.
+	 * It is possible they may be un-deleted in the future (for example by a conflicted merge or undo).
+	 *
+	 * Not called for children of deleted nodes.
+	 *
+	 * @param path - first node in the deleted range.
+	 * @param count - length of deleted range.
+	 */
 	onDelete(path: UpPath, count: number): void;
-	onInsert(path: UpPath, content: readonly Delta.ProtoNode[]): void;
-	onSetValue(path: UpPath, field: FieldKey | undefined, value: Value): void;
+	/**
+	 * @param path - location which first node of inserted range will have after insert.
+	 * Any nodes at this index (or after it) will be moved to the right (have their indexes increased by `content.length`).
+	 * @param content - content which is being inserted.
+	 */
+	onInsert(path: UpPath, content: Delta.ProtoNodes): void;
+	onSetValue(path: UpPath, value: Value): void;
 }

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -120,7 +120,7 @@ class ChunkedForest extends SimpleDependee implements IEditableForest {
 			onDelete: (index: number, count: number): void => {
 				visitor.onMoveOut(index, count);
 			},
-			onInsert: (index: number, content: Delta.ProtoNode[]): void => {
+			onInsert: (index: number, content: Delta.ProtoNodes): void => {
 				const chunks: TreeChunk[] = content.map((c) => chunkTree(c, this.chunker));
 				const field = this.newDetachedField();
 				this.roots.fields.set(detachedFieldAsKey(field), chunks);

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -93,6 +93,7 @@ export {
 	AnchorSetRootEvents,
 	FieldKindSpecifier,
 	AllowedUpdateType,
+	PathVisitor,
 } from "./core";
 
 export {

--- a/packages/dds/tree/src/test/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/tree/anchorSet.spec.ts
@@ -309,12 +309,12 @@ describe("AnchorSet", () => {
 					}-${count}`,
 				)();
 			},
-			onInsert(path: UpPath, content: readonly Delta.ProtoNode[]): void {
+			onInsert(path: UpPath, content: Delta.ProtoNodes): void {
 				log.logger(
 					`visitSubtreeChange.onInsert-${String(path.parentField)}-${path.parentIndex}`,
 				)();
 			},
-			onSetValue(path: UpPath, field: FieldKey, value: Value): void {
+			onSetValue(path: UpPath, value: Value): void {
 				log.logger(`visitSubtreeChange.onSetValue-${value}`)();
 			},
 		};

--- a/packages/dds/tree/src/test/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/tree/anchorSet.spec.ts
@@ -11,7 +11,6 @@ import {
 	AnchorSet,
 	Delta,
 	FieldKey,
-	FieldUpPath,
 	JsonableTree,
 	PathVisitor,
 	UpPath,
@@ -303,11 +302,17 @@ describe("AnchorSet", () => {
 		const anchor0 = anchors.track(makePath([rootFieldKeySymbol, 0]));
 		const node0 = anchors.locate(anchor0) ?? assert.fail();
 		const pathVisitor: PathVisitor = {
-			onDelete(path: FieldUpPath, index: number, count: number): void {
-				log.logger(`visitSubtreeChange.onDelete-${String(path.field)}-${index}-${count}`)();
+			onDelete(path: UpPath, count: number): void {
+				log.logger(
+					`visitSubtreeChange.onDelete-${String(path.parentField)}-${
+						path.parentIndex
+					}-${count}`,
+				)();
 			},
-			onInsert(path: FieldUpPath, index: number, content: readonly Delta.ProtoNode[]): void {
-				log.logger(`visitSubtreeChange.onInsert-${String(path.field)}-${index}`)();
+			onInsert(path: UpPath, content: readonly Delta.ProtoNode[]): void {
+				log.logger(
+					`visitSubtreeChange.onInsert-${String(path.parentField)}-${path.parentIndex}`,
+				)();
 			},
 			onSetValue(path: UpPath, field: FieldKey, value: Value): void {
 				log.logger(`visitSubtreeChange.onSetValue-${value}`)();


### PR DESCRIPTION
## Description

Incremental `SharedTree` enhancement providing support to a future [DataBinder](https://github.com/microsoft/FluidFramework/issues/14293) API.

This PR adopts newly released [emit & collect eventing ](https://github.com/microsoft/FluidFramework/pull/14931) functionality in the context of `AnchorSet` and `AnchorEvents`.

Provides for review the basis of an alternative Delta `PathVisitor` API drawing from @DLehenbauer [proposal](https://github.com/microsoft/FluidFramework/issues/14293#issuecomment-1485928510).

## Breaking Changes

This change is backward compatible.

