### PR TITLE
feat(ci): Always publish tinylicious log

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -357,6 +357,15 @@ stages:
               mergeTestResults: false
             condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
 
+          # Publish tinylicious log for troubleshooting
+          - task: PublishPipelineArtifact@1
+            displayName: Publish Artifact - Tinylicious Log
+            inputs:
+              targetPath: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log'
+              artifactName: 'tinyliciousLog'
+              publishLocation: 'pipeline'
+            condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+
           # Log Test Failures
           - template: include-log-test-failures.yml
             parameters:
@@ -373,8 +382,6 @@ stages:
                 mkdir $(Build.ArtifactStagingDirectory)/pack/
                 mkdir $(Build.ArtifactStagingDirectory)/pack/scoped/
                 mkdir $(Build.ArtifactStagingDirectory)/test-files/
-                mkdir $(Build.ArtifactStagingDirectory)/logs/
-                mv ${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log $(Build.ArtifactStagingDirectory)/logs/
                 if [[ "${{ variables.publishNonScopedPackages }}" == "True" ]]; then
                   mkdir $(Build.ArtifactStagingDirectory)/pack/non-scoped/
                 fi
@@ -413,13 +420,6 @@ stages:
             inputs:
               targetPath: '$(Build.ArtifactStagingDirectory)/test-files'
               artifactName: 'test-files'
-              publishLocation: 'pipeline'
-
-          - task: PublishPipelineArtifact@1
-            displayName: Publish Artifact - Tinylicious Log
-            inputs:
-              targetPath: '$(Build.ArtifactStagingDirectory)/logs'
-              artifactName: 'tinyliciousLog'
               publishLocation: 'pipeline'
 
         # Collect/publish/run bundle analysis

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -365,6 +365,7 @@ stages:
               artifactName: 'tinyliciousLog'
               publishLocation: 'pipeline'
             condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+            continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
 
           # Log Test Failures
           - template: include-log-test-failures.yml


### PR DESCRIPTION
## Description

Updates the pipeline that builds npm packages so that the tinylicious log is always published (step not skipped if previous steps failed) and so that subsequent steps run whether publishing the tinylicious logs succeeds or fails (in case the tinylicious tests didn't run because of an earlier failure).

This should give us more visibility into the current issues around tinylicious (some timeouts, and `main` CI builds sometimes failing that step).

[AB#4121](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4121)
