### PR TITLE
ci(docs): Use node 16 in GitHub workflows

### DIFF
--- a/.github/workflows/website-validation.yml
+++ b/.github/workflows/website-validation.yml
@@ -23,7 +23,7 @@ jobs:
           version: "^7"
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # ratchet:actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
           cache: "pnpm"
           cache-dependency-path: docs/pnpm-lock.yaml
       - name: Build site artifact
@@ -49,7 +49,7 @@ jobs:
           version: "^7"
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # ratchet:actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
           cache: "pnpm"
           cache-dependency-path: docs/pnpm-lock.yaml
       - name: pnpm lint
@@ -70,7 +70,7 @@ jobs:
           version: "^7"
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # ratchet:actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
           cache: "pnpm"
           cache-dependency-path: docs/pnpm-lock.yaml
       - name: Create results folder


### PR DESCRIPTION
Now that we're using node 16 throughout most of the repo, it's time to update the docs CI validation pipeline to use it as well.