### PR TITLE
[GC stress] Don't fail run for non GC failures

### DIFF
--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -285,26 +285,30 @@ function writeTestResultXmlFile(results: RunnerResult[], durationSec: number) {
 			name: `Runner_${index}`,
 			time: durationMs / 1000,
 		};
+		if (returnCode === GcFailureExitCode) {
+			// Failure
+			return {
+				testcase: [
+					{ _attr },
+					{
+						failure: `GC failure - check pipeline logs to find the error.`,
+					},
+				],
+			};
+		}
 		if (returnCode === 0) {
 			// Success
 			return { testcase: [{ _attr }] };
 		}
-		const failureReason =
-			returnCode === GcFailureExitCode
-				? "GC failure - check pipeline logs to find the error."
-				: `Failure code ${returnCode}`;
 		return {
-			testcase: [
-				{ _attr },
-				// Failure
-				{ failure: `Test Runner failed! ${failureReason}` },
-			],
+			// Success but with non-zero exit code.
+			testcase: [{ _attr }, { exitCode: returnCode }],
 		};
 	});
 	const suiteAttributes = {
 		name: "GC Stress Test",
 		tests: results.length,
-		failures: 0,
+		failures: results.filter(({ returnCode }) => returnCode === GcFailureExitCode).length,
 		errors: results.filter(({ returnCode }) => returnCode !== 0).length,
 		time: durationSec,
 		// timestamp: e.g. Wed, 16 Nov 2022 18:15:06 GMT


### PR DESCRIPTION
## Description
Currently, the stress test runs report as failed for non-GC failures where the test exists due to uncaught exception.
This PR changes that so that the run will report failure only because of GC failures. Added an `exitCode` property to test results where a runner exits with non-zero exitCode so it can be debugged if needed.

## Reviewer guidance
This is for an experimental stress test in test/gc-stress branch. This is not in the main FF branch and does not affect its stress test.