### PR TITLE
Minor fix in HistorianResources: remove readonly from tokenRevocationManager property

### DIFF
--- a/server/historian/packages/historian-base/src/runnerFactory.ts
+++ b/server/historian/packages/historian-base/src/runnerFactory.ts
@@ -23,7 +23,7 @@ export class HistorianResources implements core.IResources {
 		public readonly restClusterThrottlers: Map<string, core.IThrottler>,
 		public readonly cache?: historianServices.RedisCache,
 		public readonly asyncLocalStorage?: AsyncLocalStorage<string>,
-		public readonly tokenRevocationManager?: core.ITokenRevocationManager,
+		public tokenRevocationManager?: core.ITokenRevocationManager,
 	) {
 		this.webServerFactory = new services.BasicWebServerFactory();
 	}


### PR DESCRIPTION
Remove readonly from tokenRevocationManager property of HistorianResources since it needs to be injected by users like FRS