### PR TITLE
Svelte store with limitations

### DIFF
--- a/examples/hosts/app-integration/svelte-store-ff-draft/.gitignore
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/examples/hosts/app-integration/svelte-store-ff-draft/README.md
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/README.md
@@ -1,0 +1,47 @@
+# Svelte + TS + Vite
+
+This template should help get you started developing with Svelte and TypeScript in Vite.
+
+## Recommended IDE Setup
+
+[VS Code](https://code.visualstudio.com/) + [Svelte](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).
+
+## Need an official Svelte framework?
+
+Check out [SvelteKit](https://github.com/sveltejs/kit#readme), which is also powered by Vite. Deploy anywhere with its serverless-first approach and adapt to various platforms, with out of the box support for TypeScript, SCSS, and Less, and easily-added support for mdsvex, GraphQL, PostCSS, Tailwind CSS, and more.
+
+## Technical considerations
+
+**Why use this over SvelteKit?**
+
+- It brings its own routing solution which might not be preferable for some users.
+- It is first and foremost a framework that just happens to use Vite under the hood, not a Vite app.
+
+This template contains as little as possible to get started with Vite + TypeScript + Svelte, while taking into account the developer experience with regards to HMR and intellisense. It demonstrates capabilities on par with the other `create-vite` templates and is a good starting point for beginners dipping their toes into a Vite + Svelte project.
+
+Should you later need the extended capabilities and extensibility provided by SvelteKit, the template has been structured similarly to SvelteKit so that it is easy to migrate.
+
+**Why `global.d.ts` instead of `compilerOptions.types` inside `jsconfig.json` or `tsconfig.json`?**
+
+Setting `compilerOptions.types` shuts out all other types not explicitly listed in the configuration. Using triple-slash references keeps the default TypeScript setting of accepting type information from the entire workspace, while also adding `svelte` and `vite/client` type information.
+
+**Why include `.vscode/extensions.json`?**
+
+Other templates indirectly recommend extensions via the README, but this file allows VS Code to prompt the user to install the recommended extension upon opening the project.
+
+**Why enable `allowJs` in the TS template?**
+
+While `allowJs: false` would indeed prevent the use of `.js` files in the project, it does not prevent the use of JavaScript syntax in `.svelte` files. In addition, it would force `checkJs: false`, bringing the worst of both worlds: not being able to guarantee the entire codebase is TypeScript, and also having worse typechecking for the existing JavaScript. In addition, there are valid use cases in which a mixed codebase may be relevant.
+
+**Why is HMR not preserving my local component state?**
+
+HMR state preservation comes with a number of gotchas! It has been disabled by default in both `svelte-hmr` and `@sveltejs/vite-plugin-svelte` due to its often surprising behavior. You can read the details [here](https://github.com/rixo/svelte-hmr#svelte-hmr).
+
+If you have state that's important to retain within a component, consider creating an external store which would not be replaced by HMR.
+
+```ts
+// store.ts
+// An extremely simple external store
+import { writable } from 'svelte/store'
+export default writable(0)
+```

--- a/examples/hosts/app-integration/svelte-store-ff-draft/index.html
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + Svelte + TS</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/hosts/app-integration/svelte-store-ff-draft/package.json
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "svelte-store-ff-draft",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^2.0.3",
+    "@tsconfig/svelte": "^3.0.0",
+    "svelte": "^3.55.1",
+    "svelte-check": "^2.10.3",
+    "tslib": "^2.5.0",
+    "typescript": "^4.9.3",
+    "vite": "^4.2.0"
+  },
+  "dependencies": {
+    "@fluidframework/map": "workspace:>=2.0.0-internal.4.1.0 <2.0.0-internal.4.2.0",
+    "@fluidframework/tinylicious-client": "workspace:>=2.0.0-internal.4.1.0 <2.0.0-internal.4.2.0",
+    "fluid-framework": "workspace:>=2.0.0-internal.4.1.0 <2.0.0-internal.4.2.0"
+  }
+}

--- a/examples/hosts/app-integration/svelte-store-ff-draft/src/App.svelte
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/src/App.svelte
@@ -1,23 +1,23 @@
 <script>
-  import { onDestroy, onMount } from 'svelte';
-  import { getTinyliciousContainer } from './util/getTinyliciousContainer';
-  import { fluidWritable } from './util/fluidWritable';
+	import { onDestroy, onMount } from "svelte";
+	import { getTinyliciousContainer } from "./util/getTinyliciousContainer";
+	import { fluidWritable } from "./util/fluidWritable";
 
-  let text = "";
-  let syncedText;
+	let text = "";
+	let syncedText;
 
-  onMount(async () => {
-    const container = await getTinyliciousContainer();
-    syncedText = fluidWritable(container);
-    syncedText.subscribe((value) => {
-      text = value;
-    });
-  });
+	onMount(async () => {
+		const container = await getTinyliciousContainer();
+		syncedText = fluidWritable(container);
+		syncedText.subscribe((value) => {
+			text = value;
+		});
+	});
 
-  function updateText() {
-    syncedText.set(text);
-  }
+	function updateText() {
+		syncedText.set(text);
+	}
 </script>
 
-<textarea bind:value={text} on:input={updateText}></textarea>
+<textarea bind:value={text} on:input={updateText} />
 {$syncedText}

--- a/examples/hosts/app-integration/svelte-store-ff-draft/src/App.svelte
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/src/App.svelte
@@ -7,8 +7,7 @@
   let syncedText;
 
   onMount(async () => {
-    const containerId = location.hash.substring(1);
-    const container = await getTinyliciousContainer(containerId);
+    const container = await getTinyliciousContainer();
     syncedText = fluidWritable(container);
     syncedText.subscribe((value) => {
       text = value;

--- a/examples/hosts/app-integration/svelte-store-ff-draft/src/App.svelte
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/src/App.svelte
@@ -1,9 +1,7 @@
 <script>
   import { onDestroy, onMount } from 'svelte';
-  import { getTinyliciousContainer } from './lib/getTinyliciousContainer';
-  import { fluidWritable } from './lib/fluidWritable';
-  import { writable } from "svelte/store";
-  
+  import { getTinyliciousContainer } from './util/getTinyliciousContainer';
+  import { fluidWritable } from './util/fluidWritable';
 
   let text = "";
   let syncedText;

--- a/examples/hosts/app-integration/svelte-store-ff-draft/src/App.svelte
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/src/App.svelte
@@ -1,0 +1,26 @@
+<script>
+  import { onDestroy, onMount } from 'svelte';
+  import { getTinyliciousContainer } from './lib/getTinyliciousContainer';
+  import { fluidWritable } from './lib/fluidWritable';
+  import { writable } from "svelte/store";
+  
+
+  let text = "";
+  let syncedText;
+
+  onMount(async () => {
+    const containerId = location.hash.substring(1);
+    const container = await getTinyliciousContainer(containerId);
+    syncedText = fluidWritable(container);
+    syncedText.subscribe((value) => {
+      text = value;
+    });
+  });
+
+  function updateText() {
+    syncedText.set(text);
+  }
+</script>
+
+<textarea bind:value={text} on:input={updateText}></textarea>
+{$syncedText}

--- a/examples/hosts/app-integration/svelte-store-ff-draft/src/app.css
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/src/app.css
@@ -1,0 +1,80 @@
+:root {
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+
+  color-scheme: light dark;
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
+
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
+}
+
+a {
+  font-weight: 500;
+  color: #646cff;
+  text-decoration: inherit;
+}
+a:hover {
+  color: #535bf2;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  place-items: center;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+h1 {
+  font-size: 3.2em;
+  line-height: 1.1;
+}
+
+.card {
+  padding: 2em;
+}
+
+#app {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: center;
+}
+
+button {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 0.6em 1.2em;
+  font-size: 1em;
+  font-weight: 500;
+  font-family: inherit;
+  background-color: #1a1a1a;
+  cursor: pointer;
+  transition: border-color 0.25s;
+}
+button:hover {
+  border-color: #646cff;
+}
+button:focus,
+button:focus-visible {
+  outline: 4px auto -webkit-focus-ring-color;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color: #213547;
+    background-color: #ffffff;
+  }
+  a:hover {
+    color: #747bff;
+  }
+  button {
+    background-color: #f9f9f9;
+  }
+}

--- a/examples/hosts/app-integration/svelte-store-ff-draft/src/main.ts
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/src/main.ts
@@ -1,0 +1,8 @@
+import './app.css'
+import App from './App.svelte'
+
+const app = new App({
+  target: document.getElementById('app'),
+})
+
+export default app

--- a/examples/hosts/app-integration/svelte-store-ff-draft/src/util/fluidWritable.ts
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/src/util/fluidWritable.ts
@@ -1,0 +1,90 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { writable, type Writable } from "svelte/store";
+import type { SharedMap } from "@fluidframework/map";
+import type { IFluidContainer } from "fluid-framework";
+
+/**
+ * FluidStore is a Svelte store implementation that synchronizes its state with a Fluid SharedMap object.
+ * Whenever the Fluid SharedMap is updated, the FluidStore updates the internal Svelte store
+ * with the new value. Due to design limitations, it can only work with a single value and
+ * a SharedMap with the key "root" in initialObjects.
+ *
+ * @class FluidStore<T>
+ * @implements {Writable<T>}
+ */
+class FluidStore<T> implements Writable<T> {
+	private readonly internalStore: Writable<T>;
+	private readonly fluidMap: SharedMap;
+    private static readonly KEY_CONST = "value";
+
+	/**
+	 * Creates an instance of FluidStore and initializes it with the given FluidContainer and
+	 * an optional initial value.
+	 *
+	 * @constructor
+	 * @param {IFluidContainer} container - A Fluid container instance to connect the store with.
+	 * @param {T} [initialValue] - The optional initial value for the Svelte store.
+	 */
+	constructor(container: IFluidContainer, initialValue?: T) {
+		this.fluidMap = container.initialObjects.root as SharedMap;
+
+		this.internalStore = writable(initialValue);
+
+		this.fluidMap.on("valueChanged", (changed: { key: string; value: T }) => {
+			if (changed.key === FluidStore.KEY_CONST) {
+				this.internalStore.set(changed.value);
+			}
+		});
+	}
+
+	/**
+	 * Sets the value of the store.
+	 * @param {T} value - The new value to set.
+	 */
+	set(value: T): void {
+		this.fluidMap.set(FluidStore.KEY_CONST, value);
+		this.internalStore.set(value);
+	}
+
+	/**
+	 * Updates the value of the store using an updater function.
+	 * @param {(value: T) => T} updater - A function that accepts the current value and returns an updated value.
+	 */
+	update(updater: (value: T) => T): void {
+		this.internalStore.update((currentValue) => {
+			const newValue: T = updater(currentValue);
+			this.fluidMap.set(FluidStore.KEY_CONST, newValue);
+			return newValue;
+		});
+	}
+
+	/**
+	 * Subscribes to the store, runs the provided callback function
+	 * whenever the store value changes.
+	 * @param {(value: T) => void} subscriber - A callback function that runs whenever the store value changes.
+	 * @returns {() => void} - Returns an unsubscribe function.
+	 */
+	subscribe(subscriber: (value: T) => void): () => void {
+		return this.internalStore.subscribe(subscriber);
+	}
+}
+
+/**
+ * fluidWritable is a helper function that creates a new instance of the FluidStore.
+ * The FluidStore class represents a Svelte store that synchronizes its state with a
+ * Fluid SharedMap object. Due to design limitations, it can only work with a single value and
+ * a SharedMap with the key "root" in initialObjects.
+ *
+ * @function fluidWritable
+ * @param {IFluidContainer} container - A Fluid container instance to connect the store with.
+ * @param {T} [initialValue] - The optional initial value for the Svelte store.
+ * @returns {FluidStore<T>} - A new instance of the FluidStore class.
+ * @template T - The type of the value stored in the FluidStore.
+ */
+export function fluidWritable<T>(container: IFluidContainer, initialValue?: T): FluidStore<T> {
+	return new FluidStore<T>(container, initialValue);
+}

--- a/examples/hosts/app-integration/svelte-store-ff-draft/src/util/fluidWritable.ts
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/src/util/fluidWritable.ts
@@ -66,7 +66,7 @@ class FluidStore<T> implements Writable<T> {
 	 * Subscribes to the store, runs the provided callback function
 	 * whenever the store value changes.
 	 * @param {(value: T) => void} subscriber - A callback function that runs whenever the store value changes.
-	 * @returns {() => void} - Returns an unsubscribe function.
+	 * @returns {() => void} - Returns a subscribe function.
 	 */
 	subscribe(subscriber: (value: T) => void): () => void {
 		return this.internalStore.subscribe(subscriber);

--- a/examples/hosts/app-integration/svelte-store-ff-draft/src/util/fluidWritable.ts
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/src/util/fluidWritable.ts
@@ -19,7 +19,7 @@ import type { IFluidContainer } from "fluid-framework";
 class FluidStore<T> implements Writable<T> {
 	private readonly internalStore: Writable<T>;
 	private readonly fluidMap: SharedMap;
-    private static readonly KEY_CONST = "value";
+	private static readonly KEY_CONST = "value";
 
 	/**
 	 * Creates an instance of FluidStore and initializes it with the given FluidContainer and

--- a/examples/hosts/app-integration/svelte-store-ff-draft/src/util/getTinyliciousContainer.ts
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/src/util/getTinyliciousContainer.ts
@@ -10,10 +10,10 @@ const containerSchema: ContainerSchema = {
 };
 
 export async function getTinyliciousContainer(
-  containerId?: string
 ): Promise<IFluidContainer> {
   const client = new TinyliciousClient();
   let container: IFluidContainer;
+  const containerId = location.hash.substring(1);
 
   if (containerId) {
     try {

--- a/examples/hosts/app-integration/svelte-store-ff-draft/src/util/getTinyliciousContainer.ts
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/src/util/getTinyliciousContainer.ts
@@ -4,30 +4,29 @@ import { SharedMap } from "@fluidframework/map";
 import type { IFluidContainer, ContainerSchema } from "fluid-framework";
 
 const containerSchema: ContainerSchema = {
-  initialObjects: {
-    root: SharedMap,
-  },
+	initialObjects: {
+		root: SharedMap,
+	},
 };
 
-export async function getTinyliciousContainer(
-): Promise<IFluidContainer> {
-  const client = new TinyliciousClient();
-  let container: IFluidContainer;
-  const containerId = location.hash.substring(1);
+export async function getTinyliciousContainer(): Promise<IFluidContainer> {
+	const client = new TinyliciousClient();
+	let container: IFluidContainer;
+	const containerId = location.hash.substring(1);
 
-  if (containerId) {
-    try {
-      ({ container } = await client.getContainer(containerId, containerSchema));
-    } catch {
-      ({ container } = await client.createContainer(containerSchema));
-      const id = await container.attach();
-      location.hash = id;
-    }
-  } else {
-    ({ container } = await client.createContainer(containerSchema));
-    const id = await container.attach();
-    location.hash = id;
-  }
+	if (containerId) {
+		try {
+			({ container } = await client.getContainer(containerId, containerSchema));
+		} catch {
+			({ container } = await client.createContainer(containerSchema));
+			const id = await container.attach();
+			location.hash = id;
+		}
+	} else {
+		({ container } = await client.createContainer(containerSchema));
+		const id = await container.attach();
+		location.hash = id;
+	}
 
-  return container;
+	return container;
 }

--- a/examples/hosts/app-integration/svelte-store-ff-draft/src/util/getTinyliciousContainer.ts
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/src/util/getTinyliciousContainer.ts
@@ -1,0 +1,33 @@
+// getTinyliciousContainer.ts
+import { TinyliciousClient } from "@fluidframework/tinylicious-client";
+import { SharedMap } from "@fluidframework/map";
+import type { IFluidContainer, ContainerSchema } from "fluid-framework";
+
+const containerSchema: ContainerSchema = {
+  initialObjects: {
+    root: SharedMap,
+  },
+};
+
+export async function getTinyliciousContainer(
+  containerId?: string
+): Promise<IFluidContainer> {
+  const client = new TinyliciousClient();
+  let container: IFluidContainer;
+
+  if (containerId) {
+    try {
+      ({ container } = await client.getContainer(containerId, containerSchema));
+    } catch {
+      ({ container } = await client.createContainer(containerSchema));
+      const id = await container.attach();
+      location.hash = id;
+    }
+  } else {
+    ({ container } = await client.createContainer(containerSchema));
+    const id = await container.attach();
+    location.hash = id;
+  }
+
+  return container;
+}

--- a/examples/hosts/app-integration/svelte-store-ff-draft/src/vite-env.d.ts
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/examples/hosts/app-integration/svelte-store-ff-draft/svelte.config.js
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/svelte.config.js
@@ -1,0 +1,7 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+
+export default {
+  // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
+  // for more information about preprocessors
+  preprocess: vitePreprocess(),
+}

--- a/examples/hosts/app-integration/svelte-store-ff-draft/tsconfig.json
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "resolveJsonModule": true,
+    /**
+     * Typecheck JS in `.svelte` and `.js` files by default.
+     * Disable checkJs if you'd like to use dynamic types in JS.
+     * Note that setting allowJs false does not prevent the use
+     * of JS in `.svelte` files.
+     */
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/examples/hosts/app-integration/svelte-store-ff-draft/tsconfig.node.json
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/hosts/app-integration/svelte-store-ff-draft/vite.config.ts
+++ b/examples/hosts/app-integration/svelte-store-ff-draft/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [svelte()],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3194,6 +3194,31 @@ importers:
       webpack-dev-server: 4.6.0_x7pknmm2t3vm5puavzdpmh6qv4
       webpack-merge: 5.8.0
 
+  examples/hosts/app-integration/svelte-store-ff-draft:
+    specifiers:
+      '@fluidframework/map': workspace:>=2.0.0-internal.4.1.0 <2.0.0-internal.4.2.0
+      '@fluidframework/tinylicious-client': workspace:>=2.0.0-internal.4.1.0 <2.0.0-internal.4.2.0
+      '@sveltejs/vite-plugin-svelte': ^2.0.3
+      '@tsconfig/svelte': ^3.0.0
+      fluid-framework: workspace:>=2.0.0-internal.4.1.0 <2.0.0-internal.4.2.0
+      svelte: ^3.55.1
+      svelte-check: ^2.10.3
+      tslib: ^2.5.0
+      typescript: ^4.9.3
+      vite: ^4.2.0
+    dependencies:
+      '@fluidframework/map': link:../../../../packages/dds/map
+      '@fluidframework/tinylicious-client': link:../../../../packages/framework/tinylicious-client
+      fluid-framework: link:../../../../packages/framework/fluid-framework
+    devDependencies:
+      '@sveltejs/vite-plugin-svelte': 2.0.4_svelte@3.58.0+vite@4.2.2
+      '@tsconfig/svelte': 3.0.0
+      svelte: 3.58.0
+      svelte-check: 2.10.3_svelte@3.58.0
+      tslib: 2.5.0
+      typescript: 4.9.5
+      vite: 4.2.2
+
   examples/utils/bundle-size-tests:
     specifiers:
       '@cerner/duplicate-package-checker-webpack-plugin': ^2.3.0
@@ -12975,6 +13000,204 @@ packages:
       jsdoc-type-pratt-parser: 3.1.0
     dev: true
 
+  /@esbuild/android-arm/0.17.17:
+    resolution: {integrity: sha512-E6VAZwN7diCa3labs0GYvhEPL2M94WLF8A+czO8hfjREXxba8Ng7nM5VxV+9ihNXIY1iQO1XxUU4P7hbqbICxg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64/0.17.17:
+    resolution: {integrity: sha512-jaJ5IlmaDLFPNttv0ofcwy/cfeY4bh/n705Tgh+eLObbGtQBK3EPAu+CzL95JVE4nFAliyrnEu0d32Q5foavqg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64/0.17.17:
+    resolution: {integrity: sha512-446zpfJ3nioMC7ASvJB1pszHVskkw4u/9Eu8s5yvvsSDTzYh4p4ZIRj0DznSl3FBF0Z/mZfrKXTtt0QCoFmoHA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64/0.17.17:
+    resolution: {integrity: sha512-m/gwyiBwH3jqfUabtq3GH31otL/0sE0l34XKpSIqR7NjQ/XHQ3lpmQHLHbG8AHTGCw8Ao059GvV08MS0bhFIJQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64/0.17.17:
+    resolution: {integrity: sha512-4utIrsX9IykrqYaXR8ob9Ha2hAY2qLc6ohJ8c0CN1DR8yWeMrTgYFjgdeQ9LIoTOfLetXjuCu5TRPHT9yKYJVg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64/0.17.17:
+    resolution: {integrity: sha512-4PxjQII/9ppOrpEwzQ1b0pXCsFLqy77i0GaHodrmzH9zq2/NEhHMAMJkJ635Ns4fyJPFOlHMz4AsklIyRqFZWA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64/0.17.17:
+    resolution: {integrity: sha512-lQRS+4sW5S3P1sv0z2Ym807qMDfkmdhUYX30GRBURtLTrJOPDpoU0kI6pVz1hz3U0+YQ0tXGS9YWveQjUewAJw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm/0.17.17:
+    resolution: {integrity: sha512-biDs7bjGdOdcmIk6xU426VgdRUpGg39Yz6sT9Xp23aq+IEHDb/u5cbmu/pAANpDB4rZpY/2USPhCA+w9t3roQg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64/0.17.17:
+    resolution: {integrity: sha512-2+pwLx0whKY1/Vqt8lyzStyda1v0qjJ5INWIe+d8+1onqQxHLLi3yr5bAa4gvbzhZqBztifYEu8hh1La5+7sUw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32/0.17.17:
+    resolution: {integrity: sha512-IBTTv8X60dYo6P2t23sSUYym8fGfMAiuv7PzJ+0LcdAndZRzvke+wTVxJeCq4WgjppkOpndL04gMZIFvwoU34Q==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64/0.17.17:
+    resolution: {integrity: sha512-WVMBtcDpATjaGfWfp6u9dANIqmU9r37SY8wgAivuKmgKHE+bWSuv0qXEFt/p3qXQYxJIGXQQv6hHcm7iWhWjiw==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el/0.17.17:
+    resolution: {integrity: sha512-2kYCGh8589ZYnY031FgMLy0kmE4VoGdvfJkxLdxP4HJvWNXpyLhjOvxVsYjYZ6awqY4bgLR9tpdYyStgZZhi2A==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64/0.17.17:
+    resolution: {integrity: sha512-KIdG5jdAEeAKogfyMTcszRxy3OPbZhq0PPsW4iKKcdlbk3YE4miKznxV2YOSmiK/hfOZ+lqHri3v8eecT2ATwQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64/0.17.17:
+    resolution: {integrity: sha512-Cj6uWLBR5LWhcD/2Lkfg2NrkVsNb2sFM5aVEfumKB2vYetkA/9Uyc1jVoxLZ0a38sUhFk4JOVKH0aVdPbjZQeA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x/0.17.17:
+    resolution: {integrity: sha512-lK+SffWIr0XsFf7E0srBjhpkdFVJf3HEgXCwzkm69kNbRar8MhezFpkIwpk0qo2IOQL4JE4mJPJI8AbRPLbuOQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64/0.17.17:
+    resolution: {integrity: sha512-XcSGTQcWFQS2jx3lZtQi7cQmDYLrpLRyz1Ns1DzZCtn898cWfm5Icx/DEWNcTU+T+tyPV89RQtDnI7qL2PObPg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64/0.17.17:
+    resolution: {integrity: sha512-RNLCDmLP5kCWAJR+ItLM3cHxzXRTe4N00TQyQiimq+lyqVqZWGPAvcyfUBM0isE79eEZhIuGN09rAz8EL5KdLA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64/0.17.17:
+    resolution: {integrity: sha512-PAXswI5+cQq3Pann7FNdcpSUrhrql3wKjj3gVkmuz6OHhqqYxKvi6GgRBoaHjaG22HV/ZZEgF9TlS+9ftHVigA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64/0.17.17:
+    resolution: {integrity: sha512-V63egsWKnx/4V0FMYkr9NXWrKTB5qFftKGKuZKFIrAkO/7EWLFnbBZNM1CvJ6Sis+XBdPws2YQSHF1Gqf1oj/Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64/0.17.17:
+    resolution: {integrity: sha512-YtUXLdVnd6YBSYlZODjWzH+KzbaubV0YVd6UxSfoFfa5PtNJNaW+1i+Hcmjpg2nEe0YXUCNF5bkKy1NnBv1y7Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32/0.17.17:
+    resolution: {integrity: sha512-yczSLRbDdReCO74Yfc5tKG0izzm+lPMYyO1fFTcn0QNwnKmc3K+HdxZWLGKg4pZVte7XVgcFku7TIZNbWEJdeQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64/0.17.17:
+    resolution: {integrity: sha512-FNZw7H3aqhF9OyRQbDDnzUApDXfC1N6fgBhkqEO2jvYCJ+DxMTfZVqg3AX0R1khg1wHTBRD5SdcibSJ+XF6bFg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@eslint/eslintrc/1.3.3:
     resolution: {integrity: sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -18799,7 +19022,7 @@ packages:
       npmlog: 6.0.2
     dev: true
 
-  /@lerna/publish/5.6.2_nx@15.7.2+typescript@4.5.5:
+  /@lerna/publish/5.6.2_nx@15.7.2+typescript@4.9.5:
     resolution: {integrity: sha512-QaW0GjMJMuWlRNjeDCjmY/vjriGSWgkLS23yu8VKNtV5U3dt5yIKA3DNGV3HgZACuu45kQxzMDsfLzgzbGNtYA==}
     engines: {node: ^14.15.0 || >=16.0.0}
     dependencies:
@@ -18821,7 +19044,7 @@ packages:
       '@lerna/run-lifecycle': 5.6.2
       '@lerna/run-topologically': 5.6.2
       '@lerna/validation-error': 5.6.2
-      '@lerna/version': 5.6.2_nx@15.7.2+typescript@4.5.5
+      '@lerna/version': 5.6.2_nx@15.7.2+typescript@4.9.5
       fs-extra: 9.1.0
       libnpmaccess: 6.0.4
       npm-package-arg: 8.1.1
@@ -18953,7 +19176,7 @@ packages:
       npmlog: 6.0.2
     dev: true
 
-  /@lerna/version/5.6.2_nx@15.7.2+typescript@4.5.5:
+  /@lerna/version/5.6.2_nx@15.7.2+typescript@4.9.5:
     resolution: {integrity: sha512-odNSR2rTbHW++xMZSQKu/F6Syrd/sUvwDLPaMKktoOSPKmycHt/eWcuQQyACdtc43Iqeu4uQd7PCLsniqOVFrw==}
     engines: {node: ^14.15.0 || >=16.0.0}
     dependencies:
@@ -18971,7 +19194,7 @@ packages:
       '@lerna/run-topologically': 5.6.2
       '@lerna/temp-write': 5.6.2
       '@lerna/validation-error': 5.6.2
-      '@nrwl/devkit': 15.7.2_nx@15.7.2+typescript@4.5.5
+      '@nrwl/devkit': 15.7.2_nx@15.7.2+typescript@4.9.5
       chalk: 4.1.2
       dedent: 0.7.0
       load-json-file: 6.2.0
@@ -19842,12 +20065,12 @@ packages:
       - debug
     dev: true
 
-  /@nrwl/devkit/15.7.2_nx@15.7.2+typescript@4.5.5:
+  /@nrwl/devkit/15.7.2_nx@15.7.2+typescript@4.9.5:
     resolution: {integrity: sha512-HMGi7L6w2g4IrYwhb04snD8Zr24Z/gzau5i9WUNkwzrjeR1xAm0Cc9WRre221zaeohtK11gyBt7BerT1tgkNwA==}
     peerDependencies:
       nx: '>= 14.1 <= 16'
     dependencies:
-      '@phenomnomnominal/tsquery': 4.1.1_typescript@4.5.5
+      '@phenomnomnominal/tsquery': 4.1.1_typescript@4.9.5
       ejs: 3.1.8
       ignore: 5.2.4
       nx: 15.7.2
@@ -20449,13 +20672,13 @@ packages:
       node-gyp-build: 4.6.0
     dev: true
 
-  /@phenomnomnominal/tsquery/4.1.1_typescript@4.5.5:
+  /@phenomnomnominal/tsquery/4.1.1_typescript@4.9.5:
     resolution: {integrity: sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==}
     peerDependencies:
       typescript: ^3 || ^4
     dependencies:
       esquery: 1.4.2
-      typescript: 4.5.5
+      typescript: 4.9.5
     dev: true
 
   /@pmmmwh/react-refresh-webpack-plugin/0.5.9_qouehdyvslt6cyfzajsl2rhebu:
@@ -22125,6 +22348,25 @@ packages:
       resolve-from: 5.0.0
     dev: true
 
+  /@sveltejs/vite-plugin-svelte/2.0.4_svelte@3.58.0+vite@4.2.2:
+    resolution: {integrity: sha512-pjqhW00KwK2uzDGEr+yJBwut+D+4XfJO/+bHHdHzPRXn9+1Jeq5JcFHyrUiYaXgHtyhX0RsllCTm4ssAx4ZY7Q==}
+    engines: {node: ^14.18.0 || >= 16}
+    peerDependencies:
+      svelte: ^3.54.0
+      vite: ^4.0.0
+    dependencies:
+      debug: 4.3.4
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.0
+      svelte: 3.58.0
+      svelte-hmr: 0.15.1_svelte@3.58.0
+      vite: 4.2.2
+      vitefu: 0.2.4_vite@4.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
     dependencies:
@@ -22227,6 +22469,10 @@ packages:
       minimatch: 5.1.6
       mkdirp: 1.0.4
       path-browserify: 1.0.1
+    dev: true
+
+  /@tsconfig/svelte/3.0.0:
+    resolution: {integrity: sha512-pYrtLtOwku/7r1i9AMONsJMVYAtk3hzOfiGNekhtq5tYBGA7unMve8RvUclKLMT3PrihvJqUmzsRGh0RP84hKg==}
     dev: true
 
   /@types/argparse/1.0.38:
@@ -22699,6 +22945,10 @@ packages:
       prosemirror-view: 1.30.0
     dev: true
 
+  /@types/pug/2.0.6:
+    resolution: {integrity: sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==}
+    dev: true
+
   /@types/puppeteer/1.3.0:
     resolution: {integrity: sha512-kp1R8cTYymvYezTYWSECtSEDbxnCQaNe3i+fdsZh3dVz7umB8q6LATv0VdJp1DT0evS8YqCrFI5+DaDYJYo6Vg==}
     dependencies:
@@ -22745,6 +22995,13 @@ packages:
 
   /@types/retry/0.12.0:
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  /@types/sass/1.45.0:
+    resolution: {integrity: sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==}
+    deprecated: This is a stub types definition. sass provides its own type definitions, so you do not need this installed.
+    dependencies:
+      sass: 1.56.1
+    dev: true
 
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
@@ -27822,6 +28079,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /deepmerge/4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /default-browser-id/1.0.4:
     resolution: {integrity: sha512-qPy925qewwul9Hifs+3sx1ZYn14obHxpkX+mPD369w4Rzg+YkJBgi3SOvwUq81nWSjqGUegIgEPwD8u+HUnxlw==}
     engines: {node: '>=0.10.0'}
@@ -28697,6 +28959,10 @@ packages:
   /es6-object-assign/1.1.0:
     resolution: {integrity: sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==}
 
+  /es6-promise/3.3.1:
+    resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
+    dev: true
+
   /es6-promise/4.2.8:
     resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
 
@@ -28724,6 +28990,36 @@ packages:
       es5-ext: 0.10.62
       es6-iterator: 2.0.3
       es6-symbol: 3.1.3
+    dev: true
+
+  /esbuild/0.17.17:
+    resolution: {integrity: sha512-/jUywtAymR8jR4qsa2RujlAF7Krpt5VWi72Q2yuLD4e/hvtNcFQ0I1j8m/bxq238pf3/0KO5yuXNpuLx8BE1KA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.17.17
+      '@esbuild/android-arm64': 0.17.17
+      '@esbuild/android-x64': 0.17.17
+      '@esbuild/darwin-arm64': 0.17.17
+      '@esbuild/darwin-x64': 0.17.17
+      '@esbuild/freebsd-arm64': 0.17.17
+      '@esbuild/freebsd-x64': 0.17.17
+      '@esbuild/linux-arm': 0.17.17
+      '@esbuild/linux-arm64': 0.17.17
+      '@esbuild/linux-ia32': 0.17.17
+      '@esbuild/linux-loong64': 0.17.17
+      '@esbuild/linux-mips64el': 0.17.17
+      '@esbuild/linux-ppc64': 0.17.17
+      '@esbuild/linux-riscv64': 0.17.17
+      '@esbuild/linux-s390x': 0.17.17
+      '@esbuild/linux-x64': 0.17.17
+      '@esbuild/netbsd-x64': 0.17.17
+      '@esbuild/openbsd-x64': 0.17.17
+      '@esbuild/sunos-x64': 0.17.17
+      '@esbuild/win32-arm64': 0.17.17
+      '@esbuild/win32-ia32': 0.17.17
+      '@esbuild/win32-x64': 0.17.17
     dev: true
 
   /escalade/3.1.1:
@@ -30438,7 +30734,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       at-least-node: 1.0.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.0
     dev: true
@@ -33210,7 +33506,7 @@ packages:
       '@jest/types': 26.6.2
       babel-jest: 26.6.3_@babel+core@7.20.2
       chalk: 4.1.2
-      deepmerge: 4.2.2
+      deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
       jest-environment-jsdom: 26.6.2
@@ -34374,15 +34670,15 @@ packages:
       '@lerna/init': 5.6.2
       '@lerna/link': 5.6.2
       '@lerna/list': 5.6.2
-      '@lerna/publish': 5.6.2_nx@15.7.2+typescript@4.5.5
+      '@lerna/publish': 5.6.2_nx@15.7.2+typescript@4.9.5
       '@lerna/run': 5.6.2
-      '@lerna/version': 5.6.2_nx@15.7.2+typescript@4.5.5
-      '@nrwl/devkit': 15.7.2_nx@15.7.2+typescript@4.5.5
+      '@lerna/version': 5.6.2_nx@15.7.2+typescript@4.9.5
+      '@nrwl/devkit': 15.7.2_nx@15.7.2+typescript@4.9.5
       import-local: 3.1.0
       inquirer: 8.2.5
       npmlog: 6.0.2
       nx: 15.7.2
-      typescript: 4.5.5
+      typescript: 4.9.5
     transitivePeerDependencies:
       - '@swc-node/register'
       - '@swc/core'
@@ -35035,6 +35331,19 @@ packages:
   /macos-release/2.3.0:
     resolution: {integrity: sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==}
     engines: {node: '>=6'}
+    dev: true
+
+  /magic-string/0.25.9:
+    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
+    dependencies:
+      sourcemap-codec: 1.4.8
+    dev: true
+
+  /magic-string/0.30.0:
+    resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
   /make-dir/1.3.0:
@@ -36131,6 +36440,12 @@ packages:
 
   /nanoid/3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
+  /nanoid/3.3.6:
+    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
@@ -38263,6 +38578,15 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
+  /postcss/8.4.22:
+    resolution: {integrity: sha512-XseknLAfRHzVWjCEtdviapiBtfLdgyzExD50Rg2ePaucEesyh8Wv4VPdW0nbyDa1ydbrAxV19jvMT4+LFmcNUA==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.6
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
+
   /posthtml-parser/0.2.1:
     resolution: {integrity: sha512-nPC53YMqJnc/+1x4fRYFfm81KV2V+G9NZY+hTohpYg64Ay7NemWWcV4UWuy/SgMupqQ3kJ88M/iRfZmSnxT+pw==}
     dependencies:
@@ -40139,6 +40463,14 @@ packages:
     resolution: {integrity: sha512-oO8f2SI04dJk3pbj2KOMJ4G6QfPAgqcGmrYGmansIcpRewIPT2ljWEt5I+ip6EgiyaLo+RXkkUWw74M25HDkMA==}
     dev: true
 
+  /rollup/3.20.6:
+    resolution: {integrity: sha512-2yEB3nQXp/tBQDN0hJScJQheXdvU2wFhh6ld7K/aiZ1vYcak6N/BKjY1QrU6BvO2JWYS8bEs14FRaxXosxy2zw==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /rope-sequence/1.3.3:
     resolution: {integrity: sha512-85aZYCxweiD5J8yTEbw+E6A27zSnLPNDL0WfPdw3YYodq7WjnTKo0q4dtyQ2gz23iPT8Q9CUyJtAaUNcTxRf5Q==}
     dev: false
@@ -40213,6 +40545,13 @@ packages:
     dependencies:
       tslib: 2.5.0
 
+  /sade/1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+    dependencies:
+      mri: 1.2.0
+    dev: true
+
   /safe-buffer/5.1.1:
     resolution: {integrity: sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==}
     dev: true
@@ -40248,6 +40587,15 @@ packages:
 
   /safer-buffer/2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  /sander/0.5.1:
+    resolution: {integrity: sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==}
+    dependencies:
+      es6-promise: 3.3.1
+      graceful-fs: 4.2.11
+      mkdirp: 0.5.6
+      rimraf: 2.7.1
+    dev: true
 
   /sane/4.1.0:
     resolution: {integrity: sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==}
@@ -40914,6 +41262,16 @@ packages:
       ip: 2.0.0
       smart-buffer: 4.2.0
 
+  /sorcery/0.10.0:
+    resolution: {integrity: sha512-R5ocFmKZQFfSTstfOtHjJuAwbpGyf9qjQa1egyhvXSbM7emjrtLXtGdZsDJDABC85YBfVvrOiGWKSYXPKdvP1g==}
+    hasBin: true
+    dependencies:
+      buffer-crc32: 0.2.13
+      minimist: 1.2.8
+      sander: 0.5.1
+      sourcemap-codec: 1.4.8
+    dev: true
+
   /sort-json/2.0.1:
     resolution: {integrity: sha512-s8cs2bcsQCzo/P2T/uoU6Js4dS/jnX8+4xunziNoq9qmSpZNCrRIAIvp4avsz0ST18HycV4z/7myJ7jsHWB2XQ==}
     hasBin: true
@@ -41013,6 +41371,11 @@ packages:
   /source-map/0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
+
+  /sourcemap-codec/1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
+    dev: true
 
   /space-separated-tokens/1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
@@ -41726,6 +42089,99 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  /svelte-check/2.10.3_svelte@3.58.0:
+    resolution: {integrity: sha512-Nt1aWHTOKFReBpmJ1vPug0aGysqPwJh2seM1OvICfM2oeyaA62mOiy5EvkXhltGfhCcIQcq2LoE0l1CwcWPjlw==}
+    hasBin: true
+    peerDependencies:
+      svelte: ^3.24.0
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.17
+      chokidar: 3.5.3
+      fast-glob: 3.2.12
+      import-fresh: 3.3.0
+      picocolors: 1.0.0
+      sade: 1.8.1
+      svelte: 3.58.0
+      svelte-preprocess: 4.10.7_aswnnyxiuwffgztcffmr7c7eny
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - coffeescript
+      - less
+      - node-sass
+      - postcss
+      - postcss-load-config
+      - pug
+      - sass
+      - stylus
+      - sugarss
+    dev: true
+
+  /svelte-hmr/0.15.1_svelte@3.58.0:
+    resolution: {integrity: sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==}
+    engines: {node: ^12.20 || ^14.13.1 || >= 16}
+    peerDependencies:
+      svelte: '>=3.19.0'
+    dependencies:
+      svelte: 3.58.0
+    dev: true
+
+  /svelte-preprocess/4.10.7_aswnnyxiuwffgztcffmr7c7eny:
+    resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
+    engines: {node: '>= 9.11.2'}
+    requiresBuild: true
+    peerDependencies:
+      '@babel/core': ^7.10.2
+      coffeescript: ^2.5.1
+      less: ^3.11.3 || ^4.0.0
+      node-sass: '*'
+      postcss: ^7 || ^8
+      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
+      pug: ^3.0.0
+      sass: ^1.26.8
+      stylus: ^0.55.0
+      sugarss: ^2.0.0
+      svelte: ^3.23.0
+      typescript: ^3.9.5 || ^4.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      coffeescript:
+        optional: true
+      less:
+        optional: true
+      node-sass:
+        optional: true
+      postcss:
+        optional: true
+      postcss-load-config:
+        optional: true
+      pug:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@types/pug': 2.0.6
+      '@types/sass': 1.45.0
+      detect-indent: 6.1.0
+      magic-string: 0.25.9
+      sorcery: 0.10.0
+      strip-indent: 3.0.0
+      svelte: 3.58.0
+      typescript: 4.9.5
+    dev: true
+
+  /svelte/3.58.0:
+    resolution: {integrity: sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==}
+    engines: {node: '>= 8'}
+    dev: true
+
   /svg-baker-runtime/1.4.7:
     resolution: {integrity: sha512-Zorfwwj5+lWjk/oxwSMsRdS2sPQQdTmmsvaSpzU+i9ZWi3zugHLt6VckWfnswphQP0LmOel3nggpF5nETbt6xw==}
     dependencies:
@@ -42042,7 +42498,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.15.1
-      webpack: 5.76.2_webpack-cli@4.10.0
+      webpack: 5.76.2
 
   /terser/4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -42748,6 +43204,12 @@ packages:
 
   /typescript/4.8.4:
     resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /typescript/4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
@@ -43505,6 +43967,50 @@ packages:
       replace-ext: 1.0.1
     dev: true
 
+  /vite/4.2.2:
+    resolution: {integrity: sha512-PcNtT5HeDxb3QaSqFYkEum8f5sCVe0R3WK20qxgIvNBZPXU/Obxs/+ubBMeE7nLWeCo2LDzv+8hRYSlcaSehig==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.17.17
+      postcss: 8.4.22
+      resolve: 1.22.1
+      rollup: 3.20.6
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vitefu/0.2.4_vite@4.2.2:
+    resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      vite: 4.2.2
+    dev: true
+
   /vm-browserify/1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
     dev: true
@@ -44150,7 +44656,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /webpack/5.76.2_webpack-cli@4.10.0:
     resolution: {integrity: sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==}


### PR DESCRIPTION
There needs to be design improvements, currently there are two limitations.
- it can only work with a single value
  - I set the passed in generic type, so over the wire the entire object has to change
- At a minimum, when passing a Container into fluidWritable the initialObjects of ContainerSchema needs to contain a SharedMap with the key "root".
```ts
const containerSchema: ContainerSchema = {
	initialObjects: {
		root: SharedMap,
	},
};
```

The API currently resides in examples/hosts/app-integration/svelte-store-ff-draft/src/util/fluidWritable.ts, it is a svelte writable extension that allows the same functionality as a store would.

