### PR TITLE
fix(build-cli): Use shell in exec and bump

### DIFF
--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -210,7 +210,14 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 			}
 		}
 
-		await bumpReleaseGroup(context, bumpArg, packageOrReleaseGroup, scheme, exactDepType);
+		await bumpReleaseGroup(
+			context,
+			bumpArg,
+			packageOrReleaseGroup,
+			scheme,
+			exactDepType,
+			this.logger,
+		);
 
 		if (shouldInstall) {
 			if (!(await FluidRepo.ensureInstalled(updatedPackages, false))) {

--- a/build-tools/packages/build-cli/src/commands/exec.ts
+++ b/build-tools/packages/build-cli/src/commands/exec.ts
@@ -17,7 +17,12 @@ export default class ExecCommand extends PackageCommand<typeof ExecCommand> {
 	};
 
 	protected async processPackage(directory: string): Promise<void> {
-		const result = await execa(this.args.cmd, { cwd: directory });
+		// TODO: The shell option should not need to be true. AB#4067
+		const result = await execa(this.args.cmd, {
+			cwd: directory,
+			stdio: "inherit",
+			shell: true,
+		});
 		this.log(result.all);
 	}
 }

--- a/build-tools/packages/build-cli/src/lib/bump.ts
+++ b/build-tools/packages/build-cli/src/lib/bump.ts
@@ -172,28 +172,42 @@ export async function bumpReleaseGroup(
 		: bumpType;
 
 	let name: string;
-	let cmd: string;
+	const cmds: [string, string[]][] = [];
 	let workingDir: string;
 
 	// Run npm version in each package to set its version in package.json. Also regenerates packageVersion.ts if needed.
 	if (releaseGroupOrPackage instanceof MonoRepo) {
 		workingDir = context.gitRepo.resolvedRoot;
 		name = releaseGroupOrPackage.kind;
-		cmd = `flub exec -g ${name} -- "npm version '${translatedVersion.version}' && npm run build:genver"`;
+		cmds.push(
+			[`flub`, [`exec`, "-g", name, "--", `"npm version ${translatedVersion.version}"`]],
+			[`npm`, ["run", "build:genver"]],
+		);
 	} else {
 		workingDir = releaseGroupOrPackage.directory;
 		name = releaseGroupOrPackage.name;
-		cmd = `npm version '${translatedVersion.version}'`;
+		cmds.push([`npm`, ["version", translatedVersion.version]]);
 		if (releaseGroupOrPackage.getScript("build:genver") !== undefined) {
-			cmd += " && npm run build:genver";
+			cmds.push([`npm`, ["run", "build:genver"]]);
 		}
 	}
 
-	try {
-		const results = await execa(cmd, { cwd: workingDir });
-		log?.verbose(results.stdout);
-	} catch (error: any) {
-		log?.errorLog(`Error running command: ${cmd}\n${error}`);
+	for (const [cmd, args] of cmds) {
+		log?.verbose(`Running command: ${cmd} in ${workingDir}`);
+		try {
+			// TODO: The shell option should not need to be true. AB#4067
+			// eslint-disable-next-line no-await-in-loop
+			const results = await execa(cmd, args, {
+				cwd: workingDir,
+				stdio: "inherit",
+				shell: true,
+			});
+			if (results.all !== undefined) {
+				log?.verbose(results.all);
+			}
+		} catch (error: any) {
+			log?.errorLog(`Error running command: ${cmd} ${args}\n${error}`);
+		}
 	}
 
 	if (releaseGroupOrPackage instanceof Package) {


### PR DESCRIPTION
When running in CI and in some local environments, the `flub exec` and `flub bump` commands don't seem to work with some commands, such as `npm`, because they can't be found by the spawned subprocess. I worked around this by passing `shell: true` into the options, but that's not a great long-term solution. Longer term solution is tracked by [AB#4067](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4067).

I also updated the execa usage in the `bump` command to pass arguments using an array. I originally did this for debugging but it seems more flexible and reliable than the old string-only approach, so I left it in place.