### PR TITLE
Milan fluid summary compress (DocumentService.connectToStorage method injection)

### DIFF
--- a/api-report/azure-client.api.md
+++ b/api-report/azure-client.api.md
@@ -6,6 +6,7 @@
 
 import { ContainerSchema } from '@fluidframework/fluid-static';
 import { IClient } from '@fluidframework/protocol-definitions';
+import { ICompressionStorageConfig } from '@fluidframework/driver-utils';
 import { IConfigProviderBase } from '@fluidframework/telemetry-utils';
 import { IFluidContainer } from '@fluidframework/fluid-static';
 import { IMember } from '@fluidframework/fluid-static';
@@ -48,6 +49,8 @@ export interface AzureClientProps {
     readonly configProvider?: IConfigProviderBase;
     readonly connection: AzureRemoteConnectionConfig | AzureLocalConnectionConfig;
     readonly logger?: ITelemetryBaseLogger;
+    // (undocumented)
+    readonly summaryCompression?: boolean | ICompressionStorageConfig;
 }
 
 // @public

--- a/api-report/driver-definitions.api.md
+++ b/api-report/driver-definitions.api.md
@@ -152,6 +152,7 @@ export interface IDocumentService {
     connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection>;
     connectToStorage(): Promise<IDocumentStorageService>;
     dispose(error?: any): void;
+    hasStorage?(): boolean;
     policies?: IDocumentServicePolicies;
     // (undocumented)
     resolvedUrl: IResolvedUrl;

--- a/api-report/driver-definitions.api.md
+++ b/api-report/driver-definitions.api.md
@@ -155,6 +155,7 @@ export interface IDocumentService {
     policies?: IDocumentServicePolicies;
     // (undocumented)
     resolvedUrl: IResolvedUrl;
+    saveStorage?(storage: IDocumentStorageService): void;
 }
 
 // @public (undocumented)

--- a/api-report/driver-utils.api.md
+++ b/api-report/driver-utils.api.md
@@ -12,6 +12,7 @@ import { ICreateBlobResponse } from '@fluidframework/protocol-definitions';
 import { IDeltasFetchResult } from '@fluidframework/driver-definitions';
 import { IDocumentAttributes } from '@fluidframework/protocol-definitions';
 import { IDocumentMessage } from '@fluidframework/protocol-definitions';
+import { IDocumentServiceFactory } from '@fluidframework/driver-definitions';
 import { IDocumentStorageService } from '@fluidframework/driver-definitions';
 import { IDocumentStorageServicePolicies } from '@fluidframework/driver-definitions';
 import { IDriverErrorBase } from '@fluidframework/driver-definitions';
@@ -37,6 +38,9 @@ import { IUrlResolver } from '@fluidframework/driver-definitions';
 import { IVersion } from '@fluidframework/protocol-definitions';
 import { LoaderCachingPolicy } from '@fluidframework/driver-definitions';
 import { LoggingError } from '@fluidframework/telemetry-utils';
+
+// @public (undocumented)
+export function applyStorageCompression(documentServiceFactory: IDocumentServiceFactory, config?: ICompressionStorageConfig): IDocumentServiceFactory;
 
 // @public (undocumented)
 export class AuthorizationError extends LoggingError implements IAuthorizationError, IFluidErrorBase {
@@ -159,6 +163,16 @@ export const getRetryDelayFromError: (error: any) => number | undefined;
 
 // @public
 export const getRetryDelaySecondsFromError: (error: any) => number | undefined;
+
+// @public (undocumented)
+export interface ICompressionStorageConfig {
+    // Warning: (ae-forgotten-export) The symbol "SummaryCompressionAlgorithm" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    algorithm: SummaryCompressionAlgorithm;
+    // (undocumented)
+    minSizeToCompress: number;
+}
 
 // @public
 export class InsecureUrlResolver implements IUrlResolver {

--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -9,7 +9,7 @@ import {
 } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";
 import { IDocumentServiceFactory, IUrlResolver } from "@fluidframework/driver-definitions";
-import { ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
+import { applyStorageCompression, ensureFluidResolvedUrl } from "@fluidframework/driver-utils";
 import {
 	ContainerSchema,
 	DOProviderContainerRuntimeFactory,
@@ -65,10 +65,22 @@ export class AzureClient {
 		// The local service implementation differs from the Azure Fluid Relay in blob
 		// storage format. Azure Fluid Relay supports whole summary upload. Local currently does not.
 		const isRemoteConnection = isAzureRemoteConnectionConfig(this.props.connection);
-		this.documentServiceFactory = new RouterliciousDocumentServiceFactory(
+		const origDocumentServiceFactory: IDocumentServiceFactory = new RouterliciousDocumentServiceFactory(
 			this.props.connection.tokenProvider,
 			{ enableWholeSummaryUpload: isRemoteConnection, enableDiscovery: isRemoteConnection },
 		);
+		let wrappedDocumentServiceFactory: IDocumentServiceFactory = origDocumentServiceFactory;
+		if (props.summaryCompression !== undefined) {
+			if(typeof props.summaryCompression === "boolean") {
+				if(props.summaryCompression) {
+					wrappedDocumentServiceFactory = applyStorageCompression(origDocumentServiceFactory);
+				}
+			} else {
+				wrappedDocumentServiceFactory = applyStorageCompression(origDocumentServiceFactory
+					, props.summaryCompression);
+			}
+		}
+		this.documentServiceFactory = wrappedDocumentServiceFactory;
 		this.configProvider = props.configProvider;
 	}
 

--- a/azure/packages/azure-client/src/interfaces.ts
+++ b/azure/packages/azure-client/src/interfaces.ts
@@ -7,6 +7,7 @@ import { IMember, IServiceAudience } from "@fluidframework/fluid-static";
 import { IUser } from "@fluidframework/protocol-definitions";
 import { ITokenProvider } from "@fluidframework/routerlicious-driver";
 import { IConfigProviderBase } from "@fluidframework/telemetry-utils";
+import { ICompressionStorageConfig } from "@fluidframework/driver-utils";
 
 // Re-export so developers can build loggers without pulling in common-definitions
 export { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/common-definitions";
@@ -28,6 +29,8 @@ export interface AzureClientProps {
 	 * Base interface for providing configurations to control experimental features. If unsure, leave this undefined.
 	 */
 	readonly configProvider?: IConfigProviderBase;
+
+	readonly summaryCompression?: boolean | ICompressionStorageConfig;
 }
 
 /**

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -334,6 +334,13 @@ export interface IDocumentService {
 	connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection>;
 
 	/**
+	 * This method saves the IDocumentStorageService into this instance. It is used to possibly
+	 * replace the cached internal storage by the storage wrapped by adapters so that the local class
+	 * methods of this instance also use the wrapped storage with adapters.  
+	 */
+	saveStorage?(storage: IDocumentStorageService): void;
+
+	/**
 	 * Dispose storage. Called by storage consumer (Container) when it's done with storage (Container closed).
 	 * Useful for storage to commit any pending state if any (including any local caching).
 	 * Please note that it does not remove the need for caller to close all active delta connections,

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -336,9 +336,14 @@ export interface IDocumentService {
 	/**
 	 * This method saves the IDocumentStorageService into this instance. It is used to possibly
 	 * replace the cached internal storage by the storage wrapped by adapters so that the local class
-	 * methods of this instance also use the wrapped storage with adapters.  
+	 * methods of this instance also use the wrapped storage with adapters.
 	 */
 	saveStorage?(storage: IDocumentStorageService): void;
+
+	/**
+	 * This method returns true if there is a storage associated with this document service.
+	 */
+	hasStorage?(): boolean;
 
 	/**
 	 * Dispose storage. Called by storage consumer (Container) when it's done with storage (Container closed).

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -266,6 +266,10 @@ export class DocumentService implements api.IDocumentService {
 		this.documentStorageService = storage as DocumentStorageService;
 	}
 
+	public hasStorage(): boolean {
+		return this.documentStorageService !== undefined;
+	}
+
 	/**
 	 * Re-discover session URLs if necessary.
 	 */

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -262,6 +262,10 @@ export class DocumentService implements api.IDocumentService {
 		}
 	}
 
+	public saveStorage(storage: api.IDocumentStorageService): void {
+		this.documentStorageService = storage as DocumentStorageService;
+	}
+
 	/**
 	 * Re-discover session URLs if necessary.
 	 */

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -72,6 +72,7 @@
 		"@fluidframework/protocol-definitions": "^1.1.0",
 		"@fluidframework/telemetry-utils": ">=2.0.0-internal.4.1.0 <2.0.0-internal.5.0.0",
 		"axios": "^0.26.0",
+		"lz4js": "^0.2.0",
 		"url": "^0.11.0",
 		"uuid": "^8.3.1"
 	},

--- a/packages/loader/driver-utils/src/adapters/compression/blobProtocol.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/blobProtocol.ts
@@ -1,0 +1,170 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Buffer, IsoBuffer } from "@fluidframework/common-utils";
+
+/**
+ * This class represents the object instatiation of the header which is optionaly writen at the
+ * beginning of the binary blob. It supports conversion to / from the binary array.
+ * The binary representation is as follows :
+ * - HEADER ID : 16 bytes of unique identifier : f4e72832a5bd47d7a2f35ed47ed94a3c
+ * - HEADER CONTENT LENGTH : 4 bytes of length of the rest of header content (after the length field)
+ * - HEADER CONTENT :  HEADER CONTENT LENGTH bytes
+ */
+export class BlobHeader {
+	public static readonly ENCODING = "utf-8";
+	public static readonly HEADER_PREFIX = new Uint8Array([
+		0xf4, 0xe7, 0x28, 0x32, 0xa5, 0xbd, 0x47, 0xd7, 0xa2, 0xf3, 0x5e, 0xd4, 0x7e, 0xd9, 0x4a,
+		0x3c,
+	]);
+	constructor(private readonly _fields: { [key: string]: string }) {}
+	public getValue(key: string): string {
+		return this._fields[key];
+	}
+
+	/**
+	 * This method returns the length of the binary representation of this header object.
+	 * @returns Returns the length of the binary representation of this header object.
+	 */
+	public headerLength(): number {
+		return this.toBinary().byteLength;
+	}
+
+	/**
+	 * This method converts this header object to binary array.
+	 * @returns this header object as binary array.
+	 */
+	public toBinary(): IsoBuffer {
+		const contentStr = JSON.stringify(this._fields);
+		const contentBinary: IsoBuffer = IsoBuffer.from(contentStr, BlobHeader.ENCODING);
+		const contentBinaryLength = contentBinary.byteLength;
+		const contentBinaryLengthBuf = new ArrayBuffer(4);
+		const view = new DataView(contentBinaryLengthBuf);
+		view.setUint32(0, contentBinaryLength, false);
+
+		return concat([
+			BlobHeader.HEADER_PREFIX,
+			IsoBuffer.from(contentBinaryLengthBuf),
+			contentBinary,
+		]);
+	}
+
+	/**
+	 * This method converts the binary array to header object, if not present, undefined is returned.
+	 * @returns header object
+	 */
+	public static fromBinary(buffer: IsoBuffer): BlobHeader | undefined {
+		const possibleHeader = buffer.slice(0, BlobHeader.HEADER_PREFIX.byteLength);
+		if (!isEqual(possibleHeader, BlobHeader.HEADER_PREFIX)) {
+			return undefined;
+		}
+		const arrayBuffer = toArrayBuffer(buffer);
+		const view = new DataView(arrayBuffer);
+		const contentBinaryLength = view.getUint32(BlobHeader.HEADER_PREFIX.byteLength, false);
+		const contentPos = BlobHeader.HEADER_PREFIX.byteLength + 4;
+		const contentBinary = arrayBuffer.slice(contentPos, contentPos + contentBinaryLength);
+		const contentStr = IsoBuffer.from(contentBinary).toString(BlobHeader.ENCODING);
+		return new BlobHeader(JSON.parse(contentStr) as { [key: string]: string });
+	}
+
+	/**
+	 * This method returns the rest of the message cutting of the complete header from the given byte array.
+	 * @param buffer - The byte array
+	 * @returns The rest of the message cutting of the complete header from the given byte array.
+	 */
+	public static skipHeader(buffer: IsoBuffer): IsoBuffer {
+		const header = this.fromBinary(buffer);
+		return !this.fromBinary(buffer) ? buffer : buffer.slice(header?.headerLength());
+	}
+}
+
+function toArrayBuffer(buf: number[] | Buffer): ArrayBuffer {
+	const ab = new ArrayBuffer(buf.length);
+	const view = IsoBuffer.from(ab);
+	for (const [i, element] of buf.entries()) {
+		view[i] = element;
+	}
+	return ab;
+}
+
+/**
+ * This method writes the binary representation of the given header at the beginning of the given buffer.
+ * @param header - The header to be written.
+ * @param buffer - The buffer containing the binary blob
+ * @returns The buffer with header
+ */
+export function writeBlobHeader(header: BlobHeader, buffer: ArrayBufferLike): ArrayBufferLike {
+	const binaryHeader = header.toBinary();
+	const totalLength = buffer.byteLength + binaryHeader.byteLength;
+	const contentBuffer = IsoBuffer.from(buffer);
+	const newBuffer = concat([binaryHeader, contentBuffer], totalLength);
+	return newBuffer;
+}
+
+/**
+ * This function converts the binary array to header object, if not present, undefined is returned.
+ * @param buffer - binary array representation of header object
+ * @returns header object
+ */
+export function readBlobHeader(buffer: ArrayBufferLike): BlobHeader | undefined {
+	return BlobHeader.fromBinary(IsoBuffer.from(buffer));
+}
+
+/**
+ * This method returns the rest of the message cutting of the complete header from the given byte array.
+ * @param buffer - The byte array
+ * @returns The rest of the message cutting of the complete header from the given byte array.
+ */
+export function skipHeader(buffer: ArrayBufferLike): ArrayBufferLike {
+	return BlobHeader.skipHeader(IsoBuffer.from(buffer));
+}
+
+/**
+ * This class uses the Builder pattern to generate new BlobHeader object.
+ */
+export class BlobHeaderBuilder {
+	private readonly _fields = {};
+	public addField(key: string, value: string): void {
+		this._fields[key] = value;
+	}
+	public build(): BlobHeader {
+		return new BlobHeader(this._fields);
+	}
+}
+
+function concat(args: IsoBuffer[], totalLength?: number): Buffer {
+	let merged = args[0];
+	for (let i = 1; i < args.length; i++) {
+		merged = concatTwo(merged, args[i], totalLength);
+	}
+	return merged;
+}
+
+function concatTwo(arrayOne: IsoBuffer, arrayTwo: IsoBuffer, totalLength?: number): IsoBuffer {
+	let arrayTwoReduced = arrayTwo;
+	if (totalLength !== undefined) {
+		if (arrayOne.length > totalLength) {
+			return arrayOne.subarray(0, totalLength);
+		} else if (arrayOne.length + arrayTwo.length > totalLength) {
+			arrayTwoReduced = arrayTwo.subarray(0, totalLength - arrayOne.length);
+		}
+	}
+	const mergedArray = new IsoBuffer(arrayOne.length + arrayTwo.length);
+	mergedArray.set(arrayOne);
+	mergedArray.set(arrayTwoReduced, arrayOne.length);
+	return mergedArray;
+}
+
+function isEqual(arrayOne: IsoBuffer, arrayTwo: IsoBuffer): boolean {
+	if (arrayOne.length !== arrayTwo.length) {
+		return false;
+	}
+	for (const [i, element] of arrayOne.entries()) {
+		if (element !== arrayTwo[i]) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/packages/loader/driver-utils/src/adapters/compression/documentServiceCompressionAdapter.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/documentServiceCompressionAdapter.ts
@@ -4,22 +4,21 @@
  */
 
 import { IDocumentService, IDocumentStorageService } from "@fluidframework/driver-definitions";
-import { ICompressionStorageConfig } from "../predefinedAdapters";
 import { DocumentServiceProxy } from "../../documentServiceProxy";
+import { ICompressionStorageConfig , DocumentStorageServiceCompressionAdapter } from "./documentStorageServiceCompressionAdapter";
 
-export class DocumentServiceFactoryCompressionAdapter extends DocumentServiceProxy {
+export class DocumentServiceCompressionAdapter extends DocumentServiceProxy {
+	private readonly oldConnectToStorage;
+	constructor(service: IDocumentService, private readonly _config: ICompressionStorageConfig) {
+		super(service);
+		this.oldConnectToStorage = this.service.connectToStorage.bind(this.service);
+		service.connectToStorage = this.connectToStorageOverride.bind(this);
+	}
 
-  constructor(
-	service: IDocumentService,
-	private readonly _config: ICompressionStorageConfig,
-  ) {
-	super(service);
-  }
-
-  public async connectToStorage(): Promise<IDocumentStorageService> {
-	return this.service.connectToStorage();		
-}
-
-
-
+	public async connectToStorageOverride(): Promise<IDocumentStorageService> {
+		const storage = await this.oldConnectToStorage();
+		const wrapped = new DocumentStorageServiceCompressionAdapter(storage, this._config);
+		this.saveStorage(wrapped);
+		return wrapped;
+	}
 }

--- a/packages/loader/driver-utils/src/adapters/compression/documentServiceCompressionAdapter.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/documentServiceCompressionAdapter.ts
@@ -1,0 +1,25 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IDocumentService, IDocumentStorageService } from "@fluidframework/driver-definitions";
+import { ICompressionStorageConfig } from "../predefinedAdapters";
+import { DocumentServiceProxy } from "../../documentServiceProxy";
+
+export class DocumentServiceFactoryCompressionAdapter extends DocumentServiceProxy {
+
+  constructor(
+	service: IDocumentService,
+	private readonly _config: ICompressionStorageConfig,
+  ) {
+	super(service);
+  }
+
+  public async connectToStorage(): Promise<IDocumentStorageService> {
+	return this.service.connectToStorage();		
+}
+
+
+
+}

--- a/packages/loader/driver-utils/src/adapters/compression/documentServiceFactoryCompressionAdapter.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/documentServiceFactoryCompressionAdapter.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
+import { IDocumentService, IDocumentServiceFactory, IResolvedUrl } from "@fluidframework/driver-definitions";
+import { ISummaryTree } from "@fluidframework/protocol-definitions";
+import { ICompressionStorageConfig } from "../predefinedAdapters";
+import { DocumentServiceFactoryProxy } from "../../documentServiceFactoryProxy";
+
+
+
+export class DocumentServiceFactoryCompressionAdapter extends DocumentServiceFactoryProxy {
+	constructor(
+		serviceFactory: IDocumentServiceFactory,
+		private readonly _config: ICompressionStorageConfig,
+	) {
+		super(serviceFactory);
+	}
+
+	public async createContainer(
+		createNewSummary: ISummaryTree | undefined,
+		createNewResolvedUrl: IResolvedUrl,
+		logger?: ITelemetryBaseLogger,
+		clientIsSummarizer?: boolean,
+	): Promise<IDocumentService>{
+		const service = await this.serviceFactory.createContainer(
+			createNewSummary,
+			createNewResolvedUrl,
+			logger,
+			clientIsSummarizer,
+		);
+		return service;
+	}
+
+	public async createDocumentService(
+		resolvedUrl: IResolvedUrl,
+	): Promise<IDocumentService> {
+		const service = await this.serviceFactory.createDocumentService(resolvedUrl);
+		return service;
+	}
+
+
+}

--- a/packages/loader/driver-utils/src/adapters/compression/documentServiceFactoryCompressionAdapter.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/documentServiceFactoryCompressionAdapter.ts
@@ -6,8 +6,9 @@
 import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import { IDocumentService, IDocumentServiceFactory, IResolvedUrl } from "@fluidframework/driver-definitions";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
-import { ICompressionStorageConfig } from "../predefinedAdapters";
 import { DocumentServiceFactoryProxy } from "../../documentServiceFactoryProxy";
+import { ICompressionStorageConfig } from "./documentStorageServiceCompressionAdapter";
+import { DocumentServiceCompressionAdapter } from "./documentServiceCompressionAdapter";
 
 
 
@@ -31,14 +32,14 @@ export class DocumentServiceFactoryCompressionAdapter extends DocumentServiceFac
 			logger,
 			clientIsSummarizer,
 		);
-		return service;
+		return new  DocumentServiceCompressionAdapter(service, this._config);
 	}
 
 	public async createDocumentService(
 		resolvedUrl: IResolvedUrl,
 	): Promise<IDocumentService> {
 		const service = await this.serviceFactory.createDocumentService(resolvedUrl);
-		return service;
+		return new  DocumentServiceCompressionAdapter(service, this._config);
 	}
 
 

--- a/packages/loader/driver-utils/src/adapters/compression/documentStorageServiceCompressionAdapter.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/documentStorageServiceCompressionAdapter.ts
@@ -1,0 +1,201 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+
+import { compress, decompress } from "lz4js";
+import {
+	ISummaryTree,
+	ISummaryBlob,
+	SummaryType,
+	ICreateBlobResponse,
+	SummaryObject,
+} from "@fluidframework/protocol-definitions";
+import { IsoBuffer, Uint8ArrayToString } from "@fluidframework/common-utils";
+import { IDocumentStorageService, ISummaryContext } from "@fluidframework/driver-definitions";
+import { DocumentStorageServiceProxy } from "../../documentStorageServiceProxy";
+import {
+	BlobHeaderBuilder,
+	readBlobHeader,
+	skipHeader,
+	writeBlobHeader,
+} from "./blobProtocol";
+
+export enum SummaryCompressionAlgorithm {
+	None = 1,
+	LZ4 = 2,
+}
+
+const algorithmKey = "ALG";
+const defaultMinSizeToCompress = 500;
+
+/**
+ * This class extends the SummaryStorageAdapter so that it can apply various kinds of compressions
+ * to the blob payload.
+ */
+export class DocumentStorageServiceCompressionAdapter extends DocumentStorageServiceProxy {
+	constructor(
+		service: IDocumentStorageService,
+		private readonly _algorithm: SummaryCompressionAlgorithm | undefined,
+		private readonly _minSizeToCompress: number | undefined,
+		private readonly _isUseB64OnCompressed: boolean | undefined,
+	) {
+		super(service);
+		if (this._minSizeToCompress === undefined) {
+			this._minSizeToCompress = defaultMinSizeToCompress;
+		}
+	}
+
+	public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
+		return super.createBlob(this.encodeBlob(file));
+	}
+	public async readBlob(id: string): Promise<ArrayBufferLike> {
+		return this.decodeBlob(await super.readBlob(id));
+	}
+	public async uploadSummaryWithContext(
+		summary: ISummaryTree,
+		context: ISummaryContext,
+	): Promise<string> {
+		const prep = {
+			prepSummary: recursivelyReplace(summary, this.blobReplacer, context) as ISummaryTree,
+			prepContext: context,
+		};
+		console.log(`Miso Summary Upload: ${  JSON.stringify(prep.prepSummary).length}`);
+		return super.uploadSummaryWithContext(prep.prepSummary, prep.prepContext);
+	}
+	public get algorithm(): SummaryCompressionAlgorithm | undefined {
+		return this._algorithm;
+	}
+	private readonly blobReplacer = (
+		_input: SummaryObject,
+		_context?: ISummaryContext,
+	): SummaryObject => {
+		if (_input.type === SummaryType.Blob) {
+			const summaryBlob: ISummaryBlob = _input;
+			const decompressed: Uint8Array =
+				typeof summaryBlob.content === "string"
+					? new TextEncoder().encode(summaryBlob.content)
+					: summaryBlob.content;
+			if (
+				this._minSizeToCompress !== undefined &&
+				decompressed.length < this._minSizeToCompress
+			) {
+				return _input;
+			}
+			const compressed: ArrayBufferLike = this.encodeBlob(decompressed);
+			let newSummaryBlob;
+			if (this._isUseB64OnCompressed !== undefined && this._isUseB64OnCompressed) {
+				// TODO: This step is now needed, it looks like the function summaryTreeUploadManager#writeSummarPyBlob
+				// fails on assertion at 2 different generations of the hash which do not lead to
+				// the same result if the ISummaryBlob.content is in the form of ArrayBufferLike
+				const compressedString = Uint8ArrayToString(IsoBuffer.from(compressed), "base64");
+				const compressedEncoded = new TextEncoder().encode(compressedString);
+				newSummaryBlob = {
+					type: SummaryType.Blob,
+					content: compressedEncoded,
+				};
+			} else {
+				// This line will replace the 3 lines above when the bug is fixed.
+				// const newSummaryBlob: ISummaryBlob = { type: SummaryType.Blob, content: IsoBuffer.from(compressed)};
+				newSummaryBlob = {
+					type: SummaryType.Blob,
+					content: IsoBuffer.from(compressed),
+				};
+			}
+			return newSummaryBlob;
+		} else {
+			return _input;
+		}
+	};
+
+	private encodeBlob(file: ArrayBufferLike): ArrayBufferLike {
+		let compressed: ArrayBufferLike;
+		if (this._algorithm === undefined || this._algorithm === SummaryCompressionAlgorithm.None) {
+			return file;
+		} else {
+			if (this._algorithm === SummaryCompressionAlgorithm.LZ4) {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+				compressed = compress(file) as ArrayBufferLike;
+			} else {
+				throw new Error(`Unknown Algorithm ${this._algorithm}`);
+			}
+		}
+		const headerBuilder: BlobHeaderBuilder = new BlobHeaderBuilder();
+		headerBuilder.addField(algorithmKey, this._algorithm.toString(10));
+		return writeBlobHeader(headerBuilder.build(), compressed);
+	}
+
+	private decodeBlob(file: ArrayBufferLike): ArrayBufferLike {
+		let compressedEncoded = file;
+		let header = readBlobHeader(compressedEncoded);
+		if (!header) {
+			// TODO: Due to the function summaryTreeUploadManager#writeSummaryBlob issue
+			// where the binary blob representation inside ISummaryTree causes assertion issues
+			// with the hash comparison we need to be prepared that the blob together with the
+			// blob header is base64 encoded. We need to try whether it is the case.
+			const compressedString = new TextDecoder().decode(compressedEncoded);
+			compressedEncoded = IsoBuffer.from(compressedString, "base64");
+			header = readBlobHeader(compressedEncoded);
+			if (!header) {
+				return file;
+			}
+		}
+		let decompressed: ArrayBufferLike;
+		const input = skipHeader(compressedEncoded);
+		const myAlgorithm = Number(header.getValue(algorithmKey));
+		if (myAlgorithm === SummaryCompressionAlgorithm.LZ4) {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			decompressed = decompress(input) as ArrayBufferLike;
+		} else {
+			throw new Error(`Unknown Algorithm ${this._algorithm}`);
+		}
+		return decompressed;
+	}
+}
+
+export function recursivelyReplace(
+	input: SummaryObject,
+	replacer: (input: SummaryObject, context?: ISummaryContext) => SummaryObject,
+	context?: ISummaryContext,
+): SummaryObject {
+	// Note: Caller is responsible for ensuring that `input` is defined / non-null.
+	//       (Required for Object.keys() below.)
+
+	// Execute the `replace` on the current input.  Note that Caller is responsible for ensuring that `input`
+	// is a non-null object.
+	const maybeReplaced = replacer(input, context);
+
+	// If the replacer made a substitution there is no need to decscend further. IFluidHandles are always
+	// leaves in the object graph.
+	if (maybeReplaced !== input) {
+		return maybeReplaced;
+	}
+
+	// Otherwise descend into the object graph looking for IFluidHandle instances.
+	let clone: object | undefined;
+	for (const key of Object.keys(input)) {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+		const value = input[key];
+
+		if (Boolean(value) && typeof value === "object") {
+			// Note: `input` must not contain circular references (as object must
+			//       be JSON serializable.)  Therefore, guarding against infinite recursion here would only
+			//       lead to a later error when attempting to stringify().
+			const replaced = recursivelyReplace(value as SummaryObject, replacer, context);
+
+			// If the `replaced` object is different than the original `value` then the subgraph contained one
+			// or more handles.  If this happens, we need to return a clone of the `input` object where the
+			// current property is replaced by the `replaced` value.
+			if (replaced !== value) {
+				// Lazily create a shallow clone of the `input` object if we haven't done so already.
+				clone = clone ?? (Array.isArray(input) ? [...input] : { ...input });
+
+				// Overwrite the current property `key` in the clone with the `replaced` value.
+				clone[key] = replaced;
+			}
+		}
+	}
+	return (clone ?? input) as SummaryObject;
+}

--- a/packages/loader/driver-utils/src/adapters/compression/index.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/index.ts
@@ -4,6 +4,8 @@
  */
 
 export {
-	SummaryCompressionAlgorithm,
-	DocumentStorageServiceCompressionAdapter as CompressionDocumentStorageAdapter,
+	SummaryCompressionAlgorithm, ICompressionStorageConfig
 } from "./documentStorageServiceCompressionAdapter";
+export {
+	DocumentServiceFactoryCompressionAdapter,
+} from "./documentServiceFactoryCompressionAdapter";

--- a/packages/loader/driver-utils/src/adapters/compression/index.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/index.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export {
+	SummaryCompressionAlgorithm,
+	DocumentStorageServiceCompressionAdapter as CompressionDocumentStorageAdapter,
+} from "./documentStorageServiceCompressionAdapter";

--- a/packages/loader/driver-utils/src/adapters/index.ts
+++ b/packages/loader/driver-utils/src/adapters/index.ts
@@ -3,9 +3,8 @@
  * Licensed under the MIT License.
  */
 
-export { SummaryCompressionAlgorithm } from "./compression";
+export { SummaryCompressionAlgorithm, ICompressionStorageConfig} from "./compression";
 
 export {
-	ICompressionStorageConfig,
 	applyStorageCompression,
 } from "./predefinedAdapters";

--- a/packages/loader/driver-utils/src/adapters/index.ts
+++ b/packages/loader/driver-utils/src/adapters/index.ts
@@ -1,0 +1,11 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { SummaryCompressionAlgorithm } from "./compression";
+
+export {
+	ICompressionStorageConfig,
+	applyStorageCompression,
+} from "./predefinedAdapters";

--- a/packages/loader/driver-utils/src/adapters/predefinedAdapters.ts
+++ b/packages/loader/driver-utils/src/adapters/predefinedAdapters.ts
@@ -4,7 +4,7 @@
  */
 
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
-import { SummaryCompressionAlgorithm } from "./compression";
+import { SummaryCompressionAlgorithm, DocumentServiceFactoryCompressionAdapter, ICompressionStorageConfig} from "./compression";
 
 
 
@@ -15,11 +15,7 @@ export function applyStorageCompression(
 	if (config.algorithm === undefined) {
 		return documentServiceFactory;
 	}
-	return documentServiceFactory;
+	return new DocumentServiceFactoryCompressionAdapter(documentServiceFactory, config);
 }
 
-export interface ICompressionStorageConfig {
-	algorithm: SummaryCompressionAlgorithm;
-	minSizeToCompress: number;
-}
 

--- a/packages/loader/driver-utils/src/adapters/predefinedAdapters.ts
+++ b/packages/loader/driver-utils/src/adapters/predefinedAdapters.ts
@@ -1,0 +1,25 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IDocumentServiceFactory } from "@fluidframework/driver-definitions";
+import { SummaryCompressionAlgorithm } from "./compression";
+
+
+
+export function applyStorageCompression(
+	documentServiceFactory: IDocumentServiceFactory,
+	config: ICompressionStorageConfig = { algorithm: SummaryCompressionAlgorithm.LZ4, minSizeToCompress: 500 },
+): IDocumentServiceFactory {
+	if (config.algorithm === undefined) {
+		return documentServiceFactory;
+	}
+	return documentServiceFactory;
+}
+
+export interface ICompressionStorageConfig {
+	algorithm: SummaryCompressionAlgorithm;
+	minSizeToCompress: number;
+}
+

--- a/packages/loader/driver-utils/src/documentServiceFactoryProxy.ts
+++ b/packages/loader/driver-utils/src/documentServiceFactoryProxy.ts
@@ -1,0 +1,53 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ITelemetryBaseLogger } from "@fluidframework/common-definitions";
+import {
+	IDocumentService,
+	IDocumentServiceFactory,
+	IResolvedUrl,
+} from "@fluidframework/driver-definitions";
+import { ISummaryTree } from "@fluidframework/protocol-definitions";
+
+/**
+ * This abstract class implements IDocumentServicefactory interface. It uses delegation pattern.
+ * It delegates all calls to IDocumentService implementation passed to constructor.
+ */
+
+export abstract class DocumentServiceFactoryProxy implements IDocumentServiceFactory {
+	constructor(private readonly _serviceFactory: IDocumentServiceFactory) {}
+
+	public get serviceFactory(): IDocumentServiceFactory {
+		return this._serviceFactory;
+	}
+
+	public async createContainer(
+		createNewSummary: ISummaryTree | undefined,
+		createNewResolvedUrl: IResolvedUrl,
+		logger?: ITelemetryBaseLogger,
+		clientIsSummarizer?: boolean,
+	): Promise<IDocumentService> {
+		return this.serviceFactory.createContainer(
+			createNewSummary,
+			createNewResolvedUrl,
+			logger,
+			clientIsSummarizer,
+		);
+	}
+
+	public async createDocumentService(
+		resolvedUrl: IResolvedUrl,
+		logger?: ITelemetryBaseLogger,
+		clientIsSummarizer?: boolean
+	): Promise<IDocumentService> {
+		return this.serviceFactory.createDocumentService(
+			resolvedUrl,
+			logger,
+			clientIsSummarizer,
+		);
+	}
+		
+	
+}

--- a/packages/loader/driver-utils/src/documentServiceProxy.ts
+++ b/packages/loader/driver-utils/src/documentServiceProxy.ts
@@ -40,6 +40,12 @@ export abstract class DocumentServiceProxy implements IDocumentService {
 		return this._service.resolvedUrl;
 	}
 
+	public saveStorage(storage: IDocumentStorageService): void {
+		if(this._service.saveStorage !== undefined) {
+			this._service.saveStorage(storage);
+		}
+	}
+
 
 }
 

