### PR TITLE
refactor(client-debugger): Remove `IContainerDevtools` from the package exports

### DIFF
--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -6,7 +6,6 @@
 
 import { AttachState } from '@fluidframework/container-definitions';
 import { ConnectionState } from '@fluidframework/container-loader';
-import { IAudience } from '@fluidframework/container-definitions';
 import { IClient } from '@fluidframework/protocol-definitions';
 import { IContainer } from '@fluidframework/container-definitions';
 import { IDisposable } from '@fluidframework/common-definitions';
@@ -352,18 +351,6 @@ export interface HasFluidObjectId {
 }
 
 // @public
-export interface IContainerDevtools extends IDisposable {
-    readonly audience: IAudience;
-    readonly container: IContainer;
-    readonly containerData?: IFluidLoadable | Record<string, IFluidLoadable>;
-    readonly containerId: string;
-    readonly containerNickname?: string;
-    dispose(): void;
-    getAudienceHistory(): readonly AudienceChangeLogEntry[];
-    getContainerConnectionLog(): readonly ConnectionStateChangeLogEntry[];
-}
-
-// @public
 export interface IDevtoolsMessage<TData = unknown> {
     data: TData;
     type: string;
@@ -372,9 +359,6 @@ export interface IDevtoolsMessage<TData = unknown> {
 // @public
 export interface IFluidDevtools extends IDisposable {
     closeContainerDevtools(containerId: string): void;
-    getAllContainerDevtools(): readonly IContainerDevtools[];
-    getContainerDevtools(containerId: string): IContainerDevtools | undefined;
-    readonly logger: DevtoolsLogger | undefined;
     registerContainerDevtools(props: ContainerDevtoolsProps): void;
 }
 

--- a/packages/tools/client-debugger/client-debugger/src/ContainerDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/ContainerDevtools.ts
@@ -45,13 +45,13 @@ import { AudienceClientMetadata } from "./AudienceMetadata";
 import { ContainerDevtoolsFeature, ContainerDevtoolsFeatureFlags } from "./Features";
 
 /**
- * Properties for configuring a {@link IContainerDevtools}.
+ * Properties for registering a {@link @fluidframework/container-definitions#IContainer} with the Devtools.
  *
  * @public
  */
 export interface ContainerDevtoolsProps {
 	/**
-	 * The Container with which the {@link IContainerDevtools} instance will be associated.
+	 * The Container to register with the Devtools.
 	 */
 	container: IContainer;
 

--- a/packages/tools/client-debugger/client-debugger/src/Features.ts
+++ b/packages/tools/client-debugger/client-debugger/src/Features.ts
@@ -39,7 +39,7 @@ export type DevtoolsFeatureFlags = {
 };
 
 /**
- * Describes features supported by {@link IContainerDevtools}.
+ * Describes features supported by the Devtools for a specific Container instance.
  *
  * @public
  */
@@ -52,19 +52,18 @@ export enum ContainerDevtoolsFeature {
 }
 
 /**
- * Describes the set of {@link ContainerDevtoolsFeature | container-related features} supported by a
- * {@link IContainerDevtools} instance.
+ * Describes the set of {@link ContainerDevtoolsFeature | container-related features} supported by the Devtools.
  *
  * @remarks
  *
  * This has two primary purposes:
  *
  * 1. It can be used to signal to consumers of the Devtools what kinds of functionality are supported (at runtime)
- * by a {@link IContainerDevtools} instance.
+ * by the Devtools for a specific Container instance.
  *
  * 2. It can be used to make backwards compatible changes easier to make.
  * By adding a flag to this object for new features, consumers can easily verify whether or not that feature
- * is supported by the corresponding {@link IContainerDevtools} instance before attempting to use it.
+ * is supported by the Devtools for a specific Container instance.
  *
  * @public
  */

--- a/packages/tools/client-debugger/client-debugger/src/FluidDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidDevtools.ts
@@ -122,7 +122,7 @@ export interface FluidDevtoolsProps {
  */
 export class FluidDevtools implements IFluidDevtools {
 	/**
-	 * {@inheritDoc IFluidDevtools.logger}
+	 * (optional) telemetry logger associated with the Fluid runtime.
 	 */
 	public readonly logger: DevtoolsLogger | undefined;
 
@@ -278,7 +278,8 @@ export class FluidDevtools implements IFluidDevtools {
 	}
 
 	/**
-	 * {@inheritDoc IFluidDevtools.getContainerDevtools}
+	 * Gets the registed Container Devtools associated with the provided Container ID, if one exists.
+	 * Otherwise returns `undefined`.
 	 */
 	public getContainerDevtools(containerId: string): IContainerDevtools | undefined {
 		if (this.disposed) {
@@ -289,16 +290,7 @@ export class FluidDevtools implements IFluidDevtools {
 	}
 
 	/**
-	 * Gets the set of features supported by this instance.
-	 */
-	private getSupportedFeatures(): DevtoolsFeatureFlags {
-		return {
-			[DevtoolsFeature.Telemetry]: this.logger !== undefined,
-		};
-	}
-
-	/**
-	 * {@inheritDoc IFluidDevtools.getAllContainerDevtools}
+	 * Gets all Container-level devtools instances.
 	 */
 	public getAllContainerDevtools(): readonly IContainerDevtools[] {
 		if (this.disposed) {
@@ -333,6 +325,15 @@ export class FluidDevtools implements IFluidDevtools {
 		this.postContainerList();
 
 		this._disposed = true;
+	}
+
+	/**
+	 * Gets the set of features supported by this instance.
+	 */
+	private getSupportedFeatures(): DevtoolsFeatureFlags {
+		return {
+			[DevtoolsFeature.Telemetry]: this.logger !== undefined,
+		};
 	}
 }
 

--- a/packages/tools/client-debugger/client-debugger/src/IContainerDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/IContainerDevtools.ts
@@ -18,7 +18,7 @@ import { AudienceChangeLogEntry, ConnectionStateChangeLogEntry } from "./Logs";
  * {@link @fluidframework/container-definitions#IContainer} and
  * {@link @fluidframework/container-definitions#IAudience}.
  *
- * @public
+ * @internal
  */
 export interface IContainerDevtools extends IDisposable {
 	/**

--- a/packages/tools/client-debugger/client-debugger/src/IFluidDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/IFluidDevtools.ts
@@ -5,8 +5,6 @@
 import { IDisposable } from "@fluidframework/common-definitions";
 
 import { ContainerDevtoolsProps } from "./ContainerDevtools";
-import { DevtoolsLogger } from "./DevtoolsLogger";
-import { IContainerDevtools } from "./IContainerDevtools";
 
 /**
  * Fluid Devtools. A single instance is used to generate and communicate stats associated with the general Fluid
@@ -14,38 +12,26 @@ import { IContainerDevtools } from "./IContainerDevtools";
  *
  * @remarks
  *
- * Supports registering {@link IContainerDevtools | Container-level Devtools} objects for specific
- * {@link @fluidframework/container-definitions#IContainer}s (via {@link IFluidDevtools.registerContainerDevtools}).
+ * Supports registering {@link @fluidframework/container-definitions#IContainer}s for Container-level stats
+ * (via {@link IFluidDevtools.registerContainerDevtools}).
  *
  * @public
  */
 export interface IFluidDevtools extends IDisposable {
 	/**
-	 * (optional) telemetry logger associated with the Fluid runtime.
-	 */
-	readonly logger: DevtoolsLogger | undefined;
-
-	/**
-	 * Initializes a {@link IContainerDevtools} from the provided properties and stores it for future reference.
+	 * Registers the provided {@link @fluidframework/container-definitions#IContainer} with the Devtools to begin
+	 * generating stats for it.
+	 *
+	 * @remarks To remove the Container from the Devtools, call {@link IFluidDevtools.closeContainerDevtools}.
 	 *
 	 * @throws Will throw if devtools have already been registered for the specified Container ID.
 	 */
 	registerContainerDevtools(props: ContainerDevtoolsProps): void;
 
 	/**
-	 * Closes ({@link IContainerDevtools.dispose | disposes}) a registered Container devtools associated with the
-	 * provided Container ID.
+	 * Removes the Container with the specified ID from the Devtools.
+	 *
+	 * @remarks Will no-op if no such Container is registered.
 	 */
 	closeContainerDevtools(containerId: string): void;
-
-	/**
-	 * Gets the registed Container Devtools associated with the provided Container ID, if one exists.
-	 * Otherwise returns `undefined`.
-	 */
-	getContainerDevtools(containerId: string): IContainerDevtools | undefined;
-
-	/**
-	 * Gets all Container-level devtools instances.
-	 */
-	getAllContainerDevtools(): readonly IContainerDevtools[];
 }

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -75,7 +75,6 @@ export {
 	DevtoolsFeature,
 	DevtoolsFeatureFlags,
 } from "./Features";
-export { IContainerDevtools } from "./IContainerDevtools";
 export { IFluidDevtools } from "./IFluidDevtools";
 export { DevtoolsLogger } from "./DevtoolsLogger";
 export { FluidDevtoolsProps, initializeFluidDevtools } from "./FluidDevtools";

--- a/packages/tools/client-debugger/client-debugger/src/messaging/container-devtools-messages/ContainerDevtoolsFeatures.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/container-devtools-messages/ContainerDevtoolsFeatures.ts
@@ -27,14 +27,13 @@ export namespace ContainerDevtoolsFeatures {
 	 */
 	export interface MessageData extends HasContainerId {
 		/**
-		 * Describes the set of features supported by the {@link IContainerDevtools} instance associated with the
-		 * specified {@link HasContainerId.containerId}.
+		 * {@inheritDoc ContainerDevtoolsFeatureFlags}
 		 */
 		features: ContainerDevtoolsFeatureFlags;
 	}
 
 	/**
-	 * Outbound message containing the set of features supported by the {@link IContainerDevtools} instance associated
+	 * Outbound message containing the set of features supported by the Container-level Devtools instance associated
 	 * with the specified {@link HasContainerId.containerId}.
 	 *
 	 * @public

--- a/packages/tools/client-debugger/client-debugger/src/messaging/container-devtools-messages/GetContainerDevtoolsFeatures.ts
+++ b/packages/tools/client-debugger/client-debugger/src/messaging/container-devtools-messages/GetContainerDevtoolsFeatures.ts
@@ -27,7 +27,7 @@ export namespace GetContainerDevtoolsFeatures {
 	export type MessageData = HasContainerId;
 
 	/**
-	 * Inbound message requesting the set of features supported by the {@link IContainerDevtools} instance
+	 * Inbound message requesting the set of features supported by the Container-level Devtools instance
 	 * corresponding to the provided {@link HasContainerId.containerId}.
 	 *
 	 * Will result in the {@link ContainerDevtoolsFeatures.Message} message being posted.


### PR DESCRIPTION
The interface is not used externally, and really doesn't need to be exported. We can always re-add it later as needed.

Most of the other changes in this PR are updating docs to not `@link` reference the removed API member.