### PR TITLE
 importing mocha-test-setup using file protocol in api-markdown-documenter

### DIFF
--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -68,6 +68,7 @@
 		"chalk": "^2.4.2"
 	},
 	"devDependencies": {
+		"@fluid-internal/mocha-test-setup": "file:../packages/test/mocha-test-setup",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.1",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",


### PR DESCRIPTION
Test to see if importing mocha-test-setup using the file protocol in api-markdown-documenter passes in CI
https://github.com/microsoft/FluidFramework/pull/15001