### PR TITLE
Eager final telemetry correction

### DIFF
--- a/experimental/dds/tree/src/id-compressor/IdCompressor.ts
+++ b/experimental/dds/tree/src/id-compressor/IdCompressor.ts
@@ -659,10 +659,12 @@ export class IdCompressor {
 				currentCluster.count += remainingCapacity;
 				eagerFinalIdCount = remainingCapacity;
 				remainingCount -= remainingCapacity;
-				this.logger?.sendTelemetryEvent({
-					eventName: 'SharedTreeIdCompressor:OverfilledCluster',
-					sessionId: this.localSessionId,
-				});
+				if (isLocal) {
+					this.logger?.sendTelemetryEvent({
+						eventName: 'SharedTreeIdCompressor:OverfilledCluster',
+						sessionId: this.localSessionId,
+					});
+				}
 			}
 		} else {
 			// Session has never made a cluster, form a new one with the session UUID as the baseUuid

--- a/packages/dds/tree/src/id-compressor/idCompressor.ts
+++ b/packages/dds/tree/src/id-compressor/idCompressor.ts
@@ -635,10 +635,12 @@ export class IdCompressor {
 				newBaseUuid = incrementUuid(currentCluster.baseUuid, currentCluster.capacity);
 				currentCluster.count += remainingCapacity;
 				remainingCount -= remainingCapacity;
-				this.logger?.sendTelemetryEvent({
-					eventName: "RuntimeIdCompressor:OverfilledCluster",
-					sessionId: this.localSessionId,
-				});
+				if (isLocal) {
+					this.logger?.sendTelemetryEvent({
+						eventName: "RuntimeIdCompressor:OverfilledCluster",
+						sessionId: this.localSessionId,
+					});
+				}
 			}
 		} else {
 			// Session has never made a cluster, form a new one with the session UUID as the baseUuid


### PR DESCRIPTION
## Description
There's a missing `isLocal` check for the `OverfilledCluster` event that results in emission for all clients. This means that the event will emit for every client that it occurs. This isn't a common event, but it should still be fixed for accurate data and to avoid emitting unnecessary telemetry events. 

We originally thought we could calculate the correct eager final count in finalize, but we actually need to maintain a count in `generateCompressedId()` to do this accurately. This change keeps a count and emits it as part of the status event, clearing after emission.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
