### PR TITLE
Summarizer: Log SummarizeTelemetry even if something fails

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2345,31 +2345,33 @@ export class ContainerRuntime
 			runSweep,
 		});
 
-		let gcStats: IGCStats | undefined;
-		if (runGC) {
-			gcStats = await this.collectGarbage(
-				{ logger: summaryLogger, runSweep, fullGC },
+		try {
+			let gcStats: IGCStats | undefined;
+			if (runGC) {
+				gcStats = await this.collectGarbage(
+					{ logger: summaryLogger, runSweep, fullGC },
+					telemetryContext,
+				);
+			}
+
+			const { stats, summary } = await this.summarizerNode.summarize(
+				fullTree,
+				trackState,
 				telemetryContext,
 			);
+
+			assert(
+				summary.type === SummaryType.Tree,
+				0x12f /* "Container Runtime's summarize should always return a tree" */,
+			);
+
+			return { stats, summary, gcStats };
+		} finally {
+			this.logger.sendTelemetryEvent({
+				eventName: "SummarizeTelemetry",
+				details: telemetryContext.serialize(),
+			});
 		}
-
-		const { stats, summary } = await this.summarizerNode.summarize(
-			fullTree,
-			trackState,
-			telemetryContext,
-		);
-
-		this.logger.sendTelemetryEvent({
-			eventName: "SummarizeTelemetry",
-			details: telemetryContext.serialize(),
-		});
-
-		assert(
-			summary.type === SummaryType.Tree,
-			0x12f /* "Container Runtime's summarize should always return a tree" */,
-		);
-
-		return { stats, summary, gcStats };
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -465,6 +465,13 @@ export class GarbageCollector implements IGarbageCollector {
 		const fullGC =
 			options.fullGC ??
 			(this.configs.runFullGC === true || this.summaryStateTracker.doesSummaryStateNeedReset);
+
+		// Add the options that are used to run GC to the telemetry context.
+		telemetryContext?.setMultiple("fluid_GC", "Options", {
+			fullGC,
+			runSweep: options.runSweep,
+		});
+
 		const logger = options.logger
 			? ChildLogger.create(options.logger, undefined, {
 					all: { completedGCRuns: () => this.completedRuns },
@@ -488,12 +495,6 @@ export class GarbageCollector implements IGarbageCollector {
 			});
 			return undefined;
 		}
-
-		// Add the options that are used to run GC to the telemetry context.
-		telemetryContext?.setMultiple("fluid_GC", "Options", {
-			fullGC,
-			runSweep: options.runSweep,
-		});
 
 		return PerformanceEvent.timedExecAsync(
 			logger,

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -441,8 +441,7 @@ describeNoCompat("Summaries", (getTestObjectProvider) => {
 	});
 });
 
-//* ONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLY
-describeNoCompat.only("Summaries", (getTestObjectProvider) => {
+describeNoCompat("Summaries", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	beforeEach(() => {
 		provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -441,7 +441,8 @@ describeNoCompat("Summaries", (getTestObjectProvider) => {
 	});
 });
 
-describeNoCompat("Summaries", (getTestObjectProvider) => {
+//* ONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLYONLY
+describeNoCompat.only("Summaries", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	beforeEach(() => {
 		provider = getTestObjectProvider();
@@ -466,15 +467,17 @@ describeNoCompat("Summaries", (getTestObjectProvider) => {
 			if (injectFailure) {
 				// force an exception under containerRuntime.summarize.
 				// SummarizeTelemetry event should still be logged
-				(containerRuntime as any).collectGarbage = undefined;
+				(containerRuntime as any).summarizerNode = undefined;
 			}
 
-			await containerRuntime.summarize({
-				runGC: false,
-				fullTree: false,
-				trackState: false,
-				summaryLogger: new TelemetryNullLogger(),
-			});
+			await containerRuntime
+				.summarize({
+					runGC: false,
+					fullTree: false,
+					trackState: false,
+					summaryLogger: new TelemetryNullLogger(),
+				})
+				.catch(() => {});
 
 			const summarizeTelemetryEvents = mockLogger.events.filter(
 				(event) => event.eventName === "fluid:telemetry:SummarizeTelemetry",
@@ -482,7 +485,7 @@ describeNoCompat("Summaries", (getTestObjectProvider) => {
 			assert.strictEqual(
 				summarizeTelemetryEvents.length,
 				1,
-				"There should only be one event",
+				"There should be exactly one event",
 			);
 
 			const parsed = JSON.parse(summarizeTelemetryEvents[0].details as string);

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -447,41 +447,56 @@ describeNoCompat("Summaries", (getTestObjectProvider) => {
 		provider = getTestObjectProvider();
 	});
 
-	it("TelemetryContext is populated with data", async () => {
-		const mockLogger = new MockLogger();
-		const container = await createContainer(provider, {}, mockLogger);
-		const defaultDataStore = await requestFluidObject<ITestDataObject>(
-			container,
-			defaultDataStoreId,
-		);
-		const containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
-		await provider.ensureSynchronized();
+	const getTestFn =
+		(injectFailure: boolean = false) =>
+		async () => {
+			const mockLogger = new MockLogger();
+			const container = await createContainer(provider, {}, mockLogger);
+			const defaultDataStore = await requestFluidObject<ITestDataObject>(
+				container,
+				defaultDataStoreId,
+			);
+			const containerRuntime = defaultDataStore._context.containerRuntime as ContainerRuntime;
+			await provider.ensureSynchronized();
 
-		const directory1 = defaultDataStore._root;
-		directory1.set("key", "value");
-		assert.strictEqual(await directory1.get("key"), "value", "value1 is not set");
+			const directory1 = defaultDataStore._root;
+			directory1.set("key", "value");
+			assert.strictEqual(await directory1.get("key"), "value", "value1 is not set");
 
-		await containerRuntime.summarize({
-			runGC: false,
-			fullTree: false,
-			trackState: false,
-			summaryLogger: new TelemetryNullLogger(),
-		});
+			if (injectFailure) {
+				// force an exception under containerRuntime.summarize.
+				// SummarizeTelemetry event should still be logged
+				(containerRuntime as any).collectGarbage = undefined;
+			}
 
-		const summarizeTelemetryEvents = mockLogger.events.filter(
-			(event) => event.eventName === "fluid:telemetry:SummarizeTelemetry",
-		);
-		assert.strictEqual(summarizeTelemetryEvents.length, 1, "There should only be one event");
+			await containerRuntime.summarize({
+				runGC: false,
+				fullTree: false,
+				trackState: false,
+				summaryLogger: new TelemetryNullLogger(),
+			});
 
-		const parsed = JSON.parse(summarizeTelemetryEvents[0].details as string);
-		assert(parsed && typeof parsed === "object", "Should be proper JSON");
+			const summarizeTelemetryEvents = mockLogger.events.filter(
+				(event) => event.eventName === "fluid:telemetry:SummarizeTelemetry",
+			);
+			assert.strictEqual(
+				summarizeTelemetryEvents.length,
+				1,
+				"There should only be one event",
+			);
 
-		assert.notStrictEqual(
-			summarizeTelemetryEvents[0].details,
-			"{}",
-			"Should not be empty JSON object",
-		);
-	});
+			const parsed = JSON.parse(summarizeTelemetryEvents[0].details as string);
+			assert(parsed && typeof parsed === "object", "Should be proper JSON");
+
+			assert.notStrictEqual(
+				summarizeTelemetryEvents[0].details,
+				"{}",
+				"Should not be empty JSON object",
+			);
+		};
+
+	it("TelemetryContext is populated with data", getTestFn());
+	it("TelemetryContext is populated with data even if summarize fails", getTestFn(true));
 });
 
 describeNoCompat("SingleCommit Summaries Tests", (getTestObjectProvider) => {


### PR DESCRIPTION
## Description

This event contains critical metadata for debugging/diagnosing issues, but it's only logged if the Summarizer succeeds.

## Reviewer Guidance

Highly recommend checking "hide whitespace" when looking at the changes.

Fixes [AB#4189](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4189)

