### PR TITLE
refactor(client-debugger): Remove unused event listener Devtools APIs

### DIFF
--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -18,7 +18,6 @@ import { ITelemetryBaseEvent } from '@fluidframework/common-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/common-definitions';
 import { ITelemetryLoggerPropertyBags } from '@fluidframework/telemetry-utils';
 import { TelemetryLogger } from '@fluidframework/telemetry-utils';
-import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @public
 export interface AudienceChangeLogEntry extends LogEntry {
@@ -236,7 +235,7 @@ export namespace DisconnectContainer {
 }
 
 // @internal
-export class FluidDevtools extends TypedEventEmitter<FluidDevtoolsEvents> implements IFluidDevtools {
+export class FluidDevtools implements IFluidDevtools {
     constructor(props?: FluidDevtoolsProps);
     closeContainerDevtools(containerId: string): void;
     // (undocumented)
@@ -247,14 +246,6 @@ export class FluidDevtools extends TypedEventEmitter<FluidDevtoolsEvents> implem
     getContainerDevtools(containerId: string): IContainerDevtools | undefined;
     readonly logger: DevtoolsLogger | undefined;
     registerContainerDevtools(props: ContainerDevtoolsProps): void;
-}
-
-// @public
-export interface FluidDevtoolsEvents extends IEvent {
-    // @eventProperty
-    (event: "containerDevtoolsRegistered", listener: (containerId: string) => void): void;
-    // @eventProperty
-    (event: "containerDevtoolsClosed", listener: (containerId: string) => void): void;
 }
 
 // @public
@@ -408,7 +399,7 @@ export interface IDevtoolsMessage<TData = unknown> {
 }
 
 // @public
-export interface IFluidDevtools extends IEventProvider<FluidDevtoolsEvents>, IDisposable {
+export interface IFluidDevtools extends IDisposable {
     closeContainerDevtools(containerId: string): void;
     getAllContainerDevtools(): readonly IContainerDevtools[];
     getContainerDevtools(containerId: string): IContainerDevtools | undefined;

--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -73,7 +73,7 @@ export interface ConnectionStateChangeLogEntry extends StateChangeLogEntry<Conta
 }
 
 // @internal @sealed
-export class ContainerDevtools extends TypedEventEmitter<ContainerDevtoolsEvents> implements IContainerDevtools {
+export class ContainerDevtools implements IContainerDevtools {
     constructor(props: ContainerDevtoolsProps);
     get audience(): IAudience;
     readonly container: IContainer;
@@ -85,11 +85,6 @@ export class ContainerDevtools extends TypedEventEmitter<ContainerDevtoolsEvents
     get disposed(): boolean;
     getAudienceHistory(): readonly AudienceChangeLogEntry[];
     getContainerConnectionLog(): readonly ConnectionStateChangeLogEntry[];
-}
-
-// @public
-export interface ContainerDevtoolsEvents extends IEvent {
-    (event: "disposed", listener: () => void): any;
 }
 
 // @public
@@ -395,7 +390,7 @@ export interface HasFluidObjectId {
 }
 
 // @public
-export interface IContainerDevtools extends IEventProvider<ContainerDevtoolsEvents>, IDisposable {
+export interface IContainerDevtools extends IDisposable {
     readonly audience: IAudience;
     readonly container: IContainer;
     readonly containerData?: IFluidLoadable | Record<string, IFluidLoadable>;

--- a/packages/tools/client-debugger/client-debugger/src/ContainerDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/ContainerDevtools.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { TypedEventEmitter } from "@fluidframework/common-utils";
 import { IAudience, IContainer } from "@fluidframework/container-definitions";
 import { IFluidLoadable } from "@fluidframework/core-interfaces";
 import { IClient } from "@fluidframework/protocol-definitions";
@@ -18,7 +17,7 @@ import {
 	RootHandleNode,
 	VisualizeSharedObject,
 } from "./data-visualization";
-import { IContainerDevtools, ContainerDevtoolsEvents } from "./IContainerDevtools";
+import { IContainerDevtools } from "./IContainerDevtools";
 import { AudienceChangeLogEntry, ConnectionStateChangeLogEntry } from "./Logs";
 import {
 	AudienceSummary,
@@ -156,10 +155,7 @@ export interface ContainerDevtoolsProps {
  * @sealed
  * @internal
  */
-export class ContainerDevtools
-	extends TypedEventEmitter<ContainerDevtoolsEvents>
-	implements IContainerDevtools
-{
+export class ContainerDevtools implements IContainerDevtools {
 	/**
 	 * {@inheritDoc IContainerDevtools.containerId}
 	 */
@@ -461,8 +457,6 @@ export class ContainerDevtools
 
 	// #endregion
 
-	private readonly debuggerDisposedHandler = (): boolean => this.emit("disposed");
-
 	/**
 	 * Message logging options used by the debugger.
 	 */
@@ -480,8 +474,6 @@ export class ContainerDevtools
 	private _disposed: boolean;
 
 	public constructor(props: ContainerDevtoolsProps) {
-		super();
-
 		this.containerId = props.containerId;
 		this.containerData = props.containerData;
 		this.container = props.container;
@@ -555,8 +547,6 @@ export class ContainerDevtools
 		this.dataVisualizer?.off("update", this.dataUpdateHandler);
 		this.dataVisualizer?.dispose();
 		this.dataVisualizer = undefined;
-
-		this.debuggerDisposedHandler(); // Notify consumers that the debugger has been disposed.
 
 		this._disposed = true;
 	}

--- a/packages/tools/client-debugger/client-debugger/src/IContainerDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/IContainerDevtools.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IDisposable, IEvent, IEventProvider } from "@fluidframework/common-definitions";
+import { IDisposable } from "@fluidframework/common-definitions";
 import { IAudience, IContainer } from "@fluidframework/container-definitions";
 import { IFluidLoadable } from "@fluidframework/core-interfaces";
 
@@ -14,27 +14,13 @@ import { AudienceChangeLogEntry, ConnectionStateChangeLogEntry } from "./Logs";
 // - Pass diffs instead of all data in change events (probably requires defining separate full-dump messages from delta messages)
 
 /**
- * Events emitted by {@link IContainerDevtools}.
- *
- * @public
- */
-export interface ContainerDevtoolsEvents extends IEvent {
-	/**
-	 * Emitted when the {@link IContainerDevtools} itself has been disposed.
-	 *
-	 * @see {@link IContainerDevtools.dispose}
-	 */
-	(event: "disposed", listener: () => void);
-}
-
-/**
  * Fluid debug session associated with a Fluid Client via its
  * {@link @fluidframework/container-definitions#IContainer} and
  * {@link @fluidframework/container-definitions#IAudience}.
  *
  * @public
  */
-export interface IContainerDevtools extends IEventProvider<ContainerDevtoolsEvents>, IDisposable {
+export interface IContainerDevtools extends IDisposable {
 	/**
 	 * The ID of {@link IContainerDevtools.container}.
 	 */

--- a/packages/tools/client-debugger/client-debugger/src/IFluidDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/IFluidDevtools.ts
@@ -2,32 +2,11 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IDisposable, IEvent, IEventProvider } from "@fluidframework/common-definitions";
+import { IDisposable } from "@fluidframework/common-definitions";
 
 import { ContainerDevtoolsProps } from "./ContainerDevtools";
 import { DevtoolsLogger } from "./DevtoolsLogger";
 import { IContainerDevtools } from "./IContainerDevtools";
-
-/**
- * Events emitted by {@link IFluidDevtools}.
- *
- * @public
- */
-export interface FluidDevtoolsEvents extends IEvent {
-	/**
-	 * Emitted when a {@link IContainerDevtools} is registered for a Container.
-	 *
-	 * @eventProperty
-	 */
-	(event: "containerDevtoolsRegistered", listener: (containerId: string) => void): void;
-
-	/**
-	 * Emitted when a {@link IContainerDevtools} is closed for a Container.
-	 *
-	 * @eventProperty
-	 */
-	(event: "containerDevtoolsClosed", listener: (containerId: string) => void): void;
-}
 
 /**
  * Fluid Devtools. A single instance is used to generate and communicate stats associated with the general Fluid
@@ -40,7 +19,7 @@ export interface FluidDevtoolsEvents extends IEvent {
  *
  * @public
  */
-export interface IFluidDevtools extends IEventProvider<FluidDevtoolsEvents>, IDisposable {
+export interface IFluidDevtools extends IDisposable {
 	/**
 	 * (optional) telemetry logger associated with the Fluid runtime.
 	 */

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -76,7 +76,7 @@ export {
 	DevtoolsFeatureFlags,
 } from "./Features";
 export { IContainerDevtools } from "./IContainerDevtools";
-export { FluidDevtoolsEvents, IFluidDevtools } from "./IFluidDevtools";
+export { IFluidDevtools } from "./IFluidDevtools";
 export { DevtoolsLogger } from "./DevtoolsLogger";
 export { FluidDevtools, FluidDevtoolsProps, initializeFluidDevtools } from "./FluidDevtools";
 export {

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -75,7 +75,7 @@ export {
 	DevtoolsFeature,
 	DevtoolsFeatureFlags,
 } from "./Features";
-export { ContainerDevtoolsEvents, IContainerDevtools } from "./IContainerDevtools";
+export { IContainerDevtools } from "./IContainerDevtools";
 export { FluidDevtoolsEvents, IFluidDevtools } from "./IFluidDevtools";
 export { DevtoolsLogger } from "./DevtoolsLogger";
 export { FluidDevtools, FluidDevtoolsProps, initializeFluidDevtools } from "./FluidDevtools";

--- a/packages/tools/client-debugger/client-debugger/src/test/FluidDevtools.test.ts
+++ b/packages/tools/client-debugger/client-debugger/src/test/FluidDevtools.test.ts
@@ -20,16 +20,6 @@ describe("FluidDevtools unit tests", () => {
 	it("Container change events", () => {
 		const devtools = new FluidDevtools();
 
-		let containerRegistered = false;
-		let containerDevtoolsClosed = false;
-
-		devtools.on("containerDevtoolsRegistered", () => {
-			containerRegistered = true;
-		});
-		devtools.on("containerDevtoolsClosed", () => {
-			containerDevtoolsClosed = true;
-		});
-
 		expect(devtools.getAllContainerDevtools().length).to.equal(0);
 
 		const container = createMockContainer();
@@ -40,8 +30,6 @@ describe("FluidDevtools unit tests", () => {
 		};
 		devtools.registerContainerDevtools(containerProps);
 
-		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-		expect(containerRegistered).to.be.true;
 		expect(devtools.getAllContainerDevtools().length).to.equal(1);
 
 		const containerDevtools = devtools.getContainerDevtools(containerId);
@@ -52,8 +40,6 @@ describe("FluidDevtools unit tests", () => {
 
 		devtools.closeContainerDevtools(containerId);
 
-		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-		expect(containerDevtoolsClosed).to.be.true;
 		expect(devtools.getAllContainerDevtools().length).to.equal(0);
 		// eslint-disable-next-line @typescript-eslint/no-unused-expressions, @typescript-eslint/no-non-null-assertion
 		expect(containerDevtools!.disposed).to.be.true;


### PR DESCRIPTION
All communication with the Devtools is currently done via Window-based message passing. The event listener APIs are an artifact of earlier prototyping. We can always re-add these as needed, but starting with a minimal API surface seems ideal.