### PR TITLE
Remove skip since the test-azure-frs pipeline test is working

### DIFF
--- a/azure/packages/test/end-to-end-tests/src/test/containerCopy.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/containerCopy.spec.ts
@@ -120,11 +120,11 @@ describe("Container copy scenarios", () => {
 	 * Expected behavior: an error should not be thrown nor should a rejected promise
 	 * be returned.
 	 */
-	it.skip("TEST FAILING SO SKIPPED - can sucesfully copy document from a specific version", async () => {
+	it("can sucesfully copy document from a specific version", async () => {
 		const { container } = await client.createContainer(schema);
 		const containerId = await container.attach();
 
-		await timeoutPromise((resolve) => container.once("connected", () => resolve()), {
+		await timeoutPromise((resolve) => container.once("connected", resolve), {
 			durationMs: connectTimeoutMs,
 			errorMsg: "container connect() timeout",
 		});
@@ -138,7 +138,7 @@ describe("Container copy scenarios", () => {
 		const { container: containerCopy } = await resources;
 
 		const newContainerId = await containerCopy.attach();
-		await timeoutPromise((resolve) => containerCopy.once("connected", () => resolve()), {
+		await timeoutPromise((resolve) => containerCopy.once("connected", resolve), {
 			durationMs: connectTimeoutMs,
 			errorMsg: "container connect() timeout",
 		});


### PR DESCRIPTION
Test case: "can sucesfully copy document from a specific version" is failing
Example failing run: https://dev.azure.com/fluidframework/internal/_build/results?buildId=146762&view=logs&j=0ab14b9f-e499-56d5-97b1-fd98b70ea339&t=b3b126df-85da-521c-c1c9-bb5b4719d797&l=43

Temporarily skipped the test case to unblock pipeline: [Skip failing E2E perf test by ms-avocado · Pull Request #14940 · microsoft/FluidFramework (github.com)](https://github.com/microsoft/FluidFramework/pull/14940)
[AB#3934](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3934)
