### PR TITLE
fix: Add missing dev dependency from recent PR

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -138,6 +138,7 @@
 		"nyc": "^15.1.0",
 		"prettier": "~2.6.2",
 		"rimraf": "^4.4.0",
+		"source-map-support": "^0.5.16",
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -119,6 +119,7 @@
 		"mocha": "^10.2.0",
 		"semver": "^7.3.4",
 		"sinon": "^7.4.2",
+		"source-map-support": "^0.5.16",
 		"start-server-and-test": "^1.11.7",
 		"tinylicious": "0.7.2",
 		"url": "^0.11.0",
@@ -138,7 +139,6 @@
 		"nyc": "^15.1.0",
 		"prettier": "~2.6.2",
 		"rimraf": "^4.4.0",
-		"source-map-support": "^0.5.16",
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9826,6 +9826,7 @@ importers:
       mocha: 10.2.0
       semver: 7.3.8
       sinon: 7.5.0
+      source-map-support: 0.5.21
       start-server-and-test: 1.14.0
       tinylicious: 0.7.2
       url: 0.11.0
@@ -9844,7 +9845,6 @@ importers:
       nyc: 15.1.0
       prettier: 2.6.2
       rimraf: 4.4.0
-      source-map-support: 0.5.21
       typescript: 4.5.5
 
   packages/test/test-gc-sweep-tests:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9772,6 +9772,7 @@ importers:
       rimraf: ^4.4.0
       semver: ^7.3.4
       sinon: ^7.4.2
+      source-map-support: ^0.5.16
       start-server-and-test: ^1.11.7
       tinylicious: 0.7.2
       typescript: ~4.5.5
@@ -9843,6 +9844,7 @@ importers:
       nyc: 15.1.0
       prettier: 2.6.2
       rimraf: 4.4.0
+      source-map-support: 0.5.21
       typescript: 4.5.5
 
   packages/test/test-gc-sweep-tests:
@@ -30480,7 +30482,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
     requiresBuild: true
     dependencies:
       bindings: 1.5.0


### PR DESCRIPTION
## Description

In a [recent PR](https://github.com/microsoft/FluidFramework/pull/14995/) we missed adding a dev dependency for the `source-map-support` package used in `.mocharc.js`. This adds it so the e2e tests pipeline works again.
