### PR TITLE
[main -> lts] r11s-driver: Use correct id for snapshot version cache (#14400)

### DIFF
--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -226,19 +226,21 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
             },
         );
         const normalizedWholeSummary = convertWholeFlatSummaryToSnapshotTreeAndBlobs(wholeFlatSummary);
+        assert(
+            normalizedWholeSummary.snapshotTree.id !== undefined,
+            0x275 /* "Root tree should contain the id" */,
+        );
         const wholeFlatSummaryId: string = wholeFlatSummary.id;
-        const snapshotTreeId = normalizedWholeSummary.snapshotTree.id;
-        assert(snapshotTreeId !== undefined, 0x275 /* "Root tree should contain the id" */);
         const snapshotTreeVersion = { id: wholeFlatSummaryId, snapshotTree: normalizedWholeSummary.snapshotTree };
 
         const cachePs: Promise<any>[] = [
-            this.snapshotTreeCache.put(
-                this.getCacheKey(snapshotTreeId),
+        this.snapshotTreeCache.put(
+                this.getCacheKey(wholeFlatSummaryId),
                 snapshotTreeVersion,
             ),
             this.initBlobCache(normalizedWholeSummary.blobs),
         ];
-        if (snapshotTreeId !== versionId) {
+        if (wholeFlatSummaryId !== versionId) {
             // versionId could be "latest". When summarizer checks cache for "latest", we want it to be available.
             // TODO: For in-memory cache, <latest,snapshotTree> will be a shared pointer with <snapshotId,snapshotTree>,
             // However, for something like Redis, this will cache the same value twice. Alternatively, could we simply


### PR DESCRIPTION
Patch #14400 into LTS to improve doc load performance for new Gitrest storage performance in AFR.
