### PR TITLE
fix(fluid-devtools): Add missing key prop for React

### DIFF
--- a/packages/tools/client-debugger/client-debugger-view/src/DevtoolsView.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/DevtoolsView.tsx
@@ -355,6 +355,7 @@ function Menu(props: MenuProps): React.ReactElement {
 
 	menuSections.push(
 		<ContainersMenuSection
+			key="containers-menu-section"
 			containers={containers}
 			currentContainerSelection={
 				currentSelection?.type === "containerMenuSelection"


### PR DESCRIPTION
## Description

Adds missing `key` prop to a React element. This gets rid of this error logged to the console by React:

<img width="829" alt="image" src="https://user-images.githubusercontent.com/716334/234738384-e00caed1-6a89-4e7d-9887-59666a21a4ba.png">
