### PR TITLE
R11s: Simplify and share throttle config helpers

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -70,108 +70,20 @@ data:
             "enableConnectionCountLogging": {{ .Values.alfred.enableConnectionCountLogging }},
             "throttling": {
                 "restCallsPerTenant": {
-                    "generalRestCall": {
-                        "maxPerMs": {{ .Values.alfred.throttling.restCallsPerTenant.generalRestCall.maxPerMs }},
-                        "maxBurst": {{ .Values.alfred.throttling.restCallsPerTenant.generalRestCall.maxBurst }},
-                        "minCooldownIntervalInMs": {{ .Values.alfred.throttling.restCallsPerTenant.generalRestCall.minCooldownIntervalInMs }},
-                        "minThrottleIntervalInMs": {{ .Values.alfred.throttling.restCallsPerTenant.generalRestCall.minThrottleIntervalInMs }},
-                        "maxInMemoryCacheSize": {{ .Values.alfred.throttling.restCallsPerTenant.generalRestCall.maxInMemoryCacheSize }},
-                        "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.restCallsPerTenant.generalRestCall.maxInMemoryCacheAgeInMs }},
-                        "enableEnhancedTelemetry": {{ .Values.alfred.throttling.restCallsPerTenant.generalRestCall.enableEnhancedTelemetry }}
-                    },
-                    "createDoc": {
-                        "maxPerMs": {{ .Values.alfred.throttling.restCallsPerTenant.createDoc.maxPerMs }},
-                        "maxBurst": {{ .Values.alfred.throttling.restCallsPerTenant.createDoc.maxBurst }},
-                        "minCooldownIntervalInMs": {{ .Values.alfred.throttling.restCallsPerTenant.createDoc.minCooldownIntervalInMs }},
-                        "minThrottleIntervalInMs": {{ .Values.alfred.throttling.restCallsPerTenant.createDoc.minThrottleIntervalInMs }},
-                        "maxInMemoryCacheSize": {{ .Values.alfred.throttling.restCallsPerTenant.createDoc.maxInMemoryCacheSize }},
-                        "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.restCallsPerTenant.createDoc.maxInMemoryCacheAgeInMs }},
-                        "enableEnhancedTelemetry": {{ .Values.alfred.throttling.restCallsPerTenant.createDoc.enableEnhancedTelemetry }}
-                    },
-                    "getDeltas": {
-                        "maxPerMs": {{ .Values.alfred.throttling.restCallsPerTenant.getDeltas.maxPerMs }},
-                        "maxBurst": {{ .Values.alfred.throttling.restCallsPerTenant.getDeltas.maxBurst }},
-                        "minCooldownIntervalInMs": {{ .Values.alfred.throttling.restCallsPerTenant.getDeltas.minCooldownIntervalInMs }},
-                        "minThrottleIntervalInMs": {{ .Values.alfred.throttling.restCallsPerTenant.getDeltas.minThrottleIntervalInMs }},
-                        "maxInMemoryCacheSize": {{ .Values.alfred.throttling.restCallsPerTenant.getDeltas.maxInMemoryCacheSize }},
-                        "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.restCallsPerTenant.getDeltas.maxInMemoryCacheAgeInMs }},
-                        "enableEnhancedTelemetry": {{ .Values.alfred.throttling.restCallsPerTenant.getDeltas.enableEnhancedTelemetry }}
-                    },
-                    "getSession": {
-                        "maxPerMs": {{ .Values.alfred.throttling.restCallsPerTenant.getSession.maxPerMs }},
-                        "maxBurst": {{ .Values.alfred.throttling.restCallsPerTenant.getSession.maxBurst }},
-                        "minCooldownIntervalInMs": {{ .Values.alfred.throttling.restCallsPerTenant.getSession.minCooldownIntervalInMs }},
-                        "minThrottleIntervalInMs": {{ .Values.alfred.throttling.restCallsPerTenant.getSession.minThrottleIntervalInMs }},
-                        "maxInMemoryCacheSize": {{ .Values.alfred.throttling.restCallsPerTenant.getSession.maxInMemoryCacheSize }},
-                        "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.restCallsPerTenant.getSession.maxInMemoryCacheAgeInMs }},
-                        "enableEnhancedTelemetry": {{ .Values.alfred.throttling.restCallsPerTenant.getSession.enableEnhancedTelemetry }}
-                    }
+                    "generalRestCall": {{ toJson .Values.alfred.throttling.restCallsPerTenant.generalRestCall }},
+                    "createDoc": {{ toJson .Values.alfred.throttling.restCallsPerTenant.createDoc }},
+                    "getDeltas": {{ toJson .Values.alfred.throttling.restCallsPerTenant.getDeltas }},
+                    "getSession": {{ toJson .Values.alfred.throttling.restCallsPerTenant.getSession }}}
                 },
                 "restCallsPerCluster": {
-                    "createDoc": {
-                        "maxPerMs": {{ .Values.alfred.throttling.restCallsPerCluster.createDoc.maxPerMs }},
-                        "maxBurst": {{ .Values.alfred.throttling.restCallsPerCluster.createDoc.maxBurst }},
-                        "minCooldownIntervalInMs": {{ .Values.alfred.throttling.restCallsPerCluster.createDoc.minCooldownIntervalInMs }},
-                        "minThrottleIntervalInMs": {{ .Values.alfred.throttling.restCallsPerCluster.createDoc.minThrottleIntervalInMs }},
-                        "maxInMemoryCacheSize": {{ .Values.alfred.throttling.restCallsPerCluster.createDoc.maxInMemoryCacheSize }},
-                        "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.restCallsPerCluster.createDoc.maxInMemoryCacheAgeInMs }},
-                        "enableEnhancedTelemetry": {{ .Values.alfred.throttling.restCallsPerCluster.createDoc.enableEnhancedTelemetry }}
-                    },
-                    "getDeltas": {
-                        "maxPerMs": {{ .Values.alfred.throttling.restCallsPerCluster.getDeltas.maxPerMs }},
-                        "maxBurst": {{ .Values.alfred.throttling.restCallsPerCluster.getDeltas.maxBurst }},
-                        "minCooldownIntervalInMs": {{ .Values.alfred.throttling.restCallsPerCluster.getDeltas.minCooldownIntervalInMs }},
-                        "minThrottleIntervalInMs": {{ .Values.alfred.throttling.restCallsPerCluster.getDeltas.minThrottleIntervalInMs }},
-                        "maxInMemoryCacheSize": {{ .Values.alfred.throttling.restCallsPerCluster.getDeltas.maxInMemoryCacheSize }},
-                        "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.restCallsPerCluster.getDeltas.maxInMemoryCacheAgeInMs }},
-                        "enableEnhancedTelemetry": {{ .Values.alfred.throttling.restCallsPerCluster.getDeltas.enableEnhancedTelemetry }}
-                    },
-                    "getSession": {
-                        "maxPerMs": {{ .Values.alfred.throttling.restCallsPerCluster.getSession.maxPerMs }},
-                        "maxBurst": {{ .Values.alfred.throttling.restCallsPerCluster.getSession.maxBurst }},
-                        "minCooldownIntervalInMs": {{ .Values.alfred.throttling.restCallsPerCluster.getSession.minCooldownIntervalInMs }},
-                        "minThrottleIntervalInMs": {{ .Values.alfred.throttling.restCallsPerCluster.getSession.minThrottleIntervalInMs }},
-                        "maxInMemoryCacheSize": {{ .Values.alfred.throttling.restCallsPerCluster.getSession.maxInMemoryCacheSize }},
-                        "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.restCallsPerCluster.getSession.maxInMemoryCacheAgeInMs }},
-                        "enableEnhancedTelemetry": {{ .Values.alfred.throttling.restCallsPerCluster.getSession.enableEnhancedTelemetry }}
-                    }
+                    "createDoc": {{ toJson .Values.alfred.throttling.restCallsPerCluster.createDoc }},
+                    "getDeltas": {{ toJson .Values.alfred.throttling.restCallsPerCluster.getDeltas }},
+                    "getSession": {{ toJson .Values.alfred.throttling.restCallsPerCluster.getSession }}}
                 },
