### PR TITLE
improvement(client-debugger): Allow registering data visualizers in root Devtools for use across all Containers

### DIFF
--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -266,6 +266,7 @@ export interface FluidDevtoolsEvents extends IEvent {
 
 // @public
 export interface FluidDevtoolsProps {
+    dataVisualizers?: Record<string, VisualizeSharedObject>;
     initialContainers?: ContainerDevtoolsProps[];
     logger?: DevtoolsLogger;
 }

--- a/packages/tools/client-debugger/client-debugger/src/ContainerDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/ContainerDevtools.ts
@@ -76,8 +76,6 @@ export interface ContainerDevtoolsProps {
 	 */
 	containerData?: Record<string, IFluidLoadable>;
 
-	// TODO: Accept custom data visualizers.
-
 	/**
 	 * (optional) Nickname for the {@link ContainerDevtoolsProps.container | Container} / debugger instance.
 	 *

--- a/packages/tools/client-debugger/client-debugger/src/FluidDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidDevtools.ts
@@ -22,6 +22,7 @@ import { FluidDevtoolsEvents, IFluidDevtools } from "./IFluidDevtools";
 import { ContainerMetadata } from "./ContainerMetadata";
 import { DevtoolsFeature, DevtoolsFeatureFlags } from "./Features";
 import { DevtoolsLogger } from "./DevtoolsLogger";
+import { VisualizeSharedObject } from "./data-visualization";
 
 // TODOs:
 // - Devtools disposal
@@ -79,6 +80,19 @@ export interface FluidDevtoolsProps {
 	 * @remarks Additional Containers can be registered with the Devtools via {@link IFluidDevtools.registerContainerDevtools}.
 	 */
 	initialContainers?: ContainerDevtoolsProps[];
+
+	/**
+	 * (optional) Configurations for generating visual representations of
+	 * {@link @fluidframework/shared-object-base#ISharedObject}s associated with individual Containers.
+	 *
+	 * @remarks
+	 *
+	 * If not specified, then only `SharedObject` types natively known by the system will be visualized, and using
+	 * default visualization implementations.
+	 *
+	 * If a visualizer configuration is specified for a shared object type that has a default visualizer, the custom one will be used.
+	 */
+	dataVisualizers?: Record<string, VisualizeSharedObject>;
 }
 
 /**
@@ -122,6 +136,13 @@ export class FluidDevtools
 	 * Maps from Container IDs to the corresponding devtools instance.
 	 */
 	private readonly containers: Map<string, ContainerDevtools>;
+
+	/**
+	 * Global data visualizers to apply to all {@link IContainerDevtools} instances registered with this object.
+	 *
+	 * @remarks If the user specifies data visualizers alongside a specific Container, those will take precedence over these.
+	 */
+	private readonly dataVisualizers?: Record<string, VisualizeSharedObject>;
 
 	/**
 	 * Private {@link FluidDevtools.disposed} tracking.
@@ -207,6 +228,7 @@ export class FluidDevtools
 		}
 
 		this.logger = props?.logger;
+		this.dataVisualizers = props?.dataVisualizers;
 
 		// Register listener for inbound messages from the window (globalThis)
 		globalThis.addEventListener?.("message", this.windowMessageHandler);
@@ -226,13 +248,18 @@ export class FluidDevtools
 			throw new UsageError(useAfterDisposeErrorText);
 		}
 
-		const { containerId } = props;
+		const { containerId, dataVisualizers: containerVisualizers } = props;
 
 		if (this.containers.has(containerId)) {
 			throw new UsageError(getContainerAlreadyRegisteredErrorText(containerId));
 		}
 
-		const containerDevtools = new ContainerDevtools(props);
+		const dataVisualizers = mergeDataVisualizers(this.dataVisualizers, containerVisualizers);
+
+		const containerDevtools = new ContainerDevtools({
+			...props,
+			dataVisualizers,
+		});
 		this.containers.set(containerId, containerDevtools);
 		this.emit("containerDevtoolsRegistered", containerId);
 	}
@@ -329,4 +356,24 @@ export class FluidDevtools
  */
 export function initializeFluidDevtools(props?: FluidDevtoolsProps): IFluidDevtools {
 	return new FluidDevtools(props);
+}
+
+/**
+ * Merges an optional set of global visualizers with an optional set of Container-local visualizers, such that
+ * Container-level visualizers take precedence when present.
+ */
+function mergeDataVisualizers(
+	globalVisualizers?: Record<string, VisualizeSharedObject>,
+	containerVisualizers?: Record<string, VisualizeSharedObject>,
+): Record<string, VisualizeSharedObject> | undefined {
+	if (globalVisualizers === undefined) {
+		return containerVisualizers;
+	}
+	if (containerVisualizers === undefined) {
+		return globalVisualizers;
+	}
+	return {
+		...globalVisualizers,
+		...containerVisualizers,
+	};
 }


### PR DESCRIPTION
These changes still allow registering Container-specific visualizer options, but also allow registering a single set with the root Devtools to be re-used across all registered Containers. Container-level options take precedence over global ones.

This gap was really evident as I started prototyping the 3rd party API entry-point - figured I would check it in separately.