### PR TITLE
Milan fluid summary compress exp1

### DIFF
--- a/api-report/azure-client.api.md
+++ b/api-report/azure-client.api.md
@@ -47,6 +47,8 @@ export class AzureClient {
 export interface AzureClientProps {
     readonly configProvider?: IConfigProviderBase;
     readonly connection: AzureRemoteConnectionConfig | AzureLocalConnectionConfig;
+    // (undocumented)
+    readonly enableSummaryCompression?: boolean;
     readonly logger?: ITelemetryBaseLogger;
 }
 

--- a/api-report/driver-definitions.api.md
+++ b/api-report/driver-definitions.api.md
@@ -24,6 +24,15 @@ import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ITokenClaims } from '@fluidframework/protocol-definitions';
 import { IVersion } from '@fluidframework/protocol-definitions';
 
+// @public
+export function applyStorageAdapters(storage: IDocumentStorageService, storageAdapters?: StorageAdapterBuilderType[]): IDocumentStorageService;
+
+// @public (undocumented)
+export function createCompressionStorageAdapterBuilder(config?: ICompressionStorageConfig): StorageAdapterBuilderType;
+
+// @public (undocumented)
+export function createDefaultCompressionConfig(): ICompressionStorageConfig;
+
 // @public (undocumented)
 export type DriverError = IThrottlingWarning | IGenericNetworkError | IAuthorizationError | ILocationRedirectionError | IDriverBasicError;
 
@@ -88,6 +97,14 @@ export interface IAuthorizationError extends IDriverErrorBase {
     readonly errorType: DriverErrorType.authorizationError;
     // (undocumented)
     readonly tenantId?: string;
+}
+
+// @public (undocumented)
+export interface ICompressionStorageConfig {
+    // (undocumented)
+    algorithm: SummaryCompressionAlgorithm;
+    // (undocumented)
+    minSizeToCompress: number;
 }
 
 // @public
