### PR TITLE
fix(tree): Fix test to not be dependent on op order

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -646,7 +646,7 @@ describe("SharedTree", () => {
 			remove(tree2, 1, 1);
 			await provider.ensureSynchronized();
 
-			// Validate insertion and deletion
+			// Validate deletion
 			const testValuesAfterDeletion = getTestValues(tree1);
 			assert.equal(testValuesAfterDeletion.length, 1);
 			assert.equal(testValuesAfterDeletion[0], value);


### PR DESCRIPTION
This fixes a failure when enabling the simulateReadConnectionUsingDelay option on TestTreeProvider.createTree.