### PR TITLE
[GC stress] Added another none activity to increase the chances of incremental summary

### DIFF
--- a/packages/test/test-service-load/src/gcDataStores.ts
+++ b/packages/test/test-service-load/src/gcDataStores.ts
@@ -73,8 +73,8 @@ const ReferenceActivityType = {
 	CreateAndReference: 3,
 	/** Revive an unreferenced child object. */
 	Revive: 4,
-	/** Max value of enum. This is just used as the max value for generating an activity at random. */
-	Max: 5,
+	/** The count of enum values. This is used as the max value for generating an activity at random. */
+	Count: 5,
 };
 type ReferenceActivityType = typeof ReferenceActivityType[keyof typeof ReferenceActivityType];
 
@@ -86,8 +86,8 @@ const BlobActivityType = {
 	None: 0,
 	/** Get the blob via its handle. */
 	GetBlob: 1,
-	/** Max value of enum. This is just used as the max value for generating an activity at random. */
-	Max: 2,
+	/** The count of enum values. This is used as the max value for generating an activity at random. */
+	Count: 5,
 };
 type BlobActivityType = typeof BlobActivityType[keyof typeof BlobActivityType];
 
@@ -99,8 +99,8 @@ const LeafActivityType = {
 	None: 0,
 	/** Send one or more ops */
 	SendOps: 1,
-	/** Max value of enum. This is just used as the max value for generating an activity at random. */
-	Max: 2,
+	/** The count of enum values. This is used as the max value for generating an activity at random. */
+	Count: 5,
 };
 type LeafActivityType = typeof LeafActivityType[keyof typeof LeafActivityType];
 
@@ -146,7 +146,7 @@ class AttachmentBlobObject implements IGCActivityObject {
 	 * 2. None - Do nothing. This is to have summaries where no blobs are retrieved.
 	 */
 	private async runActivity(config: IRunConfig) {
-		const activityType = config.random.integer(0, BlobActivityType.Max - 1);
+		const activityType = config.random.integer(0, BlobActivityType.Count - 1);
 		switch (activityType) {
 			case BlobActivityType.GetBlob: {
 				await this.handle.get();
@@ -222,7 +222,7 @@ export class DataObjectLeaf extends BaseDataObject implements IGCActivityObject 
 	 * 2. None - Do nothing. This is to have summaries where this data store or its DDS does not change.
 	 */
 	private runActivity(config: IRunConfig) {
-		const activityType = config.random.integer(0, LeafActivityType.Max - 1);
+		const activityType = config.random.integer(0, LeafActivityType.Count - 1);
 		switch (activityType) {
 			case LeafActivityType.SendOps: {
 				this.counter.increment(1);
@@ -557,7 +557,7 @@ export class DataObjectNonCollab extends BaseDataObject implements IGCActivityOb
 		const maxActivityIndex =
 			this.referencedDataObjects.length < maxRunningLeafDataObjects &&
 			this.referencedAttachmentBlobs.length < maxRunningAttachmentBlobs
-				? ReferenceActivityType.Max - 1
+				? ReferenceActivityType.Count - 1
 				: ReferenceActivityType.Unreference;
 		const activityType = config.random.integer(0, maxActivityIndex);
 		return Promise.all([
@@ -626,6 +626,7 @@ export class DataObjectNonCollab extends BaseDataObject implements IGCActivityOb
 				break;
 			}
 			case ReferenceActivityType.None:
+			case ReferenceActivityType.AnotherNone:
 			default:
 				break;
 		}
@@ -701,6 +702,7 @@ export class DataObjectNonCollab extends BaseDataObject implements IGCActivityOb
 				break;
 			}
 			case ReferenceActivityType.None:
+			case ReferenceActivityType.AnotherNone:
 			default:
 				break;
 		}

--- a/packages/test/test-service-load/src/gcDataStores.ts
+++ b/packages/test/test-service-load/src/gcDataStores.ts
@@ -87,7 +87,7 @@ const BlobActivityType = {
 	/** Get the blob via its handle. */
 	GetBlob: 1,
 	/** The count of enum values. This is used as the max value for generating an activity at random. */
-	Count: 5,
+	Count: 2,
 };
 type BlobActivityType = typeof BlobActivityType[keyof typeof BlobActivityType];
 
@@ -100,7 +100,7 @@ const LeafActivityType = {
 	/** Send one or more ops */
 	SendOps: 1,
 	/** The count of enum values. This is used as the max value for generating an activity at random. */
-	Count: 5,
+	Count: 2,
 };
 type LeafActivityType = typeof LeafActivityType[keyof typeof LeafActivityType];
 


### PR DESCRIPTION
## Description
One of the interesting scenarios for GC is incremental summary / GC for data stores and DDSes. Bascially, if a data store or DDS did not change since the last summary, it will re-use the GC / summary data from the previous summary. This goes down a different code path and has known to cause GC bugs.
This change increases the chances of that by adding another activity which doesn't do anything, thereby increasing the chances of doing an incremental summary for a data store.

## Reviewer guidance
This is for an experimental stress test in test/gc-stress branch. This is not in the main FF branch and does not affect its stress test