### PR TITLE
Fix cached snapshot id

### DIFF
--- a/packages/drivers/routerlicious-driver/src/contracts.ts
+++ b/packages/drivers/routerlicious-driver/src/contracts.ts
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ISnapshotTree } from "@fluidframework/protocol-definitions";
+
+/**
+ * Normalized Whole Summary with decoded blobs and unflattened snapshot tree.
+ */
+export interface INormalizedWholeSummary {
+	blobs: Map<string, ArrayBuffer>;
+	snapshotTree: ISnapshotTree;
+	sequenceNumber: number | undefined;
+	id: string;
+}

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -8,7 +8,6 @@ import * as api from "@fluidframework/driver-definitions";
 import { DriverErrorType } from "@fluidframework/driver-definitions";
 import { RateLimiter, NetworkErrorBasic, canRetryOnError } from "@fluidframework/driver-utils";
 import { IClient } from "@fluidframework/protocol-definitions";
-import { INormalizedWholeSummary } from "@fluidframework/server-services-client";
 import io from "socket.io-client";
 import { PerformanceEvent, wrapError } from "@fluidframework/telemetry-utils";
 import { ITelemetryLogger } from "@fluidframework/common-definitions";
@@ -25,6 +24,7 @@ import { pkgVersion as driverVersion } from "./packageVersion";
 import { GitManager } from "./gitManager";
 import { Historian } from "./historian";
 import { RestWrapper } from "./restWrapperBase";
