### PR TITLE
Stress test dispose logic

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -410,7 +410,7 @@ export class LoadTestDataStoreModel {
 	}
 
 	public async volunteerForTask() {
-		if (this.runtime.disposed) {
+		if (this.isPermanentlyDisconnected()) {
 			return;
 		}
 		if (!this.assigned()) {
@@ -485,6 +485,13 @@ export class LoadTestDataStoreModel {
 				!disposed ? `quorum: ${this.runtime.getQuorum().getMembers().size}` : "",
 			);
 		}
+	}
+
+	private isPermanentlyDisconnected(): boolean {
+		return (
+			this.runtime.disposed ||
+			(!this.runtime.connected && this.runtime.deltaManager.readOnlyInfo.readonly === true)
+		);
 	}
 }
 
@@ -660,7 +667,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 				  };
 
 		try {
-			while (dataModel.counter.value < clientSendCount && !this.disposed) {
+			while (dataModel.counter.value < clientSendCount && !this.isPermanentlyDisconnected()) {
 				// this enables a quick ramp down. due to restart, some clients can lag
 				// leading to a slow ramp down. so if there are less than half the clients
 				// and it's partner is done, return true to complete the runner.
@@ -677,7 +684,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 			}
 
 			reportOpCount("Completed");
-			return !this.runtime.disposed;
+			return !this.isPermanentlyDisconnected();
 		} catch (error: any) {
 			reportOpCount("Exception", error);
 			throw error;
@@ -726,7 +733,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 		const signalsGapMs = cycleMs / signalsPerCycle;
 		let submittedSignals = 0;
 		try {
-			while (submittedSignals < clientSignalsSendCount && !this.runtime.disposed) {
+			while (submittedSignals < clientSignalsSendCount && !this.isPermanentlyDisconnected()) {
 				// all the clients are sending signals;
 				// with signals, there is no particular need to have staggered writers and readers
 				if (this.runtime.connected) {
@@ -739,6 +746,13 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 		} catch (e) {
 			console.error("Error during submitting signals: ", e);
 		}
+	}
+
+	private isPermanentlyDisconnected(): boolean {
+		return (
+			this.runtime.disposed ||
+			(!this.runtime.connected && this.runtime.deltaManager.readOnlyInfo.readonly === true)
+		);
 	}
 }
 

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -265,18 +265,8 @@ async function runnerProcess(
 				);
 			}
 
-			const closeDisposeProm = new Promise<boolean>((resolve) => {
-				const resAndClear = () => {
-					resolve(false);
-					container?.off("closed", resAndClear);
-					container?.off("disposed", resAndClear);
-				};
-				container?.once("closed", () => resAndClear);
-				container?.once("disposed", () => resAndClear);
-			});
-
 			printStatus(runConfig, `running`);
-			done = await Promise.race([closeDisposeProm, test.run(runConfig, reset)]);
+			done = await test.run(runConfig, reset);
 			reset = false;
 			printStatus(runConfig, done ? `finished` : "closed");
 		} catch (error) {


### PR DESCRIPTION
# [AB#4137](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4137)

[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

**TODO**: Current implementation does not work. It still hangs in the `test.run` code as it waits for a `"connect"` or `"dispose"` event from the runtime

The exact place that it's failing is on the following check:
https://github.com/microsoft/FluidFramework/blob/main/packages/test/test-service-load/src/loadTestDataStore.ts#L663

We are assuming we can continue trying to send ops (waiting for a connect or dispose event), and that's where it hangs. We already received a disconnect event and know that the runtime is disconnected and readonly.