### PR TITLE
[v2int4.1 Port] Fix submit blobAttach ops (#15360)

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1212,15 +1212,9 @@ export class ContainerRuntime
 			() => this.storage,
 			(localId: string, blobId?: string) => {
 				if (!this.disposed) {
-					// eslint-disable-next-line @typescript-eslint/no-floating-promises
-					Promise.resolve().then(() => {
-						// Blob attaches need to be in their own batch (grouped batching would hide metadata)
-						this.flush();
-						this.submit(ContainerMessageType.BlobAttach, undefined, undefined, {
-							localId,
-							blobId,
-						});
-						this.flush();
+					this.submit(ContainerMessageType.BlobAttach, undefined, undefined, {
+						localId,
+						blobId,
 					});
 				}
 			},

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -5,7 +5,7 @@
 
 import { assert } from "@fluidframework/common-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { ContainerRuntimeMessage } from "..";
+import { ContainerMessageType, ContainerRuntimeMessage } from "..";
 import { IBatch } from "./definitions";
 
 interface IGroupedMessage {
@@ -25,6 +25,10 @@ export class OpGroupingManager {
 		}
 
 		for (const message of batch.content) {
+			// Blob attaches cannot be grouped (grouped batching would hide metadata)
+			if (message.deserializedContent.type === ContainerMessageType.BlobAttach) {
+				return batch;
+			}
 			if (message.metadata) {
 				const keys = Object.keys(message.metadata);
 				assert(keys.length < 2, 0x5dd /* cannot group ops with metadata */);


### PR DESCRIPTION
# [AB#4215](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4215)

Issue caused by https://github.com/microsoft/FluidFramework/pull/14512

"blobAttach" ops cannot be in their own batch as there may be some dependencies on proceeding ops submitted. They also cannot be grouped as it would hide metadata from service.
Thus, if a batch has any "blobAttach" ops, it cannot be grouped.

https://github.com/microsoft/FluidFramework/pull/14512#discussion_r1149271275