### PR TITLE
feat(fluid-devtools): Tooltip to clarify ContainerID vs DocumentID

### DIFF
--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
@@ -12,6 +12,7 @@ import { IDisposable } from '@fluidframework/common-definitions';
 import { IEvent } from '@fluidframework/common-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
+import { IResolvedUrl } from '@fluidframework/driver-definitions';
 import { ISharedObject } from '@fluidframework/shared-object-base';
 import { ITelemetryBaseEvent } from '@fluidframework/common-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
@@ -155,6 +156,7 @@ export interface ContainerStateMetadata extends HasContainerKey {
     closed: boolean;
     // (undocumented)
     connectionState: ConnectionState;
+    resolvedUrl?: IResolvedUrl;
     userId?: string;
 }
 

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -65,6 +65,7 @@
 		"@fluidframework/container-utils": "workspace:~",
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/counter": "workspace:~",
+		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/matrix": "workspace:~",
 		"@fluidframework/protocol-definitions": "^1.1.0",
@@ -75,7 +76,6 @@
 	"devDependencies": {
 		"@fluidframework/build-common": "^1.2.0",
 		"@fluidframework/build-tools": "^0.19.0-165129",
-		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/tools/devtools/devtools-core/src/ContainerDevtools.ts
+++ b/packages/tools/devtools/devtools-core/src/ContainerDevtools.ts
@@ -553,6 +553,7 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 			closed: this.container.closed,
 			clientId: this.container.clientId,
 			userId: clientId === undefined ? undefined : this.audience.getMember(clientId)?.user.id,
+			resolvedUrl: this.container.resolvedUrl,
 		};
 	}
 

--- a/packages/tools/devtools/devtools-core/src/ContainerMetadata.ts
+++ b/packages/tools/devtools/devtools-core/src/ContainerMetadata.ts
@@ -5,6 +5,7 @@
 
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
+import { IResolvedUrl } from "@fluidframework/driver-definitions";
 import { HasContainerKey } from "./CommonInterfaces";
 
 /**
@@ -39,4 +40,9 @@ export interface ContainerStateMetadata extends HasContainerKey {
 	 * @remarks Will be undefined when the Container is not connected.
 	 */
 	userId?: string;
+
+	/**
+	 * The container's resolved URL, once it has been attached.
+	 */
+	resolvedUrl?: IResolvedUrl;
 }

--- a/packages/tools/devtools/devtools-example/src/index.tsx
+++ b/packages/tools/devtools/devtools-example/src/index.tsx
@@ -40,7 +40,7 @@ function DevToolsView(): React.ReactElement {
 				zIndex: "2",
 				backgroundColor: "lightgray", // TODO: remove
 			}}
-			defaultSize={{ width: 500, height: "100%" }}
+			defaultSize={{ width: 550, height: "100%" }}
 			className={"debugger-panel"}
 		>
 			<DevtoolsPanel messageRelay={new WindowMessageRelay("fluid-client-debugger-inline")} />

