### PR TITLE
Add TestTreeProviderLite

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/editable-tree/editableTree.editing.spec.ts
@@ -78,7 +78,9 @@ function getTestSchema(fieldKind: FieldKind): SchemaData {
 	);
 }
 
-// TODO: Tests which are testing collaboration between multiple trees should be adjusted to not do that, or moved elsewhere (merge/collaboration is not the focus of this file).
+// TODO: There are two kinds of users of this in this file. Both should be changed:
+// Tests which are testing collaboration between multiple trees should be adjusted to not do that, or moved elsewhere (merge/collaboration is not the focus of this file).
+// Tests which are using a single tree should just use a MockFluidDataStoreRuntime instead of all the complexity of TestTreeProvider.
 function createSharedTrees(
 	schemaData: SchemaData,
 	data?: JsonableTree[],

--- a/packages/dds/tree/src/test/feature-libraries/identifierIndex.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/identifierIndex.spec.ts
@@ -68,7 +68,7 @@ describe("Node Identifier Index", () => {
 	}
 
 	it("can look up a node that was inserted", () => {
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
 		const id = makeId();
 		initializeTestTree(
@@ -85,7 +85,7 @@ describe("Node Identifier Index", () => {
 	});
 
 	it("can look up a deep node that was inserted", () => {
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
 		const id = makeId();
 		initializeTestTree(
@@ -118,7 +118,7 @@ describe("Node Identifier Index", () => {
 	});
 
 	it("can look up multiple nodes that were inserted at once", () => {
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
 		const ids = [makeId(), makeId(), makeId()];
 		initializeTestTree(
@@ -157,7 +157,7 @@ describe("Node Identifier Index", () => {
 	});
 
 	it("can look up multiple nodes that were inserted over time", () => {
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
 		const idA = makeId();
 		initializeTestTree(
@@ -188,7 +188,7 @@ describe("Node Identifier Index", () => {
 	});
 
 	it("forgets about nodes that are deleted", () => {
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
 		initializeTestTree(
 			tree,
@@ -206,7 +206,7 @@ describe("Node Identifier Index", () => {
 	});
 
 	it("fails if multiple nodes have the same ID", () => {
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
 		const id = makeId();
 		assert.throws(
@@ -238,7 +238,7 @@ describe("Node Identifier Index", () => {
 	});
 
 	it("can look up a node that was loaded from summary", async () => {
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
 		const id = makeId();
 		initializeTestTree(
@@ -282,7 +282,7 @@ describe("Node Identifier Index", () => {
 			identifierSchema,
 		);
 
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
 		initializeTestTree(
 			tree,
@@ -298,7 +298,7 @@ describe("Node Identifier Index", () => {
 	});
 
 	it("skips nodes which have identifiers of the wrong type", () => {
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
 		initializeTestTree(
 			tree,
@@ -315,7 +315,7 @@ describe("Node Identifier Index", () => {
 
 	it("skips nodes which should have identifiers, but do not", () => {
 		// This is policy choice rather than correctness. It could also fail.
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
 		initializeTestTree(
 			tree,
@@ -338,7 +338,7 @@ describe("Node Identifier Index", () => {
 			identifierSchema,
 		);
 
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
 		initializeTestTree(
 			tree,
@@ -370,7 +370,7 @@ describe("Node Identifier Index", () => {
 			identifierSchema,
 		);
 
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
 		const id = makeId();
 		initializeTestTree(
@@ -387,7 +387,7 @@ describe("Node Identifier Index", () => {
 	});
 
 	it("is synchronized after each batch update", () => {
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
 
 		const id = makeId();
@@ -429,7 +429,7 @@ describe("Node Identifier Index", () => {
 			identifierSchema,
 		);
 
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		const [tree] = provider.trees;
 		const id = makeId();
 		initializeTestTree(
@@ -451,7 +451,7 @@ describe("Node Identifier Index", () => {
 
 	function describeForkingTests(prefork: boolean): void {
 		function getTree(): ISharedTreeView {
-			const provider = new TestTreeProviderLite(1);
+			const provider = new TestTreeProviderLite();
 			const [tree] = provider.trees;
 			return prefork ? tree.fork() : tree;
 		}

--- a/packages/dds/tree/src/test/feature-libraries/identifierIndex.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/identifierIndex.spec.ts
@@ -17,7 +17,7 @@ import {
 	SharedTreeFactory,
 } from "../../shared-tree";
 import { brand, compareSets } from "../../util";
-import { TestTreeProvider, initializeTestTree } from "../utils";
+import { TestTreeProviderLite, initializeTestTree } from "../utils";
 import {
 	createField,
 	FieldKinds,
@@ -67,8 +67,8 @@ describe("Node Identifier Index", () => {
 		assert(compareSets({ a: new Set(tree.identifiedNodes.keys()), b: new Set(ids) }));
 	}
 
-	it("can look up a node that was inserted", async () => {
-		const provider = await TestTreeProvider.create(1);
+	it("can look up a node that was inserted", () => {
+		const provider = new TestTreeProviderLite(1);
 		const [tree] = provider.trees;
 		const id = makeId();
 		initializeTestTree(
@@ -84,8 +84,8 @@ describe("Node Identifier Index", () => {
 		assertIds(tree, [id]);
 	});
 
-	it("can look up a deep node that was inserted", async () => {
-		const provider = await TestTreeProvider.create(1);
+	it("can look up a deep node that was inserted", () => {
+		const provider = new TestTreeProviderLite(1);
 		const [tree] = provider.trees;
 		const id = makeId();
 		initializeTestTree(
@@ -117,8 +117,8 @@ describe("Node Identifier Index", () => {
 		assertIds(tree, [id]);
 	});
 
-	it("can look up multiple nodes that were inserted at once", async () => {
-		const provider = await TestTreeProvider.create(1);
+	it("can look up multiple nodes that were inserted at once", () => {
+		const provider = new TestTreeProviderLite(1);
 		const [tree] = provider.trees;
 		const ids = [makeId(), makeId(), makeId()];
 		initializeTestTree(
@@ -156,8 +156,8 @@ describe("Node Identifier Index", () => {
 		assertIds(tree, ids);
 	});
 
-	it("can look up multiple nodes that were inserted over time", async () => {
-		const provider = await TestTreeProvider.create(1);
+	it("can look up multiple nodes that were inserted over time", () => {
+		const provider = new TestTreeProviderLite(1);
 		const [tree] = provider.trees;
 		const idA = makeId();
 		initializeTestTree(
@@ -187,8 +187,8 @@ describe("Node Identifier Index", () => {
 		assertIds(tree, [idA, idB]);
 	});
 
-	it("forgets about nodes that are deleted", async () => {
-		const provider = await TestTreeProvider.create(1);
+	it("forgets about nodes that are deleted", () => {
+		const provider = new TestTreeProviderLite(1);
 		const [tree] = provider.trees;
 		initializeTestTree(
 			tree,
@@ -205,8 +205,8 @@ describe("Node Identifier Index", () => {
 		assertIds(tree, []);
 	});
 
-	it("fails if multiple nodes have the same ID", async () => {
-		const provider = await TestTreeProvider.create(1);
+	it("fails if multiple nodes have the same ID", () => {
+		const provider = new TestTreeProviderLite(1);
 		const [tree] = provider.trees;
 		const id = makeId();
 		assert.throws(
@@ -238,7 +238,7 @@ describe("Node Identifier Index", () => {
 	});
 
 	it("can look up a node that was loaded from summary", async () => {
-		const provider = await TestTreeProvider.create(1);
+		const provider = new TestTreeProviderLite(1);
 		const [tree] = provider.trees;
 		const id = makeId();
 		initializeTestTree(
@@ -251,7 +251,7 @@ describe("Node Identifier Index", () => {
 			},
 			nodeSchemaData,
 		);
-		await provider.ensureSynchronized();
+		provider.processMessages();
 		const summary = await tree.summarize();
 
 		const factory = new SharedTreeFactory();
@@ -268,7 +268,7 @@ describe("Node Identifier Index", () => {
 		assertIds(tree2, [id]);
 	});
 
-	it("skips nodes which have identifiers, but are not in schema", async () => {
+	it("skips nodes which have identifiers, but are not in schema", () => {
 		// This is missing the global identifier field on the node
 		const nodeSchemaNoIdentifier = TypedSchema.tree("node", {
 			local: { child: nodeFieldSchema },
@@ -282,7 +282,7 @@ describe("Node Identifier Index", () => {
 			identifierSchema,
 		);
 
-		const provider = await TestTreeProvider.create(1);
+		const provider = new TestTreeProviderLite(1);
 		const [tree] = provider.trees;
 		initializeTestTree(
 			tree,
@@ -297,8 +297,8 @@ describe("Node Identifier Index", () => {
 		assertIds(tree, []);
 	});
 
-	it("skips nodes which have identifiers of the wrong type", async () => {
-		const provider = await TestTreeProvider.create(1);
+	it("skips nodes which have identifiers of the wrong type", () => {
+		const provider = new TestTreeProviderLite(1);
 		const [tree] = provider.trees;
 		initializeTestTree(
 			tree,
@@ -313,9 +313,9 @@ describe("Node Identifier Index", () => {
 		assertIds(tree, []);
 	});
 
-	it("skips nodes which should have identifiers, but do not", async () => {
+	it("skips nodes which should have identifiers, but do not", () => {
 		// This is policy choice rather than correctness. It could also fail.
-		const provider = await TestTreeProvider.create(1);
+		const provider = new TestTreeProviderLite(1);
 		const [tree] = provider.trees;
 		initializeTestTree(
 			tree,
@@ -330,7 +330,7 @@ describe("Node Identifier Index", () => {
 		assertIds(tree, []);
 	});
 
-	it("is disabled if identifier field is not in the global schema", async () => {
+	it("is disabled if identifier field is not in the global schema", () => {
 		// This is missing the global identifier field
 		const nodeSchemaDataNoIdentifier = SchemaAware.typedSchemaData(
 			[[rootFieldKey, nodeFieldSchema]],
@@ -338,7 +338,7 @@ describe("Node Identifier Index", () => {
 			identifierSchema,
 		);
 
-		const provider = await TestTreeProvider.create(1);
+		const provider = new TestTreeProviderLite(1);
 		const [tree] = provider.trees;
 		initializeTestTree(
 			tree,
@@ -355,7 +355,7 @@ describe("Node Identifier Index", () => {
 		assert(!index.identifiersAreInSchema(tree.context.schema));
 	});
 
-	it("respects extra global fields", async () => {
+	it("respects extra global fields", () => {
 		// This is missing the global identifier field on the node, but has "extra global fields" enabled
 		const nodeSchemaNoIdentifier = TypedSchema.tree("node", {
 			local: { child: nodeFieldSchema },
@@ -370,7 +370,7 @@ describe("Node Identifier Index", () => {
 			identifierSchema,
 		);
 
-		const provider = await TestTreeProvider.create(1);
+		const provider = new TestTreeProviderLite(1);
 		const [tree] = provider.trees;
 		const id = makeId();
 		initializeTestTree(
@@ -386,8 +386,8 @@ describe("Node Identifier Index", () => {
 		assertIds(tree, [id]);
 	});
 
-	it("is synchronized after each batch update", async () => {
-		const provider = await TestTreeProvider.create(1);
+	it("is synchronized after each batch update", () => {
+		const provider = new TestTreeProviderLite(1);
 		const [tree] = provider.trees;
 
 		const id = makeId();
@@ -415,7 +415,7 @@ describe("Node Identifier Index", () => {
 	});
 
 	// TODO: Schema changes are not yet fully hooked up to eventing. A schema change should probably trigger
-	it.skip("reacts to schema changes", async () => {
+	it.skip("reacts to schema changes", () => {
 		// This is missing the global identifier field on the node
 		const nodeSchemaNoIdentifier = TypedSchema.tree("node", {
 			local: { child: nodeFieldSchema },
@@ -429,7 +429,7 @@ describe("Node Identifier Index", () => {
 			identifierSchema,
 		);
 
-		const provider = await TestTreeProvider.create(1);
+		const provider = new TestTreeProviderLite(1);
 		const [tree] = provider.trees;
 		const id = makeId();
 		initializeTestTree(
@@ -450,14 +450,14 @@ describe("Node Identifier Index", () => {
 	});
 
 	function describeForkingTests(prefork: boolean): void {
-		async function getTree(): Promise<ISharedTreeView> {
-			const provider = await TestTreeProvider.create(1);
+		function getTree(): ISharedTreeView {
+			const provider = new TestTreeProviderLite(1);
 			const [tree] = provider.trees;
 			return prefork ? tree.fork() : tree;
 		}
 		describe(`forking from ${prefork ? "a fork" : "the root"}`, () => {
-			it("does not mutate the base when mutating a fork", async () => {
-				const tree = await getTree();
+			it("does not mutate the base when mutating a fork", () => {
+				const tree = getTree();
 				const id = makeId();
 				initializeTestTree(
 					tree,
@@ -478,8 +478,8 @@ describe("Node Identifier Index", () => {
 				assertIds(tree, []);
 			});
 
-			it("does not mutate the fork when mutating a base", async () => {
-				const tree = await getTree();
+			it("does not mutate the fork when mutating a base", () => {
+				const tree = getTree();
 				const id = makeId();
 				initializeTestTree(
 					tree,

--- a/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
@@ -444,7 +444,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 				percentile: number,
 				testName: string,
 			) => {
-				const provider = new TestTreeProviderLite(1);
+				const provider = new TestTreeProviderLite();
 				initializeOpDataCollection(provider, testName);
 				initializeTestTree(provider.trees[0]);
 				deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
@@ -484,7 +484,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 
 		describe("1b. With Single transaction", () => {
 			const benchmarkInsertNodesWithSingleTx = (percentile: number, testName: string) => {
-				const provider = new TestTreeProviderLite(1);
+				const provider = new TestTreeProviderLite();
 				initializeOpDataCollection(provider, testName);
 				initializeTestTree(provider.trees[0]);
 				deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
@@ -529,7 +529,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 				percentile: number,
 				testName: string,
 			) => {
-				const provider = new TestTreeProviderLite(1);
+				const provider = new TestTreeProviderLite();
 				initializeOpDataCollection(provider, testName);
 				const childByteSize = getSuccessfulOpByteSize("DELETE", "INDIVIDUAL", percentile);
 				initializeTestTree(
@@ -565,7 +565,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 
 		describe("2b. With Single transaction", () => {
 			const benchmarkDeleteNodesWithSingleTx = (percentile: number, testName: string) => {
-				const provider = new TestTreeProviderLite(1);
+				const provider = new TestTreeProviderLite();
 				initializeOpDataCollection(provider, testName);
 				const childByteSize = getSuccessfulOpByteSize("DELETE", "SINGLE", percentile);
 				initializeTestTree(
@@ -603,7 +603,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 	describe("3. Edit Nodes", () => {
 		describe("3a. With Individual transactions", () => {
 			const benchmarkEditNodesWithIndividualTxs = (percentile: number, testName: string) => {
-				const provider = new TestTreeProviderLite(1);
+				const provider = new TestTreeProviderLite();
 				initializeOpDataCollection(provider, testName);
 				// Note that the child node byte size for the intial tree here should be arbitrary
 				initializeTestTree(
@@ -651,7 +651,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 
 		describe("3b. With Single transaction", () => {
 			const benchmarkEditNodesWithSingleTx = (percentile: number, testName: string) => {
-				const provider = new TestTreeProviderLite(1);
+				const provider = new TestTreeProviderLite();
 				initializeOpDataCollection(provider, testName);
 				// Note that the child node byte size for the intial tree here should be arbitrary
 				initializeTestTree(
@@ -707,7 +707,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 				deleteNodeCount: number,
 				editNodeCount: number,
 			) => {
-				const provider = new TestTreeProviderLite(1);
+				const provider = new TestTreeProviderLite();
 				initializeOpDataCollection(provider, testName);
 
 				// delete
@@ -910,7 +910,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 				deleteNodeCount: number,
 				editNodeCount: number,
 			) => {
-				const provider = new TestTreeProviderLite(1);
+				const provider = new TestTreeProviderLite();
 				initializeOpDataCollection(provider, testName);
 
 				// delete

--- a/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
@@ -9,7 +9,7 @@ import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions"
 import { emptyField, FieldKinds, namedTreeSchema, singleTextCursor } from "../../feature-libraries";
 import { ISharedTree } from "../../shared-tree";
 import { brand, getOrAddEmptyToMap } from "../../util";
-import { ITestTreeProvider, TestTreeProvider } from "../utils";
+import { TestTreeProviderLite } from "../utils";
 import {
 	FieldKey,
 	fieldSchema,
@@ -143,9 +143,9 @@ const getInitialJsonTreeWithChildren = (numChildNodes: number, childNodeByteSize
 	return jsonTree;
 };
 
-const insertNodesWithIndividualTransactions = async (
+const insertNodesWithIndividualTransactions = (
 	tree: ISharedTree,
-	provider: ITestTreeProvider,
+	provider: TestTreeProviderLite,
 	jsonNode: JsonableTree,
 	count: number,
 ) => {
@@ -161,12 +161,12 @@ const insertNodesWithIndividualTransactions = async (
 		field.insert(0, writeCursor);
 		tree.transaction.commit();
 	}
-	await provider.ensureSynchronized();
+	provider.processMessages();
 };
 
-const insertNodesWithSingleTransaction = async (
+const insertNodesWithSingleTransaction = (
 	tree: ISharedTree,
-	provider: ITestTreeProvider,
+	provider: TestTreeProviderLite,
 	jsonNode: JsonableTree,
 	count: number,
 ) => {
@@ -181,12 +181,12 @@ const insertNodesWithSingleTransaction = async (
 		field.insert(0, singleTextCursor(jsonNode));
 	}
 	tree.transaction.commit();
-	await provider.ensureSynchronized();
+	provider.processMessages();
 };
 
-const deleteNodesWithIndividualTransactions = async (
+const deleteNodesWithIndividualTransactions = (
 	tree: ISharedTree,
-	provider: ITestTreeProvider,
+	provider: TestTreeProviderLite,
 	numDeletes: number,
 	deletesPerTransaction: number,
 ) => {
@@ -200,13 +200,13 @@ const deleteNodesWithIndividualTransactions = async (
 		const field = tree.editor.sequenceField(path, childrenFieldKey);
 		field.delete(getChildrenlength(tree) - 1, deletesPerTransaction);
 		tree.transaction.commit();
-		await provider.ensureSynchronized();
+		provider.processMessages();
 	}
 };
 
-const deleteNodesWithSingleTransaction = async (
+const deleteNodesWithSingleTransaction = (
 	tree: ISharedTree,
-	provider: ITestTreeProvider,
+	provider: TestTreeProviderLite,
 	numDeletes: number,
 ) => {
 	tree.transaction.start();
@@ -218,7 +218,7 @@ const deleteNodesWithSingleTransaction = async (
 	const field = tree.editor.sequenceField(path, childrenFieldKey);
 	field.delete(0, numDeletes);
 	tree.transaction.commit();
-	await provider.ensureSynchronized();
+	provider.processMessages();
 };
 
 const getEditPayloadInBytes = (numBytes: number) => {
@@ -229,9 +229,9 @@ const getEditPayloadInBytes = (numBytes: number) => {
 	return payload;
 };
 
-const editNodesWithIndividualTransactions = async (
+const editNodesWithIndividualTransactions = (
 	tree: ISharedTree,
-	provider: ITestTreeProvider,
+	provider: TestTreeProviderLite,
 	numChildrenToEdit: number,
 	editPayload: Value,
 ) => {
@@ -249,13 +249,13 @@ const editNodesWithIndividualTransactions = async (
 		};
 		tree.editor.setValue(childPath, editPayload);
 		tree.transaction.commit();
-		await provider.ensureSynchronized();
+		provider.processMessages();
 	}
 };
 
-const editNodesWithSingleTransaction = async (
+const editNodesWithSingleTransaction = (
 	tree: ISharedTree,
-	provider: ITestTreeProvider,
+	provider: TestTreeProviderLite,
 	numChildrenToEdit: number,
 	editPayload: Value,
 ) => {
@@ -274,7 +274,7 @@ const editNodesWithSingleTransaction = async (
 		tree.editor.setValue(childPath, editPayload);
 	}
 	tree.transaction.commit();
-	await provider.ensureSynchronized();
+	provider.processMessages();
 };
 
 /**
@@ -344,10 +344,10 @@ describe("SharedTree Op Size Benchmarks", () => {
 	const currentTestOps: ISequencedDocumentMessage[] = [];
 
 	const registerOpListener = (
-		provider: ITestTreeProvider,
+		provider: TestTreeProviderLite,
 		resultArray: ISequencedDocumentMessage[],
 	) => {
-		provider.containers[0].deltaManager.on("op", (message) => {
+		provider.trees[0].on("op", (message) => {
 			if (message?.type === "op") {
 				resultArray.push(message);
 			}
@@ -395,7 +395,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 		};
 	};
 
-	const initializeOpDataCollection = (provider: ITestTreeProvider, testName: string) => {
+	const initializeOpDataCollection = (provider: TestTreeProviderLite, testName: string) => {
 		currentBenchmarkName = testName;
 		currentTestOps.length = 0;
 		registerOpListener(provider, currentTestOps);
@@ -440,18 +440,18 @@ describe("SharedTree Op Size Benchmarks", () => {
 
 	describe("1. Insert Nodes", () => {
 		describe("1a. With Individual transactions", () => {
-			const benchmarkInsertNodesWithIndividualTxs = async (
+			const benchmarkInsertNodesWithIndividualTxs = (
 				percentile: number,
 				testName: string,
 			) => {
-				const provider = await TestTreeProvider.create(1);
+				const provider = new TestTreeProviderLite(1);
 				initializeOpDataCollection(provider, testName);
 				initializeTestTree(provider.trees[0]);
 				deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
 				const jsonNode = getJsonNode(
 					getSuccessfulOpByteSize("INSERT", "INDIVIDUAL", percentile),
 				);
-				await insertNodesWithIndividualTransactions(
+				insertNodesWithIndividualTransactions(
 					provider.trees[0],
 					provider,
 					jsonNode,
@@ -460,22 +460,22 @@ describe("SharedTree Op Size Benchmarks", () => {
 				assertChildNodeCount(provider.trees[0], BENCHMARK_NODE_COUNT);
 			};
 
-			it(`1a.a. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} small nodes in ${BENCHMARK_NODE_COUNT} transactions`, async () => {
-				await benchmarkInsertNodesWithIndividualTxs(
+			it(`1a.a. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} small nodes in ${BENCHMARK_NODE_COUNT} transactions`, () => {
+				benchmarkInsertNodesWithIndividualTxs(
 					0.01,
 					`1a.a. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} small nodes in ${BENCHMARK_NODE_COUNT} individual transactions`,
 				);
 			});
 
-			it(`1a.b. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, async () => {
-				await benchmarkInsertNodesWithIndividualTxs(
+			it(`1a.b. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, () => {
+				benchmarkInsertNodesWithIndividualTxs(
 					0.5,
 					`1a.b. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium nodes in ${BENCHMARK_NODE_COUNT} individual transactions`,
 				);
 			});
 
-			it(`1a.c. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} large nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, async () => {
-				await benchmarkInsertNodesWithIndividualTxs(
+			it(`1a.c. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} large nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, () => {
+				benchmarkInsertNodesWithIndividualTxs(
 					1,
 					`1a.c. [Insert] [Individual Txs] ${BENCHMARK_NODE_COUNT} large nodes in ${BENCHMARK_NODE_COUNT} individual transactions`,
 				);
@@ -483,18 +483,15 @@ describe("SharedTree Op Size Benchmarks", () => {
 		});
 
 		describe("1b. With Single transaction", () => {
-			const benchmarkInsertNodesWithSingleTx = async (
-				percentile: number,
-				testName: string,
-			) => {
-				const provider = await TestTreeProvider.create(1);
+			const benchmarkInsertNodesWithSingleTx = (percentile: number, testName: string) => {
+				const provider = new TestTreeProviderLite(1);
 				initializeOpDataCollection(provider, testName);
 				initializeTestTree(provider.trees[0]);
 				deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
 				const jsonNode = getJsonNode(
 					getSuccessfulOpByteSize("INSERT", "SINGLE", percentile),
 				);
-				await insertNodesWithSingleTransaction(
+				insertNodesWithSingleTransaction(
 					provider.trees[0],
 					provider,
 					jsonNode,
@@ -503,22 +500,22 @@ describe("SharedTree Op Size Benchmarks", () => {
 				assertChildNodeCount(provider.trees[0], BENCHMARK_NODE_COUNT);
 			};
 
-			it(`1b.a. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} small nodes in 1 transaction`, async () => {
-				await benchmarkInsertNodesWithSingleTx(
+			it(`1b.a. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} small nodes in 1 transaction`, () => {
+				benchmarkInsertNodesWithSingleTx(
 					0.01,
 					`1b.a. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} small nodes in 1 transaction`,
 				);
 			});
 
-			it(`1b.b. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} medium nodes in 1 transaction`, async () => {
-				await benchmarkInsertNodesWithSingleTx(
+			it(`1b.b. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} medium nodes in 1 transaction`, () => {
+				benchmarkInsertNodesWithSingleTx(
 					0.5,
 					`1b.b. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} medium nodes in 1 transaction`,
 				);
 			});
 
-			it(`1b.c. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} large nodes in 1 transaction`, async () => {
-				await benchmarkInsertNodesWithSingleTx(
+			it(`1b.c. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} large nodes in 1 transaction`, () => {
+				benchmarkInsertNodesWithSingleTx(
 					1,
 					`1b.c. [Insert] [Single Tx] ${BENCHMARK_NODE_COUNT} large nodes in 1 transaction`,
 				);
@@ -528,11 +525,11 @@ describe("SharedTree Op Size Benchmarks", () => {
 
 	describe("2. Delete Nodes", () => {
 		describe("2a. With Individual transactions", () => {
-			const benchmarkDeleteNodesWithIndividualTxs = async (
+			const benchmarkDeleteNodesWithIndividualTxs = (
 				percentile: number,
 				testName: string,
 			) => {
-				const provider = await TestTreeProvider.create(1);
+				const provider = new TestTreeProviderLite(1);
 				initializeOpDataCollection(provider, testName);
 				const childByteSize = getSuccessfulOpByteSize("DELETE", "INDIVIDUAL", percentile);
 				initializeTestTree(
@@ -540,26 +537,26 @@ describe("SharedTree Op Size Benchmarks", () => {
 					getInitialJsonTreeWithChildren(100, childByteSize),
 				);
 				deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
-				await deleteNodesWithIndividualTransactions(provider.trees[0], provider, 100, 1);
+				deleteNodesWithIndividualTransactions(provider.trees[0], provider, 100, 1);
 				assertChildNodeCount(provider.trees[0], 0);
 			};
 
-			it(`2a.a. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} small nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, async () => {
-				await benchmarkDeleteNodesWithIndividualTxs(
+			it(`2a.a. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} small nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, () => {
+				benchmarkDeleteNodesWithIndividualTxs(
 					0.01,
 					`2a.a. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} small nodes in ${BENCHMARK_NODE_COUNT} individual transactions`,
 				);
 			});
 
-			it(`2a.b. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, async () => {
-				await benchmarkDeleteNodesWithIndividualTxs(
+			it(`2a.b. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, () => {
+				benchmarkDeleteNodesWithIndividualTxs(
 					0.5,
 					`2a.b. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium nodes in ${BENCHMARK_NODE_COUNT} individual transactions`,
 				);
 			});
 
-			it(`2a.c. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} large nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, async () => {
-				await benchmarkDeleteNodesWithIndividualTxs(
+			it(`2a.c. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} large nodes in ${BENCHMARK_NODE_COUNT} individual transactions`, () => {
+				benchmarkDeleteNodesWithIndividualTxs(
 					1,
 					`2a.c. [Delete] [Individual Txs] ${BENCHMARK_NODE_COUNT} large nodes in ${BENCHMARK_NODE_COUNT} individual transactions`,
 				);
@@ -567,11 +564,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 		});
 
 		describe("2b. With Single transaction", () => {
-			const benchmarkDeleteNodesWithSingleTx = async (
-				percentile: number,
-				testName: string,
-			) => {
-				const provider = await TestTreeProvider.create(1);
+			const benchmarkDeleteNodesWithSingleTx = (percentile: number, testName: string) => {
+				const provider = new TestTreeProviderLite(1);
 				initializeOpDataCollection(provider, testName);
 				const childByteSize = getSuccessfulOpByteSize("DELETE", "SINGLE", percentile);
 				initializeTestTree(
@@ -579,26 +573,26 @@ describe("SharedTree Op Size Benchmarks", () => {
 					getInitialJsonTreeWithChildren(100, childByteSize),
 				);
 				deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
-				await deleteNodesWithSingleTransaction(provider.trees[0], provider, 100);
+				deleteNodesWithSingleTransaction(provider.trees[0], provider, 100);
 				assertChildNodeCount(provider.trees[0], 0);
 			};
 
-			it(`2b.a. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} small nodes in 1 transaction containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`, async () => {
-				await benchmarkDeleteNodesWithSingleTx(
+			it(`2b.a. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} small nodes in 1 transaction containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`, () => {
+				benchmarkDeleteNodesWithSingleTx(
 					0.01,
 					`2b.a. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} small nodes in 1 transaction containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`,
 				);
 			});
 
-			it(`2b.b. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} medium nodes in 1 transactions containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`, async () => {
-				await benchmarkDeleteNodesWithSingleTx(
+			it(`2b.b. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} medium nodes in 1 transactions containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`, () => {
+				benchmarkDeleteNodesWithSingleTx(
 					0.5,
 					`2b.b. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} medium nodes in 1 transactions containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`,
 				);
 			});
 
-			it(`2b.c. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} large nodes in 1 transactions containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`, async () => {
-				await benchmarkDeleteNodesWithSingleTx(
+			it(`2b.c. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} large nodes in 1 transactions containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`, () => {
+				benchmarkDeleteNodesWithSingleTx(
 					1,
 					`2b.c. [Delete] [Single Tx] ${BENCHMARK_NODE_COUNT} large nodes in 1 transactions containing 1 delete of ${BENCHMARK_NODE_COUNT} nodes`,
 				);
@@ -608,11 +602,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 
 	describe("3. Edit Nodes", () => {
 		describe("3a. With Individual transactions", () => {
-			const benchmarkEditNodesWithIndividualTxs = async (
-				percentile: number,
-				testName: string,
-			) => {
-				const provider = await TestTreeProvider.create(1);
+			const benchmarkEditNodesWithIndividualTxs = (percentile: number, testName: string) => {
+				const provider = new TestTreeProviderLite(1);
 				initializeOpDataCollection(provider, testName);
 				// Note that the child node byte size for the intial tree here should be arbitrary
 				initializeTestTree(
@@ -623,7 +614,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 				const editPayload = getEditPayloadInBytes(
 					getSuccessfulOpByteSize("EDIT", "INDIVIDUAL", percentile),
 				);
-				await editNodesWithIndividualTransactions(
+				editNodesWithIndividualTransactions(
 					provider.trees[0],
 					provider,
 					BENCHMARK_NODE_COUNT,
@@ -636,22 +627,22 @@ describe("SharedTree Op Size Benchmarks", () => {
 				);
 			};
 
-			it(`3a.a. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} small changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`, async () => {
-				await benchmarkEditNodesWithIndividualTxs(
+			it(`3a.a. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} small changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`, () => {
+				benchmarkEditNodesWithIndividualTxs(
 					0.01,
 					`3a.a. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} small changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`,
 				);
 			});
 
-			it(`3a.b. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`, async () => {
-				await benchmarkEditNodesWithIndividualTxs(
+			it(`3a.b. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`, () => {
+				benchmarkEditNodesWithIndividualTxs(
 					0.5,
 					`3a.b. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} medium changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`,
 				);
 			});
 
-			it(`3a.c. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} large changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`, async () => {
-				await benchmarkEditNodesWithIndividualTxs(
+			it(`3a.c. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} large changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`, () => {
+				benchmarkEditNodesWithIndividualTxs(
 					1,
 					`3a.c. [Edit] [Individual Txs] ${BENCHMARK_NODE_COUNT} large changes in ${BENCHMARK_NODE_COUNT} transactions containing 1 edit`,
 				);
@@ -659,8 +650,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 		});
 
 		describe("3b. With Single transaction", () => {
-			const benchmarkEditNodesWithSingleTx = async (percentile: number, testName: string) => {
-				const provider = await TestTreeProvider.create(1);
+			const benchmarkEditNodesWithSingleTx = (percentile: number, testName: string) => {
+				const provider = new TestTreeProviderLite(1);
 				initializeOpDataCollection(provider, testName);
 				// Note that the child node byte size for the intial tree here should be arbitrary
 				initializeTestTree(
@@ -671,7 +662,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 				const editPayload = getEditPayloadInBytes(
 					getSuccessfulOpByteSize("EDIT", "SINGLE", percentile),
 				);
-				await editNodesWithSingleTransaction(
+				editNodesWithSingleTransaction(
 					provider.trees[0],
 					provider,
 					BENCHMARK_NODE_COUNT,
@@ -684,22 +675,22 @@ describe("SharedTree Op Size Benchmarks", () => {
 				);
 			};
 
-			it(`3b.a. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} small edits in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`, async () => {
-				await benchmarkEditNodesWithSingleTx(
+			it(`3b.a. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} small edits in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`, () => {
+				benchmarkEditNodesWithSingleTx(
 					0.01,
 					`3b.a. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} small changes in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`,
 				);
 			});
 
-			it(`3b.b. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} medium changes in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`, async () => {
-				await benchmarkEditNodesWithSingleTx(
+			it(`3b.b. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} medium changes in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`, () => {
+				benchmarkEditNodesWithSingleTx(
 					0.5,
 					`3b.b. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} medium changes in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`,
 				);
 			});
 
-			it(`3b.c. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} large changes in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`, async () => {
-				await benchmarkEditNodesWithSingleTx(
+			it(`3b.c. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} large changes in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`, () => {
+				benchmarkEditNodesWithSingleTx(
 					1,
 					`3b.c. [Edit] [Single Tx] ${BENCHMARK_NODE_COUNT} large changes in 1 transaction containing ${BENCHMARK_NODE_COUNT} edits`,
 				);
@@ -709,14 +700,14 @@ describe("SharedTree Op Size Benchmarks", () => {
 
 	describe("4. Insert, Delete & Edit Nodes", () => {
 		describe("4a. Insert, Delete & Edit Nodes in Individual Transactions", () => {
-			const benchmarkInsertDeleteEditNodesWithInvidiualTxs = async (
+			const benchmarkInsertDeleteEditNodesWithInvidiualTxs = (
 				percentile: number,
 				testName: string,
 				insertNodeCount: number,
 				deleteNodeCount: number,
 				editNodeCount: number,
 			) => {
-				const provider = await TestTreeProvider.create(1);
+				const provider = new TestTreeProviderLite(1);
 				initializeOpDataCollection(provider, testName);
 
 				// delete
@@ -726,7 +717,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 					getInitialJsonTreeWithChildren(deleteNodeCount, childByteSize),
 				);
 				deleteCurrentOps(); // We don't want to record the ops from initializing the tree.
-				await deleteNodesWithIndividualTransactions(
+				deleteNodesWithIndividualTransactions(
 					provider.trees[0],
 					provider,
 					deleteNodeCount,
@@ -738,7 +729,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 				const insertChildNode = getJsonNode(
 					getSuccessfulOpByteSize("INSERT", "INDIVIDUAL", percentile),
 				);
-				await insertNodesWithIndividualTransactions(
+				insertNodesWithIndividualTransactions(
 					provider.trees[0],
 					provider,
 					insertChildNode,
@@ -751,7 +742,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 				if (insertNodeCount < editNodeCount) {
 					const remainder = editNodeCount - insertNodeCount;
 					saveAndResetCurrentOps();
-					await insertNodesWithIndividualTransactions(
+					insertNodesWithIndividualTransactions(
 						provider.trees[0],
 						provider,
 						getJsonNode(childByteSize),
@@ -762,7 +753,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 				const editPayload = getEditPayloadInBytes(
 					getSuccessfulOpByteSize("EDIT", "INDIVIDUAL", percentile),
 				);
-				await editNodesWithIndividualTransactions(
+				editNodesWithIndividualTransactions(
 					provider.trees[0],
 					provider,
 					editNodeCount,
@@ -774,8 +765,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 			describe("4a.a. [Combination] [Individual Txs] With individual transactions and an equal distribution of operation type", () => {
 				const oneThirdNodeCount = Math.floor(BENCHMARK_NODE_COUNT * (1 / 3));
 
-				it(`4a.a.a. [Combination] [Individual Txs] insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithInvidiualTxs(
+				it(`4a.a.a. [Combination] [Individual Txs] insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.01,
 						`4a.a.a. [Combination] [Individual Txs] insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`,
 						oneThirdNodeCount,
@@ -784,8 +775,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4a.a.b. [Combination] [Individual Txs] insert ${oneThirdNodeCount} medium nodes, delete ${oneThirdNodeCount} medium nodes, edit ${oneThirdNodeCount} nodes with medium payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithInvidiualTxs(
+				it(`4a.a.b. [Combination] [Individual Txs] insert ${oneThirdNodeCount} medium nodes, delete ${oneThirdNodeCount} medium nodes, edit ${oneThirdNodeCount} nodes with medium payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.5,
 						`4a.a.b. [Combination] [Individual Txs] insert ${oneThirdNodeCount} medium nodes, delete ${oneThirdNodeCount} medium nodes, edit ${oneThirdNodeCount} nodes with medium payloads`,
 						oneThirdNodeCount,
@@ -794,8 +785,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4a.a.c. [Combination] [Individual Txs] insert ${oneThirdNodeCount} large nodes, delete ${oneThirdNodeCount} large medium, edit ${oneThirdNodeCount} nodes with large payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithInvidiualTxs(
+				it(`4a.a.c. [Combination] [Individual Txs] insert ${oneThirdNodeCount} large nodes, delete ${oneThirdNodeCount} large medium, edit ${oneThirdNodeCount} nodes with large payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						1,
 						`4a.a.c. [Combination] [Individual Txs] insert ${oneThirdNodeCount} large nodes, delete ${oneThirdNodeCount} large medium, edit ${oneThirdNodeCount} nodes with large payloads`,
 						oneThirdNodeCount,
@@ -809,8 +800,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
 				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
 
-				it(`4a.b.a. [Combination] [Individual Txs] Insert ${seventyPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithInvidiualTxs(
+				it(`4a.b.a. [Combination] [Individual Txs] Insert ${seventyPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.01,
 						`4a.b.a. [Combination] [Individual Txs] Insert ${seventyPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`,
 						seventyPercentCount,
@@ -819,8 +810,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4a.b.b. [Combination] [Individual Txs] Insert ${seventyPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithInvidiualTxs(
+				it(`4a.b.b. [Combination] [Individual Txs] Insert ${seventyPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.5,
 						`4a.b.b. [Combination] [Individual Txs] Insert ${seventyPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`,
 						seventyPercentCount,
@@ -829,8 +820,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4a.b.c. [Combination] [Individual Txs] Insert ${seventyPercentCount} large nodes, delete ${fifteenPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithInvidiualTxs(
+				it(`4a.b.c. [Combination] [Individual Txs] Insert ${seventyPercentCount} large nodes, delete ${fifteenPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						1,
 						`4a.b.c. [Combination] [Individual Txs] Insert ${seventyPercentCount} large nodes, delete ${fifteenPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`,
 						seventyPercentCount,
@@ -844,8 +835,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
 				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
 
-				it(`4a.c.a. [Combination] [Individual Txs] Insert ${fifteenPercentCount} small nodes, delete ${seventyPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithInvidiualTxs(
+				it(`4a.c.a. [Combination] [Individual Txs] Insert ${fifteenPercentCount} small nodes, delete ${seventyPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.01,
 						`4a.c.a. [Combination] [Individual Txs] Insert ${fifteenPercentCount} small nodes, delete ${seventyPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`,
 						fifteenPercentCount,
@@ -854,8 +845,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4a.c.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithInvidiualTxs(
+				it(`4a.c.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.5,
 						`4a.c.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`,
 						fifteenPercentCount,
@@ -864,8 +855,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4a.c.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithInvidiualTxs(
+				it(`4a.c.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						1,
 						`4a.c.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`,
 						fifteenPercentCount,
@@ -879,8 +870,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
 				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
 
-				it(`4a.d.a. [Combination] [Individual Txs] Insert ${fifteenPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${seventyPercentCount} nodes with small payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithInvidiualTxs(
+				it(`4a.d.a. [Combination] [Individual Txs] Insert ${fifteenPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${seventyPercentCount} nodes with small payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.01,
 						`4a.d.a. [Combination] [Individual Txs] Insert ${fifteenPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${seventyPercentCount} nodes with small payloads`,
 						fifteenPercentCount,
@@ -889,8 +880,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4a.d.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${seventyPercentCount} nodes with medium payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithInvidiualTxs(
+				it(`4a.d.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${seventyPercentCount} nodes with medium payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						0.5,
 						`4a.d.b. [Combination] [Individual Txs] Insert ${fifteenPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${seventyPercentCount} nodes with medium payloads`,
 						fifteenPercentCount,
@@ -899,8 +890,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4a.d.c. [Combination] [Individual Txs] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${seventyPercentCount} nodes with large payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithInvidiualTxs(
+				it(`4a.d.c. [Combination] [Individual Txs] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${seventyPercentCount} nodes with large payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithInvidiualTxs(
 						1,
 						`4a.d.c. [Combination] [Individual Txs] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${seventyPercentCount} nodes with large payloads`,
 						fifteenPercentCount,
@@ -912,14 +903,14 @@ describe("SharedTree Op Size Benchmarks", () => {
 		});
 
 		describe("4b. Insert, Delete & Edit Nodes in Single Transactions", () => {
-			const benchmarkInsertDeleteEditNodesWithSingleTxs = async (
+			const benchmarkInsertDeleteEditNodesWithSingleTxs = (
 				percentile: number,
 				testName: string,
 				insertNodeCount: number,
 				deleteNodeCount: number,
 				editNodeCount: number,
 			) => {
-				const provider = await TestTreeProvider.create(1);
+				const provider = new TestTreeProviderLite(1);
 				initializeOpDataCollection(provider, testName);
 
 				// delete
@@ -929,18 +920,14 @@ describe("SharedTree Op Size Benchmarks", () => {
 					getInitialJsonTreeWithChildren(deleteNodeCount, childByteSize),
 				);
 				deleteCurrentOps(); // We don't want to record the ops from initializing the tree.
-				await deleteNodesWithSingleTransaction(
-					provider.trees[0],
-					provider,
-					deleteNodeCount,
-				);
+				deleteNodesWithSingleTransaction(provider.trees[0], provider, deleteNodeCount);
 				assertChildNodeCount(provider.trees[0], 0);
 
 				// insert
 				const insertChildNode = getJsonNode(
 					getSuccessfulOpByteSize("INSERT", "SINGLE", percentile),
 				);
-				await insertNodesWithSingleTransaction(
+				insertNodesWithSingleTransaction(
 					provider.trees[0],
 					provider,
 					insertChildNode,
@@ -953,7 +940,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 				if (insertNodeCount < editNodeCount) {
 					const remainder = editNodeCount - insertNodeCount;
 					saveAndResetCurrentOps();
-					await insertNodesWithIndividualTransactions(
+					insertNodesWithIndividualTransactions(
 						provider.trees[0],
 						provider,
 						getJsonNode(childByteSize),
@@ -964,7 +951,7 @@ describe("SharedTree Op Size Benchmarks", () => {
 				const editPayload = getEditPayloadInBytes(
 					getSuccessfulOpByteSize("EDIT", "SINGLE", percentile),
 				);
-				await editNodesWithSingleTransaction(
+				editNodesWithSingleTransaction(
 					provider.trees[0],
 					provider,
 					editNodeCount,
@@ -976,8 +963,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 			describe("4b.a. [Combination] [Single Tx] With single transactions and an equal distribution of operation type", () => {
 				const oneThirdNodeCount = Math.floor(BENCHMARK_NODE_COUNT * (1 / 3));
 
-				it(`4b.a.a. [Combination] [Single Tx] insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithSingleTxs(
+				it(`4b.a.a. [Combination] [Single Tx] insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.01,
 						`4b.a.a. [Combination] [Single Tx] insert ${oneThirdNodeCount} small nodes, delete ${oneThirdNodeCount} small nodes, edit ${oneThirdNodeCount} nodes with small payloads`,
 						oneThirdNodeCount,
@@ -986,8 +973,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4b.a.b. [Combination] [Single Tx] insert ${oneThirdNodeCount} medium nodes, delete ${oneThirdNodeCount} medium nodes, edit ${oneThirdNodeCount} nodes with medium payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithSingleTxs(
+				it(`4b.a.b. [Combination] [Single Tx] insert ${oneThirdNodeCount} medium nodes, delete ${oneThirdNodeCount} medium nodes, edit ${oneThirdNodeCount} nodes with medium payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.5,
 						`4b.a.b. [Combination] [Single Tx] insert ${oneThirdNodeCount} medium nodes, delete ${oneThirdNodeCount} medium nodes, edit ${oneThirdNodeCount} nodes with medium payloads`,
 						oneThirdNodeCount,
@@ -996,8 +983,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4b.a.c. [Combination] [Single Tx] insert ${oneThirdNodeCount} large nodes, delete ${oneThirdNodeCount} large medium, edit ${oneThirdNodeCount} nodes with large payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithSingleTxs(
+				it(`4b.a.c. [Combination] [Single Tx] insert ${oneThirdNodeCount} large nodes, delete ${oneThirdNodeCount} large medium, edit ${oneThirdNodeCount} nodes with large payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						1,
 						`4b.a.c. [Combination] [Single Tx] insert ${oneThirdNodeCount} large nodes, delete ${oneThirdNodeCount} large medium, edit ${oneThirdNodeCount} nodes with large payloads`,
 						oneThirdNodeCount,
@@ -1011,8 +998,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
 				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
 
-				it(`4b.b.a. [Combination] [Single Tx] Insert ${seventyPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithSingleTxs(
+				it(`4b.b.a. [Combination] [Single Tx] Insert ${seventyPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.01,
 						`4b.b.a. [Combination] [Single Tx] Insert ${seventyPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`,
 						seventyPercentCount,
@@ -1021,8 +1008,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4b.b.b. [Combination] [Single Tx] Insert ${seventyPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithSingleTxs(
+				it(`4b.b.b. [Combination] [Single Tx] Insert ${seventyPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.5,
 						`4b.b.b. [Combination] [Single Tx] Insert ${seventyPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`,
 						seventyPercentCount,
@@ -1031,8 +1018,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4b.b.c. [Combination] [Single Tx] Insert ${seventyPercentCount} large nodes, delete ${fifteenPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithSingleTxs(
+				it(`4b.b.c. [Combination] [Single Tx] Insert ${seventyPercentCount} large nodes, delete ${fifteenPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						1,
 						`4b.b.c. [Combination] [Single Tx] Insert ${seventyPercentCount} large nodes, delete ${fifteenPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`,
 						seventyPercentCount,
@@ -1046,8 +1033,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
 				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
 
-				it(`4b.c.a. [Combination] [Single Tx] Insert ${fifteenPercentCount} small nodes, delete ${seventyPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithSingleTxs(
+				it(`4b.c.a. [Combination] [Single Tx] Insert ${fifteenPercentCount} small nodes, delete ${seventyPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.01,
 						`4b.c.a. [Combination] [Single Tx] Insert ${fifteenPercentCount} small nodes, delete ${seventyPercentCount} small nodes, edit ${fifteenPercentCount} nodes with small payloads`,
 						fifteenPercentCount,
@@ -1056,8 +1043,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4b.c.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithSingleTxs(
+				it(`4b.c.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.5,
 						`4b.c.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`,
 						fifteenPercentCount,
@@ -1066,8 +1053,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4b.c.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithSingleTxs(
+				it(`4b.c.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${fifteenPercentCount} nodes with large payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						1,
 						`4a.c.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} medium nodes, delete ${seventyPercentCount} medium nodes, edit ${fifteenPercentCount} nodes with medium payloads`,
 						fifteenPercentCount,
@@ -1081,8 +1068,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 				const seventyPercentCount = BENCHMARK_NODE_COUNT * 0.7;
 				const fifteenPercentCount = BENCHMARK_NODE_COUNT * 0.15;
 
-				it(`4b.d.a. [Combination] [Single Tx] Insert ${fifteenPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${seventyPercentCount} nodes with small payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithSingleTxs(
+				it(`4b.d.a. [Combination] [Single Tx] Insert ${fifteenPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${seventyPercentCount} nodes with small payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.01,
 						`4a.d.a. [Combination] [Single Tx] Insert ${fifteenPercentCount} small nodes, delete ${fifteenPercentCount} small nodes, edit ${seventyPercentCount} nodes with small payloads`,
 						fifteenPercentCount,
@@ -1091,8 +1078,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4b.d.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${seventyPercentCount} nodes with medium payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithSingleTxs(
+				it(`4b.d.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${seventyPercentCount} nodes with medium payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						0.5,
 						`4b.d.b. [Combination] [Single Tx] Insert ${fifteenPercentCount} medium nodes, delete ${fifteenPercentCount} medium nodes, edit ${seventyPercentCount} nodes with medium payloads`,
 						fifteenPercentCount,
@@ -1101,8 +1088,8 @@ describe("SharedTree Op Size Benchmarks", () => {
 					);
 				});
 
-				it(`4b.d.c. [Combination] Single Txs] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${seventyPercentCount} nodes with large payloads`, async () => {
-					await benchmarkInsertDeleteEditNodesWithSingleTxs(
+				it(`4b.d.c. [Combination] Single Txs] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${seventyPercentCount} nodes with large payloads`, () => {
+					benchmarkInsertDeleteEditNodesWithSingleTxs(
 						1,
 						`4b.d.c. [Combination] [Single Tx] Insert ${fifteenPercentCount} large nodes, delete ${seventyPercentCount} large nodes, edit ${seventyPercentCount} nodes with large payloads`,
 						fifteenPercentCount,

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -21,7 +21,12 @@ import {
 	SchemaAware,
 } from "../../feature-libraries";
 import { brand, fail, TransactionResult } from "../../util";
-import { SharedTreeTestFactory, SummarizeType, TestTreeProvider } from "../utils";
+import {
+	SharedTreeTestFactory,
+	SummarizeType,
+	TestTreeProvider,
+	TestTreeProviderLite,
+} from "../utils";
 import { ISharedTree, ISharedTreeView, SharedTreeFactory, runSynchronous } from "../../shared-tree";
 import {
 	compareUpPaths,
@@ -48,10 +53,10 @@ const globalFieldKey: GlobalFieldKey = brand("globalFieldKey");
 const globalFieldKeySymbol = symbolFromKey(globalFieldKey);
 
 describe("SharedTree", () => {
-	it("reads only one node", async () => {
+	it("reads only one node", () => {
 		// This is a regression test for a scenario in which a transaction would apply its delta twice,
 		// inserting two nodes instead of just one
-		const provider = await TestTreeProvider.create(1);
+		const provider = new TestTreeProviderLite(1);
 		runSynchronous(provider.trees[0], (t) => {
 			const writeCursor = singleTextCursor({ type: brand("LonelyNode") });
 			const field = t.editor.sequenceField(undefined, rootFieldKeySymbol);
@@ -210,8 +215,8 @@ describe("SharedTree", () => {
 		validateRootField(tree2, ["A", "B", "C"]);
 	});
 
-	it("has bounded memory growth in EditManager", async () => {
-		const provider = await TestTreeProvider.create(2);
+	it("has bounded memory growth in EditManager", () => {
+		const provider = new TestTreeProviderLite(2);
 		const [tree1, tree2] = provider.trees;
 
 		// Make some arbitrary number of edits
@@ -219,14 +224,14 @@ describe("SharedTree", () => {
 			insert(tree1, 0, "");
 		}
 
-		await provider.ensureSynchronized();
+		provider.processMessages();
 
 		// These two edit will have ref numbers that correspond to the last of the above edits
 		insert(tree1, 0, "");
 		insert(tree2, 0, "");
 
 		// This synchronization point should ensure that both trees see the edits with the higher ref numbers.
-		await provider.ensureSynchronized();
+		provider.processMessages();
 
 		// It's not clear if we'll ever want to expose the EditManager to ISharedTree consumers or
 		// if we'll ever expose some memory stats in which the trunk length would be included.
@@ -257,15 +262,15 @@ describe("SharedTree", () => {
 	});
 
 	describe("Editing", () => {
-		it("can insert and delete a node in a sequence field", async () => {
+		it("can insert and delete a node in a sequence field", () => {
 			const value = "42";
-			const provider = await TestTreeProvider.create(2);
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 
 			// Insert node
 			setTestValue(tree1, value);
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			// Validate insertion
 			assert.equal(getTestValue(tree2), value);
@@ -273,15 +278,15 @@ describe("SharedTree", () => {
 			// Delete node
 			remove(tree1, 0, 1);
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			assert.equal(getTestValue(tree1), undefined);
 			assert.equal(getTestValue(tree2), undefined);
 		});
 
-		it("can handle competing deletes", async () => {
+		it("can handle competing deletes", () => {
 			for (const index of [0, 1, 2, 3]) {
-				const provider = await TestTreeProvider.create(4);
+				const provider = new TestTreeProviderLite(4);
 				const [tree1, tree2, tree3, tree4] = provider.trees;
 				const sequence: JsonableTree[] = [
 					{ type: brand("Number"), value: 0 },
@@ -290,13 +295,13 @@ describe("SharedTree", () => {
 					{ type: brand("Number"), value: 3 },
 				];
 				initializeTestTree(tree1, sequence);
-				await provider.ensureSynchronized();
+				provider.processMessages();
 
 				remove(tree1, index, 1);
 				remove(tree2, index, 1);
 				remove(tree3, index, 1);
 
-				await provider.ensureSynchronized();
+				provider.processMessages();
 
 				const expectedSequence = [0, 1, 2, 3];
 				expectedSequence.splice(index, 1);
@@ -307,9 +312,9 @@ describe("SharedTree", () => {
 			}
 		});
 
-		it("can insert and delete a node in an optional field", async () => {
+		it("can insert and delete a node in an optional field", () => {
 			const value = "42";
-			const provider = await TestTreeProvider.create(2);
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 
 			// Insert node
@@ -321,7 +326,7 @@ describe("SharedTree", () => {
 				field.set(undefined, false);
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			assert.equal(getTestValue(tree1), undefined);
 			assert.equal(getTestValue(tree2), undefined);
 
@@ -331,13 +336,13 @@ describe("SharedTree", () => {
 				field.set(singleTextCursor({ type: brand("TestValue"), value: 43 }), true);
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			assert.equal(getTestValue(tree1), 43);
 			assert.equal(getTestValue(tree2), 43);
 		});
 
-		it("can edit a global field", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("can edit a global field", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 
 			// Insert root node
@@ -357,7 +362,7 @@ describe("SharedTree", () => {
 				field.insert(0, writeCursor);
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			// Validate insertion
 			{
@@ -384,7 +389,7 @@ describe("SharedTree", () => {
 				field.delete(0, 1);
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			// Validate deletion
 			{
@@ -459,20 +464,20 @@ describe("SharedTree", () => {
 			validateTree(branch, [initialState]);
 		}
 
-		it("can abandon a transaction", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("can abandon a transaction", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1] = provider.trees;
 			abortTransaction(tree1);
 		});
 
-		it("can abandon a transaction on a branch", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("can abandon a transaction on a branch", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree] = provider.trees;
 			abortTransaction(tree.fork());
 		});
 
-		it("can insert multiple nodes", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("can insert multiple nodes", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 
 			// Insert nodes
@@ -486,7 +491,7 @@ describe("SharedTree", () => {
 				field.insert(1, singleTextCursor({ type: brand("Test"), value: 2 }));
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			// Validate insertion
 			{
@@ -501,8 +506,8 @@ describe("SharedTree", () => {
 			}
 		});
 
-		it("can move nodes across fields", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("can move nodes across fields", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 
 			const initialState: JsonableTree = {
@@ -531,7 +536,7 @@ describe("SharedTree", () => {
 				tree1.editor.move(rootPath, brand("foo"), 1, 2, rootPath, brand("bar"), 1);
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const expectedState: JsonableTree = {
 				type: brand("Node"),
@@ -550,8 +555,8 @@ describe("SharedTree", () => {
 			validateTree(tree2, [expectedState]);
 		});
 
-		it("can make multiple moves in a transaction", async () => {
-			const provider = await TestTreeProvider.create(1);
+		it("can make multiple moves in a transaction", () => {
+			const provider = new TestTreeProviderLite(1);
 			const [tree] = provider.trees;
 
 			const initialState: JsonableTree = {
@@ -582,13 +587,13 @@ describe("SharedTree", () => {
 					qux: [{ type: brand("Node"), value: "a" }],
 				},
 			};
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			validateTree(tree, [expectedState]);
 		});
 	});
 
 	describe("Events", () => {
-		it("triggers events for local and subtree changes", async () => {
+		it("triggers events for local and subtree changes", () => {
 			const view = testTreeView();
 			const root = view.context.root.getNode(0);
 			const log: string[] = [];
@@ -620,7 +625,7 @@ describe("SharedTree", () => {
 			]);
 		});
 
-		it("propagates path and value args for local and subtree changes", async () => {
+		it("propagates path and value args for local and subtree changes", () => {
 			const view = testTreeView();
 			const root = view.context.root.getNode(0);
 			const log: string[] = [];
@@ -658,28 +663,28 @@ describe("SharedTree", () => {
 	});
 
 	describe("Rebasing", () => {
-		it("can rebase two inserts", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("can rebase two inserts", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 			insert(tree1, 0, "y");
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			insert(tree1, 0, "x");
 			insert(tree2, 1, "a", "c");
 			insert(tree2, 2, "b");
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const expected = ["x", "y", "a", "b", "c"];
 			validateRootField(tree1, expected);
 			validateRootField(tree2, expected);
 		});
 
-		it("can rebase delete over move", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("can rebase delete over move", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 
 			insert(tree1, 0, "a", "b");
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			// Move b before a
 			runSynchronous(tree1, () => {
@@ -697,15 +702,15 @@ describe("SharedTree", () => {
 			// Delete b
 			remove(tree2, 1, 1);
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const expected = ["a"];
 			validateRootField(tree1, expected);
 			validateRootField(tree2, expected);
 		});
 
-		it("can rebase delete over cross-field move", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("can rebase delete over cross-field move", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 
 			const initialState: JsonableTree = {
@@ -723,7 +728,7 @@ describe("SharedTree", () => {
 				},
 			};
 			initializeTestTree(tree1, initialState);
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const rootPath = {
 				parent: undefined,
@@ -742,7 +747,7 @@ describe("SharedTree", () => {
 				field.delete(2, 1);
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const expectedState: JsonableTree = {
 				type: brand("Node"),
@@ -759,8 +764,8 @@ describe("SharedTree", () => {
 			validateTree(tree2, [expectedState]);
 		});
 
-		it.skip("can rebase cross-field move over delete", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it.skip("can rebase cross-field move over delete", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 
 			const initialState: JsonableTree = {
@@ -778,7 +783,7 @@ describe("SharedTree", () => {
 				},
 			};
 			initializeTestTree(tree1, initialState);
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const rootPath = {
 				parent: undefined,
@@ -797,7 +802,7 @@ describe("SharedTree", () => {
 				tree2.editor.move(rootPath, brand("foo"), 1, 2, rootPath, brand("bar"), 1);
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const expectedState: JsonableTree = {
 				type: brand("Node"),
@@ -813,6 +818,7 @@ describe("SharedTree", () => {
 			validateTree(tree1, [expectedState]);
 			validateTree(tree2, [expectedState]);
 		});
+
 		it("rebases stashed ops with prior state present", async () => {
 			const provider = await TestTreeProvider.create(2);
 			insert(provider.trees[0], 0, "a");
@@ -843,11 +849,11 @@ describe("SharedTree", () => {
 	});
 
 	describe("Constraints", () => {
-		it("transaction dropped when constraint violated", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("transaction dropped when constraint violated", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 			insert(tree1, 0, "a");
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const rootPath = {
 				parent: undefined,
@@ -864,16 +870,16 @@ describe("SharedTree", () => {
 				tree1.editor.setValue(rootPath, "b");
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			validateRootField(tree1, ["c"]);
 			validateRootField(tree2, ["c"]);
 		});
 
-		it("transaction successful when constraint not violated", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("transaction successful when constraint not violated", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 			insert(tree1, 0, "a");
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const rootPath = {
 				parent: undefined,
@@ -890,16 +896,16 @@ describe("SharedTree", () => {
 				tree1.editor.setValue(rootPath, "b");
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			validateRootField(tree1, ["b"]);
 			validateRootField(tree2, ["b"]);
 		});
 
-		it("transaction successful when constraint eventually fixed", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("transaction successful when constraint eventually fixed", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 			insert(tree1, 0, "a");
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const rootPath = {
 				parent: undefined,
@@ -924,16 +930,16 @@ describe("SharedTree", () => {
 				tree1.editor.setValue(rootPath, "b");
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			validateRootField(provider.trees[0], ["b"]);
 			validateRootField(provider.trees[1], ["b"]);
 		});
 
-		it("transaction dropped with violated constraints on different fields", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("transaction dropped with violated constraints on different fields", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 			insert(tree1, 0, "a", "x");
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const rootPath = {
 				parent: undefined,
@@ -960,16 +966,16 @@ describe("SharedTree", () => {
 				tree1.editor.setValue(rootPath, "c");
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			validateRootField(tree1, ["b", "y"]);
 			validateRootField(tree2, ["b", "y"]);
 		});
 
-		it("transaction successful with constraints eventually fixed on different fields", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("transaction successful with constraints eventually fixed on different fields", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 			insert(tree1, 0, "a", "x");
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const rootPath = {
 				parent: undefined,
@@ -1001,16 +1007,16 @@ describe("SharedTree", () => {
 				tree1.editor.setValue(rootPath, "c");
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			validateRootField(provider.trees[1], ["c", "x"]);
 			validateRootField(provider.trees[0], ["c", "x"]);
 		});
 
-		it("constraints violated delta is propagated", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("constraints violated delta is propagated", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 			insert(tree1, 0, "a", "x");
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const rootPath = {
 				parent: undefined,
@@ -1036,16 +1042,16 @@ describe("SharedTree", () => {
 				tree1.editor.setValue(rootPath, "c");
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			validateRootField(tree1, ["b", "y"]);
 			validateRootField(tree2, ["b", "y"]);
 		});
 
-		it("uses first defined constraint for node in transaction", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("uses first defined constraint for node in transaction", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 			insert(tree1, 0, "a");
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const rootPath = {
 				parent: undefined,
@@ -1063,16 +1069,16 @@ describe("SharedTree", () => {
 				tree1.editor.setValue(rootPath, "b");
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			validateRootField(tree1, ["b"]);
 			validateRootField(tree2, ["b"]);
 		});
 
-		it("ignores constraint on node after a node is changed in the same transaction", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("ignores constraint on node after a node is changed in the same transaction", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 			insert(tree1, 0, "a");
-			await provider.ensureSynchronized();
+			provider.processMessages();
 
 			const rootPath = {
 				parent: undefined,
@@ -1090,15 +1096,15 @@ describe("SharedTree", () => {
 				tree1.editor.addValueConstraint(rootPath, "b");
 			});
 
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			validateRootField(tree1, ["b"]);
 			validateRootField(tree2, ["b"]);
 		});
 	});
 
 	describe("Anchors", () => {
-		it("Anchors can be created and dereferenced", async () => {
-			const provider = await TestTreeProvider.create(1);
+		it("Anchors can be created and dereferenced", () => {
+			const provider = new TestTreeProviderLite(1);
 			const tree = provider.trees[0];
 
 			const initialState: JsonableTree = {
@@ -1136,7 +1142,7 @@ describe("SharedTree", () => {
 	});
 
 	describe("Views", () => {
-		itView("can fork and apply edits without affecting the parent", async (parent) => {
+		itView("can fork and apply edits without affecting the parent", (parent) => {
 			setTestValue(parent, "parent");
 			const child = parent.fork();
 			setTestValue(child, "child");
@@ -1144,7 +1150,7 @@ describe("SharedTree", () => {
 			assert.deepEqual(getTestValues(child), ["parent", "child"]);
 		});
 
-		itView("can apply edits without affecting a fork", async (parent) => {
+		itView("can apply edits without affecting a fork", (parent) => {
 			const child = parent.fork();
 			assert.equal(getTestValue(parent), undefined);
 			assert.equal(getTestValue(child), undefined);
@@ -1153,14 +1159,14 @@ describe("SharedTree", () => {
 			assert.equal(getTestValue(child), undefined);
 		});
 
-		itView("can merge changes into a parent", async (parent) => {
+		itView("can merge changes into a parent", (parent) => {
 			const child = parent.fork();
 			setTestValue(child, "view");
 			parent.merge(child);
 			assert.equal(getTestValue(parent), "view");
 		});
 
-		itView("can rebase over a parent view", async (parent) => {
+		itView("can rebase over a parent view", (parent) => {
 			const child = parent.fork();
 			setTestValue(parent, "root");
 			assert.equal(getTestValue(child), undefined);
@@ -1168,7 +1174,7 @@ describe("SharedTree", () => {
 			assert.equal(getTestValue(child), "root");
 		});
 
-		itView("can rebase over a child view", async (view) => {
+		itView("can rebase over a child view", (view) => {
 			const parent = view.fork();
 			setTestValue(parent, "P1");
 			const child = parent.fork();
@@ -1179,7 +1185,7 @@ describe("SharedTree", () => {
 			assert.deepEqual(getTestValues(parent), ["P1", "C1", "P2"]);
 		});
 
-		itView("merge changes through multiple views", async (viewA) => {
+		itView("merge changes through multiple views", (viewA) => {
 			const viewB = viewA.fork();
 			const viewC = viewB.fork();
 			const viewD = viewC.fork();
@@ -1192,7 +1198,7 @@ describe("SharedTree", () => {
 			assert.equal(getTestValue(viewC), "view");
 		});
 
-		itView("merge correctly when multiple ancestors are mutated", async (viewA) => {
+		itView("merge correctly when multiple ancestors are mutated", (viewA) => {
 			const viewB = viewA.fork();
 			const viewC = viewB.fork();
 			const viewD = viewC.fork();
@@ -1206,7 +1212,7 @@ describe("SharedTree", () => {
 			assert.equal(getTestValue(viewB), "D");
 		});
 
-		itView("can merge a parent view into a child", async (view) => {
+		itView("can merge a parent view into a child", (view) => {
 			const parent = view.fork();
 			setTestValue(parent, "P1");
 			const child = parent.fork();
@@ -1217,7 +1223,7 @@ describe("SharedTree", () => {
 			assert.deepEqual(getTestValues(parent), ["P1", "P2"]);
 		});
 
-		itView("can perform a complicated merge scenario", async (viewA) => {
+		itView("can perform a complicated merge scenario", (viewA) => {
 			const viewB = viewA.fork();
 			const viewC = viewB.fork();
 			const viewD = viewC.fork();
@@ -1254,7 +1260,7 @@ describe("SharedTree", () => {
 			]);
 		});
 
-		itView("update anchors after applying a change", async (view) => {
+		itView("update anchors after applying a change", (view) => {
 			setTestValue(view, "A");
 			let cursor = view.forest.allocateCursor();
 			moveToDetachedField(view.forest, cursor);
@@ -1268,7 +1274,7 @@ describe("SharedTree", () => {
 			cursor.clear();
 		});
 
-		itView("update anchors after merging into a parent", async (parent) => {
+		itView("update anchors after merging into a parent", (parent) => {
 			setTestValue(parent, "A");
 			let cursor = parent.forest.allocateCursor();
 			moveToDetachedField(parent.forest, cursor);
@@ -1284,7 +1290,7 @@ describe("SharedTree", () => {
 			cursor.clear();
 		});
 
-		itView("can be mutated after merging", async (parent) => {
+		itView("can be mutated after merging", (parent) => {
 			const child = parent.fork();
 			setTestValue(child, "A");
 			parent.merge(child);
@@ -1295,7 +1301,7 @@ describe("SharedTree", () => {
 			assert.deepEqual(getTestValues(parent), ["A", "B"]);
 		});
 
-		itView("can rebase after merging", async (parent) => {
+		itView("can rebase after merging", (parent) => {
 			const child = parent.fork();
 			setTestValue(child, "A");
 			parent.merge(child);
@@ -1304,14 +1310,14 @@ describe("SharedTree", () => {
 			assert.deepEqual(getTestValues(child), ["A", "B"]);
 		});
 
-		itView("can be read after merging", async (parent) => {
+		itView("can be read after merging", (parent) => {
 			setTestValue(parent, "root");
 			const child = parent.fork();
 			parent.merge(child);
 			assert.equal(getTestValue(child), "root");
 		});
 
-		itView("properly fork the tree schema", async (parent) => {
+		itView("properly fork the tree schema", (parent) => {
 			const schemaA: SchemaData = {
 				treeSchema: new Map([]),
 				globalFieldSchema: new Map(),
@@ -1332,25 +1338,25 @@ describe("SharedTree", () => {
 			assert.equal(getSchema(child), "schemaB");
 		});
 
-		it("submit edits to Fluid when merging into the root view", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("submit edits to Fluid when merging into the root view", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 			const baseView = tree1.fork();
 			const view = baseView.fork();
 			// Modify the view, but tree2 should remain unchanged until the edit merges all the way up
 			setTestValue(view, "42");
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			assert.equal(getTestValue(tree2), undefined);
 			baseView.merge(view);
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			assert.equal(getTestValue(tree2), undefined);
 			tree1.merge(baseView);
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			assert.equal(getTestValue(tree2), "42");
 		});
 
-		it("do not squash commits", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("do not squash commits", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 			let opsReceived = 0;
 			tree2.on("op", () => (opsReceived += 1));
@@ -1360,7 +1366,7 @@ describe("SharedTree", () => {
 			setTestValue(view, "B");
 			baseView.merge(view);
 			tree1.merge(baseView);
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			assert.equal(opsReceived, 2);
 		});
 	});
@@ -1373,27 +1379,27 @@ describe("SharedTree", () => {
 			field.insert(0, nodes);
 		}
 
-		itView("update the tree while open", async (view) => {
+		itView("update the tree while open", (view) => {
 			view.transaction.start();
 			pushTestValueDirect(view, 42);
 			assert.equal(getTestValue(view), 42);
 		});
 
-		itView("update the tree after committing", async (view) => {
+		itView("update the tree after committing", (view) => {
 			view.transaction.start();
 			pushTestValueDirect(view, 42);
 			view.transaction.commit();
 			assert.equal(getTestValue(view), 42);
 		});
 
-		itView("revert the tree after aborting", async (view) => {
+		itView("revert the tree after aborting", (view) => {
 			view.transaction.start();
 			pushTestValueDirect(view, 42);
 			view.transaction.abort();
 			assert.equal(getTestValue(view), undefined);
 		});
 
-		itView("can nest", async (view) => {
+		itView("can nest", (view) => {
 			view.transaction.start();
 			pushTestValueDirect(view, "A");
 			view.transaction.start();
@@ -1405,7 +1411,7 @@ describe("SharedTree", () => {
 			assert.deepEqual(getTestValues(view), ["A", "B"]);
 		});
 
-		itView("can span a view fork and merge", async (view) => {
+		itView("can span a view fork and merge", (view) => {
 			view.transaction.start();
 			const fork = view.fork();
 			pushTestValueDirect(fork, 42);
@@ -1414,7 +1420,7 @@ describe("SharedTree", () => {
 			assert.equal(getTestValue(view), 42);
 		});
 
-		itView("fail if in progress when view merges", async (view) => {
+		itView("fail if in progress when view merges", (view) => {
 			const fork = view.fork();
 			fork.transaction.start();
 			assert.throws(
@@ -1427,7 +1433,7 @@ describe("SharedTree", () => {
 			);
 		});
 
-		itView("do not close across forks", async (view) => {
+		itView("do not close across forks", (view) => {
 			view.transaction.start();
 			const fork = view.fork();
 			assert.throws(
@@ -1436,7 +1442,7 @@ describe("SharedTree", () => {
 			);
 		});
 
-		itView("do not affect pre-existing forks", async (view) => {
+		itView("do not affect pre-existing forks", (view) => {
 			const fork = view.fork();
 			pushTestValueDirect(view, "A");
 			fork.transaction.start();
@@ -1447,7 +1453,7 @@ describe("SharedTree", () => {
 			assert.deepEqual(getTestValues(view), ["A", "B", "C"]);
 		});
 
-		itView("can commit over a branch that pulls", async (view) => {
+		itView("can commit over a branch that pulls", (view) => {
 			view.transaction.start();
 			pushTestValueDirect(view, 42);
 			const fork = view.fork();
@@ -1456,7 +1462,7 @@ describe("SharedTree", () => {
 			assert.equal(getTestValue(fork), 42);
 		});
 
-		itView("can handle a pull while in progress", async (view) => {
+		itView("can handle a pull while in progress", (view) => {
 			const fork = view.fork();
 			fork.transaction.start();
 			setTestValue(view, 42);
@@ -1466,7 +1472,7 @@ describe("SharedTree", () => {
 			assert.equal(getTestValue(fork), 42);
 		});
 
-		itView("update anchors correctly", async (view) => {
+		itView("update anchors correctly", (view) => {
 			setTestValue(view, "A");
 			let cursor = view.forest.allocateCursor();
 			moveToDetachedField(view.forest, cursor);
@@ -1480,7 +1486,7 @@ describe("SharedTree", () => {
 			cursor.clear();
 		});
 
-		itView("can handle a complicated scenario", async (view) => {
+		itView("can handle a complicated scenario", (view) => {
 			pushTestValueDirect(view, "A");
 			view.transaction.start();
 			pushTestValueDirect(view, "B");
@@ -1526,23 +1532,23 @@ describe("SharedTree", () => {
 			]);
 		});
 
-		it("don't send ops before committing", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("don't send ops before committing", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 			let opsReceived = 0;
 			tree2.on("op", () => (opsReceived += 1));
 			tree1.transaction.start();
 			pushTestValueDirect(tree1, 42);
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			assert.equal(opsReceived, 0);
 			tree1.transaction.commit();
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			assert.equal(opsReceived, 1);
 			assert.deepEqual(getTestValue(tree2), 42);
 		});
 
-		it("send only one op after committing", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("send only one op after committing", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 			let opsReceived = 0;
 			tree2.on("op", () => (opsReceived += 1));
@@ -1550,13 +1556,13 @@ describe("SharedTree", () => {
 			pushTestValueDirect(tree1, 42);
 			pushTestValueDirect(tree1, 43);
 			tree1.transaction.commit();
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			assert.equal(opsReceived, 1);
 			assert.deepEqual(getTestValues(tree2), [42, 43]);
 		});
 
-		it("do not send an op after committing if nested", async () => {
-			const provider = await TestTreeProvider.create(2);
+		it("do not send an op after committing if nested", () => {
+			const provider = new TestTreeProviderLite(2);
 			const [tree1, tree2] = provider.trees;
 			let opsReceived = 0;
 			tree2.on("op", () => (opsReceived += 1));
@@ -1564,12 +1570,12 @@ describe("SharedTree", () => {
 			tree1.transaction.start();
 			pushTestValueDirect(tree1, 42);
 			tree1.transaction.commit();
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			assert.equal(opsReceived, 0);
 			assert.deepEqual(getTestValues(tree2), []);
 			pushTestValueDirect(tree1, 43);
 			tree1.transaction.commit();
-			await provider.ensureSynchronized();
+			provider.processMessages();
 			assert.equal(opsReceived, 1);
 			assert.deepEqual(getTestValues(tree2), [42, 43]);
 		});
@@ -2045,14 +2051,14 @@ function validateTree(tree: ISharedTreeView, expected: JsonableTree[]): void {
  * one where `view` is the root SharedTree view and the other where `view` is a fork.
  * This is useful for testing because both `SharedTree` and `SharedTreeFork` implement `ISharedTreeView` in different ways.
  */
-function itView(title: string, fn: (view: ISharedTreeView) => Promise<void>): void {
-	it(`${title} (root view)`, async () => {
-		const provider = await TestTreeProvider.create(1);
-		await fn(provider.trees[0]);
+function itView(title: string, fn: (view: ISharedTreeView) => void): void {
+	it(`${title} (root view)`, () => {
+		const provider = new TestTreeProviderLite(1);
+		fn(provider.trees[0]);
 	});
 
-	it(`${title} (forked view)`, async () => {
-		const provider = await TestTreeProvider.create(1);
-		await fn(provider.trees[0].fork());
+	it(`${title} (forked view)`, () => {
+		const provider = new TestTreeProviderLite(1);
+		fn(provider.trees[0].fork());
 	});
 }

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -56,7 +56,7 @@ describe("SharedTree", () => {
 	it("reads only one node", () => {
 		// This is a regression test for a scenario in which a transaction would apply its delta twice,
 		// inserting two nodes instead of just one
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		runSynchronous(provider.trees[0], (t) => {
 			const writeCursor = singleTextCursor({ type: brand("LonelyNode") });
 			const field = t.editor.sequenceField(undefined, rootFieldKeySymbol);
@@ -556,7 +556,7 @@ describe("SharedTree", () => {
 		});
 
 		it("can make multiple moves in a transaction", () => {
-			const provider = new TestTreeProviderLite(1);
+			const provider = new TestTreeProviderLite();
 			const [tree] = provider.trees;
 
 			const initialState: JsonableTree = {
@@ -1104,7 +1104,7 @@ describe("SharedTree", () => {
 
 	describe("Anchors", () => {
 		it("Anchors can be created and dereferenced", () => {
-			const provider = new TestTreeProviderLite(1);
+			const provider = new TestTreeProviderLite();
 			const tree = provider.trees[0];
 
 			const initialState: JsonableTree = {
@@ -2053,12 +2053,12 @@ function validateTree(tree: ISharedTreeView, expected: JsonableTree[]): void {
  */
 function itView(title: string, fn: (view: ISharedTreeView) => void): void {
 	it(`${title} (root view)`, () => {
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		fn(provider.trees[0]);
 	});
 
 	it(`${title} (forked view)`, () => {
-		const provider = new TestTreeProviderLite(1);
+		const provider = new TestTreeProviderLite();
 		fn(provider.trees[0].fork());
 	});
 }

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -310,7 +310,7 @@ export class TestTreeProviderLite {
 
 	/**
 	 * Create a new {@link TestTreeProviderLite} with a number of trees pre-initialized.
-	 * @param trees - the number of trees to initialize this provider with.
+	 * @param trees - the number of trees created by this provider.
 	 * @param factory - an optional factory to use for creating and loading trees. See {@link SharedTreeTestFactory}.
 	 *
 	 * @example
@@ -321,7 +321,8 @@ export class TestTreeProviderLite {
 	 * provider.processMessages();
 	 * ```
 	 */
-	public constructor(trees = 0, private readonly factory = new SharedTreeFactory()) {
+	public constructor(trees = 1, private readonly factory = new SharedTreeFactory()) {
+		assert(trees >= 1, "Must initialize provider with at least one tree");
 		const t: ISharedTree[] = [];
 		for (let i = 0; i < trees; i++) {
 			const runtime = new MockFluidDataStoreRuntime();

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -24,6 +24,11 @@ import {
 	summarizeNow,
 	ITestContainerConfig,
 } from "@fluidframework/test-utils";
+import {
+	MockContainerRuntimeFactory,
+	MockFluidDataStoreRuntime,
+	MockStorage,
+} from "@fluidframework/test-runtime-utils";
 import { ISummarizer } from "@fluidframework/container-runtime";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { ISharedTree, ISharedTreeView, SharedTreeFactory } from "../shared-tree";
@@ -158,9 +163,9 @@ export class TestTreeProvider {
 	/**
 	 * Create a new {@link TestTreeProvider} with a number of trees pre-initialized.
 	 * @param trees - the number of trees to initialize this provider with. This is the same as calling
+	 * {@link create} followed by {@link createTree} _trees_ times.
 	 * @param summarizeType - enum to manually, automatically, or disable summarization
 	 * @param factory - The factory to use for creating and loading trees. See {@link SharedTreeTestFactory}.
-	 * {@link create} followed by {@link createTree} _trees_ times.
 	 *
 	 * @example
 	 * ```ts
@@ -292,6 +297,57 @@ export class TestTreeProvider {
 				return Reflect.get(this.provider, prop, receiver) as unknown;
 			},
 		});
+	}
+}
+
+/**
+ * A test helper class that creates one or more SharedTrees connected to a mock runtime.
+ */
+export class TestTreeProviderLite {
+	private static readonly treeId = "TestSharedTree";
+	private readonly runtimeFactory = new MockContainerRuntimeFactory();
+	public readonly trees: readonly ISharedTree[];
+
+	/**
+	 * Create a new {@link TestTreeProviderLite} with a number of trees pre-initialized.
+	 * @param trees - the number of trees to initialize this provider with.
+	 * @param factory - an optional factory to use for creating and loading trees. See {@link SharedTreeTestFactory}.
+	 *
+	 * @example
+	 * ```ts
+	 * const provider = new TestTreeProviderLite(2);
+	 * assert(provider.trees[0].isAttached());
+	 * assert(provider.trees[1].isAttached());
+	 * provider.processMessages();
+	 * ```
+	 */
+	public constructor(trees = 0, private readonly factory = new SharedTreeFactory()) {
+		const t: ISharedTree[] = [];
+		for (let i = 0; i < trees; i++) {
+			const runtime = new MockFluidDataStoreRuntime();
+			const tree = this.factory.create(runtime, TestTreeProviderLite.treeId);
+			const containerRuntime = this.runtimeFactory.createContainerRuntime(runtime);
+			tree.connect({
+				deltaConnection: containerRuntime.createDeltaConnection(),
+				objectStorage: new MockStorage(),
+			});
+			t.push(tree);
+		}
+		this.trees = t;
+	}
+
+	public processMessages(count?: number): void {
+		this.runtimeFactory.processSomeMessages(
+			count ?? this.runtimeFactory.outstandingMessageCount,
+		);
+	}
+
+	public get minimumSequenceNumber(): number {
+		return this.runtimeFactory.getMinSeq();
+	}
+
+	public get sequenceNumber(): number {
+		return this.runtimeFactory.sequenceNumber;
 	}
 }
 


### PR DESCRIPTION
## Description

This replaces many of the SharedTree tests that used `TestTreeProvider` with ones that use a new class `TestTreeProviderLite` instead. `TestTreeProviderLite` uses minimal mocks to test a SharedTree, and is suitable for tests that want to test a single tree or a few connected trees. It does not allow for any control over summarization or connection/reconnection flows like `TestTreeProvider` does, but it is far lighter weight. It should be the default for tests that want to test SharedTree, and `TestTreeProvider` should only be used for more complicated scenarios that need the extra features. Some migrated tests now run noticeably faster, for example the op size summary tests.