### PR TITLE
refactor (protocol-definitions): Deprecate MessageType.RemoteHelp Op

### DIFF
--- a/common/lib/protocol-definitions/CHANGELOG.md
+++ b/common/lib/protocol-definitions/CHANGELOG.md
@@ -6,3 +6,8 @@
 
 This member was related to an experimental feature that did not ship. As a result it is unused/ignored by all consumers.
 This change deprecates it, to be removed in a later release.
+
+### Deprecate RemoteHelp from MessageType
+
+The RemoteHelp MessageType is no longer used by the server side so it is safe to deprecate this op type.
+This change deprecates it, to be removed in a later release.

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -539,6 +539,7 @@ export enum MessageType {
     Operation = "op",
     Propose = "propose",
     Reject = "reject",
+    // @deprecated
     RemoteHelp = "remoteHelp",
     RoundTrip = "tripComplete",
     Summarize = "summarize",

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -59,6 +59,7 @@ export enum MessageType {
 
 	/**
 	 * Message to indicate the need of a remote agent for a document.
+	 * @deprecated 1.2.0 - Unused from a legacy feature, will be removed entirely in an upcoming release.
 	 */
 	RemoteHelp = "remoteHelp",
 


### PR DESCRIPTION
https://github.com/microsoft/FluidFramework/issues/9709

Deprecating MessageType.RemoteHelp. I have confirmed it's a concept that no longer exists and that none of the server teams are using this code any longer, so I am deprecating it in this PR, with a follow up remove PR to come. There is code in the foreman lambda that uses this Op. I have confirmed that it is okay to remove that code also. A different PR will remove the foreman lambda code since it is a different release group.