--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -48,6 +48,7 @@ import { useMessageRelay } from "../MessageRelayContext";
 import { Waiting } from "./Waiting";
 import {
 	clientIdTooltipText,
+	containerIdTooltipText,
 	containerResolvedUrlTooltipText,
 	containerStatusTooltipText,
 	deltaStorageUrlTooltipText,
@@ -316,6 +317,15 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 						columnProps={columnSizing_unstable}
 					/>
 					<DataRow
+						label="Container ID"
+						infoTooltipContent={containerIdTooltipText}
+						value={
+							(containerState.resolvedUrl as IResolvedUrl)?.id ??
+							"Container is not attached"
+						}
+						columnProps={columnSizing_unstable}
+					/>
+					<DataRow
 						label="Resolved URL"
 						infoTooltipContent={containerResolvedUrlTooltipText}
 						value={
@@ -337,8 +347,7 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 						label="Delta Storage URL"
 						infoTooltipContent={ordererUrlTooltipText}
 						value={
-							resolvedUrl?.endpoints?.ordererUrl ??
-							waitingForContainerToAttachText
+							resolvedUrl?.endpoints?.ordererUrl ?? waitingForContainerToAttachText
 						}
 						columnProps={columnSizing_unstable}
 					/>
@@ -346,8 +355,7 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 						label="Delta Storage URL"
 						infoTooltipContent={storageUrlTooltipText}
 						value={
-							resolvedUrl?.endpoints?.storageUrl ??
-							waitingForContainerToAttachText
+							resolvedUrl?.endpoints?.storageUrl ?? waitingForContainerToAttachText
 						}
 						columnProps={columnSizing_unstable}
 					/>

--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -51,12 +51,14 @@ import {
 	containerIdTooltipText,
 	containerResolvedUrlTooltipText,
 	containerStatusTooltipText,
-	deltaStorageUrlTooltipText,
-	ordererUrlTooltipText,
-	storageUrlTooltipText,
 	userIdTooltipText,
-	waitingForContainerToAttachText,
 } from "./TooltipTexts";
+
+/**
+ * Temporary text for labels that are undefined until a container is attached.
+ */
+export const waitingForContainerToAttachText =
+	"Container is not attached, or this endpoint doesn't apply to the service being used.";
 
 // Ensure FluentUI icons are initialized for use below.
 initializeFluentUiIcons();
@@ -326,31 +328,6 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 						label="Resolved URL"
 						infoTooltipContent={containerResolvedUrlTooltipText}
 						value={resolvedUrl?.url ?? waitingForContainerToAttachText}
-						columnProps={columnSizing_unstable}
-					/>
-					<DataRow
-						label="Orderer URL"
-						infoTooltipContent={ordererUrlTooltipText}
-						value={
-							resolvedUrl?.endpoints?.ordererUrl ?? waitingForContainerToAttachText
-						}
-						columnProps={columnSizing_unstable}
-					/>
-					<DataRow
-						label="Storage URL"
-						infoTooltipContent={storageUrlTooltipText}
-						value={
-							resolvedUrl?.endpoints?.storageUrl ?? waitingForContainerToAttachText
-						}
-						columnProps={columnSizing_unstable}
-					/>
-					<DataRow
-						label="Delta Storage URL"
-						infoTooltipContent={deltaStorageUrlTooltipText}
-						value={
-							resolvedUrl?.endpoints?.deltaStorageUrl ??
-							waitingForContainerToAttachText
-						}
 						columnProps={columnSizing_unstable}
 					/>
 				</Table>

--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -319,19 +319,13 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 					<DataRow
 						label="Container ID"
 						infoTooltipContent={containerIdTooltipText}
-						value={
-							(containerState.resolvedUrl as IResolvedUrl)?.id ??
-							"Container is not attached"
-						}
+						value={resolvedUrl?.id ?? waitingForContainerToAttachText}
 						columnProps={columnSizing_unstable}
 					/>
 					<DataRow
 						label="Resolved URL"
 						infoTooltipContent={containerResolvedUrlTooltipText}
-						value={
-							(containerState.resolvedUrl as IResolvedUrl)?.url ??
-							"Container is not attached"
-						}
+						value={resolvedUrl?.url ?? waitingForContainerToAttachText}
 						columnProps={columnSizing_unstable}
 					/>
 					<DataRow

--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -50,6 +50,9 @@ import {
 	clientIdTooltipText,
 	containerResolvedUrlTooltipText,
 	containerStatusTooltipText,
+	deltaStorageUrlTooltipText,
+	ordererUrlTooltipText,
+	storageUrlTooltipText,
 	userIdTooltipText,
 } from "./TooltipTexts";
 
@@ -195,8 +198,8 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 	const [columns] = React.useState<TableColumnDefinition<Item>[]>(columnsDef);
 	const [columnSizingOptions] = React.useState<TableColumnSizingOptions>({
 		containerProperty: {
-			idealWidth: 70,
-			minWidth: 70,
+			idealWidth: 130,
+			minWidth: 130,
 		},
 	});
 
@@ -284,6 +287,8 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 		}
 	}
 
