### PR TITLE
Increase Canary Stress Timeout to 4 hours

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -137,7 +137,7 @@ stages:
         testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
-        timeoutInMinutes: 120
+        timeoutInMinutes: 240
         testCommand: start:frs:canary
         env:
           fluid__test__driver__frsCanary: $(automation-fluid-driver-frs-canary-stress-test)


### PR DESCRIPTION
https://dev.azure.com/fluidframework/internal/_build/results?buildId=155905&view=logs&j=c7213352-638b-50b5-3c0e-1624a2e64f62&t=b07448fb-6653-5288-d115-8a4b2a0b6833&l=24 is timing out, seeing if thats the only issue