### PR TITLE
Fix a bug where child summarizer node's paths are incorrectly set to parent's paths

### DIFF
--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
@@ -69,7 +69,7 @@ class SummaryNodeWithGC extends SummaryNode {
  * - Adds trackState param to summarize. If trackState is false, it bypasses the SummarizerNode and calls
  * directly into summarizeInternal method.
  */
-class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNodeWithGC {
+export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNodeWithGC {
 	// Tracks the work-in-progress used routes during summary.
 	private wipSerializedUsedRoutes: string | undefined;
 

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
@@ -536,8 +536,8 @@ class SummarizerNodeWithGC extends SummarizerNode implements IRootSummarizerNode
 						JSON.stringify(newSerializedRoutes),
 						{
 							referenceSequenceNumber: value.referenceSequenceNumber,
-							basePath: value.basePath,
-							localPath: value.localPath,
+							basePath: child.latestSummary.basePath,
+							localPath: child.latestSummary.localPath,
 						},
 					);
 					child.addPendingSummary(key, newLatestSummaryNode);

--- a/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
@@ -22,10 +22,10 @@ import { IFetchSnapshotResult } from "../summary/summarizerNode";
 import {
 	createRootSummarizerNodeWithGC,
 	IRootSummarizerNodeWithGC,
+	SummarizerNodeWithGC,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../summary/summarizerNode/summarizerNodeWithGc";
 // eslint-disable-next-line import/no-internal-modules
-import { SummaryNode } from "../summary/summarizerNode/summarizerNodeUtils";
 import { cloneGCData } from "../gc";
 
 describe("SummarizerNodeWithGC Tests", () => {
@@ -423,8 +423,12 @@ describe("SummarizerNodeWithGC Tests", () => {
 			assert(result.latestSummaryUpdated === true, "should update");
 			assert(result.wasSummaryTracked === true, "should be tracked");
 			const leafNodePath = `${ids[0]}/${ids[1]}/${ids[2]}`;
-			const leafNodeLatestSummary = (leafNode as any).latestSummary as SummaryNode;
-			assert.strictEqual(leafNodeLatestSummary.fullPath.toString(), leafNodePath);
+			const leafNodeLatestSummary = (leafNode as SummarizerNodeWithGC).latestSummary;
+			assert.strictEqual(
+				leafNodeLatestSummary?.fullPath.toString(),
+				leafNodePath,
+				"The child node's latest summary path is incorrect",
+			);
 		});
 
 		it("Should add GC pending summary node created after parent node was summarized with empty used routes", async () => {
@@ -469,8 +473,12 @@ describe("SummarizerNodeWithGC Tests", () => {
 			assert(result.latestSummaryUpdated === true, "should update");
 			assert(result.wasSummaryTracked === true, "should be tracked");
 			const leafNodePath = `${ids[0]}/${ids[1]}/${ids[2]}`;
-			const leafNodeLatestSummary = (leafNode as any).latestSummary as SummaryNode;
-			assert.strictEqual(leafNodeLatestSummary.fullPath.toString(), leafNodePath);
+			const leafNodeLatestSummary = (leafNode as SummarizerNodeWithGC).latestSummary;
+			assert.strictEqual(
+				leafNodeLatestSummary?.fullPath.toString(),
+				leafNodePath,
+				"The child node's latest summary path is incorrect",
+			);
 		});
 	});
 });

--- a/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
@@ -24,6 +24,8 @@ import {
 	IRootSummarizerNodeWithGC,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../summary/summarizerNode/summarizerNodeWithGc";
+// eslint-disable-next-line import/no-internal-modules
+import { SummaryNode } from "../summary/summarizerNode/summarizerNodeUtils";
 import { cloneGCData } from "../gc";
 
 describe("SummarizerNodeWithGC Tests", () => {
@@ -420,6 +422,9 @@ describe("SummarizerNodeWithGC Tests", () => {
 			);
 			assert(result.latestSummaryUpdated === true, "should update");
 			assert(result.wasSummaryTracked === true, "should be tracked");
+			const leafNodePath = `${ids[0]}/${ids[1]}/${ids[2]}`;
+			const leafNodeLatestSummary = (leafNode as any).latestSummary as SummaryNode;
+			assert.strictEqual(leafNodeLatestSummary.fullPath.toString(), leafNodePath);
 		});
 
 		it("Should add GC pending summary node created after parent node was summarized with empty used routes", async () => {
@@ -463,6 +468,9 @@ describe("SummarizerNodeWithGC Tests", () => {
 			);
 			assert(result.latestSummaryUpdated === true, "should update");
 			assert(result.wasSummaryTracked === true, "should be tracked");
+			const leafNodePath = `${ids[0]}/${ids[1]}/${ids[2]}`;
+			const leafNodeLatestSummary = (leafNode as any).latestSummary as SummaryNode;
+			assert.strictEqual(leafNodeLatestSummary.fullPath.toString(), leafNodePath);
 		});
 	});
 });


### PR DESCRIPTION
## Bug
When a child summarizer node is created, if a parent node has any pending summaries, it creates one for the child node as well. In [this instance](https://github.com/microsoft/FluidFramework/blob/4f62d86b9b0469a133414bb2feae8f7c929f60fb/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts#L680), the path of the parent node is incorrectly copied over to the child summarizer node.
Once this happens, if the child node does not change until the next summary, it's SummaryHandle's path will incorrectly point to the parent's summary tree from the previous summary. The summary for this node will now be corrupted. Any containers loading from this summary cannot load this node anymore.
We see this happening in production for DDSs (child node = DDS, parent node = data store).

Note that this is a rare scenario where a data store has to be realized after a summary op is submitted and before the ack is received. That's why we don't see a lot of hits for this.

[AB#4132](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4132)

## Fix
When creating pending summaries for child summarizer node, use the child's latest summary's path.