### PR TITLE
Avoid mutating options object in mixinAttributor

### DIFF
--- a/packages/framework/attributor/src/mixinAttributor.ts
+++ b/packages/framework/attributor/src/mixinAttributor.ts
@@ -137,12 +137,21 @@ export const mixinAttributor = (Base: typeof ContainerRuntime = ContainerRuntime
 			const mc = loggerToMonitoringContext(context.taggedLogger);
 
 			const shouldTrackAttribution = mc.config.getBoolean(enableOnNewFileKey) ?? false;
+			let options = context.options;
 			if (shouldTrackAttribution) {
-				(context.options.attribution ??= {}).track = true;
+				const attributionOptions = {
+					...(context.options.attribution ?? {}),
+					track: true,
+				};
+
+				options = {
+					...context.options,
+					attribution: attributionOptions,
+				};
 			}
 
 			const runtime = (await Base.load(
-				context,
+				shouldTrackAttribution ? { ...context, options } : context,
 				registryEntries,
 				requestHandler,
 				runtimeOptions,


### PR DESCRIPTION
## Description

This reduces potential for future bugs--no reason that the context options need to be mutated here.
