### PR TITLE
Add summarizer restart feature to frs and tinylicious configs 

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -37,6 +37,11 @@
 						"Fluid.Container.summarizeProtocolTree2": [true, false],
 						"Fluid.ContainerRuntime.Test.SummarizationRecoveryMethod": ["restart", "default"]
 					}
+				},
+				"tinylicious": {
+					"configurations": {
+						"Fluid.ContainerRuntime.Test.SummarizationRecoveryMethod": ["restart", "default"]
+					}
 				}
 			},
 			"content": {
@@ -61,6 +66,13 @@
 				"opSizeinBytes": 214800,
 				"largeOpRate": 2000,
 				"numClients": 12
+			},
+			"optionOverrides": {
+				"routerlicious": {
+					"configurations": {
+						"Fluid.ContainerRuntime.Test.SummarizationRecoveryMethod": ["restart", "default"]
+					}
+				}
 			}
 		},
 		"full": {


### PR DESCRIPTION
[AB#4061](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4061)

Enable restart in frs and tinylicious stress tests