### PR TITLE
[v2int/4.1] Set default GC version to 2 instead of 3

### DIFF
--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -158,9 +158,7 @@ export function generateGCConfigs(
 
 	// If version upgrade is not enabled, fall back to the stable GC version.
 	const gcVersionInEffect =
-		mc.config.getBoolean(gcVersionUpgradeToV3Key) === false
-			? stableGCVersion
-			: currentGCVersion;
+		mc.config.getBoolean(gcVersionUpgradeToV3Key) === true ? currentGCVersion : stableGCVersion;
 
 	return {
 		gcEnabled,

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -23,7 +23,7 @@ import {
 export type GCVersion = number;
 
 /** The stable version of garbage collection in production. */
-export const stableGCVersion: GCVersion = 1;
+export const stableGCVersion: GCVersion = 2;
 /** The current version of garbage collection. */
 export const currentGCVersion: GCVersion = 3;
 

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -47,7 +47,7 @@ import {
 	oneDayMs,
 	GCVersion,
 	disableSweepLogKey,
-	currentGCVersion,
+	stableGCVersion,
 } from "../../gc";
 import {
 	dataStoreAttributesBlobName,
@@ -147,7 +147,7 @@ describe("Garbage Collection Tests", () => {
 			metadata = {
 				...metadata,
 				...gcMetadata,
-				gcFeature: gcMetadata.gcFeature ?? currentGCVersion,
+				gcFeature: gcMetadata.gcFeature ?? stableGCVersion,
 				summaryFormatVersion: 1,
 				message: undefined,
 			};
@@ -787,7 +787,7 @@ describe("Garbage Collection Tests", () => {
 				const gcMetadata: IGCMetadata = {
 					gcFeature,
 				};
-				const { snapshotTree, gcBlobsMap } = getSnapshotWithGCVersion(currentGCVersion);
+				const { snapshotTree, gcBlobsMap } = getSnapshotWithGCVersion(gcFeature);
 				return createGarbageCollector(
 					{ baseSnapshot: snapshotTree },
 					gcBlobsMap,
@@ -796,7 +796,7 @@ describe("Garbage Collection Tests", () => {
 			}
 
 			it("reads all GC data from base snapshot when GC version does not change", async () => {
-				const garbageCollector = createGCOverride(currentGCVersion);
+				const garbageCollector = createGCOverride(stableGCVersion);
 
 				// GC state, tombstone state and deleted nodes should all be read from base snapshot.
 				const baseSnapshotData = await garbageCollector.baseSnapshotDataP;
@@ -833,7 +833,7 @@ describe("Garbage Collection Tests", () => {
 			});
 
 			it("discards GC state and tombstone state in base snapshot when GC version changes", async () => {
-				const garbageCollector = createGCOverride(currentGCVersion + 1);
+				const garbageCollector = createGCOverride(stableGCVersion + 1);
 
 				// GC state and tombstone state should be discarded but deleted nodes should be read from base snapshot.
 				const baseSnapshotData = await garbageCollector.baseSnapshotDataP;
@@ -870,11 +870,11 @@ describe("Garbage Collection Tests", () => {
 			});
 
 			it("reads all GC data from when refreshing from snapshot with same GC version", async () => {
-				const garbageCollector = createGCOverride(currentGCVersion);
+				const garbageCollector = createGCOverride(stableGCVersion);
 				await garbageCollector.initializeBaseState();
 
 				// Get a snapshot with the current GC version and refresh latest summary state from it.
-				const { snapshotTree, gcBlobsMap } = getSnapshotWithGCVersion(currentGCVersion);
+				const { snapshotTree, gcBlobsMap } = getSnapshotWithGCVersion(stableGCVersion);
 				const refreshSummaryResult: RefreshSummaryResult = {
 					latestSummaryUpdated: true,
 					wasSummaryTracked: false, // Indicates that state has to be updated from the snapshot in the result.
@@ -910,11 +910,11 @@ describe("Garbage Collection Tests", () => {
 			});
 
 			it("discards all GC data from when refreshing from snapshot with different GC version", async () => {
-				const garbageCollector = createGCOverride(currentGCVersion);
+				const garbageCollector = createGCOverride(stableGCVersion);
 				await garbageCollector.initializeBaseState();
 
 				// Get a snapshot with different GC version from current and refresh latest summary state from it.
-				const { snapshotTree, gcBlobsMap } = getSnapshotWithGCVersion(currentGCVersion + 1);
+				const { snapshotTree, gcBlobsMap } = getSnapshotWithGCVersion(stableGCVersion + 1);
 				const refreshSummaryResult: RefreshSummaryResult = {
 					latestSummaryUpdated: true,
 					wasSummaryTracked: false, // Indicates that state has to be updated from the snapshot in the result.

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -248,7 +248,7 @@ describe("Garbage Collection configurations", () => {
 			const expectedOutputMetadata: IGCMetadata = {
 				...inputMetadata,
 				sweepEnabled: false, // Hardcoded, not used
-				gcFeature: currentGCVersion,
+				gcFeature: stableGCVersion,
 			};
 			assert.deepEqual(
 				outputMetadata,
@@ -314,7 +314,7 @@ describe("Garbage Collection configurations", () => {
 			assert(gc.configs.sweepTimeoutMs !== undefined, "sweepTimeoutMs incorrect");
 			assert.equal(
 				gc.summaryStateTracker.latestSummaryGCVersion,
-				currentGCVersion,
+				stableGCVersion,
 				"latestSummaryGCVersion incorrect",
 			);
 		});
@@ -407,7 +407,7 @@ describe("Garbage Collection configurations", () => {
 		it("Metadata Roundtrip", () => {
 			const expectedMetadata: IGCMetadata = {
 				sweepEnabled: false, // hardcoded, not used
-				gcFeature: currentGCVersion,
+				gcFeature: stableGCVersion,
 				sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
 				sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
 				gcFeatureMatrix: { tombstoneGeneration: 2, sweepGeneration: 2 },
@@ -444,7 +444,7 @@ describe("Garbage Collection configurations", () => {
 		it("Metadata Roundtrip with only sweepGeneration", () => {
 			const expectedMetadata: IGCMetadata = {
 				sweepEnabled: false, // hardcoded, not used
-				gcFeature: currentGCVersion,
+				gcFeature: stableGCVersion,
 				sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
 				sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
 				gcFeatureMatrix: { sweepGeneration: 2, tombstoneGeneration: undefined },
@@ -625,7 +625,7 @@ describe("Garbage Collection configurations", () => {
 
 			const expectedMetadata: IGCMetadata = {
 				sweepEnabled: false,
-				gcFeature: currentGCVersion,
+				gcFeature: stableGCVersion,
 				sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
 				sweepTimeoutMs: expectedSweepTimeoutMs,
 				gcFeatureMatrix: undefined,

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -14,7 +14,7 @@ import {
 	IResolvedUrl,
 } from "@fluidframework/driver-definitions";
 import { IFileSnapshot } from "@fluidframework/replay-driver";
-import { TelemetryLogger } from "@fluidframework/telemetry-utils";
+import { ConfigTypes, IConfigProviderBase, TelemetryLogger } from "@fluidframework/telemetry-utils";
 import { getNormalizedSnapshot, ISnapshotNormalizerConfig } from "@fluidframework/tool-utils";
 import stringify from "json-stable-stringify";
 import { FluidObject } from "@fluidframework/core-interfaces";
@@ -166,6 +166,15 @@ export async function loadContainer(
 		new ReplayRuntimeFactory(runtimeOptions, dataStoreRegistries),
 	);
 
+	// Add a config provider to the Loader to enable / disable features.
+	const settings: Record<string, ConfigTypes> = {};
+	const configProvider: IConfigProviderBase = {
+		getRawConfig: (name: string): ConfigTypes => settings[name],
+	};
+	// Enable GCVersionUpgradeToV3 feature. This is for the snapshot tests which are already using GC version 3
+	// but the default version was changed to 2. Once the default is 3, this will be removed.
+	settings["Fluid.GarbageCollection.GCVersionUpgradeToV3"] = true;
+
 	// Load the Fluid document while forcing summarizeProtocolTree option
 	const loader = new Loader({
 		urlResolver,
@@ -175,6 +184,7 @@ export async function loadContainer(
 			? { ...loaderOptions, summarizeProtocolTree: true }
 			: { summarizeProtocolTree: true },
 		logger,
+		configProvider,
 	});
 
 	return loader.resolve({ url: resolved.url });


### PR DESCRIPTION
Port #15265 to release/v2int/4.1

The GC version was upgraded to 3 in internal.4.1 release since we fixed couple of GC bugs. However, there are couple more bugs that will be fixed by this change - [Close the summarizer instead of Refreshing Latest Ack from Server by tyler-cai-microsoft · Pull Request #15009 · microsoft/FluidFramework
(github.com)](https://github.com/microsoft/FluidFramework/pull/15009).

The GC version will have to be upgraded again after the above change to regenerate the GC data. That would cause full tree summaries yet again. So, revert the GC version 3 upgrade and do that once the remaining GC bugs are fixed.
