### PR TITLE
(merge-tree): Early exit block updates on some local ref codepaths

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -279,6 +279,15 @@ function applyRangeReference(stack: Stack<ReferencePosition>, delta: ReferencePo
 	}
 }
 
+/**
+ * Reference types which have special bookkeeping within the merge tree (in {@link HierMergeBlock}s)
+ * and thus require updating path lengths when changed.
+ *
+ * TODO:AB#4069: This functionality is old and not well-tested. It's not clear how much of it is needed--
+ * we should better test the parts that are necessary and remove the rest.
+ */
+const hierRefTypes = ReferenceType.NestBegin | ReferenceType.NestEnd | ReferenceType.Tile;
+
 function addNodeReferences(
 	mergeTree: MergeTree,
 	node: IMergeNode,
@@ -871,7 +880,8 @@ export class MergeTree {
 				}
 			}
 		}
-		// TODO is it required to update the path lengths?
+		// TODO:AB#4069: This update might be avoidable by checking if the old segment
+		// had hierarchical refs before sliding using `segment.localRefs?.hierRefCount`.
 		if (newSegment) {
 			this.blockUpdatePathLengths(
 				newSegment.parent,
@@ -2199,7 +2209,7 @@ export class MergeTree {
 		const segment = lref.getSegment();
 		if (segment) {
 			const removedRefs = segment?.localRefs?.removeLocalRef(lref);
-			if (removedRefs !== undefined) {
+			if (removedRefs !== undefined && refTypeIncludesFlag(lref, hierRefTypes)) {
 				this.blockUpdatePathLengths(
 					segment.parent,
 					TreeMaintenanceSequenceNumber,
@@ -2228,7 +2238,13 @@ export class MergeTree {
 
 		const segRef = localRefs.createLocalRef(offset, refType, properties);
 
-		this.blockUpdatePathLengths(segment.parent, TreeMaintenanceSequenceNumber, LocalClientId);
+		if (refTypeIncludesFlag(refType, hierRefTypes)) {
+			this.blockUpdatePathLengths(
+				segment.parent,
+				TreeMaintenanceSequenceNumber,
+				LocalClientId,
+			);
+		}
 		return segRef;
 	}
 


### PR DESCRIPTION
## Description

This avoids doing some unnecessary work in some common codepaths for interval collections. I've also created [AB#4069](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4069) to track further cleanup of this area (there's a lot of associated merge-tree code which isn't well-tested)