### PR TITLE
ci(build-tools): Use tilde interdependencies

### DIFF
--- a/scripts/update-package-version.sh
+++ b/scripts/update-package-version.sh
@@ -1,0 +1,21 @@
+echo SETVERSION_VERSION=$SETVERSION_VERSION
+echo SETVERSION_CODEVERSION=$SETVERSION_CODEVERSION
+echo RELEASE_GROUP=$RELEASE_GROUP
+echo INTERDEPENDENCY_RANGE="$INTERDEPENDENCY_RANGE"
+
+if [ -f "lerna.json" ]; then
+  if [ "$VERSION_RELEASE" = "release" ]; then
+    if [ "$INTERDEPENDENCY_RANGE" != " " ]; then
+      echo command="flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType=\"$INTERDEPENDENCY_RANGE\" -xv"
+      flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType="$INTERDEPENDENCY_RANGE" -xv
+    else
+      echo command="flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType=\"\" -xv"
+      flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType="$INTERDEPENDENCY_RANGE" -xv
+    fi
+  else
+    echo command="flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType=\"\" -xv"
+    flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType="" -xv
+  fi
+else
+  npm version $SETVERSION_VERSION --no-git-tag-version -f --allow-same-version
+fi

--- a/scripts/update-package-version.sh
+++ b/scripts/update-package-version.sh
@@ -10,15 +10,15 @@ echo INTERDEPENDENCY_RANGE="'$INTERDEPENDENCY_RANGE'"
 if [ -f "lerna.json" ]; then
   if [ "$VERSION_RELEASE" = "release" ]; then
     # this is a release build of a release group
-    if [ "$INTERDEPENDENCY_RANGE" != " " ]; then
+    # if [ "$INTERDEPENDENCY_RANGE" != " " ]; then
       # tilde or caret dependency ranges
       echo command="flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType=\"$INTERDEPENDENCY_RANGE\" -xv"
       flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType="$INTERDEPENDENCY_RANGE" -xv
-    else
-      # exact dependencies
-      echo command="flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType=\"\" -xv"
-      flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType="$INTERDEPENDENCY_RANGE" -xv
-    fi
+    # else
+    #   # exact dependencies
+    #   echo command="flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType=\"\" -xv"
+    #   flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType="$INTERDEPENDENCY_RANGE" -xv
+    # fi
   else
     # this is a dev/test build of a release group
     echo command="flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType=\"\" -xv"

--- a/scripts/update-package-version.sh
+++ b/scripts/update-package-version.sh
@@ -1,21 +1,30 @@
+# This script is used in the "update package versions" step in our CI build pipelines.
+# It takes version data from environment variables and updates the package versions accordingly.
+# The environment variables are set earlier in the pipeline, in the "set package version" step.
+
 echo SETVERSION_VERSION=$SETVERSION_VERSION
 echo SETVERSION_CODEVERSION=$SETVERSION_CODEVERSION
 echo RELEASE_GROUP=$RELEASE_GROUP
-echo INTERDEPENDENCY_RANGE="$INTERDEPENDENCY_RANGE"
+echo INTERDEPENDENCY_RANGE="'$INTERDEPENDENCY_RANGE'"
 
 if [ -f "lerna.json" ]; then
   if [ "$VERSION_RELEASE" = "release" ]; then
+    # this is a release build of a release group
     if [ "$INTERDEPENDENCY_RANGE" != " " ]; then
+      # tilde or caret dependency ranges
       echo command="flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType=\"$INTERDEPENDENCY_RANGE\" -xv"
       flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType="$INTERDEPENDENCY_RANGE" -xv
     else
+      # exact dependencies
       echo command="flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType=\"\" -xv"
       flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType="$INTERDEPENDENCY_RANGE" -xv
     fi
   else
+    # this is a dev/test build of a release group
     echo command="flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType=\"\" -xv"
     flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType="" -xv
   fi
 else
+  # this is an independent package
   npm version $SETVERSION_VERSION --no-git-tag-version -f --allow-same-version
 fi

--- a/scripts/update-package-version.sh
+++ b/scripts/update-package-version.sh
@@ -12,19 +12,24 @@ if [ -f "lerna.json" ]; then
     # this is a release build of a release group
     # if [ "$INTERDEPENDENCY_RANGE" != " " ]; then
       # tilde or caret dependency ranges
+      # echo "release group release build with tilde or caret deps"
+      echo "release group with '$INTERDEPENDENCY_RANGE' deps"
       echo command="flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType=\"$INTERDEPENDENCY_RANGE\" -xv"
       flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType="$INTERDEPENDENCY_RANGE" -xv
     # else
     #   # exact dependencies
+    #   echo "release group release build with exact deps"
     #   echo command="flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType=\"\" -xv"
     #   flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType="$INTERDEPENDENCY_RANGE" -xv
     # fi
   else
-    # this is a dev/test build of a release group
+    # this is a non-release build of a release group
+    echo "release group non-release build"
     echo command="flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType=\"\" -xv"
     flub bump $RELEASE_GROUP --exact $SETVERSION_VERSION --exactDepType="" -xv
   fi
 else
   # this is an independent package
