### PR TITLE
fix(release): Independent packages should use release branches

### DIFF
--- a/build-tools/packages/build-cli/src/lib/branches.ts
+++ b/build-tools/packages/build-cli/src/lib/branches.ts
@@ -242,6 +242,6 @@ export function getDefaultBumpTypeForBranch(branchName: string): VersionBumpType
 export function getReleaseSourceForReleaseGroup(
 	releaseGroupOrPackage: ReleaseGroup | ReleasePackage,
 ): ReleaseSource {
-  // All packages and release groups use release branches.
+	// All packages and release groups use release branches.
 	return "releaseBranches";
 }

--- a/build-tools/packages/build-cli/src/lib/branches.ts
+++ b/build-tools/packages/build-cli/src/lib/branches.ts
@@ -242,13 +242,6 @@ export function getDefaultBumpTypeForBranch(branchName: string): VersionBumpType
 export function getReleaseSourceForReleaseGroup(
 	releaseGroupOrPackage: ReleaseGroup | ReleasePackage,
 ): ReleaseSource {
-	if (!isReleaseGroup(releaseGroupOrPackage)) {
-		return "direct";
-	}
-
-	if ([MonoRepoKind.BuildTools].includes(releaseGroupOrPackage)) {
-		return "interactive";
-	}
-
+  // All packages and release groups use release branches.
 	return "releaseBranches";
 }


### PR DESCRIPTION
We've decided that all packages and release groups should use release branches, so I've updated the code to reflect this.