### PR TITLE
remove(client-debugger-view): `ContainerDevtools` and `FluidDevtools` classes from package exports

### DIFF
--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -71,21 +71,6 @@ export interface ConnectionStateChangeLogEntry extends StateChangeLogEntry<Conta
     clientId: string | undefined;
 }
 
-// @internal @sealed
-export class ContainerDevtools implements IContainerDevtools {
-    constructor(props: ContainerDevtoolsProps);
-    get audience(): IAudience;
-    readonly container: IContainer;
-    readonly containerData?: Record<string, IFluidLoadable>;
-    readonly containerId: string;
-    readonly containerNickname?: string;
-    dispose(): void;
-    // (undocumented)
-    get disposed(): boolean;
-    getAudienceHistory(): readonly AudienceChangeLogEntry[];
-    getContainerConnectionLog(): readonly ConnectionStateChangeLogEntry[];
-}
-
 // @public
 export enum ContainerDevtoolsFeature {
     ContainerData = "container-data"
@@ -232,20 +217,6 @@ export namespace DisconnectContainer {
         type: typeof MessageType;
     }
     export type MessageData = HasContainerId;
-}
-
-// @internal
-export class FluidDevtools implements IFluidDevtools {
-    constructor(props?: FluidDevtoolsProps);
-    closeContainerDevtools(containerId: string): void;
-    // (undocumented)
-    dispose(): void;
-    // (undocumented)
-    get disposed(): boolean;
-    getAllContainerDevtools(): readonly IContainerDevtools[];
-    getContainerDevtools(containerId: string): IContainerDevtools | undefined;
-    readonly logger: DevtoolsLogger | undefined;
-    registerContainerDevtools(props: ContainerDevtoolsProps): void;
 }
 
 // @public

