### PR TITLE
Bump minimum lts version to 1.3.4

### DIFF
--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -33,7 +33,7 @@ interface CompatConfig {
 // N and N - 1
 const defaultVersions = [0, -1];
 // we are currently supporting 0.45 long-term
-const LTSVersions = ["^0.45.0"];
+const LTSVersions = ["^1.3.4"];
 
 function genConfig(compatVersion: number | string): CompatConfig[] {
 	if (compatVersion === 0) {


### PR DESCRIPTION
[AB#3899](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3899)

Our data suggests that we can bump our LTS version that we do newest runtime vs oldest loader version comparisons, please review the task to view the data.

As for our azure build packages, we do not support cross version dependencies as we bundle everything together