### PR TITLE
Refactor/Fix logic of snapshot fetching and improving perf for r11s driver

### DIFF
--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -93,6 +93,12 @@ export function getW3CData(url: string, initiatorType: string): {
     reqStartToResponseEndTime: number | undefined;
 };
 
+// @public (undocumented)
+export function promiseRaceWithWinner<T>(promises: Promise<T>[]): Promise<{
+    index: number;
+    value: T;
+}>;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/drivers/driver-base/src/driverUtils.ts
+++ b/packages/drivers/driver-base/src/driverUtils.ts
@@ -87,3 +87,14 @@ export function getW3CData(url: string, initiatorType: string) {
 		reqStartToResponseEndTime,
 	};
 }
+
+// An implementation of Promise.race that gives you the winner of the promise race
+export async function promiseRaceWithWinner<T>(
+	promises: Promise<T>[],
+): Promise<{ index: number; value: T }> {
+	return new Promise((resolve, reject) => {
+		promises.forEach((p, index) => {
+			p.then((v) => resolve({ index, value: v })).catch(reject);
+		});
+	});
+}

--- a/packages/drivers/driver-base/src/driverUtils.ts
+++ b/packages/drivers/driver-base/src/driverUtils.ts
@@ -90,7 +90,10 @@ export function getW3CData(url: string, initiatorType: string) {
 	};
 }
 
-// An implementation of Promise.race that gives you the winner of the promise race
+/*
+ * An implementation of Promise.race that gives you the winner of the promise race.
+ * If one of the promises is rejected before any other is resolved, this method will return the error/reason from that rejection.
+ */
 export async function promiseRaceWithWinner<T>(
 	promises: Promise<T>[],
 ): Promise<{ index: number; value: T }> {

--- a/packages/drivers/driver-base/src/index.ts
+++ b/packages/drivers/driver-base/src/index.ts
@@ -4,4 +4,4 @@
  */
 
 export { DocumentDeltaConnection } from "./documentDeltaConnection";
-export { getW3CData } from "./driverUtils";
+export { getW3CData, promiseRaceWithWinner } from "./driverUtils";

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -8,6 +8,7 @@ import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert, delay, performance } from "@fluidframework/common-utils";
 import { loggerToMonitoringContext, PerformanceEvent } from "@fluidframework/telemetry-utils";
 import * as api from "@fluidframework/protocol-definitions";
