### PR TITLE
fix(client-debugger-chrome-extension): Fix the chrome extension build

### DIFF
--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/test/Utilities.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/test/Utilities.ts
@@ -86,10 +86,5 @@ export function stubGlobals(): Globals {
 
 	return {
 		browser: stubbedBrowser,
-		document: undefined,
-		eval: undefined,
-		fetch: (): void => {},
-		location: undefined,
-		window: undefined,
 	};
 }

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/src/utilities/Globals.ts
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/src/utilities/Globals.ts
@@ -8,20 +8,9 @@ declare const browser: typeof chrome;
 // Normalize access to extension APIs across browsers.
 const _browser: typeof chrome = typeof browser !== "undefined" ? browser : chrome;
 
-// Include references to web browser globals to facilitate mocks during testing.
-const _document = document;
-const _eval = eval; // eslint-disable-line no-eval
-const _location = location;
-const _MutationObserver = MutationObserver;
-const _window = window;
-
 export {
 	_browser as browser,
-	_document as document,
-	_eval as eval,
-	_location as location,
-	_MutationObserver as MutationObserver,
-	_window as window,
+	// TODO: other globals as necessary
 };
 
 /**
@@ -29,9 +18,5 @@ export {
  */
 export interface Globals {
 	browser: typeof chrome;
-	document?: Document;
-	eval?: (script: string) => unknown;
-	fetch?: () => void;
-	location?: Location;
-	window?: Window & typeof globalThis;
+	// TODO: other globals as necessary
 }

--- a/packages/tools/client-debugger/client-debugger-chrome-extension/webpack.config.js
+++ b/packages/tools/client-debugger/client-debugger-chrome-extension/webpack.config.js
@@ -59,7 +59,13 @@ module.exports = {
 			process: "process/browser",
 		}),
 		new CopyPlugin({
-			patterns: [{ from: ".", to: ".", context: "public" }],
+			patterns: [
+				// Copy assets from `public`
+				{ from: ".", to: ".", context: "public" },
+
+				// Copy HTML resources from source
+				{ from: "**/*.html", to: ".", context: "src" },
+			],
 		}),
 	],
 };


### PR DESCRIPTION
The previous PR that added script unit testing (#15253) inadvertently broke the actual extension build. A couple of changes were required to get things working again:
1. Reduce the number of browser global variables we are stubbing (we weren't using most of them anyways, so removing the unused ones seemed the fastest way to resolve some compatibility issues).
2. Ensure that the webpack build copies the necessary `.html` assets.