### PR TITLE
refactor(client-debugger): Rename "isDebuggerMessage" to "isDevtoolsMessage"

### DIFF
--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/background/BackgroundScript.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/background/BackgroundScript.ts
@@ -6,7 +6,7 @@
 import {
 	ISourcedDevtoolsMessage,
 	devtoolsMessageSource,
-	isDebuggerMessage,
+	isDevtoolsMessage,
 } from "@fluid-tools/client-debugger";
 
 import {
@@ -54,7 +54,7 @@ browser.runtime.onConnect.addListener((devtoolsPort: Port): void => {
 	 * connections as needed.
 	 */
 	const devtoolsMessageListener = (message: Partial<ISourcedDevtoolsMessage>): void => {
-		if (!isDebuggerMessage(message)) {
+		if (!isDevtoolsMessage(message)) {
 			// Since this handler is attached strictly to our Devtools Script port,
 			// we should *only* see our own messages.
 			console.error(
@@ -100,7 +100,7 @@ browser.runtime.onConnect.addListener((devtoolsPort: Port): void => {
 						(tabMessage: Partial<ISourcedDevtoolsMessage>): void => {
 							// Only forward messages coming from the devtools library on the page.
 							if (
-								isDebuggerMessage(tabMessage) &&
+								isDevtoolsMessage(tabMessage) &&
 								tabMessage.source === devtoolsMessageSource
 							) {
 								relayMessageToPort(

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/content/ContentScript.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/content/ContentScript.ts
@@ -6,7 +6,7 @@
 import {
 	devtoolsMessageSource,
 	ISourcedDevtoolsMessage,
-	isDebuggerMessage,
+	isDevtoolsMessage,
 } from "@fluid-tools/client-debugger";
 
 import { extensionMessageSource, relayMessageToPort, relayMessageToWindow } from "../messaging";
@@ -48,7 +48,7 @@ browser.runtime.onConnect.addListener((backgroundPort: Port) => {
 
 		// Only relay message if it is one of ours, and if the source is the window's debugger
 		// (and not a message originating from the extension).
-		if (isDebuggerMessage(message) && message.source === devtoolsMessageSource) {
+		if (isDevtoolsMessage(message) && message.source === devtoolsMessageSource) {
 			relayMessageToPort(
 				message,
 				"webpage",
@@ -65,7 +65,7 @@ browser.runtime.onConnect.addListener((backgroundPort: Port) => {
 	backgroundPort.onMessage.addListener((message: Partial<ISourcedDevtoolsMessage>) => {
 		// Only relay message if it is one of ours, and if the source is the extension
 		// (and not the window).
-		if (isDebuggerMessage(message) && message.source === extensionMessageSource) {
+		if (isDevtoolsMessage(message) && message.source === extensionMessageSource) {
 			relayMessageToWindow(
 				message,
 				"Background Worker worker",

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/devtools/BackgroundConnection.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/devtools/BackgroundConnection.ts
@@ -9,7 +9,7 @@ import {
 	ISourcedDevtoolsMessage,
 	IMessageRelay,
 	IMessageRelayEvents,
-	isDebuggerMessage,
+	isDevtoolsMessage,
 	devtoolsMessageSource,
 } from "@fluid-tools/client-debugger";
 
@@ -134,7 +134,7 @@ export class BackgroundConnection
 	private readonly onBackgroundServiceMessage = (
 		message: Partial<ISourcedDevtoolsMessage>,
 	): boolean => {
-		if (!isDebuggerMessage(message)) {
+		if (!isDevtoolsMessage(message)) {
 			return false;
 		}
 

--- a/packages/tools/client-debugger/client-debugger-view/src/WindowMessageRelay.ts
+++ b/packages/tools/client-debugger/client-debugger-view/src/WindowMessageRelay.ts
@@ -9,7 +9,7 @@ import {
 	ISourcedDevtoolsMessage,
 	IMessageRelay,
 	IMessageRelayEvents,
-	isDebuggerMessage,
+	isDevtoolsMessage,
 	devtoolsMessageSource,
 } from "@fluid-tools/client-debugger";
 
@@ -65,7 +65,7 @@ export class WindowMessageRelay
 		event: MessageEvent<Partial<ISourcedDevtoolsMessage>>,
 	): void => {
 		const message = event.data;
-		if (isDebuggerMessage(message) && message.source === devtoolsMessageSource) {
+		if (isDevtoolsMessage(message) && message.source === devtoolsMessageSource) {
 			// Forward incoming message onto subscribers.
 			this.emit("message", message);
 		}

--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -440,7 +440,7 @@ export interface InboundHandlers {
 export function initializeFluidDevtools(props?: FluidDevtoolsProps): IFluidDevtools;
 
 // @internal
-export function isDebuggerMessage(value: Partial<ISourcedDevtoolsMessage>): value is ISourcedDevtoolsMessage;
+export function isDevtoolsMessage(value: Partial<ISourcedDevtoolsMessage>): value is ISourcedDevtoolsMessage;
 
 // @public
 export interface ISourcedDevtoolsMessage<TData = unknown> extends IDevtoolsMessage<TData> {

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -112,7 +112,7 @@ export {
 	handleIncomingMessage,
 	handleIncomingWindowMessage,
 	InboundHandlers,
-	isDebuggerMessage,
+	isDevtoolsMessage,
 	MessageLoggingOptions,
 	postMessagesToWindow,
 	RootDataVisualizations,

--- a/packages/tools/client-debugger/client-debugger/src/messaging/Utilities.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/Utilities.ts
@@ -106,7 +106,7 @@ export function handleIncomingMessage(
 ): void {
 	// TODO: remove loggingOptions once things settle.
 
-	if (message === undefined || !isDebuggerMessage(message)) {
+	if (message === undefined || !isDevtoolsMessage(message)) {
 		return;
 	}
 
@@ -130,7 +130,7 @@ export function handleIncomingMessage(
  *
  * @internal
  */
-export function isDebuggerMessage(
+export function isDevtoolsMessage(
 	value: Partial<ISourcedDevtoolsMessage>,
 ): value is ISourcedDevtoolsMessage {
 	return typeof value.source === "string" && value.type !== undefined;

--- a/packages/tools/client-debugger/client-debugger/src/messaging/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/index.ts
@@ -43,7 +43,7 @@ export {
 	handleIncomingMessage,
 	handleIncomingWindowMessage,
 	InboundHandlers,
-	isDebuggerMessage,
+	isDevtoolsMessage,
 	MessageLoggingOptions,
 	postMessagesToWindow,
 } from "./Utilities";


### PR DESCRIPTION
This was missed when the event types were renamed.