### PR TITLE
ci: Create draft release notes on tag push

### DIFF
--- a/.changeset/templates/patch-changelog.hbs
+++ b/.changeset/templates/patch-changelog.hbs
@@ -1,0 +1,21 @@
+{{#each releases}}
+  {{#if summary}}
+    {{summary}}
+  {{/if}}
+
+  ## What's Changed
+
+  {{#each merges}}
+    - {{#if commit.breaking}}**Breaking change:** {{/if}}{{message}}{{#if href}} [`#{{id}}`]({{href}}){{/if}}
+  {{/each}}
+  {{#each fixes}}
+    - {{#if commit.breaking}}**Breaking change:** {{/if}}{{commit.subject}}{{#each fixes}}{{#if href}} [`#{{id}}`]({{href}}){{/if}}{{/each}}
+  {{/each}}
+  {{#each commits}}
+    - {{#if breaking}}**Breaking change:** {{/if}}{{subject}}{{#if href}} [`{{shorthash}}`]({{href}}){{/if}}
+  {{/each}}
+
+  {{#if href}}
+    **Full Changelog**: {{href}}
+  {{/if}}
+{{/each}}

--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -16,8 +16,7 @@ jobs:
           persist-credentials: false
 
       - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # ratchet:pnpm/action-setup@v2
-      - name: Extract cached dependencies
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # ratchet:actions/setup-node@v3
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # ratchet:actions/setup-node@v3
         with:
           node-version-file: .nvmrc
           cache: "pnpm"

--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -1,5 +1,13 @@
 name: "push-tag-create-release"
 
+# When a release tag is pushed to the repo, this workflow is triggered. It first installs the Fluid build-tools, then
+# uses the flub release fromTag command to load some release metadata into an environment variable. Once loaded, it
+# checks out the tagged commit and runs flub release report to generate release reports. It also uses auto-changelog to
+# create a changelog for patch releases (only patches). All the artifacts are uploaded for debugging purposes.
+
+# Once the artifacts are created, the workflow creates a GitHub release and attaches the release reports to it. The
+# release is a draft so that the release engineer can verify the contents before publishing.
+
 on:
   push:
     tags:

--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -15,15 +15,7 @@ jobs:
           fetch-depth: "0" # all history
           persist-credentials: false
 
-      # pnpm dependencies cannot be cached until pnpm is installed, which is done by corepack. So we set up node, enable
-      # corepack, then set up node again with the cache.
-      # WORKAROUND: https://github.com/actions/setup-node/issues/531#issuecomment-1416814256
-      # - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # ratchet:actions/setup-node@v3
-      #   with:
-      #     node-version-file: .nvmrc
       - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # ratchet:pnpm/action-setup@v2
-      # - name: Enable corepack
-      #   run: corepack enable
       - name: Extract cached dependencies
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # ratchet:actions/setup-node@v3
         with:

--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -79,21 +79,10 @@ jobs:
           path: reports
           retention-days: 7
 
-      # The release title will eventually be calculated outside the workflow as part of the RELEASE_JSON variable.
-      - name: Set release title (client)
-        if: fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'client'
-        run: |
-          echo "RELEASE_TITLE=Fluid Framework v${{ fromJson(env.RELEASE_JSON).version }} (${{
-          fromJson(env.RELEASE_JSON).releaseType }})" >> $GITHUB_ENV
-      - name: Set release title
-        if: fromJson(env.RELEASE_JSON).packageOrReleaseGroup != 'client'
-        run: |
-          echo "RELEASE_TITLE=${{ fromJson(env.RELEASE_JSON).packageOrReleaseGroup }} v${{ fromJson(env.RELEASE_JSON).version }} (${{ fromJson(env.RELEASE_JSON).releaseType }})" >> $GITHUB_ENV
-
       # Generate changelog
       - name: Generate changelog
-        # This changelog is only for client patch releases
-        if: fromJson(env.RELEASE_JSON).releaseType == 'patch' && fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'client'
+        # This changelog is only for client patch releases and build-tools releases
+        if: (fromJson(env.RELEASE_JSON).releaseType == 'patch' && fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'client') || fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'build-tools'
         run: |
           # We only need the root dependencies
           pnpm install -w --frozen-lockfile
@@ -127,8 +116,7 @@ jobs:
           draft: true
           omitDraftDuringUpdate: true # don't change the draft state when updating
 
-          # Created in the "Set release title" step
-          name: ${{ env.RELEASE_TITLE }}
+          name: ${{ fromJson(env.RELEASE_JSON).title }}
           omitNameDuringUpdate: false # always overwrite the name
 
           # Created in the "Generate changelog" step

--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -1,0 +1,142 @@
+name: "push-tag-create-release"
+
+on:
+  push:
+    tags:
+      - "*_v*"
+
+jobs:
+  create-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
+        with:
+          fetch-depth: "0" # all history
+          persist-credentials: false
+
+      # pnpm dependencies cannot be cached until pnpm is installed, which is done by corepack. So we set up node, enable
+      # corepack, then set up node again with the cache.
+      # WORKAROUND: https://github.com/actions/setup-node/issues/531#issuecomment-1416814256
+      # - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # ratchet:actions/setup-node@v3
+      #   with:
+      #     node-version-file: .nvmrc
+      - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # ratchet:pnpm/action-setup@v2
+      # - name: Enable corepack
+      #   run: corepack enable
+      - name: Extract cached dependencies
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # ratchet:actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install Fluid build tools
+        continue-on-error: true
+        run: |
+          cd build-tools
+          pnpm install --frozen-lockfile
+          pnpm run build:compile
+
+          # add the bin dir of build-cli to the path
+          cd packages/build-cli/bin
+          echo "$(pwd)" >> $GITHUB_PATH
+
+      - name: Check build-tools installation
+        run: |
+          # Info for debugging
+          which flub
+          flub --help
+          flub commands
+
+      - name: Get release metadata JSON
+        run: |
+          flub release fromTag ${{ github.ref }} --json | jq -c > release-metadata.json
+      - name: Upload release metadata JSON
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # ratchet:actions/upload-artifact@v3
+        with:
+          name: release-metadata
+          path: release-metadata.json
+          retention-days: 3
+      - name: Load release metadata into env variable
+        run: |
+          echo "RELEASE_JSON=$(cat release-metadata.json)" >> $GITHUB_ENV
+      - name: Set releaseType output variable
+        run: |
+         echo "releaseType=${{ fromJson(env.RELEASE_JSON).packageOrReleaseGroup }}" >> "$GITHUB_OUTPUT"
+
+      # Generate release reports
+      - name: Check out tag
+        run: |
+          git checkout ${{ github.ref }}
+      - name: Create release reports (manifests)
+        run: |
+          mkdir reports
+          flub release report -g ${{ fromJson(env.RELEASE_JSON).packageOrReleaseGroup }} -o reports
+      - name: Upload release reports
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # ratchet:actions/upload-artifact@v3
+        with:
+          name: release-reports
+          path: reports
+          retention-days: 7
+
+      # The release title will eventually be calculated outside the workflow as part of the RELEASE_JSON variable.
+      - name: Set release title (client)
+        if: fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'client'
+        run: |
+          echo "RELEASE_TITLE=Fluid Framework v${{ fromJson(env.RELEASE_JSON).version }} (${{
+          fromJson(env.RELEASE_JSON).releaseType }})" >> $GITHUB_ENV
+      - name: Set release title
+        if: fromJson(env.RELEASE_JSON).packageOrReleaseGroup != 'client'
+        run: |
+          echo "RELEASE_TITLE=${{ fromJson(env.RELEASE_JSON).packageOrReleaseGroup }} v${{ fromJson(env.RELEASE_JSON).version }} (${{ fromJson(env.RELEASE_JSON).releaseType }})" >> $GITHUB_ENV
+
+      # Generate changelog
+      - name: Generate changelog
+        # This changelog is only for client patch releases
+        if: fromJson(env.RELEASE_JSON).releaseType == 'patch' && fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'client'
+        run: |
+          # We only need the root dependencies
+          pnpm install -w --frozen-lockfile
+
+          # starting and ending versions are the same because we want to generate a changelog for a single release
+          pnpm exec auto-changelog \
+          --starting-version ${{ fromJson(env.RELEASE_JSON).tag }} \
+          --ending-version ${{ fromJson(env.RELEASE_JSON).tag }} \
+          --tag-prefix ${{ fromJson(env.RELEASE_JSON).packageOrReleaseGroup }}_v \
+          --output auto-changelog.md \
+          --template .changeset/templates/patch-changelog.hbs
+      - name: Generate changelog
+        # This changelog is a basically empty one used for everything except client.
+        if: fromJson(env.RELEASE_JSON).releaseType != 'patch' || fromJson(env.RELEASE_JSON).packageOrReleaseGroup != 'client'
+        run: |
+          echo "This is a **${{ fromJson(env.RELEASE_JSON).releaseType }}** release." > auto-changelog.md
+
+      # Only creates GH releases for client releases.
+      - name: Create GH release
+        if: fromJson(env.RELEASE_JSON).packageOrReleaseGroup == 'client'
+        uses: ncipollo/release-action@eb05307dcee34deaad054e98128088a30d7980dc # ratchet:ncipollo/release-action@main
+        with:
+          # Allow updates to existing releases.
+          allowUpdates: true
+
+          # Will skip if a published (non-draft) release already exists.
+          skipIfReleaseExists: true
+
+          # Leave the release as a draft so that the release engineer can verify it before it's public. Once we are
+          # more confident in the automation, we may update this workflow to publish the release as well.
+          draft: true
+          omitDraftDuringUpdate: true # don't change the draft state when updating
+
+          # Created in the "Set release title" step
+          name: ${{ env.RELEASE_TITLE }}
+          omitNameDuringUpdate: false # always overwrite the name
+
+          # Created in the "Generate changelog" step
+          bodyFile: auto-changelog.md
+          omitBodyDuringUpdate: true # Don't overwrite the body
+
+          # Created in the "Create release reports (manifests)" step
+          artifacts: "reports/*.*"
+          artifactErrorsFailBuild: true
+          tag: ${{ fromJson(env.RELEASE_JSON).tag }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -34,6 +34,9 @@ tools/pipelines/
 **/api-report/*
 **/*.api.md
 
+# Templates
+.changeset/templates/
+
 # Test json
 build-tools/packages/build-tools/src/test/data/
 experimental/dds/tree/src/test/documents/

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
 		"@microsoft/api-documenter": "^7.21.6",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@octokit/core": "^4.0.5",
+		"auto-changelog": "^2.4.0",
 		"c8": "^7.7.1",
 		"changesets-format-with-issue-links": "^0.3.0",
 		"concurrently": "^7.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ importers:
       '@microsoft/api-documenter': ^7.21.6
       '@microsoft/api-extractor': ^7.34.4
       '@octokit/core': ^4.0.5
+      auto-changelog: ^2.4.0
       c8: ^7.7.1
       changesets-format-with-issue-links: ^0.3.0
       concurrently: ^7.6.0
@@ -40,6 +41,7 @@ importers:
       '@microsoft/api-documenter': 7.21.6
       '@microsoft/api-extractor': 7.34.4
       '@octokit/core': 4.2.0
+      auto-changelog: 2.4.0
       c8: 7.7.1
       changesets-format-with-issue-links: 0.3.0_@changesets+cli@2.26.1
       concurrently: 7.6.0
@@ -24585,6 +24587,20 @@ packages:
   /auto-bind/4.0.0:
     resolution: {integrity: sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==}
     engines: {node: '>=8'}
+
+  /auto-changelog/2.4.0:
+    resolution: {integrity: sha512-vh17hko1c0ItsEcw6m7qPRf3m45u+XK5QyCrrBFViElZ8jnKrPC1roSznrd1fIB/0vR/zawdECCRJtTuqIXaJw==}
+    engines: {node: '>=8.3'}
+    hasBin: true
+    dependencies:
+      commander: 7.2.0
+      handlebars: 4.7.7
+      node-fetch: 2.6.9
+      parse-github-url: 1.0.2
+      semver: 7.3.8
+    transitivePeerDependencies:
+      - encoding
+    dev: true
 
   /autoprefixer/9.8.8:
     resolution: {integrity: sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==}


### PR DESCRIPTION
This change adds a new GitHub actions pipeline that will automate the release creation on tag push, including creating the report files and uploading them to the release. The OCE/release engineer will just need to hit "publish" on the release in GitHub to make it public. For patch releases we'll even generate the release notes automatically. For minors and majors that's still a manual process.

## How it works

When a release tag is pushed to the repo, the workflow is triggered. It first installs the Fluid build-tools, then uses the `flub release fromTag` command to load some release metadata into an environment variable. Once loaded, it checks out the tagged commit and runs `flub release report` to generate release reports. It also uses auto-changelog to create a changelog for patch releases (only patches). All the artifacts are uploaded for debugging purposes.

Once the artifacts are created, the workflow creates a GitHub release and attaches the release reports to it. The release is a draft so that the release engineer can verify the contents before publishing.