### PR TITLE
Enable storage per doc

### DIFF
--- a/server/BREAKING.md
+++ b/server/BREAKING.md
@@ -1,4 +1,12 @@
 > **Note:** These breaking changes are only relevant to the server packages and images released from `./routerlicious`.
+## 0.1041 Breaking Changes
+- [writeSummaryTree function from `ISummaryUploadManager` returns new type](#writeSummaryTree-function-from-ISummaryUploadManager-returns-new-type)
+#### `writeSummaryTree` function from `ISummaryUploadManager` returns new type
+Before: returning ID of created tree as a string.
+
+- [DocumentStorage class take one additional boolean parameter](#DocumentStorage-class-take-one-additional-boolean-parameter)
+#### `DocumentStorage` class take one additional boolean parameter
+One more boolean parameter need for DocumentStorage class to indicate if storage is per tenant or per doc.
 
 ## 0.1042 Breaking Changes
 

--- a/server/historian/packages/historian-base/src/app.ts
+++ b/server/historian/packages/historian-base/src/app.ts
@@ -19,7 +19,7 @@ import {
 import { BaseTelemetryProperties, HttpProperties } from "@fluidframework/server-services-telemetry";
 import { RestLessServer } from "@fluidframework/server-services-shared";
 import * as routes from "./routes";
-import { ICache, ITenantService } from "./services";
+import { ICache, IStorageNameProvider, ITenantService } from "./services";
 import { getDocumentIdFromRequest, getTenantIdFromRequest } from "./utils";
 
 export function create(
@@ -27,6 +27,7 @@ export function create(
 	tenantService: ITenantService,
 	restTenantThrottlers: Map<string, IThrottler>,
 	restClusterThrottlers: Map<string, IThrottler>,
+	storageNameProvider: IStorageNameProvider,
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	tokenRevocationManager?: ITokenRevocationManager,
@@ -78,6 +79,7 @@ export function create(
 		tenantService,
 		restTenantThrottlers,
 		restClusterThrottlers,
+		storageNameProvider,
 		cache,
 		asyncLocalStorage,
 		tokenRevocationManager,

--- a/server/historian/packages/historian-base/src/overrides.ts
+++ b/server/historian/packages/historian-base/src/overrides.ts
@@ -1,0 +1,10 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IStorageNameProvider } from "./services";
+
+export interface IHistorianResourcesCustomizations {
+	storageNameProvider?: IStorageNameProvider;
+}

--- a/server/historian/packages/historian-base/src/routes/git/blobs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/blobs.ts
@@ -14,7 +14,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IStorageNameProvider, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -22,6 +22,7 @@ export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
 	restTenantThrottlers: Map<string, IThrottler>,
+	storageNameProvider: IStorageNameProvider,
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	tokenRevocationManager?: ITokenRevocationManager,
@@ -41,14 +42,15 @@ export function create(
 		authorization: string,
 		body: git.ICreateBlobParams,
 	): Promise<git.ICreateBlobResponse> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.createBlob(body);
 	}
 
@@ -58,14 +60,15 @@ export function create(
 		sha: string,
 		useCache: boolean,
 	): Promise<git.IBlob> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.getBlob(sha, useCache);
 	}
 

--- a/server/historian/packages/historian-base/src/routes/git/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/git/commits.ts
@@ -14,7 +14,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IStorageNameProvider, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -22,6 +22,7 @@ export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
 	restTenantThrottlers: Map<string, IThrottler>,
+	storageNameProvider: IStorageNameProvider,
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	tokenRevocationManager?: ITokenRevocationManager,
@@ -41,14 +42,15 @@ export function create(
 		authorization: string,
 		params: ICreateCommitParams,
 	): Promise<ICommit> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.createCommit(params);
 	}
 
@@ -58,14 +60,15 @@ export function create(
 		sha: string,
 		useCache: boolean,
 	): Promise<ICommit> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.getCommit(sha, useCache);
 	}
 

--- a/server/historian/packages/historian-base/src/routes/git/refs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/refs.ts
@@ -18,7 +18,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IStorageNameProvider, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -26,6 +26,7 @@ export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
 	restTenantThrottlers: Map<string, IThrottler>,
+	storageNameProvider: IStorageNameProvider,
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	tokenRevocationManager?: ITokenRevocationManager,
@@ -41,26 +42,28 @@ export function create(
 	);
 
 	async function getRefs(tenantId: string, authorization: string): Promise<git.IRef[]> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.getRefs();
 	}
 
 	async function getRef(tenantId: string, authorization: string, ref: string): Promise<git.IRef> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.getRef(ref);
 	}
 
@@ -69,14 +72,15 @@ export function create(
 		authorization: string,
 		params: ICreateRefParamsExternal,
 	): Promise<git.IRef> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.createRef(params);
 	}
 
@@ -86,26 +90,28 @@ export function create(
 		ref: string,
 		params: IPatchRefParamsExternal,
 	): Promise<git.IRef> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.updateRef(ref, params);
 	}
 
 	async function deleteRef(tenantId: string, authorization: string, ref: string): Promise<void> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.deleteRef(ref);
 	}
 

--- a/server/historian/packages/historian-base/src/routes/git/tags.ts
+++ b/server/historian/packages/historian-base/src/routes/git/tags.ts
@@ -14,7 +14,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IStorageNameProvider, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -22,6 +22,7 @@ export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
 	restTenantThrottlers: Map<string, IThrottler>,
