### PR TITLE
[AzureClient] Remove AzureFunctionTokenProvider from e2e tests

### DIFF
--- a/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
@@ -41,7 +41,7 @@ export function createAzureClient(
 		? {
 				tenantId,
 				tokenProvider: createAzureTokenProvider(userID ?? "foo", userName ?? "bar"),
-				endpoint: endPoint ?? "https://us.fluidrelay.azure.com",
+				endpoint: endPoint,
 				type: "remote",
 		  }
 		: {

--- a/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
@@ -33,6 +33,9 @@ export function createAzureClient(
 		name: userName ?? uuid(),
 	};
 	const endPoint = process.env.azure__fluid__relay__service__endpoint as string;
+	if (endPoint === undefined) {
+		throw new Error("Azure FRS endpoint is missing");
+	}
 
 	// use AzureClient remote mode will run against live Azure Fluid Relay.
 	// Default to running Tinylicious for PR validation

--- a/azure/packages/test/end-to-end-tests/src/test/AzureTokenFactory.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/AzureTokenFactory.ts
@@ -2,19 +2,12 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { AzureFunctionTokenProvider, ITokenProvider } from "@fluidframework/azure-client";
+import { ITokenProvider } from "@fluidframework/azure-client";
 import { InsecureTokenProvider } from "@fluidframework/test-client-utils";
 
 export function createAzureTokenProvider(userId: string, userName: string): ITokenProvider {
-	const fnUrl = process.env.azure__fluid__relay__service__function__url as string;
 	const key = process.env.azure__fluid__relay__service__key as string;
-
-	if (fnUrl) {
-		return new AzureFunctionTokenProvider(`${fnUrl}/api/GetFrsToken`, {
-			userId,
-			userName,
-		});
-	} else if (key) {
+	if (key) {
 		const userConfig = {
 			id: userId,
 			name: userName,


### PR DESCRIPTION
## Description

This PR updates AzureClient e2e tests to no longer use `AzureFunctionTokenProvider` and removes the default endpoint value.

[AB#4136](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4136)