### PR TITLE
Use JSON.stringify/parse to clone the client rather than lodash due to bundle size

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -748,7 +748,7 @@ export class Container
 
 		// Warning: this is only a shallow clone.  Mutation of any individual loader option will mutate it for
 		// all clients that were loaded from the same loader (including summarizer clients).
-		this.options = this.options = {
+		this.options = {
 			...this.loader.services.options,
 		};
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -5,8 +5,6 @@
 
 // eslint-disable-next-line import/no-internal-modules
 import merge from "lodash/merge";
-// eslint-disable-next-line import/no-internal-modules
-import cloneDeep from "lodash/cloneDeep";
 
 import { v4 as uuid } from "uuid";
 import {
@@ -748,7 +746,11 @@ export class Container
 		// Prefix all events in this file with container-loader
 		this.mc = loggerToMonitoringContext(ChildLogger.create(this.subLogger, "Container"));
 
-		this.options = cloneDeep(this.loader.services.options);
+		// Warning: this is only a shallow clone.  Mutation of any individual loader option will mutate it for
+		// all clients that were loaded from the same loader (including summarizer clients).
+		this.options = this.options = {
+			...this.loader.services.options,
+		};
 
 		this._deltaManager = this.createDeltaManager();
 
@@ -1777,7 +1779,10 @@ export class Container
 	private get client(): IClient {
 		const client: IClient =
 			this.options?.client !== undefined
-				? (this.options.client as IClient)
+				? // this.options.client is shared by ALL containers spawned by the same Loader (including the summarizer)
+				  // We're doing a cheap clone here to ensure it doesn't get tainted by the merge() that happens below, since
+				  // the override should only apply to the individual container it is given to.
+				  (JSON.parse(JSON.stringify(this.options.client)) as IClient)
 				: {
 						details: {
 							capabilities: { interactive: true },


### PR DESCRIPTION
Reverting the full clone of the options back to just a shallow clone as it was prior to #15124, and scoping the clone to just the `client` since that's where the bug was impacting.  Using JSON.stringify/parse trick to clone it without requiring the relatively large bundle size increase that comes with lodash/cloneDeep.