-                "socketConnectionsPerTenant": {
-                    "maxPerMs": {{ .Values.alfred.throttling.socketConnectionsPerTenant.maxPerMs }},
-                    "maxBurst": {{ .Values.alfred.throttling.socketConnectionsPerTenant.maxBurst }},
-                    "minCooldownIntervalInMs": {{ .Values.alfred.throttling.socketConnectionsPerTenant.minCooldownIntervalInMs }},
-                    "minThrottleIntervalInMs": {{ .Values.alfred.throttling.socketConnectionsPerTenant.minThrottleIntervalInMs }},
-                    "maxInMemoryCacheSize": {{ .Values.alfred.throttling.socketConnectionsPerTenant.maxInMemoryCacheSize }},
-                    "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.socketConnectionsPerTenant.maxInMemoryCacheAgeInMs }},
-                    "enableEnhancedTelemetry": {{ .Values.alfred.throttling.socketConnectionsPerTenant.enableEnhancedTelemetry }}
-                },
-                "socketConnectionsPerCluster": {
-                    "maxPerMs": {{ .Values.alfred.throttling.socketConnectionsPerCluster.maxPerMs }},
-                    "maxBurst": {{ .Values.alfred.throttling.socketConnectionsPerCluster.maxBurst }},
-                    "minCooldownIntervalInMs": {{ .Values.alfred.throttling.socketConnectionsPerCluster.minCooldownIntervalInMs }},
-                    "minThrottleIntervalInMs": {{ .Values.alfred.throttling.socketConnectionsPerCluster.minThrottleIntervalInMs }},
-                    "maxInMemoryCacheSize": {{ .Values.alfred.throttling.socketConnectionsPerCluster.maxInMemoryCacheSize }},
-                    "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.socketConnectionsPerCluster.maxInMemoryCacheAgeInMs }},
-                    "enableEnhancedTelemetry": {{ .Values.alfred.throttling.socketConnectionsPerCluster.enableEnhancedTelemetry }}
-                },
-                "submitOps": {
-                    "maxPerMs": {{ .Values.alfred.throttling.submitOps.maxPerMs }},
-                    "maxBurst": {{ .Values.alfred.throttling.submitOps.maxBurst }},
-                    "minCooldownIntervalInMs": {{ .Values.alfred.throttling.submitOps.minCooldownIntervalInMs }},
-                    "minThrottleIntervalInMs": {{ .Values.alfred.throttling.submitOps.minThrottleIntervalInMs }},
-                    "maxInMemoryCacheSize": {{ .Values.alfred.throttling.submitOps.maxInMemoryCacheSize }},
-                    "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.submitOps.maxInMemoryCacheAgeInMs }},
-                    "enableEnhancedTelemetry": {{ .Values.alfred.throttling.submitOps.enableEnhancedTelemetry }}
-                },
-                "submitSignal": {
-                    "maxPerMs": {{ .Values.alfred.throttling.submitSignal.maxPerMs }},
-                    "maxBurst": {{ .Values.alfred.throttling.submitSignal.maxBurst }},
-                    "minCooldownIntervalInMs": {{ .Values.alfred.throttling.submitSignal.minCooldownIntervalInMs }},
-                    "minThrottleIntervalInMs": {{ .Values.alfred.throttling.submitSignal.minThrottleIntervalInMs }},
-                    "maxInMemoryCacheSize": {{ .Values.alfred.throttling.submitSignal.maxInMemoryCacheSize }},
-                    "maxInMemoryCacheAgeInMs": {{ .Values.alfred.throttling.submitSignal.maxInMemoryCacheAgeInMs }},
-                    "enableEnhancedTelemetry": {{ .Values.alfred.throttling.submitSignal.enableEnhancedTelemetry }}
-                }
+                "socketConnectionsPerTenant": {{ toJson .Values.alfred.throttling.socketConnectionsPerTenant }},
+                "socketConnectionsPerCluster": {{ toJson .Values.alfred.throttling.socketConnectionsPerCluster }},
+                "submitOps": {{ toJson .Values.alfred.throttling.submitOps }},
+                "submitSignal": {{ toJson .Values.alfred.throttling.submitSignal }}}
             },
             "topic": "{{ .Values.kafka.topics.rawdeltas }}",
             "bucket": "snapshots",

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -29,54 +29,14 @@ alfred:
         maxInMemoryCacheAgeInMs: 60000
         enableEnhancedTelemetry: false
     restCallsPerCluster:
