### PR TITLE
Fix undo of overlapping remove of multiple segments

### DIFF
--- a/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollbackFarm.spec.ts
@@ -72,6 +72,7 @@ describe("MergeTree.Client", () => {
 				}
 
 				logger.validate();
+				logger.dispose();
 			}
 		}).timeout(30 * 10000);
 	});

--- a/packages/dds/merge-tree/src/test/revertibleFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/revertibleFarm.spec.ts
@@ -205,6 +205,7 @@ describe("MergeTree.Client", () => {
 						errorPrefix: "After Re-Revert (redo)",
 						baseText: redoBaseText,
 					});
+					logger.dispose();
 				}
 			});
 		}

--- a/packages/dds/merge-tree/src/test/revertibles.spec.ts
+++ b/packages/dds/merge-tree/src/test/revertibles.spec.ts
@@ -181,36 +181,55 @@ describe("MergeTree.Revertibles", () => {
 		logger.validate({ baseText: "123" });
 	});
 
-	it("revert overlapping remove of multiple segments", () => {
-		const clients = createClientsAtInitialState(
-			{ initialState: "1-23", options: { mergeTreeUseNewLengthCalculations: true } },
-			"A",
-			"B",
-			"C",
-		);
-		const logger = new TestClientLogger(clients.all);
-		let seq = 0;
-		const ops: ISequencedDocumentMessage[] = [];
+	for (const { name, removeStart, removeEnd, expectedPostRemove } of [
+		{
+			name: "revert overlapping remove",
+			removeStart: 0,
+			removeEnd: 1,
+			expectedPostRemove: "23",
+		},
+		{
+			name: "revert overlapping remove of multiple segments",
+			removeStart: 0,
+			removeEnd: 2,
+			expectedPreRemove: "23",
+		},
+	]) {
+		it(name, () => {
+			const clients = createClientsAtInitialState(
+				{ initialState: "1-23", options: { mergeTreeUseNewLengthCalculations: true } },
+				"A",
+				"B",
+				"C",
+			);
+			const logger = new TestClientLogger(clients.all);
+			let seq = 0;
+			const ops: ISequencedDocumentMessage[] = [];
 
-		const clientB_Revertibles: MergeTreeDeltaRevertible[] = [];
-		const clientBDriver = createRevertDriver(clients.B);
-		clientBDriver.submitOpCallback = (op) => ops.push(clients.B.makeOpMessage(op, ++seq));
+			const clientB_Revertibles: MergeTreeDeltaRevertible[] = [];
+			const clientBDriver = createRevertDriver(clients.B);
+			clientBDriver.submitOpCallback = (op) => ops.push(clients.B.makeOpMessage(op, ++seq));
 
-		clients.B.on("delta", (op, delta) => {
-			appendToMergeTreeDeltaRevertibles(clientBDriver, delta, clientB_Revertibles);
+			clients.B.on("delta", (op, delta) => {
+				appendToMergeTreeDeltaRevertibles(clientBDriver, delta, clientB_Revertibles);
+			});
+
+			ops.push(
+				clients.C.makeOpMessage(clients.C.removeRangeLocal(removeStart, removeEnd), ++seq),
+			);
+			ops.push(
+				clients.B.makeOpMessage(clients.B.removeRangeLocal(removeStart, removeEnd), ++seq),
+			);
+
+			ops.splice(0).forEach((op) => clients.all.forEach((c) => c.applyMsg(op)));
+			logger.validate({ baseText: expectedPostRemove });
+
+			revertMergeTreeDeltaRevertibles(clientBDriver, clientB_Revertibles.splice(0));
+
+			ops.splice(0).forEach((op) => clients.all.forEach((c) => c.applyMsg(op)));
+			logger.validate({ baseText: "123" });
 		});
-
-		ops.push(clients.C.makeOpMessage(clients.C.removeRangeLocal(0, 2), ++seq));
-		ops.push(clients.B.makeOpMessage(clients.B.removeRangeLocal(0, 2), ++seq));
-
-		ops.splice(0).forEach((op) => clients.all.forEach((c) => c.applyMsg(op)));
-		logger.validate({ baseText: "3" });
-
-		revertMergeTreeDeltaRevertibles(clientBDriver, clientB_Revertibles.splice(0));
-
-		ops.splice(0).forEach((op) => clients.all.forEach((c) => c.applyMsg(op)));
-		logger.validate({ baseText: "123" });
-	});
+	}
 
 	it("revert two overlapping removes", () => {
 		const clients = createClientsAtInitialState(

--- a/packages/dds/merge-tree/src/test/revertibles.spec.ts
+++ b/packages/dds/merge-tree/src/test/revertibles.spec.ts
@@ -181,9 +181,9 @@ describe("MergeTree.Revertibles", () => {
 		logger.validate({ baseText: "123" });
 	});
 
-	it("revert overlapping remove", () => {
+	it("revert overlapping remove of multiple segments", () => {
 		const clients = createClientsAtInitialState(
-			{ initialState: "123", options: { mergeTreeUseNewLengthCalculations: true } },
+			{ initialState: "1-23", options: { mergeTreeUseNewLengthCalculations: true } },
 			"A",
 			"B",
 			"C",
@@ -200,11 +200,11 @@ describe("MergeTree.Revertibles", () => {
 			appendToMergeTreeDeltaRevertibles(clientBDriver, delta, clientB_Revertibles);
 		});
 
-		ops.push(clients.B.makeOpMessage(clients.B.removeRangeLocal(0, 1), ++seq));
-		ops.push(clients.C.makeOpMessage(clients.C.removeRangeLocal(0, 1), ++seq));
+		ops.push(clients.C.makeOpMessage(clients.C.removeRangeLocal(0, 2), ++seq));
+		ops.push(clients.B.makeOpMessage(clients.B.removeRangeLocal(0, 2), ++seq));
 
 		ops.splice(0).forEach((op) => clients.all.forEach((c) => c.applyMsg(op)));
-		logger.validate({ baseText: "23" });
+		logger.validate({ baseText: "3" });
 
 		revertMergeTreeDeltaRevertibles(clientBDriver, clientB_Revertibles.splice(0));
 


### PR DESCRIPTION
## Description

Fixes an issue spotted in merge-tree while doing the recent undo/redo asymptotics improvements. There's more context [here](https://github.com/microsoft/FluidFramework/pull/14737#discussion_r1160281800) or in the test case. The gist of the problem is that we didn't preserve the order of local references when sliding them, which undo-redo cares about.

Resolves [AB#4031](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4031).

This also addresses some of the cleanup feedback on https://github.com/microsoft/FluidFramework/pull/14737, as it was the simplest way to fix this issue.
