### PR TITLE
fix(bump): Pass allow-same-version to npm version

### DIFF
--- a/build-tools/packages/build-cli/src/lib/bump.ts
+++ b/build-tools/packages/build-cli/src/lib/bump.ts
@@ -186,7 +186,13 @@ export async function bumpReleaseGroup(
 		cmds.push(
 			[
 				`flub`,
-				[`exec`, "-g", name, "--", `"npm version ${translatedVersion.version}"`],
+				[
+					`exec`,
+					"-g",
+					name,
+					"--",
+					`"npm version ${translatedVersion.version} --allow-same-version"`,
+				],
 				options,
 			],
 			["pnpm", ["-r", "run", "build:genver"], options],

--- a/build-tools/packages/build-cli/src/lib/bump.ts
+++ b/build-tools/packages/build-cli/src/lib/bump.ts
@@ -204,7 +204,7 @@ export async function bumpReleaseGroup(
 			stdio: "inherit",
 			shell: true,
 		};
-		cmds.push([`npm`, ["version", translatedVersion.version], options]);
+		cmds.push([`npm`, ["version", translatedVersion.version, "--allow-same-version"], options]);
 		if (releaseGroupOrPackage.getScript("build:genver") !== undefined) {
 			cmds.push([`npm`, ["run", "build:genver"], options]);
 		}


### PR DESCRIPTION
`npm version` fails when setting the same version, which we do in CI when publishing release packages. This updates our uses of npm version to pass `--allow-same-version`.

Example failure in the publishing pipeline due to this issue: <https://dev.azure.com/fluidframework/internal/_build/results?buildId=151607&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=035f10b1-6721-511e-bd48-d7e028467fc2>