### PR TITLE
fix(ci): Only try to upload t9s log if some task created it

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -358,14 +358,15 @@ stages:
             condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
 
           # Publish tinylicious log for troubleshooting
-          - task: PublishPipelineArtifact@1
-            displayName: Publish Artifact - Tinylicious Log
-            inputs:
-              targetPath: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log'
-              artifactName: 'tinyliciousLog'
-              publishLocation: 'pipeline'
-            condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
-            continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
+          - ${{ if contains(convertToJson(parameters.taskTest), 'tinylicious') }}:
+            - task: PublishPipelineArtifact@1
+              displayName: Publish Artifact - Tinylicious Log
+              inputs:
+                targetPath: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log'
+                artifactName: 'tinyliciousLog'
+                publishLocation: 'pipeline'
+              condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+              continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
 
           # Log Test Failures
           - template: include-log-test-failures.yml


### PR DESCRIPTION
## Description

A previous PR made changes to the ADO step that publishes the tinylicious log during CI runs, but pipelines that don't run tinylicious tests started to report warnings because the step doesn't find the file and can't publish it.

This PR makes the step conditional on some test task matching the string "tinylicious" which should mean that the file will be generated.

## Reviewer guidance

(msft internal links)
[Run of a pipeline that doesn't have tinylicious tests](https://dev.azure.com/fluidframework/internal/_build/results?buildId=153629&view=results), step is correctly skipped, no warnings reported.
[Run of a pipeline that does have tinylicious tests](https://dev.azure.com/fluidframework/internal/_build/results?buildId=153634&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=540d6e87-1033-59ae-be90-43f5a42b2d73), step is correctly run, and succeeds.