### PR TITLE
Breaking md changes for loader runtime compat update to 1.3.4 from 0.45.0

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -20,6 +20,7 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 ## 2.0.0-internal.4.1.0 Breaking changes
 
 -   [Ability to enable grouped batching](#Ability-to-enable-grouped-batching)
+-   [Testing support for LTS is moved from 0.45 to 1.3.4](#Testing-support-for-LTS-is-moved-from-0.45-to-1.3.4)
 
 ### Ability to enable grouped batching
 
@@ -36,6 +37,9 @@ and verifying that the following expectation changes won't have any effects:
 -   messages within the same batch will have the same sequence number
 -   client sequence numbers on batch messages can only be used to order messages with the same sequenceNumber
 -   requires all ops to be processed by runtime layer (version "2.0.0-internal.1.2.0" or later https://github.com/microsoft/FluidFramework/pull/11832)
+
+### Testing support for LTS is moved from 0.45.0 to 1.3.4
+Internal end to end full-compatibility testing for the loader-runtime boundary has been bumped from the oldest loader LTS version in 0.45.0 to the new oldest loader LTS version 1.3.4. 
 
 ## 2.0.0-internal.4.1.0 Upcoming changes
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -40,7 +40,7 @@ and verifying that the following expectation changes won't have any effects:
 
 ### Testing support for LTS is moved from 0.45.0 to 1.3.4
 
-Internal end to end full-compatibility testing for the loader-runtime boundary has been bumped from the oldest loader LTS version in 0.45.0 to the new oldest loader LTS version 1.3.4.
+Internal end-to-end full-compatibility testing for the loader-runtime boundary has been bumped from the oldest loader LTS version in 0.45.0 to the new oldest loader LTS version 1.3.4. For customers using azure packages, the loader-runtime are bundled together.
 
 ## 2.0.0-internal.4.1.0 Upcoming changes
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -39,7 +39,8 @@ and verifying that the following expectation changes won't have any effects:
 -   requires all ops to be processed by runtime layer (version "2.0.0-internal.1.2.0" or later https://github.com/microsoft/FluidFramework/pull/11832)
 
 ### Testing support for LTS is moved from 0.45.0 to 1.3.4
-Internal end to end full-compatibility testing for the loader-runtime boundary has been bumped from the oldest loader LTS version in 0.45.0 to the new oldest loader LTS version 1.3.4. 
+
+Internal end to end full-compatibility testing for the loader-runtime boundary has been bumped from the oldest loader LTS version in 0.45.0 to the new oldest loader LTS version 1.3.4.
 
 ## 2.0.0-internal.4.1.0 Upcoming changes
 


### PR DESCRIPTION
In this PR: https://github.com/microsoft/FluidFramework/pull/15146 we bumped the loader runtime compatibility boundary from 0.45.0 to 1.3.4. This PR notes that change in the `BREAKING.md` file.