### PR TITLE
Use FieldUpPath in editing

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -394,11 +394,9 @@ export interface EditDescription {
     // (undocumented)
     change: FieldChangeset;
     // (undocumented)
-    field: FieldKey;
+    field: FieldUpPath;
     // (undocumented)
     fieldKind: FieldKindIdentifier;
-    // (undocumented)
-    path: UpPath | undefined;
 }
 
 // @alpha
@@ -671,15 +669,15 @@ export interface IDefaultEditBuilder {
     // (undocumented)
     addValueConstraint(path: UpPath, value: Value): void;
     // (undocumented)
-    move(sourcePath: UpPath | undefined, sourceField: FieldKey, sourceIndex: number, count: number, destPath: UpPath | undefined, destField: FieldKey, destIndex: number): void;
+    move(sourceField: FieldUpPath, sourceIndex: number, count: number, destinationField: FieldUpPath, destIndex: number): void;
     // (undocumented)
-    optionalField(parent: UpPath | undefined, field: FieldKey): OptionalFieldEditBuilder;
+    optionalField(field: FieldUpPath): OptionalFieldEditBuilder;
     // (undocumented)
-    sequenceField(parent: UpPath | undefined, field: FieldKey): SequenceFieldEditBuilder;
+    sequenceField(field: FieldUpPath): SequenceFieldEditBuilder;
     // (undocumented)
     setValue(path: UpPath, value: Value): void;
     // (undocumented)
-    valueField(parent: UpPath | undefined, field: FieldKey): ValueFieldEditBuilder;
+    valueField(field: FieldUpPath): ValueFieldEditBuilder;
 }
 
 // @alpha
@@ -1052,7 +1050,7 @@ export class ModularEditBuilder extends ProgressiveEditBuilderBase<ModularChange
     generateId(count?: number): ChangesetLocalId;
     // (undocumented)
     setValue(path: UpPath, value: Value): void;