--- a/packages/tools/client-debugger/client-debugger/src/ContainerDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/ContainerDevtools.ts
@@ -51,7 +51,7 @@ import { ContainerDevtoolsFeature, ContainerDevtoolsFeatureFlags } from "./Featu
  */
 export interface ContainerDevtoolsProps {
 	/**
-	 * The Container with which the {@link ContainerDevtools} instance will be associated.
+	 * The Container with which the {@link IContainerDevtools} instance will be associated.
 	 */
 	container: IContainer;
 
@@ -153,7 +153,6 @@ export interface ContainerDevtoolsProps {
  * TODO: Document others as they are added.
  *
  * @sealed
- * @internal
  */
 export class ContainerDevtools implements IContainerDevtools {
 	/**

--- a/packages/tools/client-debugger/client-debugger/src/Features.ts
+++ b/packages/tools/client-debugger/client-debugger/src/Features.ts
@@ -4,30 +4,30 @@
  */
 
 /**
- * Describes features supported by {@link FluidDevtools}.
+ * Describes features supported by {@link IFluidDevtools}.
  *
  * @public
  */
 export enum DevtoolsFeature {
 	/**
-	 * Indicates that the {@link FluidDevtools} instance is capable of providing Fluid telemetry events.
+	 * Indicates that the {@link IFluidDevtools} instance is capable of providing Fluid telemetry events.
 	 */
 	Telemetry = "telemetry",
 }
 
 /**
- * Describes the set of {@link DevtoolsFeature | features} supported by a {@link FluidDevtools} instance.
+ * Describes the set of {@link DevtoolsFeature | features} supported by a {@link IFluidDevtools} instance.
  *
  * @remarks
  *
  * This has two primary purposes:
  *
  * 1. It can be used to signal to consumers of the Devtools what kinds of functionality are supported (at runtime)
- * by a {@link FluidDevtools} instance.
+ * by a {@link IFluidDevtools} instance.
  *
  * 2. It can be used to make backwards compatible changes easier to make.
  * By adding a flag to this object for new features, consumers can easily verify whether or not that feature
- * is supported by the {@link FluidDevtools} instance before attempting to use it.
+ * is supported by the {@link IFluidDevtools} instance before attempting to use it.
  *
  * @public
  */
@@ -39,7 +39,7 @@ export type DevtoolsFeatureFlags = {
 };
 
 /**
- * Describes features supported by {@link ContainerDevtools}.
+ * Describes features supported by {@link IContainerDevtools}.
  *
  * @public
  */
@@ -53,18 +53,18 @@ export enum ContainerDevtoolsFeature {
 
 /**
  * Describes the set of {@link ContainerDevtoolsFeature | container-related features} supported by a
- * {@link ContainerDevtools} instance.
+ * {@link IContainerDevtools} instance.
  *
  * @remarks
  *
  * This has two primary purposes:
  *
  * 1. It can be used to signal to consumers of the Devtools what kinds of functionality are supported (at runtime)
- * by a {@link ContainerDevtools} instance.
+ * by a {@link IContainerDevtools} instance.
  *
  * 2. It can be used to make backwards compatible changes easier to make.
  * By adding a flag to this object for new features, consumers can easily verify whether or not that feature
- * is supported by the corresponding {@link ContainerDevtools} instance before attempting to use it.
+ * is supported by the corresponding {@link IContainerDevtools} instance before attempting to use it.
  *
  * @public
  */

--- a/packages/tools/client-debugger/client-debugger/src/FluidDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidDevtools.ts
@@ -44,8 +44,8 @@ export const useAfterDisposeErrorText =
 	"The devtools instance has been disposed. Further operations are invalid.";
 
 /**
- * Error text thrown when a user attempts to register a {@link ContainerDevtools} instance for an ID that is already
- * registered with the {@link FluidDevtools}.
+ * Error text thrown when a user attempts to register a {@link IContainerDevtools} instance for an ID that is already
+ * registered with the {@link IFluidDevtools}.
  *
  * @privateRemarks Exported for test purposes only.
  */
@@ -57,7 +57,7 @@ export function getContainerAlreadyRegisteredErrorText(containerId: string): str
 }
 
 /**
- * Properties for configuring a {@link FluidDevtools}.
+ * Properties for configuring a {@link IFluidDevtools}.
  *
  * @public
  */
@@ -67,7 +67,7 @@ export interface FluidDevtoolsProps {
 	 *
 	 * @remarks
 	 *
-	 * Note: {@link FluidDevtools} does not register this logger with the Fluid runtime; that must be done separately.
+	 * Note: {@link IFluidDevtools} does not register this logger with the Fluid runtime; that must be done separately.
 	 *
 	 * This is provided to the Devtools instance strictly to enable communicating supported / desired functionality with
 	 * external listeners.
@@ -119,8 +119,6 @@ export interface FluidDevtoolsProps {
  * (via {@link GetContainerList.Message}).
  *
  * TODO: Document others as they are added.
- *
- * @internal
  */
 export class FluidDevtools implements IFluidDevtools {
 	/**

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -46,7 +46,7 @@
 export { AudienceClientMetadata, MemberChangeKind } from "./AudienceMetadata";
 export { FluidObjectId, HasContainerId, HasFluidObjectId } from "./CommonInterfaces";
 export { ContainerStateChangeKind } from "./Container";
-export { ContainerDevtools, ContainerDevtoolsProps } from "./ContainerDevtools";
+export { ContainerDevtoolsProps } from "./ContainerDevtools";
 export { ContainerMetadata, ContainerStateMetadata } from "./ContainerMetadata";
 export {
 	FluidHandleNode,
@@ -78,7 +78,7 @@ export {
 export { IContainerDevtools } from "./IContainerDevtools";
 export { IFluidDevtools } from "./IFluidDevtools";
 export { DevtoolsLogger } from "./DevtoolsLogger";
-export { FluidDevtools, FluidDevtoolsProps, initializeFluidDevtools } from "./FluidDevtools";
+export { FluidDevtoolsProps, initializeFluidDevtools } from "./FluidDevtools";
 export {
 	AudienceChangeLogEntry,
 	ConnectionStateChangeLogEntry,

--- a/packages/tools/client-debugger/client-debugger/src/messaging/container-devtools-messages/ContainerDevtoolsFeatures.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/container-devtools-messages/ContainerDevtoolsFeatures.ts
@@ -27,14 +27,14 @@ export namespace ContainerDevtoolsFeatures {
 	 */
 	export interface MessageData extends HasContainerId {
 		/**
-		 * Describes the set of features supported by the {@link ContainerDevtools} instance associated with the
+		 * Describes the set of features supported by the {@link IContainerDevtools} instance associated with the
 		 * specified {@link HasContainerId.containerId}.
 		 */
 		features: ContainerDevtoolsFeatureFlags;
 	}
 
 	/**
-	 * Outbound message containing the set of features supported by the {@link ContainerDevtools} instance associated
+	 * Outbound message containing the set of features supported by the {@link IContainerDevtools} instance associated
 	 * with the specified {@link HasContainerId.containerId}.
 	 *
 	 * @public

--- a/packages/tools/client-debugger/client-debugger/src/messaging/container-devtools-messages/GetContainerDevtoolsFeatures.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/container-devtools-messages/GetContainerDevtoolsFeatures.ts
@@ -27,7 +27,7 @@ export namespace GetContainerDevtoolsFeatures {
 	export type MessageData = HasContainerId;
 
 	/**
-	 * Inbound message requesting the set of features supported by the {@link ContainerDevtools} instance
+	 * Inbound message requesting the set of features supported by the {@link IContainerDevtools} instance
 	 * corresponding to the provided {@link HasContainerId.containerId}.
 	 *
 	 * Will result in the {@link ContainerDevtoolsFeatures.Message} message being posted.

--- a/packages/tools/client-debugger/client-debugger/src/messaging/devtools-messages/DevtoolsFeatures.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/devtools-messages/DevtoolsFeatures.ts
@@ -26,13 +26,13 @@ export namespace DevtoolsFeatures {
 	 */
 	export interface MessageData {
 		/**
-		 * Describes the set of features supported by the {@link FluidDevtools} instance.
+		 * Describes the set of features supported by the {@link IFluidDevtools} instance.
 		 */
 		features: Features;
 	}
 
 	/**
-	 * Outbound message containing the set of features supported by the {@link FluidDevtools} instance.
+	 * Outbound message containing the set of features supported by the {@link IFluidDevtools} instance.
 	 *
 	 * @public
 	 */

--- a/packages/tools/client-debugger/client-debugger/src/messaging/devtools-messages/GetDevtoolsFeatures.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/devtools-messages/GetDevtoolsFeatures.ts
@@ -19,7 +19,7 @@ export namespace GetDevtoolsFeatures {
 	export const MessageType = "GET_DEVTOOLS_FEATURES";
 
 	/**
-	 * Inbound message requesting the set of features supported by the {@link FluidDevtools} instance.
+	 * Inbound message requesting the set of features supported by the {@link IFluidDevtools} instance.
 	 * Will result in the {@link DevtoolsFeatures.Message} message being posted.
 	 *
 	 * @public


### PR DESCRIPTION
Reducing the exports to only the corresponding interfaces.