@@ -304,6 +321,17 @@ export interface IWebResolvedUrl extends IResolvedUrlBase {
 export enum LoaderCachingPolicy {
     NoCaching = 0,
     Prefetch = 1
+}
+
+// @public (undocumented)
+export type StorageAdapterBuilderType = (storage: IDocumentStorageService) => IDocumentStorageService;
+
+// @public (undocumented)
+export enum SummaryCompressionAlgorithm {
+    // (undocumented)
+    LZ4 = 2,
+    // (undocumented)
+    None = 1
 }
 
 // (No @packageDocumentation comment for this package)

--- a/api-report/routerlicious-driver.api.md
+++ b/api-report/routerlicious-driver.api.md
@@ -11,6 +11,7 @@ import { ISession } from '@fluidframework/server-services-client';
 import { ISummaryTree } from '@fluidframework/protocol-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ITokenClaims } from '@fluidframework/protocol-definitions';
+import { StorageAdapterBuilderType } from '@fluidframework/driver-definitions';
 
 // @public
 export class DefaultTokenProvider implements ITokenProvider {
@@ -63,7 +64,7 @@ export interface ITokenService {
 
 // @public
 export class RouterliciousDocumentServiceFactory implements IDocumentServiceFactory {
-    constructor(tokenProvider: ITokenProvider, driverPolicies?: Partial<IRouterliciousDriverPolicies>);
+    constructor(tokenProvider: ITokenProvider, driverPolicies?: Partial<IRouterliciousDriverPolicies>, storageAdapterBuilders?: StorageAdapterBuilderType[]);
     // (undocumented)
     createContainer(createNewSummary: ISummaryTree | undefined, resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
     // (undocumented)

--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -8,7 +8,7 @@ import {
 	IFluidModuleWithDetails,
 } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";
-import { IDocumentServiceFactory, IUrlResolver } from "@fluidframework/driver-definitions";
+import { IDocumentServiceFactory, IUrlResolver, StorageAdapterBuilderType, createCompressionStorageAdapterBuilder } from "@fluidframework/driver-definitions";
 import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
 import {
 	ContainerSchema,
@@ -59,6 +59,10 @@ export class AzureClient {
 	 * @param props - Properties for initializing a new AzureClient instance
 	 */
 	public constructor(private readonly props: AzureClientProps) {
+		const compressAdapters: StorageAdapterBuilderType[] = [];
+		if(props.enableSummaryCompression !== undefined && props.enableSummaryCompression) {
+			compressAdapters.push(createCompressionStorageAdapterBuilder());
+		}
 		// remove trailing slash from URL if any
 		props.connection.endpoint = props.connection.endpoint.replace(/\/$/, "");
 		this.urlResolver = new AzureUrlResolver();
@@ -68,6 +72,7 @@ export class AzureClient {
 		this.documentServiceFactory = new RouterliciousDocumentServiceFactory(
 			this.props.connection.tokenProvider,
 			{ enableWholeSummaryUpload: isRemoteConnection, enableDiscovery: isRemoteConnection },
+			compressAdapters
 		);
 		this.configProvider = props.configProvider;
 	}

--- a/azure/packages/azure-client/src/interfaces.ts
+++ b/azure/packages/azure-client/src/interfaces.ts
@@ -28,6 +28,8 @@ export interface AzureClientProps {
 	 * Base interface for providing configurations to control experimental features. If unsure, leave this undefined.
 	 */
 	readonly configProvider?: IConfigProviderBase;
+
+	readonly enableSummaryCompression?: boolean;
 }
 
 /**

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -40,8 +40,10 @@
 	},
 	"dependencies": {
 		"@fluidframework/common-definitions": "^0.20.1",
+		"@fluidframework/common-utils": "^1.1.1",
 		"@fluidframework/core-interfaces": ">=2.0.0-internal.4.1.0 <2.0.0-internal.5.0.0",
-		"@fluidframework/protocol-definitions": "^1.1.0"
+		"@fluidframework/protocol-definitions": "^1.1.0",
+		"lz4js": "^0.2.0"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "^0.13.1",

--- a/packages/common/driver-definitions/src/adapters/compression/index.ts
+++ b/packages/common/driver-definitions/src/adapters/compression/index.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export {
+	SummaryCompressionAlgorithm,
+	CompressionSummaryStorageAdapter,
+} from "./summaryStorageCompressionAdapter";

--- a/packages/common/driver-definitions/src/adapters/compression/summaryBlobProtocol.ts
+++ b/packages/common/driver-definitions/src/adapters/compression/summaryBlobProtocol.ts
@@ -1,0 +1,170 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Buffer, IsoBuffer } from "@fluidframework/common-utils";
+
+/**
+ * This class represents the object instatiation of the header which is optionaly writen at the
+ * beginning of the binary blob. It supports conversion to / from the binary array.
+ * The binary representation is as follows :
+ * - HEADER ID : 16 bytes of unique identifier : f4e72832a5bd47d7a2f35ed47ed94a3c
+ * - HEADER CONTENT LENGTH : 4 bytes of length of the rest of header content (after the length field)
+ * - HEADER CONTENT :  HEADER CONTENT LENGTH bytes
+ */
+export class BlobHeader {
+	public static readonly ENCODING = "utf-8";
+	public static readonly HEADER_PREFIX = new Uint8Array([
+		0xf4, 0xe7, 0x28, 0x32, 0xa5, 0xbd, 0x47, 0xd7, 0xa2, 0xf3, 0x5e, 0xd4, 0x7e, 0xd9, 0x4a,
+		0x3c,
+	]);
+	constructor(private readonly _fields: { [key: string]: string }) {}
+	public getValue(key: string): string {
+		return this._fields[key];
+	}
+
+	/**
+	 * This method returns the length of the binary representation of this header object.
+	 * @returns Returns the length of the binary representation of this header object.
+	 */
+	public headerLength(): number {
+		return this.toBinary().byteLength;
+	}
+
+	/**
+	 * This method converts this header object to binary array.
+	 * @returns this header object as binary array.
+	 */
+	public toBinary(): IsoBuffer {
+		const contentStr = JSON.stringify(this._fields);
+		const contentBinary: IsoBuffer = IsoBuffer.from(contentStr, BlobHeader.ENCODING);
+		const contentBinaryLength = contentBinary.byteLength;
+		const contentBinaryLengthBuf = new ArrayBuffer(4);
+		const view = new DataView(contentBinaryLengthBuf);
+		view.setUint32(0, contentBinaryLength, false);
+
+		return concat([
+			BlobHeader.HEADER_PREFIX,
+			IsoBuffer.from(contentBinaryLengthBuf),
+			contentBinary,
+		]);
+	}
+
+	/**
+	 * This method converts the binary array to header object, if not present, undefined is returned.
+	 * @returns header object
+	 */
+	public static fromBinary(buffer: IsoBuffer): BlobHeader | undefined {
+		const possibleHeader = buffer.slice(0, BlobHeader.HEADER_PREFIX.byteLength);
+		if (!isEqual(possibleHeader, BlobHeader.HEADER_PREFIX)) {
+			return undefined;
+		}
+		const arrayBuffer = toArrayBuffer(buffer);
+		const view = new DataView(arrayBuffer);
+		const contentBinaryLength = view.getUint32(BlobHeader.HEADER_PREFIX.byteLength, false);
+		const contentPos = BlobHeader.HEADER_PREFIX.byteLength + 4;
+		const contentBinary = arrayBuffer.slice(contentPos, contentPos + contentBinaryLength);
+		const contentStr = IsoBuffer.from(contentBinary).toString(BlobHeader.ENCODING);
+		return new BlobHeader(JSON.parse(contentStr) as { [key: string]: string });
+	}
+
+	/**
+	 * This method returns the rest of the message cutting of the complete header from the given byte array.
+	 * @param buffer - The byte array
+	 * @returns The rest of the message cutting of the complete header from the given byte array.
+	 */
+	public static skipHeader(buffer: IsoBuffer): IsoBuffer {
+		const header = this.fromBinary(buffer);
+		return !this.fromBinary(buffer) ? buffer : buffer.slice(header?.headerLength());
+	}
+}
+
+function toArrayBuffer(buf: number[] | Buffer): ArrayBuffer {
+	const ab = new ArrayBuffer(buf.length);
+	const view = IsoBuffer.from(ab);
+	for (const [i, element] of buf.entries()) {
+		view[i] = element;
+	}
+	return ab;
+}
+
+/**
+ * This method writes the binary representation of the given header at the beginning of the given buffer.
+ * @param header - The header to be written.
+ * @param buffer - The buffer containing the binary blob
+ * @returns The buffer with header
+ */
+export function writeBlobHeader(header: BlobHeader, buffer: ArrayBufferLike): ArrayBufferLike {
+	const binaryHeader = header.toBinary();
+	const totalLength = buffer.byteLength + binaryHeader.byteLength;
+	const contentBuffer = IsoBuffer.from(buffer);
+	const newBuffer = concat([binaryHeader, contentBuffer], totalLength);
+	return newBuffer;
+}
+
+/**
+ * This function converts the binary array to header object, if not present, undefined is returned.
+ * @param buffer - binary array representation of header object
+ * @returns header object
+ */
+export function readBlobHeader(buffer: ArrayBufferLike): BlobHeader | undefined {
+	return BlobHeader.fromBinary(IsoBuffer.from(buffer));
+}
+
+/**
+ * This method returns the rest of the message cutting of the complete header from the given byte array.
+ * @param buffer - The byte array
+ * @returns The rest of the message cutting of the complete header from the given byte array.
+ */
+export function skipHeader(buffer: ArrayBufferLike): ArrayBufferLike {
+	return BlobHeader.skipHeader(IsoBuffer.from(buffer));
+}
+
+/**
+ * This class uses the Builder pattern to generate new BlobHeader object.
+ */
+export class BlobHeaderBuilder {
+	private readonly _fields = {};
+	public addField(key: string, value: string): void {
+		this._fields[key] = value;
+	}
+	public build(): BlobHeader {
+		return new BlobHeader(this._fields);
+	}
+}
+
+function concat(args: IsoBuffer[], totalLength?: number): Buffer {
+	let merged = args[0];
+	for (let i = 1; i < args.length; i++) {
+		merged = concatTwo(merged, args[i], totalLength);
+	}
+	return merged;
+}
+
+function concatTwo(arrayOne: IsoBuffer, arrayTwo: IsoBuffer, totalLength?: number): IsoBuffer {
+	let arrayTwoReduced = arrayTwo;
+	if (totalLength !== undefined) {
+		if (arrayOne.length > totalLength) {
+			return arrayOne.subarray(0, totalLength);
+		} else if (arrayOne.length + arrayTwo.length > totalLength) {
+			arrayTwoReduced = arrayTwo.subarray(0, totalLength - arrayOne.length);
+		}
+	}
+	const mergedArray = new IsoBuffer(arrayOne.length + arrayTwo.length);
+	mergedArray.set(arrayOne);
+	mergedArray.set(arrayTwoReduced, arrayOne.length);
+	return mergedArray;
+}
+
+function isEqual(arrayOne: IsoBuffer, arrayTwo: IsoBuffer): boolean {
+	if (arrayOne.length !== arrayTwo.length) {
+		return false;
+	}
+	for (const [i, element] of arrayOne.entries()) {
+		if (element !== arrayTwo[i]) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/packages/common/driver-definitions/src/adapters/compression/summaryStorageCompressionAdapter.ts
+++ b/packages/common/driver-definitions/src/adapters/compression/summaryStorageCompressionAdapter.ts
@@ -1,0 +1,200 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+
+import { compress, decompress } from "lz4js";
+import {
+	ISummaryTree,
+	ISummaryBlob,
+	SummaryType,
+	ICreateBlobResponse,
+	SummaryObject,
+} from "@fluidframework/protocol-definitions";
+import { IsoBuffer, Uint8ArrayToString } from "@fluidframework/common-utils";
+import { IDocumentStorageService, ISummaryContext } from "../../";
+import { SummaryStorageAdapter } from "../summaryStorageAdapter";
+import {
+	BlobHeaderBuilder,
+	readBlobHeader,
+	skipHeader,
+	writeBlobHeader,
+} from "./summaryBlobProtocol";
+
+export enum SummaryCompressionAlgorithm {
+	None = 1,
+	LZ4 = 2,
+}
+
+const algorithmKey = "ALG";
+const defaultMinSizeToCompress = 500;
+
+/**
+ * This class extends the SummaryStorageAdapter so that it can apply various kinds of compressions
+ * to the blob payload.
+ */
+export class CompressionSummaryStorageAdapter extends SummaryStorageAdapter {
+	constructor(
+		service: IDocumentStorageService,
+		private readonly _algorithm: SummaryCompressionAlgorithm | undefined,
+		private readonly _minSizeToCompress: number | undefined,
+		private readonly _isUseB64OnCompressed: boolean | undefined,
+	) {
+		super(service);
+		if (this._minSizeToCompress === undefined) {
+			this._minSizeToCompress = defaultMinSizeToCompress;
+		}
+	}
+
+	public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
+		return super.createBlob(this.encodeBlob(file));
+	}
+	public async readBlob(id: string): Promise<ArrayBufferLike> {
+		return this.decodeBlob(await super.readBlob(id));
+	}
+	public async uploadSummaryWithContext(
+		summary: ISummaryTree,
+		context: ISummaryContext,
+	): Promise<string> {
+		const prep = {
+			prepSummary: recursivelyReplace(summary, this.blobReplacer, context) as ISummaryTree,
+			prepContext: context,
+		};
+		return super.uploadSummaryWithContext(prep.prepSummary, prep.prepContext);
+	}
+	public get algorithm(): SummaryCompressionAlgorithm | undefined {
+		return this._algorithm;
+	}
+	private readonly blobReplacer = (
+		_input: SummaryObject,
+		_context?: ISummaryContext,
+	): SummaryObject => {
+		if (_input.type === SummaryType.Blob) {
+			const summaryBlob: ISummaryBlob = _input;
+			const decompressed: Uint8Array =
+				typeof summaryBlob.content === "string"
+					? new TextEncoder().encode(summaryBlob.content)
+					: summaryBlob.content;
+			if (
+				this._minSizeToCompress !== undefined &&
+				decompressed.length < this._minSizeToCompress
+			) {
+				return _input;
+			}
+			const compressed: ArrayBufferLike = this.encodeBlob(decompressed);
+			let newSummaryBlob;
+			if (this._isUseB64OnCompressed !== undefined && this._isUseB64OnCompressed) {
+				// TODO: This step is now needed, it looks like the function summaryTreeUploadManager#writeSummarPyBlob
+				// fails on assertion at 2 different generations of the hash which do not lead to
+				// the same result if the ISummaryBlob.content is in the form of ArrayBufferLike
+				const compressedString = Uint8ArrayToString(IsoBuffer.from(compressed), "base64");
+				const compressedEncoded = new TextEncoder().encode(compressedString);
+				newSummaryBlob = {
+					type: SummaryType.Blob,
+					content: compressedEncoded,
+				};
+			} else {
+				// This line will replace the 3 lines above when the bug is fixed.
+				// const newSummaryBlob: ISummaryBlob = { type: SummaryType.Blob, content: IsoBuffer.from(compressed)};
+				newSummaryBlob = {
+					type: SummaryType.Blob,
+					content: IsoBuffer.from(compressed),
+				};
+			}
+			return newSummaryBlob;
+		} else {
+			return _input;
+		}
+	};
+
+	private encodeBlob(file: ArrayBufferLike): ArrayBufferLike {
+		let compressed: ArrayBufferLike;
+		if (this._algorithm === undefined || this._algorithm === SummaryCompressionAlgorithm.None) {
+			return file;
+		} else {
+			if (this._algorithm === SummaryCompressionAlgorithm.LZ4) {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+				compressed = compress(file) as ArrayBufferLike;
+			} else {
+				throw new Error(`Unknown Algorithm ${this._algorithm}`);
+			}
+		}
+		const headerBuilder: BlobHeaderBuilder = new BlobHeaderBuilder();
+		headerBuilder.addField(algorithmKey, this._algorithm.toString(10));
+		return writeBlobHeader(headerBuilder.build(), compressed);
+	}
+
+	private decodeBlob(file: ArrayBufferLike): ArrayBufferLike {
+		let compressedEncoded = file;
+		let header = readBlobHeader(compressedEncoded);
+		if (!header) {
+			// TODO: Due to the function summaryTreeUploadManager#writeSummaryBlob issue
+			// where the binary blob representation inside ISummaryTree causes assertion issues
+			// with the hash comparison we need to be prepared that the blob together with the
+			// blob header is base64 encoded. We need to try whether it is the case.
+			const compressedString = new TextDecoder().decode(compressedEncoded);
+			compressedEncoded = IsoBuffer.from(compressedString, "base64");
+			header = readBlobHeader(compressedEncoded);
+			if (!header) {
+				return file;
+			}
+		}
+		let decompressed: ArrayBufferLike;
+		const input = skipHeader(compressedEncoded);
+		const myAlgorithm = Number(header.getValue(algorithmKey));
+		if (myAlgorithm === SummaryCompressionAlgorithm.LZ4) {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			decompressed = decompress(input) as ArrayBufferLike;
+		} else {
+			throw new Error(`Unknown Algorithm ${this._algorithm}`);
+		}
+		return decompressed;
+	}
+}
+
+export function recursivelyReplace(
+	input: SummaryObject,
+	replacer: (input: SummaryObject, context?: ISummaryContext) => SummaryObject,
+	context?: ISummaryContext,
+): SummaryObject {
+	// Note: Caller is responsible for ensuring that `input` is defined / non-null.
+	//       (Required for Object.keys() below.)
+
+	// Execute the `replace` on the current input.  Note that Caller is responsible for ensuring that `input`
+	// is a non-null object.
+	const maybeReplaced = replacer(input, context);
+
+	// If the replacer made a substitution there is no need to decscend further. IFluidHandles are always
+	// leaves in the object graph.
+	if (maybeReplaced !== input) {
+		return maybeReplaced;
+	}
+
+	// Otherwise descend into the object graph looking for IFluidHandle instances.
+	let clone: object | undefined;
+	for (const key of Object.keys(input)) {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+		const value = input[key];
+
+		if (Boolean(value) && typeof value === "object") {
+			// Note: `input` must not contain circular references (as object must
+			//       be JSON serializable.)  Therefore, guarding against infinite recursion here would only
+			//       lead to a later error when attempting to stringify().
+			const replaced = recursivelyReplace(value as SummaryObject, replacer, context);
+
+			// If the `replaced` object is different than the original `value` then the subgraph contained one
+			// or more handles.  If this happens, we need to return a clone of the `input` object where the
+			// current property is replaced by the `replaced` value.
+			if (replaced !== value) {
+				// Lazily create a shallow clone of the `input` object if we haven't done so already.
+				clone = clone ?? (Array.isArray(input) ? [...input] : { ...input });
+
+				// Overwrite the current property `key` in the clone with the `replaced` value.
+				clone[key] = replaced;
+			}
+		}
+	}
+	return (clone ?? input) as SummaryObject;
+}

--- a/packages/common/driver-definitions/src/adapters/compression/summaryStorageCompressionAdapter.ts
+++ b/packages/common/driver-definitions/src/adapters/compression/summaryStorageCompressionAdapter.ts
@@ -62,6 +62,7 @@ export class CompressionSummaryStorageAdapter extends SummaryStorageAdapter {
 			prepSummary: recursivelyReplace(summary, this.blobReplacer, context) as ISummaryTree,
 			prepContext: context,
 		};
+		console.log(`Miso Summary Upload: ${  JSON.stringify(prep.prepSummary).length}`);
 		return super.uploadSummaryWithContext(prep.prepSummary, prep.prepContext);
 	}
 	public get algorithm(): SummaryCompressionAlgorithm | undefined {

--- a/packages/common/driver-definitions/src/adapters/index.ts
+++ b/packages/common/driver-definitions/src/adapters/index.ts
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { SummaryCompressionAlgorithm } from "./compression";
+
+export {
+	createCompressionStorageAdapterBuilder,
+	ICompressionStorageConfig,
+	createDefaultCompressionConfig,
+	applyStorageAdapters,
+	StorageAdapterBuilderType,
+} from "./predefinedAdapters";

--- a/packages/common/driver-definitions/src/adapters/predefinedAdapters.ts
+++ b/packages/common/driver-definitions/src/adapters/predefinedAdapters.ts
@@ -1,0 +1,58 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IDocumentStorageService } from "..";
+import { CompressionSummaryStorageAdapter, SummaryCompressionAlgorithm } from "./compression";
+
+function applyStorageCompression(
+	storage: IDocumentStorageService,
+	algorithm: SummaryCompressionAlgorithm | undefined = SummaryCompressionAlgorithm.LZ4,
+	minSizeToCompress: number | undefined = 500,
+): IDocumentStorageService {
+	if (algorithm === undefined) {
+		return storage;
+	}
+	return new CompressionSummaryStorageAdapter(storage, algorithm, minSizeToCompress, true);
+}
+
+export interface ICompressionStorageConfig {
+	algorithm: SummaryCompressionAlgorithm;
+	minSizeToCompress: number;
+}
+
+export type StorageAdapterBuilderType = (
+	storage: IDocumentStorageService,
+) => IDocumentStorageService;
+
+export function createDefaultCompressionConfig(): ICompressionStorageConfig {
+	return {
+		algorithm: SummaryCompressionAlgorithm.LZ4,
+		minSizeToCompress: 500,
+	};
+}
+
+export function createCompressionStorageAdapterBuilder(
+	config: ICompressionStorageConfig = createDefaultCompressionConfig(),
+): StorageAdapterBuilderType {
+	return (storage: IDocumentStorageService): IDocumentStorageService => {
+		return applyStorageCompression(storage, config.algorithm, config.minSizeToCompress);
+	};
+}
+
+/**
+ * This function obtains an array of storage adapter builders that are used to wrap the storage service.
+ * It also obtain the IDocumentStorageService objects and it wraps it with the adapters.
+ */
+export function applyStorageAdapters(
+	storage: IDocumentStorageService,
+	storageAdapters: StorageAdapterBuilderType[] = [],
+): IDocumentStorageService {
+	let storageService = storage;
+	for (const adapter of storageAdapters) {
+		storageService = adapter(storageService);
+	}
+	return storageService;
+}
+

--- a/packages/common/driver-definitions/src/adapters/summaryStorageAdapter.ts
+++ b/packages/common/driver-definitions/src/adapters/summaryStorageAdapter.ts
@@ -1,0 +1,61 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import {
+	ICreateBlobResponse,
+	ISnapshotTree,
+	ISummaryHandle,
+	ISummaryTree,
+	IVersion,
+} from "@fluidframework/protocol-definitions";
+import { IDocumentStorageService, IDocumentStorageServicePolicies, ISummaryContext } from "../";
+/**
+ * This class is a base class for building the classes which use the
+ * Delegation Pattern to intercept methods of IDocumentStorageService implementation.
+ * Those extended classes can add the postprocessing of summary data structures prior sending to Fluid Server
+ * and preprocessing of summary data structures received from Fluid Server.
+ */
+export class SummaryStorageAdapter implements IDocumentStorageService {
+	public get service(): IDocumentStorageService {
+		return this._service;
+	}
+
+	constructor(private readonly _service: IDocumentStorageService) {}
+	public get repositoryUrl(): string {
+		return this._service.repositoryUrl;
+	}
+	public get policies(): IDocumentStorageServicePolicies | undefined {
+		return this._service.policies;
+	}
+	public async getSnapshotTree(
+		version?: IVersion | undefined,
+		scenarioName?: string | undefined,
+		// eslint-disable-next-line @rushstack/no-new-null
+	): Promise<ISnapshotTree | null> {
+		return this._service.getSnapshotTree(version, scenarioName);
+	}
+	public async getVersions(
+		// eslint-disable-next-line @rushstack/no-new-null
+		versionId: string | null,
+		count: number,
+		scenarioName?: string | undefined,
+	): Promise<IVersion[]> {
+		return this._service.getVersions(versionId, count, scenarioName);
+	}
+	public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
+		return this._service.createBlob(file);
+	}
+	public async readBlob(id: string): Promise<ArrayBufferLike> {
+		return this._service.readBlob(id);
+	}
+	public async uploadSummaryWithContext(
+		summary: ISummaryTree,
+		context: ISummaryContext,
+	): Promise<string> {
+		return this._service.uploadSummaryWithContext(summary, context);
+	}
+	public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
+		return this._service.downloadSummary(handle);
+	}
+}

--- a/packages/common/driver-definitions/src/index.ts
+++ b/packages/common/driver-definitions/src/index.ts
@@ -43,3 +43,11 @@ export {
 	IWebResolvedUrl,
 	IUrlResolver,
 } from "./urlResolver";
+export {
+	createCompressionStorageAdapterBuilder,
+	ICompressionStorageConfig,
+	createDefaultCompressionConfig,
+	applyStorageAdapters,
+	StorageAdapterBuilderType,
+	SummaryCompressionAlgorithm,
+} from "./adapters";

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -63,6 +63,7 @@ export class DocumentService implements api.IDocumentService {
 		private readonly blobCache: ICache<ArrayBufferLike>,
 		private readonly snapshotTreeCache: ICache<ISnapshotTreeVersion>,
 		private readonly discoverFluidResolvedUrl: () => Promise<api.IFluidResolvedUrl>,
+		private readonly storageAdapterBuilders?: api.StorageAdapterBuilderType[],
 	) {}
 
 	private documentStorageService: DocumentStorageService | undefined;
@@ -126,6 +127,7 @@ export class DocumentService implements api.IDocumentService {
 			storageManager,
 			this.logger,
 			this.documentStorageServicePolicies,
+			this.storageAdapterBuilders,
 			this.driverPolicies,
 			this.blobCache,
 			this.snapshotTreeCache,

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -12,6 +12,7 @@ import {
 	IFluidResolvedUrl,
 	IResolvedUrl,
 	LoaderCachingPolicy,
+	StorageAdapterBuilderType,
 } from "@fluidframework/driver-definitions";
 import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
@@ -55,10 +56,12 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 	private readonly driverPolicies: IRouterliciousDriverPolicies;
 	private readonly blobCache: ICache<ArrayBufferLike>;
 	private readonly snapshotTreeCache: ICache<ISnapshotTreeVersion>;
+	private readonly storageAdapterBuilders?: StorageAdapterBuilderType[];
 
 	constructor(
 		private readonly tokenProvider: ITokenProvider,
 		driverPolicies: Partial<IRouterliciousDriverPolicies> = {},
+		storageAdapterBuilders?: StorageAdapterBuilderType[],
 	) {
 		// Use the maximum allowed by the policy (IDocumentStorageServicePolicies.maximumCacheDurationMs set below)
 		const snapshotCacheExpiryMs: FiveDaysMs = maximumSnapshotCacheDurationMs;
@@ -71,6 +74,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 		this.snapshotTreeCache = this.driverPolicies.enableInternalSummaryCaching
 			? new InMemoryCache<ISnapshotTreeVersion>(snapshotCacheExpiryMs)
 			: new NullCache<ISnapshotTreeVersion>();
+		this.storageAdapterBuilders = storageAdapterBuilders;
 	}
 
 	/**
@@ -301,6 +305,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			this.blobCache,
 			this.snapshotTreeCache,
 			discoverFluidResolvedUrl,
+			this.storageAdapterBuilders,
 		);
 	}
 }

--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -69,7 +69,10 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
 			!driverPolicies?.enableWholeSummaryUpload &&
 			policies.caching === LoaderCachingPolicy.Prefetch
 		) {
-			return new PrefetchDocumentStorageService(storageService);
+			const retStorage = adapterBuilders !== undefined ? 
+			    applyStorageAdapters(new PrefetchDocumentStorageService(storageService), 
+			    adapterBuilders) : storageService;		
+			return retStorage;
 		}
 		return adapterBuilders !== undefined ? applyStorageAdapters(storageService, adapterBuilders) : storageService;		
 	}

--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -8,6 +8,8 @@ import {
 	IDocumentStorageService,
 	IDocumentStorageServicePolicies,
 	LoaderCachingPolicy,
+	StorageAdapterBuilderType,
+	applyStorageAdapters,
 } from "@fluidframework/driver-definitions";
 import { ISnapshotTree, IVersion } from "@fluidframework/protocol-definitions";
 import { GitManager } from "@fluidframework/server-services-client";
@@ -33,6 +35,7 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
 		manager: GitManager,
 		logger: ITelemetryLogger,
 		policies: IDocumentStorageServicePolicies,
+		adapterBuilders?: StorageAdapterBuilderType[],
 		driverPolicies?: IRouterliciousDriverPolicies,
 		blobCache?: ICache<ArrayBufferLike>,
 		snapshotTreeCache?: ICache<ISnapshotTreeVersion>,
@@ -68,7 +71,7 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
 		) {
 			return new PrefetchDocumentStorageService(storageService);
 		}
-		return storageService;
+		return adapterBuilders !== undefined ? applyStorageAdapters(storageService, adapterBuilders) : storageService;		
 	}
 
 	constructor(
@@ -76,6 +79,7 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
 		public manager: GitManager,
 		logger: ITelemetryLogger,
 		policies: IDocumentStorageServicePolicies,
+		adapterBuilders?: StorageAdapterBuilderType[],
 		driverPolicies?: IRouterliciousDriverPolicies,
 		blobCache?: ICache<ArrayBufferLike>,
 		snapshotTreeCache?: ICache<ISnapshotTreeVersion>,
@@ -88,6 +92,7 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
 				manager,
 				logger,
 				policies,
+				adapterBuilders,
 				driverPolicies,
 				blobCache,
 				snapshotTreeCache,


### PR DESCRIPTION
This draft PR has no ambition to be merged into main and it is only hacked PoC, no clean code. It is the base for our Monday discussion with @vladsud @DLehenbauer @dstanesc which shows, how AzureClient could pass flag to enable compression of summaries. The big challenge is location of compression adapter files, so far stored in driver-definitions which until now  offered only interfaces. The code works only with routerlicious driver which is directly instantiated with AzureClient. The DocumentStorageService at routerlicious driver calls also IDocumentStorageService.getSnapshotTree which is not implemented at the compression adapter. The adapter so far uses 16 byte header approach, if we agree on the approach and the location of source files, it will be converted to 1 byte solution. 

We also need to discuss

- Initial upload of summary looks to bypass IDocumentStorageService
  - Should we change this or possibly encode all blobs of the received summary? Or should we expect those blobs to be unencoded and should they be listed in the compressionMarker blob?
  - Should the compressionMarker blob be created at container.ts at the appSummary?
- Is routerlicious driver good place to introduce compression?