-        createDoc:
-            maxPerMs: 1000000
-            maxBurst: 1000000
-            minCooldownIntervalInMs: 1000000
-            minThrottleIntervalInMs: 1000000
-            maxInMemoryCacheSize: 1000
-            maxInMemoryCacheAgeInMs: 60000
-            enableEnhancedTelemetry: false
-        getDeltas:
-            maxPerMs: 1000000
-            maxBurst: 1000000
-            minCooldownIntervalInMs: 1000000
-            minThrottleIntervalInMs: 1000000
-            maxInMemoryCacheSize: 1000
-            maxInMemoryCacheAgeInMs: 60000
-            enableEnhancedTelemetry: false
-    socketConnectionsPerTenant:
-        maxPerMs: 1000000
-        maxBurst: 1000000
-        minCooldownIntervalInMs: 1000000
-        minThrottleIntervalInMs: 1000000
-        maxInMemoryCacheSize: 1000
-        maxInMemoryCacheAgeInMs: 60000
-        enableEnhancedTelemetry: false
-    socketConnectionsPerCluster:
-        maxPerMs: 1000000
-        maxBurst: 1000000
-        minCooldownIntervalInMs: 1000000
-        minThrottleIntervalInMs: 1000000
-        maxInMemoryCacheSize: 1000
-        maxInMemoryCacheAgeInMs: 60000
-        enableEnhancedTelemetry: false
-    submitOps:
-        maxPerMs: 1000000
-        maxBurst: 1000000
-        minCooldownIntervalInMs: 1000000
-        minThrottleIntervalInMs: 1000000
-        maxInMemoryCacheSize: 1000
-        maxInMemoryCacheAgeInMs: 60000
-        enableEnhancedTelemetry: false
-    submitSignal:
-        maxPerMs: 1000000
-        maxBurst: 1000000
-        minCooldownIntervalInMs: 1000000
-        minThrottleIntervalInMs: 1000000
-        maxInMemoryCacheSize: 1000
-        maxInMemoryCacheAgeInMs: 60000
-        enableEnhancedTelemetry: false
+        createDoc: 
+            maxPerInterval: 1000000
+            intervalInMs: 1000000
+        getDeltas: disabled
+    socketConnectionsPerTenant: disabled
+    socketConnectionsPerCluster: disabled
+    submitOps: disabled
+    submitSignal: disabled
   socketIoAdapter:
     enableCustomSocketIoAdapter: true
     shouldDisableDefaultNamespace: false

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -254,16 +254,9 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 				redisParamsForThrottling,
 			);
 
