### PR TITLE
feat:(fluid-devtools) If the webpage does not have an initialized Devtools, the extension will spin forever

### DIFF
--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -181,22 +181,16 @@ export function DevtoolsView(): React.ReactElement {
 		// Query for supported feature set
 		messageRelay.postMessage(getSupportedFeaturesMessage);
 
-		// Add a timeout for the query
-		if (!supportedFeatures) {
-			queryTimer.current = setTimeout(() => {
-				setQueryTimedOut(true);
-			}, queryTimeoutInMilliseconds);
-		}
-
 		return (): void => {
 			messageRelay.off("message", messageHandler);
-			clearTimeout(queryTimer.current);
 		};
 	}, [messageRelay, setSupportedFeatures]);
 
 	// Manage the query timeout
 	React.useEffect(() => {
-		if (queryTimedOut) {
+		if (supportedFeatures === undefined) {
+			// If we have queried for the supported feature list but have not received
+			// a response yet, queue a timer.
 			const timeout = setTimeout(() => {
 				setQueryTimedOut(false);
 			}, queryTimeoutInMilliseconds);
@@ -204,7 +198,11 @@ export function DevtoolsView(): React.ReactElement {
 				clearTimeout(timeout);
 			};
 		}
-	}, [queryTimedOut, setQueryTimedOut]);
+
+		return (): void => {
+			clearTimeout(queryTimer.current);
+		};
+	}, [supportedFeatures, setQueryTimedOut]);
 
 	function retryQuery(): void {
 		setQueryTimedOut(false);

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -152,7 +152,6 @@ export function DevtoolsView(): React.ReactElement {
 	const [queryTimedOut, setQueryTimedOut] = React.useState(false);
 	const queryTimeoutInMilliseconds = 30_000; // 30 seconds
 	const messageRelay = useMessageRelay();
-	const queryTimer = React.useRef<NodeJS.Timeout>();
 
 	React.useEffect(() => {
 		/**
@@ -190,17 +189,13 @@ export function DevtoolsView(): React.ReactElement {
 		if (supportedFeatures === undefined) {
 			// If we have queried for the supported feature list but have not received
 			// a response yet, queue a timer.
-			const timeout = setTimeout(() => {
+			const queryTimer = setTimeout(() => {
 				setQueryTimedOut(true);
 			}, queryTimeoutInMilliseconds);
 			return (): void => {
-				clearTimeout(timeout);
+				clearTimeout(queryTimer);
 			};
 		}
-
-		return (): void => {
-			clearTimeout(queryTimer.current);
-		};
 	}, [supportedFeatures, setQueryTimedOut]);
 
 	function retryQuery(): void {

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -191,7 +191,7 @@ export function DevtoolsView(): React.ReactElement {
 			// If we have queried for the supported feature list but have not received
 			// a response yet, queue a timer.
 			const timeout = setTimeout(() => {
-				setQueryTimedOut(false);
+				setQueryTimedOut(true);
 			}, queryTimeoutInMilliseconds);
 			return (): void => {
 				clearTimeout(timeout);
@@ -215,7 +215,7 @@ export function DevtoolsView(): React.ReactElement {
 					<>
 						<div>Devtools not found. Timeout exceeded.</div>
 						<TooltipHost
-							content="Refresh Containers list"
+							content="Retry searching for Devtools"
 							id="retry-query-button-tooltip"
 						>
 							<Button onClick={retryQuery}>Search again</Button>

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import React, { useRef } from "react";
+import React from "react";
 import { useId } from "@fluentui/react-hooks";
 import {
 	ContainerList,
@@ -152,7 +152,7 @@ export function DevtoolsView(): React.ReactElement {
 	const [queryTimedOut, setQueryTimedOut] = React.useState(false);
 	const queryTimeoutInMilliseconds = 30_000; // 30 seconds
 	const messageRelay = useMessageRelay();
-	const queryTimer = useRef<NodeJS.Timeout>();
+	const queryTimer = React.useRef<NodeJS.Timeout>();
 
 	React.useEffect(() => {
 		/**
@@ -162,7 +162,6 @@ export function DevtoolsView(): React.ReactElement {
 			[DevtoolsFeatures.MessageType]: (untypedMessage) => {
 				const message = untypedMessage as DevtoolsFeatures.Message;
 				setSupportedFeatures(message.data.features);
-				clearTimeout(queryTimer.current); // Clear the timeout when found the supported features
 				return true;
 			},
 		};
@@ -215,7 +214,12 @@ export function DevtoolsView(): React.ReactElement {
 				queryTimedOut ? (
 					<>
 						<div>Devtools not found. Timeout exceeded.</div>
-						<button onClick={retryQuery}>Search again</button>
+						<TooltipHost
+							content="Refresh Containers list"
+							id="retry-query-button-tooltip"
+						>
+							<Button onClick={retryQuery}>Search again</Button>
+						</TooltipHost>
 					</>
 				) : (
 					<Waiting />

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import React from "react";
+import React, { useRef } from "react";
 import { useId } from "@fluentui/react-hooks";
 import {
 	ContainerList,
@@ -152,7 +152,7 @@ export function DevtoolsView(): React.ReactElement {
 	const [queryTimedOut, setQueryTimedOut] = React.useState(false);
 	const queryTimeoutInMilliseconds = 30_000; // 30 seconds
 	const messageRelay = useMessageRelay();
-	let queryTimer;
+	const queryTimer = useRef<NodeJS.Timeout>();
 
 	React.useEffect(() => {
 		/**
@@ -162,7 +162,7 @@ export function DevtoolsView(): React.ReactElement {
 			[DevtoolsFeatures.MessageType]: (untypedMessage) => {
 				const message = untypedMessage as DevtoolsFeatures.Message;
 				setSupportedFeatures(message.data.features);
-				clearTimeout(queryTimer); // Clear the timeout when cleaning up
+				clearTimeout(queryTimer.current); // Clear the timeout when found the supported features
 				return true;
 			},
 		};
@@ -183,14 +183,14 @@ export function DevtoolsView(): React.ReactElement {
 
 		// Add a timeout for the query
 		if (!supportedFeatures) {
-			queryTimer = setTimeout(() => {
+			queryTimer.current = setTimeout(() => {
 				setQueryTimedOut(true);
 			}, queryTimeoutInMilliseconds);
 		}
 
 		return (): void => {
 			messageRelay.off("message", messageHandler);
-			clearTimeout(queryTimer);
+			clearTimeout(queryTimer.current);
 		};
 	}, [messageRelay, setSupportedFeatures]);
 


### PR DESCRIPTION
## Description

Currently, the extension assumes that it has a corresponding Devtools instance it can talk to, but this isn't always the case. We need to update our query logic to not wait indefinitely for data to be returned from potentially nonexistent Devtools. We can likely accomplish this by adding a timeout to our root supported-features query - if we don't hear back within some time period, display a notice to the user that Devtools could not be found, and what they need to do to enable them.

We should also include a "look again" refresh button just in case there was actually a communication error, or if the extension was launched before app initialization.

## Sample
