### PR TITLE
ci: Skip publish steps for markdown-magic

### DIFF
--- a/tools/pipelines/build-api-markdown-documenter.yml
+++ b/tools/pipelines/build-api-markdown-documenter.yml
@@ -15,9 +15,9 @@ parameters:
     - prerelease
     - release
 - name: publishOverride
-  displayName: Publish Override (default = based on branch)
+  displayName: Publish Override (default = skip)
   type: string
-  default: default
+  default: skip
   values:
     - default
     - skip

--- a/tools/pipelines/build-api-markdown-documenter.yml
+++ b/tools/pipelines/build-api-markdown-documenter.yml
@@ -17,7 +17,7 @@ parameters:
 - name: publishOverride
   displayName: Publish Override (default = skip)
   type: string
-  default: skip
+  default: default
   values:
     - default
     - skip

--- a/tools/pipelines/build-api-markdown-documenter.yml
+++ b/tools/pipelines/build-api-markdown-documenter.yml
@@ -15,7 +15,7 @@ parameters:
     - prerelease
     - release
 - name: publishOverride
-  displayName: Publish Override (default = skip)
+  displayName: Publish Override (default = based on branch)
   type: string
   default: default
   values:

--- a/tools/pipelines/build-markdown-magic.yml
+++ b/tools/pipelines/build-markdown-magic.yml
@@ -17,7 +17,7 @@ parameters:
 - name: publishOverride
   displayName: Publish Override (default = based on branch)
   type: string
-  default: default
+  default: skip
   values:
     - default
     - skip

--- a/tools/pipelines/build-markdown-magic.yml
+++ b/tools/pipelines/build-markdown-magic.yml
@@ -15,7 +15,7 @@ parameters:
     - prerelease
     - release
 - name: publishOverride
-  displayName: Publish Override (default = based on branch)
+  displayName: Publish Override (default = skip)
   type: string
   default: skip
   values:


### PR DESCRIPTION
The package is private, so the publish steps should be skipped by default.