### PR TITLE
Remove bad void usage

### DIFF
--- a/packages/framework/attributor/src/mixinAttributor.ts
+++ b/packages/framework/attributor/src/mixinAttributor.ts
@@ -164,7 +164,7 @@ export const mixinAttributor = (Base: typeof ContainerRuntime = ContainerRuntime
 					eventName: "initialize",
 				},
 				async (event) => {
-					void runtime.runtimeAttributor?.initialize(
+					await runtime.runtimeAttributor?.initialize(
 						deltaManager,
 						audience,
 						baseSnapshot,


### PR DESCRIPTION
## Description

I missed this in review of #15033--the perf event (as well as container runtime construction) should be awaiting initialization of the attributor before returning.
