### PR TITLE
ci: Don't set version in bundle-size artifacts pipeline

### DIFF
--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -45,6 +45,7 @@ extends:
     taskBuildDocs: false
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm
+    setVersionInPipeline: false
     buildDirectory: .
     tagName: bundle-artifacts
     poolBuild: Large

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -45,7 +45,6 @@ extends:
     taskBuildDocs: false
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm
-    setVersionInPipeline: false
     buildDirectory: .
     tagName: bundle-artifacts
     poolBuild: Large

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -271,7 +271,7 @@ stages:
         # the pipeline is special - it runs a client build but doesn't publish anything. Working around this properly is
         # challenging and would create a much bigger change. Since this is the only pipeline that sets this variable to
         # true, we use that to determine whether to set versions.
-        - ${{ if eq(${{ parameters.taskPublishBundleSizeArtifacts }}, false) }}:
+        - ${{ if eq(parameters.taskPublishBundleSizeArtifacts, false) }}:
           - template: include-set-package-version.yml
             parameters:
               buildDirectory: ${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -97,11 +97,6 @@ parameters:
   type: string
   default: 'npm ci --unsafe-perm'
 
-# If true (the default), the pipeline will set the version of the package. This should only be set to false carefully.
-- name: setVersionInPipeline
-  type: boolean
-  default: true
-
 # If true, then this pipeline will check and format package.json files according to prettier settings.
 - name: usesPrettier
   type: boolean

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -272,8 +272,11 @@ stages:
             script: |
               ${{ parameters.packageManagerInstallCommand }}
 
-        # Set version
-        - ${{ if eq(parameters.setVersionInPipeline, true) }}:
+        # This check is a workaround. We don't want to set versions for the build-bundle-size-artifacts pipeline because
+        # the pipeline is special - it runs a client build but doesn't publish anything. Working around this properly is
+        # challenging and would create a much bigger change. Since this is the only pipeline that sets this variable to
+        # true, we use that to determine whether to set versions.
+        - ${{ if eq(${{ parameters.taskPublishBundleSizeArtifacts }}, false) }}:
           - template: include-set-package-version.yml
             parameters:
               buildDirectory: ${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -97,6 +97,11 @@ parameters:
   type: string
   default: 'npm ci --unsafe-perm'
 
+# If true (the default), the pipeline will set the version of the package. This should only be set to false carefully.
+- name: setVersionInPipeline
+  type: boolean
+  default: true
+
 # If true, then this pipeline will check and format package.json files according to prettier settings.
 - name: usesPrettier
   type: boolean
@@ -268,13 +273,14 @@ stages:
               ${{ parameters.packageManagerInstallCommand }}
 
         # Set version
-        - template: include-set-package-version.yml
-          parameters:
-            buildDirectory: ${{ parameters.buildDirectory }}
-            buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
-            buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
-            tagName: ${{ parameters.tagName }}
-            usesPrettier: ${{ parameters.usesPrettier }}
+        - ${{ if eq(parameters.setVersionInPipeline, true) }}:
+          - template: include-set-package-version.yml
+            parameters:
+              buildDirectory: ${{ parameters.buildDirectory }}
+              buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
+              buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
+              tagName: ${{ parameters.tagName }}
+              usesPrettier: ${{ parameters.usesPrettier }}
 
         # Build
         - ${{ if ne(parameters.taskBuild, 'false') }}:


### PR DESCRIPTION
We don't want to set versions for the build-bundle-size-artifacts pipeline because the pipeline is special - it runs a client build but doesn't publish anything. Working around this properly in either the pipeline or `flub bump` is challenging and would create a much bigger change. Since this is the only pipeline that sets this variable to true, we use that to determine whether to set versions.

I could also add a new parameter, but again, that would be a much bigger change and I don't anticipate the parameter being used anywhere else.