-		interface IThrottleConfig {
-			maxPerMs: number;
-			maxBurst: number;
-			minCooldownIntervalInMs: number;
-			minThrottleIntervalInMs: number;
-			maxInMemoryCacheSize: number;
-			maxInMemoryCacheAgeInMs: number;
-			enableEnhancedTelemetry?: boolean;
-		}
-		const configureThrottler = (throttleConfig: Partial<IThrottleConfig>): core.IThrottler => {
+		const configureThrottler = (
+			throttleConfig: Partial<utils.IThrottleConfig>,
+		): core.IThrottler => {
 			const throttlerHelper = new services.ThrottlerHelper(
 				redisThrottleAndUsageStorageManager,
 				throttleConfig.maxPerMs,
@@ -280,25 +273,29 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 			);
 		};
 
-		// Rest API Throttler
-		const restApiTenantThrottleConfig: Partial<IThrottleConfig> =
-			config.get("alfred:throttling:restCallsPerTenant:generalRestCall") ?? {};
+		// Per-tenant Rest API Throttlers
+		const restApiTenantThrottleConfig = utils.getThrottleConfig(
+			config.get("alfred:throttling:restCallsPerTenant:generalRestCall"),
+		);
 		const restTenantThrottler = configureThrottler(restApiTenantThrottleConfig);
 
-		const restApiTenantCreateDocThrottleConfig: Partial<IThrottleConfig> =
-			config.get("alfred:throttling:restCallsPerTenant:createDoc") ?? {};
+		const restApiTenantCreateDocThrottleConfig = utils.getThrottleConfig(
+			config.get("alfred:throttling:restCallsPerTenant:createDoc"),
+		);
 		const restTenantCreateDocThrottler = configureThrottler(
 			restApiTenantCreateDocThrottleConfig,
 		);
 
-		const restApiTenantGetDeltasThrottleConfig: Partial<IThrottleConfig> =
-			config.get("alfred:throttling:restCallsPerTenant:getDeltas") ?? {};
+		const restApiTenantGetDeltasThrottleConfig = utils.getThrottleConfig(
+			config.get("alfred:throttling:restCallsPerTenant:getDeltas"),
+		);
 		const restTenantGetDeltasThrottler = configureThrottler(
 			restApiTenantGetDeltasThrottleConfig,
 		);
 
-		const restApiTenantGetSessionThrottleConfig: Partial<IThrottleConfig> =
-			config.get("alfred:throttling:restCallsPerTenant:getSession") ?? {};
+		const restApiTenantGetSessionThrottleConfig = utils.getThrottleConfig(
+			config.get("alfred:throttling:restCallsPerTenant:getSession"),
+		);
 		const restTenantGetSessionThrottler = configureThrottler(
 			restApiTenantGetSessionThrottleConfig,
 		);
@@ -312,16 +309,20 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 		);
 		restTenantThrottlers.set(Constants.generalRestCallThrottleIdPrefix, restTenantThrottler);
 
-		const restApiCreateDocThrottleConfig: Partial<IThrottleConfig> =
-			config.get("alfred:throttling:restCallsPerCluster:createDoc") ?? {};
+		// Per-cluster Rest API Throttlers
+		const restApiCreateDocThrottleConfig = utils.getThrottleConfig(
+			config.get("alfred:throttling:restCallsPerCluster:createDoc"),
+		);
 		const restCreateDocThrottler = configureThrottler(restApiCreateDocThrottleConfig);
 
-		const restApiGetDeltasThrottleConfig: Partial<IThrottleConfig> =
-			config.get("alfred:throttling:restCallsPerCluster:getDeltas") ?? {};
+		const restApiGetDeltasThrottleConfig = utils.getThrottleConfig(
+			config.get("alfred:throttling:restCallsPerCluster:getDeltas"),
+		);
 		const restGetDeltasThrottler = configureThrottler(restApiGetDeltasThrottleConfig);
 
-		const restApiGetSessionThrottleConfig: Partial<IThrottleConfig> =
-			config.get("alfred:throttling:restCallsPerCluster:getSession") ?? {};
+		const restApiGetSessionThrottleConfig = utils.getThrottleConfig(
+			config.get("alfred:throttling:restCallsPerCluster:getSession"),
+		);
 		const restGetSessionThrottler = configureThrottler(restApiGetSessionThrottleConfig);
 
 		const restClusterThrottlers = new Map<string, core.IThrottler>();
@@ -330,26 +331,30 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 		restClusterThrottlers.set(Constants.getSessionThrottleIdPrefix, restGetSessionThrottler);
 
 		// Socket Connection Throttler
-		const socketConnectionThrottleConfigPerTenant: Partial<IThrottleConfig> =
-			config.get("alfred:throttling:socketConnectionsPerTenant") ?? {};
+		const socketConnectionThrottleConfigPerTenant = utils.getThrottleConfig(
+			config.get("alfred:throttling:socketConnectionsPerTenant"),
+		);
 		const socketConnectTenantThrottler = configureThrottler(
 			socketConnectionThrottleConfigPerTenant,
 		);
 
