### PR TITLE
docs: Fix `@defaultValue` comment tag syntax

### DIFF
--- a/packages/drivers/tinylicious-driver/src/insecureTinyliciousTokenProvider.ts
+++ b/packages/drivers/tinylicious-driver/src/insecureTinyliciousTokenProvider.ts
@@ -21,7 +21,7 @@ export class InsecureTinyliciousTokenProvider implements ITokenProvider {
 		 *
 		 * @param scopes - See {@link @fluidframework/protocol-definitions#ITokenClaims.scopes}
 		 *
-		 * @defaultValue - [ ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite ]
+		 * @defaultValue [ ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite ]
 		 */
 		private readonly scopes?: ScopeType[],
 	) {}

--- a/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
+++ b/packages/runtime/test-runtime-utils/src/insecureTokenProvider.ts
@@ -33,7 +33,7 @@ export class InsecureTokenProvider implements ITokenProvider {
 		 *
 		 * @param scopes - See {@link @fluidframework/protocol-definitions#ITokenClaims.scopes}
 		 *
-		 * @defaultValue - [ ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite ]
+		 * @defaultValue [ ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite ]
 		 */
 		private readonly scopes?: ScopeType[],
 	) {}


### PR DESCRIPTION
`@defaultValue` tags should not be followed by an `-`. 

See [here](https://github.com/microsoft/FluidFramework/wiki/TSDoc-Guidelines#defaultvalue) for guidance.