--- a/packages/loader/driver-utils/src/documentServiceProxy.ts
+++ b/packages/loader/driver-utils/src/documentServiceProxy.ts
@@ -44,8 +44,19 @@ export abstract class DocumentServiceProxy implements IDocumentService {
 		if(this._service.saveStorage !== undefined) {
 			this._service.saveStorage(storage);
 		}
+		else {
+			throw new Error("saveStorage is not implemented");
+		}
 	}
 
+	public hasStorage(): boolean {
+		if(this._service.hasStorage !== undefined) {
+			return this._service.hasStorage();
+		}
+		else {
+			throw new Error("hasStorage is not implemented");
+		}
+	}
 
 }
 

--- a/packages/loader/driver-utils/src/documentServiceProxy.ts
+++ b/packages/loader/driver-utils/src/documentServiceProxy.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IDocumentDeltaConnection, IDocumentDeltaStorageService, IDocumentService, IDocumentStorageService, IResolvedUrl } from "@fluidframework/driver-definitions";
+import { IClient } from "@fluidframework/protocol-definitions";
+
+
+/**
+ * This abstract class implements IDocumentService interface. It uses delegation pattern.
+ * It delegates all calls to IDocumentService implementation passed to constructor.
+ */
+
+export abstract class DocumentServiceProxy implements IDocumentService {
+
+	constructor (private readonly _service: IDocumentService) {}
+
+	public get service(): IDocumentService {
+		return this._service;
+	}
+
+	public async connectToStorage(): Promise<IDocumentStorageService> {
+		return this._service.connectToStorage();		
+	}
+
+	public async connectToDeltaStorage(): Promise<IDocumentDeltaStorageService> {
+		return this._service.connectToDeltaStorage();
+	}
+
+	public async connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection> {
+		return this._service.connectToDeltaStream(client);
+	}
+
+	public dispose(error?: any): void {
+		this._service.dispose(error);
+	}
+
+	public get resolvedUrl(): IResolvedUrl {
+		return this._service.resolvedUrl;
+	}
+
+
+}
+

