### PR TITLE
R11s: allow additional axios config in restwrapper

### DIFF
--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -538,19 +538,19 @@ export abstract class RestWrapper {
     // (undocumented)
     protected defaultQueryString: Record<string, unknown>;
     // (undocumented)
-    delete<T>(url: string, queryString?: Record<string, unknown>, headers?: AxiosRequestHeaders): Promise<T>;
+    delete<T>(url: string, queryString?: Record<string, unknown>, headers?: AxiosRequestHeaders, additionalOptions?: Partial<Omit<AxiosRequestConfig, "baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url">>): Promise<T>;
     // (undocumented)
     protected generateQueryString(queryStringValues: Record<string, unknown>): string;
     // (undocumented)
-    get<T>(url: string, queryString?: Record<string, unknown>, headers?: AxiosRequestHeaders): Promise<T>;
+    get<T>(url: string, queryString?: Record<string, unknown>, headers?: AxiosRequestHeaders, additionalOptions?: Partial<Omit<AxiosRequestConfig, "baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url">>): Promise<T>;
     // (undocumented)
     protected readonly maxBodyLength: number;
     // (undocumented)
     protected readonly maxContentLength: number;
     // (undocumented)
-    patch<T>(url: string, requestBody: any, queryString?: Record<string, unknown>, headers?: AxiosRequestHeaders): Promise<T>;
+    patch<T>(url: string, requestBody: any, queryString?: Record<string, unknown>, headers?: AxiosRequestHeaders, additionalOptions?: Partial<Omit<AxiosRequestConfig, "baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url">>): Promise<T>;
     // (undocumented)
-    post<T>(url: string, requestBody: any, queryString?: Record<string, unknown>, headers?: AxiosRequestHeaders): Promise<T>;
+    post<T>(url: string, requestBody: any, queryString?: Record<string, unknown>, headers?: AxiosRequestHeaders, additionalOptions?: Partial<Omit<AxiosRequestConfig, "baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url">>): Promise<T>;
     // (undocumented)
     protected abstract request<T>(options: AxiosRequestConfig, statusCode: number): Promise<T>;
 }

--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -23,8 +23,10 @@ export abstract class RestWrapper {
 		url: string,
 		queryString?: Record<string, unknown>,
 		headers?: AxiosRequestHeaders,
+        additionalOptions?: Partial<Omit<AxiosRequestConfig, "baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url">>,
 	): Promise<T> {
 		const options: AxiosRequestConfig = {
+            ...additionalOptions,
 			baseURL: this.baseurl,
 			headers,
 			maxBodyLength: this.maxBodyLength,
@@ -40,8 +42,10 @@ export abstract class RestWrapper {
 		requestBody: any,
 		queryString?: Record<string, unknown>,
 		headers?: AxiosRequestHeaders,
+        additionalOptions?: Partial<Omit<AxiosRequestConfig, "baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url">>,
 	): Promise<T> {
 		const options: AxiosRequestConfig = {
+            ...additionalOptions,
 			baseURL: this.baseurl,
 			data: requestBody,
 			headers,
@@ -57,8 +61,10 @@ export abstract class RestWrapper {
 		url: string,
 		queryString?: Record<string, unknown>,
 		headers?: AxiosRequestHeaders,
+        additionalOptions?: Partial<Omit<AxiosRequestConfig, "baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url">>,
 	): Promise<T> {
 		const options: AxiosRequestConfig = {
+            ...additionalOptions,
 			baseURL: this.baseurl,
 			headers,
 			maxBodyLength: this.maxBodyLength,
@@ -74,8 +80,10 @@ export abstract class RestWrapper {
 		requestBody: any,
 		queryString?: Record<string, unknown>,
 		headers?: AxiosRequestHeaders,
+        additionalOptions?: Partial<Omit<AxiosRequestConfig, "baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url">>,
 	): Promise<T> {
 		const options: AxiosRequestConfig = {
+            ...additionalOptions,
 			baseURL: this.baseurl,
 			data: requestBody,
 			headers,


### PR DESCRIPTION
## Description

It would be useful to be able to pass in additional Axios request configs to RestWrapper, such as `signal` or `cancelToken`
