### PR TITLE
Protocol Definitions Typing Improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,43 +1,45 @@
 {
-    "eslint.workingDirectories": [
-        {
-            "mode": "auto"
-        }
-    ],
-    "typescript.tsdk": "node_modules/typescript/lib",
+	"eslint.workingDirectories": [
+		{
+			"mode": "auto"
+		}
+	],
+	"typescript.tsdk": "node_modules/typescript/lib",
 
-    // Autodetecting tasks on a repo this size makes 'Tasks: Run Build Task' unusably slow.
-    // (See https://github.com/Microsoft/vscode/issues/34387)
-    "typescript.tsc.autoDetect": "off",
-    "npm.autoDetect": "off",
+	// Autodetecting tasks on a repo this size makes 'Tasks: Run Build Task' unusably slow.
+	// (See https://github.com/Microsoft/vscode/issues/34387)
+	"typescript.tsc.autoDetect": "off",
+	"npm.autoDetect": "off",
 
-    "files.associations": {
-        "tools/pipelines/*.yml": "azure-pipelines",
-        // good-fences' fence files support comments, so detect them as "jsonc" instead of "json":
-        "fence.json": "jsonc",
-        ".git-blame-ignore-revs": "ignore"
-    },
-    "[azure-pipelines].customSchemaFile": "",
-    "deno.enable": false,
-    "deno.lint": false,
-    "deno.unstable": false,
+	"files.associations": {
+		"tools/pipelines/*.yml": "azure-pipelines",
+		// good-fences' fence files support comments, so detect them as "jsonc" instead of "json":
+		"fence.json": "jsonc",
+		".git-blame-ignore-revs": "ignore"
+	},
+	"[azure-pipelines].customSchemaFile": "",
+	"deno.enable": false,
+	"deno.lint": false,
+	"deno.unstable": false,
 
-    // Custom dictionary for 'streetsidesoftware.code-spell-checker' extension.
-    "cSpell.words": [
-        "endregion",
-        "injective",
-        "losslessly",
-        "mitigations",
-        "multinomial",
-        "nonfinite",
-        "pseudorandomly",
-        "Tinylicious",
-        "tombstoned",
-        "TSDoc",
-        "unaugmented"
-    ],
+	// Custom dictionary for 'streetsidesoftware.code-spell-checker' extension.
+	"cSpell.words": [
+		"endregion",
+		"injective",
+		"losslessly",
+		"mitigations",
+		"multinomial",
+		"nacked",
+		"nonfinite",
+		"pseudorandomly",
+		"retriable",
+		"Tinylicious",
+		"tombstoned",
+		"TSDoc",
+		"unaugmented"
+	],
 
-    // Enable prettier as default formatter, and disable rules that disagree with it
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.insertSpaces": false
+	// Enable prettier as default formatter, and disable rules that disagree with it
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"editor.insertSpaces": false
 }

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -152,10 +152,10 @@ export interface IDocumentAttributes {
 export interface IDocumentMessage {
     clientSequenceNumber: number;
     compression?: string;
-    contents: any;
-    metadata?: any;
+    contents: unknown;
+    metadata?: unknown;
     referenceSequenceNumber: number;
-    serverMetadata?: any;
+    serverMetadata?: unknown;
     traces?: ITrace[];
     type: string;
 }
@@ -198,7 +198,7 @@ export interface IProcessMessageResult {
 // @public
 export interface IProposal {
     key: string;
-    value: any;
+    value: unknown;
 }
 
 // @public (undocumented)
@@ -253,11 +253,11 @@ export type IQuorumEvents = IQuorumClientsEvents & IQuorumProposalsEvents;
 // @public
 export interface IQuorumProposals extends IEventProvider<IQuorumProposalsEvents>, IDisposable {
     // (undocumented)
-    get(key: string): any;
+    get(key: string): unknown;
     // (undocumented)
     has(key: string): boolean;
     // (undocumented)
-    propose(key: string, value: any): Promise<void>;
+    propose(key: string, value: unknown): Promise<void>;
 }
 
 // @public
@@ -265,7 +265,7 @@ export interface IQuorumProposalsEvents extends IErrorEvent {
     // (undocumented)
     (event: "addProposal", listener: (proposal: ISequencedProposal) => void): any;
     // (undocumented)
-    (event: "approveProposal", listener: (sequenceNumber: number, key: string, value: any, approvalSequenceNumber: number) => void): any;
+    (event: "approveProposal", listener: (sequenceNumber: number, key: string, value: unknown, approvalSequenceNumber: number) => void): any;
 }
 
 // @public
@@ -282,20 +282,20 @@ export interface ISequencedDocumentAugmentedMessage extends ISequencedDocumentMe
 
 // @public
 export interface ISequencedDocumentMessage {
-    clientId: string;
+    clientId: string | null;
     clientSequenceNumber: number;
     compression?: string;
-    contents: any;
+    contents: unknown;
     // (undocumented)
     data?: string;
     // @alpha
     expHash1?: string;
-    metadata?: any;
+    metadata?: unknown;
     minimumSequenceNumber: number;
     origin?: IBranchOrigin;
     referenceSequenceNumber: number;
     sequenceNumber: number;
-    serverMetadata?: any;
+    serverMetadata?: unknown;
     timestamp: number;
     traces?: ITrace[];
     type: string;
@@ -328,10 +328,9 @@ export interface ISignalClient {
 // @public (undocumented)
 export interface ISignalMessage {
     clientConnectionNumber?: number;
-    // (undocumented)
     clientId: string | null;
     // (undocumented)
-    content: any;
+    content: unknown;
     referenceSequenceNumber?: number;
 }
 

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -109,7 +109,7 @@ export interface IConnect {
     mode: ConnectionMode;
     nonce?: string;
     relayUserAgent?: string;
-    supportedFeatures?: Record<string, any>;
+    supportedFeatures?: Record<string, unknown>;
     tenantId: string;
     token: string | null;
     versions: string[];
@@ -130,7 +130,7 @@ export interface IConnected {
     nonce?: string;
     relayServiceAgent?: string;
     serviceConfiguration: IClientConfiguration;
-    supportedFeatures?: Record<string, any>;
+    supportedFeatures?: Record<string, unknown>;
     supportedVersions: string[];
     timestamp?: number;
     version: string;

--- a/common/lib/protocol-definitions/src/consensus.ts
+++ b/common/lib/protocol-definitions/src/consensus.ts
@@ -60,8 +60,6 @@ export interface IQuorumProposalsEvents extends IErrorEvent {
 		listener: (
 			sequenceNumber: number,
 			key: string,
-			// TODO: use `unknown` instead.
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			value: unknown,
 			approvalSequenceNumber: number,
 		) => void,

--- a/common/lib/protocol-definitions/src/consensus.ts
+++ b/common/lib/protocol-definitions/src/consensus.ts
@@ -22,8 +22,6 @@ export interface IProposal {
 	/**
 	 * The value of the proposal.
 	 */
-	// TODO: use `unknown` instead.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	value: unknown;
 }
 

--- a/common/lib/protocol-definitions/src/consensus.ts
+++ b/common/lib/protocol-definitions/src/consensus.ts
@@ -24,7 +24,7 @@ export interface IProposal {
 	 */
 	// TODO: use `unknown` instead.
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	value: any;
+	value: unknown;
 }
 
 /**
@@ -62,7 +62,7 @@ export interface IQuorumProposalsEvents extends IErrorEvent {
 			key: string,
 			// TODO: use `unknown` instead.
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			value: any,
+			value: unknown,
 			approvalSequenceNumber: number,
 		) => void,
 	);
@@ -86,15 +86,11 @@ export interface IQuorumClients extends IEventProvider<IQuorumClientsEvents>, ID
  * Interface for tracking proposals in the Quorum.
  */
 export interface IQuorumProposals extends IEventProvider<IQuorumProposalsEvents>, IDisposable {
-	// TODO: use `unknown` instead.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	propose(key: string, value: any): Promise<void>;
+	propose(key: string, value: unknown): Promise<void>;
 
 	has(key: string): boolean;
 
-	// TODO: return `unknown` instead.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	get(key: string): any;
+	get(key: string): unknown;
 }
 
 /**

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -150,23 +150,17 @@ export interface IDocumentMessage {
 	/**
 	 * The contents of the message.
 	 */
-	// TODO: use `unknown` instead.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	contents: any;
+	contents: unknown;
 
 	/**
 	 * App provided metadata about the operation.
 	 */
-	// TODO: use `unknown` instead.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	metadata?: any;
+	metadata?: unknown;
 
 	/**
 	 * Server provided metadata about the operation.
 	 */
-	// TODO: use `unknown` instead.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	serverMetadata?: any;
+	serverMetadata?: unknown;
 
 	/**
 	 * Traces related to the packet.
@@ -214,7 +208,7 @@ export interface ISequencedDocumentMessage {
 	/**
 	 * The client ID that submitted the delta.
 	 */
-	clientId: string;
+	clientId: string | null;
 
 	/**
 	 * The sequenced identifier.
@@ -244,23 +238,17 @@ export interface ISequencedDocumentMessage {
 	/**
 	 * The contents of the message.
 	 */
-	// TODO: use `unknown` instead.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	contents: any;
+	contents: unknown;
 
 	/**
 	 * App provided metadata about the operation.
 	 */
-	// TODO: use `unknown` instead.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	metadata?: any;
+	metadata?: unknown;
 
 	/**
 	 * Server provided metadata about the operation.
 	 */
-	// TODO: use `unknown` instead.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	serverMetadata?: any;
+	serverMetadata?: unknown;
 
 	/**
 	 * Origin branch information for the message.
@@ -308,9 +296,7 @@ export interface ISignalMessage {
 	// eslint-disable-next-line @rushstack/no-new-null
 	clientId: string | null;
 
-	// TODO: use `unknown` instead.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	content: any;
+	content: unknown;
 
 	/**
 	 * Counts the number of signals sent by the client

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -7,7 +7,7 @@ export enum MessageType {
 	/**
 	 * Empty operation message. Used to send an updated reference sequence number.
 	 * Relay service is free to coalesce these messages or fully drop them, if
-	 * another op was used to update MSN to a number equal or higher than referenced
+	 * another message was used to update MSN to a number equal or higher than referenced
 	 * sequence number in Noop.
 	 */
 	NoOp = "noop",
@@ -38,22 +38,22 @@ export enum MessageType {
 	Accept = "accept",
 
 	/**
-	 * Summary operation (op).
+	 * Summary operation (message).
 	 */
 	Summarize = "summarize",
 
 	/**
-	 * Summary operation (op) written.
+	 * Summary operation (message) written.
 	 */
 	SummaryAck = "summaryAck",
 
 	/**
-	 * Summary operation (op) write failure.
+	 * Summary operation (message) write failure.
 	 */
 	SummaryNack = "summaryNack",
 
 	/**
-	 * Operation (op) produced by container runtime.
+	 * Operation (message) produced by container runtime.
 	 */
 	Operation = "op",
 
@@ -168,7 +168,7 @@ export interface IDocumentMessage {
 	traces?: ITrace[];
 
 	/**
-	 * The compression algorithm that was used to compress contents of this op.
+	 * The compression algorithm that was used to compress contents of this message.
 	 * @experimental Not ready for use
 	 */
 	compression?: string;
@@ -206,8 +206,10 @@ export interface IBranchOrigin {
  */
 export interface ISequencedDocumentMessage {
 	/**
-	 * The client ID that submitted the delta.
+	 * The client ID that submitted the message.
+	 * For server generated messages the clientId will be null;
 	 */
+	// eslint-disable-next-line @rushstack/no-new-null
 	clientId: string | null;
 
 	/**
@@ -277,7 +279,7 @@ export interface ISequencedDocumentMessage {
 	expHash1?: string;
 
 	/**
-	 * The compression algorithm that was used to compress contents of this op.
+	 * The compression algorithm that was used to compress contents of this message.
 	 * @experimental Not ready for use.
 	 */
 	compression?: string;
@@ -292,7 +294,10 @@ export interface ISequencedDocumentAugmentedMessage extends ISequencedDocumentMe
 }
 
 export interface ISignalMessage {
-	// TODO: Update this to use undefined instead of null.
+	/**
+	 * The client ID that submitted the message.
+	 * For server generated messages the clientId will be null.
+	 */
 	// eslint-disable-next-line @rushstack/no-new-null
 	clientId: string | null;
 
@@ -346,11 +351,11 @@ export interface IServerError {
 }
 
 /**
- * Data about the original proposed summary op.
+ * Data about the original proposed summary message.
  */
 export interface ISummaryProposal {
 	/**
-	 * Actual sequence number of the summary op proposal.
+	 * Actual sequence number of the summary message proposal.
 	 */
 	summarySequenceNumber: number;
 }
@@ -365,7 +370,7 @@ export interface ISummaryAck {
 	handle: string;
 
 	/**
-	 * Information about the proposed summary op.
+	 * Information about the proposed summary message.
 	 */
 	summaryProposal: ISummaryProposal;
 }
@@ -375,13 +380,13 @@ export interface ISummaryAck {
  */
 export interface ISummaryNack {
 	/**
-	 * Information about the proposed summary op.
+	 * Information about the proposed summary message.
 	 */
 	summaryProposal: ISummaryProposal;
 
 	/**
 	 * An error code number that represents the error. It will be a valid HTTP error code.
-	 * 403 errors are non retryable.
+	 * 403 errors are non retriable.
 	 * 400 errors are always immediately retriable.
 	 * 429 errors are retriable or non retriable (depends on type field).
 	 */
@@ -428,7 +433,7 @@ export interface IQueueMessage {
 export interface INackContent {
 	/**
 	 * An error code number that represents the error. It will be a valid HTTP error code.
-	 * 403 errors are non retryable and client should acquire a new identity before reconnection.
+	 * 403 errors are non retriable and client should acquire a new identity before reconnection.
 	 * 400 errors are always immediately retriable
 	 * 429 errors are retriable or non retriable (depends on type field).
 	 */
@@ -453,9 +458,9 @@ export interface INackContent {
 
 /**
  * Type of the Nack.
- * InvalidScopeError: Client's token is not valid for the intended op.
- * ThrottlingError: Retryable after retryAfter number.
- * BadRequestError: Clients op is invalid and should retry immediately with a valid op.
+ * InvalidScopeError: Client's token is not valid for the intended message.
+ * ThrottlingError: Retriable after retryAfter number.
+ * BadRequestError: Clients message is invalid and should retry immediately with a valid message.
  * LimitExceededError: Service is having issues. Client should not retry.
  */
 export enum NackErrorType {

--- a/common/lib/protocol-definitions/src/sockets.ts
+++ b/common/lib/protocol-definitions/src/sockets.ts
@@ -66,9 +66,7 @@ export interface IConnect {
 	 * Features supported might be service specific.
 	 * If we have standardized features across all services, they need to be exposed in more structured way.
 	 */
-	// TODO: use `unknown` instead.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	supportedFeatures?: Record<string, any>;
+	supportedFeatures?: Record<string, unknown>;
 
 	/**
 	 * Properties that client can send to server to tell info about client environment. These are a bunch of properties
@@ -161,9 +159,7 @@ export interface IConnected {
 	 * Features supported might be service specific.
 	 * If we have standardized features across all services, they need to be exposed in more structured way.
 	 */
-	// TODO: use `unknown` instead.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	supportedFeatures?: Record<string, any>;
+	supportedFeatures?: Record<string, unknown>;
 
 	/**
 	 * The time the client connected


### PR DESCRIPTION
## Description

 - Change usages of `any` to `unknown`. This changes nothing a runtime, but forces typescript users to safely access the value
 - Add `null` to ISequencedDocumentMessage.client id, as `null` is and always has been a valid value at runtime which must be handled. Server generated message currently have `null` as the value for `clientId`.
 - Change references to `op` or `delta` in comments to message, as messages do not map one to one with ops in many cases
 - Fix spelling errors.