### PR TITLE
Removing the dependency of aqueduct on DependencyContainer

### DIFF
--- a/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
@@ -74,7 +74,7 @@ export class BaseContainerRuntimeFactory
 	): Promise<ContainerRuntime> {
 		const scope: Partial<IProvideFluidDependencySynthesizer> = context.scope;
 		if (this.dependencyContainer) {
-			const dc = new DependencyContainer<FluidObject<IContainerRuntime>>(
+			const dc = new DependencyContainer<FluidObject>(
 				this.dependencyContainer,
 				scope.IFluidDependencySynthesizer,
 			);

--- a/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
@@ -40,7 +40,7 @@ export class BaseContainerRuntimeFactory
 
 	/**
 	 * @param registryEntries - The data store registry for containers produced
-	 * @param dependencyContainer -
+	 * @param dependencyContainer - deprecated, will be removed in a future release
 	 * @param requestHandlers - Request handlers for containers produced
 	 * @param runtimeOptions - The runtime options passed to the ContainerRuntime when instantiating it
 	 * @param initializeEntryPoint - Function that will initialize the entryPoint of the ContainerRuntime instances
@@ -73,13 +73,14 @@ export class BaseContainerRuntimeFactory
 		existing: boolean,
 	): Promise<ContainerRuntime> {
 		const scope: Partial<IProvideFluidDependencySynthesizer> = context.scope;
-		const dc = new DependencyContainer<FluidObject<IContainerRuntime>>(
-			this.dependencyContainer,
-			scope.IFluidDependencySynthesizer,
-		);
-		scope.IFluidDependencySynthesizer = dc;
-
-		const runtime: ContainerRuntime = await ContainerRuntime.loadRuntime({
+		if (this.dependencyContainer) {
+			const dc = new DependencyContainer<FluidObject<IContainerRuntime>>(
+				this.dependencyContainer,
+				scope.IFluidDependencySynthesizer,
+			);
+			scope.IFluidDependencySynthesizer = dc;
+		}
+		return ContainerRuntime.loadRuntime({
 			context,
 			requestHandler: buildRuntimeRequestHandler(...this.requestHandlers),
 			existing,
@@ -88,11 +89,6 @@ export class BaseContainerRuntimeFactory
 			containerScope: scope,
 			initializeEntryPoint: this.initializeEntryPoint,
 		});
-
-		// we register the runtime so developers of providers can use it in the factory pattern.
-		dc.register(IContainerRuntime, runtime);
-
-		return runtime;
 	}
 
 	/**

--- a/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
@@ -26,6 +26,15 @@ const defaultDataStoreId = "default";
 export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRuntimeFactory {
 	public static readonly defaultDataStoreId = defaultDataStoreId;
 
+	/**
+	 * Constructor
+	 * @param defaultFactory -
+	 * @param registryEntries -
+	 * @param dependencyContainer - deprecated, will be removed in a future release
+	 * @param requestHandlers -
+	 * @param runtimeOptions -
+	 * @param initializeEntryPoint -
+	 */
 	constructor(
 		protected readonly defaultFactory: IFluidDataStoreFactory,
 		registryEntries: NamedFluidDataStoreRegistryEntries,

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -23,8 +23,8 @@ import {
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { IChannelFactory, IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import {
+	AsyncFluidObjectProvider,
 	FluidObjectSymbolProvider,
-	DependencyContainer,
 	IFluidDependencySynthesizer,
 } from "@fluidframework/synthesize";
 
@@ -96,8 +96,14 @@ async function createDataObject<
 	// access DDSes or other services of runtime as objects are not fully initialized.
 	// In order to use object, we need to go through full initialization by calling finishInitialization().
 	const scope: FluidObject<IFluidDependencySynthesizer> = context.scope;
-	const dependencyContainer = new DependencyContainer(scope.IFluidDependencySynthesizer);
-	const providers = dependencyContainer.synthesize<I["OptionalProviders"]>(optionalProviders, {});
+	const providers =
+		scope.IFluidDependencySynthesizer?.synthesize<I["OptionalProviders"]>(
+			optionalProviders,
+			{},
+		) ??
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+		({} as AsyncFluidObjectProvider<never>);
+
 	const instance = new ctor({ runtime, context, providers, initProps });
 
 	// if it's a newly created object, we need to wait for it to finish initialization


### PR DESCRIPTION
## Description
Removing the dependency of aqueduct on a particular DependencyContainer implementation. This allows flexibility for how to implement the IFluidDependencySynthesizer.

This PR doesn't quite remove all dependencies to avoid a breaking change. It does however remove the dependency of pureDataObjectFastory on DependencyContainer which is what matters the most.

## Breaking Changes
IContainerRuntime is no longer registered in DependencyContainer in BaseContainerRuntimeFactory. This is not an interface breaking change.

## Reviewer Guidance
- Any concerns here about backwards compatibility? IProvideContainerRuntime has been marked deprecated for 8 months.
- I am not sure why I can't assign {} to AsyncFluidObjectProvider<I["OptionalProviders"]> requiring a cast. Help required from someone more familiar with those types.