-		const socketConnectionThrottleConfigPerCluster: Partial<IThrottleConfig> =
-			config.get("alfred:throttling:socketConnectionsPerCluster") ?? {};
+		const socketConnectionThrottleConfigPerCluster = utils.getThrottleConfig(
+			config.get("alfred:throttling:socketConnectionsPerCluster"),
+		);
 		const socketConnectClusterThrottler = configureThrottler(
 			socketConnectionThrottleConfigPerCluster,
 		);
 
 		// Socket SubmitOp Throttler
-		const submitOpThrottleConfig: Partial<IThrottleConfig> =
-			config.get("alfred:throttling:submitOps") ?? {};
+		const submitOpThrottleConfig = utils.getThrottleConfig(
+			config.get("alfred:throttling:submitOps"),
+		);
 		const socketSubmitOpThrottler = configureThrottler(submitOpThrottleConfig);
 
 		// Socket SubmitSignal Throttler
-		const submitSignalThrottleConfig: Partial<IThrottleConfig> =
-			config.get("alfred:throttling:submitSignals") ?? {};
+		const submitSignalThrottleConfig = utils.getThrottleConfig(
+			config.get("alfred:throttling:submitSignals"),
+		);
 		const socketSubmitSignalThrottler = configureThrottler(submitSignalThrottleConfig);
 		const documentRepository =
 			customizations?.documentRepository ??

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -60,108 +60,20 @@
 		"enableConnectionCountLogging": false,
 		"throttling": {
 			"restCallsPerTenant": {
-				"generalRestCall": {
-					"maxPerMs": 1000000,
-					"maxBurst": 1000000,
-					"minCooldownIntervalInMs": 1000000,
-					"minThrottleIntervalInMs": 1000000,
-					"maxInMemoryCacheSize": 1000,
-					"maxInMemoryCacheAgeInMs": 60000,
-					"enableEnhancedTelemetry": false
-				},
-				"createDoc": {
-					"maxPerMs": 1000000,
-					"maxBurst": 1000000,
-					"minCooldownIntervalInMs": 1000000,
-					"minThrottleIntervalInMs": 1000000,
-					"maxInMemoryCacheSize": 1000,
-					"maxInMemoryCacheAgeInMs": 60000,
-					"enableEnhancedTelemetry": false
-				},
-				"getDeltas": {
-					"maxPerMs": 1000000,
-					"maxBurst": 1000000,
-					"minCooldownIntervalInMs": 1000000,
-					"minThrottleIntervalInMs": 1000000,
-					"maxInMemoryCacheSize": 1000,
-					"maxInMemoryCacheAgeInMs": 60000,
-					"enableEnhancedTelemetry": false
-				},
-				"getSession": {
-					"maxPerMs": 1000000,
-					"maxBurst": 1000000,
-					"minCooldownIntervalInMs": 1000000,
-					"minThrottleIntervalInMs": 1000000,
-					"maxInMemoryCacheSize": 1000,
-					"maxInMemoryCacheAgeInMs": 60000,
-					"enableEnhancedTelemetry": false
-				}
+				"generalRestCall": "disabled",
+				"createDoc": "disabled",
+				"getDeltas": "disabled",
+				"getSession": "disabled"
 			},
 			"restCallsPerCluster": {
-				"createDoc": {
-					"maxPerMs": 1000000,
-					"maxBurst": 1000000,
-					"minCooldownIntervalInMs": 1000000,
-					"minThrottleIntervalInMs": 1000000,
-					"maxInMemoryCacheSize": 1000,
-					"maxInMemoryCacheAgeInMs": 60000,
-					"enableEnhancedTelemetry": false
-				},
-				"getDeltas": {
-					"maxPerMs": 1000000,
-					"maxBurst": 1000000,
-					"minCooldownIntervalInMs": 1000000,
-					"minThrottleIntervalInMs": 1000000,
-					"maxInMemoryCacheSize": 1000,
-					"maxInMemoryCacheAgeInMs": 60000,
-					"enableEnhancedTelemetry": false
-				},
-				"getSession": {
-					"maxPerMs": 1000000,
-					"maxBurst": 1000000,
-					"minCooldownIntervalInMs": 1000000,
-					"minThrottleIntervalInMs": 1000000,
-					"maxInMemoryCacheSize": 1000,
-					"maxInMemoryCacheAgeInMs": 60000,
-					"enableEnhancedTelemetry": false
-				}
+				"createDoc": "disabled",
+				"getDeltas": "disabled",
+				"getSession": "disabled"
 			},
-			"socketConnectionsPerTenant": {
-				"maxPerMs": 1000000,
-				"maxBurst": 1000000,
-				"minCooldownIntervalInMs": 1000000,
-				"minThrottleIntervalInMs": 1000000,
-				"maxInMemoryCacheSize": 1000,
-				"maxInMemoryCacheAgeInMs": 60000,
-				"enableEnhancedTelemetry": false
-			},
-			"socketConnectionsPerCluster": {
-				"maxPerMs": 1000000,
-				"maxBurst": 1000000,
-				"minCooldownIntervalInMs": 1000000,
-				"minThrottleIntervalInMs": 1000000,
-				"maxInMemoryCacheSize": 1000,
-				"maxInMemoryCacheAgeInMs": 60000,
-				"enableEnhancedTelemetry": false
-			},
-			"submitOps": {
-				"maxPerMs": 1000000,
-				"maxBurst": 1000000,
-				"minCooldownIntervalInMs": 1000000,
-				"minThrottleIntervalInMs": 1000000,
-				"maxInMemoryCacheSize": 1000,
-				"maxInMemoryCacheAgeInMs": 60000,
-				"enableEnhancedTelemetry": false
-			},
-			"submitSignal": {
-				"maxPerMs": 1000000,
-				"maxBurst": 1000000,
-				"minCooldownIntervalInMs": 1000000,
-				"minThrottleIntervalInMs": 1000000,
-				"maxInMemoryCacheSize": 1000,
-				"maxInMemoryCacheAgeInMs": 60000,
-				"enableEnhancedTelemetry": false
-			}
+			"socketConnectionsPerTenant": "disabled",
+			"socketConnectionsPerCluster": "disabled",
+			"submitOps": "disabled",
+			"submitSignal": "disabled"
 		},
 		"topic": "rawdeltas",
 		"bucket": "snapshots",

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -36,6 +36,7 @@ export {
 	executeRedisMultiWithHmsetExpireAndLpush,
 	IRedisParameters,
 } from "./redisUtils";
