### PR TITLE
fix(tree2): Use --parentProcess to prevent OOM during benchmark tests run in CI

### DIFF
--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -37,7 +37,7 @@
 		"prettier": "prettier --check . --ignore-path ../../../.prettierignore",
 		"prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
 		"test": "npm run test:mocha",
-		"test:benchmark:report": "mocha --exit --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 60000",
+		"test:benchmark:report": "mocha --exit --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 60000",
 		"test:coverage": "nyc npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"test:mocha": "mocha",
 		"test:mocha:multireport": "cross-env FLUID_TEST_MULTIREPORT=1 npm run test:mocha",


### PR DESCRIPTION
## Description

Some perf benchmark tests in @fluid-experimental/tree2 have been causing the Performance Benchmarks pipeline to OOM since they were introduced. It seems there's an actual memory leak there, but since locally they run with the `--parentProcess` flag (which has the effect of preventing the OOM even if that's not why it is used), we're adding the flag to the npm script used to run the tests in CI so the pipeline can complete successfully, while the OOM issue is investigated (@CraigMacomber will file an issue to tackle that separately).

[AB#4203](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4203)