### PR TITLE
Various small refactors in SharedTreeCore

### DIFF
--- a/experimental/dds/tree2/src/core/undo/undoRedoManager.ts
+++ b/experimental/dds/tree2/src/core/undo/undoRedoManager.ts
@@ -35,11 +35,8 @@ export class UndoRedoManager<TChange, TEditor extends ChangeFamilyEditor> {
 	 * Adds the provided commit to the undo commit tree.
 	 * Should be called for all commits on the relevant branch, including undo commits.
 	 */
-	public trackCommit(
-		commit: GraphCommit<TChange>,
-		undoRedoManagerCommitType?: UndoRedoManagerCommitType,
-	): void {
-		switch (undoRedoManagerCommitType) {
+	public trackCommit(commit: GraphCommit<TChange>, type: UndoRedoManagerCommitType): void {
+		switch (type) {
 			case UndoRedoManagerCommitType.Undo:
 				// TODO check if this is the correct commit?
 				this.headUndoableCommit = this.headUndoableCommit?.parent;

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -81,12 +81,12 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 	) {
 		super();
 		this.editor = this.changeFamily.buildEditor(
-			(change) => this.applyChange(change),
+			(change) => this.applyChange(change, UndoRedoManagerCommitType.Undoable),
 			new AnchorSet(), // This branch class handles the anchor rebasing, so we don't want the editor to do any rebasing; so pass it a dummy anchor set.
 		);
 	}
 
-	private applyChange(change: TChange, isUndoRedoCommit?: UndoRedoManagerCommitType): void {
+	private applyChange(change: TChange, undoRedoType: UndoRedoManagerCommitType): void {
 		this.assertNotDisposed();
 		const revision = mintRevisionTag();
 		this.head = mintCommit(this.head, {
@@ -100,7 +100,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 
 		// If this is not part of a transaction, add it to the undo commit tree
 		if (!this.isTransacting()) {
-			this.undoRedoManager.trackCommit(this.head, isUndoRedoCommit);
+			this.undoRedoManager.trackCommit(this.head, undoRedoType);
 		}
 
 		this.emitAndRebaseAnchors(change);
@@ -145,7 +145,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 
 			// If this transaction is not nested, add it to the undo commit tree
 			if (!this.isTransacting()) {
-				this.undoRedoManager.trackCommit(this.head);
+				this.undoRedoManager.trackCommit(this.head, UndoRedoManagerCommitType.Undoable);
 			}
 
 			// If there is still an ongoing transaction (because this transaction was nested inside of an outer transaction)

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -36,6 +36,7 @@ import {
 	tagChange,
 	TaggedChange,
 	UndoRedoManager,
+	UndoRedoManagerCommitType,
 } from "../core";
 import { SharedTreeBranch } from ".";
 
@@ -510,7 +511,7 @@ export class EditManager<
 	): void {
 		this.trunk = mintTrunkCommit(this.trunk, commit, sequenceNumber);
 		if (local) {
-			this.trunkUndoRedoManager.trackCommit(this.trunk);
+			this.trunkUndoRedoManager.trackCommit(this.trunk, UndoRedoManagerCommitType.Undoable);
 		}
 		this.trunkUndoRedoManager.repairDataStoreProvider.applyDelta(
 			this.changeFamily.intoDelta(commit.change),

--- a/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
@@ -261,7 +261,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 	 * @param undoRedoType - if provided, the new commit will be tracked for undo/redo
 	 * @returns the new commit that was appended to the root local branch
 	 */
-	protected applyChange(
+	private applyChange(
 		change: TChange,
 		revision: RevisionTag,
 		undoRedoType: UndoRedoManagerCommitType | undefined,

--- a/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
@@ -178,7 +178,11 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		);
 
 		this.changeCodec = changeFamily.codecs.resolve(formatVersion);
-		this.editor = this.changeFamily.buildEditor((change) => this.applyChange(change), anchors);
+		this.editor = this.changeFamily.buildEditor(
+			(change) =>
+				this.applyChange(change, mintRevisionTag(), UndoRedoManagerCommitType.Undoable),
+			anchors,
+		);
 	}
 
 	// TODO: SharedObject's merging of the two summary methods into summarizeCore is not what we want here:
@@ -217,14 +221,20 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		await Promise.all(loadSummaries);
 	}
 
+	/**
+	 * Submits an op to the Fluid runtime containing the given commit
+	 * @param commit - the commit to submit
+	 * @param undoRedoType - if provided, `commit` will be tracked for undo/redo
+	 */
 	private submitCommit(
 		commit: Commit<TChange>,
-		isUndoRedoCommit?: UndoRedoManagerCommitType,
-		skipUndoRedoManagerTracking = false,
+		undoRedoType: UndoRedoManagerCommitType | undefined,
 	): void {
+		// Edits should not be submitted until all transactions finish
+		assert(!this.isTransacting(), "Unexpected edit submitted during transaction");
 		// Nested transactions are tracked as part of the outermost transaction
-		if (!this.isTransacting() && !skipUndoRedoManagerTracking) {
-			this.editManager.localBranchUndoRedoManager.trackCommit(commit, isUndoRedoCommit);
+		if (undoRedoType !== undefined) {
+			this.editManager.localBranchUndoRedoManager.trackCommit(commit, undoRedoType);
 		}
 
 		// Edits submitted before the first attach are treated as sequenced because they will be included
@@ -244,30 +254,24 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 	}
 
 	/**
-	 * Update the state of the tree (including all indexes) according to the given change.
-	 * If there is not currently a transaction open, the change will be submitted to Fluid.
+	 * Update the state of the tree (including all indexes) according to the given change by creating a new commit and
+	 * appending it the root local branch. If there is not currently a transaction open, the change will be submitted to Fluid.
 	 * @param change - The change to apply.
 	 * @param revision - The revision to associate with the change.
-	 * Defaults to a new, randomly generated, revision if not provided.
+	 * @param undoRedoType - if provided, the new commit will be tracked for undo/redo
+	 * @returns the new commit that was appended to the root local branch
 	 */
 	protected applyChange(
 		change: TChange,
-		revision?: RevisionTag,
-		undoRedoManagerCommitType?: UndoRedoManagerCommitType,
-		skipUndoRedoManagerTracking?: boolean,
+		revision: RevisionTag,
+		undoRedoType: UndoRedoManagerCommitType | undefined,
 	): GraphCommit<TChange> {
-		const [commit, delta] = this.addLocalChange(
-			change,
-			revision ?? mintRevisionTag(),
-			undoRedoManagerCommitType,
-			skipUndoRedoManagerTracking,
-			false,
-		);
+		const [commit, delta] = this.addLocalChange(change, revision);
 
 		// submitCommit should not be called for stashed ops so this is kept separate from
 		// addLocalChange
 		if (!this.isTransacting()) {
-			this.submitCommit(commit, undoRedoManagerCommitType, skipUndoRedoManagerTracking);
+			this.submitCommit(commit, undoRedoType);
 		}
 
 		this.emitLocalChange(change, delta);
@@ -275,18 +279,12 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 	}
 
 	/**
-	 * Adds the local change to the editmanager and returns the commit with the given change.
+	 * Creates a new commit with the given change and appends it the root local branch.
 	 * @param change - The change to apply
 	 * @param revision - The revision to associate with the change.
-	 * @returns Commit object with the change, revision and localsessionid
+	 * @returns the commit and the delta resulting from applying `change`
 	 */
-	private addLocalChange(
-		change: TChange,
-		revision: RevisionTag,
-		undoRedoManagerCommitType?: UndoRedoManagerCommitType,
-		skipUndoRedoManagerTracking = false,
-		shouldEmitChange = true,
-	): [Commit<TChange>, Delta.Root] {
+	private addLocalChange(change: TChange, revision: RevisionTag): [Commit<TChange>, Delta.Root] {
 		const commit: Commit<TChange> = {
 			change,
 			revision,
@@ -294,19 +292,6 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		};
 		const delta = this.editManager.addLocalChange(revision, change, false);
 		this.transactions.repairStore?.capture(this.changeFamily.intoDelta(change), revision);
-
-		if (shouldEmitChange) {
-			// If this change should be emitted, track the commit in the undo redo manager
-			// before the local change is applied
-			if (!this.isTransacting() && !skipUndoRedoManagerTracking) {
-				this.editManager.localBranchUndoRedoManager.trackCommit(
-					commit,
-					undoRedoManagerCommitType,
-				);
-			}
-			this.emitLocalChange(change, delta);
-		}
-
 		return [commit, delta];
 	}
 
@@ -349,7 +334,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		this.editor.exitTransaction();
 		const squashCommit = this.editManager.squashLocalChanges(startRevision);
 		if (!this.isTransacting()) {
-			this.submitCommit(squashCommit);
+			this.submitCommit(squashCommit, UndoRedoManagerCommitType.Undoable);
 		}
 		return TransactionResult.Commit;
 	}
@@ -381,7 +366,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 
 		const undoChange = this.editManager.localBranchUndoRedoManager.undo();
 		if (undoChange !== undefined) {
-			this.applyChange(undoChange, undefined, UndoRedoManagerCommitType.Undo);
+			this.applyChange(undoChange, mintRevisionTag(), UndoRedoManagerCommitType.Undo);
 		}
 	}
 
@@ -433,7 +418,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 			} of markedCommits) {
 				// Only track commits that are undoable.
 				const commitType = isUndoable ? UndoRedoManagerCommitType.Undoable : undefined;
-				this.applyChange(change, revision, commitType, !isUndoable);
+				this.applyChange(change, revision, commitType);
 				this.changeFamily.rebaser.rebaseAnchors(this.anchors, change);
 			}
 		} else {
@@ -453,7 +438,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 			// Apply the changes without tracking them in the undo redo manager because
 			// `updateAfterRebase` takes care of tracking any applicable commits in the rebased branch.
 			changes.forEach(({ change, revision }) => {
-				this.applyChange(change, revision, undefined, true);
+				this.applyChange(change, revision, undefined);
 				this.changeFamily.rebaser.rebaseAnchors(this.anchors, change);
 			});
 		}
@@ -478,12 +463,18 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		const { revision } = parseCommit(content, this.changeCodec);
 		const [commit] = this.editManager.findLocalCommit(revision);
 		// Skip tracking commits as undoable during resubmit.
-		this.submitCommit(commit, undefined, true);
+		this.submitCommit(commit, undefined);
 	}
 
 	protected applyStashedOp(content: JsonCompatibleReadOnly): undefined {
+		assert(!this.isTransacting(), "Unexpected transaction is open while applying stashed ops");
 		const { revision, change } = parseCommit(content, this.changeCodec);
-		this.addLocalChange(change, revision);
+		const [commit, delta] = this.addLocalChange(change, revision);
+		this.editManager.localBranchUndoRedoManager.trackCommit(
+			commit,
+			UndoRedoManagerCommitType.Undoable,
+		);
+		this.emitLocalChange(change, delta);
 		return;
 	}
 

--- a/experimental/dds/tree2/src/test/shared-tree-core/utils.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/utils.ts
@@ -10,8 +10,8 @@ import {
 	GraphCommit,
 	ITreeCursorSynchronous,
 	RepairDataStore,
-	RevisionTag,
 	UndoRedoManagerCommitType,
+	mintRevisionTag,
 } from "../../core";
 import {
 	defaultChangeFamily,
@@ -50,16 +50,10 @@ export class TestSharedTreeCore extends SharedTreeCore<DefaultEditBuilder, Defau
 
 	public override applyChange(
 		change: DefaultChangeset,
-		revision?: RevisionTag,
-		undoRedoManagerCommitType?: UndoRedoManagerCommitType,
-		skipUndoRedoManagerTracking?: boolean,
+		revision = mintRevisionTag(),
+		undoRedoType?: UndoRedoManagerCommitType,
 	): GraphCommit<DefaultChangeset> {
-		return super.applyChange(
-			change,
-			revision,
-			undoRedoManagerCommitType,
-			skipUndoRedoManagerTracking,
-		);
+		return super.applyChange(change, revision, undoRedoType);
 	}
 
 	public override startTransaction(

--- a/experimental/dds/tree2/src/test/shared-tree-core/utils.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/utils.ts
@@ -5,14 +5,7 @@
 import { IChannelAttributes, IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { SharedTreeBranch, SharedTreeCore, Summarizable } from "../../shared-tree-core";
-import {
-	AnchorSet,
-	GraphCommit,
-	ITreeCursorSynchronous,
-	RepairDataStore,
-	UndoRedoManagerCommitType,
-	mintRevisionTag,
-} from "../../core";
+import { AnchorSet, GraphCommit, ITreeCursorSynchronous, RepairDataStore } from "../../core";
 import {
 	defaultChangeFamily,
 	DefaultChangeset,
@@ -46,14 +39,6 @@ export class TestSharedTreeCore extends SharedTreeCore<DefaultEditBuilder, Defau
 			TestSharedTreeCore.attributes,
 			id,
 		);
-	}
-
-	public override applyChange(
-		change: DefaultChangeset,
-		revision = mintRevisionTag(),
-		undoRedoType?: UndoRedoManagerCommitType,
-	): GraphCommit<DefaultChangeset> {
-		return super.applyChange(change, revision, undoRedoType);
 	}
 
 	public override startTransaction(

--- a/experimental/dds/tree2/src/test/undo/undoRedoManager.spec.ts
+++ b/experimental/dds/tree2/src/test/undo/undoRedoManager.spec.ts
@@ -28,7 +28,7 @@ describe("UndoRedoManager", () => {
 			};
 			const childCommit = createTestGraphCommit([0], 1, localSessionId);
 			const manager = undoRedoManagerFactory(parent);
-			manager.trackCommit(childCommit);
+			manager.trackCommit(childCommit, UndoRedoManagerCommitType.Undoable);
 
 			const headUndoCommit = manager.headUndoable;
 			assert.equal(headUndoCommit?.commit, childCommit);
@@ -56,7 +56,7 @@ describe("UndoRedoManager", () => {
 			};
 			const manager = undoRedoManagerFactory(initialCommit);
 			const undoableCommit = createTestGraphCommit([0], 1, localSessionId);
-			manager.trackCommit(undoableCommit);
+			manager.trackCommit(undoableCommit, UndoRedoManagerCommitType.Undoable);
 			manager.undo();
 			const fakeInvertedCommit = createTestGraphCommit([0, 1], 2, localSessionId);
 			manager.trackCommit(fakeInvertedCommit, UndoRedoManagerCommitType.Undo);


### PR DESCRIPTION
* The undo/redo type parameter in `trackCommit`, `applyChange`, `submitCommit`, etc. is now required. This is because a developer adding a new call to any of those functions needs to think about how their new case interacts with undo/redo in order to avoid introducing bugs. The functions that had a "skip" parameter have had that parameter collapsed into the undo/redo type parameter for brevity. An explicit value of `undefined` now means "don't track WRT undo/redo".
* `addLocalChange` is no longer responsible for either tracking undo/redo commits or emitting change events. It never did so when called from `applyChange`, but rather only when called from `applyStashedOp` - and the return signature of `addLocalChange` makes it very easy for `applyStashedOp` to do those two things itself. This reduces the parameters passed to `addLocalChange` and makes its scope of responsibility clearer.
* `applyChange` is now private rather than protected. Perhaps it will be re-exposed in the future, but there's no need for it be exposed currently.
* `applyChange` now requires a revision tag parameter. This forces callers to double check whether they already have a revision handy, or want to make a new one (which is just a call to `mintRevisionTag()`).
* Added and corrected documentation for the relevant functions