+	storageNameProvider: IStorageNameProvider,
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	tokenRevocationManager?: ITokenRevocationManager,
@@ -41,26 +42,28 @@ export function create(
 		authorization: string,
 		params: git.ICreateTagParams,
 	): Promise<git.ITag> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.createTag(params);
 	}
 
 	async function getTag(tenantId: string, authorization: string, tag: string): Promise<git.ITag> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.getTag(tag);
 	}
 

--- a/server/historian/packages/historian-base/src/routes/git/trees.ts
+++ b/server/historian/packages/historian-base/src/routes/git/trees.ts
@@ -14,7 +14,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IStorageNameProvider, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -22,6 +22,7 @@ export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
 	restTenantThrottlers: Map<string, IThrottler>,
+	storageNameProvider: IStorageNameProvider,
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	tokenRevocationManager?: ITokenRevocationManager,
@@ -41,14 +42,15 @@ export function create(
 		authorization: string,
 		params: git.ICreateTreeParams,
 	): Promise<git.ITree> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.createTree(params);
 	}
 
@@ -59,14 +61,15 @@ export function create(
 		recursive: boolean,
 		useCache: boolean,
 	): Promise<git.ITree> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.getTree(sha, recursive, useCache);
 	}
 

--- a/server/historian/packages/historian-base/src/routes/index.ts
+++ b/server/historian/packages/historian-base/src/routes/index.ts
@@ -7,7 +7,7 @@ import { AsyncLocalStorage } from "async_hooks";
 import { IThrottler, ITokenRevocationManager } from "@fluidframework/server-services-core";
 import { Router } from "express";
 import * as nconf from "nconf";
-import { ICache, ITenantService } from "../services";
+import { ICache, IStorageNameProvider, ITenantService } from "../services";
 /* eslint-disable import/no-internal-modules */
 import * as blobs from "./git/blobs";
 import * as commits from "./git/commits";
