### PR TITLE
[GC stress] Fix error codes on process.exit

### DIFF
--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -403,35 +403,6 @@ function setupTelemetry(
 		});
 		stdErrLine++;
 	});
-
-	process.on("uncaughtException", (err, origin) => {
-		console.log(`Uncaught exception: ${err}\n` + `Exception origin: ${origin}`);
-		logger.send({
-			eventName: "Runner uncaught exception",
-			testHarnessEvent: true,
-			category: "error",
-			lineNo: stdErrLine,
-			runId,
-			username,
-			error: err,
-			origin,
-		});
-		throw new Error(`Uncaught exception: ${err}\n` + `Exception origin: ${origin}`);
-	});
-
-	process.on("unhandledRejection", (reason, promise) => {
-		console.log("Unhandled Rejection at:", promise, "reason:", reason);
-		logger.send({
-			eventName: "Runner unhandled rejection",
-			testHarnessEvent: true,
-			category: "error",
-			lineNo: stdErrLine,
-			runId,
-			username,
-			reason,
-		});
-		throw new Error(`Unhandled Rejection at: ${promise}. Reason: ${reason}`);
-	});
 }
 
 main().catch((error) => {

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -34,6 +34,7 @@ import {
 	generateLoaderOptions,
 	generateRuntimeOptions,
 } from "./optionsMatrix";
+import { GcFailureExitCode } from "./testConfigFile";
 
 function printStatus(runConfig: IRunConfig, message: string) {
 	if (runConfig.verbose) {
@@ -127,7 +128,7 @@ async function main() {
 		}
 	});
 
-	let result = -1;
+	let result = 255;
 	try {
 		result = await runnerProcess(
 			driver,
@@ -149,10 +150,7 @@ async function main() {
 		console.log(`xxxxxxxxx Runner failed. Error: ${JSON.stringify(e)}`);
 	} finally {
 		if (testFailed) {
-			result = -2;
-		}
-		if (result === -1) {
-			console.log(`xxxxxxxxx Test failed`);
+			result = GcFailureExitCode;
 		}
 		await safeExit(result, url, runId);
 	}

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -9,6 +9,8 @@ import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { ConfigTypes } from "@fluidframework/telemetry-utils";
 import { TestDriverTypes } from "@fluidframework/test-driver-definitions";
 
+export const GcFailureExitCode = 254;
+
 /** Type modeling the structure of the testConfig.json file */
 export interface ITestConfig {
 	profiles: { [name: string]: ILoadTestConfig | undefined };


### PR DESCRIPTION
Apparently, the exit error code in node cannot be negative. Calling process.exit(-1) sets the code to 255, proces.exit(-2) sets it to 254 and so on, i.e., it wraps around. That's the reason the failures in the GC stress tests weren't repoted correctly.
Updated the tests to use 255 for regular test failures and 254 for GC failures.

## Reviewer guidance
This is for an experimental stress test in test/gc-stress branch. This is not in the main FF branch and does not affect its stress test