### PR TITLE
feat:(fluid-devtools) Add button in menu to refresh list of containters

### DIFF
--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import React from "react";
-
+import { useId } from "@fluentui/react-hooks";
 import {
 	ContainerList,
 	ContainerMetadata,
@@ -17,8 +17,9 @@ import {
 	ISourcedDevtoolsMessage,
 } from "@fluid-experimental/devtools-core";
 
-import { IStackItemStyles, IStackStyles, Stack } from "@fluentui/react";
-import { FluentProvider } from "@fluentui/react-components";
+import { IStackItemStyles, IStackStyles, Stack, TooltipHost } from "@fluentui/react";
+import { FluentProvider, Button } from "@fluentui/react-components";
+import { ArrowSync24Regular } from "@fluentui/react-icons";
 import {
 	ContainerDevtoolsView,
 	TelemetryView,
@@ -440,10 +441,44 @@ function ContainersMenuSection(props: ContainersMenuSectionProps): React.ReactEl
 		);
 	}
 
-	// TODO: add button to refresh list of containers
 	return (
-		<MenuSection header="Containers" key="container-selection-menu-section">
-			{containerSectionInnerView}
-		</MenuSection>
+		<div>
+			<MenuSection
+				header="Containers"
+				key="container-selection-menu-section"
+				refreshIcon={<RefreshButton />}
+			>
+				{containerSectionInnerView}
+			</MenuSection>
+		</div>
+	);
+}
+
+/**
+ * A refresh button to retrive the latest list of containers.
+ */
+function RefreshButton(): React.ReactElement {
+	const messageRelay = useMessageRelay();
+	const refreshButtonTooltipId = useId("connect-button-tooltip");
+	const transparentButtonStyle = {
+		backgroundColor: "transparent",
+		border: "none",
+		cursor: "pointer",
+	};
+
+	function handleRefreshClick(): void {
+		// Query for list of Containers
+		messageRelay.postMessage(getContainerListMessage);
+	}
+
+	return (
+		<TooltipHost content="Refresh Containers list" id={refreshButtonTooltipId}>
+			<Button
+				icon={<ArrowSync24Regular />}
+				style={transparentButtonStyle}
+				onClick={handleRefreshClick}
+				aria-label="Refresh Containers list"
+			></Button>
+		</TooltipHost>
 	);
 }

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -457,7 +457,7 @@ function ContainersMenuSection(props: ContainersMenuSectionProps): React.ReactEl
  */
 function RefreshButton(): React.ReactElement {
 	const messageRelay = useMessageRelay();
-	const refreshButtonTooltipId = useId("connect-button-tooltip");
+	const refreshButtonTooltipId = useId("refresh-container-list-button-tooltip");
 	const transparentButtonStyle = {
 		backgroundColor: "transparent",
 		border: "none",

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -442,15 +442,13 @@ function ContainersMenuSection(props: ContainersMenuSectionProps): React.ReactEl
 	}
 
 	return (
-		<div>
-			<MenuSection
-				header="Containers"
-				key="container-selection-menu-section"
-				refreshIcon={<RefreshButton />}
-			>
-				{containerSectionInnerView}
-			</MenuSection>
-		</div>
+		<MenuSection
+			header="Containers"
+			key="container-selection-menu-section"
+			icon={<RefreshButton />}
+		>
+			{containerSectionInnerView}
+		</MenuSection>
 	);
 }
 

--- a/packages/tools/devtools/devtools-view/src/components/Menu.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/Menu.tsx
@@ -18,7 +18,7 @@ export type MenuSectionProps = React.PropsWithChildren<{
 	/**
 	 * The refresh icon to display in the header of the menu section.
 	 */
-	refreshIcon?: React.ReactElement;
+	icon?: React.ReactElement;
 }>;
 
 /**
@@ -27,13 +27,13 @@ export type MenuSectionProps = React.PropsWithChildren<{
  * @internal
  */
 export function MenuSection(props: MenuSectionProps): React.ReactElement {
-	const { header, refreshIcon, children } = props;
+	const { header, icon, children } = props;
 
 	return (
 		<Stack>
 			<Stack.Item styles={menuSectionHeaderStyles}>
 				{header}
-				{refreshIcon}
+				{icon}
 			</Stack.Item>
 			{children}
 		</Stack>

--- a/packages/tools/devtools/devtools-view/src/components/Menu.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/Menu.tsx
@@ -14,6 +14,11 @@ export type MenuSectionProps = React.PropsWithChildren<{
 	 * The text to display in header of the menu section.
 	 */
 	header: string;
+
+	/**
+	 * The refresh icon to display in the header of the menu section.
+	 */
+	refreshIcon?: React.ReactElement;
 }>;
 
 /**
@@ -22,11 +27,14 @@ export type MenuSectionProps = React.PropsWithChildren<{
  * @internal
  */
 export function MenuSection(props: MenuSectionProps): React.ReactElement {
-	const { header, children } = props;
+	const { header, refreshIcon, children } = props;
 
 	return (
 		<Stack>
-			<Stack.Item styles={menuSectionHeaderStyles}>{header}</Stack.Item>
+			<Stack.Item styles={menuSectionHeaderStyles}>
+				{header}
+				{refreshIcon}
+			</Stack.Item>
 			{children}
 		</Stack>
 	);


### PR DESCRIPTION
## Description

In the previous UI we had a button to refresh the containers, which I didn't port to the new UI. We should have that functionality in case something happens with the messaging infrastructure and a new container doesn't show up automatically in the menu, or a container that should disappear somehow isn't removed.

I'm thinking a small icon-only button within the "Containers" header (standard refresh icon) to trigger a new request for container data (the same request we currently do when the Fluid dev tools UI renders for the first time).

## Sample
<img width="908" alt="Screenshot 2023-04-26 174929" src="https://user-images.githubusercontent.com/114451900/234732222-85dcfef6-2f6b-440f-9618-134b79e468d2.png">

