### PR TITLE
Update getIntervalId return type and intervalCollection test setup 

### DIFF
--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -318,7 +318,7 @@ export class SequenceInterval implements ISerializableInterval {
     compareEnd(b: SequenceInterval): number;
     compareStart(b: SequenceInterval): number;
     end: LocalReferencePosition;
-    getIntervalId(): string | undefined;
+    getIntervalId(): string;
     // (undocumented)
     intervalType: IntervalType;
     // @deprecated

--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -119,7 +119,7 @@ export class Interval implements ISerializableInterval {
     end: number;
     // (undocumented)
     getAdditionalPropertySets(): PropertySet[];
-    getIntervalId(): string | undefined;
+    getIntervalId(): string;
     // (undocumented)
     getProperties(): PropertySet;
     // @deprecated

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -224,11 +224,9 @@ export class Interval implements ISerializableInterval {
 	/**
 	 * {@inheritDoc ISerializableInterval.getIntervalId}
 	 */
-	public getIntervalId(): string | undefined {
+	public getIntervalId(): string {
 		const id = this.properties?.[reservedIntervalIdKey];
-		if (id === undefined) {
-			return undefined;
-		}
+		assert(id !== undefined, "interval ID should not be undefined");
 		return `${id}`;
 	}
 
@@ -574,6 +572,7 @@ export class SequenceInterval implements ISerializableInterval {
 	 */
 	public getIntervalId(): string {
 		const id = this.properties?.[reservedIntervalIdKey];
+		assert(id !== undefined, "interval ID should not be undefined");
 		return `${id}`;
 	}
 

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -572,11 +572,8 @@ export class SequenceInterval implements ISerializableInterval {
 	/**
 	 * {@inheritDoc ISerializableInterval.getIntervalId}
 	 */
-	public getIntervalId(): string | undefined {
+	public getIntervalId(): string {
 		const id = this.properties?.[reservedIntervalIdKey];
-		if (id === undefined) {
-			return undefined;
-		}
 		return `${id}`;
 	}
 

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -166,7 +166,7 @@ describe("SharedString interval collections", () => {
 			beforeEach(() => {
 				sharedString.insertText(0, "01234");
 				collection = sharedString.getIntervalCollection("test");
-				collection2 = sharedString.getIntervalCollection("test");
+				collection2 = sharedString2.getIntervalCollection("test");
 				containerRuntimeFactory.processAllMessages();
 			});
 

--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -533,7 +533,7 @@ describeNoCompat("SharedInterval", (getTestObjectProvider) => {
 
 			for (interval of intervalArray) {
 				const id = interval.getIntervalId();
-				intervals2.removeIntervalById(id as string);
+				intervals2.removeIntervalById(id);
 			}
 
 			await provider.ensureSynchronized();
@@ -664,7 +664,7 @@ describeNoCompat("SharedInterval", (getTestObjectProvider) => {
 				assert.strictEqual(interval1?.getIntervalId(), id1);
 				assert.strictEqual(interval2?.getIntervalId(), id1);
 				for (interval1 of intervals1) {
-					const id: string = interval1?.getIntervalId() as string;
+					const id: string = interval1?.getIntervalId();
 					assert.strictEqual(
 						interval1?.start.getOffset(),
 						intervals2.getIntervalById(id)?.start.getOffset(),
@@ -677,7 +677,7 @@ describeNoCompat("SharedInterval", (getTestObjectProvider) => {
 					);
 				}
 				for (interval2 of intervals2) {
-					const id: string = interval2?.getIntervalId() as string;
+					const id: string = interval2?.getIntervalId();
 					assert.strictEqual(
 						interval2?.start.getOffset(),
 						intervals1.getIntervalById(id)?.start.getOffset(),


### PR DESCRIPTION
Related to https://github.com/jzaffiro/FluidFramework/pull/3. Intervals now have immutable IDs, so there's no need to return undefined from this API anymore. I had this in the linked PR, but it was decided that the change should go into main instead of the interval topic branch. While I was writing tests for the linked item, I saw that the same sharedString was accidentally being used to create two interval collections that should be distinct. 