### PR TITLE
Ensure server breaking changes are made correctly

### DIFF
--- a/build-tools/packages/build-cli/docs/bump.md
+++ b/build-tools/packages/build-cli/docs/bump.md
@@ -108,15 +108,10 @@ EXAMPLES
   Bump dependencies on packages in the server release group to the greatest released version in the client release
   group. Include pre-release versions.
 
-    $ flub bump deps server -g client -t greatest -p
+    $ flub bump deps server -g client -t greatest --prerelease
 
   Bump dependencies on server packages to the current version across the repo, replacing any pre-release ranges with
   release ranges.
 
     $ flub bump deps server -t latest
-
-  Bump dependencies on packages in server release group to the latest released version in the client release group
-  against main branch. Include pre-release versions.
-
-    $ flub bump deps server -g client -t latest -b main --prerelease
 ```

--- a/build-tools/packages/build-cli/docs/bump.md
+++ b/build-tools/packages/build-cli/docs/bump.md
@@ -70,13 +70,12 @@ Update the dependency version of a specified package or release group. That is, 
 USAGE
   $ flub bump deps PACKAGE_OR_RELEASE_GROUP [-v] [--prerelease -t
     latest|newest|greatest|minor|patch|@next|@canary] [--onlyBumpPrerelease] [-g
-    client|server|azure|build-tools|gitrest|historian | -p <value>] [-x | --install | --commit |  |  | ] [-b <value>]
+    client|server|azure|build-tools|gitrest|historian | -p <value>] [-x | --install | --commit |  |  | ]
 
 ARGUMENTS
   PACKAGE_OR_RELEASE_GROUP  The name of a package or a release group.
 
 FLAGS
-  -b, --branchName=<value>     Takes in the branch name as main or next
   -g, --releaseGroup=<option>  Only bump dependencies within this release group.
                                <options: client|server|azure|build-tools|gitrest|historian>
   -p, --package=<value>        Only bump dependencies of this package.

--- a/build-tools/packages/build-cli/docs/bump.md
+++ b/build-tools/packages/build-cli/docs/bump.md
@@ -70,12 +70,13 @@ Update the dependency version of a specified package or release group. That is, 
 USAGE
   $ flub bump deps PACKAGE_OR_RELEASE_GROUP [-v] [--prerelease -t
     latest|newest|greatest|minor|patch|@next|@canary] [--onlyBumpPrerelease] [-g
-    client|server|azure|build-tools|gitrest|historian | -p <value>] [-x | --install | --commit |  |  | ]
+    client|server|azure|build-tools|gitrest|historian | -p <value>] [-x | --install | --commit |  |  | ] [-b <value>]
 
 ARGUMENTS
   PACKAGE_OR_RELEASE_GROUP  The name of a package or a release group.
 
 FLAGS
+  -b, --branchName=<value>     Takes in the branch name as main or next
   -g, --releaseGroup=<option>  Only bump dependencies within this release group.
                                <options: client|server|azure|build-tools|gitrest|historian>
   -p, --package=<value>        Only bump dependencies of this package.
@@ -114,4 +115,9 @@ EXAMPLES
   release ranges.
 
     $ flub bump deps server -t latest
+
+  Bump dependencies on packages in server release group to the latest released version in the client release group
+  against main branch. Include pre-release versions.
+
+    $ flub bump deps server -g client -t latest -b main --prerelease
 ```

--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -8,7 +8,7 @@ import chalk from "chalk";
 import inquirer from "inquirer";
 import * as semver from "semver";
 