--- a/packages/loader/driver-utils/src/index.ts
+++ b/packages/loader/driver-utils/src/index.ts
@@ -49,3 +49,5 @@ export {
 	isCombinedAppAndProtocolSummary,
 } from "./summaryForCreateNew";
 export { convertSummaryTreeToSnapshotITree } from "./treeConversions";
+export { applyStorageCompression, ICompressionStorageConfig } from "./adapters";
+


### PR DESCRIPTION
For review @vladsud @DLehenbauer @dstanesc 
When implementing the general compression of summaries at the Fluid Framework, we identified 3 interfaces / implementations which should be wrapped by adapters to add the compression to the summarizer.

The `IStorageDocumentService` contains all methods to send and receive blobs to / from the server.
The `IDocumentService` contains `connectToStorage `method to obtain the `IStorageDocumentService` implementation
The `IDocumentServiceFactory`  contains methods `createContainer` and `createDocumentService`, which create `IDocumentService` implementation.

The original idea was to wrap IDocumentServiceFactory by DocumentServiceFactoryProxy adapter and wrap methods of `IDocumentServiceFactory.createContainer` and `IDocumentServiceFactory.createDocumentService` so that they will return wrapped `IDocumentService` implementation (wrapped by `DocumentServiceProxy`). The method `IDocumentService.connectToStorage`  would be wrapped to return `IStorageDocumentService`  wrapped by `StorageDocumentServiceProxy`. This way the caller of the method  `IStorageDocumentService.connectToStorage` will call the wrapped 'connectToStorage' which will apply the compression to `IStorageDocumentService` methods.

