### PR TITLE
Add ES2020 to library in build common config

### DIFF
--- a/common/build/build-common/ts-common-config.json
+++ b/common/build/build-common/ts-common-config.json
@@ -15,6 +15,6 @@
 		"types": [],
 		"strict": true,
 		"pretty": true,
-		"lib": ["DOM", "DOM.Iterable"]
+		"lib": ["ES2020", "DOM", "DOM.Iterable"]
 	}
 }


### PR DESCRIPTION
## Description
 Mistakenly removed the ES2017 version in this PR: https://github.com/microsoft/FluidFramework/pull/14892 when upgrading to ES2020. Adding ES2020 back.