### PR TITLE
Fix benchmark pipeline link

### DIFF
--- a/build-tools/packages/build-cli/src/instructionalPromptWriter.ts
+++ b/build-tools/packages/build-cli/src/instructionalPromptWriter.ts
@@ -64,7 +64,7 @@ export const ADOPipelineLinks = new Map<ReleasePackage | ReleaseGroup | undefine
 	],
 	[
 		"@fluid-tools/benchmark",
-		"https://dev.azure.com/fluidframework/internal/_build?definitionId=96",
+		"https://dev.azure.com/fluidframework/internal/_build?definitionId=62",
 	],
 	[
 		"@fluidframework/test-tools",


### PR DESCRIPTION

## Description

The old link was the performance test pipeline, not the one used to build and publish the package.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
