### PR TITLE
Use optional index signatures in json types

### DIFF
--- a/api-report/tree.api.md
+++ b/api-report/tree.api.md
@@ -894,12 +894,12 @@ export type JsonCompatible = string | number | boolean | null | JsonCompatible[]
 
 // @alpha
 export type JsonCompatibleObject = {
-    [P in string]: JsonCompatible;
+    [P in string]?: JsonCompatible;
 };
 
 // @alpha
 export type JsonCompatibleReadOnly = string | number | boolean | null | readonly JsonCompatibleReadOnly[] | {
-    readonly [P in string]: JsonCompatibleReadOnly | undefined;
+    readonly [P in string]?: JsonCompatibleReadOnly;
 };
 
 // @alpha (undocumented)

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldChangeEncoder.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldChangeEncoder.ts
@@ -75,7 +75,7 @@ export function encodeForJson<TNodeChange>(
 			}
 		}
 	}
-	return jsonMarks as JsonCompatibleReadOnly;
+	return jsonMarks;
 }
 
 export function decodeJson<TNodeChange>(

--- a/packages/dds/tree/src/test/domains/json/jsObjectUtil.ts
+++ b/packages/dds/tree/src/test/domains/json/jsObjectUtil.ts
@@ -19,7 +19,7 @@ function cloneObject(obj: JsonCompatibleObject | JsonCompatible[]): JsonCompatib
 				enumerable: true,
 				configurable: true,
 				writable: true,
-				value: clone(obj[key]),
+				value: clone(obj[key] as JsonCompatible),
 			});
 		}
 		return result;

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -192,7 +192,7 @@ export type JsonCompatible =
  * but instead mostly restricts access to it.
  * @alpha
  */
-export type JsonCompatibleObject = { [P in string]: JsonCompatible };
+export type JsonCompatibleObject = { [P in string]?: JsonCompatible };
 
 /**
  * Use for readonly view of Json compatible data.
@@ -208,7 +208,7 @@ export type JsonCompatibleReadOnly =
 	// eslint-disable-next-line @rushstack/no-new-null
 	| null
 	| readonly JsonCompatibleReadOnly[]
-	| { readonly [P in string]: JsonCompatibleReadOnly | undefined };
+	| { readonly [P in string]?: JsonCompatibleReadOnly };
 
 /**
  * Returns if a particular json compatible value is an object.
@@ -216,6 +216,6 @@ export type JsonCompatibleReadOnly =
  */
 export function isJsonObject(
 	value: JsonCompatibleReadOnly,
-): value is { readonly [P in string]: JsonCompatibleReadOnly | undefined } {
+): value is { readonly [P in string]?: JsonCompatibleReadOnly } {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
## Description

This makes assignability of literals to the Json types work better, as well as makes JsonCompatibleReadOnly a subtype of JsonCompatible like it should be.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