+	const resolvedUrl: IResolvedUrl | undefined = containerState.resolvedUrl as IResolvedUrl;
+
 	return (
 		<Stack>
 			<StackItem align="center">
@@ -315,6 +320,33 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 						value={
 							(containerState.resolvedUrl as IResolvedUrl)?.url ??
 							"Container is not attached"
+						}
+						columnProps={columnSizing_unstable}
+					/>
+					<DataRow
+						label="Delta Storage URL"
+						infoTooltipContent={deltaStorageUrlTooltipText}
+						value={
+							resolvedUrl?.endpoints?.deltaStorageUrl ??
+							"Container is not attached, or this endpoint doesn't apply to the service being used."
+						}
+						columnProps={columnSizing_unstable}
+					/>
+					<DataRow
+						label="Delta Storage URL"
+						infoTooltipContent={ordererUrlTooltipText}
+						value={
+							resolvedUrl?.endpoints?.ordererUrl ??
+							"Container is not attached, or this endpoint doesn't apply to the service being used."
+						}
+						columnProps={columnSizing_unstable}
+					/>
+					<DataRow
+						label="Delta Storage URL"
+						infoTooltipContent={storageUrlTooltipText}
+						value={
+							resolvedUrl?.endpoints?.storageUrl ??
+							"Container is not attached, or this endpoint doesn't apply to the service being used."
 						}
 						columnProps={columnSizing_unstable}
 					/>

--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -45,7 +45,12 @@ import { initializeFluentUiIcons } from "../InitializeIcons";
 import { connectionStateToString } from "../Utilities";
 import { useMessageRelay } from "../MessageRelayContext";
 import { Waiting } from "./Waiting";
-import { clientIdTooltipText, containerStatusTooltipText, userIdTooltipText } from "./TooltipTexts";
+import {
+	clientIdTooltipText,
+	containerKeyTooltipText,
+	containerStatusTooltipText,
+	userIdTooltipText,
+} from "./TooltipTexts";
 
 // Ensure FluentUI icons are initialized for use below.
 initializeFluentUiIcons();
@@ -301,6 +306,12 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 						label="User ID"
 						infoTooltipContent={userIdTooltipText}
 						value={containerState.userId}
+						columnProps={columnSizing_unstable}
+					/>
+					<DataRow
+						label="Container Key"
+						infoTooltipContent={containerKeyTooltipText}
+						value={containerState.containerKey}
 						columnProps={columnSizing_unstable}
 					/>
 				</Table>

--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -54,6 +54,7 @@ import {
 	ordererUrlTooltipText,
 	storageUrlTooltipText,
 	userIdTooltipText,
+	waitingForContainerToAttachText,
 } from "./TooltipTexts";
 
 // Ensure FluentUI icons are initialized for use below.
@@ -328,7 +329,7 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 						infoTooltipContent={deltaStorageUrlTooltipText}
 						value={
 							resolvedUrl?.endpoints?.deltaStorageUrl ??
-							"Container is not attached, or this endpoint doesn't apply to the service being used."
+							waitingForContainerToAttachText
 						}
 						columnProps={columnSizing_unstable}
 					/>
@@ -337,7 +338,7 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 						infoTooltipContent={ordererUrlTooltipText}
 						value={
 							resolvedUrl?.endpoints?.ordererUrl ??
-							"Container is not attached, or this endpoint doesn't apply to the service being used."
+							waitingForContainerToAttachText
 						}
 						columnProps={columnSizing_unstable}
 					/>
@@ -346,7 +347,7 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 						infoTooltipContent={storageUrlTooltipText}
 						value={
 							resolvedUrl?.endpoints?.storageUrl ??
-							"Container is not attached, or this endpoint doesn't apply to the service being used."
+							waitingForContainerToAttachText
 						}
 						columnProps={columnSizing_unstable}
 					/>

--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -40,6 +40,7 @@ import {
 } from "@fluid-experimental/devtools-core";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
+import { IResolvedUrl } from "@fluidframework/driver-definitions";
 
 import { initializeFluentUiIcons } from "../InitializeIcons";
 import { connectionStateToString } from "../Utilities";
@@ -47,7 +48,7 @@ import { useMessageRelay } from "../MessageRelayContext";
 import { Waiting } from "./Waiting";
 import {
 	clientIdTooltipText,
-	containerKeyTooltipText,
+	containerResolvedUrlTooltipText,
 	containerStatusTooltipText,
 	userIdTooltipText,
 } from "./TooltipTexts";
@@ -309,9 +310,12 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 						columnProps={columnSizing_unstable}
 					/>
 					<DataRow
-						label="Container Key"
-						infoTooltipContent={containerKeyTooltipText}
-						value={containerState.containerKey}
+						label="Resolved URL"
+						infoTooltipContent={containerResolvedUrlTooltipText}
+						value={
+							(containerState.resolvedUrl as IResolvedUrl)?.url ??
+							"Container is not attached"
+						}
 						columnProps={columnSizing_unstable}
 					/>
 				</Table>

--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -329,16 +329,7 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 						columnProps={columnSizing_unstable}
 					/>
 					<DataRow
-						label="Delta Storage URL"
-						infoTooltipContent={deltaStorageUrlTooltipText}
-						value={
-							resolvedUrl?.endpoints?.deltaStorageUrl ??
-							waitingForContainerToAttachText
-						}
-						columnProps={columnSizing_unstable}
-					/>
-					<DataRow
-						label="Delta Storage URL"
+						label="Orderer URL"
 						infoTooltipContent={ordererUrlTooltipText}
 						value={
 							resolvedUrl?.endpoints?.ordererUrl ?? waitingForContainerToAttachText
@@ -346,10 +337,19 @@ export function ContainerSummaryView(props: ContainerSummaryViewProps): React.Re
 						columnProps={columnSizing_unstable}
 					/>
 					<DataRow
-						label="Delta Storage URL"
+						label="Storage URL"
 						infoTooltipContent={storageUrlTooltipText}
 						value={
 							resolvedUrl?.endpoints?.storageUrl ?? waitingForContainerToAttachText
+						}
+						columnProps={columnSizing_unstable}
+					/>
+					<DataRow
+						label="Delta Storage URL"
+						infoTooltipContent={deltaStorageUrlTooltipText}
+						value={
+							resolvedUrl?.endpoints?.deltaStorageUrl ??
+							waitingForContainerToAttachText
 						}
 						columnProps={columnSizing_unstable}
 					/>

--- a/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
@@ -62,6 +62,12 @@ export const storageUrlTooltipText =
 	"Endpoint where the Fluid service provides the latest snapshot of the Fluid Container's contents.";
 
 /**
+ * Temporary text for labels that are undefined until a container is attached.
+ */
+export const waitingForContainerToAttachText =
+	"Container is not attached, or this endpoint doesn't apply to the service being used.";
+
+/**
  * Description of the Client's "Mode" property in the audience view.
  */
 export const clientModeTooltipText = (

--- a/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
@@ -52,30 +52,6 @@ export const containerIdTooltipText =
 export const containerResolvedUrlTooltipText = "Fluid-internal URL that identifies the container.";
 
 /**
- * Description of the Container "Delta Storage URL" property in the summary view.
- */
-export const deltaStorageUrlTooltipText =
-	"Endpoint where the Fluid service provides recent ops that it has in storage";
-
-/**
- * Description of the Container "Orderer URL" property in the summary view.
- */
-export const ordererUrlTooltipText =
-	"Endpoint where the Fluid service receives unsequenced ops/messages and broadcasts sequenced ops/messages.";
-
-/**
- * Description of the Container "Storage URL" property in the summary view.
- */
-export const storageUrlTooltipText =
-	"Endpoint where the Fluid service provides the latest snapshot of the Fluid Container's contents.";
-
-/**
- * Temporary text for labels that are undefined until a container is attached.
- */
-export const waitingForContainerToAttachText =
-	"Container is not attached, or this endpoint doesn't apply to the service being used.";
-
-/**
  * Description of the Client's "Mode" property in the audience view.
  */
 export const clientModeTooltipText = (

--- a/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
@@ -39,6 +39,16 @@ export const containerStatusTooltipText = (
 );
 
 /**
+ * Description of the Container "ID" property in the summary view.
+ */
+export const containerKeyTooltipText = (
+	<div>
+		User-specified identifier that uniquely identifies the container within this session of
+		Fluid Devtools.
+	</div>
+);
+
+/**
  * Description of the Client's "Mode" property in the audience view.
  */
 export const clientModeTooltipText = (

--- a/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
@@ -39,6 +39,14 @@ export const containerStatusTooltipText = (
 );
 
 /**
+ * Description of the Container "Container ID" property in the summary view.
+ */
+export const containerIdTooltipText =
+	"Id that uniquely identifies the Fluid Container within the service where it lives. " +
+	"NOTE: it is not the same thing as the 'containerId' field found in some telemetry events, " +
+	"which is an ephemeral id generated locally as part of creating/loading a Fluid Container.";
+
+/**
  * Description of the Container "Resolved URL" property in the summary view.
  */
 export const containerResolvedUrlTooltipText = "Fluid-internal URL that identifies the container.";

--- a/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
@@ -41,9 +41,25 @@ export const containerStatusTooltipText = (
 /**
  * Description of the Container "Resolved URL" property in the summary view.
  */
-export const containerResolvedUrlTooltipText = (
-	<div>URL that identifies the container within the current loader.</div>
-);
+export const containerResolvedUrlTooltipText = "Fluid-internal URL that identifies the container.";
+
+/**
+ * Description of the Container "Delta Storage URL" property in the summary view.
+ */
+export const deltaStorageUrlTooltipText =
+	"Endpoint where the Fluid service provides recent ops that it has in storage";
+
+/**
+ * Description of the Container "Orderer URL" property in the summary view.
+ */
+export const ordererUrlTooltipText =
+	"Endpoint where the Fluid service receives unsequenced ops/messages and broadcasts sequenced ops/messages.";
+
+/**
+ * Description of the Container "Storage URL" property in the summary view.
+ */
+export const storageUrlTooltipText =
+	"Endpoint where the Fluid service provides the latest snapshot of the Fluid Container's contents.";
 
 /**
  * Description of the Client's "Mode" property in the audience view.

--- a/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
@@ -39,13 +39,10 @@ export const containerStatusTooltipText = (
 );
 
 /**
- * Description of the Container "ID" property in the summary view.
+ * Description of the Container "Resolved URL" property in the summary view.
  */
-export const containerKeyTooltipText = (
-	<div>
-		User-specified identifier that uniquely identifies the container within this session of
-		Fluid Devtools.
-	</div>
+export const containerResolvedUrlTooltipText = (
+	<div>URL that identifies the container within the current loader.</div>
 );
 
 /**

--- a/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
@@ -43,6 +43,7 @@ export const containerStatusTooltipText = (
  */
 export const containerIdTooltipText =
 	"Id that uniquely identifies the Fluid Container within the service where it lives. " +
+	"Sometimes also called 'documentId'. " +
 	"NOTE: it is not the same thing as the 'containerId' field found in some telemetry events, " +
 	"which is an ephemeral id generated locally as part of creating/loading a Fluid Container.";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15661,6 +15661,9 @@ importers:
       '@fluidframework/counter':
         specifier: workspace:~
         version: link:../../../dds/counter
+      '@fluidframework/driver-definitions':
+        specifier: workspace:~
+        version: link:../../../common/driver-definitions
       '@fluidframework/map':
         specifier: workspace:~
         version: link:../../../dds/map
@@ -15686,9 +15689,6 @@ importers:
       '@fluidframework/build-tools':
         specifier: ^0.19.0-165129
         version: 0.19.0-165129
-      '@fluidframework/driver-definitions':
-        specifier: workspace:~
-        version: link:../../../common/driver-definitions
       '@fluidframework/eslint-config-fluid':
         specifier: ^2.0.0
         version: 2.0.0(eslint@8.6.0)(typescript@4.5.5)


### PR DESCRIPTION
## Description

Updates the fields displayed in the container summary view.

<img width="593" alt="image" src="https://user-images.githubusercontent.com/716334/235813555-ee52738f-d80c-43b9-906d-72de936a83ba.png">

Had to increase the ideal/min column width so the icons didn't move to a new line, and apply some inline styles to it to get them vertically centered with respect to their labels.

Tooltip looks like this:

<img width="477" alt="image" src="https://user-images.githubusercontent.com/716334/235813650-d276b319-cbe0-491a-8203-c7accfa87729.png">

## Reviewer Guidance

Particularly interested in making the tooltips for the endpoints accurate, since I'm not too familiar with the purpose/features of each endpoint.

[AB#3638](https://dev.azure.com/fluidframework/internal/_workitems/edit/3638)