### PR TITLE
Log the sequence number the runtime loads from

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1412,6 +1412,7 @@ export class ContainerRuntime
 			eventName: "ContainerLoadStats",
 			...this.createContainerMetadata,
 			...this.dataStores.containerLoadStats,
+			dmInitialSeqNumber: this.deltaManager.initialSequenceNumber,
 			summaryNumber: loadSummaryNumber,
 			summaryFormatVersion: metadata?.summaryFormatVersion,
 			disableIsolatedChannels: metadata?.disableIsolatedChannels,


### PR DESCRIPTION
Investigating a summary bug, we were struggling to figure out the sequence number the summarizer loaded from. This will help us with that information.