### PR TITLE
Fix GC tests failing with default read mode

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
@@ -23,20 +23,10 @@ import {
 	getUrlFromDetachedBlobStorage,
 	MockDetachedBlobStorage,
 } from "../mockDetachedBlobStorage";
-import { getGCStateFromSummary } from "./gcTestSummaryUtils";
-
-const waitForContainerConnectionWriteMode = async (container: IContainer) => {
-	const resolveIfActive = (res: () => void) => {
-		if (container.deltaManager.active) {
-			res();
-		}
-	};
-	if (!container.deltaManager.active) {
-		await new Promise<void>((resolve) =>
-			container.on("connected", () => resolveIfActive(resolve)),
-		);
-	}
-};
+import {
+	getGCStateFromSummary,
+	waitForContainerWriteModeConnectionWrite,
+} from "./gcTestSummaryUtils";
 
 /**
  * Validates that unreferenced blobs are marked as unreferenced and deleted correctly.
@@ -264,7 +254,7 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 			// uses the timestamp of the op.
 			defaultDataStore._root.set("make container connect in", "write mode");
 			// Make sure we are connected or we may get a local ID handle
-			await waitForContainerConnectionWriteMode(container);
+			await waitForContainerWriteModeConnectionWrite(container);
 
 			// Upload the same blob. This will get de-duped and we will get back a handle with another localId. Both of
 			// these blobs should be mapped to the same storageId.
@@ -343,7 +333,7 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 			// uses the timestamp of the op.
 			defaultDataStore._root.set("make container connect in", "write mode");
 			// Make sure we are connected or we may get a local ID handle
-			await waitForContainerConnectionWriteMode(container);
+			await waitForContainerWriteModeConnectionWrite(container);
 
 			// Upload the same blob. This will get de-duped and we will get back a handle with another localId. This and
 			// the blobs uploaded in detached mode should map to the same storageId.
@@ -427,7 +417,7 @@ describeNoCompat("Garbage collection of blobs", (getTestObjectProvider) => {
 			// GC requires at least one op to have been processed. It needs a server timestamp and
 			// uses the timestamp of the op.
 			defaultDataStore._root.set("make container connect in", "write mode");
-			await waitForContainerConnectionWriteMode(container);
+			await waitForContainerWriteModeConnectionWrite(container);
 
 			// Summarize once before uploading the blob in disconnected container. This will make sure that when GC
 			// runs next, it has GC data from previous run to do reference validation.

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -25,6 +25,7 @@ import {
 	itExpects,
 	TestDataObjectType,
 } from "@fluid-internal/test-version-utils";
+import { waitForContainerWriteModeConnectionWrite } from "./gcTestSummaryUtils";
 
 /**
  * Validates this scenario: When a GC node (data store or attachment blob) becomes inactive, i.e, it has been
@@ -313,16 +314,21 @@ describeNoCompat("GC inactive nodes tests", (getTestObjectProvider) => {
 				// Wait for inactive timeout. This will ensure that the unreferenced data store is inactive.
 				await waitForInactiveTimeout();
 
-				// Load a non-summarizer container from the above summary that uses the mock logger.
+				// Load a non-summarizer container from the above summary that uses the mock logger. This container has to
+				// be in "write" mode for GC to initialize unreferenced nodes from summary.
 				const container2 = await provider.loadTestContainer(
 					{
-						// AB#3982 track work to removing this exception using simulateReadConnectionUsingDelay
-						simulateReadConnectionUsingDelay: false,
 						...testContainerConfig,
 						loaderProps: { logger: mockLogger },
 					},
 					{ [LoaderHeader.version]: summaryVersion1 },
 				);
+				const defaultDataStoreContainer2 = await requestFluidObject<ITestDataObject>(
+					container2,
+					"/",
+				);
+				defaultDataStoreContainer2._root.set("mode", "write");
+				await waitForContainerWriteModeConnectionWrite(container2);
 
 				// Load the inactive data store. This should result in a loaded event from the non-summarizer container.
 				await container2.request({ url });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
@@ -19,19 +19,7 @@ import {
 } from "@fluid-internal/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions";
 import { defaultGCConfig } from "./gcTestConfigs";
-
-const ensureContainerConnectedWriteMode = async (container: IContainer) => {
-	const resolveIfActive = (res: () => void) => {
-		if (container.deltaManager.active) {
-			res();
-		}
-	};
-	if (!container.deltaManager.active) {
-		await new Promise<void>((resolve) =>
-			container.on("connected", () => resolveIfActive(resolve)),
-		);
-	}
-};
+import { waitForContainerWriteModeConnectionWrite } from "./gcTestSummaryUtils";
 
 /**
  * Validates that we generate correct garbage collection stats, such as total number of nodes, number of unreferenced
@@ -120,7 +108,7 @@ describeNoCompat("Garbage Collection Stats", (getTestObjectProvider) => {
 		const blob1Contents = "Blob contents 1";
 		const blob2Contents = "Blob contents 2";
 		// Blob stats will be different if we upload while not connected
-		await ensureContainerConnectedWriteMode(container);
+		await waitForContainerWriteModeConnectionWrite(container);
 		const blob1Handle = await mainDataStore._context.uploadBlob(
 			stringToBuffer(blob1Contents, "utf-8"),
 		);
@@ -173,7 +161,7 @@ describeNoCompat("Garbage Collection Stats", (getTestObjectProvider) => {
 		const blob1Contents = "Blob contents 1";
 		const blob2Contents = "Blob contents 2";
 		// Blob stats will be different if we upload while not connected
-		await ensureContainerConnectedWriteMode(container);
+		await waitForContainerWriteModeConnectionWrite(container);
 		const blob1Handle = await mainDataStore._context.uploadBlob(
 			stringToBuffer(blob1Contents, "utf-8"),
 		);
@@ -273,7 +261,7 @@ describeNoCompat("Garbage Collection Stats", (getTestObjectProvider) => {
 		const blob1Contents = "Blob contents 1";
 		const blob2Contents = "Blob contents 2";
 		// Blob stats will be different if we upload while not connected
-		await ensureContainerConnectedWriteMode(container);
+		await waitForContainerWriteModeConnectionWrite(container);
 		const blob1Handle = await mainDataStore._context.uploadBlob(
 			stringToBuffer(blob1Contents, "utf-8"),
 		);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -25,7 +25,11 @@ import {
 	getUrlFromDetachedBlobStorage,
 	MockDetachedBlobStorage,
 } from "../mockDetachedBlobStorage";
-import { getGCDeletedStateFromSummary, getGCStateFromSummary } from "./gcTestSummaryUtils";
+import {
+	getGCDeletedStateFromSummary,
+	getGCStateFromSummary,
+	waitForContainerWriteModeConnectionWrite,
+} from "./gcTestSummaryUtils";
 
 /**
  * These tests validate that SweepReady attachment blobs are correctly swept. Swept attachment blobs should be
@@ -691,19 +695,6 @@ describeNoCompat("GC attachment blob sweep tests", (getTestObjectProvider) => {
 			return { summarizer, summarizerContainer };
 		}
 
-		const ensureContainerConnectedWriteMode = async (container: IContainer) => {
-			const resolveIfActive = (res: () => void) => {
-				if (container.deltaManager.active) {
-					res();
-				}
-			};
-			if (!container.deltaManager.active) {
-				await new Promise<void>((resolve) =>
-					container.on("connected", () => resolveIfActive(resolve)),
-				);
-			}
-		};
-
 		beforeEach(async function () {
 			if (provider.driver.type !== "local") {
 				this.skip();
@@ -740,7 +731,7 @@ describeNoCompat("GC attachment blob sweep tests", (getTestObjectProvider) => {
 				// Connect the container after the blob is uploaded. Send an op to transition it to write mode.
 				mainContainer.connect();
 				mainDataStore._root.set("transition to write", "true");
-				await ensureContainerConnectedWriteMode(mainContainer);
+				await waitForContainerWriteModeConnectionWrite(mainContainer);
 
 				// Remove the blob's handle to unreference it.
 				mainDataStore._root.delete("blob");
@@ -817,7 +808,7 @@ describeNoCompat("GC attachment blob sweep tests", (getTestObjectProvider) => {
 				// Connect the container after the blob is uploaded. Send an op to transition the container to write mode.
 				mainContainer.connect();
 				mainDataStore._root.set("transition to write", "true");
-				await ensureContainerConnectedWriteMode(mainContainer);
+				await waitForContainerWriteModeConnectionWrite(mainContainer);
 
 				// Upload the same blob. This will get de-duped and we will get back another blob handle. Both this and
 				// the blob uploaded in disconnected mode should be different.
@@ -919,7 +910,7 @@ describeNoCompat("GC attachment blob sweep tests", (getTestObjectProvider) => {
 				// Connect the container after the blob is uploaded. Send an op to transition the container to write mode.
 				mainContainer.connect();
 				mainDataStore._root.set("transition to write", "true");
-				await ensureContainerConnectedWriteMode(mainContainer);
+				await waitForContainerWriteModeConnectionWrite(mainContainer);
 
 				// Add the blob handles to reference them.
 				mainDataStore._root.set("blob1", blobHandle1);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -71,13 +71,9 @@ describeNoCompat("GC data store sweep tests", (getTestObjectProvider) => {
 	});
 
 	async function loadContainer(summaryVersion: string) {
-		return provider.loadTestContainer(
-			// AB#3982 track work to removing this exception using simulateReadConnectionUsingDelay
-			{ simulateReadConnectionUsingDelay: false, ...testContainerConfig },
-			{
-				[LoaderHeader.version]: summaryVersion,
-			},
-		);
+		return provider.loadTestContainer(testContainerConfig, {
+			[LoaderHeader.version]: summaryVersion,
+		});
 	}
 
 	const makeContainer = async () => {
@@ -177,7 +173,12 @@ describeNoCompat("GC data store sweep tests", (getTestObjectProvider) => {
 		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
 			"Send ops fails for swept datastores in summarizing container loaded before sweep timeout",
-			[{ eventName: "fluid:telemetry:FluidDataStoreContext:GC_Deleted_DataStore_Changed" }],
+			[
+				{
+					eventName: "fluid:telemetry:FluidDataStoreContext:GC_Deleted_DataStore_Changed",
+					clientType: "noninteractive/summarizer",
+				},
+			],
 			async () => {
 				const { summarizerDataObject, summarizer } =
 					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
@@ -201,7 +202,12 @@ describeNoCompat("GC data store sweep tests", (getTestObjectProvider) => {
 
 		itExpects(
 			"Send signals fails for swept datastores in summarizing container loaded before sweep timeout",
-			[{ eventName: "fluid:telemetry:FluidDataStoreContext:GC_Deleted_DataStore_Changed" }],
+			[
+				{
+					eventName: "fluid:telemetry:FluidDataStoreContext:GC_Deleted_DataStore_Changed",
+					clientType: "noninteractive/summarizer",
+				},
+			],
 			async () => {
 				const { summarizerDataObject, summarizer } =
 					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
@@ -243,6 +249,7 @@ describeNoCompat("GC data store sweep tests", (getTestObjectProvider) => {
 			[
 				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
+					clientType: "interactive",
 				},
 				// Summarizer client's request
 				{
@@ -306,20 +313,20 @@ describeNoCompat("GC data store sweep tests", (getTestObjectProvider) => {
 			"Receiving ops for swept datastores fails in client after sweep timeout and summarizing container",
 			[
 				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
+					clientType: "noninteractive/summarizer",
 				},
 				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
-				},
-				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
+					clientType: "interactive",
 				},
 				{
 					eventName: "fluid:telemetry:Container:ContainerClose",
+					clientType: "noninteractive/summarizer",
+				},
+				{
+					eventName: "fluid:telemetry:Container:ContainerClose",
+					clientType: "interactive",
 				},
 			],
 			async () => {
@@ -362,20 +369,20 @@ describeNoCompat("GC data store sweep tests", (getTestObjectProvider) => {
 			"Receiving signals for swept datastores fails in client after sweep timeout and summarizing container",
 			[
 				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
+					clientType: "noninteractive/summarizer",
 				},
 				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
-				},
-				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
+					clientType: "interactive",
 				},
 				{
 					eventName: "fluid:telemetry:Container:ContainerClose",
+					clientType: "noninteractive/summarizer",
+				},
+				{
+					eventName: "fluid:telemetry:Container:ContainerClose",
+					clientType: "interactive",
 				},
 			],
 			async () => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -858,7 +858,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 		);
 
 		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-		itExpects.only(
+		itExpects(
 			"Can un-tombstone datastores by storing a handle",
 			[
 				// When confirming it's tombstoned

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -858,7 +858,7 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 		);
 
 		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
-		itExpects(
+		itExpects.only(
 			"Can un-tombstone datastores by storing a handle",
 			[
 				// When confirming it's tombstoned
@@ -870,6 +870,13 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
 					category: "generic",
+					clientType: "interactive",
+				},
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived",
+					category: "generic",
+					clientType: "noninteractive/summarizer",
 				},
 				{
 					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived",

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -89,13 +89,9 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 		const config = disableTombstoneFailureViaOption
 			? testContainerConfigWithFutureMinGcOption
 			: testContainerConfig;
-		return provider.loadTestContainer(
-			// AB#3982 track work to removing this exception using simulateReadConnectionUsingDelay
-			{ simulateReadConnectionUsingDelay: false, ...config },
-			{
-				[LoaderHeader.version]: summaryVersion,
-			},
-		);
+		return provider.loadTestContainer(config, {
+			[LoaderHeader.version]: summaryVersion,
+		});
 	}
 
 	const makeContainer = async (config: ITestContainerConfig = testContainerConfig) => {
@@ -282,10 +278,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			[
 				{
 					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
-				},
-				{
-					eventName:
 						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
 					error: "Context is tombstoned! Call site [process]",
 				},
@@ -443,10 +435,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			[
 				{
 					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
-				},
-				{
-					eventName:
 						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
 					error: "Context is tombstoned! Call site [processSignal]",
 				},
@@ -543,10 +531,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 					category: "generic",
 					headers: expectedHeadersLogged.request_allowTombstone,
 				},
-				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
-				},
 				// Summarizer client's request
 				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
@@ -628,10 +612,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 					category: "generic",
 					gcTombstoneEnforcementAllowed: false,
 				},
-				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
-				},
 			],
 			async function () {
 				// Note: The Summarizers in this test don't use the "future" GC option - it only matters for the interactive client
@@ -672,10 +652,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
 					category: "generic",
 					gcTombstoneEnforcementAllowed: false,
-				},
-				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
 				},
 			],
 			async function () {
@@ -769,10 +745,6 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
 					category: "generic",
 					headers: expectedHeadersLogged.request_allowTombstone,
-				},
-				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
 				},
 			],
 			async () => {
@@ -890,22 +862,19 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 			"Can un-tombstone datastores by storing a handle",
 			[
 				// When confirming it's tombstoned
-				{ eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested" },
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+					clientType: "interactive",
+				},
 				// When reviving it
 				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
 					category: "generic",
 				},
 				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
+					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived",
+					clientType: "noninteractive/summarizer",
 				},
-				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Datastore_Revived",
-					category: "generic",
-				},
-				{ eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Revived" },
 			],
 			async () => {
 				const { unreferencedId, summarizingContainer, summarizer } =
@@ -985,14 +954,14 @@ describeNoCompat("GC data store tombstone tests", (getTestObjectProvider) => {
 	itExpects(
 		"Loading/Using tombstone allowed when configured",
 		[
-			{ eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested" },
 			{
-				eventName:
-					"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Loaded",
+				eventName: "fluid:telemetry:ContainerRuntime:GC_Tombstone_DataStore_Requested",
+				clientType: "interactive",
 			},
 			{
 				eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
 				callSite: "submitMessage",
+				clientType: "interactive",
 			},
 			{
 				eventName: "fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",


### PR DESCRIPTION
As part of [#3904](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3904), container is loaded in "read" mode be default. Some GC tests were failing with this change so a workaround was added to load the container in "write" mode for tests tests.

This PR removes that workaround and makes the tests work with "read" mode containers. There are 2 ways these tests are fixed:
1. The test in `gcInactiveNodes.spec.ts` requires the container to be in "write" mode so that the GC data in base snapshot is loaded and marks unreferenced nodes as inactive. So, updated the test to send an op and wait for "write" connection.
2. The other tests were not testing the inactive / sweep ready state but rather tombstone / deleted state. For these, the container does not need to load in "write" mode. So, for these tests removed the expected inactive / sweep ready errors since they won't happen in loaded containers anymore.

[AB#3982](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3982)