### PR TITLE
Don't send op when nested SharedTree transaction completes

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -220,7 +220,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 	 */
 	protected applyChange(change: TChange, revision?: RevisionTag): void {
 		const commit = this.addLocalChange(change, revision ?? mintRevisionTag());
-		if (this.transactions.size === 0) {
+		if (!this.isTransacting()) {
 			this.submitCommit(commit);
 		}
 	}
@@ -274,7 +274,9 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		const { startRevision } = this.transactions.pop();
 		this.editor.exitTransaction();
 		const squashCommit = this.editManager.squashLocalChanges(startRevision);
-		this.submitCommit(squashCommit);
+		if (!this.isTransacting()) {
+			this.submitCommit(squashCommit);
+		}
 		return TransactionResult.Commit;
 	}
 


### PR DESCRIPTION
Also, fix a small cursor disposal bug in a test helper.