### PR TITLE
fix labeler for tree2 move

### DIFF
--- a/.github/actions-labeler.yml
+++ b/.github/actions-labeler.yml
@@ -15,7 +15,7 @@
 
 "area: dds: tree":
   - experimental/dds/tree/**
-  - packages/dds/tree/**
+  - experimental/dds/tree2/**
 
 "area: dds: propertydds":
   - experimental/PropertyDDS/**


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The sections included below are suggestions for what you may want to include.
Feel free to remove or alter parts of this template that do not offer value for your specific change.

## Description

Fixes the auto labeler after a move of the SharedTree repo.