-    submitChange(path: UpPath | undefined, field: FieldKey, fieldKind: FieldKindIdentifier, change: FieldChangeset, maxId?: ChangesetLocalId): void;
+    submitChange(field: FieldUpPath, fieldKind: FieldKindIdentifier, change: FieldChangeset, maxId?: ChangesetLocalId): void;
     // (undocumented)
     submitChanges(changes: EditDescription[], maxId?: ChangesetLocalId): void;
 }

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableField.ts
@@ -85,18 +85,16 @@ function getPrimaryArrayKey(
  */
 export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements EditableField {
 	public readonly fieldKey: FieldKey;
-	public readonly fieldSchema: FieldSchema;
 	public readonly [arrayLikeMarkerSymbol]: true;
 
 	public constructor(
 		context: ProxyContext,
-		fieldSchema: FieldSchema,
+		public readonly fieldSchema: FieldSchema,
 		cursor: ITreeSubscriptionCursor,
 	) {
-		assert(cursor.mode === CursorLocationType.Fields, 0x453 /* must be in fields mode */);
 		super(context, cursor);
+		assert(cursor.mode === CursorLocationType.Fields, 0x453 /* must be in fields mode */);
 		this.fieldKey = cursor.getFieldKey();
-		this.fieldSchema = fieldSchema;
 		this[arrayLikeMarkerSymbol] = true;
 	}
 
@@ -183,7 +181,7 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 			0x456 /* Index must be less than or equal to length. */,
 		);
 		const fieldPath = this.cursor.getFieldPath();
-		this.context.insertNodes(fieldPath.parent, fieldPath.field, index, newContent);
+		this.context.insertNodes(fieldPath, index, newContent);
 	}
 
 	public deleteNodes(index: number, count?: number): void {
@@ -199,7 +197,7 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 		const maxCount = this.length - index;
 		const _count = count === undefined || count > maxCount ? maxCount : count;
 		const fieldPath = this.cursor.getFieldPath();
-		this.context.deleteNodes(fieldPath.parent, fieldPath.field, index, _count);
+		this.context.deleteNodes(fieldPath, index, _count);
 	}
 
 	public replaceNodes(
@@ -225,7 +223,7 @@ export class FieldProxyTarget extends ProxyTarget<FieldAnchor> implements Editab
 		const maxCount = this.length - index;
 		const _count = count === undefined || count > maxCount ? maxCount : count;
 		const fieldPath = this.cursor.getFieldPath();
-		this.context.replaceNodes(fieldPath.parent, fieldPath.field, index, _count, newContent);
+		this.context.replaceNodes(fieldPath, index, _count, newContent);
 	}
 }
 

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTree.ts
@@ -198,18 +198,18 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 	public createField(fieldKey: FieldKey, newContent: ITreeCursor | ITreeCursor[]): void {
 		assert(!this.has(fieldKey), 0x44f /* The field already exists. */);
 		const fieldKind = this.lookupFieldKind(fieldKey);
-		const path = this.anchorNode;
+		const path = { parent: this.anchorNode, field: fieldKey };
 		switch (fieldKind.multiplicity) {
 			case Multiplicity.Optional: {
 				assert(
 					!Array.isArray(newContent),
 					0x450 /* Use single cursor to create the optional field */,
 				);
-				this.context.setOptionalField(path, fieldKey, newContent, true);
+				this.context.setOptionalField(path, newContent, true);
 				break;
 			}
 			case Multiplicity.Sequence: {
-				this.context.insertNodes(path, fieldKey, 0, newContent);
+				this.context.insertNodes(path, 0, newContent);
 				break;
 			}
 			case Multiplicity.Value:
@@ -225,15 +225,15 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 
 	public deleteField(fieldKey: FieldKey): void {
 		const fieldKind = this.lookupFieldKind(fieldKey);
-		const path = this.anchorNode;
+		const path = { parent: this.anchorNode, field: fieldKey };
 		switch (fieldKind.multiplicity) {
 			case Multiplicity.Optional: {
-				this.context.setOptionalField(path, fieldKey, undefined, false);
+				this.context.setOptionalField(path, undefined, false);
 				break;
 			}
 			case Multiplicity.Sequence: {
 				const length = this.fieldLength(fieldKey);
-				this.context.deleteNodes(path, fieldKey, 0, length);
+				this.context.deleteNodes(path, 0, length);
 				break;
 			}
 			case Multiplicity.Value:
@@ -248,14 +248,14 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 		newContent: undefined | ITreeCursor | ITreeCursor[],
 	): void {
 		const fieldKind = this.lookupFieldKind(fieldKey);
-		const path = this.anchorNode;
+		const path = { parent: this.anchorNode, field: fieldKey };
 		switch (fieldKind.multiplicity) {
 			case Multiplicity.Optional: {
 				assert(
 					!Array.isArray(newContent),
 					0x4cd /* It is invalid to replace the optional field using the array data. */,
 				);
-				this.context.setOptionalField(path, fieldKey, newContent, !this.has(fieldKey));
+				this.context.setOptionalField(path, newContent, !this.has(fieldKey));
 				break;
 			}
 			case Multiplicity.Sequence: {
@@ -271,7 +271,7 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 				 * for the desired `replaceField` semantics is not yet avaialble.
 				 */
 				// TODO: update implementation once the low-level editing API is available.
-				this.context.replaceNodes(path, fieldKey, 0, length, newContent);
+				this.context.replaceNodes(path, 0, length, newContent);
 				break;
 			}
 			case Multiplicity.Value: {
@@ -283,7 +283,7 @@ export class NodeProxyTarget extends ProxyTarget<Anchor> {
 					newContent !== undefined,
 					0x5cd /* It is invalid to replace a value field with undefined */,
 				);
-				this.context.setValueField(path, fieldKey, newContent);
+				this.context.setValueField(path, newContent);
 				break;
 			}
 			default:

--- a/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTreeContext.ts
+++ b/experimental/dds/tree2/src/feature-libraries/editable-tree/editableTreeContext.ts
@@ -14,9 +14,9 @@ import {
 	Value,
 	ITreeCursor,
 	UpPath,
-	FieldKey,
 	SchemaDataAndPolicy,
 	ForestEvents,
+	FieldUpPath,
 } from "../../core";
 import { ISubscribable } from "../../events";
 import { DefaultEditBuilder } from "../defaultChangeFamily";
@@ -212,57 +212,45 @@ export class ProxyContext implements EditableTreeContext {
 		this.editor.setValue(path, value);
 	}
 
-	public setValueField(
-		path: UpPath | undefined,
-		fieldKey: FieldKey,
-		newContent: ITreeCursor,
-	): void {
-		const field = this.editor.valueField(path, fieldKey);
-		field.set(newContent);
+	public setValueField(field: FieldUpPath, newContent: ITreeCursor): void {
+		const fieldEditor = this.editor.valueField(field);
+		fieldEditor.set(newContent);
 	}
 
 	public setOptionalField(
-		path: UpPath | undefined,
-		fieldKey: FieldKey,
+		field: FieldUpPath,
 		newContent: ITreeCursor | undefined,
 		wasEmpty: boolean,
 	): void {
-		const field = this.editor.optionalField(path, fieldKey);
-		field.set(newContent, wasEmpty);
+		const fieldEditor = this.editor.optionalField(field);
+		fieldEditor.set(newContent, wasEmpty);
 	}
 
 	public insertNodes(
-		path: UpPath | undefined,
-		fieldKey: FieldKey,
+		field: FieldUpPath,
 		index: number,
 		newContent: ITreeCursor | ITreeCursor[],
 	): void {
-		const field = this.editor.sequenceField(path, fieldKey);
-		field.insert(index, newContent);
+		const fieldEditor = this.editor.sequenceField(field);
+		fieldEditor.insert(index, newContent);
 	}
 
-	public deleteNodes(
-		path: UpPath | undefined,
-		fieldKey: FieldKey,
-		index: number,
-		count: number,
-	): void {
-		const field = this.editor.sequenceField(path, fieldKey);
-		field.delete(index, count);
+	public deleteNodes(field: FieldUpPath, index: number, count: number): void {
+		const fieldEditor = this.editor.sequenceField(field);
+		fieldEditor.delete(index, count);
 	}
 
 	public replaceNodes(
-		path: UpPath | undefined,
-		fieldKey: FieldKey,
+		field: FieldUpPath,
 		index: number,
 		count: number,
 		newContent: ITreeCursor | ITreeCursor[],
 	): void {
-		const field = this.editor.sequenceField(path, fieldKey);
-		field.delete(index, count);
+		const fieldEditor = this.editor.sequenceField(field);
+		fieldEditor.delete(index, count);
 
 		if (!Array.isArray(newContent) || newContent.length > 0) {
-			field.insert(index, newContent);
+			fieldEditor.insert(index, newContent);
 		}
 	}
 

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -22,6 +22,7 @@ import {
 	tagChange,
 	makeAnonChange,
 	ChangeFamilyEditor,
+	FieldUpPath,
 } from "../../core";
 import {
 	addToNestedSet,
@@ -1129,20 +1130,18 @@ export class ModularEditBuilder
 
 	/**
 	 * Adds a change to the edit builder
-	 * @param path - path to the parent node of the field being edited
 	 * @param field - the field which is being edited
 	 * @param fieldKind - the kind of the field
 	 * @param change - the change to the field
 	 * @param maxId - the highest `ChangesetLocalId` used in this change
 	 */
 	public submitChange(
-		path: UpPath | undefined,
-		field: FieldKey,
+		field: FieldUpPath,
 		fieldKind: FieldKindIdentifier,
 		change: FieldChangeset,
 		maxId: ChangesetLocalId = brand(-1),
 	): void {
-		const changeMap = this.buildChangeMap(path, field, fieldKind, change);
+		const changeMap = this.buildChangeMap(field, fieldKind, change);
 		this.applyChange(makeModularChangeset(changeMap, maxId));
 	}
 
@@ -1150,7 +1149,7 @@ export class ModularEditBuilder
 		const changeMaps = changes.map((change) =>
 			makeAnonChange(
 				makeModularChangeset(
-					this.buildChangeMap(change.path, change.field, change.fieldKind, change.change),
+					this.buildChangeMap(change.field, change.fieldKind, change.change),
 				),
 			),
 		);
@@ -1166,14 +1165,13 @@ export class ModularEditBuilder
 	}
 
 	private buildChangeMap(
-		path: UpPath | undefined,
-		field: FieldKey,
+		field: FieldUpPath,
 		fieldKind: FieldKindIdentifier,
 		change: FieldChangeset,
 	): FieldChangeMap {
-		let fieldChangeMap: FieldChangeMap = new Map([[field, { fieldKind, change }]]);
+		let fieldChangeMap: FieldChangeMap = new Map([[field.field, { fieldKind, change }]]);
 
-		let remainingPath = path;
+		let remainingPath = field.parent;
 		while (remainingPath !== undefined) {
 			const nodeChange: NodeChangeset = { fieldChanges: fieldChangeMap };
 			const fieldChange = genericFieldKind.changeHandler.editor.buildChildChange(
@@ -1200,8 +1198,7 @@ export class ModularEditBuilder
 			nodeChange,
 		);
 		this.submitChange(
-			path.parent,
-			path.parentField,
+			{ parent: path.parent, field: path.parentField },
 			genericFieldKind.identifier,
 			brand(fieldChange),
 		);
@@ -1216,8 +1213,7 @@ export class ModularEditBuilder
 			nodeChange,
 		);
 		this.submitChange(
-			path.parent,
-			path.parentField,
+			{ parent: path.parent, field: path.parentField },
 			genericFieldKind.identifier,
 			brand(fieldChange),
 		);
@@ -1228,8 +1224,7 @@ export class ModularEditBuilder
  * @alpha
  */
 export interface EditDescription {
-	path: UpPath | undefined;
-	field: FieldKey;
+	field: FieldUpPath;
 	fieldKind: FieldKindIdentifier;
 	change: FieldChangeset;
 }

--- a/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/schematizedTree.ts
@@ -80,7 +80,9 @@ export function schematizeView(
 				lookupGlobalFieldSchema(config.schema, rootFieldKey),
 				config.initialTree,
 			);
-			tree.editor.sequenceField(undefined, rootFieldKeySymbol).insert(0, newContent);
+			tree.editor
+				.sequenceField({ parent: undefined, field: rootFieldKeySymbol })
+				.insert(0, newContent);
 
 			// If intermediate schema is not final desired schema, update to the final schema:
 			if (incrementalSchemaUpdate !== config.schema) {

--- a/experimental/dds/tree2/src/test/feature-libraries/defaultChangeFamily.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/defaultChangeFamily.spec.ts
@@ -227,7 +227,7 @@ describe("DefaultEditBuilder", () => {
 	describe("Value Field Edits", () => {
 		it("Can overwrite a populated root field", () => {
 			const { builder, forest } = initializeEditableForest({ type: jsonObject.name });
-			builder.valueField(undefined, rootKey).set(singleTextCursor(nodeX));
+			builder.valueField({ parent: undefined, field: rootKey }).set(singleTextCursor(nodeX));
 			expectForest(forest, nodeX);
 		});
 
@@ -247,7 +247,7 @@ describe("DefaultEditBuilder", () => {
 					],
 				},
 			});
-			builder.valueField(root_foo2, fooKey).set(singleTextCursor(nodeX));
+			builder.valueField({ parent: root_foo2, field: fooKey }).set(singleTextCursor(nodeX));
 			const expected = {
 				type: jsonObject.name,
 				fields: {
@@ -270,7 +270,9 @@ describe("DefaultEditBuilder", () => {
 	describe("Optional Field Edits", () => {
 		it("Can overwrite a populated root field", () => {
 			const { builder, forest } = initializeEditableForest({ type: jsonObject.name });
-			builder.optionalField(undefined, rootKey).set(singleTextCursor(nodeX), false);
+			builder
+				.optionalField({ parent: undefined, field: rootKey })
+				.set(singleTextCursor(nodeX), false);
 			expectForest(forest, nodeX);
 		});
 
@@ -290,7 +292,9 @@ describe("DefaultEditBuilder", () => {
 					],
 				},
 			});
-			builder.optionalField(root_foo2, fooKey).set(singleTextCursor(nodeX), false);
+			builder
+				.optionalField({ parent: root_foo2, field: fooKey })
+				.set(singleTextCursor(nodeX), false);
 			const expected = {
 				type: jsonObject.name,
 				fields: {
@@ -311,7 +315,9 @@ describe("DefaultEditBuilder", () => {
 
 		it("Can set an empty root field", () => {
 			const { builder, forest } = initializeEditableForest();
-			builder.optionalField(undefined, rootKey).set(singleTextCursor(nodeX), true);
+			builder
+				.optionalField({ parent: undefined, field: rootKey })
+				.set(singleTextCursor(nodeX), true);
 			expectForest(forest, nodeX);
 		});
 
@@ -326,7 +332,9 @@ describe("DefaultEditBuilder", () => {
 					],
 				},
 			});
-			builder.optionalField(root_foo2, fooKey).set(singleTextCursor(nodeX), true);
+			builder
+				.optionalField({ parent: root_foo2, field: fooKey })
+				.set(singleTextCursor(nodeX), true);
 			const expected = {
 				type: jsonObject.name,
 				fields: {
@@ -344,7 +352,9 @@ describe("DefaultEditBuilder", () => {
 	describe("Sequence Field Edits", () => {
 		it("Can insert a root node", () => {
 			const { builder, forest } = initializeEditableForest();
-			builder.sequenceField(undefined, rootKey).insert(0, singleTextCursor(nodeX));
+			builder
+				.sequenceField({ parent: undefined, field: rootKey })
+				.insert(0, singleTextCursor(nodeX));
 			expectForest(forest, nodeX);
 		});
 
@@ -370,7 +380,9 @@ describe("DefaultEditBuilder", () => {
 					],
 				},
 			});
-			builder.sequenceField(root_foo2, fooKey).insert(5, singleTextCursor(nodeX));
+			builder
+				.sequenceField({ parent: root_foo2, field: fooKey })
+				.insert(5, singleTextCursor(nodeX));
 			const expected = {
 				type: jsonObject.name,
 				fields: {
@@ -398,7 +410,7 @@ describe("DefaultEditBuilder", () => {
 
 		it("Can delete a root node", () => {
 			const { builder, forest } = initializeEditableForest(nodeX);
-			builder.sequenceField(undefined, rootKey).delete(0, 1);
+			builder.sequenceField({ parent: undefined, field: rootKey }).delete(0, 1);
 			expectForest(forest, []);
 		});
 
@@ -426,7 +438,7 @@ describe("DefaultEditBuilder", () => {
 					],
 				},
 			});
-			builder.sequenceField(root_foo2, fooKey).delete(5, 2);
+			builder.sequenceField({ parent: root_foo2, field: fooKey }).delete(5, 2);
 			const expected = {
 				type: jsonObject.name,
 				fields: {

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -674,7 +674,11 @@ describe("ModularChangeFamily", () => {
 			parentIndex: 0,
 		};
 
-		editor.submitChange(path, fieldB, valueField.identifier, brand(valueChange1a));
+		editor.submitChange(
+			{ parent: path, field: fieldB },
+			valueField.identifier,
+			brand(valueChange1a),
+		);
 		const changes = editor.getChanges();
 		const nodeChange: NodeChangeset = {
 			fieldChanges: new Map([

--- a/experimental/dds/tree2/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
@@ -31,9 +31,15 @@ const fieldC: FieldKey = brand("FieldC");
 describe("rebase", () => {
 	it("delete over cross-field move", () => {
 		const editor = new DefaultEditBuilder(family, () => {}, new AnchorSet());
-		editor.move(undefined, fieldA, 1, 2, undefined, fieldB, 2);
-		editor.sequenceField(undefined, fieldA).delete(1, 1);
-		editor.sequenceField(undefined, fieldB).delete(2, 1);
+		editor.move(
+			{ parent: undefined, field: fieldA },
+			1,
+			2,
+			{ parent: undefined, field: fieldB },
+			2,
+		);
+		editor.sequenceField({ parent: undefined, field: fieldA }).delete(1, 1);
+		editor.sequenceField({ parent: undefined, field: fieldB }).delete(2, 1);
 		const [move, remove, expected] = editor.getChanges();
 		const rebased = family.rebase(remove, makeAnonChange(move));
 		const rebasedDelta = normalizeDelta(family.intoDelta(rebased));
@@ -43,9 +49,21 @@ describe("rebase", () => {
 
 	it("cross-field move over delete", () => {
 		const editor = new DefaultEditBuilder(family, () => {}, new AnchorSet());
-		editor.sequenceField(undefined, fieldA).delete(1, 1);
-		editor.move(undefined, fieldA, 1, 2, undefined, fieldB, 2);
-		editor.move(undefined, fieldA, 1, 1, undefined, fieldB, 2);
+		editor.sequenceField({ parent: undefined, field: fieldA }).delete(1, 1);
+		editor.move(
+			{ parent: undefined, field: fieldA },
+			1,
+			2,
+			{ parent: undefined, field: fieldB },
+			2,
+		);
+		editor.move(
+			{ parent: undefined, field: fieldA },
+			1,
+			1,
+			{ parent: undefined, field: fieldB },
+			2,
+		);
 		const [remove, move, expected] = editor.getChanges();
 		const rebased = family.rebase(move, makeAnonChange(remove));
 		const rebasedDelta = normalizeDelta(family.intoDelta(rebased));
@@ -56,9 +74,27 @@ describe("rebase", () => {
 	// See bug 4071
 	it.skip("cross-field move composition", () => {
 		const editor = new DefaultEditBuilder(family, () => {}, new AnchorSet());
-		editor.move(undefined, fieldA, 0, 1, undefined, fieldB, 0);
-		editor.move(undefined, fieldB, 0, 1, undefined, fieldC, 0);
-		editor.move(undefined, fieldA, 0, 1, undefined, fieldC, 0);
+		editor.move(
+			{ parent: undefined, field: fieldA },
+			0,
+			1,
+			{ parent: undefined, field: fieldB },
+			0,
+		);
+		editor.move(
+			{ parent: undefined, field: fieldB },
+			0,
+			1,
+			{ parent: undefined, field: fieldC },
+			0,
+		);
+		editor.move(
+			{ parent: undefined, field: fieldA },
+			0,
+			1,
+			{ parent: undefined, field: fieldC },
+			0,
+		);
 		const [move1, move2, expected] = editor.getChanges();
 		const composed = family.compose([makeAnonChange(move1), makeAnonChange(move2)]);
 		const actualDelta = normalizeDelta(family.intoDelta(composed));

--- a/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
@@ -429,7 +429,7 @@ describe("Branches", () => {
 	/** Apply an arbitrary but unique change to the given branch and return the tag for the new commit */
 	function change(branch: DefaultBranch): RevisionTag {
 		const cursor = singleTextCursor({ type: brand("TestValue"), value: changeValue });
-		branch.editor.valueField(undefined, rootFieldKeySymbol).set(cursor);
+		branch.editor.valueField({ parent: undefined, field: rootFieldKeySymbol }).set(cursor);
 		return branch.getHead().revision;
 	}
 

--- a/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -374,7 +374,7 @@ describe("SharedTreeCore", () => {
 function changeTree<TChange, TEditor extends DefaultEditBuilder>(
 	tree: SharedTreeCore<TEditor, TChange>,
 ): void {
-	const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+	const field = tree.editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 	field.insert(0, singleTextCursor({ type: brand("Node"), value: 42 }));
 }
 

--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -239,7 +239,10 @@ describe("Editing", () => {
 			const seqDelABC = sequencer.sequence(delABC);
 
 			const revABC = tree2.runTransaction((forest, editor) => {
-				const field = editor.sequenceField(undefined, rootFieldKeySymbol);
+				const field = editor.sequenceField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
 				field.revive(0, 3, seqDelABC.revision, fakeRepair, 1);
 			});
 
@@ -265,7 +268,10 @@ describe("Editing", () => {
 			const seqDelABC = sequencer.sequence(delABC);
 
 			const revABC = tree2.runTransaction((forest, editor) => {
-				const field = editor.sequenceField(undefined, rootFieldKeySymbol);
+				const field = editor.sequenceField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
 				field.revive(0, 3, seqDelABC.revision, fakeRepair, 1, true);
 			});
 
@@ -282,7 +288,10 @@ describe("Editing", () => {
 			const tree1 = TestTree.fromJson(["a", "b"]);
 
 			const change = tree1.runTransaction((forest, editor) => {
-				const rootField = editor.sequenceField(undefined, rootFieldKeySymbol);
+				const rootField = editor.sequenceField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
 				rootField.move(0, 1, 1);
 			});
 
@@ -303,9 +312,12 @@ describe("Editing", () => {
 					parentField: rootFieldKeySymbol,
 					parentIndex: 0,
 				};
-				const fooField = editor.sequenceField(node1, brand("foo"));
+				const fooField = editor.sequenceField({ parent: node1, field: brand("foo") });
 				fooField.move(0, 1, 1);
-				const rootField = editor.sequenceField(undefined, rootFieldKeySymbol);
+				const rootField = editor.sequenceField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
 				rootField.move(0, 1, 1);
 			});
 
@@ -330,12 +342,18 @@ describe("Editing", () => {
 
 			// Cause a rebase of tree2's edits
 			const e1 = tree1.runTransaction((forest, editor) => {
-				const field = editor.optionalField(undefined, rootFieldKeySymbol);
+				const field = editor.optionalField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
 				field.set(singleJsonCursor("41"), true);
 			});
 
 			const e2 = tree2.runTransaction((forest, editor) => {
-				const field = editor.optionalField(undefined, rootFieldKeySymbol);
+				const field = editor.optionalField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
 				field.set(singleJsonCursor("42"), true);
 			});
 
@@ -365,7 +383,7 @@ describe("Editing", () => {
  */
 function insert(tree: TestTree, index: number, ...values: string[]): TestTreeEdit {
 	return tree.runTransaction((forest, editor) => {
-		const field = editor.sequenceField(undefined, rootFieldKeySymbol);
+		const field = editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 		const nodes = values.map((value) => singleTextCursor({ type: jsonString.name, value }));
 		field.insert(index, nodes);
 	});
@@ -373,7 +391,7 @@ function insert(tree: TestTree, index: number, ...values: string[]): TestTreeEdi
 
 function remove(tree: TestTree, index: number, count: number): TestTreeEdit {
 	return tree.runTransaction((forest, editor) => {
-		const field = editor.sequenceField(undefined, rootFieldKeySymbol);
+		const field = editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 		field.delete(index, count);
 	});
 }

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -80,7 +80,7 @@ function applyFieldEdit(tree: ISharedTree, fieldEdit: FieldEdit): void {
 function applySequenceFieldEdit(tree: ISharedTree, change: FuzzFieldChange): void {
 	switch (change.type) {
 		case "insert": {
-			const field = tree.editor.sequenceField(change.parent, change.field);
+			const field = tree.editor.sequenceField({ parent: change.parent, field: change.field });
 			field.insert(
 				change.index,
 				singleTextCursor({ type: brand("Test"), value: change.value }),
@@ -88,10 +88,10 @@ function applySequenceFieldEdit(tree: ISharedTree, change: FuzzFieldChange): voi
 			break;
 		}
 		case "delete": {
-			const field = tree.editor.sequenceField(
-				change.firstNode?.parent,
-				change.firstNode?.parentField,
-			);
+			const field = tree.editor.sequenceField({
+				parent: change.firstNode?.parent,
+				field: change.firstNode?.parentField,
+			});
 			field.delete(change.firstNode?.parentIndex, change.count);
 			break;
 		}

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzUtils.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/fuzzUtils.ts
@@ -84,7 +84,7 @@ export function makeTree(initialState: JsonableTree): ISharedTree {
 	const runtime = new MockFluidDataStoreRuntime();
 	const tree = factory.create(runtime, "TestSharedTree");
 	tree.storedSchema.update(testSchema);
-	const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+	const field = tree.editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 	field.insert(0, singleTextCursor(initialState));
 	return tree;
 }

--- a/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/opSize.bench.ts
@@ -70,7 +70,7 @@ function initializeTestTree(tree: ISharedTree, state: JsonableTree = initialTest
 	tree.storedSchema.update(fullSchemaData);
 	// inserts a node with the initial AppState as the root of the tree
 	const writeCursor = singleTextCursor(state);
-	const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+	const field = tree.editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 	field.insert(0, writeCursor);
 }
 
@@ -157,7 +157,7 @@ const insertNodesWithIndividualTransactions = (
 			parentIndex: 0,
 		};
 		const writeCursor = singleTextCursor(jsonNode);
-		const field = tree.editor.sequenceField(path, childrenFieldKey);
+		const field = tree.editor.sequenceField({ parent: path, field: childrenFieldKey });
 		field.insert(0, writeCursor);
 		tree.transaction.commit();
 	}
@@ -176,7 +176,7 @@ const insertNodesWithSingleTransaction = (
 		parentField: rootFieldKeySymbol,
 		parentIndex: 0,
 	};
-	const field = tree.editor.sequenceField(path, childrenFieldKey);
+	const field = tree.editor.sequenceField({ parent: path, field: childrenFieldKey });
 	for (let i = 0; i < count; i++) {
 		field.insert(0, singleTextCursor(jsonNode));
 	}
@@ -197,7 +197,7 @@ const deleteNodesWithIndividualTransactions = (
 			parentField: rootFieldKeySymbol,
 			parentIndex: 0,
 		};
-		const field = tree.editor.sequenceField(path, childrenFieldKey);
+		const field = tree.editor.sequenceField({ parent: path, field: childrenFieldKey });
 		field.delete(getChildrenlength(tree) - 1, deletesPerTransaction);
 		tree.transaction.commit();
 		provider.processMessages();
@@ -215,7 +215,7 @@ const deleteNodesWithSingleTransaction = (
 		parentField: rootFieldKeySymbol,
 		parentIndex: 0,
 	};
-	const field = tree.editor.sequenceField(path, childrenFieldKey);
+	const field = tree.editor.sequenceField({ parent: path, field: childrenFieldKey });
 	field.delete(0, numDeletes);
 	tree.transaction.commit();
 	provider.processMessages();

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -59,7 +59,7 @@ describe("SharedTree", () => {
 		const provider = new TestTreeProviderLite();
 		runSynchronous(provider.trees[0], (t) => {
 			const writeCursor = singleTextCursor({ type: brand("LonelyNode") });
-			const field = t.editor.sequenceField(undefined, rootFieldKeySymbol);
+			const field = t.editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 			field.insert(0, writeCursor);
 		});
 
@@ -322,7 +322,10 @@ describe("SharedTree", () => {
 
 			// Delete node
 			runSynchronous(tree1, () => {
-				const field = tree1.editor.optionalField(undefined, rootFieldKeySymbol);
+				const field = tree1.editor.optionalField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
 				field.set(undefined, false);
 			});
 
@@ -332,7 +335,10 @@ describe("SharedTree", () => {
 
 			// Set node
 			runSynchronous(tree1, () => {
-				const field = tree1.editor.optionalField(undefined, rootFieldKeySymbol);
+				const field = tree1.editor.optionalField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
 				field.set(singleTextCursor({ type: brand("TestValue"), value: 43 }), true);
 			});
 
@@ -351,14 +357,14 @@ describe("SharedTree", () => {
 			// Insert child in global field
 			runSynchronous(tree1, () => {
 				const writeCursor = singleTextCursor({ type: brand("TestValue"), value: 43 });
-				const field = tree1.editor.sequenceField(
-					{
+				const field = tree1.editor.sequenceField({
+					parent: {
 						parent: undefined,
 						parentField: rootFieldKeySymbol,
 						parentIndex: 0,
 					},
-					globalFieldKeySymbol,
-				);
+					field: globalFieldKeySymbol,
+				});
 				field.insert(0, writeCursor);
 			});
 
@@ -378,14 +384,14 @@ describe("SharedTree", () => {
 
 			// Delete node
 			runSynchronous(tree2, () => {
-				const field = tree2.editor.sequenceField(
-					{
+				const field = tree2.editor.sequenceField({
+					parent: {
 						parent: undefined,
 						parentField: rootFieldKeySymbol,
 						parentIndex: 0,
 					},
-					globalFieldKeySymbol,
-				);
+					field: globalFieldKeySymbol,
+				});
 				field.delete(0, 1);
 			});
 
@@ -414,7 +420,10 @@ describe("SharedTree", () => {
 			};
 			initializeTestTree(branch, initialState);
 			runSynchronous(branch, () => {
-				const rootField = branch.editor.sequenceField(undefined, rootFieldKeySymbol);
+				const rootField = branch.editor.sequenceField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
 				const root0Path = {
 					parent: undefined,
 					parentField: rootFieldKeySymbol,
@@ -425,8 +434,8 @@ describe("SharedTree", () => {
 					parentField: rootFieldKeySymbol,
 					parentIndex: 1,
 				};
-				const foo0 = branch.editor.sequenceField(root0Path, fooKey);
-				const foo1 = branch.editor.sequenceField(root1Path, fooKey);
+				const foo0 = branch.editor.sequenceField({ parent: root0Path, field: fooKey });
+				const foo1 = branch.editor.sequenceField({ parent: root1Path, field: fooKey });
 				branch.editor.setValue(
 					{
 						parent: root0Path,
@@ -482,12 +491,18 @@ describe("SharedTree", () => {
 
 			// Insert nodes
 			runSynchronous(tree1, () => {
-				const field = tree1.editor.sequenceField(undefined, rootFieldKeySymbol);
+				const field = tree1.editor.sequenceField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
 				field.insert(0, singleTextCursor({ type: brand("Test"), value: 1 }));
 			});
 
 			runSynchronous(tree1, () => {
-				const field = tree1.editor.sequenceField(undefined, rootFieldKeySymbol);
+				const field = tree1.editor.sequenceField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
 				field.insert(1, singleTextCursor({ type: brand("Test"), value: 2 }));
 			});
 
@@ -533,7 +548,13 @@ describe("SharedTree", () => {
 					parentField: rootFieldKeySymbol,
 					parentIndex: 0,
 				};
-				tree1.editor.move(rootPath, brand("foo"), 1, 2, rootPath, brand("bar"), 1);
+				tree1.editor.move(
+					{ parent: rootPath, field: brand("foo") },
+					1,
+					2,
+					{ parent: rootPath, field: brand("bar") },
+					1,
+				);
 			});
 
 			provider.processMessages();
@@ -574,10 +595,28 @@ describe("SharedTree", () => {
 			};
 			// Perform multiple moves that should each be assigned a unique ID
 			runSynchronous(tree, () => {
-				tree.editor.move(rootPath, brand("foo"), 0, 1, rootPath, brand("bar"), 0);
-				tree.editor.move(rootPath, brand("bar"), 0, 1, rootPath, brand("baz"), 0);
+				tree.editor.move(
+					{ parent: rootPath, field: brand("foo") },
+					0,
+					1,
+					{ parent: rootPath, field: brand("bar") },
+					0,
+				);
+				tree.editor.move(
+					{ parent: rootPath, field: brand("bar") },
+					0,
+					1,
+					{ parent: rootPath, field: brand("baz") },
+					0,
+				);
 				runSynchronous(tree, () => {
-					tree.editor.move(rootPath, brand("baz"), 0, 1, rootPath, brand("qux"), 0);
+					tree.editor.move(
+						{ parent: rootPath, field: brand("baz") },
+						0,
+						1,
+						{ parent: rootPath, field: brand("qux") },
+						0,
+					);
 				});
 			});
 
@@ -824,12 +863,10 @@ describe("SharedTree", () => {
 			// Move b before a
 			runSynchronous(tree1, () => {
 				tree1.editor.move(
-					undefined,
-					rootFieldKeySymbol,
+					{ parent: undefined, field: rootFieldKeySymbol },
 					1,
 					1,
-					undefined,
-					rootFieldKeySymbol,
+					{ parent: undefined, field: rootFieldKeySymbol },
 					0,
 				);
 			});
@@ -873,12 +910,18 @@ describe("SharedTree", () => {
 
 			// Move bc between d and e.
 			runSynchronous(tree1, () => {
-				tree1.editor.move(rootPath, brand("foo"), 1, 2, rootPath, brand("bar"), 1);
+				tree1.editor.move(
+					{ parent: rootPath, field: brand("foo") },
+					1,
+					2,
+					{ parent: rootPath, field: brand("bar") },
+					1,
+				);
 			});
 
 			// Delete c
 			runSynchronous(tree2, () => {
-				const field = tree2.editor.sequenceField(rootPath, brand("foo"));
+				const field = tree2.editor.sequenceField({ parent: rootPath, field: brand("foo") });
 				field.delete(2, 1);
 			});
 
@@ -928,13 +971,19 @@ describe("SharedTree", () => {
 
 			// Delete c
 			runSynchronous(tree1, () => {
-				const field = tree1.editor.sequenceField(rootPath, brand("foo"));
+				const field = tree1.editor.sequenceField({ parent: rootPath, field: brand("foo") });
 				field.delete(2, 1);
 			});
 
 			// Move bc between d and e.
 			runSynchronous(tree2, () => {
-				tree2.editor.move(rootPath, brand("foo"), 1, 2, rootPath, brand("bar"), 1);
+				tree2.editor.move(
+					{ parent: rootPath, field: brand("foo") },
+					1,
+					2,
+					{ parent: rootPath, field: brand("bar") },
+					1,
+				);
 			});
 
 			provider.processMessages();
@@ -1509,7 +1558,10 @@ describe("SharedTree", () => {
 	describe("Transactions", () => {
 		/** like `pushTestValue`, but does not wrap the operation in a transaction */
 		function pushTestValueDirect(view: ISharedTreeView, value: TreeValue): void {
-			const field = view.editor.sequenceField(undefined, rootFieldKeySymbol);
+			const field = view.editor.sequenceField({
+				parent: undefined,
+				field: rootFieldKeySymbol,
+			});
 			const nodes = singleTextCursor({ type: brand("Node"), value });
 			field.insert(0, nodes);
 		}
@@ -1796,7 +1848,10 @@ describe("SharedTree", () => {
 			actual = mapCursorField(readCursor, jsonableTreeFromCursor);
 			readCursor.free();
 			runSynchronous(tree2, () => {
-				const field = tree2.editor.sequenceField(rootPath, brand("Test"));
+				const field = tree2.editor.sequenceField({
+					parent: rootPath,
+					field: brand("Test"),
+				});
 				field.insert(
 					0,
 					singleTextCursor({ type: brand("Test"), value: -9007199254740991 }),
@@ -1815,7 +1870,10 @@ describe("SharedTree", () => {
 			actual = mapCursorField(readCursor, jsonableTreeFromCursor);
 			readCursor.free();
 			runSynchronous(tree1, () => {
-				const field = tree1.editor.sequenceField(rootPath, brand("Test"));
+				const field = tree1.editor.sequenceField({
+					parent: rootPath,
+					field: brand("Test"),
+				});
 				field.insert(
 					0,
 					singleTextCursor({ type: brand("Test"), value: -9007199254740991 }),
@@ -1832,7 +1890,10 @@ describe("SharedTree", () => {
 			actual = mapCursorField(readCursor, jsonableTreeFromCursor);
 			readCursor.free();
 			runSynchronous(tree2, () => {
-				const field = tree2.editor.sequenceField(rootPath, brand("foo"));
+				const field = tree2.editor.sequenceField({
+					parent: rootPath,
+					field: brand("foo"),
+				});
 				field.delete(1, 1);
 			});
 			readCursor = tree2.forest.allocateCursor();
@@ -1852,7 +1913,10 @@ describe("SharedTree", () => {
 			actual = mapCursorField(readCursor, jsonableTreeFromCursor);
 			readCursor.free();
 			runSynchronous(tree1, () => {
-				const field = tree1.editor.sequenceField(undefined, rootFieldKeySymbol);
+				const field = tree1.editor.sequenceField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
 				field.insert(
 					1,
 					singleTextCursor({ type: brand("Test"), value: -9007199254740991 }),
@@ -1887,7 +1951,10 @@ describe("SharedTree", () => {
 			actual = mapCursorField(readCursor, jsonableTreeFromCursor);
 			readCursor.free();
 			runSynchronous(tree0, () => {
-				const field = tree0.editor.sequenceField(rootPath, brand("foo"));
+				const field = tree0.editor.sequenceField({
+					parent: rootPath,
+					field: brand("foo"),
+				});
 				field.delete(1, 1);
 			});
 			readCursor = tree0.forest.allocateCursor();
@@ -1901,7 +1968,10 @@ describe("SharedTree", () => {
 			actual = mapCursorField(readCursor, jsonableTreeFromCursor);
 			readCursor.free();
 			runSynchronous(tree1, () => {
-				const field = tree1.editor.sequenceField(rootPath, brand("Test"));
+				const field = tree1.editor.sequenceField({
+					parent: rootPath,
+					field: brand("Test"),
+				});
 				field.delete(0, 1);
 			});
 			readCursor = tree1.forest.allocateCursor();
@@ -1917,7 +1987,10 @@ describe("SharedTree", () => {
 			actual = mapCursorField(readCursor, jsonableTreeFromCursor);
 			readCursor.free();
 			runSynchronous(tree0, () => {
-				const field = tree0.editor.sequenceField(rootPath, brand("Test"));
+				const field = tree0.editor.sequenceField({
+					parent: rootPath,
+					field: brand("Test"),
+				});
 				field.insert(
 					0,
 					singleTextCursor({ type: brand("Test"), value: -9007199254740991 }),
@@ -1986,7 +2059,10 @@ describe("SharedTree", () => {
 				parentIndex: 1,
 			};
 			runSynchronous(tree, () => {
-				const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+				const field = tree.editor.sequenceField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
 				field.insert(
 					1,
 					singleTextCursor({ type: brand("Test"), value: -9007199254740991 }),
@@ -2004,7 +2080,10 @@ describe("SharedTree", () => {
 
 			// edit 2
 			runSynchronous(tree, () => {
-				const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+				const field = tree.editor.sequenceField({
+					parent: undefined,
+					field: rootFieldKeySymbol,
+				});
 				field.delete(0, 1);
 				return TransactionResult.Abort;
 			});
@@ -2058,7 +2137,10 @@ function initializeTestTree(
 		// Apply an edit to the tree which inserts a node with a value
 		runSynchronous(tree, () => {
 			const writeCursors = state.map(singleTextCursor);
-			const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+			const field = tree.editor.sequenceField({
+				parent: undefined,
+				field: rootFieldKeySymbol,
+			});
 			field.insert(0, writeCursors);
 		});
 	}
@@ -2134,7 +2216,7 @@ function getTestValues({ forest }: ISharedTreeView): TreeValue[] {
  */
 function insert(tree: ISharedTreeView, index: number, ...values: TreeValue[]): void {
 	runSynchronous(tree, () => {
-		const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+		const field = tree.editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 		const nodes = values.map((value) =>
 			singleTextCursor({ type: testValueSchema.name, value }),
 		);
@@ -2144,7 +2226,7 @@ function insert(tree: ISharedTreeView, index: number, ...values: TreeValue[]): v
 
 function remove(tree: ISharedTree, index: number, count: number): void {
 	runSynchronous(tree, () => {
-		const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+		const field = tree.editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 		field.delete(index, count);
 	});
 }

--- a/experimental/dds/tree2/src/test/shared-tree/summaryBenchmarkSizes.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/summaryBenchmarkSizes.ts
@@ -90,7 +90,7 @@ function setTestValue(tree: ISharedTree, value: TreeValue, index: number): void 
 	// Apply an edit to the tree which inserts a node with a value
 	runSynchronous(tree, () => {
 		const writeCursor = singleTextCursor({ type: brand("TestValue"), value });
-		const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+		const field = tree.editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 		field.insert(index, writeCursor);
 	});
 }
@@ -99,7 +99,7 @@ function setTestValueOnPath(tree: ISharedTree, value: TreeValue, path: PlacePath
 	// Apply an edit to the tree which inserts a node with a value.
 	runSynchronous(tree, () => {
 		const writeCursor = singleTextCursor({ type: brand("TestValue"), value });
-		const field = tree.editor.sequenceField(path, rootFieldKeySymbol);
+		const field = tree.editor.sequenceField({ parent: path, field: rootFieldKeySymbol });
 		field.insert(0, writeCursor);
 	});
 }
@@ -188,7 +188,7 @@ function initializeTestTreeWithValue(tree: ISharedTree, value: TreeValue): void 
 	// Apply an edit to the tree which inserts a node with a value
 	runSynchronous(tree, () => {
 		const writeCursor = singleTextCursor({ type: brand("TestValue"), value });
-		const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+		const field = tree.editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 		field.insert(0, writeCursor);
 	});
 }

--- a/experimental/dds/tree2/src/test/shared-tree/undo.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/undo.spec.ts
@@ -23,7 +23,7 @@ const schema: SchemaData = {
 function makeTree(...json: string[]): ISharedTree {
 	const tree = factory.create(runtime, "TestSharedTree");
 	tree.storedSchema.update(schema);
-	const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+	const field = tree.editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 	field.insert(0, json.map(singleJsonCursor));
 	return tree;
 }
@@ -74,7 +74,7 @@ describe("Undo", () => {
 	it("the set of a node", async () => {
 		const tree = makeTree("A", "B", "C", "D");
 
-		const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+		const field = tree.editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 		field.move(0, 2, 2);
 		expectJsonTree(tree, ["C", "D", "A", "B"]);
 
@@ -87,7 +87,7 @@ describe("Undo", () => {
 		const tree = makeTree("A", "B", "C", "D");
 		const fork = tree.fork();
 
-		const field = fork.editor.sequenceField(undefined, rootFieldKeySymbol);
+		const field = fork.editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 		field.move(0, 2, 2);
 
 		expectJsonTree(fork, ["C", "D", "A", "B"]);
@@ -185,13 +185,13 @@ describe("Undo", () => {
  * @param value - The value of the inserted node.
  */
 function insert(tree: ISharedTreeView, index: number, ...values: string[]): void {
-	const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+	const field = tree.editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 	const nodes = values.map((value) => singleTextCursor({ type: jsonString.name, value }));
 	field.insert(index, nodes);
 }
 
 function remove(tree: ISharedTreeView, index: number, count: number): void {
-	const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+	const field = tree.editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 	field.delete(index, count);
 }
 

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -531,7 +531,7 @@ export function initializeTestTree(
 	tree.storedSchema.update(schema);
 	// Apply an edit to the tree which inserts a node with a value
 	const writeCursor = singleTextCursor(state);
-	const field = tree.editor.sequenceField(undefined, rootFieldKeySymbol);
+	const field = tree.editor.sequenceField({ parent: undefined, field: rootFieldKeySymbol });
 	field.insert(0, writeCursor);
 }
 


### PR DESCRIPTION
## Description

Use FieldUpPath where appropriate in the editing code.

## Breaking Changes

Some APIs are switched to take parent and field grouped into a FieldUpPath instead of separately.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


