### PR TITLE
Update typebox

### DIFF
--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/runtime-definitions": ">=2.0.0-internal.4.2.0 <2.0.0-internal.5.0.0",
 		"@fluidframework/runtime-utils": ">=2.0.0-internal.4.2.0 <2.0.0-internal.5.0.0",
 		"@fluidframework/shared-object-base": ">=2.0.0-internal.4.2.0 <2.0.0-internal.5.0.0",
-		"@sinclair/typebox": "^0.25.21",
+		"@sinclair/typebox": "^0.28.6",
 		"@ungap/structured-clone": "^0.3.4",
 		"sorted-btree": "^1.8.0",
 		"uuid": "^8.3.1"

--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/runtime-definitions": ">=2.0.0-internal.4.2.0 <2.0.0-internal.5.0.0",
 		"@fluidframework/runtime-utils": ">=2.0.0-internal.4.2.0 <2.0.0-internal.5.0.0",
 		"@fluidframework/shared-object-base": ">=2.0.0-internal.4.2.0 <2.0.0-internal.5.0.0",
-		"@sinclair/typebox": "^0.28.6",
+		"@sinclair/typebox": "^0.28.8",
 		"@ungap/structured-clone": "^0.3.4",
 		"sorted-btree": "^1.8.0",
 		"uuid": "^8.3.1"

--- a/experimental/dds/tree2/src/feature-libraries/schemaIndexFormat.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schemaIndexFormat.ts
@@ -48,27 +48,32 @@ const TreeSchemaIdentifier = brandedString<TreeSchemaIdentifier>();
 const LocalFieldKey = brandedString<LocalFieldKey>();
 const GlobalFieldKey = brandedString<GlobalFieldKey>();
 
-const FieldSchemaFormat = Type.Object(
-	{
-		kind: FieldKindIdentifier,
-		types: Type.Optional(Type.Array(TreeSchemaIdentifier)),
-	},
+const FieldSchemaFormatBase = Type.Object({
+	kind: FieldKindIdentifier,
+	types: Type.Optional(Type.Array(TreeSchemaIdentifier)),
+});
+
+const FieldSchemaFormat = Type.Intersect([FieldSchemaFormatBase], { additionalProperties: false });
+
+const NamedLocalFieldSchemaFormat = Type.Intersect(
+	[
+		FieldSchemaFormatBase,
+		Type.Object({
+			name: LocalFieldKey,
+		}),
+	],
 	{ additionalProperties: false },
 );
 
-const NamedLocalFieldSchemaFormat = Type.Intersect([
-	FieldSchemaFormat,
-	Type.Object({
-		name: LocalFieldKey,
-	}),
-]);
-
-const NamedGlobalFieldSchemaFormat = Type.Intersect([
-	FieldSchemaFormat,
-	Type.Object({
-		name: GlobalFieldKey,
-	}),
-]);
+const NamedGlobalFieldSchemaFormat = Type.Intersect(
+	[
+		FieldSchemaFormatBase,
+		Type.Object({
+			name: GlobalFieldKey,
+		}),
+	],
+	{ additionalProperties: false },
+);
 
 const TreeSchemaFormat = Type.Object(
 	{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4824,7 +4824,7 @@ importers:
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.4.2.0 <2.0.0-internal.5.0.0'
       '@fluidframework/test-utils': '>=2.0.0-internal.4.2.0 <2.0.0-internal.5.0.0'
       '@microsoft/api-extractor': ^7.34.4
-      '@sinclair/typebox': ^0.25.21
+      '@sinclair/typebox': ^0.28.6
       '@types/diff': ^3.5.1
       '@types/easy-table': ^0.0.32
       '@types/mocha': ^9.1.1
@@ -4862,7 +4862,7 @@ importers:
       '@fluidframework/runtime-definitions': link:../../../packages/runtime/runtime-definitions
       '@fluidframework/runtime-utils': link:../../../packages/runtime/runtime-utils
       '@fluidframework/shared-object-base': link:../../../packages/dds/shared-object-base
-      '@sinclair/typebox': 0.25.21
+      '@sinclair/typebox': 0.28.6
       '@ungap/structured-clone': 0.3.4
       sorted-btree: 1.8.1
       uuid: 8.3.2
@@ -20777,6 +20777,11 @@ packages:
 
   /@sinclair/typebox/0.25.21:
     resolution: {integrity: sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==}
+    dev: true
+
+  /@sinclair/typebox/0.28.6:
+    resolution: {integrity: sha512-dIlAWjH0O0zK2w0YDhLX0vYy75sE0Ie+w9NL3hWCXbegQZMgTc7RVMeNLUem6PDwN1YvKo8oZIFXEsqTM7pVDw==}
+    dev: false
 
   /@sindresorhus/is/0.14.0:
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4824,7 +4824,7 @@ importers:
       '@fluidframework/test-runtime-utils': '>=2.0.0-internal.4.2.0 <2.0.0-internal.5.0.0'
       '@fluidframework/test-utils': '>=2.0.0-internal.4.2.0 <2.0.0-internal.5.0.0'
       '@microsoft/api-extractor': ^7.34.4
-      '@sinclair/typebox': ^0.28.6
+      '@sinclair/typebox': ^0.28.8
       '@types/diff': ^3.5.1
       '@types/easy-table': ^0.0.32
       '@types/mocha': ^9.1.1
@@ -4862,7 +4862,7 @@ importers:
       '@fluidframework/runtime-definitions': link:../../../packages/runtime/runtime-definitions
       '@fluidframework/runtime-utils': link:../../../packages/runtime/runtime-utils
       '@fluidframework/shared-object-base': link:../../../packages/dds/shared-object-base
-      '@sinclair/typebox': 0.28.6
+      '@sinclair/typebox': 0.28.8
       '@ungap/structured-clone': 0.3.4
       sorted-btree: 1.8.1
       uuid: 8.3.2
@@ -20779,8 +20779,8 @@ packages:
     resolution: {integrity: sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==}
     dev: true
 
-  /@sinclair/typebox/0.28.6:
-    resolution: {integrity: sha512-dIlAWjH0O0zK2w0YDhLX0vYy75sE0Ie+w9NL3hWCXbegQZMgTc7RVMeNLUem6PDwN1YvKo8oZIFXEsqTM7pVDw==}
+  /@sinclair/typebox/0.28.8:
+    resolution: {integrity: sha512-OerNjE43mIb2RDy/RJfjS+OHfJHq3caePlVe/GXkLwLzcYevA2JPzHWSFMkpGgfoFKWdQdckKRiMVMsz40yHgw==}
     dev: false
 
   /@sindresorhus/is/0.14.0:


### PR DESCRIPTION
## Description

Updates typebox to latest. There are a few nice features of the newer version, but the main one that's relevant for our persisted types is [composition of intersect and union](https://github.com/sinclairzx81/typebox/blob/master/changelog/0.26.0.md#intersect-and-union-now-compose).

It also makes a few breaking changes to schema construction for a few types. There are some details [here](https://github.com/sinclairzx81/typebox/issues/373), but the gist of it is we should avoid constraining types until they're fully composed. So this refactors a few schemas defined in SchemaIndexFormat to follow that recommendation.