+export { IThrottleConfig, ISimpleThrottleConfig, getThrottleConfig } from "./throttlerConfigs";
 export { IThrottleMiddlewareOptions, throttle } from "./throttlerMiddleware";
 export { WinstonLumberjackEngine } from "./winstonLumberjackEngine";
 export { WebSocketTracker, DummyTokenRevocationManager } from "./tokenRevocationManager";

--- a/server/routerlicious/packages/services-utils/src/test/throttlerConfigs.spec.ts
+++ b/server/routerlicious/packages/services-utils/src/test/throttlerConfigs.spec.ts
@@ -1,0 +1,147 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+import {
+	ISimpleThrottleConfig,
+	IThrottleConfig,
+	disabledThrottleConfig,
+	getThrottleConfig,
+} from "../throttlerConfigs";
+
+describe("Throttler Configs", () => {
+	it("validates safe config types", () => {
+		// invalid
+		assert.throws(() => getThrottleConfig("disable" as any));
+		assert.throws(() => getThrottleConfig(5 as any));
+		assert.throws(() => getThrottleConfig(true as any));
+		assert.throws(() => getThrottleConfig(false as any));
+		assert.throws(() => getThrottleConfig([{}] as any));
+		// valid
+		assert.doesNotThrow(() => getThrottleConfig({ maxPerInterval: 0, intervalInMs: 0 }));
+		assert.doesNotThrow(() => getThrottleConfig({ maxPerMs: 100 }));
+		assert.doesNotThrow(() => getThrottleConfig({}));
+		assert.doesNotThrow(() => getThrottleConfig("disabled"));
+	});
+
+	it("handles disabled", () => {
+		assert.deepStrictEqual(getThrottleConfig("disabled"), disabledThrottleConfig);
+	});
+
+	it("passes along partial configs", () => {
+		const partialConfig1: Partial<IThrottleConfig> = {};
+		assert.deepStrictEqual(getThrottleConfig(partialConfig1), partialConfig1);
+		const partialConfig2: Partial<IThrottleConfig> = {
+			maxPerMs: 100,
+		};
+		assert.deepStrictEqual(getThrottleConfig(partialConfig2), partialConfig2);
+		const partialConfig3: Partial<IThrottleConfig> = {
+			maxPerMs: 50,
+			maxBurst: 2000,
+			minCooldownIntervalInMs: 30000,
+		};
+		assert.deepStrictEqual(getThrottleConfig(partialConfig3), partialConfig3);
+		const partialConfig4: Partial<IThrottleConfig> = {
+			enableEnhancedTelemetry: true,
+		};
+		assert.deepStrictEqual(getThrottleConfig(partialConfig4), partialConfig4);
+	});
+
+	it("expands simplified configs", () => {
+		const simpleConfig1: ISimpleThrottleConfig = {
+			maxPerInterval: 3_000,
+			intervalInMs: 30_000,
+		};
+		const expandedConfig1: IThrottleConfig = {
+			maxPerMs: 0.1,
+			maxBurst: 3_000,
+			minCooldownIntervalInMs: 30_000,
+			minThrottleIntervalInMs: 30_000,
+			maxInMemoryCacheSize: 1_000,
+			maxInMemoryCacheAgeInMs: 60_000,
+			enableEnhancedTelemetry: false,
+		};
+		assert.deepStrictEqual(getThrottleConfig(simpleConfig1), expandedConfig1);
+		const simpleConfig2: ISimpleThrottleConfig = {
+			maxPerInterval: 9_000,
+			intervalInMs: 30_000,
+			maxInMemoryCacheSize: 30_000,
+			maxInMemoryCacheAgeInMs: 180_000,
+		};
+		const expandedConfig2: IThrottleConfig = {
+			maxPerMs: 0.3,
+			maxBurst: 9_000,
+			minCooldownIntervalInMs: 30_000,
+			minThrottleIntervalInMs: 30_000,
+			maxInMemoryCacheSize: 30_000,
+			maxInMemoryCacheAgeInMs: 180_000,
+			enableEnhancedTelemetry: false,
+		};
+		assert.deepStrictEqual(getThrottleConfig(simpleConfig2), expandedConfig2);
+		const simpleConfig3: ISimpleThrottleConfig = {
+			maxPerInterval: 1_500,
+			intervalInMs: 30_000,
+		};
+		const expandedConfig3: IThrottleConfig = {
+			maxPerMs: 0.05,
+			maxBurst: 1_500,
+			minCooldownIntervalInMs: 30_000,
+			minThrottleIntervalInMs: 30_000,
+			maxInMemoryCacheSize: 1_000,
+			maxInMemoryCacheAgeInMs: 60_000,
+			enableEnhancedTelemetry: false,
+		};
+		assert.deepStrictEqual(getThrottleConfig(simpleConfig3), expandedConfig3);
+		const simpleConfig4: ISimpleThrottleConfig = {
+			maxPerInterval: 10_000,
+			intervalInMs: 5_000,
+		};
+		const expandedConfig4: IThrottleConfig = {
+			maxPerMs: 2,
+			maxBurst: 10_000,
+			minCooldownIntervalInMs: 5_000,
+			minThrottleIntervalInMs: 5_000,
+			maxInMemoryCacheSize: 1_000,
+			maxInMemoryCacheAgeInMs: 10_000,
+			enableEnhancedTelemetry: false,
+		};
+		assert.deepStrictEqual(getThrottleConfig(simpleConfig4), expandedConfig4);
+	});
+
+	it("expands and overrides simplified configs", () => {
+		const simpleConfig1: ISimpleThrottleConfig = {
+			maxPerInterval: 3_000,
+			intervalInMs: 30_000,
+			maxPerMs: 5,
+		};
+		const expandedConfig1: IThrottleConfig = {
+			maxPerMs: 5,
+			maxBurst: 3_000,
+			minCooldownIntervalInMs: 30_000,
+			minThrottleIntervalInMs: 30_000,
+			maxInMemoryCacheSize: 1_000,
+			maxInMemoryCacheAgeInMs: 60_000,
+			enableEnhancedTelemetry: false,
+		};
+		assert.deepStrictEqual(getThrottleConfig(simpleConfig1), expandedConfig1);
+		const simpleConfig2: ISimpleThrottleConfig = {
+			maxPerInterval: 9_000,
+			intervalInMs: 30_000,
+			maxInMemoryCacheSize: 30_000,
+			maxInMemoryCacheAgeInMs: 180_000,
+			minThrottleIntervalInMs: 140_000,
+		};
+		const expandedConfig2: IThrottleConfig = {
+			maxPerMs: 0.3,
+			maxBurst: 9_000,
+			minCooldownIntervalInMs: 30_000,
+			minThrottleIntervalInMs: 140_000,
+			maxInMemoryCacheSize: 30_000,
+			maxInMemoryCacheAgeInMs: 180_000,
+			enableEnhancedTelemetry: false,
+		};
+		assert.deepStrictEqual(getThrottleConfig(simpleConfig2), expandedConfig2);
+	});
+});

