### PR TITLE
Add summary failure stage

### DIFF
--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -506,7 +506,9 @@ type SummaryGeneratorOptionalTelemetryProperties =
 	/** Actual sequence number of the summary op proposal. */
 	| "summarySequenceNumber"
 	/** Optional Retry-After time in seconds. If specified, the client should wait this many seconds before retrying. */
-	| "nackRetryAfter";
+	| "nackRetryAfter"
+	/** The stage at which the submit summary method failed at. This can help determine what type of failure we have */
+	| "stage";
 
 export type SummaryGeneratorTelemetry = Pick<
 	ITelemetryProperties,

--- a/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
@@ -295,6 +295,7 @@ export class SummaryGenerator {
 				opsSinceLastSummary:
 					referenceSequenceNumber -
 					this.heuristicData.lastSuccessfulSummary.refSequenceNumber,
+				stage: summaryData.stage,
 			};
 			summarizeTelemetryProps = this.addSummaryDataToTelemetryProps(
 				summaryData,


### PR DESCRIPTION
Looking through our summarize_cancel telemetry, I could not find the stage at which a submitSummary call failed at. This is valuable, and would be very useful in determining the relative severity of a summarize_cancel failure.