### PR TITLE
Stop process automatically when no connection available

### DIFF
--- a/server/routerlicious/packages/services-core/src/mongo.ts
+++ b/server/routerlicious/packages/services-core/src/mongo.ts
@@ -70,6 +70,8 @@ export class MongoManager {
 				Lumberjack.error("DB Reconnect failed", undefined, value);
 			});
 
+			debug("Successfully connected");
+			Lumberjack.info("Successfully connected to Db");
 			return db;
 		});
 
@@ -79,8 +81,8 @@ export class MongoManager {
 			this.reconnect(this.reconnectDelayMs);
 		});
 
-		debug("Successfully connected");
-		Lumberjack.info("Successfully connected to Db");
+		debug("Connect requested");
+		Lumberjack.info("Connect requested");
 		return databaseP;
 	}
 

--- a/server/routerlicious/packages/services/src/index.ts
+++ b/server/routerlicious/packages/services/src/index.ts
@@ -10,7 +10,7 @@ export { createMessageReceiver } from "./messageReceiver";
 export { createMessageSender } from "./messageSender";
 export { createMetricClient } from "./metricClient";
 export { DeltaManager } from "./deltaManager";
-export { MongoCollection, MongoDb, MongoDbFactory, connectionNotAvailableMode } from "./mongodb";
+export { MongoCollection, MongoDb, MongoDbFactory, ConnectionNotAvailableMode } from "./mongodb";
 export { NodeAllowList, NodeCodeLoader } from "./nodeCodeLoader";
 export { RedisCache } from "./redis";
 export { ClientManager } from "./redisClientManager";

--- a/server/routerlicious/packages/services/src/index.ts
+++ b/server/routerlicious/packages/services/src/index.ts
@@ -10,7 +10,7 @@ export { createMessageReceiver } from "./messageReceiver";
 export { createMessageSender } from "./messageSender";
 export { createMetricClient } from "./metricClient";
 export { DeltaManager } from "./deltaManager";
