### PR TITLE
Remove defunct term PII from codebase

### DIFF
--- a/common/lib/common-definitions/src/logger.ts
+++ b/common/lib/common-definitions/src/logger.ts
@@ -20,7 +20,7 @@ export type TelemetryEventPropertyType = string | number | boolean | undefined;
 /**
  * A property to be logged to telemetry containing both the value and a tag. Tags are generic strings that can be used
  * to mark pieces of information that should be organized or handled differently by loggers in various first or third
- * party scenarios. For example, tags are used to mark PII that should not be stored in logs.
+ * party scenarios. For example, tags are used to mark data that should not be stored in logs for privacy reasons.
  */
 export interface ITaggedTelemetryPropertyType {
 	value: TelemetryEventPropertyType;

--- a/experimental/dds/tree/src/Common.ts
+++ b/experimental/dds/tree/src/Common.ts
@@ -77,16 +77,16 @@ export function compareStrings<T extends string>(a: T, b: T): number {
  * Use when violations are logic errors in the program.
  * @param condition - A condition to assert is truthy
  * @param message - Message to be printed if assertion fails. Will print "Assertion failed" by default
- * @param containsPII - boolean flag for whether the message passed in contains personally identifying information (PII).
+ * @param notLogSafe - boolean flag for whether the message passed in contains data that shouldn't be logged for privacy reasons.
  *
  * @remarks
  * To avoid collisions with assertShortCode tagging in Fluid Framework, this cannot be named "assert".
  * When a non constant message is not needed, use `assert` from `@fluidframework/common-utils`;
  */
-export function assertWithMessage(condition: unknown, message?: string, containsPII = false): asserts condition {
+export function assertWithMessage(condition: unknown, message?: string, notLogSafe = false): asserts condition {
 	// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 	if (!condition) {
-		fail(message, containsPII);
+		fail(message, notLogSafe);
 	}
 }
 
@@ -94,15 +94,15 @@ export function assertWithMessage(condition: unknown, message?: string, contains
  * Fails an assertion. Throws an Error that the assertion failed.
  * Use when violations are logic errors in the program.
  * @param message - Message to be printed if assertion fails. Will print "Assertion failed" by default
- * @param containsPII - boolean flag for whether the message passed in contains personally identifying information (PII).
+ * @param notLogSafe - boolean flag for whether the message passed in contains data that shouldn't be logged for privacy reasons.
  */
-export function fail(message: string = defaultFailMessage, containsPII = false): never {
+export function fail(message: string = defaultFailMessage, notLogSafe = false): never {
 	if (process.env.NODE_ENV !== 'production') {
 		debugger;
 		console.error(message);
 	}
 
-	throw new SharedTreeAssertionError(containsPII ? 'Assertion failed' : message);
+	throw new SharedTreeAssertionError(notLogSafe ? 'Assertion failed' : message);
 }
 
 /**

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -53,9 +53,9 @@ export interface IDeltaStorageService {
 	 * @param id - document id.
 	 * @param from - first op to retrieve (inclusive)
 	 * @param to - first op not to retrieve (exclusive end)
-	 * @param fetchReason - Reason for fetching the messages. Example, gap between seq number
-	 * of Op on wire and known seq number. It should not contain any PII. It can be logged by
-	 * spo which could help in debugging sessions if any issue occurs.
+	 * @param fetchReason - Reason for fetching the messages, for logging.
+	 * Example, gap between seq number of Op on wire and known seq number.
+	 * It can be logged by spo which could help in debugging sessions if any issue occurs.
 	 */
 	get(
 		tenantId: string,
@@ -85,9 +85,9 @@ export interface IDocumentDeltaStorageService {
 	 * @param to - first op not to retrieve (exclusive end)
 	 * @param abortSignal - signal that aborts operation
 	 * @param cachedOnly - return only cached ops, i.e. ops available locally on client.
-	 * @param fetchReason - Reason for fetching the messages. Example, gap between seq number
-	 * of Op on wire and known seq number. It should not contain any PII. It can be logged by
-	 * spo which could help in debugging sessions if any issue occurs.
+	 * @param fetchReason - Reason for fetching the messages, for logging.
+	 * Example, gap between seq number of Op on wire and known seq number.
+	 * It can be logged by spo which could help in debugging sessions if any issue occurs.
 	 */
 	fetchMessages(
 		from: number,

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -713,9 +713,6 @@ export class DocumentDeltaConnection
 	 * Error raising for socket.io issues
 	 */
 	protected createErrorObject(handler: string, error?: any, canRetry = true): IAnyDriverError {
-		// Note: we suspect the incoming error object is either:
-		// - a string: log it in the message (if not a string, it may contain PII but will print as [object Object])
-		// - an Error object thrown by socket.io engine. Be careful with not recording PII!
 		let message: string;
 		if (error?.type === "TransportError") {
 			// JSON.stringify drops Error.message

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -731,7 +731,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	// for example, it's not clear if serverMetadata or timestamp property is a property of message or server state.
 	// We only extract the most obvious fields that are sufficient (with high probability) to detect sequence number
 	// reuse.
-	// Also payload goes to telemetry, so no PII, including content!!
+	// Also payload goes to telemetry, so no content or anything else that shouldn't be logged for privacy reasons
 	// Note: It's possible for a duplicate op to be broadcasted and have everything the same except the timestamp.
 	private comparableMessagePayload(m: ISequencedDocumentMessage) {
 		return `${m.clientId}-${m.type}-${m.minimumSequenceNumber}-${m.referenceSequenceNumber}-${m.timestamp}`;

--- a/packages/loader/container-utils/src/test/error.spec.ts
+++ b/packages/loader/container-utils/src/test/error.spec.ts
@@ -51,7 +51,7 @@ describe("Errors", () => {
 		it("Should skip coercion for LoggingError with errorType", () => {
 			const originalError = new LoggingError("Inherited error message", {
 				errorType: "Some error type",
-				otherProperty: "Considered PII-free property",
+				otherProperty: "some safe-to-log property",
 			});
 			const coercedError = DataProcessingError.wrapIfUnrecognized(
 				originalError,
@@ -99,7 +99,7 @@ describe("Errors", () => {
 		});
 		it("Should coerce LoggingError missing errorType", () => {
 			const originalError = new LoggingError("Inherited error message", {
-				otherProperty: "Considered PII-free property",
+				otherProperty: "some safe-to-log property",
 			});
 			const coercedError = DataProcessingError.wrapIfUnrecognized(
 				originalError,
@@ -115,15 +115,14 @@ describe("Errors", () => {
 			assert(coercedError.getTelemetryProperties().untrustedOrigin === undefined);
 			assert(coercedError.message === "Inherited error message");
 			assert(
-				coercedError.getTelemetryProperties().otherProperty ===
-					"Considered PII-free property",
+				coercedError.getTelemetryProperties().otherProperty === "some safe-to-log property",
 				"telemetryProps should be copied when wrapping",
 			);
 		});
 
 		it("Should coerce Normalized LoggingError with errorType", () => {
 			const originalError = new LoggingError("Inherited error message", {
-				otherProperty: "Considered PII-free property",
+				otherProperty: "some safe-to-log property",
 			});
 			const normalizedLoggingError = normalizeError(originalError);
 			const coercedError = DataProcessingError.wrapIfUnrecognized(
@@ -139,8 +138,7 @@ describe("Errors", () => {
 			assert(coercedError.getTelemetryProperties().untrustedOrigin === undefined);
 			assert(coercedError.message === "Inherited error message");
 			assert(
-				coercedError.getTelemetryProperties().otherProperty ===
-					"Considered PII-free property",
+				coercedError.getTelemetryProperties().otherProperty === "some safe-to-log property",
 				"telemetryProps should be copied when wrapping",
 			);
 		});

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -102,7 +102,7 @@ export function createResponseError(
 	headers?: { [key: string]: any },
 ): IResponse {
 	assert(status !== 200, 0x19b /* "Cannot not create response error on 200 status" */);
-	// Omit query string which could contain personal data (aka "PII")
+	// Omit query string which could contain personal data unfit for logging
 	const urlNoQuery = request.url?.split("?")[0];
 
 	// Capture error objects, not stack itself, as stack retrieval is very expensive operation, so we delay it

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -263,7 +263,7 @@ export class TaggedLoggerAdapter implements ITelemetryBaseLogger {
 					newEvent[key] = value;
 					break;
 				case TelemetryDataTag.UserData:
-					// Strip out anything tagged explicitly as PII.
+					// Strip out anything tagged explicitly as UserData.
 					// Alternate strategy would be to hash these props
 					newEvent[key] = "REDACTED (UserData)";
 					break;

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -348,12 +348,12 @@ describe("Error Logging", () => {
 			errorAsAny.p1 = "one";
 			errorAsAny.p4 = 4;
 			errorAsAny.p5 = { value: 5, tag: "CodeArtifact" };
-			errorAsAny.pii6 = { value: 5, tag: "UserData" };
+			errorAsAny.userData6 = { value: 5, tag: "UserData" };
 			const props = loggingError.getTelemetryProperties();
 			assert.strictEqual(props.p1, "one");
 			assert.strictEqual(props.p4, 4);
 			assert.deepStrictEqual(props.p5, { value: 5, tag: "CodeArtifact" });
-			assert.deepStrictEqual(props.pii6, { value: 5, tag: "UserData" });
+			assert.deepStrictEqual(props.userData6, { value: 5, tag: "UserData" });
 		});
 		it("Set invalid props via 'as any' - excluded from getTelemetryProperties, overwrites", () => {
 			const loggingError = new LoggingError("myMessage", { p1: 1, p2: "two", p3: true });


### PR DESCRIPTION
## Description

The term "PII" is a defunct way to refer to various forms of data that should not be logged for privacy reasons, at least within Microsoft's business operation (Other FF consumers should review their own privacy policies for what kind of data can be transmitted where/how).  To avoid confusion this PR removes this old and ambiguous term.
