### PR TITLE
fix(ci): Update name of test-files tar file for tree2

### DIFF
--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -33,7 +33,7 @@
 		"format": "npm run prettier:fix",
 		"lint": "npm run prettier && npm run eslint",
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
-		"postpack": "tar -cf ./tree.test-files.tar ./src/test ./dist/test",
+		"postpack": "tar -cf ./experimental-tree2.test-files.tar ./src/test ./dist/test",
 		"prettier": "prettier --check . --ignore-path ../../../.prettierignore",
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"test": "npm run test:mocha",


### PR DESCRIPTION
## Description

When @fluidframework/tree moved to @fluid-experimental/tree2 we didn't update the name of the `tar` file with its test-files, used by the Performance Benchmarks pipeline. The pipeline auto-generate the filename it expects based on the package scope + name so it wasn't finding the file in this case.

[AB#4183](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4183)