The usage and implementation of the method `IStorageDocumentService.connectToStorage` in the routerlicious driver (and possibly other drivers) brings challenges to the approach above as follows:

Method `routerlicious-driver - DocumentService.connectToStorage` caches the created `documentStorage` in the instance variable prior wrapping it by proxy. So far this would not be a problem because every call to the wrapped `connectToStorage` would wrap it. However this instance variable is used internally in other methods where reading of blobs happens.

This PR presents the experimental solution where the `IDocumentService` wrapper injects the wrapped method `connectToStorage` into the `IDocumentService`  instance as follows. The original `connectToStorage` is saved and the wrapped `connectToStorage`  is replacing it in original `IDocumentService` instance. The wrapped method caches  the wrapped `documentStorage` so the internal access to this method results in usage of properly wrapped object.


```
	private readonly originConnectToStorage: () => Promise<IDocumentStorageService>;
	constructor(service: IDocumentService, private readonly _config: ICompressionStorageConfig) {
		super(service);
		this.originConnectToStorage = this.service.connectToStorage.bind(this.service);
		service.connectToStorage = this.connectToStorageOverride.bind(this);
	}

	public async connectToStorageOverride(): Promise<IDocumentStorageService> {
		if(this.hasStorage()) {
			return this.originConnectToStorage();
		}
		else {
			const storage = await this.originConnectToStorage();
			const wrapped = new DocumentStorageServiceCompressionAdapter(storage, this._config);
			this.saveStorage(wrapped);
			return wrapped;
		}
	}
```

**The compression still uses 16 bytes header. The new recognition algorithm will be subject to next PR.**


