### PR TITLE
Tree: Add skipped test demonstrating cross-field move composition bug

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -207,6 +207,7 @@ export class ModularChangeFamily
 		for (const [field, changesForField] of fieldChanges) {
 			let composedField: FieldChange;
 			if (changesForField.length === 1) {
+				// BUG: This field might be affected by cross-field effects, so we must recurse into it.
 				composedField = changesForField[0];
 			} else {
 				const { fieldKind, changesets } = this.normalizeFieldChanges(

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.spec.ts
@@ -835,6 +835,22 @@ describe("SequenceField - Compose", () => {
 		assert.deepEqual(actual, []);
 	});
 
+	it("move ○ move (forward)", () => {
+		const move1 = Change.move(0, 1, 1, brand(0));
+		const move2 = Change.move(1, 1, 2, brand(1));
+		const expected = Change.move(0, 1, 2, brand(1));
+		const actual = shallowCompose([makeAnonChange(move1), makeAnonChange(move2)]);
+		assert.deepEqual(actual, expected);
+	});
+
+	it("move ○ move (back)", () => {
+		const move1 = Change.move(2, 1, 1, brand(0));
+		const move2 = Change.move(1, 1, 0, brand(1));
+		const expected = Change.move(2, 1, 0, brand(1));
+		const actual = shallowCompose([makeAnonChange(move1), makeAnonChange(move2)]);
+		assert.deepEqual(actual, expected);
+	});
+
 	it("move ○ move with no net effect (back and forward)", () => {
 		const move1 = Change.move(1, 1, 0);
 		const move2 = Change.move(0, 1, 1);


### PR DESCRIPTION
## Description

Adds a skipped test to document a bug with the composition of cross-field moves.