### PR TITLE
ci: Remove duplicate pnpm cache steps

### DIFF
--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -50,6 +50,7 @@ steps:
     parameters:
       buildDirectory: $(Build.SourcesDirectory)/build-tools
       pnpmStorePath: ${{ parameters.pnpmStorePath }}
+      enableCache: false
 
   - task: Bash@3
     name: InstallBuildTools


### PR DESCRIPTION
When installing pnpm in order to build in-repo build-tools, we can skip the cache since that was already done at that point in the pipeline.