### PR TITLE
Fix manual runs that are hitting an assert 0x162 and make default local run to be time 

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
@@ -114,5 +114,5 @@ export function benchmarkAll<T extends IBenchmarkParameters>(title: string, obj:
 			t1.minBatchCount = obj.minSampleCount;
 		}
 		benchmark(t1);
-	}	
+	}
 }

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
@@ -5,7 +5,7 @@
 
 import { IContainer } from "@fluidframework/container-definitions";
 import { ChildLogger } from "@fluidframework/telemetry-utils";
-import { DocumentType, BenchmarkType } from "@fluid-internal/test-version-utils";
+import { DocumentType, BenchmarkType, isMemoryTest } from "@fluid-internal/test-version-utils";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
 import {
@@ -90,27 +90,29 @@ export interface IBenchmarkParameters {
  * @param params - The {@link IBenchmarkParameters} parameters for the test.
  */
 export function benchmarkAll<T extends IBenchmarkParameters>(title: string, obj: T) {
-	const t: IMemoryTestObject = {
-		title,
-		...obj,
-		run: obj.run.bind(obj),
-		beforeIteration: obj.beforeIteration?.bind(obj),
-		afterIteration: obj.afterIteration?.bind(obj),
-		before: obj.before?.bind(obj),
-		after: obj.after?.bind(obj),
-	};
-	benchmarkMemory(t);
-
-	const t1: BenchmarkArguments = {
-		title,
-		...obj,
-		benchmarkFnAsync: obj.run.bind(obj),
-		before: obj.before?.bind(obj),
-		after: obj.after?.bind(obj),
-		beforeEachBatch: obj.beforeEachBatch?.bind(obj),
-	};
-	if (obj.minSampleCount !== undefined) {
-		t1.minBatchCount = obj.minSampleCount;
-	}
-	benchmark(t1);
+	if (isMemoryTest()) {
+		const t: IMemoryTestObject = {
+			title,
+			...obj,
+			run: obj.run.bind(obj),
+			beforeIteration: obj.beforeIteration?.bind(obj),
+			afterIteration: obj.afterIteration?.bind(obj),
+			before: obj.before?.bind(obj),
+			after: obj.after?.bind(obj),
+		};
+		benchmarkMemory(t);
+	} else {
+		const t1: BenchmarkArguments = {
+			title,
+			...obj,
+			benchmarkFnAsync: obj.run.bind(obj),
+			before: obj.before?.bind(obj),
+			after: obj.after?.bind(obj),
+			beforeEachBatch: obj.beforeEachBatch?.bind(obj),
+		};
+		if (obj.minSampleCount !== undefined) {
+			t1.minBatchCount = obj.minSampleCount;
+		}
+		benchmark(t1);
+	}	
 }

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarizationDocument.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarizationDocument.all.spec.ts
@@ -62,7 +62,7 @@ describeE2EDocRun(scenarioTitle, (getTestObjectProvider, getDocumentInfo) => {
 				this.container = await documentWrapper.loadDocument();
 				assert(this.container !== undefined, "container needs to be defined.");
 				await provider.ensureSynchronized();
-
+				assert(this.container.closed !== true, "container needs to be open.");
 				this.summarizerClient = await documentWrapper.summarize(summaryVersion);
 				assert(
 					this.summarizerClient.summaryVersion !== undefined,

--- a/packages/test/test-version-utils/src/describeE2eDocs.ts
+++ b/packages/test/test-version-utils/src/describeE2eDocs.ts
@@ -198,7 +198,7 @@ export const describeE2EDocsRuntime: DescribeE2EDocSuite =
 export const describeE2EDocsMemory: DescribeE2EDocSuite =
 	createE2EDocsDescribeWithType("Memory benchmarks");
 
-function isMemoryTest(): boolean {
+export function isMemoryTest(): boolean {
 	let isMemoryUsageTest: boolean = false;
 	const childArgs = [...process.execArgv, ...process.argv.slice(1)];
 	for (const flag of ["--grep", "--fgrep"]) {
@@ -210,7 +210,6 @@ function isMemoryTest(): boolean {
 	}
 	const isMemTest: boolean =
 		process.env.FLUID_E2E_MEMORY !== undefined ? true : isMemoryUsageTest ?? false;
-	console.log(`isMemTest: ${isMemTest}`);
 	return isMemTest;
 }
 

--- a/packages/test/test-version-utils/src/index.ts
+++ b/packages/test/test-version-utils/src/index.ts
@@ -27,6 +27,7 @@ export {
 	describeE2EDocsRuntime,
 	describeE2EDocRun,
 	getCurrentBenchmarkType,
+	isMemoryTest,
 } from "./describeE2eDocs";
 export { ExpectedEvents, ExpectsTest, itExpects } from "./itExpects";
 export {


### PR DESCRIPTION

## Description

An assert 0x162 is showing up when running the benchmark tests against the local service. The problem is that instead of loading an existing container, the test was creating a new one. Also, we want only the regular time test to run during the individual test debugging experience. Running both would trigger the provider to be reset after each test and would cause errors during the second test. 

Alternatives considered: 
1) Use provider = getTestObjectProvider({ resetAfterEach: false });   in each test. 
2) Change describeE2EDocs to only reset after all instead of after each