+import { promiseRaceWithWinner } from "@fluidframework/driver-base";
 import { ISummaryContext, DriverErrorType, FetchSource } from "@fluidframework/driver-definitions";
 import { RateLimiter, NonRetryableError } from "@fluidframework/driver-utils";
 import {
@@ -40,17 +41,6 @@ import { pkgVersion as driverVersion } from "./packageVersion";
 import { OdspDocumentStorageServiceBase } from "./odspDocumentStorageServiceBase";
 
 export const defaultSummarizerCacheExpiryTimeout: number = 60 * 1000; // 60 seconds.
-
-// An implementation of Promise.race that gives you the winner of the promise race
-async function promiseRaceWithWinner<T>(
-	promises: Promise<T>[],
-): Promise<{ index: number; value: T }> {
-	return new Promise((resolve, reject) => {
-		promises.forEach((p, index) => {
-			p.then((v) => resolve({ index, value: v })).catch(reject);
-		});
-	});
-}
 
 interface GetVersionsTelemetryProps {
 	cacheEntryAge?: number;

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -8,6 +8,7 @@ import * as api from "@fluidframework/driver-definitions";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { RateLimiter, NetworkErrorBasic, canRetryOnError } from "@fluidframework/driver-utils";
 import { IClient } from "@fluidframework/protocol-definitions";
+import { INormalizedWholeSummary } from "@fluidframework/server-services-client";
 import io from "socket.io-client";
 import { PerformanceEvent, wrapError } from "@fluidframework/telemetry-utils";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
@@ -63,7 +64,8 @@ export class DocumentService implements api.IDocumentService {
 		private readonly documentStorageServicePolicies: api.IDocumentStorageServicePolicies,
 		private readonly driverPolicies: IRouterliciousDriverPolicies,
 		private readonly blobCache: ICache<ArrayBufferLike>,
-		private readonly snapshotTreeCache: ICache<ISnapshotTreeVersion>,
+		private readonly wholeSnapshotTreeCache: ICache<INormalizedWholeSummary>,
+		private readonly shreddedSummaryTreeCache: ICache<ISnapshotTreeVersion>,
 		private readonly discoverFluidResolvedUrl: () => Promise<api.IFluidResolvedUrl>,
 	) {}
 
@@ -125,7 +127,8 @@ export class DocumentService implements api.IDocumentService {
 			this.documentStorageServicePolicies,
 			this.driverPolicies,
 			this.blobCache,
-			this.snapshotTreeCache,
+			this.wholeSnapshotTreeCache,
+			this.shreddedSummaryTreeCache,
 			noCacheStorageManager,
 			getStorageManager,
 		);
@@ -184,7 +187,7 @@ export class DocumentService implements api.IDocumentService {
 	 */
 	public async connectToDeltaStream(client: IClient): Promise<api.IDocumentDeltaConnection> {
 		const connect = async (refreshToken?: boolean) => {
-			let ordererToken = this.ordererRestWrapper.getToken();
+			let ordererToken = await this.ordererRestWrapper.getToken();
 			if (this.shouldUpdateDiscoveredSessionInfo()) {
 				await this.refreshDiscovery();
 			}

--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -14,12 +14,13 @@ import {
 	DocumentStorageServiceProxy,
 	PrefetchDocumentStorageService,
 } from "@fluidframework/driver-utils";
+import { INormalizedWholeSummary } from "@fluidframework/server-services-client";
 import { IRouterliciousDriverPolicies } from "./policies";
 import { ICache } from "./cache";
 import { WholeSummaryDocumentStorageService } from "./wholeSummaryDocumentStorageService";
 import { ShreddedSummaryDocumentStorageService } from "./shreddedSummaryDocumentStorageService";
-import { ISnapshotTreeVersion } from "./definitions";
 import { GitManager } from "./gitManager";
+import { ISnapshotTreeVersion } from "./definitions";
 
 export class DocumentStorageService extends DocumentStorageServiceProxy {
 	private _logTailSha: string | undefined = undefined;
@@ -35,7 +36,8 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
 		policies: IDocumentStorageServicePolicies,
 		driverPolicies?: IRouterliciousDriverPolicies,
 		blobCache?: ICache<ArrayBufferLike>,
-		snapshotTreeCache?: ICache<ISnapshotTreeVersion>,
+		snapshotTreeCache?: ICache<INormalizedWholeSummary>,
+		shreddedSummaryTreeCache?: ICache<ISnapshotTreeVersion>,
 		noCacheGitManager?: GitManager,
 		getStorageManager?: (disableCache?: boolean) => Promise<GitManager>,
 	): IDocumentStorageService {
@@ -58,7 +60,7 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
 					policies,
 					driverPolicies,
 					blobCache,
-					snapshotTreeCache,
+					shreddedSummaryTreeCache,
 					getStorageManager,
 			  );
 		// TODO: worth prefetching latest summary making version + snapshot call with WholeSummary storage?
@@ -78,7 +80,8 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
 		policies: IDocumentStorageServicePolicies,
 		driverPolicies?: IRouterliciousDriverPolicies,
 		blobCache?: ICache<ArrayBufferLike>,
-		snapshotTreeCache?: ICache<ISnapshotTreeVersion>,
+		snapshotTreeCache?: ICache<INormalizedWholeSummary>,
+		shreddedSummaryTreeCache?: ICache<ISnapshotTreeVersion>,
 		public noCacheGitManager?: GitManager,
 		getStorageManager?: (disableCache?: boolean) => Promise<GitManager>,
 	) {
@@ -91,6 +94,7 @@ export class DocumentStorageService extends DocumentStorageServiceProxy {
 				driverPolicies,
 				blobCache,
 				snapshotTreeCache,
+				shreddedSummaryTreeCache,
 				noCacheGitManager,
 				getStorageManager,
 			),

--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -5,7 +5,7 @@
 
 import type { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { assert, stringToBuffer, Uint8ArrayToString } from "@fluidframework/common-utils";
-import { getW3CData } from "@fluidframework/driver-base";
+import { getW3CData, promiseRaceWithWinner } from "@fluidframework/driver-base";
 import {
 	IDocumentStorageService,
 	ISummaryContext,
@@ -25,7 +25,6 @@ import {
 } from "@fluidframework/server-services-client";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { ICache, InMemoryCache } from "./cache";
-import { ISnapshotTreeVersion } from "./definitions";
 import { IRouterliciousDriverPolicies } from "./policies";
 import {
 	convertSnapshotAndBlobsToSummaryTree,
@@ -58,7 +57,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 		public readonly policies: IDocumentStorageServicePolicies,
 		private readonly driverPolicies?: IRouterliciousDriverPolicies,
 		private readonly blobCache: ICache<ArrayBufferLike> = new InMemoryCache(),
-		private readonly snapshotTreeCache: ICache<ISnapshotTreeVersion> = new InMemoryCache(),
+		private readonly snapshotTreeCache: ICache<INormalizedWholeSummary> = new InMemoryCache(),
 		private readonly noCacheGitManager?: GitManager,
 		private readonly getStorageManager: (
 			disableCache?: boolean,
@@ -81,14 +80,60 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 		// If this is the first versions call for the document, we know we will want the latest summary.
 		// Fetch latest summary, cache it, and return its id.
 		if (this.firstVersionsCall && count === 1) {
+			const normalizedSnapshotContents = await PerformanceEvent.timedExecAsync(
+				this.logger,
+				{
+					eventName: "ObtainSnapshot",
+					versionId: versionId ?? undefined,
+					count,
+					enableDiscovery: this.driverPolicies?.enableDiscovery,
+				},
+				async (event) => {
+					let method: string;
+					const cachedSnapshotP = this.snapshotTreeCache.get(
+						this.getCacheKey(latestSnapshotId),
+					);
+
+					const networkSnapshotP = !this.driverPolicies?.enableDiscovery
+						? this.fetchSnapshotTree(latestSnapshotId, false)
+						: this.fetchSnapshotTree(latestSnapshotId, true);
+
+					const promiseRaceWinner = await promiseRaceWithWinner([
+						cachedSnapshotP.catch(() => undefined),
+						networkSnapshotP.catch(() => undefined),
+					]);
+
+					let retrievedSnapshot = promiseRaceWinner.value;
+					method = promiseRaceWinner.index === 0 ? "cache" : "network";
+
+					if (retrievedSnapshot === undefined) {
+						// if network failed -> wait for cache ( then return network failure)
+						// If cache returned empty or failed -> wait for network (success of failure)
+						if (promiseRaceWinner.index === 1) {
+							retrievedSnapshot = await cachedSnapshotP;
+							method = "cache";
+						}
+						if (retrievedSnapshot === undefined) {
+							retrievedSnapshot = await networkSnapshotP;
+							method = "network";
+						}
+					}
+					event.end({
+						method,
+					});
+					return retrievedSnapshot;
+				},
+			);
+
+			const _id = await this.initializeFromSnapshot(
+				normalizedSnapshotContents,
+				latestSnapshotId,
+			);
 			this.firstVersionsCall = false;
-			const { id: _id, snapshotTree } = !this.driverPolicies?.enableDiscovery
-				? await this.fetchAndCacheSnapshotTree(latestSnapshotId, false)
-				: await this.fetchAndCacheSnapshotTree(latestSnapshotId, true);
 			return [
 				{
 					id: _id,
-					treeId: snapshotTree.id!,
+					treeId: normalizedSnapshotContents.snapshotTree.id!,
 				},
 			];
 		}
@@ -125,7 +170,13 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 			requestVersion = versions[0];
 		}
 
-		return (await this.fetchAndCacheSnapshotTree(requestVersion.id)).snapshotTree;
+		const normalizedWholeSnapshot = await this.snapshotTreeCache.get(
+			this.getCacheKey(requestVersion.id),
+		);
+		if (normalizedWholeSnapshot !== undefined) {
+			return normalizedWholeSnapshot.snapshotTree;
+		}
+		return (await this.fetchSnapshotTree(requestVersion.id)).snapshotTree;
 	}
 
 	public async readBlob(blobId: string): Promise<ArrayBufferLike> {
@@ -225,20 +276,10 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 		);
 	}
 
-	private async fetchAndCacheSnapshotTree(
+	private async fetchSnapshotTree(
 		versionId: string,
 		disableCache?: boolean,
-	): Promise<ISnapshotTreeVersion> {
-		const cachedSnapshotTreeVersion = await this.snapshotTreeCache.get(
-			this.getCacheKey(versionId),
-		);
-		if (cachedSnapshotTreeVersion !== undefined) {
-			return {
-				id: cachedSnapshotTreeVersion.id,
-				snapshotTree: cachedSnapshotTreeVersion.snapshotTree,
-			};
-		}
-
+	): Promise<INormalizedWholeSummary> {
 		const normalizedWholeSummary = await PerformanceEvent.timedExecAsync(
 			this.logger,
 			{
@@ -270,33 +311,35 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 			},
 		);
 
-		assert(
-			normalizedWholeSummary.snapshotTree.id !== undefined,
-			0x275 /* "Root tree should contain the id" */,
-		);
-		const wholeFlatSummaryId: string = normalizedWholeSummary.snapshotTree.id;
-		const snapshotTreeVersion = {
-			id: wholeFlatSummaryId,
-			snapshotTree: normalizedWholeSummary.snapshotTree,
-		};
+		return normalizedWholeSummary;
+	}
 
+	private async initializeFromSnapshot(
+		normalizedWholeSummary: INormalizedWholeSummary,
+		versionId: string | null,
+	): Promise<string> {
+		const wholeFlatSummaryId = normalizedWholeSummary.snapshotTree.id;
+		assert(wholeFlatSummaryId !== undefined, 0x275 /* "Root tree should contain the id" */);
 		const cachePs: Promise<any>[] = [
-			this.snapshotTreeCache.put(this.getCacheKey(wholeFlatSummaryId), snapshotTreeVersion),
+			this.snapshotTreeCache.put(
+				this.getCacheKey(wholeFlatSummaryId),
+				normalizedWholeSummary,
+			),
 			this.initBlobCache(normalizedWholeSummary.blobs),
 		];
-		if (wholeFlatSummaryId !== versionId) {
+		if (wholeFlatSummaryId !== versionId && versionId !== null) {
 			// versionId could be "latest". When summarizer checks cache for "latest", we want it to be available.
 			// TODO: For in-memory cache, <latest,snapshotTree> will be a shared pointer with <snapshotId,snapshotTree>,
 			// However, for something like Redis, this will cache the same value twice. Alternatively, could we simply
 			// cache with versionId?
 			cachePs.push(
-				this.snapshotTreeCache.put(this.getCacheKey(versionId), snapshotTreeVersion),
+				this.snapshotTreeCache.put(this.getCacheKey(versionId), normalizedWholeSummary),
 			);
 		}
 
 		await Promise.all(cachePs);
 
-		return snapshotTreeVersion;
+		return wholeFlatSummaryId;
 	}
 
 	private async initBlobCache(blobs: Map<string, ArrayBuffer>): Promise<void> {


### PR DESCRIPTION
## Description

1.) Refactor/Fix logic of snapshot fetching and improving perf.
2.) Added obtain snapshot telemetry.
3.) Fetch snapshot simultaneously from cache and network like in odsp driver otherwise, the cache will also not update ever causing container to load from initial snapshot and then it takes time to catchup as seen in stress tests.
4.) Don't fetch the token on creating the restwrapper as that would hamper performance. Rather do that only when required.