### PR TITLE
MergeTree: Simplify members, and Clean up tests

### DIFF
--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -710,7 +710,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 		segmentGroup: SegmentGroup,
 	): IMergeTreeDeltaOp[] {
 		assert(!!segmentGroup, 0x033 /* "Segment group undefined" */);
-		const NACKedSegmentGroup = this._mergeTree.pendingSegments?.shift()?.data;
+		const NACKedSegmentGroup = this._mergeTree.pendingSegments.shift()?.data;
 		assert(
 			segmentGroup === NACKedSegmentGroup,
 			0x034 /* "Segment group not at head of merge tree pending queue" */,
@@ -791,7 +791,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 					refSeq: this.getCollabWindow().currentSeq,
 				};
 				segment.segmentGroups.enqueue(newSegmentGroup);
-				this._mergeTree.pendingSegments!.push(newSegmentGroup);
+				this._mergeTree.pendingSegments.push(newSegmentGroup);
 				opList.push(newOp);
 			}
 		}

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -181,7 +181,7 @@ describe("client.applyMsg", () => {
 		assert.equal(segmentInfo.segment?.removedSeq, UnassignedSequenceNumber);
 		assert.equal(client.mergeTree.pendingSegments?.length, 1);
 
-		client.applyMsg(client.makeOpMessage(removeOp, 18));
+		client.applyMsg(client.makeOpMessage(removeOp, 18, 0));
 
 		assert.equal(segmentInfo.segment?.removedSeq, 18);
 		assert.equal(client.mergeTree.pendingSegments?.length, 0);
@@ -234,7 +234,7 @@ describe("client.applyMsg", () => {
 		assert.equal(segmentInfo.segment?.removedSeq, remoteMessage.sequenceNumber);
 		assert.equal(segmentInfo.segment?.segmentGroups.size, 1);
 
-		client.applyMsg(client.makeOpMessage(removeOp, 18));
+		client.applyMsg(client.makeOpMessage(removeOp, 18, 0));
 
 		assert.equal(segmentInfo.segment?.removedSeq, remoteMessage.sequenceNumber);
 		assert(segmentInfo.segment?.segmentGroups.empty);
@@ -594,7 +594,7 @@ describe("client.applyMsg", () => {
 	 * Client C does not match client A
 	 * ```
 	 */
-	it.skip("Concurrent insert into removed segment across block boundary", () => {
+	it("Concurrent insert into removed segment across block boundary", () => {
 		const clients = createClientsAtInitialState(
 			{ initialState: "", options: { mergeTreeUseNewLengthCalculations: true } },
 			"A",

--- a/packages/dds/merge-tree/src/zamboni.ts
+++ b/packages/dds/merge-tree/src/zamboni.ts
@@ -25,11 +25,11 @@ export function zamboniSegments(
 	}
 
 	for (let i = 0; i < zamboniSegmentsMaxCount; i++) {
-		let segmentToScour = mergeTree.getSegmentsToScour!.peek();
+		let segmentToScour = mergeTree.segmentsToScour.peek();
 		if (!segmentToScour || segmentToScour.maxSeq > mergeTree.collabWindow.minSeq) {
 			break;
 		}
-		segmentToScour = mergeTree.getSegmentsToScour!.get();
+		segmentToScour = mergeTree.segmentsToScour.get();
 		// Only skip scouring if needs scour is explicitly false, not true or undefined
 		if (segmentToScour.segment!.parent && segmentToScour.segment!.parent.needsScour !== false) {
 			const block = segmentToScour.segment!.parent;


### PR DESCRIPTION
## Description

Initially i tried to make reference sequence number handling strict: 
``` diff
        public ackPendingSegment(opArgs: IMergeTreeDeltaOpArgs) {
-               const seq = opArgs.sequencedMessage!.sequenceNumber;
-               const pendingSegmentGroup = this.pendingSegments!.shift()?.data;
+               assert(opArgs.sequencedMessage !== undefined, "must be remote op and include message");
+               const { sequenceNumber, referenceSequenceNumber } = opArgs.sequencedMessage;
+               const pendingSegmentGroup = this.pendingSegments.shift()?.data;
+               assert(pendingSegmentGroup !== undefined, "must have pending segment group");
+               assert(
+                       pendingSegmentGroup.refSeq === referenceSequenceNumber,
+                       "segment group refseq must match message's",
+               );
```

However, this lead to lots of test failures. So i removed that portion, and kept the couple tests i fixed, and a simplification to pendingSegments  and segmentsToScour, specifically, they are both no longer nullable, and are readonly.

related to [AB#4094](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4094)