### PR TITLE
Migration demo test updates

### DIFF
--- a/examples/hosts/app-integration/schema-upgrade/src/demoCodeLoader.ts
+++ b/examples/hosts/app-integration/schema-upgrade/src/demoCodeLoader.ts
@@ -20,24 +20,30 @@ import type {
 import { InventoryListContainerRuntimeFactory as InventoryListContainerRuntimeFactory1 } from "./modelVersion1";
 import { InventoryListContainerRuntimeFactory as InventoryListContainerRuntimeFactory2 } from "./modelVersion2";
 
-const v1ModuleWithDetails: IFluidModuleWithDetails = {
-	module: { fluidExport: new InventoryListContainerRuntimeFactory1() },
-	details: { package: "one" },
-};
-
-const v2ModuleWithDetails: IFluidModuleWithDetails = {
-	module: { fluidExport: new InventoryListContainerRuntimeFactory2() },
-	details: { package: "two" },
-};
-
 // This ICodeDetailsLoader specifically supports versions one and two.  Other approaches might have network calls to
 // dynamically load in the appropriate code for unknown versions.
 export class DemoCodeLoader implements ICodeDetailsLoader {
+	/**
+	 * Code loader for the demo. Supports a test mode which spawns the summarizer instantly.
+	 * @param testMode - True to enable instant summarizer spawning.
+	 */
+	public constructor(private readonly testMode = false) {}
 	public async load(source: IFluidCodeDetails): Promise<IFluidModuleWithDetails> {
 		const version = source.package;
 		if (typeof version !== "string") {
 			throw new TypeError("Unexpected code detail format");
 		}
+
+		const v1ModuleWithDetails: IFluidModuleWithDetails = {
+			module: { fluidExport: new InventoryListContainerRuntimeFactory1(this.testMode) },
+			details: { package: "one" },
+		};
+
+		const v2ModuleWithDetails: IFluidModuleWithDetails = {
+			module: { fluidExport: new InventoryListContainerRuntimeFactory2(this.testMode) },
+			details: { package: "two" },
+		};
+
 		switch (version) {
 			case "one":
 				return v1ModuleWithDetails;

--- a/examples/hosts/app-integration/schema-upgrade/src/modelVersion1/containerCode.ts
+++ b/examples/hosts/app-integration/schema-upgrade/src/modelVersion1/containerCode.ts
@@ -20,12 +20,23 @@ export const inventoryListId = "default-inventory-list";
 export const migrationToolId = "migration-tool";
 
 export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeFactory<IInventoryListAppModel> {
-	constructor() {
+	/**
+	 * Constructor for the factory. Supports a test mode which spawns the summarizer instantly.
+	 * @param testMode - True to enable instant summarizer spawning.
+	 */
+	public constructor(testMode: boolean) {
 		super(
 			new Map([
 				InventoryListInstantiationFactory.registryEntry,
 				MigrationToolInstantiationFactory.registryEntry,
 			]), // registryEntries
+			testMode
+				? {
+						summaryOptions: {
+							initialSummarizerDelayMs: 0,
+						},
+				  }
+				: undefined,
 		);
 	}
 

--- a/examples/hosts/app-integration/schema-upgrade/src/modelVersion2/containerCode.ts
+++ b/examples/hosts/app-integration/schema-upgrade/src/modelVersion2/containerCode.ts
@@ -20,12 +20,23 @@ export const inventoryListId = "default-inventory-list";
 export const migrationToolId = "migration-tool";
 
 export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeFactory<IInventoryListAppModel> {
-	constructor() {
+	/**
+	 * Constructor for the factory. Supports a test mode which spawns the summarizer instantly.
+	 * @param testMode - True to enable instant summarizer spawning.
+	 */
+	public constructor(testMode: boolean) {
 		super(
 			new Map([
 				InventoryListInstantiationFactory.registryEntry,
 				MigrationToolInstantiationFactory.registryEntry,
 			]), // registryEntries
+			testMode
+				? {
+						summaryOptions: {
+							initialSummarizerDelayMs: 0,
+						},
+				  }
+				: undefined,
 		);
 	}
 

--- a/examples/hosts/app-integration/schema-upgrade/src/view/debugView.tsx
+++ b/examples/hosts/app-integration/schema-upgrade/src/view/debugView.tsx
@@ -100,7 +100,7 @@ const MigrationStatusView: React.FC<IMigrationStatusViewProps> = (
 	})();
 
 	return (
-		<div style={{ margin: "10px 0" }}>
+		<div className="migration-status" style={{ margin: "10px 0" }}>
 			<div>Using model: {model.version}</div>
 			<div>
 				Status:

--- a/examples/hosts/app-integration/schema-upgrade/tests/index.tsx
+++ b/examples/hosts/app-integration/schema-upgrade/tests/index.tsx
@@ -3,49 +3,100 @@
  * Licensed under the MIT License.
  */
 
-import { SessionStorageModelLoader, StaticCodeLoader } from "@fluid-example/example-utils";
+import {
+	IMigratableModel,
+	IModelLoader,
+	IVersionedModel,
+	Migrator,
+	SessionStorageModelLoader,
+} from "@fluid-example/example-utils";
 
 import React from "react";
 import ReactDOM from "react-dom";
 
-import { InventoryListView } from "../src/view/inventoryView";
-import { InventoryListContainerRuntimeFactory } from "../src/modelVersion1";
 import type { IInventoryListAppModel } from "../src/modelInterfaces";
+import { DebugView, InventoryListAppView } from "../src/view";
+import { inventoryListDataTransformationCallback } from "../src/dataTransform";
+import { DemoCodeLoader } from "../src/demoCodeLoader";
+
+const updateTabForId = (id: string) => {
+	// Update the URL with the actual ID
+	location.hash = id;
+
+	// Put the ID in the tab title
+	document.title = id;
+};
+
+const isIInventoryListAppModel = (model: IVersionedModel): model is IInventoryListAppModel => {
+	return model.version === "one" || model.version === "two";
+};
+
+const getUrlForContainerId = (containerId: string) => `/#${containerId}`;
 
 /**
  * This is a helper function for loading the page. It's required because getting the Fluid Container
  * requires making async calls.
  */
 export async function createContainerAndRenderInElement(element: HTMLDivElement) {
-	const sessionStorageModelLoader = new SessionStorageModelLoader<IInventoryListAppModel>(
-		new StaticCodeLoader(new InventoryListContainerRuntimeFactory()),
-	);
-
 	let id: string;
-	let model: IInventoryListAppModel;
+	let modelLoader: IModelLoader<IMigratableModel>;
+	let model: IMigratableModel;
 
 	if (location.hash.length === 0) {
+		modelLoader = new SessionStorageModelLoader<IInventoryListAppModel>(new DemoCodeLoader());
 		// Normally our code loader is expected to match up with the version passed here.
 		// But since we're using a StaticCodeLoader that always loads the same runtime factory regardless,
 		// the version doesn't actually matter.
-		const createResponse = await sessionStorageModelLoader.createDetached("1.0");
+		const createResponse = await modelLoader.createDetached("one");
 		model = createResponse.model;
 
-		// Add a test item so we can see something.
-		model.inventoryList.addItem("testName", 3);
-
+		// Should be the same as the uuid we generated above.
 		id = await createResponse.attach();
 	} else {
 		id = location.hash.substring(1);
-		model = await sessionStorageModelLoader.loadExisting(id);
+		modelLoader = new SessionStorageModelLoader<IInventoryListAppModel>(new DemoCodeLoader());
+		model = await modelLoader.loadExisting(id);
 	}
 
-	// update the browser URL and the window title with the actual container ID
-	location.hash = id;
-	document.title = id;
+	const appDiv = document.createElement("div");
+	const debugDiv = document.createElement("div");
 
+	const render = (model: IVersionedModel) => {
+		ReactDOM.unmountComponentAtNode(appDiv);
+		// This demo uses the same view for both versions 1 & 2 - if we wanted to use different views for different model
+		// versions, we could check its version here and select the appropriate view.  Or we could even write ourselves a
+		// view code loader to pull in the view dynamically based on the version we discover.
+		if (isIInventoryListAppModel(model)) {
+			ReactDOM.render(React.createElement(InventoryListAppView, { model }), appDiv);
+
+			// The DebugView is just for demo purposes, to manually control code proposal and inspect the state.
+			ReactDOM.unmountComponentAtNode(debugDiv);
+			ReactDOM.render(
+				React.createElement(DebugView, {
+					model,
+					getUrlForContainerId,
+				}),
+				debugDiv,
+			);
+		} else {
+			throw new Error(`Don't know how to render version ${model.version}`);
+		}
+	};
+
+	const migrator = new Migrator(modelLoader, model, id, inventoryListDataTransformationCallback);
+	migrator.on("migrated", () => {
+		model.close();
+		render(migrator.currentModel);
+		updateTabForId(migrator.currentModelId);
+		model = migrator.currentModel;
+	});
+
+	// update the browser URL and the window title with the actual container ID
+	updateTabForId(id);
 	// Render it
-	ReactDOM.render(<InventoryListView inventoryList={model.inventoryList} />, element);
+	render(model);
+
+	element.append(appDiv, debugDiv);
 
 	// Setting "fluidStarted" is just for our test automation
 	// eslint-disable-next-line @typescript-eslint/dot-notation

--- a/examples/hosts/app-integration/schema-upgrade/tests/index.tsx
+++ b/examples/hosts/app-integration/schema-upgrade/tests/index.tsx
@@ -41,7 +41,11 @@ window["migrators"] = [];
  * requires making async calls.
  */
 export async function createContainerAndRenderInElement(element: HTMLDivElement) {
-	const modelLoader = new SessionStorageModelLoader<IInventoryListAppModel>(new DemoCodeLoader());
+	const searchParams = new URLSearchParams(location.search);
+	const testMode = searchParams.get("testMode") !== null;
+	const modelLoader = new SessionStorageModelLoader<IInventoryListAppModel>(
+		new DemoCodeLoader(testMode),
+	);
 	let id: string;
 	let model: IMigratableModel;
 

--- a/examples/hosts/app-integration/schema-upgrade/tests/inventoryList.test.ts
+++ b/examples/hosts/app-integration/schema-upgrade/tests/inventoryList.test.ts
@@ -22,4 +22,52 @@ describe("inventoryList", () => {
 		// Validate the input shows up
 		await page.waitForSelector("input");
 	});
+
+	it("can click the migrate debug button", async () => {
+		// Validate there is a button that can be clicked
+		await expect(page).toClick("button", { text: '"two"' });
+	});
+
+	it("shows the correct code version at pageload", async () => {
+		// Validate the migration status shows "one"
+		await page.waitForSelector(".migration-status");
+		const containsOne = await page.evaluate(() => {
+			const migrationStatusElement = document.querySelector(".migration-status");
+			return migrationStatusElement?.textContent?.includes("one") === true;
+		});
+		await expect(containsOne).toEqual(true);
+	});
+
+	it("migrates and shows the correct code version after migration", async () => {
+		// Validate the migration status shows "one" initially
+		await page.waitForSelector(".migration-status");
+		const leftContainsOne = await page.evaluate(() => {
+			const migrationStatusElements = document.querySelectorAll(".migration-status");
+			return migrationStatusElements[0]?.textContent?.includes("one") === true;
+		});
+		const rightContainsOne = await page.evaluate(() => {
+			const migrationStatusElements = document.querySelectorAll(".migration-status");
+			return migrationStatusElements[1]?.textContent?.includes("one") === true;
+		});
+		await expect(leftContainsOne).toEqual(true);
+		await expect(rightContainsOne).toEqual(true);
+
+		await expect(page).toClick("button", { text: '"two"' });
+
+		await new Promise((resolve) => {
+			setTimeout(resolve, 500);
+		});
+
+		// Validate the migration status shows "two" after the migration
+		const leftContainsTwo = await page.evaluate(() => {
+			const migrationStatusElements = document.querySelectorAll(".migration-status");
+			return migrationStatusElements[0]?.textContent?.includes("two") === true;
+		});
+		const rightContainsTwo = await page.evaluate(() => {
+			const migrationStatusElements = document.querySelectorAll(".migration-status");
+			return migrationStatusElements[1]?.textContent?.includes("two") === true;
+		});
+		await expect(leftContainsTwo).toEqual(true);
+		await expect(rightContainsTwo).toEqual(true);
+	});
 });

--- a/examples/hosts/app-integration/schema-upgrade/tests/inventoryList.test.ts
+++ b/examples/hosts/app-integration/schema-upgrade/tests/inventoryList.test.ts
@@ -5,6 +5,7 @@
 
 import { IMigrator } from "@fluid-example/example-utils";
 import { globals } from "../jest.config";
+import { IContainer } from "@fluidframework/container-definitions";
 
 // Tests disabled -- requires Tinylicious to be running, which our test environment doesn't do.
 describe("inventoryList", () => {
@@ -14,77 +15,161 @@ describe("inventoryList", () => {
 		await page.goto(globals.PATH, { waitUntil: "load", timeout: 0 });
 	}, 45000);
 
-	beforeEach(async () => {
-		await page.goto(globals.PATH, { waitUntil: "load" });
-		await page.waitFor(() => window["fluidStarted"]);
+	describe("Without summarizer connected", () => {
+		beforeEach(async () => {
+			await page.goto(globals.PATH, { waitUntil: "load" });
+			await page.waitFor(() => window["fluidStarted"]);
+		});
+
+		it("loads and there's an input", async () => {
+			// Validate the input shows up
+			await page.waitForSelector("input");
+		});
+
+		it("can click the migrate debug button", async () => {
+			// Validate there is a button that can be clicked
+			await expect(page).toClick("button", { text: '"two"' });
+		});
+
+		it("shows the correct code version at pageload", async () => {
+			// Validate the migration status shows "one"
+			await page.waitForSelector(".migration-status");
+			const containsOne = await page.evaluate(() => {
+				const migrationStatusElement = document.querySelector(".migration-status");
+				return migrationStatusElement?.textContent?.includes("one") === true;
+			});
+			await expect(containsOne).toEqual(true);
+		});
+
+		it("migrates and shows the correct code version after migration", async () => {
+			// Validate the migration status shows "one" initially
+			await Promise.all([
+				page.waitForSelector("#sbs-left .migration-status"),
+				page.waitForSelector("#sbs-right .migration-status"),
+			]);
+			const leftContainsOne = await page.evaluate(() => {
+				const migrationStatusElements = document.querySelectorAll(".migration-status");
+				return migrationStatusElements[0]?.textContent?.includes("one") === true;
+			});
+			const rightContainsOne = await page.evaluate(() => {
+				const migrationStatusElements = document.querySelectorAll(".migration-status");
+				return migrationStatusElements[1]?.textContent?.includes("one") === true;
+			});
+			await expect(leftContainsOne).toEqual(true);
+			await expect(rightContainsOne).toEqual(true);
+
+			const migratorsLength = await page.evaluate(() => {
+				return window["migrators"].length;
+			});
+			await expect(migratorsLength).toEqual(2);
+
+			// Get a promise that will resolve when both sides have finished migration
+			const migrationP = page.evaluate(() => {
+				const migrationPs = (window["migrators"] as IMigrator[]).map((migrator) => {
+					return new Promise<void>((resolve) => {
+						migrator.once("migrated", resolve);
+					});
+				});
+				return Promise.all(migrationPs);
+			});
+
+			await expect(page).toClick("button", { text: '"two"' });
+
+			await migrationP;
+
+			// Validate the migration status shows "two" after the migration
+			const leftContainsTwo = await page.evaluate(() => {
+				const migrationStatusElements = document.querySelectorAll(".migration-status");
+				return migrationStatusElements[0]?.textContent?.includes("two") === true;
+			});
+			const rightContainsTwo = await page.evaluate(() => {
+				const migrationStatusElements = document.querySelectorAll(".migration-status");
+				return migrationStatusElements[1]?.textContent?.includes("two") === true;
+			});
+			await expect(leftContainsTwo).toEqual(true);
+			await expect(rightContainsTwo).toEqual(true);
+		});
 	});
 
-	it("loads and there's an input", async () => {
-		// Validate the input shows up
-		await page.waitForSelector("input");
-	});
-
-	it("can click the migrate debug button", async () => {
-		// Validate there is a button that can be clicked
-		await expect(page).toClick("button", { text: '"two"' });
-	});
-
-	it("shows the correct code version at pageload", async () => {
-		// Validate the migration status shows "one"
-		await page.waitForSelector(".migration-status");
-		const containsOne = await page.evaluate(() => {
-			const migrationStatusElement = document.querySelector(".migration-status");
-			return migrationStatusElement?.textContent?.includes("one") === true;
+	describe("With summarizer connected", () => {
+		beforeEach(async () => {
+			await page.goto(`${globals.PATH}?testMode`, { waitUntil: "load" });
+			await page.waitFor(() => window["fluidStarted"]);
 		});
-		await expect(containsOne).toEqual(true);
-	});
 
-	it("migrates and shows the correct code version after migration", async () => {
-		// Validate the migration status shows "one" initially
-		await Promise.all([
-			page.waitForSelector("#sbs-left .migration-status"),
-			page.waitForSelector("#sbs-right .migration-status"),
-		]);
-		const leftContainsOne = await page.evaluate(() => {
-			const migrationStatusElements = document.querySelectorAll(".migration-status");
-			return migrationStatusElements[0]?.textContent?.includes("one") === true;
-		});
-		const rightContainsOne = await page.evaluate(() => {
-			const migrationStatusElements = document.querySelectorAll(".migration-status");
-			return migrationStatusElements[1]?.textContent?.includes("one") === true;
-		});
-		await expect(leftContainsOne).toEqual(true);
-		await expect(rightContainsOne).toEqual(true);
+		it("migrates after summarizer has connected", async () => {
+			// Validate the migration status shows "one" initially
+			await Promise.all([
+				page.waitForSelector("#sbs-left .migration-status"),
+				page.waitForSelector("#sbs-right .migration-status"),
+			]);
+			const leftContainsOne = await page.evaluate(() => {
+				const migrationStatusElements = document.querySelectorAll(".migration-status");
+				return migrationStatusElements[0]?.textContent?.includes("one") === true;
+			});
+			const rightContainsOne = await page.evaluate(() => {
+				const migrationStatusElements = document.querySelectorAll(".migration-status");
+				return migrationStatusElements[1]?.textContent?.includes("one") === true;
+			});
+			await expect(leftContainsOne).toEqual(true);
+			await expect(rightContainsOne).toEqual(true);
 
-		const migratorsLength = await page.evaluate(() => {
-			return window["migrators"].length;
-		});
-		await expect(migratorsLength).toEqual(2);
-
-		// Get a promise that will resolve when both sides have finished migration
-		const migrationP = page.evaluate(() => {
-			const migrationPs = (window["migrators"] as IMigrator[]).map((migrator) => {
+			// Wait until we see the summarizer join
+			await page.evaluate(() => {
+				// This is reaching a bit, but we just need to watch it for test purposes.
+				const leftQuorum = (
+					window["migrators"][0]._currentModel.container as IContainer
+				).getQuorum();
+				const alreadyHasSummarizer =
+					[...leftQuorum.getMembers().values()].find(
+						(client) => client.client.details.type === "summarizer",
+					) !== undefined;
+				if (alreadyHasSummarizer) {
+					// This should be the path taken since demo mode should spawn the summarizer instantly.
+					return;
+				}
+				// In case the summarizer isn't quite connected yet, return a Promise so we can await for it to join.
 				return new Promise<void>((resolve) => {
-					migrator.once("migrated", resolve);
+					const watchForSummarizer = (clientId, details) => {
+						if (details.type === "summarizer") {
+							resolve();
+							leftQuorum.off("addMember", watchForSummarizer);
+						}
+					};
+					leftQuorum.on("addMember", watchForSummarizer);
 				});
 			});
-			return Promise.all(migrationPs);
-		});
 
-		await expect(page).toClick("button", { text: '"two"' });
+			const migratorsLength = await page.evaluate(() => {
+				return window["migrators"].length;
+			});
+			await expect(migratorsLength).toEqual(2);
 
-		await migrationP;
+			// Get a promise that will resolve when both sides have finished migration
+			const migrationP = page.evaluate(() => {
+				const migrationPs = (window["migrators"] as IMigrator[]).map((migrator) => {
+					return new Promise<void>((resolve) => {
+						migrator.once("migrated", resolve);
+					});
+				});
+				return Promise.all(migrationPs);
+			});
 
-		// Validate the migration status shows "two" after the migration
-		const leftContainsTwo = await page.evaluate(() => {
-			const migrationStatusElements = document.querySelectorAll(".migration-status");
-			return migrationStatusElements[0]?.textContent?.includes("two") === true;
+			await expect(page).toClick("button", { text: '"two"' });
+
+			await migrationP;
+
+			// Validate the migration status shows "two" after the migration
+			const leftContainsTwo = await page.evaluate(() => {
+				const migrationStatusElements = document.querySelectorAll(".migration-status");
+				return migrationStatusElements[0]?.textContent?.includes("two") === true;
+			});
+			const rightContainsTwo = await page.evaluate(() => {
+				const migrationStatusElements = document.querySelectorAll(".migration-status");
+				return migrationStatusElements[1]?.textContent?.includes("two") === true;
+			});
+			await expect(leftContainsTwo).toEqual(true);
+			await expect(rightContainsTwo).toEqual(true);
 		});
-		const rightContainsTwo = await page.evaluate(() => {
-			const migrationStatusElements = document.querySelectorAll(".migration-status");
-			return migrationStatusElements[1]?.textContent?.includes("two") === true;
-		});
-		await expect(leftContainsTwo).toEqual(true);
-		await expect(rightContainsTwo).toEqual(true);
 	});
 });


### PR DESCRIPTION
The migration demo test had fallen pretty far behind the demo itself (e.g. wasn't even creating a `Migrator`, so couldn't actually do a migration).  This change brings it up to speed with the main demo, so it can do normal migrations.  It's not perfect, with a key issue being that the local server seems to leave zombie clients in my testing (doesn't generate proper leave messages on refresh).  However, it works as expected on initial load.

This also adds some testing of the actual migration flow, including both with and without a summarizer connected.  To achieve this I need to pass a runtime option through, so it does a little plumbing of a test option.  This option is activated by including ?testMode in the url (e.g. `http://localhost:8080/?testMode`).