### PR TITLE
fix(ci): Increase timeout for odsp and frs perf benchmarks

### DIFF
--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -17,10 +17,15 @@ parameters:
   type: string
   default: '@ff-internal/aria-logger'
 
+- name: timeoutInMinutes
+  type: number
+  default: 60
+
 jobs:
   - job: runTests
     displayName: Run tests
     pool: ${{ parameters.poolBuild }}
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     variables:
     - name: isTestBranch
       value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -45,8 +45,10 @@ parameters:
   - endpointName: 'local'
   - endpointName: 'odsp'
     lockVariableGroupName: 'e2e-odsp-lock'
+    timeoutInMinutes: 360
   - endpointName: 'frs'
     lockVariableGroupName: 'e2e-frs-lock'
+    timeoutInMinutes: 360
 
 variables:
   # We use 'chalk' to colorize output, which auto-detects color support in the
@@ -69,6 +71,7 @@ variables:
     readonly: true
   - group: prague-key-vault
 
+lockBehavior: sequential
 stages:
   # Performance unit tests - runtime
   - stage: perf_unit_tests_runtime
@@ -414,6 +417,7 @@ stages:
         parameters:
           poolBuild: ${{ parameters.poolBuild }}
           testWorkspace: ${{ variables.testWorkspace }}
+          timeoutInMinutes: ${{ coalesce(endpointObject.timeoutInMinutes, 60) }}
           customSteps:
 
           # Download test package


### PR DESCRIPTION
## Description

After the recent introduction of contention locks for the odsp and frs stages of the Performance Benchmarks pipeline (#15294), those stages started timing out / getting canceled if they couldn't obtain the lock within the default 60 min timeout for a stage. This change increases the timeout for those two stages to 360 minutes, to match the e2e tests pipeline.

Confirmed with a run from a test/ branch with these changes that the new timeout is being applied:

![image](https://user-images.githubusercontent.com/716334/235188137-69dab780-5910-40ab-aba7-131b3c332714.png)

It also adds the `lockBehavior: sequential` configuration so that every run of the pipeline executes those stages as the lock becomes available, instead of the latest run executing them and previous runs skipping them (if there are several runs queued), which is the default behavior when using these locks.