### PR TITLE
feat: Add release fromTag command

### DIFF
--- a/build-tools/packages/build-cli/docs/release.md
+++ b/build-tools/packages/build-cli/docs/release.md
@@ -4,6 +4,7 @@
 Release commands are used to manage the Fluid release process.
 
 * [`flub release`](#flub-release)
+* [`flub release fromTag TAG`](#flub-release-fromtag-tag)
 * [`flub release history`](#flub-release-history)
 * [`flub release report`](#flub-release-report)
 
@@ -46,6 +47,38 @@ DESCRIPTION
 ```
 
 _See code: [src/commands/release.ts](https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-cli/src/commands/release.ts)_
+
+## `flub release fromTag TAG`
+
+Determines release information based on a git tag argument.
+
+```
+USAGE
+  $ flub release fromTag TAG [-v] [--json]
+
+ARGUMENTS
+  TAG  A git tag that represents a release. May begin with 'refs/tags/'.
+
+FLAGS
+  -v, --verbose  Verbose logging.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Determines release information based on a git tag argument.
+
+  This command is used in CI to determine release information when a new release tag is pushed.
+
+EXAMPLES
+  Get release information based on a git tag.
+
+    $ flub release fromTag build-tools_v0.13.0
+
+  You can include the refs/tags/ part of a tag ref.
+
+    $ flub release fromTag refs/tags/2.0.0-internal.2.0.2
+```
 
 ## `flub release history`
 

--- a/build-tools/packages/build-cli/src/commands/release/fromTag.ts
+++ b/build-tools/packages/build-cli/src/commands/release/fromTag.ts
@@ -72,25 +72,23 @@ export default class FromTagCommand extends ReleaseReportBaseCommand<typeof From
 		if (taggedReleaseIndex === -1) {
 			this.error(`Release matching version '${version.version}' not found`);
 		}
+
 		const prevVersionDetails = versions[taggedReleaseIndex + 1];
-		this.warning(
-			`Previous index: ${taggedReleaseIndex + 1} version: ${prevVersionDetails?.version}`,
-		);
 		if (prevVersionDetails === undefined) {
 			this.error(`No previous release found`);
 		}
 
-		const releaseType = detectBumpType(prevVersionDetails?.version, version);
+		const previousVersion = prevVersionDetails?.version;
+		const releaseType = detectBumpType(previousVersion, version);
 		if (releaseType === undefined) {
 			this.error(
-				`Unable to determine release type for ${prevVersionDetails?.version} -> ${version.version}`,
+				`Unable to determine release type for ${previousVersion} -> ${version.version}`,
 			);
 		}
 
 		this.log(`${this.releaseGroupOrPackage} v${version.version} (${releaseType})`);
 
 		// When the --json flag is passed, the command will return the raw data as JSON.
-		const previousVersion = prevVersionDetails?.version;
 		return {
 			packageOrReleaseGroup: this.releaseGroupOrPackage,
 			tag,

--- a/build-tools/packages/build-cli/src/commands/release/fromTag.ts
+++ b/build-tools/packages/build-cli/src/commands/release/fromTag.ts
@@ -1,0 +1,131 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { Args } from "@oclif/core";
+import semver from "semver";
+
+import { sortVersions } from "../../lib";
+import { ReleaseGroup, ReleasePackage, isReleaseGroup } from "../../releaseGroups";
+import { ReleaseReportBaseCommand, ReleaseSelectionMode } from "./report";
+import { ReleaseVersion, VersionBumpType, detectBumpType } from "@fluid-tools/version-tools";
+
+/**
+ * The `release fromTag` command is used to get release information from a git tag.
+ *
+ * This command is used in CI to determine release information when a new release tag is pushed.
+ */
+export default class FromTagCommand extends ReleaseReportBaseCommand<typeof FromTagCommand> {
+	static summary = "Determines release information based on a git tag argument.";
+
+	static description =
+		"This command is used in CI to determine release information when a new release tag is pushed.";
+
+	static enableJsonFlag = true;
+
+	static args = {
+		tag: Args.string({
+			required: true,
+			description: "A git tag that represents a release. May begin with 'refs/tags/'.",
+		}),
+	};
+
+	defaultMode: ReleaseSelectionMode = "inRepo";
+	releaseGroupOrPackage: ReleaseGroup | ReleasePackage | undefined;
+
+	static examples = [
+		{
+			description: "Get release information based on a git tag.",
+			command: "<%= config.bin %> <%= command.id %> build-tools_v0.13.0",
+		},
+		{
+			description: "You can include the refs/tags/ part of a tag ref.",
+			command: "<%= config.bin %> <%= command.id %> refs/tags/2.0.0-internal.2.0.2",
+		},
+	];
+
+	async run(): Promise<{
+		packageOrReleaseGroup: ReleaseGroup | ReleasePackage;
+		tag: string;
+		date?: Date;
+		releaseType: VersionBumpType;
+		version: ReleaseVersion;
+		previousVersion?: ReleaseVersion;
+		previousTag?: string;
+	}> {
+		const tagInput = this.args.tag;
+		const context = await this.getContext();
+
+		const [releaseGroup, version, tag] = parseTag(tagInput);
+		this.releaseGroupOrPackage = releaseGroup;
+
+		this.releaseData = await this.collectReleaseData(
+			context,
+			this.defaultMode,
+			this.releaseGroupOrPackage,
+			false,
+		);
+
+		const release = this.releaseData[this.releaseGroupOrPackage];
+		this.verbose(JSON.stringify(release, undefined, 2));
+
+		const versions = sortVersions([...release.versions], "version");
+		const taggedReleaseIndex = versions.findIndex((v) => v.version === version.version);
+		if (taggedReleaseIndex === -1) {
+			this.error(`Release matching version '${version.version}' not found`);
+		}
+		const prevVersionDetails = versions[taggedReleaseIndex + 1];
+		this.warning(
+			`Previous index: ${taggedReleaseIndex + 1} version: ${prevVersionDetails?.version}`,
+		);
+		if (prevVersionDetails === undefined) {
+			this.error(`No previous release found`);
+		}
+
+		const releaseType = detectBumpType(prevVersionDetails?.version, version);
+		if (releaseType === undefined) {
+			this.error(
+				`Unable to determine release type for ${prevVersionDetails?.version} -> ${version.version}`,
+			);
+		}
+
+		this.log(`${this.releaseGroupOrPackage} v${version.version} (${releaseType})`);
+
+		// When the --json flag is passed, the command will return the raw data as JSON.
+		const previousVersion = prevVersionDetails?.version;
+		return {
+			packageOrReleaseGroup: this.releaseGroupOrPackage,
+			tag,
+			date: release.latestReleasedVersion.date,
+			releaseType,
+			version: version.version,
+			previousVersion,
+			previousTag:
+				prevVersionDetails === undefined
+					? undefined
+					: `${this.releaseGroupOrPackage}_v${previousVersion}`,
+		};
+	}
+}
+
+const pre = "refs/tags/";
+
+/**
+ * Parses a git tag string into a release group and a semver version.
+ * @param input - A git tag as a string.
+ * @returns A 3-tuple of the release group, the semver version, and the original tag.
+ */
+const parseTag = (input: string): [ReleaseGroup, semver.SemVer, string] => {
+	const tag = input.startsWith(pre) ? input.slice(pre.length) : input;
+	const [rg, ver] = tag.split("_v");
+	if (!isReleaseGroup(rg)) {
+		throw new Error(`Unknown release group parsed from tag: ${rg}`);
+	}
+
+	const version = semver.parse(ver);
+	if (version === null) {
+		throw new Error(`Invalid version parsed from tag: ${ver}`);
+	}
+
+	return [rg, version, tag];
+};

--- a/build-tools/packages/build-cli/src/commands/release/fromTag.ts
+++ b/build-tools/packages/build-cli/src/commands/release/fromTag.ts
@@ -2,13 +2,13 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+import { ReleaseVersion, VersionBumpType, detectBumpType } from "@fluid-tools/version-tools";
 import { Args } from "@oclif/core";
 import semver from "semver";
 
 import { sortVersions } from "../../lib";
 import { ReleaseGroup, ReleasePackage, isReleaseGroup } from "../../releaseGroups";
 import { ReleaseReportBaseCommand, ReleaseSelectionMode } from "./report";
-import { ReleaseVersion, VersionBumpType, detectBumpType } from "@fluid-tools/version-tools";
 
 /**
  * The `release fromTag` command is used to get release information from a git tag.
@@ -67,8 +67,6 @@ export default class FromTagCommand extends ReleaseReportBaseCommand<typeof From
 		);
 
 		const release = this.releaseData[this.releaseGroupOrPackage];
-		this.verbose(JSON.stringify(release, undefined, 2));
-
 		const versions = sortVersions([...release.versions], "version");
 		const taggedReleaseIndex = versions.findIndex((v) => v.version === version.version);
 		if (taggedReleaseIndex === -1) {

--- a/build-tools/packages/build-cli/src/commands/release/report.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report.ts
@@ -16,6 +16,7 @@ import { Context, VersionDetails } from "@fluidframework/build-tools";
 
 import {
 	ReleaseVersion,
+	VersionBumpType,
 	detectBumpType,
 	detectVersionScheme,
 	getPreviousVersions,
@@ -109,9 +110,10 @@ export abstract class ReleaseReportBaseCommand<T extends typeof Command> extends
 	 * Collect release data from the repo. Subclasses should call this in their init or run methods.
 	 *
 	 * @param context - The {@link Context}.
+	 * @param mode - The {@link ReleaseSelectionMode} to use to determine the release to report on.
 	 * @param releaseGroup - If provided, the release data collected will be limited to only the pakages in this release
 	 * group and its direct Fluid dependencies.
-	 * @param mode - The {@link ReleaseSelectionMode} to use to determine the release to report on.
+	 * @param includeDependencies - If true, the release data will include the Fluid dependencies of the release group.
 	 */
 	protected async collectReleaseData(
 		context: Context,
@@ -635,9 +637,10 @@ interface PackageReleaseData {
 	[packageName: string]: RawReleaseData;
 }
 
-interface RawReleaseData {
+export interface RawReleaseData {
 	repoVersion: VersionDetails;
 	latestReleasedVersion: VersionDetails;
+	latestReleaseType?: VersionBumpType;
 	previousReleasedVersion?: VersionDetails;
 	versions: readonly VersionDetails[];
 }


### PR DESCRIPTION
Adds a new `flub` command called `flub release fromTag`. This command determines release information based on a git tag argument. It will be used in CI to determine release information when a new release tag is pushed, so that GitHub releases can be created automatically in CI. See #15288 for more details.