--- a/server/routerlicious/packages/services-utils/src/throttlerConfigs.ts
+++ b/server/routerlicious/packages/services-utils/src/throttlerConfigs.ts
@@ -1,0 +1,92 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import safeStringify from "json-stringify-safe";
+
+/**
+ * Standard throttler config that maps to the params for Throttler and ThrottlerHelper
+ * from `@fluidframework/server-services` package.
+ */
+export interface IThrottleConfig {
+	maxPerMs: number;
+	maxBurst: number;
+	minCooldownIntervalInMs: number;
+	minThrottleIntervalInMs: number;
+	maxInMemoryCacheSize: number;
+	maxInMemoryCacheAgeInMs: number;
+	enableEnhancedTelemetry?: boolean;
+}
+/**
+ * Simplified Throttler config that can be converted to an IThrottleConfig
+ * based on the typical inputs used to determine an IThrottleConfig.
+ * This still allows overrides for specific values, but can cut down on the
+ * human math needed for each individual throttle config.
+ *
+ * Most often, we compute ThrottleConfig based on how many events we can support in a given timeframe.
+ * The resulting config is almost always the same maths, with some variation in maxInMemoryCacheSize
+ * and maxInMemoryCacheAgeInMs depending on the need.
+ */
+export interface ISimpleThrottleConfig extends Partial<IThrottleConfig> {
+	maxPerInterval: number;
+	intervalInMs: number;
+}
+const isSimpleThrottleConfig = (obj: unknown): obj is ISimpleThrottleConfig => {
+	return (
+		typeof obj === "object" &&
+		typeof (obj as ISimpleThrottleConfig).maxPerInterval === "number" &&
+		typeof (obj as ISimpleThrottleConfig).intervalInMs === "number"
+	);
+};
+const expandSimpleThrottleConfig = ({
+	maxPerInterval,
+	intervalInMs,
+	...overrides
+}: ISimpleThrottleConfig): Partial<IThrottleConfig> => {
+	const throttleConfig: Partial<IThrottleConfig> = {
+		maxPerMs: maxPerInterval / intervalInMs,
+		maxBurst: maxPerInterval,
+		minCooldownIntervalInMs: intervalInMs,
+		minThrottleIntervalInMs: intervalInMs,
+		maxInMemoryCacheSize: 1000, // A reasonable size for most uses
+		maxInMemoryCacheAgeInMs: intervalInMs * 2,
+		enableEnhancedTelemetry: false,
+		...overrides,
+	};
+	return throttleConfig;
+};
+/**
+ * Effectively disables throttling by allowing 1,000,000 events per ms and only checking throttle every 16 min.
+ * Also, will only keep throttle value in cache at a given time to avoid unnecessary memory use.
+ */
+export const disabledThrottleConfig: IThrottleConfig = {
+	maxPerMs: 1000000,
+	maxBurst: 1000000,
+	minCooldownIntervalInMs: 1000000,
+	minThrottleIntervalInMs: 1000000,
+	maxInMemoryCacheSize: 1,
+	maxInMemoryCacheAgeInMs: 1,
+	enableEnhancedTelemetry: false,
+};
+/**
+ * Get a valid IThrottleConfig from a config file value.
+ */
+export const getThrottleConfig = (
+	configValue: ISimpleThrottleConfig | Partial<IThrottleConfig> | "disabled" | undefined,
+): Partial<IThrottleConfig> => {
+	const throttleConfigValue = configValue ?? "disabled";
+	if (
+		(typeof throttleConfigValue !== "object" || Array.isArray(throttleConfigValue)) &&
+		throttleConfigValue !== "disabled"
+	) {
+		throw new Error(`Received invalid Throttle config: ${safeStringify(configValue)}`);
+	}
+	if (throttleConfigValue === "disabled") {
+		return disabledThrottleConfig;
+	}
+	if (isSimpleThrottleConfig(throttleConfigValue)) {
+		return expandSimpleThrottleConfig(throttleConfigValue);
+	}
+	return throttleConfigValue;
+};