+  echo "independent package"
   npm version $SETVERSION_VERSION --no-git-tag-version -f --allow-same-version
 fi

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -22,6 +22,14 @@ parameters:
     - default
     - skip
     - force
+- name: interdependencyRange
+  displayName: Range to use for interdependencies (only affects releases) (default = ~)
+  type: string
+  default: "~"
+  values:
+    - "^"
+    - "~"
+    - " "
 - name: buildToolsVersionToInstall
   displayName: Fluid build tools version (default = installs version in repo)
   type: string
@@ -65,6 +73,7 @@ extends:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
+    interdependencyRange: ${{ parameters.interdependencyRange }}
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm
     buildDirectory: build-tools

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -25,7 +25,7 @@ parameters:
 - name: interdependencyRange
   displayName: Range to use for interdependencies (only affects releases) (default = ~)
   type: string
-  default: "~"
+  default: " "
   values:
     - "^"
     - "~"

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -74,6 +74,12 @@ parameters:
   type: string
   default: 'npm ci --unsafe-perm'
 
+# The semver range constraint to use for interdependencies; that is, dependencies on other packages within the release
+# group
+- name: interdependencyRange
+  type: string
+  default: "^"
+
 # If true, then this pipeline will check and format package.json files according to prettier settings.
 - name: usesPrettier
   type: boolean
@@ -170,6 +176,7 @@ stages:
             componentDetection=${{ variables.componentDetection }}
             publish=${{ variables.publish }}
             canRelease=${{ variables.canRelease }}
+            interdependencyRange='${{ parameters.interdependencyRange }}'
 
             pushImage=${{ variables.pushImage }}
             releaseImage=${{ variables.releaseImage }}
@@ -261,6 +268,7 @@ stages:
           buildDirectory: ${{ parameters.buildDirectory }}
           buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
           buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
+          interdependencyRange: ${{ parameters.interdependencyRange }}
           tagName: ${{ parameters.tagName }}
           usesPrettier: ${{ parameters.usesPrettier }}
     - ${{ if eq(parameters.setVersion, false) }}:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -97,6 +97,12 @@ parameters:
   type: string
   default: 'npm ci --unsafe-perm'
 
+# The semver range constraint to use for interdependencies; that is, dependencies on other packages within the release
+# group
+- name: interdependencyRange
+  type: string
+  default: "^"
+
 # If true, then this pipeline will check and format package.json files according to prettier settings.
 - name: usesPrettier
   type: boolean
@@ -183,6 +189,7 @@ stages:
 
               Publish Parameters:
                 nonScopedPackages=${{ join(', ', parameters.nonScopedPackages) }}
+                interdependencyRange='${{ parameters.interdependencyRange }}'
 
               Computed variables:
                 shouldPublish=${{ variables.shouldPublish }}
@@ -278,6 +285,7 @@ stages:
               buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
               buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
               tagName: ${{ parameters.tagName }}
+              interdependencyRange: ${{ parameters.interdependencyRange }}
               usesPrettier: ${{ parameters.usesPrettier }}
 
         # Build

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -21,6 +21,11 @@ parameters:
   type: boolean
   default: true
 
+# The semver range constraint to use for interdependencies; that is, dependencies on other packages within the release
+# group
+- name: interdependencyRange
+  type: string
+
 # Set version
 steps:
 - ${{ if eq(parameters.buildToolsVersionToInstall, 'repo') }}:
@@ -115,25 +120,11 @@ steps:
   env:
     VERSION_RELEASE: $(release)
     RELEASE_GROUP: ${{ parameters.tagName }}
+    INTERDEPENDENCY_RANGE: ${{ parameters.interdependencyRange }}
   inputs:
-    targetType: 'inline'
+    targetType: 'filePath'
     workingDirectory: ${{ parameters.buildDirectory }}
-    script: |
-      echo SETVERSION_VERSION=$SETVERSION_VERSION
-      echo SETVERSION_CODEVERSION=$SETVERSION_CODEVERSION
-      echo RELEASE_GROUP=$RELEASE_GROUP
-
-      if [ -f "lerna.json" ]; then
-        if [ "$VERSION_RELEASE" = "release" ]; then
-          echo command="flub bump $RELEASE_GROUP --exact $(SetVersion.version) --exactDepType=\"^\" -xv"
-          flub bump $RELEASE_GROUP --exact $(SetVersion.version) --exactDepType="^" -xv
-        else
-          echo command="flub bump $RELEASE_GROUP --exact $(SetVersion.version) --exactDepType=\"\" -xv"
-          flub bump $RELEASE_GROUP --exact $(SetVersion.version) --exactDepType="" -xv
-        fi
-      else
-        npm version $(SetVersion.version) --no-git-tag-version -f --allow-same-version
-      fi
+    filePath: $(Build.SourcesDirectory)/scripts/update-package-version.sh
 
 - ${{ if eq(parameters.usesPrettier, true) }}:
   # package.json files are reformatted by the prior set version steps, so reformat them (and only them) with prettier


### PR DESCRIPTION
I've updated the build-tools release group pipeline to use `~` interdependency ranges by default. It's overridable at build-time in the ADO UI.

I also moved the "update package versions" inline script into a file because it ensures that _any_ non-0 exit code from within the script causes the step to fail. This will make debugging easier by causing a failure in the actual step that failed.