+import { INormalizedWholeSummary } from "./contracts";
 
 /**
  * Amount of time between discoveries within which we don't need to rediscover on re-connect.

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -24,7 +24,7 @@ import {
 	RateLimiter,
 } from "@fluidframework/driver-utils";
 import { ChildLogger, PerformanceEvent } from "@fluidframework/telemetry-utils";
-import { INormalizedWholeSummary, ISession } from "@fluidframework/server-services-client";
+import { ISession } from "@fluidframework/server-services-client";
 import { DocumentService } from "./documentService";
 import { IRouterliciousDriverPolicies } from "./policies";
 import { ITokenProvider } from "./tokens";
@@ -34,6 +34,7 @@ import { parseFluidUrl, replaceDocumentIdInPath, getDiscoveredFluidResolvedUrl }
 import { ICache, InMemoryCache, NullCache } from "./cache";
 import { pkgVersion as driverVersion } from "./packageVersion";
 import { ISnapshotTreeVersion } from "./definitions";
+import { INormalizedWholeSummary } from "./contracts";
 
 const maximumSnapshotCacheDurationMs: FiveDaysMs = 432_000_000; // 5 days in ms
 

--- a/packages/drivers/routerlicious-driver/src/documentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentStorageService.ts
@@ -14,13 +14,13 @@ import {
 	DocumentStorageServiceProxy,
 	PrefetchDocumentStorageService,
 } from "@fluidframework/driver-utils";
-import { INormalizedWholeSummary } from "@fluidframework/server-services-client";
 import { IRouterliciousDriverPolicies } from "./policies";
 import { ICache } from "./cache";
 import { WholeSummaryDocumentStorageService } from "./wholeSummaryDocumentStorageService";
 import { ShreddedSummaryDocumentStorageService } from "./shreddedSummaryDocumentStorageService";
 import { GitManager } from "./gitManager";
 import { ISnapshotTreeVersion } from "./definitions";
+import { INormalizedWholeSummary } from "./contracts";
 
 export class DocumentStorageService extends DocumentStorageServiceProxy {
 	private _logTailSha: string | undefined = undefined;

--- a/packages/drivers/routerlicious-driver/src/r11sSnapshotParser.ts
+++ b/packages/drivers/routerlicious-driver/src/r11sSnapshotParser.ts
@@ -1,0 +1,83 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ISnapshotTree } from "@fluidframework/protocol-definitions";
+import { IWholeFlatSummary, IWholeFlatSummaryTree } from "@fluidframework/server-services-client";
+import { stringToBuffer } from "@fluidframework/common-utils";
+import { INormalizedWholeSummary } from "./contracts";
+
+/**
+ * Build a tree heirarchy from a flat tree.
+ *
+ * @param flatTree - a flat tree
+ * @param treePrefixToRemove - tree prefix to strip
+ * @returns the heirarchical tree
+ */
+function buildHierarchy(
+	flatTree: IWholeFlatSummaryTree,
+	treePrefixToRemove: string,
+): ISnapshotTree {
+	const lookup: { [path: string]: ISnapshotTree } = {};
+	// Root tree id will be used to determine which version was downloaded.
+	const root: ISnapshotTree = { id: flatTree.id, blobs: {}, trees: {} };
+	lookup[""] = root;
+
+	for (const entry of flatTree.entries) {
+		// Strip the `treePrefixToRemove` path from tree entries such that they are stored under root.
+		const entryPath = entry.path.replace(new RegExp(`^${treePrefixToRemove}/`), "");
+		const lastIndex = entryPath.lastIndexOf("/");
+		const entryPathDir = entryPath.slice(0, Math.max(0, lastIndex));
+		const entryPathBase = entryPath.slice(lastIndex + 1);
+
+		// The flat output is breadth-first so we can assume we see tree nodes prior to their contents
+		const node = lookup[entryPathDir];
+
+		// Add in either the blob or tree
+		if (entry.type === "tree") {
+			const newTree: ISnapshotTree = {
+				blobs: {},
+				trees: {},
+				unreferenced: entry.unreferenced,
+			};
+			node.trees[decodeURIComponent(entryPathBase)] = newTree;
+			lookup[entryPath] = newTree;
+		} else if (entry.type === "blob") {
+			node.blobs[decodeURIComponent(entryPathBase)] = entry.id;
+		} else {
+			throw new Error(`Unknown entry type!!`);
+		}
+	}
+
+	return root;
+}
+
+/**
+ * Converts existing IWholeFlatSummary to snapshot tree, blob array, and sequence number.
+ *
+ * @param flatSummary - flat summary
+ * @param treePrefixToRemove - tree prefix to strip. By default we are stripping ".app" prefix
+ * @returns snapshot tree, blob array, and sequence number
+ */
+export function convertWholeFlatSummaryToSnapshotTreeAndBlobs(
+	flatSummary: IWholeFlatSummary,
+	treePrefixToRemove: string = ".app",
+): INormalizedWholeSummary {
+	const blobs = new Map<string, ArrayBuffer>();
+	if (flatSummary.blobs) {
+		flatSummary.blobs.forEach((blob) => {
+			blobs.set(blob.id, stringToBuffer(blob.content, blob.encoding ?? "utf-8"));
+		});
+	}
+	const flatSummaryTree = flatSummary.trees?.[0];
+	const sequenceNumber = flatSummaryTree?.sequenceNumber;
+	const snapshotTree = buildHierarchy(flatSummaryTree, treePrefixToRemove);
+
+	return {
+		blobs,
+		snapshotTree,
+		sequenceNumber,
+		id: flatSummary.id,
+	};
+}

--- a/packages/drivers/routerlicious-driver/src/treeUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/treeUtils.ts
@@ -10,7 +10,7 @@ import {
 	ISummaryTree,
 	SummaryObject,
 } from "@fluidframework/protocol-definitions";
-import { INormalizedWholeSummary } from "@fluidframework/server-services-client";
+import { INormalizedWholeSummary } from "./contracts";
 
 /**
  * Summary tree assembler props


### PR DESCRIPTION
## Description

1.) Snapshot id in afr could be different from id of first tree in snapshot. So use correct id as version instead of first snapshot.
For gitrest the id of snapshot is different from id of first tree in snapshot. So we need to cache with proper id and not with id of first tre. Although with the previous changes, it will still hit the cache because we use the same id but it was not the correct one.
In my previous PR https://github.com/microsoft/FluidFramework/pull/15092, I changed it to use the id of first tree which was not correct way.
2.) Add scenario name so that we can know when getWholeFlatSummary event is recorded, on snapshot load or later.