### PR TITLE
Fix assert tagging for experimental

### DIFF
--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/assertShortCode.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/assertShortCode.ts
@@ -59,7 +59,7 @@ function getAssertMessageParams(sourceFile: SourceFile): Node[] {
 
 export const handler: Handler = {
 	name: "assert-short-codes",
-	match: /^(packages|(common\/lib\/common-utils)|(server\/routerlicious\/packages\/protocol-base)).*\/tsconfig\.json/i,
+	match: /^(packages|experimental|(common\/lib\/common-utils)|(server\/routerlicious\/packages\/protocol-base)).*\/tsconfig\.json/i,
 	handler: (tsconfigPath) => {
 		if (tsconfigPath.includes("test")) {
 			return;

--- a/experimental/dds/attributable-map/src/mapKernel.ts
+++ b/experimental/dds/attributable-map/src/mapKernel.ts
@@ -425,7 +425,7 @@ export class AttributableMapKernel {
 
 			assert(
 				!attribution || attribution.type !== "local",
-				"The attribution for summarization should not be local type",
+				0x5ec /* The attribution for summarization should not be local type */,
 			);
 
 			serializableMapData[key] = localValue.makeSerialized(
@@ -690,7 +690,7 @@ export class AttributableMapKernel {
 					localOpMetadata !== undefined &&
 						isMapKeyLocalOpMetadata(localOpMetadata) &&
 						localOpMetadata.pendingMessageId < this.pendingClearMessageIds[0],
-					0x013 /* "Received out of order op when there is an unackd clear message" */,
+					0x664 /* Received out of order op when there is an unackd clear message */,
 				);
 			}
 			// If we have an unack'd clear, we can ignore all ops.
@@ -704,13 +704,13 @@ export class AttributableMapKernel {
 			if (local) {
 				assert(
 					localOpMetadata !== undefined && isMapKeyLocalOpMetadata(localOpMetadata),
-					0x014 /* pendingMessageId is missing from the local client's operation */,
+					0x665 /* pendingMessageId is missing from the local client's operation */,
 				);
 				const pendingMessageIds = this.pendingKeys.get(op.key);
 				assert(
 					pendingMessageIds !== undefined &&
 						pendingMessageIds[0] === localOpMetadata.pendingMessageId,
-					0x2fa /* Unexpected pending message received */,
+					0x666 /* Unexpected pending message received */,
 				);
 				pendingMessageIds.shift();
 				if (pendingMessageIds.length === 0) {
@@ -741,12 +741,12 @@ export class AttributableMapKernel {
 				if (local) {
 					assert(
 						isClearLocalOpMetadata(localOpMetadata),
-						0x015 /* "pendingMessageId is missing from the local client's clear operation" */,
+						0x667 /* pendingMessageId is missing from the local client's clear operation */,
 					);
 					const pendingClearMessageId = this.pendingClearMessageIds.shift();
 					assert(
 						pendingClearMessageId === localOpMetadata.pendingMessageId,
-						0x2fb /* pendingMessageId does not match */,
+						0x668 /* pendingMessageId does not match */,
 					);
 					this.clearAllAttribution();
 					return;
@@ -761,13 +761,13 @@ export class AttributableMapKernel {
 			submit: (op: IMapClearOperation, localOpMetadata: IMapClearLocalOpMetadata) => {
 				assert(
 					isClearLocalOpMetadata(localOpMetadata),
-					0x2fc /* Invalid localOpMetadata for clear */,
+					0x669 /* Invalid localOpMetadata for clear */,
 				);
 				// We don't reuse the metadata pendingMessageId but send a new one on each submit.
 				const pendingClearMessageId = this.pendingClearMessageIds.shift();
 				assert(
 					pendingClearMessageId === localOpMetadata.pendingMessageId,
-					0x2fd /* pendingMessageId does not match */,
+					0x66a /* pendingMessageId does not match */,
 				);
 				this.submitMapClearMessage(op, localOpMetadata.previousMap);
 			},
@@ -871,17 +871,14 @@ export class AttributableMapKernel {
 	 * @param localOpMetadata - Metadata from the previous submit
 	 */
 	private resubmitMapKeyMessage(op: IMapKeyOperation, localOpMetadata: MapLocalOpMetadata): void {
-		assert(
-			isMapKeyLocalOpMetadata(localOpMetadata),
-			0x2fe /* Invalid localOpMetadata in submit */,
-		);
+		assert(isMapKeyLocalOpMetadata(localOpMetadata), "Invalid localOpMetadata in submit");
 
 		// clear the old pending message id
 		const pendingMessageIds = this.pendingKeys.get(op.key);
 		assert(
 			pendingMessageIds !== undefined &&
 				pendingMessageIds[0] === localOpMetadata.pendingMessageId,
-			0x2ff /* Unexpected pending message received */,
+			"Unexpected pending message received",
 		);
 		pendingMessageIds.shift();
 		if (pendingMessageIds.length === 0) {

--- a/experimental/dds/attributable-map/src/mapKernel.ts
+++ b/experimental/dds/attributable-map/src/mapKernel.ts
@@ -425,7 +425,7 @@ export class AttributableMapKernel {
 
 			assert(
 				!attribution || attribution.type !== "local",
-				0x5ec /* The attribution for summarization should not be local type */,
+				"The attribution for summarization should not be local type",
 			);
 
 			serializableMapData[key] = localValue.makeSerialized(
@@ -690,7 +690,7 @@ export class AttributableMapKernel {
 					localOpMetadata !== undefined &&
 						isMapKeyLocalOpMetadata(localOpMetadata) &&
 						localOpMetadata.pendingMessageId < this.pendingClearMessageIds[0],
-					0x664 /* Received out of order op when there is an unackd clear message */,
+					"Received out of order op when there is an unackd clear message",
 				);
 			}
 			// If we have an unack'd clear, we can ignore all ops.
@@ -704,13 +704,13 @@ export class AttributableMapKernel {
 			if (local) {
 				assert(
 					localOpMetadata !== undefined && isMapKeyLocalOpMetadata(localOpMetadata),
-					0x665 /* pendingMessageId is missing from the local client's operation */,
+					"pendingMessageId is missing from the local client's operation",
 				);
 				const pendingMessageIds = this.pendingKeys.get(op.key);
 				assert(
 					pendingMessageIds !== undefined &&
 						pendingMessageIds[0] === localOpMetadata.pendingMessageId,
-					0x666 /* Unexpected pending message received */,
+					"Unexpected pending message received",
 				);
 				pendingMessageIds.shift();
 				if (pendingMessageIds.length === 0) {
@@ -741,12 +741,12 @@ export class AttributableMapKernel {
 				if (local) {
 					assert(
 						isClearLocalOpMetadata(localOpMetadata),
-						0x667 /* pendingMessageId is missing from the local client's clear operation */,
+						"pendingMessageId is missing from the local client's clear operation",
 					);
 					const pendingClearMessageId = this.pendingClearMessageIds.shift();
 					assert(
 						pendingClearMessageId === localOpMetadata.pendingMessageId,
-						0x668 /* pendingMessageId does not match */,
+						"pendingMessageId does not match",
 					);
 					this.clearAllAttribution();
 					return;
@@ -761,13 +761,13 @@ export class AttributableMapKernel {
 			submit: (op: IMapClearOperation, localOpMetadata: IMapClearLocalOpMetadata) => {
 				assert(
 					isClearLocalOpMetadata(localOpMetadata),
-					0x669 /* Invalid localOpMetadata for clear */,
+					"Invalid localOpMetadata for clear",
 				);
 				// We don't reuse the metadata pendingMessageId but send a new one on each submit.
 				const pendingClearMessageId = this.pendingClearMessageIds.shift();
 				assert(
 					pendingClearMessageId === localOpMetadata.pendingMessageId,
-					0x66a /* pendingMessageId does not match */,
+					"pendingMessageId does not match",
 				);
 				this.submitMapClearMessage(op, localOpMetadata.previousMap);
 			},

--- a/experimental/dds/ot/ot/src/ot.ts
+++ b/experimental/dds/ot/ot/src/ot.ts
@@ -83,8 +83,7 @@ export abstract class SharedOT<TState, TOp> extends SharedObject {
 	protected abstract transform(input: TOp, transform: TOp): TOp;
 
 	protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats {
-		// Summarizer must not have locally pending changes.
-		assert(this.pendingOps.length === 0, 0);
+		assert(this.pendingOps.length === 0, "Summarizer must not have locally pending changes.");
 
 		return createSingleBlobSummary("header", serializer.stringify(this.global, this.handle));
 	}

--- a/experimental/dds/tree/src/ChangeTypes.ts
+++ b/experimental/dds/tree/src/ChangeTypes.ts
@@ -3,8 +3,9 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from '@fluidframework/common-utils';
 import { NodeId, TraitLabel, UuidString } from './Identifiers';
-import { assert, assertNotUndefined } from './Common';
+import { assertNotUndefined } from './Common';
 import { ConstraintEffect, NodeData, Payload, Side, TreeNodeSequence } from './persisted-types';
 import { TraitLocation } from './TreeView';
 import { getNodeId } from './NodeIdUtilities';
@@ -363,9 +364,14 @@ export const StableRange = {
 	from: (start: StablePlace): { to: (end: StablePlace) => StableRange } => ({
 		to: (end: StablePlace): StableRange => {
 			if (start.referenceTrait && end.referenceTrait) {
-				const message = 'StableRange must be constructed with endpoints from the same trait';
-				assert(start.referenceTrait.parent === end.referenceTrait.parent, message);
-				assert(start.referenceTrait.label === end.referenceTrait.label, message);
+				assert(
+					start.referenceTrait.parent === end.referenceTrait.parent,
+					'StableRange must be constructed with endpoints from the same trait'
+				);
+				assert(
+					start.referenceTrait.label === end.referenceTrait.label,
+					'StableRange must be constructed with endpoints from the same trait'
+				);
 			}
 			return { start, end };
 		},

--- a/experimental/dds/tree/src/Checkout.ts
+++ b/experimental/dds/tree/src/Checkout.ts
@@ -3,9 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from '@fluidframework/common-utils';
 import { ChildLogger, EventEmitterWithErrorHandling } from '@fluidframework/telemetry-utils';
 import { IDisposable, IErrorEvent, ITelemetryLogger, ITelemetryProperties } from '@fluidframework/common-definitions';
-import { assert, fail, RestOrArray, unwrapRestOrArray } from './Common';
+import { assertWithMessage, fail, RestOrArray, unwrapRestOrArray } from './Common';
 import { EditId } from './Identifiers';
 import { CachingLogViewer } from './LogViewer';
 import { TreeView } from './TreeView';
@@ -257,7 +258,7 @@ export abstract class Checkout extends EventEmitterWithErrorHandling<ICheckoutEv
 	public applyChanges(changes: readonly Change[]): void;
 	public applyChanges(...changes: readonly Change[]): void;
 	public applyChanges(...changes: RestOrArray<Change>): void {
-		assert(this.currentEdit, 'Changes must be applied as part of an ongoing edit.');
+		assert(this.currentEdit !== undefined, 'Changes must be applied as part of an ongoing edit.');
 		const changeArray = unwrapRestOrArray(changes);
 		const { status } = this.currentEdit.applyChanges(changeArray.map((c) => this.tree.internalizeChange(c)));
 		this.validateChangesApplied({ status, failure: this.currentEdit.failure });
@@ -272,7 +273,7 @@ export abstract class Checkout extends EventEmitterWithErrorHandling<ICheckoutEv
 	protected tryApplyChangesInternal(changes: readonly ChangeInternal[]): EditStatus;
 	protected tryApplyChangesInternal(...changes: readonly ChangeInternal[]): EditStatus;
 	protected tryApplyChangesInternal(...changes: RestOrArray<ChangeInternal>): EditStatus {
-		assert(this.currentEdit, 'Changes must be applied as part of an ongoing edit.');
+		assert(this.currentEdit !== undefined, 'Changes must be applied as part of an ongoing edit.');
 		const changeArray = unwrapRestOrArray(changes);
 		const { status } = this.currentEdit.applyChanges(changeArray);
 		if (status === EditStatus.Applied) {
@@ -304,7 +305,7 @@ export abstract class Checkout extends EventEmitterWithErrorHandling<ICheckoutEv
 	public tryApplyEdit(...changes: RestOrArray<Change>): EditId | undefined {
 		this.openEdit();
 
-		assert(this.currentEdit, 'Changes must be applied as part of an ongoing edit.');
+		assert(this.currentEdit !== undefined, 'Changes must be applied as part of an ongoing edit.');
 		const changeArray = unwrapRestOrArray(changes);
 		const { status } = this.currentEdit.applyChanges(changeArray.map((c) => this.tree.internalizeChange(c)));
 		if (status === EditStatus.Applied) {
@@ -379,7 +380,7 @@ export abstract class Checkout extends EventEmitterWithErrorHandling<ICheckoutEv
 	 * @param editIds - the edits to revert
 	 */
 	public revert(editId: EditId): void {
-		assert(this.currentEdit !== undefined);
+		assertWithMessage(this.currentEdit !== undefined);
 		const index = this.tree.edits.getIndexOfId(editId);
 		const edit =
 			this.tree.edits.tryGetEditAtIndex(index) ?? fail('Edit with the specified ID does not exist in memory');

--- a/experimental/dds/tree/src/Common.ts
+++ b/experimental/dds/tree/src/Common.ts
@@ -78,8 +78,12 @@ export function compareStrings<T extends string>(a: T, b: T): number {
  * @param condition - A condition to assert is truthy
  * @param message - Message to be printed if assertion fails. Will print "Assertion failed" by default
  * @param containsPII - boolean flag for whether the message passed in contains personally identifying information (PII).
+ *
+ * @remarks
+ * To avoid collisions with assertShortCode tagging in Fluid Framework, this cannot be named "assert".
+ * When a non constant message is not needed, use `assert` from `@fluidframework/common-utils`;
  */
-export function assert(condition: unknown, message?: string, containsPII = false): asserts condition {
+export function assertWithMessage(condition: unknown, message?: string, containsPII = false): asserts condition {
 	// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 	if (!condition) {
 		fail(message, containsPII);
@@ -125,7 +129,7 @@ export function fail(message: string = defaultFailMessage, containsPII = false):
  * @param message - Message to be printed if assertion fails.
  */
 export function assertNotUndefined<T>(value: T | undefined, message = 'value must not be undefined'): T {
-	assert(value !== undefined, message);
+	assertWithMessage(value !== undefined, message);
 	return value;
 }
 
@@ -135,7 +139,7 @@ export function assertNotUndefined<T>(value: T | undefined, message = 'value mus
  * @param message - Message to be printed if assertion fails.
  */
 export function assertArrayOfOne<T>(array: readonly T[], message = 'array value must contain exactly one item'): T {
-	assert(array.length === 1, message);
+	assertWithMessage(array.length === 1, message);
 	return array[0];
 }
 

--- a/experimental/dds/tree/src/EditLog.ts
+++ b/experimental/dds/tree/src/EditLog.ts
@@ -4,10 +4,10 @@
  */
 
 import BTree from 'sorted-btree';
-import { TypedEventEmitter } from '@fluidframework/common-utils';
+import { TypedEventEmitter, assert } from '@fluidframework/common-utils';
 import type { IEvent, ITelemetryLogger } from '@fluidframework/common-definitions';
 import { compareArrays } from '@fluidframework/core-utils';
-import { assert, fail } from './Common';
+import { fail } from './Common';
 import type { EditId } from './Identifiers';
 import type { StringInterner } from './StringInterner';
 import { Edit, EditLogSummary, EditWithoutId, FluidEditHandle } from './persisted-types';
@@ -387,7 +387,7 @@ export class EditLog<TChange = unknown> extends TypedEventEmitter<IEditLogEvents
 
 		if (orderedEdit.isLocal) {
 			const firstLocal = this.allEditIds.get(this.localEdits[0].id) ?? fail('edit not found');
-			assert(firstLocal.isLocal);
+			assert(firstLocal.isLocal, 'local edit should be local');
 			return (
 				this._earliestAvailableEditIndex +
 				this.numberOfSequencedEdits +

--- a/experimental/dds/tree/src/Forest.ts
+++ b/experimental/dds/tree/src/Forest.ts
@@ -4,7 +4,8 @@
  */
 
 import BTree from 'sorted-btree';
-import { fail, assert, copyPropertyIfDefined, compareBtrees, compareFiniteNumbers } from './Common';
+import { assert } from '@fluidframework/common-utils';
+import { fail, copyPropertyIfDefined, compareBtrees, compareFiniteNumbers } from './Common';
 import { NodeId, TraitLabel } from './Identifiers';
 import { comparePayloads } from './PayloadUtilities';
 import { NodeData, Payload } from './persisted-types';
@@ -211,7 +212,7 @@ export class Forest {
 	): Forest {
 		assert(index >= 0, 'invalid attach index');
 		const parentNode = this.nodes.get(parentId);
-		assert(parentNode, 'can not insert children under node that does not exist');
+		assert(parentNode !== undefined, 'can not insert children under node that does not exist');
 		const mutableNodes = this.nodes.clone();
 		const traits = new Map(parentNode.traits);
 		const trait = traits.get(label) ?? [];
@@ -262,7 +263,7 @@ export class Forest {
 	): { forest: Forest; detached: readonly NodeId[] } {
 		assert(startIndex >= 0 && endIndex >= startIndex, 'invalid detach index range');
 		const parentNode = this.nodes.get(parentId);
-		assert(parentNode, 'can not detach children under node that does not exist');
+		assert(parentNode !== undefined, 'can not detach children under node that does not exist');
 		if (startIndex === endIndex) {
 			return { forest: this, detached: [] };
 		}
@@ -312,7 +313,7 @@ export class Forest {
 	// eslint-disable-next-line @rushstack/no-new-null
 	public setValue(nodeId: NodeId, value: Payload | null): Forest {
 		const node = this.nodes.get(nodeId);
-		assert(node, 'can not replace payload for node that does not exist');
+		assert(node !== undefined, 'can not replace payload for node that does not exist');
 		const mutableNodes = this.nodes.clone();
 		const newNode = { ...node };
 		if (value !== null) {
@@ -400,7 +401,7 @@ export class Forest {
 			if (isParentedForestNode(node)) {
 				const parent = this.get(node.parentId);
 				const trait = parent.traits.get(node.traitParent);
-				assert(trait !== undefined);
+				assert(trait !== undefined, 'trait exists');
 				assert(trait.includes(node.identifier), 'node is parented incorrectly');
 			}
 
@@ -408,7 +409,7 @@ export class Forest {
 				assert(trait.length > 0, 'trait is present but empty');
 				for (const childId of trait) {
 					const child = this.nodes.get(childId);
-					assert(child, 'child in trait is not in forest');
+					assert(child !== undefined, 'child in trait is not in forest');
 					assert(isParentedForestNode(child), 'child is not parented');
 					assert(child.parentId === node.identifier, 'child parent pointer is incorrect');
 					assert(

--- a/experimental/dds/tree/src/HistoryEditFactory.ts
+++ b/experimental/dds/tree/src/HistoryEditFactory.ts
@@ -3,9 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from '@fluidframework/common-utils';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
 import { DetachedSequenceId, isDetachedSequenceId, NodeId } from './Identifiers';
-import { assert, fail } from './Common';
+import { fail } from './Common';
 import { rangeFromStableRange } from './TreeViewUtilities';
 import {
 	ChangeInternal,

--- a/experimental/dds/tree/src/LogViewer.ts
+++ b/experimental/dds/tree/src/LogViewer.ts
@@ -5,8 +5,8 @@
 
 import Denque from 'denque';
 import { IEvent } from '@fluidframework/common-definitions';
-import { TypedEventEmitter } from '@fluidframework/common-utils';
-import { assert, fail, noop } from './Common';
+import { assert, TypedEventEmitter } from '@fluidframework/common-utils';
+import { fail, noop } from './Common';
 import { EditLog, SequencedOrderedEditId } from './EditLog';
 import { EditId } from './Identifiers';
 import { Revision, RevisionValueCache } from './RevisionValueCache';

--- a/experimental/dds/tree/src/NodeIdUtilities.ts
+++ b/experimental/dds/tree/src/NodeIdUtilities.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from './Common';
 import { IdCompressor, isFinalId } from './id-compressor';
 import { FinalNodeId, NodeId, OpSpaceNodeId, SessionId, StableNodeId } from './Identifiers';
 import { NodeData } from './persisted-types';
+import { assertWithMessage } from './Common';
 
 /**
  * An object which can generate node IDs and convert node IDs between compressed and stable variants
@@ -125,12 +125,12 @@ export function sequencedIdNormalizer<TId extends OpSpaceNodeId>(
 	return {
 		normalizeToOpSpace: (id) => {
 			const normalized = idNormalizer.normalizeToOpSpace(id);
-			assert(isFinalId(normalized));
+			assertWithMessage(isFinalId(normalized));
 			return normalized;
 		},
 		normalizeToSessionSpace: (id) => {
 			const normalized = idNormalizer.normalizeToSessionSpace(id, idNormalizer.localSessionId);
-			assert(isFinalId(normalized));
+			assertWithMessage(isFinalId(normalized));
 			return normalized;
 		},
 	};

--- a/experimental/dds/tree/src/RevisionValueCache.ts
+++ b/experimental/dds/tree/src/RevisionValueCache.ts
@@ -3,9 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from '@fluidframework/common-utils';
 import BTree from 'sorted-btree';
 import LRU from 'lru-cache';
-import { assert, fail, compareFiniteNumbers } from './Common';
+import { fail, compareFiniteNumbers } from './Common';
 
 /**
  * A revision corresponds to an index in an `EditLog`.

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { bufferToString } from '@fluidframework/common-utils';
+import { assert, bufferToString } from '@fluidframework/common-utils';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import {
 	IFluidDataStoreRuntime,
@@ -23,7 +23,7 @@ import {
 import { ITelemetryLogger, ITelemetryProperties } from '@fluidframework/common-definitions';
 import { ChildLogger, ITelemetryLoggerPropertyBags, PerformanceEvent } from '@fluidframework/telemetry-utils';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
-import { assert, fail, copyPropertyIfDefined, RestOrArray, unwrapRestOrArray } from './Common';
+import { fail, copyPropertyIfDefined, RestOrArray, unwrapRestOrArray } from './Common';
 import { EditHandle, EditLog, OrderedEditSet } from './EditLog';
 import {
 	EditId,

--- a/experimental/dds/tree/src/SharedTreeEncoder.ts
+++ b/experimental/dds/tree/src/SharedTreeEncoder.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IsoBuffer } from '@fluidframework/common-utils';
-import { assert, fail } from './Common';
+import { IsoBuffer, assert } from '@fluidframework/common-utils';
+import { assertWithMessage, fail } from './Common';
 import { EditLog } from './EditLog';
 import { convertTreeNodes, newEdit } from './EditUtilities';
 import { AttributionId, DetachedSequenceId, FinalNodeId, OpSpaceNodeId, TraitLabel } from './Identifiers';
@@ -152,7 +152,10 @@ export class SharedTreeEncoder_0_1_1 {
 		}: SharedTreeSummary,
 		attributionId: AttributionId
 	): SummaryContents {
-		assert(version === WriteFormat.v0_1_1, `Invalid summary version to decode: ${version}, expected: 0.1.1`);
+		assertWithMessage(
+			version === WriteFormat.v0_1_1,
+			`Invalid summary version to decode: ${version}, expected: 0.1.1`
+		);
 		assert(typeof editHistory === 'object', '0.1.1 summary encountered with non-object edit history.');
 
 		const idCompressor = hasOngoingSession(serializedIdCompressor)
@@ -166,7 +169,7 @@ export class SharedTreeEncoder_0_1_1 {
 				? this.treeCompressor.decompress(compressedTree, interner, sequencedNormalizer)
 				: undefined;
 		const { editChunks, editIds } = editHistory;
-		assert(editChunks !== undefined, 'Missing editChunks on 0.1.1 summary.');
+		assertWithMessage(editChunks !== undefined, 'Missing editChunks on 0.1.1 summary.');
 		assert(editIds !== undefined, 'Missing editIds on 0.1.1 summary.');
 
 		const uncompressedChunks = editChunks.map(({ startRevision, chunk }) => ({
@@ -291,7 +294,7 @@ export class SharedTreeEncoder_0_1_1 {
 		idNormalizer: ContextualizedNodeIdNormalizer<FinalNodeId>,
 		interner: StringInterner
 	): EditWithoutId<ChangeInternal>[] {
-		assert(
+		assertWithMessage(
 			contents.version === WriteFormat.v0_1_1,
 			`Invalid editChunk to decode: ${contents.version}. Expected 0.1.1.`
 		);

--- a/experimental/dds/tree/src/TransactionInternal.ts
+++ b/experimental/dds/tree/src/TransactionInternal.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { assert, copyPropertyIfDefined, fail, Result } from './Common';
+import { assert } from '@fluidframework/common-utils';
+import { assertWithMessage, copyPropertyIfDefined, fail, Result } from './Common';
 import { NodeId, DetachedSequenceId, TraitLabel, isDetachedSequenceId } from './Identifiers';
 import { rangeFromStableRange } from './TreeViewUtilities';
 import {
@@ -773,7 +774,7 @@ export namespace TransactionInternal {
 			}
 			while (unprocessed.length > 0) {
 				const node = unprocessed.pop();
-				assert(node !== undefined && !isDetachedSequenceId(node));
+				assertWithMessage(node !== undefined && !isDetachedSequenceId(node));
 				const traits = new Map<TraitLabel, readonly NodeId[]>();
 				// eslint-disable-next-line no-restricted-syntax
 				for (const key in node.traits) {

--- a/experimental/dds/tree/src/TreeCompressor.ts
+++ b/experimental/dds/tree/src/TreeCompressor.ts
@@ -2,12 +2,13 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+import { assert } from '@fluidframework/common-utils';
 import { isDetachedSequenceId } from './Identifiers';
 import type { Definition, DetachedSequenceId, InternedStringId, OpSpaceNodeId, TraitLabel } from './Identifiers';
 import type { StringInterner } from './StringInterner';
 import type { CompressedTraits, CompressedPlaceholderTree, PlaceholderTree, Payload } from './persisted-types';
 import type { ContextualizedNodeIdNormalizer } from './NodeIdUtilities';
-import { assert, fail, Mutable } from './Common';
+import { fail, Mutable } from './Common';
 
 /**
  * Compresses a given {@link PlaceholderTree} into a more compact serializable format.

--- a/experimental/dds/tree/src/TreeView.ts
+++ b/experimental/dds/tree/src/TreeView.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { assert, copyPropertyIfDefined, fail } from './Common';
+import { assert } from '@fluidframework/common-utils';
+import { copyPropertyIfDefined, fail } from './Common';
 import { NodeId, TraitLabel } from './Identifiers';
 import { Delta, Forest, isParentedForestNode } from './Forest';
 import { NodeData, Side } from './persisted-types';

--- a/experimental/dds/tree/src/TreeViewUtilities.ts
+++ b/experimental/dds/tree/src/TreeViewUtilities.ts
@@ -4,7 +4,7 @@
  */
 
 import { StablePlace, StableRange } from './ChangeTypes';
-import { assert, fail } from './Common';
+import { assertWithMessage, fail } from './Common';
 import { TraitLocation, TreeView, TreeViewPlace, TreeViewRange } from './TreeView';
 
 /**
@@ -25,7 +25,7 @@ export function rangeFromStableRange(view: TreeView, range: StableRange): TreeVi
 export function placeFromStablePlace(view: TreeView, stablePlace: StablePlace): TreeViewPlace {
 	const { side } = stablePlace;
 	if (stablePlace.referenceSibling === undefined) {
-		assert(stablePlace.referenceTrait !== undefined);
+		assertWithMessage(stablePlace.referenceTrait !== undefined);
 		return {
 			trait: stablePlace.referenceTrait,
 			side,

--- a/experimental/dds/tree/src/UuidUtilities.ts
+++ b/experimental/dds/tree/src/UuidUtilities.ts
@@ -4,7 +4,7 @@
  */
 
 import { v4, NIL } from 'uuid';
-import { assert } from './Common';
+import { assertWithMessage } from './Common';
 import { StableId, UuidString } from './Identifiers';
 
 const hexadecimalCharCodes = Array.from('09afAF').map((c) => c.charCodeAt(0)) as [
@@ -31,7 +31,7 @@ export const nilUuid = assertIsUuidString(NIL);
  * Asserts that the given string is a UUID
  */
 export function assertIsUuidString(uuidString: string): UuidString {
-	assert(isUuidString(uuidString), `${uuidString} is not an UuidString`);
+	assertWithMessage(isUuidString(uuidString), `${uuidString} is not an UuidString`);
 	return uuidString;
 }
 
@@ -73,7 +73,7 @@ export function generateStableId(): StableId {
  * Asserts that the given string is a stable ID.
  */
 export function assertIsStableId(stableId: string): StableId {
-	assert(isStableId(stableId), `${stableId} is not a StableId.`);
+	assertWithMessage(isStableId(stableId), `${stableId} is not a StableId.`);
 	return stableId;
 }
 

--- a/experimental/dds/tree/src/id-compressor/AppendOnlySortedMap.ts
+++ b/experimental/dds/tree/src/id-compressor/AppendOnlySortedMap.ts
@@ -5,7 +5,8 @@
 
 /* eslint-disable no-bitwise */
 
-import { assert, fail } from '../Common';
+import { assert } from '@fluidframework/common-utils';
+import { fail } from '../Common';
 
 /**
  * A map in which entries are always added in key-sorted order.

--- a/experimental/dds/tree/src/id-compressor/IdCompressor.ts
+++ b/experimental/dds/tree/src/id-compressor/IdCompressor.ts
@@ -5,10 +5,10 @@
 
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
 
+import { assert } from '@fluidframework/common-utils';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
 import BTree from 'sorted-btree';
 import {
-	assert,
 	hasLength,
 	assertNotUndefined,
 	compareFiniteNumbers,
@@ -19,6 +19,7 @@ import {
 	getOrCreate,
 	Mutable,
 	setPropertyIfDefined,
+	assertWithMessage,
 } from '../Common';
 import {
 	LocalCompressedId,
@@ -426,7 +427,7 @@ export class IdCompressor {
 	 * @returns the session object for the supplied ID
 	 */
 	private createSession(sessionId: SessionId, attributionId: AttributionId | undefined): Session {
-		assert(!this.clustersAndOverridesInversion.has(sessionId));
+		assertWithMessage(!this.clustersAndOverridesInversion.has(sessionId));
 		const existingSession = this.sessions.get(sessionId);
 		if (existingSession !== undefined) {
 			fail('createSession must only be called once for each session ID.');
@@ -492,7 +493,7 @@ export class IdCompressor {
 	public takeNextCreationRange(): IdCreationRange {
 		const lastLocalInRange = -this.localIdCount as UnackedLocalId;
 		const lastTakenNormalized = this.lastTakenLocalId ?? 0;
-		assert(lastLocalInRange <= lastTakenNormalized);
+		assertWithMessage(lastLocalInRange <= lastTakenNormalized);
 
 		// The attribution ID is sent with each range, but it can be elided after the first IDs are allocated.
 		const sendAttributionId = this.lastTakenLocalId === undefined;
@@ -507,8 +508,8 @@ export class IdCompressor {
 				),
 			] as (readonly [UnackedLocalId, string])[];
 			if (hasLength(overrides, 1)) {
-				assert(overrides[0][0] <= firstLocalInRange);
-				assert(overrides[overrides.length - 1][0] >= lastLocalInRange);
+				assertWithMessage(overrides[0][0] <= firstLocalInRange);
+				assertWithMessage(overrides[overrides.length - 1][0] >= lastLocalInRange);
 				ids = {
 					overrides,
 				};
@@ -1674,7 +1675,9 @@ export class IdCompressor {
 			localSessionId = serializedSessionData[0];
 			const attributionIndex = serializedSessionData[1];
 			if (attributionIndex !== undefined) {
-				assert(serializedAttributionIds !== undefined && serializedAttributionIds.length > attributionIndex);
+				assertWithMessage(
+					serializedAttributionIds !== undefined && serializedAttributionIds.length > attributionIndex
+				);
 				attributionId = serializedAttributionIds[attributionIndex];
 			}
 			serializedLocalState = serializedWithSession.localState;
@@ -1810,7 +1813,7 @@ export class IdCompressor {
 			);
 		}
 
-		assert(
+		assertWithMessage(
 			compressor.localSession.lastFinalizedLocalId === undefined ||
 				compressor.localIdCount >= -compressor.localSession.lastFinalizedLocalId
 		);

--- a/experimental/dds/tree/src/id-compressor/NumericUuid.ts
+++ b/experimental/dds/tree/src/id-compressor/NumericUuid.ts
@@ -5,9 +5,9 @@
 
 /* eslint-disable no-bitwise */
 
-import { assert, fail } from '../Common';
 import { SessionId, StableId } from '../Identifiers';
 import { generateStableId } from '../UuidUtilities';
+import { assertWithMessage, fail } from '../Common';
 
 /**
  * A UUID (128 bit identifier) optimized for use as a 128 bit unsigned integer with fast addition and toString operations.
@@ -173,7 +173,7 @@ export function incrementUuid(uuid: NumericUuid, amount: number): NumericUuid {
 			// The variant chunk itself also overflowed. We'll need to carry the overflow further, into the upper string region of the UUID.
 			const upperString = ChunkMath.Upper.parse(stringEntry);
 			const upperNumber = Number.parseInt(upperString, 16);
-			assert(upperNumber <= maxUpperNumber);
+			assertWithMessage(upperNumber <= maxUpperNumber);
 			const newUpperNumber = upperNumber + 1;
 			if (newUpperNumber > maxUpperNumber) {
 				fail('Exceeded maximum numeric UUID');
@@ -316,7 +316,7 @@ namespace ChunkMath {
 		// 2. The numerically important bits (i.e. not the variant identifier bits vv which are constant) are extracted into a single number
 		const variantChunk = Variant.parse(stringEntry);
 		const variantNumber = getNumericValue(variantChunk);
-		assert(variantNumber <= maxVariantNumber);
+		assertWithMessage(variantNumber <= maxVariantNumber);
 		// 3. Add one to the variant number to produce our new variant number.
 		const newVariantNumber = variantNumber + 1;
 		// 4. The variant identifier bits are added back into the number, which is then turned back into a hex string

--- a/experimental/dds/tree/src/id-compressor/SessionIdNormalizer.ts
+++ b/experimental/dds/tree/src/id-compressor/SessionIdNormalizer.ts
@@ -5,7 +5,8 @@
 
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
 
-import { assert, compareFiniteNumbers, compareFiniteNumbersReversed, fail, Mutable } from '../Common';
+import { assert } from '@fluidframework/common-utils';
+import { compareFiniteNumbers, compareFiniteNumbersReversed, fail, Mutable } from '../Common';
 import { FinalCompressedId, LocalCompressedId, SessionSpaceCompressedId } from '../Identifiers';
 import { AppendOnlyDoublySortedMap } from './AppendOnlySortedMap';
 import { SerializedSessionIdNormalizer } from './persisted-types';

--- a/experimental/dds/tree/src/persisted-types/0.1.1.ts
+++ b/experimental/dds/tree/src/persisted-types/0.1.1.ts
@@ -2,7 +2,9 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { assert, assertNotUndefined, ReplaceRecursive } from '../Common';
+
+import { assert } from '@fluidframework/common-utils';
+import { assertNotUndefined, ReplaceRecursive } from '../Common';
 // These are re-exported from a persisted-types file.
 import type {
 	IdCreationRange,
@@ -417,9 +419,14 @@ export const StableRangeInternal = {
 	from: (start: StablePlaceInternal): { to: (end: StablePlaceInternal) => StableRangeInternal } => ({
 		to: (end: StablePlaceInternal): StableRangeInternal => {
 			if (start.referenceTrait && end.referenceTrait) {
-				const message = 'StableRange must be constructed with endpoints from the same trait';
-				assert(start.referenceTrait.parent === end.referenceTrait.parent, message);
-				assert(start.referenceTrait.label === end.referenceTrait.label, message);
+				assert(
+					start.referenceTrait.parent === end.referenceTrait.parent,
+					'StableRange must be constructed with endpoints from the same trait'
+				);
+				assert(
+					start.referenceTrait.label === end.referenceTrait.label,
+					'StableRange must be constructed with endpoints from the same trait'
+				);
 			}
 			return { start, end };
 		},

--- a/experimental/dds/tree/src/test/Forest.perf.tests.ts
+++ b/experimental/dds/tree/src/test/Forest.perf.tests.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from 'assert';
 import { benchmark, BenchmarkType, isInPerformanceTestingMode } from '@fluid-tools/benchmark';
 import { v4 } from 'uuid';
 
-import { assert } from '../Common';
 import { Definition, NodeId, TraitLabel } from '../Identifiers';
 import { Forest, ForestNode } from '../Forest';
 import { RevisionView } from '../RevisionView';

--- a/experimental/dds/tree/src/test/IdCompressor.tests.ts
+++ b/experimental/dds/tree/src/test/IdCompressor.tests.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { v4, v5 } from 'uuid';
 import { MockLogger } from '@fluidframework/telemetry-utils';
 import { take } from '@fluid-internal/stochastic-test-utils';
@@ -22,7 +22,7 @@ import {
 	SessionId,
 	StableId,
 } from '../Identifiers';
-import { assert, assertNotUndefined, fail } from '../Common';
+import { assertNotUndefined, fail } from '../Common';
 import {
 	createSessionId,
 	incrementUuid,

--- a/experimental/dds/tree/src/test/LogViewer.tests.ts
+++ b/experimental/dds/tree/src/test/LogViewer.tests.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from 'assert';
 import { expect } from 'chai';
 import { v4 as uuidv4 } from 'uuid';
 import { EditLog } from '../EditLog';
@@ -15,7 +16,7 @@ import {
 	SequencedEditResultCallback,
 } from '../LogViewer';
 import { EditId } from '../Identifiers';
-import { assert, copyPropertyIfDefined, fail } from '../Common';
+import { copyPropertyIfDefined, fail } from '../Common';
 import { initialTree } from '../InitialTree';
 import {
 	ChangeInternal,

--- a/experimental/dds/tree/src/test/SessionIdNormalizer.tests.ts
+++ b/experimental/dds/tree/src/test/SessionIdNormalizer.tests.ts
@@ -4,7 +4,7 @@
  */
 
 import { benchmark, BenchmarkType } from '@fluid-tools/benchmark';
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 import {
 	BaseFuzzTestState,
 	chain,
@@ -16,7 +16,7 @@ import {
 	take,
 	makeRandom,
 } from '@fluid-internal/stochastic-test-utils';
-import { assert, fail } from '../Common';
+import { fail } from '../Common';
 import { isFinalId, isLocalId } from '../id-compressor';
 import { SessionIdNormalizer } from '../id-compressor/SessionIdNormalizer';
 import { FinalCompressedId, LocalCompressedId, SessionSpaceCompressedId } from '../Identifiers';

--- a/experimental/dds/tree/src/test/SharedTree.perf.tests.ts
+++ b/experimental/dds/tree/src/test/SharedTree.perf.tests.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from 'assert';
 import { benchmark, BenchmarkType } from '@fluid-tools/benchmark';
 import { MockContainerRuntimeFactory } from '@fluidframework/test-runtime-utils';
-import { assert } from '../Common';
 import { EditLog } from '../EditLog';
 import { SharedTree } from '../SharedTree';
 import { runSummaryLoadPerfTests } from './utilities/SummaryLoadPerfTests';

--- a/experimental/dds/tree/src/test/Summary.tests.ts
+++ b/experimental/dds/tree/src/test/Summary.tests.ts
@@ -4,10 +4,10 @@
  */
 import * as fs from 'fs';
 import { join } from 'path';
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 import { v5 } from 'uuid';
 import { Change, StablePlace, StableRange } from '../ChangeTypes';
-import { assert, fail, RecursiveMutable } from '../Common';
+import { fail, RecursiveMutable } from '../Common';
 import { areRevisionViewsSemanticallyEqual } from '../EditUtilities';
 import { EditId, NodeId, SessionId, StableId, TraitLabel } from '../Identifiers';
 import { initialTree } from '../InitialTree';

--- a/experimental/dds/tree/src/test/TransactionInternal.tests.ts
+++ b/experimental/dds/tree/src/test/TransactionInternal.tests.ts
@@ -3,9 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 import { DetachedSequenceId, NodeId, TraitLabel } from '../Identifiers';
-import { assert } from '../Common';
 import { getChangeNodeFromViewNode } from '../SerializationUtilities';
 import { GenericTransaction, TransactionInternal } from '../TransactionInternal';
 import {

--- a/experimental/dds/tree/src/test/TreeCompression.tests.ts
+++ b/experimental/dds/tree/src/test/TreeCompression.tests.ts
@@ -3,9 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 import { v4 as uuidv4 } from 'uuid';
-import { assert } from '../Common';
 import { walkTree } from '../EditUtilities';
 import { createSessionId, IdCompressor, isFinalId, isLocalId } from '../id-compressor';
 import {

--- a/experimental/dds/tree/src/test/utilities/IdCompressorTestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/IdCompressorTestUtilities.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable no-bitwise */
 
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 import {
 	Generator,
 	createWeightedGenerator,
@@ -18,7 +18,7 @@ import {
 	BaseFuzzTestState,
 } from '@fluid-internal/stochastic-test-utils';
 import { ITelemetryLogger } from '@fluidframework/common-definitions';
-import { assert, assertNotUndefined, ClosedMap, fail, getOrCreate } from '../../Common';
+import { assertNotUndefined, ClosedMap, fail, getOrCreate } from '../../Common';
 import { IdCompressor, isLocalId } from '../../id-compressor/IdCompressor';
 import {
 	createSessionId,

--- a/experimental/dds/tree/src/test/utilities/TestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/TestUtilities.ts
@@ -4,6 +4,7 @@
  */
 
 import { resolve } from 'path';
+import { assert } from '@fluidframework/common-utils';
 import { v5 as uuidv5 } from 'uuid';
 import { expect } from 'chai';
 import { LocalServerTestDriver } from '@fluid-internal/test-drivers';
@@ -40,7 +41,7 @@ import {
 	SessionId,
 	StableNodeId,
 } from '../../Identifiers';
-import { assert, fail, identity, ReplaceRecursive } from '../../Common';
+import { fail, identity, ReplaceRecursive } from '../../Common';
 import { IdCompressor } from '../../id-compressor';
 import { createSessionId } from '../../id-compressor/NumericUuid';
 import { getChangeNodeFromViewNode } from '../../SerializationUtilities';


### PR DESCRIPTION
## Description

Before this change, the `experimental` directory was not processed by assert tagging.

This change fixes several issues that prevent assert tagging for working on `experimental`.

A future run of assert tagging will do the actual tagging for the experimental directory.

There are two main issues this fixed:
- experimental/dds/attributable-map/src/mapKernel.ts had short codes which collided with those in packages/dds/map/src/mapKernel.ts
- experimental/dds/tree had its own `assert` method with a signature that did not work with tagging. It has been renamed to `assertWithMessage` and usages have either been ported to a different assert, or moved to the renamed assertWithMessage.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