-export { MongoCollection, MongoDb, MongoDbFactory } from "./mongodb";
+export { MongoCollection, MongoDb, MongoDbFactory, connectionNotAvailableMode } from "./mongodb";
 export { NodeAllowList, NodeCodeLoader } from "./nodeCodeLoader";
 export { RedisCache } from "./redis";
 export { ClientManager } from "./redisClientManager";

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { ConnectionNotAvailableMode } from "../../mongodb";
 import { BaseMongoExceptionRetryRule, IMongoExceptionRetryRule } from "../IMongoExceptionRetryRule";
 class InternalErrorRule extends BaseMongoExceptionRetryRule {
 	private static readonly codeName = "InternalError";
@@ -44,7 +46,10 @@ class NoConnectionAvailableRule extends BaseMongoExceptionRetryRule {
 		"no connection available for operation and number of stored operation";
 	protected defaultRetryDecision: boolean = false;
 
-	constructor(retryRuleOverride: Map<string, boolean>) {
+	constructor(
+		retryRuleOverride: Map<string, boolean>,
+		private readonly connectionNotAvailableMode: ConnectionNotAvailableMode,
+	) {
 		super("NoConnectionAvailableRule", retryRuleOverride);
 	}
 
@@ -57,6 +62,17 @@ class NoConnectionAvailableRule extends BaseMongoExceptionRetryRule {
 			error.message &&
 			(error.message as string).startsWith(NoConnectionAvailableRule.messagePrefix)
 		);
+	}
+
+	public shouldRetry(): boolean {
+		if (this.connectionNotAvailableMode === "stop") {
+			// This logic is to automate the process of handling a pod with death note on it, so
+			// kubernetes would automatically handle the restart process.
+			Lumberjack.warning(`${this.ruleName} will restart the process`);
+			process.exit(1);
+		}
+
+		return super.shouldRetry();
 	}
 }
 
@@ -285,6 +301,7 @@ class ConnectionClosedMongoErrorRule extends BaseMongoExceptionRetryRule {
 // Maintain the list from more strick faster comparison to less strict slower comparison
 export function createMongoErrorRetryRuleset(
 	retryRuleOverride: Map<string, boolean>,
+	connectionNotAvailableMode: ConnectionNotAvailableMode,
 ): IMongoExceptionRetryRule[] {
 	const mongoErrorRetryRuleset: IMongoExceptionRetryRule[] = [
 		// The rules are using exactly equal
@@ -302,7 +319,7 @@ export function createMongoErrorRetryRuleset(
 		new PoolDestroyedRule(retryRuleOverride),
 
 		// The rules are using string startWith
-		new NoConnectionAvailableRule(retryRuleOverride),
+		new NoConnectionAvailableRule(retryRuleOverride, connectionNotAvailableMode),
 		new RequestSizeLargeRule(retryRuleOverride),
 		new RequestTimedOutWithHttpInfo(retryRuleOverride),
 

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
@@ -68,8 +68,8 @@ class NoConnectionAvailableRule extends BaseMongoExceptionRetryRule {
 		if (this.connectionNotAvailableMode === "stop") {
 			// This logic is to automate the process of handling a pod with death note on it, so
 			// kubernetes would automatically handle the restart process.
-			Lumberjack.warning(`${this.ruleName} will restart the process`);
-			process.exit(1);
+			Lumberjack.warning(`${this.ruleName} will terminate the process`);
+			process.kill(process.pid, "SIGTERM");
 		}
 
 		return super.shouldRetry();

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoErrorRetryAnalyzer.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoErrorRetryAnalyzer.ts
@@ -4,6 +4,7 @@
  */
 
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { ConnectionNotAvailableMode } from "../mongodb";
 import { DefaultExceptionRule } from "./defaultExceptionRule";
 import { IMongoExceptionRetryRule } from "./IMongoExceptionRetryRule";
 import { createMongoErrorRetryRuleset } from "./mongoError";
@@ -15,16 +16,28 @@ export class MongoErrorRetryAnalyzer {
 	private readonly mongoErrorRetryRuleset: IMongoExceptionRetryRule[];
 	private readonly defaultRule: IMongoExceptionRetryRule;
 
-	public static getInstance(retryRuleOverride: Map<string, boolean>): MongoErrorRetryAnalyzer {
+	public static getInstance(
+		retryRuleOverride: Map<string, boolean>,
+		connectionNotAvailableMode: ConnectionNotAvailableMode,
+	): MongoErrorRetryAnalyzer {
 		if (!this.instance) {
-			this.instance = new MongoErrorRetryAnalyzer(retryRuleOverride);
+			this.instance = new MongoErrorRetryAnalyzer(
+				retryRuleOverride,
+				connectionNotAvailableMode,
+			);
 		}
 		return this.instance;
 	}
 
-	private constructor(retryRuleOverride: Map<string, boolean>) {
+	private constructor(
+		retryRuleOverride: Map<string, boolean>,
+		connectionNotAvailableMode: ConnectionNotAvailableMode,
+	) {
 		this.mongoNetworkErrorRetryRuleset = createMongoNetworkErrorRetryRuleset(retryRuleOverride);
-		this.mongoErrorRetryRuleset = createMongoErrorRetryRuleset(retryRuleOverride);
+		this.mongoErrorRetryRuleset = createMongoErrorRetryRuleset(
+			retryRuleOverride,
+			connectionNotAvailableMode,
+		);
 		this.defaultRule = new DefaultExceptionRule(retryRuleOverride);
 	}
 

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -447,7 +447,7 @@ export class MongoDb implements core.IDb {
 	}
 }
 
-export type ConnectionNotAvailableMode = "dontRetry" | "stop"; // Ideally we should have 'delayRetry' options, but that requires more refactor on our retry engine so hold for this mode;
+export type ConnectionNotAvailableMode = "ruleBehavior" | "stop"; // Ideally we should have 'delayRetry' options, but that requires more refactor on our retry engine so hold for this mode;
 
 interface IMongoDBConfig {
 	operationsDbEndpoint: string;
@@ -470,7 +470,7 @@ export class MongoDbFactory implements core.IDbFactory {
 	private readonly connectionPoolMaxSize?: number;
 	private readonly retryEnabled: boolean = false;
 	private readonly telemetryEnabled: boolean = false;
-	private readonly connectionNotAvailableMode: ConnectionNotAvailableMode = "dontRetry";
+	private readonly connectionNotAvailableMode: ConnectionNotAvailableMode = "ruleBehavior";
 	private readonly retryRuleOverride: Map<string, boolean>;
 	constructor(config: IMongoDBConfig) {
 		const {
@@ -490,7 +490,7 @@ export class MongoDbFactory implements core.IDbFactory {
 		this.bufferMaxEntries = bufferMaxEntries;
 		this.connectionPoolMinSize = connectionPoolMinSize;
 		this.connectionPoolMaxSize = connectionPoolMaxSize;
-		this.connectionNotAvailableMode = connectionNotAvailableMode ?? "dontRetry";
+		this.connectionNotAvailableMode = connectionNotAvailableMode ?? "ruleBehavior";
 		this.retryEnabled = config.facadeLevelRetry || false;
 		this.telemetryEnabled = config.facadeLevelTelemetry || false;
 		this.retryRuleOverride = config.facadeLevelRetryRuleOverride

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -447,6 +447,8 @@ export class MongoDb implements core.IDb {
 	}
 }
 
+export type ConnectionNotAvailableMode = "notRetry" | "stop"; // Ideally we should have 'delayRetry' options, but that requires more refactor on our retry engine so hold for this mode;
+
 interface IMongoDBConfig {
 	operationsDbEndpoint: string;
 	bufferMaxEntries: number | undefined;
@@ -457,6 +459,7 @@ interface IMongoDBConfig {
 	facadeLevelRetry?: boolean;
 	facadeLevelTelemetry?: boolean;
 	facadeLevelRetryRuleOverride?: any;
+	connectionNotAvailableMode?: ConnectionNotAvailableMode;
 }
 
 export class MongoDbFactory implements core.IDbFactory {
@@ -467,6 +470,7 @@ export class MongoDbFactory implements core.IDbFactory {
 	private readonly connectionPoolMaxSize?: number;
 	private readonly retryEnabled: boolean = false;
 	private readonly telemetryEnabled: boolean = false;
+	private readonly connectionNotAvailableMode: ConnectionNotAvailableMode = "notRetry";
 	private readonly retryRuleOverride: Map<string, boolean>;
 	constructor(config: IMongoDBConfig) {
 		const {
@@ -476,6 +480,7 @@ export class MongoDbFactory implements core.IDbFactory {
 			globalDbEndpoint,
 			connectionPoolMinSize,
 			connectionPoolMaxSize,
+			connectionNotAvailableMode,
 		} = config;
 		if (globalDbEnabled) {
 			this.globalDbEndpoint = globalDbEndpoint;
@@ -485,6 +490,7 @@ export class MongoDbFactory implements core.IDbFactory {
 		this.bufferMaxEntries = bufferMaxEntries;
 		this.connectionPoolMinSize = connectionPoolMinSize;
 		this.connectionPoolMaxSize = connectionPoolMaxSize;
+		this.connectionNotAvailableMode = connectionNotAvailableMode ?? "notRetry";
 		this.retryEnabled = config.facadeLevelRetry || false;
 		this.telemetryEnabled = config.facadeLevelTelemetry || false;
 		this.retryRuleOverride = config.facadeLevelRetryRuleOverride
@@ -522,7 +528,10 @@ export class MongoDbFactory implements core.IDbFactory {
 			options,
 		);
 
-		const retryAnalyzer = MongoErrorRetryAnalyzer.getInstance(this.retryRuleOverride);
+		const retryAnalyzer = MongoErrorRetryAnalyzer.getInstance(
+			this.retryRuleOverride,
+			this.connectionNotAvailableMode,
+		);
 
 		return new MongoDb(connection, this.retryEnabled, this.telemetryEnabled, retryAnalyzer);
 	}

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -447,7 +447,7 @@ export class MongoDb implements core.IDb {
 	}
 }
 
-export type ConnectionNotAvailableMode = "notRetry" | "stop"; // Ideally we should have 'delayRetry' options, but that requires more refactor on our retry engine so hold for this mode;
+export type ConnectionNotAvailableMode = "dontRetry" | "stop"; // Ideally we should have 'delayRetry' options, but that requires more refactor on our retry engine so hold for this mode;
 
 interface IMongoDBConfig {
 	operationsDbEndpoint: string;
@@ -470,7 +470,7 @@ export class MongoDbFactory implements core.IDbFactory {
 	private readonly connectionPoolMaxSize?: number;
 	private readonly retryEnabled: boolean = false;
 	private readonly telemetryEnabled: boolean = false;
-	private readonly connectionNotAvailableMode: ConnectionNotAvailableMode = "notRetry";
+	private readonly connectionNotAvailableMode: ConnectionNotAvailableMode = "dontRetry";
 	private readonly retryRuleOverride: Map<string, boolean>;
 	constructor(config: IMongoDBConfig) {
 		const {
@@ -490,7 +490,7 @@ export class MongoDbFactory implements core.IDbFactory {
 		this.bufferMaxEntries = bufferMaxEntries;
 		this.connectionPoolMinSize = connectionPoolMinSize;
 		this.connectionPoolMaxSize = connectionPoolMaxSize;
-		this.connectionNotAvailableMode = connectionNotAvailableMode ?? "notRetry";
+		this.connectionNotAvailableMode = connectionNotAvailableMode ?? "dontRetry";
 		this.retryEnabled = config.facadeLevelRetry || false;
 		this.telemetryEnabled = config.facadeLevelTelemetry || false;
 		this.retryRuleOverride = config.facadeLevelRetryRuleOverride


### PR DESCRIPTION
The no connection available exception has taken too many efforts from our OCE, this change is to stop the process right away and leverage on kubernetes to reboot the service for us

## Description

Stop a service with exit code 1 if it hit the no connection available exception