-import { FluidRepo, MonoRepo, Package } from "@fluidframework/build-tools";
+import { FluidRepo, MonoRepo, MonoRepoKind, Package } from "@fluidframework/build-tools";
 
 import {
 	ReleaseVersion,
@@ -107,6 +107,11 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 
 		if (args.package_or_release_group === undefined) {
 			this.error("ERROR: No dependency provided.");
+		}
+
+		// can be removed once server team owns their releases
+		if (args.package_or_release_group === MonoRepoKind.Server && flags.bumpType === "minor") {
+			this.error(`ERROR: Server release are always a ${chalk.bold("MAJOR")} release`);
 		}
 
 		if (bumpType === undefined && flags.exact === undefined) {

--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -109,7 +109,8 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 			this.error("ERROR: No dependency provided.");
 		}
 
-		// can be removed once server team owns their releases
+		// eslint-disable-next-line no-warning-comments
+		// TODO: can be removed once server team owns server releases
 		if (args.package_or_release_group === MonoRepoKind.Server && flags.bumpType === "minor") {
 			this.error(`ERROR: Server release are always a ${chalk.bold("MAJOR")} release`);
 		}

--- a/build-tools/packages/build-cli/src/commands/bump/deps.ts
+++ b/build-tools/packages/build-cli/src/commands/bump/deps.ts
@@ -6,12 +6,7 @@ import { Flags } from "@oclif/core";
 import chalk from "chalk";
 import stripAnsi from "strip-ansi";
 
-import {
-	FluidRepo,
-	GitRepo,
-	MonoRepoKind,
-	getResolvedFluidRoot,
-} from "@fluidframework/build-tools";
+import { FluidRepo, MonoRepoKind } from "@fluidframework/build-tools";
 
 import { packageOrReleaseGroupArg } from "../../args";
 import { BaseCommand } from "../../base";
@@ -120,13 +115,11 @@ export default class DepsCommand extends BaseCommand<typeof DepsCommand> {
 			this.error("ERROR: No dependency provided.");
 		}
 
-		const resolvedRoot = await getResolvedFluidRoot();
-		const gitRepo = new GitRepo(resolvedRoot);
-		const branchName = await gitRepo.getCurrentBranchName();
+		const branchName = await context.gitRepo.getCurrentBranchName();
 
 		// can be removed once server team owns their releases
 		if (args.package_or_release_group === MonoRepoKind.Server && flags.updateType === "minor") {
-			this.error(`ERROR: Server release are always a ${chalk.bold("MAJOR")} release`);
+			this.error(`Server release are always a ${chalk.bold("MAJOR")} release`);
 		}
 
 		if (args.package_or_release_group === MonoRepoKind.Server && flags.prerelease === true) {

--- a/build-tools/packages/build-cli/src/commands/bump/deps.ts
+++ b/build-tools/packages/build-cli/src/commands/bump/deps.ts
@@ -90,18 +90,13 @@ export default class DepsCommand extends BaseCommand<typeof DepsCommand> {
 		{
 			description:
 				"Bump dependencies on packages in the server release group to the greatest released version in the client release group. Include pre-release versions.",
-			command: "<%= config.bin %> <%= command.id %> server -g client -t greatest -p",
+			command:
+				"<%= config.bin %> <%= command.id %> server -g client -t greatest --prerelease",
 		},
 		{
 			description:
 				"Bump dependencies on server packages to the current version across the repo, replacing any pre-release ranges with release ranges.",
 			command: "<%= config.bin %> <%= command.id %> server -t latest",
-		},
-		{
-			description:
-				"Bump dependencies on packages in server release group to the latest released version in the client release group against main branch. Include pre-release versions.",
-			command:
-				"<%= config.bin %> <%= command.id %> server -g client -t latest -b main --prerelease",
 		},
 	];
 

--- a/build-tools/packages/build-cli/src/commands/release.ts
+++ b/build-tools/packages/build-cli/src/commands/release.ts
@@ -18,6 +18,8 @@ import { PromptWriter } from "../instructionalPromptWriter";
 import { FluidReleaseMachine } from "../machines";
 import { getRunPolicyCheckDefault } from "../repoConfig";
 import { StateMachineCommand } from "../stateMachineCommand";
+import { MonoRepoKind } from "@fluidframework/build-tools";
+import chalk from "chalk";
 
 /**
  * Releases a package or release group. This command is mostly scaffolding and setting up the state machine, handlers,
@@ -68,6 +70,12 @@ export default class ReleaseCommand extends StateMachineCommand<typeof ReleaseCo
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const releaseGroup = flags.releaseGroup ?? flags.package!;
 		const releaseVersion = context.getVersion(releaseGroup);
+
+		// eslint-disable-next-line no-warning-comments
+		// TODO: can be removed once server team owns server releases
+		if (flags.releaseGroup === MonoRepoKind.Server && flags.bumpType === "minor") {
+			this.error(`ERROR: Server release are always a ${chalk.bold("MAJOR")} release`);
+		}
 
 		// oclif doesn't support nullable boolean flags, so this works around that limitation by checking the args
 		// passed into the command. If neither are passed, then the default is determined by the branch config.

--- a/build-tools/packages/build-cli/src/commands/release.ts
+++ b/build-tools/packages/build-cli/src/commands/release.ts
@@ -74,7 +74,7 @@ export default class ReleaseCommand extends StateMachineCommand<typeof ReleaseCo
 		// eslint-disable-next-line no-warning-comments
 		// TODO: can be removed once server team owns server releases
 		if (flags.releaseGroup === MonoRepoKind.Server && flags.bumpType === "minor") {
-			this.error(`ERROR: Server release are always a ${chalk.bold("MAJOR")} release`);
+			this.error(`Server release are always a ${chalk.bold("MAJOR")} release`);
 		}
 
 		// oclif doesn't support nullable boolean flags, so this works around that limitation by checking the args


### PR DESCRIPTION
This PR adds checks in the release tools from preventing to do:

1. Server minor release. All the server changes (breaking/non-breaking) are targeted towards main. There would be no minor server release.
2. No server prereleases consumed in the main branch by client packages. Server prereleases can be consumed in next only.

This is a temporary solution until we make sure that server `minor` releases can be done without introducing breaking changes.
