### PR TITLE
RunningSummarizer will listen to DeltaManager for non-runtime ops

### DIFF
--- a/api-report/container-runtime.api.md
+++ b/api-report/container-runtime.api.md
@@ -645,7 +645,7 @@ export type SubmitSummaryResult = IBaseSummarizeResult | IGenerateSummaryTreeRes
 export class Summarizer extends EventEmitter implements ISummarizer {
     constructor(
     runtime: ISummarizerRuntime, configurationGetter: () => ISummaryConfiguration,
-    internalsProvider: ISummarizerInternalsProvider, handleContext: IFluidHandleContext, summaryCollection: SummaryCollection, runCoordinatorCreateFn: (runtime: IConnectableRuntime) => Promise<ICancellableSummarizerController>, listenToDeltaManagerOps?: boolean);
+    internalsProvider: ISummarizerInternalsProvider, handleContext: IFluidHandleContext, summaryCollection: SummaryCollection, runCoordinatorCreateFn: (runtime: IConnectableRuntime) => Promise<ICancellableSummarizerController>);
     // (undocumented)
     close(): void;
     static create(loader: ILoader, url: string): Promise<ISummarizer>;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1328,7 +1328,6 @@ export class ContainerRuntime
 							// information. The proxy delta manager would always return false for summarizer client.
 							() => this.innerDeltaManager.active,
 						),
-					!this.groupedBatchingEnabled,
 				);
 			} else if (
 				SummarizerClientElection.clientDetailsPermitElection(this.context.clientDetails)

--- a/packages/runtime/container-runtime/src/summary/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizer.ts
@@ -87,7 +87,6 @@ export class Summarizer extends EventEmitter implements ISummarizer {
 		private readonly runCoordinatorCreateFn: (
 			runtime: IConnectableRuntime,
 		) => Promise<ICancellableSummarizerController>,
-		private readonly listenToDeltaManagerOps: boolean = true,
 	) {
 		super();
 		this.logger = ChildLogger.create(this.runtime.logger, "Summarizer");
@@ -268,7 +267,6 @@ export class Summarizer extends EventEmitter implements ISummarizer {
 			runCoordinator /* cancellationToken */,
 			(reason) => runCoordinator.stop(reason) /* stopSummarizerCallback */,
 			this.runtime,
-			this.listenToDeltaManagerOps,
 		);
 		this.runningSummarizer = runningSummarizer;
 		this.starting = false;

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import sinon from "sinon";
-import { Deferred } from "@fluidframework/common-utils";
+import { Deferred, TypedEventEmitter } from "@fluidframework/common-utils";
 import {
 	IDocumentMessage,
 	ISequencedDocumentMessage,
@@ -18,6 +18,8 @@ import {
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import { MockDeltaManager } from "@fluidframework/test-runtime-utils";
 import { IDeltaManager } from "@fluidframework/container-definitions";
+import { IContainerRuntimeEvents } from "@fluidframework/container-runtime-definitions";
+import { isRuntimeMessage } from "@fluidframework/driver-utils";
 import { ISummaryConfiguration } from "../../containerRuntime";
 import {
 	getFailMessage,
@@ -29,10 +31,12 @@ import {
 	ISummarizeHeuristicData,
 } from "../../summary";
 
-class MockRuntime {
+class MockRuntime extends TypedEventEmitter<IContainerRuntimeEvents> {
 	constructor(
 		public readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
-	) {}
+	) {
+		super();
+	}
 }
 
 describe("Runtime", () => {
@@ -94,6 +98,7 @@ describe("Runtime", () => {
 					type,
 				};
 				mockDeltaManager.emit("op", op);
+				mockRuntime.emit("op", op, isRuntimeMessage({ type }));
 				await flushPromises();
 			}
 
@@ -106,11 +111,12 @@ describe("Runtime", () => {
 					type: MessageType.NoOp,
 				};
 				mockDeltaManager.emit("op", op);
+				mockRuntime.emit("op", op, isRuntimeMessage({ type: MessageType.NoOp }));
 				await flushPromises();
 			}
 
 			function emitBroadcast(timestamp = Date.now()) {
-				mockDeltaManager.emit("op", {
+				const op = {
 					type: MessageType.Summarize,
 					clientId: summarizerClientId,
 					referenceSequenceNumber: lastRefSeq,
@@ -120,7 +126,9 @@ describe("Runtime", () => {
 						handle: "test-broadcast-handle",
 					},
 					timestamp,
-				});
+				};
+				mockDeltaManager.emit("op", op);
+				mockRuntime.emit("op", op, isRuntimeMessage(op));
 			}
 
 			async function emitAck() {
@@ -131,11 +139,13 @@ describe("Runtime", () => {
 					handle: "test-ack-handle",
 					summaryProposal,
 				};
-				mockDeltaManager.emit("op", {
+				const op = {
 					data: JSON.stringify(contents),
 					type: MessageType.SummaryAck,
 					sequenceNumber: ++lastRefSeq,
-				});
+				};
+				mockDeltaManager.emit("op", op);
+				mockRuntime.emit("op", op, isRuntimeMessage(op));
 
 				await flushPromises(); // let summarize run
 			}
@@ -149,11 +159,13 @@ describe("Runtime", () => {
 					retryAfter: retryAfterSeconds,
 					message: "test-nack",
 				};
-				mockDeltaManager.emit("op", {
+				const op = {
 					data: JSON.stringify(contents),
 					type: MessageType.SummaryNack,
 					sequenceNumber: ++lastRefSeq,
-				});
+				};
+				mockDeltaManager.emit("op", op);
+				mockRuntime.emit("op", op, isRuntimeMessage(op));
 
 				await flushPromises();
 			}
@@ -248,7 +260,6 @@ describe("Runtime", () => {
 						stopCall++;
 					},
 					mockRuntime as any as ISummarizerRuntime,
-					true /* listenToDeltaManagerOps */,
 				);
 			};
 

--- a/packages/runtime/container-runtime/src/test/summary/summaryManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/summaryManager.spec.ts
@@ -158,7 +158,6 @@ describe("Summary Manager", () => {
 				// stopSummarizerCallback
 				(reason) => {},
 				mockRuntime as any as ISummarizerRuntime,
-				true /* listenToDeltaManagerOps */,
 			);
 			await Promise.all([this.stopDeferred.promise, this.runDeferred.promise]);
 			await runningSummarizer.waitStop(true);


### PR DESCRIPTION
# [AB#4020](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4020)

[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

Our loader version may not be fully saturated to pass all ops to runtime, so we need to continue listening to the `DeltaManager` `"op"` event.
See https://github.com/microsoft/FluidFramework/pull/14512#discussion_r1160024212

Removal of listening to DeltaManager's `"op"` event is tracked by [AB#3883](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3883)