### PR TITLE
[GC stress] Add blob de-duping scenario

### DIFF
--- a/packages/test/test-service-load/README.md
+++ b/packages/test/test-service-load/README.md
@@ -15,7 +15,7 @@ The goal of these tests is to validate that garbage collection (GC) works correc
 
 ## Architecture
 
-The following picture shows how the clients / containers are set up. The dashed line indicate collaboration happening between data stores.
+The following picture shows how the clients / containers are set up. The dashed line indicate collaboration happening between clients.
 ![Architecture](./gcStressTestArchitecture.png)
 
 There are n clients that are running in parallel. Each client starts by loading a root data store and running it and it has the following objects:

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -109,7 +109,6 @@
 		"ps-node": "^0.1.6",
 		"start-server-and-test": "^1.11.7",
 		"tinylicious": "0.7.2",
-		"uuid": "^8.3.1",
 		"xml": "^1.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Description
Added blob de-duping scenario to the GC stress tests. Every time a client in a runner restarts, the blobs it will upload will have duplicate content from the previous run. This should get us coverage of blob de-duping scenarios and should not happen very frequently.

[AB#3341](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3341)

## Reviewer guidance
This is for an experimental stress test in test/gc-stress branch. This is not in the main FF branch and does not affect its stress test.