### PR TITLE
fix(bump): Fix incorrect paths when bumping release groups

### DIFF
--- a/build-tools/packages/build-cli/src/lib/bump.ts
+++ b/build-tools/packages/build-cli/src/lib/bump.ts
@@ -172,41 +172,50 @@ export async function bumpReleaseGroup(
 		: bumpType;
 
 	let name: string;
-	const cmds: [string, string[]][] = [];
-	let workingDir: string;
+	const cmds: [string, string[], execa.Options | undefined][] = [];
+	let options: execa.Options | undefined;
 
 	// Run npm version in each package to set its version in package.json. Also regenerates packageVersion.ts if needed.
 	if (releaseGroupOrPackage instanceof MonoRepo) {
-		workingDir = context.gitRepo.resolvedRoot;
 		name = releaseGroupOrPackage.kind;
+		options = {
+			cwd: releaseGroupOrPackage.repoPath,
+			stdio: "inherit",
+			shell: true,
+		};
 		cmds.push(
-			[`flub`, [`exec`, "-g", name, "--", `"npm version ${translatedVersion.version}"`]],
-			[`npm`, ["run", "build:genver"]],
+			[
+				`flub`,
+				[`exec`, "-g", name, "--", `"npm version ${translatedVersion.version}"`],
+				options,
+			],
+			["pnpm", ["-r", "run", "build:genver"], options],
 		);
 	} else {
-		workingDir = releaseGroupOrPackage.directory;
 		name = releaseGroupOrPackage.name;
-		cmds.push([`npm`, ["version", translatedVersion.version]]);
+		options = {
+			cwd: releaseGroupOrPackage.directory,
+			stdio: "inherit",
+			shell: true,
+		};
+		cmds.push([`npm`, ["version", translatedVersion.version], options]);
 		if (releaseGroupOrPackage.getScript("build:genver") !== undefined) {
-			cmds.push([`npm`, ["run", "build:genver"]]);
+			cmds.push([`pnpm`, ["run", "build:genver"], options]);
 		}
 	}
 
-	for (const [cmd, args] of cmds) {
-		log?.verbose(`Running command: ${cmd} in ${workingDir}`);
+	for (const [cmd, args, opts] of cmds) {
+		log?.verbose(`Running command: ${cmd} ${args} in ${opts?.cwd}`);
 		try {
 			// TODO: The shell option should not need to be true. AB#4067
 			// eslint-disable-next-line no-await-in-loop
-			const results = await execa(cmd, args, {
-				cwd: workingDir,
-				stdio: "inherit",
-				shell: true,
-			});
+			const results = await execa(cmd, args, options);
 			if (results.all !== undefined) {
 				log?.verbose(results.all);
 			}
 		} catch (error: any) {
 			log?.errorLog(`Error running command: ${cmd} ${args}\n${error}`);
+			throw error;
 		}
 	}
 

--- a/build-tools/packages/build-cli/src/lib/bump.ts
+++ b/build-tools/packages/build-cli/src/lib/bump.ts
@@ -200,7 +200,7 @@ export async function bumpReleaseGroup(
 		};
 		cmds.push([`npm`, ["version", translatedVersion.version], options]);
 		if (releaseGroupOrPackage.getScript("build:genver") !== undefined) {
-			cmds.push([`pnpm`, ["run", "build:genver"], options]);
+			cmds.push([`npm`, ["run", "build:genver"], options]);
 		}
 	}
 


### PR DESCRIPTION
When bumping release groups, the spawned subprocesses were using the repo root as the working directory, which meant that the command did not work properly for most release groups.

I fixed the paths and did some other refactoring to make the code a bit cleaner.