### PR TITLE
Restart summarizer after 10 seconds

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3229,8 +3229,13 @@ export class ContainerRuntime
 				error,
 			);
 
+			const testDelayOverrideMs =
+				this.mc.config.getNumber(
+					"Fluid.ContainerRuntime.Test.CloseSummarizerOnSummaryStaleDelayOverrideMs",
+				) ?? defaultRestartDelayMs;
+
 			// Delay 10 seconds before restarting summarizer to prevent the summarizer from restarting too frequently.
-			await delay(defaultRestartDelayMs);
+			await delay(testDelayOverrideMs);
 			this._summarizer?.stop("latestSummaryStateStale");
 			this.closeFn();
 			throw error;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -509,7 +509,7 @@ const defaultCompressionConfig = {
 
 const defaultChunkSizeInBytes = 204800;
 
-const defaultCloseSummarizerDelayMs = 10000; // 10 seconds
+export const defaultCloseSummarizerDelayMs = 10000; // 10 seconds
 
 /**
  * @deprecated - use ContainerRuntimeMessage instead

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -31,6 +31,7 @@ import {
 } from "@fluidframework/container-runtime-definitions";
 import {
 	assert,
+	delay,
 	LazyPromise,
 	Trace,
 	TypedEventEmitter,
@@ -507,6 +508,8 @@ const defaultCompressionConfig = {
 };
 
 const defaultChunkSizeInBytes = 204800;
+
+const defaultRestartDelayMs = 10000; // 10 seconds
 
 /**
  * @deprecated - use ContainerRuntimeMessage instead
@@ -3225,6 +3228,9 @@ export class ContainerRuntime
 				},
 				error,
 			);
+
+			// Delay 10 seconds before restarting summarizer to prevent the summarizer from restarting too frequently.
+			await delay(defaultRestartDelayMs);
 			this._summarizer?.stop("latestSummaryStateStale");
 			this.closeFn();
 			throw error;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -509,7 +509,7 @@ const defaultCompressionConfig = {
 
 const defaultChunkSizeInBytes = 204800;
 
-export const defaultCloseSummarizerDelayMs = 10000; // 10 seconds
+const defaultCloseSummarizerDelayMs = 10000; // 10 seconds
 
 /**
  * @deprecated - use ContainerRuntimeMessage instead

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -677,6 +677,7 @@ export class RunningSummarizer implements IDisposable {
 				}
 
 				if (this.shouldAbortOnSummaryFailure) {
+					// There's no need to delay here as we already have summarizeAttemptDelay given to us by the server.
 					this.mc.logger.sendTelemetryEvent(
 						{
 							eventName: "ClosingSummarizerOnSummaryStale",

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -25,7 +25,7 @@ import { MockDeltaManager } from "@fluidframework/test-runtime-utils";
 import { IDeltaManager } from "@fluidframework/container-definitions";
 import { IContainerRuntimeEvents } from "@fluidframework/container-runtime-definitions";
 import { isRuntimeMessage } from "@fluidframework/driver-utils";
-import { ISummaryConfiguration, defaultCloseSummarizerDelayMs } from "../../containerRuntime";
+import { ISummaryConfiguration } from "../../containerRuntime";
 import {
 	getFailMessage,
 	neverCancelledSummaryToken,
@@ -667,63 +667,6 @@ describe("Runtime", () => {
 					assert.strictEqual(stopCall, 0);
 					await emitNack();
 					assert.strictEqual(stopCall, 1);
-				});
-
-				it("Should not retry on failure when stopping instead of restarting", async () => {
-					settings["Fluid.ContainerRuntime.Test.SummarizationRecoveryMethod"] = "restart";
-					settings["Fluid.ContainerRuntime.Test.SummarizationRecoveryMethod"] = "restart";
-					await startRunningSummarizer();
-					await emitNextOp();
-
-					// too early, should not run yet
-					await emitNextOp(summaryConfig.maxOps - 1);
-					assertRunCounts(0, 0, 0);
-
-					// now should run a normal run
-					await emitNextOp(1);
-					assertRunCounts(1, 0, 0);
-					const retryProps1 = {
-						summarizeCount: 1,
-						summaryAttemptsPerPhase: 1,
-						summaryAttempts: 1,
-						summaryAttemptPhase: 1,
-					};
-					assert(
-						mockLogger.matchEvents([
-							{ eventName: "Running:Summarize_generate", ...retryProps1 },
-							{ eventName: "Running:Summarize_Op", ...retryProps1 },
-						]),
-						"unexpected log sequence",
-					);
-
-					// should not run, because our summary hasn't been acked/nacked yet
-					await emitNextOp(summaryConfig.maxOps + 1);
-					assertRunCounts(1, 0, 0);
-
-					// should run with refresh after first nack
-					await emitNack();
-					await tickAndFlushPromises(defaultCloseSummarizerDelayMs);
-					assertRunCounts(2, 0, 0, "retry1 should not refreshLatestAck");
-					const retryProps2 = {
-						summarizeCount: 1,
-						summarizerSuccessfulAttempts: 0,
-					};
-					assert(
-						mockLogger.matchEvents([
-							{
-								eventName: "Running:Summarize_cancel",
-								...retryProps1,
-								reason: getFailMessage("summaryNack"),
-							},
-							{
-								eventName: "Running:ClosingSummarizerOnSummaryStale",
-								...retryProps2,
-							},
-						]),
-						"unexpected log sequence",
-					);
-					assert.strictEqual(stopCall, 1);
-					assert(mockRuntime.disposed, "runtime should be disposed!");
 				});
 
 				it("Should retry after delay on failures with retryAfter", async () => {

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -25,7 +25,7 @@ import { MockDeltaManager } from "@fluidframework/test-runtime-utils";
 import { IDeltaManager } from "@fluidframework/container-definitions";
 import { IContainerRuntimeEvents } from "@fluidframework/container-runtime-definitions";
 import { isRuntimeMessage } from "@fluidframework/driver-utils";
-import { ISummaryConfiguration } from "../../containerRuntime";
+import { ISummaryConfiguration, defaultCloseSummarizerDelayMs } from "../../containerRuntime";
 import {
 	getFailMessage,
 	neverCancelledSummaryToken,
@@ -671,6 +671,7 @@ describe("Runtime", () => {
 
 				it("Should not retry on failure when stopping instead of restarting", async () => {
 					settings["Fluid.ContainerRuntime.Test.SummarizationRecoveryMethod"] = "restart";
+					settings["Fluid.ContainerRuntime.Test.SummarizationRecoveryMethod"] = "restart";
 					await startRunningSummarizer();
 					await emitNextOp();
 
@@ -701,7 +702,8 @@ describe("Runtime", () => {
 
 					// should run with refresh after first nack
 					await emitNack();
-					assertRunCounts(2, 0, 0, "retry1 should be refreshLatestAck");
+					await tickAndFlushPromises(defaultCloseSummarizerDelayMs);
+					assertRunCounts(2, 0, 0, "retry1 should not refreshLatestAck");
 					const retryProps2 = {
 						summarizeCount: 1,
 						summarizerSuccessfulAttempts: 0,

--- a/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
@@ -33,6 +33,7 @@ describeNoCompat("Summarizer closes instead of refreshing", (getTestObjectProvid
 	beforeEach(async () => {
 		provider = getTestObjectProvider({ syncSummarizer: true });
 		settings["Fluid.ContainerRuntime.Test.SummarizationRecoveryMethod"] = "restart";
+		settings["Fluid.ContainerRuntime.Test.CloseSummarizerOnSummaryStaleDelayOverrideMs"] = 0; // so that we don't have to wait for the timeout
 	});
 
 	itExpects(

--- a/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
@@ -33,7 +33,7 @@ describeNoCompat("Summarizer closes instead of refreshing", (getTestObjectProvid
 	beforeEach(async () => {
 		provider = getTestObjectProvider({ syncSummarizer: true });
 		settings["Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod"] = "restart";
-		settings["Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs"] = 10000;
+		settings["Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs"] = 100;
 	});
 
 	itExpects(

--- a/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
@@ -32,8 +32,8 @@ describeNoCompat("Summarizer closes instead of refreshing", (getTestObjectProvid
 
 	beforeEach(async () => {
 		provider = getTestObjectProvider({ syncSummarizer: true });
-		settings["Fluid.ContainerRuntime.Test.SummarizationRecoveryMethod"] = "restart";
-		settings["Fluid.ContainerRuntime.Test.CloseSummarizerOnSummaryStaleDelayOverrideMs"] = 0; // so that we don't have to wait for the timeout
+		settings["Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod"] = "restart";
+		settings["Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs"] = 10000;
 	});
 
 	itExpects(
@@ -54,7 +54,6 @@ describeNoCompat("Summarizer closes instead of refreshing", (getTestObjectProvid
 				mockConfigProvider(settings),
 			);
 
-			await provider.ensureSynchronized();
 			const summarizeResults = summarizer.summarizeOnDemand({
 				reason: "end-to-end test",
 				refreshLatestAck: true,


### PR DESCRIPTION
[AB#3898](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3898)

In order to prevent the summarizer from restarting in rapid succession in which we make lots of network calls that would be throttled, we will delay 10 seconds before we close the summarizer.

If the summarizer restarts too frequently, it would slow down the client which would be problematic and a degradation of user experience.