### PR TITLE
refactor(client-debugger): Remove "devtoolsDisposed" event from IFluidDevtools

### DIFF
--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -260,8 +260,6 @@ export interface FluidDevtoolsEvents extends IEvent {
     (event: "containerDevtoolsRegistered", listener: (containerId: string) => void): void;
     // @eventProperty
     (event: "containerDevtoolsClosed", listener: (containerId: string) => void): void;
-    // @eventProperty
-    (event: "devtoolsDisposed", listener: () => void): void;
 }
 
 // @public

--- a/packages/tools/client-debugger/client-debugger/src/FluidDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidDevtools.ts
@@ -311,9 +311,6 @@ export class FluidDevtools
 		this.containers.clear();
 		this.postContainerList(); // Notify listeners that the list of Containers changed.
 
-		// Notify listeners that the devtools have been disposed.
-		this.emit("devtoolsDisposed");
-
 		this._disposed = true;
 	}
 }

--- a/packages/tools/client-debugger/client-debugger/src/IFluidDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/IFluidDevtools.ts
@@ -27,14 +27,6 @@ export interface FluidDevtoolsEvents extends IEvent {
 	 * @eventProperty
 	 */
 	(event: "containerDevtoolsClosed", listener: (containerId: string) => void): void;
-
-	/**
-	 * Emitted when the {@link IFluidDevtools} instance is
-	 * {@link @fluidframework/common-definitions#IDisposable.dispose | disposed};
-	 *
-	 * @eventProperty
-	 */
-	(event: "devtoolsDisposed", listener: () => void): void;
 }
 
 /**

--- a/packages/tools/client-debugger/client-debugger/src/test/FluidDevtools.test.ts
+++ b/packages/tools/client-debugger/client-debugger/src/test/FluidDevtools.test.ts
@@ -64,16 +64,8 @@ describe("FluidDevtools unit tests", () => {
 	it("Disposal", () => {
 		const devtools = new FluidDevtools();
 
-		let devtoolsClosed = false;
-
-		devtools.on("devtoolsDisposed", () => {
-			devtoolsClosed = true;
-		});
-
 		devtools.dispose();
 
-		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-		expect(devtoolsClosed).to.be.true;
 		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 		expect(devtools.disposed).to.be.true;
 


### PR DESCRIPTION
This event was added assuming that the visualization tooling would require direct access to the Devtools object, and would need to know when the consuming app disposed of the instance. Since the only consumer of the Devtools object will be the consuming application, there is no need for this event.