### PR DESCRIPTION
## Description

Currently, the configs we have to set for Throttling in R11s are usually unnecessarily complex. We can hide a lot of this complexity for the typical use-cases, while still allowing overrides for specific needs to keep the current level of flexibility and control.

### Typical Scenario

**Request:**
We can only support 10,000 HTTP requests per hour. Let's set our throttle limits accordingly.

**Dev Work Today:**
If we want to check throttling on a 30 second interval, then for 10,000 limit per hour, then we can allow `(10,000 requests / 1h) * (1h / 60min) * (1min / 60s) = 10,000 requests / 3600 seconds = 2.77 reqs/second`. So then burst is `2.77 * 30 = 83.33 reqs/30s` and then perMs is `(2.77 requests / second) * (1s / 1000ms) = 0.00277 reqs/ms` and cooldown should just equal throttle interval, and max cache age should be 2x interval duration...
```js
{
  maxPerMs: 0.00277,
  maxBurst: 83.33,
  minCooldownIntervalInMs: 30_000,
  minThrottleIntervalInMs: 30_000,
  maxInMemoryCacheSize: 1_000,
  maxInMemoryCacheAgeInMs: 60_000,
  enableEnhancedTelemetry: false,
}
```

**Dev Work Now:**
If we want to check throttling on a 30 second interval, then for 10,000 limit per hour, then we can allow `(10,000 requests / 1h) * (1h / 60min) * (1min / 60s) = 10,000 requests / 3600 seconds = 2.77 reqs/second`. So then burst is `2.77 * 30 = 83.33 reqs/30s`.
```js
{
  maxPerInterval: 83.33,
  intervalInMs: 30_000
}
```

### Notes

This only cuts out 2 of the math steps, but it will make the configs much more intuitive and maintainable, while still allowing the more fine-tuned approach we have now if needed.

## Alternative Approach

We could even further reduce the maths needed by providing 3 options for simplified config like
```ts
{
  maxPerIntervalDuration: 10_000,
  intervalDurationInMs: 3_600_000, // ms in 1 hour
  throttleCheckIntervalInMs: 30_000,
}
```
where `throttleCheckIntervalInMs` would be the `30s` from above, and then `maxPerIntervalDuration` would be relative to `intervalDurationInMs`, and then internal maths would be done to convert that to be relative to do the previously manual `a reqs / b time -> x reqs / y seconds` conversion.

I think the downside of this alternative approach is that it still has the `throttleCheckIntervalInMs` implementation detail, whereas the approach I used in this PR is more "implementation agnostic" so that we could keep these configs for different throttling implementations with a different conversion helper in the code.