@@ -41,6 +41,7 @@ export function create(
 	tenantService: ITenantService,
 	restTenantThrottlers: Map<string, IThrottler>,
 	restClusterThrottlers: Map<string, IThrottler>,
+	storageNameProvider: IStorageNameProvider,
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	tokenRevocationManager?: ITokenRevocationManager,
@@ -51,6 +52,7 @@ export function create(
 				config,
 				tenantService,
 				restTenantThrottlers,
+				storageNameProvider,
 				cache,
 				asyncLocalStorage,
 				tokenRevocationManager,
@@ -59,6 +61,7 @@ export function create(
 				config,
 				tenantService,
 				restTenantThrottlers,
+				storageNameProvider,
 				cache,
 				asyncLocalStorage,
 				tokenRevocationManager,
@@ -67,6 +70,7 @@ export function create(
 				config,
 				tenantService,
 				restTenantThrottlers,
+				storageNameProvider,
 				cache,
 				asyncLocalStorage,
 				tokenRevocationManager,
@@ -75,6 +79,7 @@ export function create(
 				config,
 				tenantService,
 				restTenantThrottlers,
+				storageNameProvider,
 				cache,
 				asyncLocalStorage,
 				tokenRevocationManager,
@@ -83,6 +88,7 @@ export function create(
 				config,
 				tenantService,
 				restTenantThrottlers,
+				storageNameProvider,
 				cache,
 				asyncLocalStorage,
 				tokenRevocationManager,
@@ -93,6 +99,7 @@ export function create(
 				config,
 				tenantService,
 				restTenantThrottlers,
+				storageNameProvider,
 				cache,
 				asyncLocalStorage,
 				tokenRevocationManager,
@@ -101,6 +108,7 @@ export function create(
 				config,
 				tenantService,
 				restTenantThrottlers,
+				storageNameProvider,
 				cache,
 				asyncLocalStorage,
 				tokenRevocationManager,
@@ -109,6 +117,7 @@ export function create(
 				config,
 				tenantService,
 				restTenantThrottlers,
+				storageNameProvider,
 				cache,
 				asyncLocalStorage,
 				tokenRevocationManager,
@@ -119,6 +128,7 @@ export function create(
 			tenantService,
 			restTenantThrottlers,
 			restClusterThrottlers,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
 			tokenRevocationManager,

--- a/server/historian/packages/historian-base/src/routes/repository/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/commits.ts
@@ -14,7 +14,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IStorageNameProvider, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -22,6 +22,7 @@ export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
 	restTenantThrottlers: Map<string, IThrottler>,
+	storageNameProvider: IStorageNameProvider,
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	tokenRevocationManager?: ITokenRevocationManager,
@@ -42,14 +43,15 @@ export function create(
 		sha: string,
 		count: number,
 	): Promise<git.ICommitDetails[]> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.getCommits(sha, count);
 	}
 

--- a/server/historian/packages/historian-base/src/routes/repository/contents.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/contents.ts
@@ -13,7 +13,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IStorageNameProvider, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -21,6 +21,7 @@ export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
 	restTenantThrottlers: Map<string, IThrottler>,
+	storageNameProvider: IStorageNameProvider,
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	tokenRevocationManager?: ITokenRevocationManager,
@@ -41,14 +42,15 @@ export function create(
 		path: string,
 		ref: string,
 	): Promise<any> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.getContent(path, ref);
 	}
 

--- a/server/historian/packages/historian-base/src/routes/repository/headers.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/headers.ts
@@ -14,7 +14,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../../services";
+import { ICache, IStorageNameProvider, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -22,6 +22,7 @@ export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
 	restTenantThrottlers: Map<string, IThrottler>,
+	storageNameProvider: IStorageNameProvider,
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	tokenRevocationManager?: ITokenRevocationManager,
@@ -42,14 +43,15 @@ export function create(
 		sha: string,
 		useCache: boolean,
 	): Promise<IHeader> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.getHeader(sha, useCache);
 	}
 
@@ -59,14 +61,15 @@ export function create(
 		sha: string,
 		useCache: boolean,
 	): Promise<any> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.getFullTree(sha, useCache);
 	}
 

--- a/server/historian/packages/historian-base/src/routes/summaries.ts
+++ b/server/historian/packages/historian-base/src/routes/summaries.ts
@@ -18,7 +18,8 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, ITenantService } from "../services";
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { ICache, IStorageNameProvider, ITenantService } from "../services";
 import { parseToken, Constants } from "../utils";
 import * as utils from "./utils";
 
@@ -27,6 +28,7 @@ export function create(
 	tenantService: ITenantService,
 	restTenantThrottlers: Map<string, IThrottler>,
 	restClusterThrottlers: Map<string, IThrottler>,
+	storageNameProvider: IStorageNameProvider,
 	cache?: ICache,
 	asyncLocalStorage?: AsyncLocalStorage<string>,
 	tokenRevocationManager?: ITokenRevocationManager,
@@ -83,14 +85,15 @@ export function create(
 		sha: string,
 		useCache: boolean,
 	): Promise<IWholeFlatSummary> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
+		});
 		return service.getSummary(sha, useCache);
 	}
 
@@ -100,15 +103,27 @@ export function create(
 		params: IWholeSummaryPayload,
 		initial?: boolean,
 	): Promise<IWriteSummaryResponse> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-		);
-		return service.createSummary(params, initial);
+			initialUpload: initial,
+		});
+		const result = await service.createSummary(params, initial);
+		// TODO: change to dot-notation when new version publishes
+		if (initial) {
+			// eslint-disable-next-line @typescript-eslint/dot-notation
+			result["initialStorageName"] = service.storageName;
+			// eslint-disable-next-line @typescript-eslint/dot-notation
+			if (!result["initialStorageName"]) {
+				Lumberjack.warning("Storage name not found for create summary", result);
+			}
+		}
+		return result;
 	}
 
 	async function deleteSummary(
@@ -116,15 +131,16 @@ export function create(
 		authorization: string,
 		softDelete: boolean,
 	): Promise<boolean[]> {
-		const service = await utils.createGitService(
+		const service = await utils.createGitService({
 			config,
 			tenantId,
 			authorization,
 			tenantService,
+			storageNameProvider,
 			cache,
 			asyncLocalStorage,
-			true,
-		);
+			allowDisabledTenant: true,
+		});
 		const deletionPs = [service.deleteSummary(softDelete)];
 		if (!softDelete) {
 			deletionPs.push(

--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -11,7 +11,13 @@ import { ITokenClaims } from "@fluidframework/protocol-definitions";
 import { NetworkError } from "@fluidframework/server-services-client";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import { ITokenRevocationManager } from "@fluidframework/server-services-core";
-import { ICache, ITenantService, RestGitService, ITenantCustomDataExternal } from "../services";
+import {
+	ICache,
+	ITenantService,
+	RestGitService,
+	ITenantCustomDataExternal,
+	IStorageNameProvider,
+} from "../services";
 import { containsPathTraversal, parseToken } from "../utils";
 
 /**
@@ -60,31 +66,51 @@ export function handleResponse<T>(
 	);
 }
 
-export async function createGitService(
-	config: nconf.Provider,
-	tenantId: string,
-	authorization: string,
-	tenantService: ITenantService,
-	cache?: ICache,
-	asyncLocalStorage?: AsyncLocalStorage<string>,
-	allowDisabledTenant = false,
-): Promise<RestGitService> {
+export class createGitServiceArgs {
+	config: nconf.Provider;
+	tenantId: string;
+	authorization: string;
+	tenantService: ITenantService;
+	storageNameProvider: IStorageNameProvider;
+	cache?: ICache;
+	asyncLocalStorage?: AsyncLocalStorage<string>;
+	initialUpload?: boolean = false;
+	allowDisabledTenant?: boolean = false;
+}
+
+export async function createGitService(createArgs: createGitServiceArgs): Promise<RestGitService> {
+	const {
+		config,
+		tenantId,
+		authorization,
+		tenantService,
+		storageNameProvider,
+		cache,
+		asyncLocalStorage,
+		initialUpload,
+		allowDisabledTenant,
+	} = createArgs;
 	const token = parseToken(tenantId, authorization);
+	const decoded = decode(token) as ITokenClaims;
+	const documentId = decoded.documentId;
+	if (containsPathTraversal(documentId)) {
+		// Prevent attempted directory traversal.
+		throw new NetworkError(400, `Invalid document id: ${documentId}`);
+	}
 	const details = await tenantService.getTenant(tenantId, token, allowDisabledTenant);
 	const customData: ITenantCustomDataExternal = details.customData;
 	const writeToExternalStorage = !!customData?.externalStorageData;
-	const storageName = customData?.storageName;
-	const decoded = decode(token) as ITokenClaims;
 	const storageUrl = config.get("storageUrl") as string | undefined;
-	if (containsPathTraversal(decoded.documentId)) {
-		// Prevent attempted directory traversal.
-		throw new NetworkError(400, `Invalid document id: ${decoded.documentId}`);
-	}
+	const storageName =
+		(initialUpload
+			? await storageNameProvider?.assignStorageName(tenantId, documentId)
+			: await storageNameProvider?.retrieveStorageName(tenantId, documentId)) ??
+		customData?.storageName;
 	const service = new RestGitService(
 		details.storage,
 		writeToExternalStorage,
 		tenantId,
-		decoded.documentId,
+		documentId,
 		cache,
 		asyncLocalStorage,
 		storageName,

--- a/server/historian/packages/historian-base/src/runner.ts
+++ b/server/historian/packages/historian-base/src/runner.ts
@@ -15,7 +15,7 @@ import {
 import { Provider } from "nconf";
 import * as winston from "winston";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
-import { ICache, ITenantService } from "./services";
+import { ICache, IStorageNameProvider, ITenantService } from "./services";
 import * as app from "./app";
 
 export class HistorianRunner implements IRunner {
@@ -29,6 +29,7 @@ export class HistorianRunner implements IRunner {
 		private readonly riddler: ITenantService,
 		public readonly restTenantThrottlers: Map<string, IThrottler>,
 		public readonly restClusterThrottlers: Map<string, IThrottler>,
+		private readonly storageNameProvider: IStorageNameProvider,
 		private readonly cache?: ICache,
 		private readonly asyncLocalStorage?: AsyncLocalStorage<string>,
 		private readonly tokenRevocationManager?: ITokenRevocationManager,
@@ -43,6 +44,7 @@ export class HistorianRunner implements IRunner {
 			this.riddler,
 			this.restTenantThrottlers,
 			this.restClusterThrottlers,
+			this.storageNameProvider,
 			this.cache,
 			this.asyncLocalStorage,
 			this.tokenRevocationManager,

--- a/server/historian/packages/historian-base/src/runnerFactory.ts
+++ b/server/historian/packages/historian-base/src/runnerFactory.ts
@@ -11,6 +11,7 @@ import winston from "winston";
 import * as historianServices from "./services";
 import { normalizePort, Constants } from "./utils";
 import { HistorianRunner } from "./runner";
+import { IHistorianResourcesCustomizations } from "./overrides";
 
 export class HistorianResources implements core.IResources {
 	public webServerFactory: core.IWebServerFactory;
@@ -21,6 +22,7 @@ export class HistorianResources implements core.IResources {
 		public readonly riddler: historianServices.ITenantService,
 		public readonly restTenantThrottlers: Map<string, core.IThrottler>,
 		public readonly restClusterThrottlers: Map<string, core.IThrottler>,
+		public readonly storageNameProvider: historianServices.IStorageNameProvider,
 		public readonly cache?: historianServices.RedisCache,
 		public readonly asyncLocalStorage?: AsyncLocalStorage<string>,
 		public tokenRevocationManager?: core.ITokenRevocationManager,
@@ -37,7 +39,10 @@ export class HistorianResources implements core.IResources {
 }
 
 export class HistorianResourcesFactory implements core.IResourcesFactory<HistorianResources> {
-	public async create(config: Provider): Promise<HistorianResources> {
+	public async create(
+		config: Provider,
+		customizations?: IHistorianResourcesCustomizations,
+	): Promise<HistorianResources> {
 		const redisConfig = config.get("redis");
 		const redisOptions: Redis.RedisOptions = {
 			host: redisConfig.host,
@@ -175,12 +180,18 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
 
 		const port = normalizePort(process.env.PORT || "3000");
 
+		const storagePerDocEnabled = config.get("storage:perDocEnabled");
+		const storageNameProvider = storagePerDocEnabled
+			? customizations?.storageNameProvider ?? new historianServices.StorageNameProvider()
+			: undefined;
+
 		return new HistorianResources(
 			config,
 			port,
 			riddler,
 			restTenantThrottlers,
 			restClusterThrottlers,
+			storageNameProvider,
 			gitCache,
 			asyncLocalStorage,
 		);
@@ -196,6 +207,7 @@ export class HistorianRunnerFactory implements core.IRunnerFactory<HistorianReso
 			resources.riddler,
 			resources.restTenantThrottlers,
 			resources.restClusterThrottlers,
+			resources.storageNameProvider,
 			resources.cache,
 			resources.asyncLocalStorage,
 			resources.tokenRevocationManager,

--- a/server/historian/packages/historian-base/src/services/definitions.ts
+++ b/server/historian/packages/historian-base/src/services/definitions.ts
@@ -97,3 +97,8 @@ export interface IOauthAccessInfo {
 	refreshToken: string;
 	expiresAt: string;
 }
+
+export interface IStorageNameProvider {
+	assignStorageName(tenantId: string, documentId: string): Promise<string>;
+	retrieveStorageName(tenantId: string, documentId: string): Promise<string>;
+}

--- a/server/historian/packages/historian-base/src/services/index.ts
+++ b/server/historian/packages/historian-base/src/services/index.ts
@@ -10,6 +10,7 @@ export {
 	IExternalStorage,
 	IOauthAccessInfo,
 	IStorage,
+	IStorageNameProvider,
 	ITenant,
 	ITenantCustomDataExternal,
 	ITenantService,
@@ -18,3 +19,4 @@ export { RedisCache } from "./redisCache";
 export { RedisTenantCache } from "./redisTenantCache";
 export { IDocument, RestGitService } from "./restGitService";
 export { RiddlerService } from "./riddlerService";
+export { StorageNameProvider } from "./storageNameProvider";

--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -61,7 +61,7 @@ export class RestGitService {
 		private readonly documentId: string,
 		private readonly cache?: ICache,
 		private readonly asyncLocalStorage?: AsyncLocalStorage<string>,
-		private readonly storageName?: string,
+		public readonly storageName?: string,
 		private readonly storageUrl?: string,
 	) {
 		const defaultHeaders: AxiosRequestHeaders =

--- a/server/historian/packages/historian-base/src/services/storageNameProvider.ts
+++ b/server/historian/packages/historian-base/src/services/storageNameProvider.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IStorageNameProvider } from "./definitions";
+
+/**
+ * Manager to fetch deltas from Alfred using the internal URL.
+ */
+export class StorageNameProvider implements IStorageNameProvider {
+	public constructor() {}
+
+	public async assignStorageName(tenantId: string, documentId: string): Promise<string> {
+		return undefined;
+	}
+
+	public async retrieveStorageName(tenantId: string, documentId: string): Promise<string> {
+		return undefined;
+	}
+}

--- a/server/historian/packages/historian-base/src/test/routes.spec.ts
+++ b/server/historian/packages/historian-base/src/test/routes.spec.ts
@@ -101,6 +101,7 @@ describe("routes", () => {
 					defaultTenantService,
 					tenantThrottlers,
 					clusterThrottlers,
+					undefined,
 					defaultCache,
 					asyncLocalStorage,
 				);
@@ -205,6 +206,7 @@ describe("routes", () => {
 					defaultTenantService,
 					tenantThrottlers,
 					clusterThrottlers,
+					undefined,
 					defaultCache,
 					asyncLocalStorage,
 				);
@@ -323,6 +325,7 @@ describe("routes", () => {
 					defaultTenantService,
 					tenantThrottlers,
 					clusterThrottlers,
+					undefined,
 					defaultCache,
 					asyncLocalStorage,
 				);
@@ -429,6 +432,7 @@ describe("routes", () => {
 					defaultTenantService,
 					tenantThrottlers,
 					clusterThrottlers,
+					undefined,
 					defaultCache,
 					asyncLocalStorage,
 				);
@@ -498,6 +502,7 @@ describe("routes", () => {
 					defaultTenantService,
 					tenantThrottlers,
 					clusterThrottlers,
+					undefined,
 					defaultCache,
 					asyncLocalStorage,
 				);
@@ -559,6 +564,7 @@ describe("routes", () => {
 					defaultTenantService,
 					tenantThrottlers,
 					clusterThrottlers,
+					undefined,
 					defaultCache,
 					asyncLocalStorage,
 				);
@@ -619,6 +625,7 @@ describe("routes", () => {
 					defaultTenantService,
 					tenantThrottlers,
 					clusterThrottlers,
+					undefined,
 					defaultCache,
 					asyncLocalStorage,
 				);
@@ -707,6 +714,7 @@ describe("routes", () => {
 					defaultTenantService,
 					tenantThrottlers,
 					clusterThrottlers,
+					undefined,
 					defaultCache,
 					asyncLocalStorage,
 				);
@@ -799,6 +807,7 @@ describe("routes", () => {
 					defaultTenantService,
 					tenantThrottlers,
 					clusterThrottlers,
+					undefined,
 					defaultCache,
 					asyncLocalStorage,
 				);
@@ -905,6 +914,7 @@ describe("routes", () => {
 					defaultTenantService,
 					tenantThrottlers,
 					clusterThrottlers,
+					undefined,
 					defaultCache,
 					asyncLocalStorage,
 				);
@@ -992,6 +1002,7 @@ describe("routes", () => {
 					defaultTenantService,
 					tenantThrottlers,
 					clusterThrottlers,
+					undefined,
 					defaultCache,
 					asyncLocalStorage,
 				);
@@ -1053,6 +1064,7 @@ describe("routes", () => {
 					defaultTenantService,
 					tenantThrottlers,
 					clusterThrottlers,
+					undefined,
 					defaultCache,
 					asyncLocalStorage,
 				);
@@ -1106,6 +1118,7 @@ describe("routes", () => {
 					defaultTenantService,
 					tenantThrottlers,
 					clusterThrottlers,
+					undefined,
 					defaultCache,
 					asyncLocalStorage,
 				);
@@ -1162,6 +1175,7 @@ describe("routes", () => {
 					defaultTenantService,
 					tenantThrottlers,
 					clusterThrottlers,
+					undefined,
 					defaultCache,
 					asyncLocalStorage,
 				);

--- a/server/routerlicious/api-report/server-services-client.api.md
+++ b/server/routerlicious/api-report/server-services-client.api.md
@@ -371,7 +371,8 @@ export interface ISummaryTree extends ISummaryTree_2 {
 
 // @public
 export interface ISummaryUploadManager {
-    writeSummaryTree(summaryTree: api.ISummaryTree, parentHandle: string, summaryType: IWholeSummaryPayloadType, sequenceNumber?: number): Promise<string>;
+    // Warning: (ae-forgotten-export) The symbol "SummaryUploadResult" needs to be exported by the entry point index.d.ts
+    writeSummaryTree(summaryTree: api.ISummaryTree, parentHandle: string, summaryType: IWholeSummaryPayloadType, sequenceNumber?: number): Promise<SummaryUploadResult>;
 }
 
 // @public (undocumented)
@@ -488,6 +489,8 @@ export interface IWholeSummaryTreeValueEntry extends IWholeSummaryTreeBaseEntry 
 export interface IWriteSummaryResponse {
     // (undocumented)
     id: string;
+    // (undocumented)
+    initialStorageName?: string;
 }
 
 // @public
@@ -559,7 +562,7 @@ export abstract class RestWrapper {
 export class SummaryTreeUploadManager implements ISummaryUploadManager {
     constructor(manager: IGitManager, blobsShaCache: Map<string, string>, getPreviousFullSnapshot: (parentHandle: string) => Promise<ISnapshotTreeEx | null | undefined>);
     // (undocumented)
-    writeSummaryTree(summaryTree: ISummaryTree_2, parentHandle: string, summaryType: IWholeSummaryPayloadType, sequenceNumber?: number, initial?: boolean): Promise<string>;
+    writeSummaryTree(summaryTree: ISummaryTree_2, parentHandle: string, summaryType: IWholeSummaryPayloadType, sequenceNumber?: number, initial?: boolean): Promise<SummaryUploadResult>;
 }
 
 // @public
@@ -581,7 +584,7 @@ export type WholeSummaryTreeValue = IWholeSummaryTree | IWholeSummaryBlob;
 export class WholeSummaryUploadManager implements ISummaryUploadManager {
     constructor(manager: IGitManager);
     // (undocumented)
-    writeSummaryTree(summaryTree: ISummaryTree, parentHandle: string | undefined, summaryType: IWholeSummaryPayloadType, sequenceNumber?: number, initial?: boolean): Promise<string>;
+    writeSummaryTree(summaryTree: ISummaryTree, parentHandle: string | undefined, summaryType: IWholeSummaryPayloadType, sequenceNumber?: number, initial?: boolean): Promise<SummaryUploadResult>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -119,8 +119,14 @@
 				"forwardCompat": false,
 				"backCompat": false
 			},
-			"RemovedClassDeclaration_ForemanLambda": {"forwardCompat": false, "backCompat": false},
-			"RemovedClassDeclaration_ForemanLambdaFactory": {"forwardCompat": false, "backCompat": false}
+			"RemovedClassDeclaration_ForemanLambda": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"RemovedClassDeclaration_ForemanLambdaFactory": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
 		}
 	}
 }

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -793,7 +793,7 @@ export class SummaryWriter implements ISummaryWriter {
 			"container",
 			sequenceNumber,
 		);
-		return uploadHandle;
+		return uploadHandle.id;
 	}
 
 	private async createWholeServiceSummary(
@@ -822,7 +822,7 @@ export class SummaryWriter implements ISummaryWriter {
 			"container",
 			sequenceNumber,
 		);
-		return uploadHandle;
+		return uploadHandle.id;
 	}
 
 	// We should optimize our API so that we don't have to do this conversion.

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -362,11 +362,13 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 
 		const enableWholeSummaryUpload = config.get("storage:enableWholeSummaryUpload") as boolean;
 		const opsCollection = await databaseManager.getDeltaCollection(undefined, undefined);
+		const storagePerDocEnabled = (config.get("storage:perDocEnabled") as boolean) ?? false;
 		const storage = new services.DocumentStorage(
 			documentRepository,
 			tenantManager,
 			enableWholeSummaryUpload,
 			opsCollection,
+			storagePerDocEnabled,
 		);
 
 		const maxSendMessageSize = bytes.parse(config.get("alfred:maxMessageSize"));

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/io.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/io.spec.ts
@@ -107,6 +107,7 @@ describe("Routerlicious", () => {
 						testTenantManager,
 						false,
 						await databaseManager.getDeltaCollection(undefined, undefined),
+						true,
 					);
 					const kafkaOrderer = new KafkaOrdererFactory(
 						producer,
@@ -566,6 +567,7 @@ Submitted Messages: ${JSON.stringify(messages, undefined, 2)}`,
 						testTenantManager,
 						false,
 						await databaseManager.getDeltaCollection(undefined, undefined),
+						true,
 					);
 					const kafkaOrderer = new KafkaOrdererFactory(
 						producer,
@@ -793,6 +795,7 @@ Submitted Messages: ${JSON.stringify(messages, undefined, 2)}`,
 				testTenantManager,
 				false,
 				await databaseManager.getDeltaCollection(undefined, undefined),
+				true,
 			);
 		});
 

--- a/server/routerlicious/packages/services-client/src/storage.ts
+++ b/server/routerlicious/packages/services-client/src/storage.ts
@@ -119,6 +119,11 @@ export interface IGitManager {
 	getSummary(sha: string): Promise<IWholeFlatSummary>;
 }
 
+export interface SummaryUploadResult {
+	id: string;
+	initialStorageName?: string;
+}
+
 /**
  * Uploads a summary to storage.
  */
@@ -129,12 +134,12 @@ export interface ISummaryUploadManager {
 	 * @param parentHandle - Parent summary acked handle (if available from summary ack)
 	 * @param summaryType - type of summary being uploaded
 	 * @param sequenceNumber - optional reference sequence number of the summary
-	 * @returns Id of created tree as a string.
+	 * @returns SummaryUploadResult, containing created tree as a string and associated storage name.
 	 */
 	writeSummaryTree(
 		summaryTree: api.ISummaryTree,
 		parentHandle: string,
 		summaryType: IWholeSummaryPayloadType,
 		sequenceNumber?: number,
-	): Promise<string>;
+	): Promise<SummaryUploadResult>;
 }

--- a/server/routerlicious/packages/services-client/src/storageContracts.ts
+++ b/server/routerlicious/packages/services-client/src/storageContracts.ts
@@ -26,6 +26,7 @@ export interface IWholeSummaryPayload {
 
 export interface IWriteSummaryResponse {
 	id: string;
+	initialStorageName?: string;
 }
 
 export type WholeSummaryTreeEntry = IWholeSummaryTreeValueEntry | IWholeSummaryTreeHandleEntry;

--- a/server/routerlicious/packages/services-client/src/summaryTreeUploadManager.ts
+++ b/server/routerlicious/packages/services-client/src/summaryTreeUploadManager.ts
@@ -18,7 +18,7 @@ import {
 	SummaryObject,
 	SummaryType,
 } from "@fluidframework/protocol-definitions";
-import { ISummaryUploadManager, IGitManager } from "./storage";
+import { ISummaryUploadManager, IGitManager, SummaryUploadResult } from "./storage";
 import { IWholeSummaryPayloadType } from "./storageContracts";
 
 /**
@@ -39,9 +39,12 @@ export class SummaryTreeUploadManager implements ISummaryUploadManager {
 		summaryType: IWholeSummaryPayloadType,
 		sequenceNumber?: number,
 		initial?: boolean,
-	): Promise<string> {
+	): Promise<SummaryUploadResult> {
 		const previousFullSnapshot = await this.getPreviousFullSnapshot(parentHandle);
-		return this.writeSummaryTreeCore(summaryTree, previousFullSnapshot ?? undefined);
+		const id = await this.writeSummaryTreeCore(summaryTree, previousFullSnapshot ?? undefined);
+		return {
+			id,
+		};
 	}
 
 	private async writeSummaryTreeCore(

--- a/server/routerlicious/packages/services-client/src/wholeSummaryUploadManager.ts
+++ b/server/routerlicious/packages/services-client/src/wholeSummaryUploadManager.ts
@@ -4,7 +4,7 @@
  */
 
 import { ISummaryTree, IWholeSummaryPayload, IWholeSummaryPayloadType } from "./storageContracts";
-import { IGitManager, ISummaryUploadManager } from "./storage";
+import { IGitManager, ISummaryUploadManager, SummaryUploadResult } from "./storage";
 import { convertSummaryTreeToWholeSummaryTree } from "./storageUtils";
 
 /**
@@ -19,18 +19,18 @@ export class WholeSummaryUploadManager implements ISummaryUploadManager {
 		summaryType: IWholeSummaryPayloadType,
 		sequenceNumber: number = 0,
 		initial: boolean = false,
-	): Promise<string> {
-		const id = await this.writeSummaryTreeCore(
+	): Promise<SummaryUploadResult> {
+		const result = await this.writeSummaryTreeCore(
 			parentHandle,
 			summaryTree,
 			summaryType,
 			sequenceNumber,
 			initial,
 		);
-		if (!id) {
+		if (!result?.id) {
 			throw new Error(`Failed to write summary tree`);
 		}
-		return id;
+		return result;
 	}
 
 	private async writeSummaryTreeCore(
@@ -39,7 +39,7 @@ export class WholeSummaryUploadManager implements ISummaryUploadManager {
 		type: IWholeSummaryPayloadType,
 		sequenceNumber: number,
 		initial: boolean,
-	): Promise<string> {
+	): Promise<SummaryUploadResult> {
 		const snapshotTree = convertSummaryTreeToWholeSummaryTree(
 			parentHandle,
 			tree,
@@ -53,6 +53,9 @@ export class WholeSummaryUploadManager implements ISummaryUploadManager {
 			type,
 		};
 
-		return this.manager.createSummary(snapshotPayload, initial).then((response) => response.id);
+		return this.manager.createSummary(snapshotPayload, initial).then((response) => ({
+			id: response.id,
+			initialStorageName: response.initialStorageName,
+		}));
 	}
 }

--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -141,4 +141,7 @@ export interface IDocument {
 	// Timestamp of when this document and related data will be hard deleted.
 	// The document is soft deleted if a scheduled deletion timestamp is present.
 	scheduledDeletionTime?: string;
+
+	// storage per doc locations
+	storageName?: string;
 }

--- a/server/routerlicious/packages/services-core/src/documentManager.ts
+++ b/server/routerlicious/packages/services-core/src/documentManager.ts
@@ -1,0 +1,10 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IDocument } from "./document";
+
+export interface IDocumentManager {
+	readDocument(tenantId: string, documentId: string): Promise<IDocument>;
+}

--- a/server/routerlicious/packages/services-core/src/index.ts
+++ b/server/routerlicious/packages/services-core/src/index.ts
@@ -41,6 +41,7 @@ export {
 	IDocumentStorage,
 	IScribe,
 } from "./document";
+export { IDocumentManager } from "./documentManager";
 export { EmptyTaskMessageSender } from "./emptyTaskMessageSender";
 export {
 	IHttpServer,

--- a/server/routerlicious/packages/services/src/documentManager.ts
+++ b/server/routerlicious/packages/services/src/documentManager.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ScopeType } from "@fluidframework/protocol-definitions";
+import { BasicRestWrapper } from "@fluidframework/server-services-client";
+import { IDocumentManager, IDocument } from "@fluidframework/server-services-core";
+import { generateToken, getCorrelationId } from "@fluidframework/server-services-utils";
+
+/**
+ * Manager to fetch document from Alfred using the internal URL.
+ */
+export class DocumentManager implements IDocumentManager {
+	constructor(private readonly internalAlfredUrl: string, private readonly key: string) {}
+
+	public async readDocument(tenantId: string, documentId: string): Promise<IDocument> {
+		const restWrapper = await this.getBasicRestWrapper(tenantId, documentId);
+		return restWrapper.get<IDocument>(`/documents/${tenantId}/${documentId}`);
+	}
+
+	private async getBasicRestWrapper(tenantId: string, documentId: string) {
+		const getDefaultHeaders = () => {
+			const jwtToken = generateToken(tenantId, documentId, this.key, [ScopeType.DocRead]);
+			return {
+				Authorization: `Basic ${jwtToken}`,
+			};
+		};
+
+		const restWrapper = new BasicRestWrapper(
+			this.internalAlfredUrl,
+			undefined /* defaultQueryString */,
+			undefined /* maxBodyLength */,
+			undefined /* maxContentLength */,
+			getDefaultHeaders(),
+			undefined /* Axios */,
+			undefined /* refreshDefaultQueryString */,
+			getDefaultHeaders /* refreshDefaultHeaders */,
+			getCorrelationId /* getCorrelationId */,
+		);
+		return restWrapper;
+	}
+}

--- a/server/routerlicious/packages/services/src/index.ts
+++ b/server/routerlicious/packages/services/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 export { getDbFactory } from "./dbFactory";
+export { DocumentManager } from "./documentManager";
 export { createProducer } from "./kafkaProducerFactory";
 export { createMessageReceiver } from "./messageReceiver";
 export { createMessageSender } from "./messageSender";

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -59,11 +59,8 @@ export class TenantManager implements core.ITenantManager {
 		documentId: string,
 		includeDisabledTenant = false,
 	): Promise<core.ITenant> {
-		const restWrapper = new BasicRestWrapper();
 		const [details, gitManager] = await Promise.all([
-			restWrapper.get<core.ITenantConfig>(`${this.endpoint}/api/tenants/${tenantId}`, {
-				includeDisabledTenant,
-			}),
+			this.getTenantConfig(tenantId, includeDisabledTenant),
 			this.getTenantGitManager(tenantId, documentId, includeDisabledTenant),
 		]);
 
@@ -80,7 +77,7 @@ export class TenantManager implements core.ITenantManager {
 		const lumberProperties = getLumberBaseProperties(documentId, tenantId);
 		const key = await core.requestWithRetry(
 			async () => this.getKey(tenantId, includeDisabledTenant),
-			"getTenantGitManager_getKey" /* callName */,
+			"getTenantGitManager" /* callName */,
 			lumberProperties /* telemetryProperties */,
 		);
 
@@ -135,5 +132,15 @@ export class TenantManager implements core.ITenantManager {
 			{ includeDisabledTenant },
 		);
 		return result.key1;
+	}
+
+	private async getTenantConfig(
+		tenantId: string,
+		includeDisabledTenant = false,
+	): Promise<core.ITenantConfig> {
+		const restWrapper = new BasicRestWrapper();
+		return restWrapper.get<core.ITenantConfig>(`${this.endpoint}/api/tenants/${tenantId}`, {
+			includeDisabledTenant,
+		});
 	}
 }


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

This provide basic services for retrieving a documents's storagename

## Description

1. renamed `getTenantGitManager` to `getContainerGitManager` for it scope change. Extended `getContainerGitManager` to take a `storageName` at create documents flow, and `gitManager` will be able to pass that info as a header to historian for historian to further consume. (Didn't touch historian part leave the experts @znewton  and @hedasilv  to play)
2. Provided `IStorageNameProvider` and a default `StorageNameProvider` that read from `tenants` collection as now. Given the abilities to provide a customized one from FRS.
3. Provided a service called `IContainerManager` and its implementation of `ContainerManager`, mainly plan for the FRS side to use it to provide FRS own override. May also need for `historian` in OSS to be able to get the container info.


## Breaking Changes

1. Added a boolean blip for document storage
2. `writeSummaryTree` function from `ISummaryUploadManager` returns new type that contains the original ID and new storageName assigned
