### PR TITLE
refactor(client-debugger): Update library to use global singleton for managing the root devtools object

### DIFF
--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -2,323 +2,428 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { TypedEventEmitter } from "@fluidframework/common-utils";
-import { IFluidLoadable } from "@fluidframework/core-interfaces";
-import { IEvent, IEventProvider } from "@fluidframework/common-definitions";
+
+import { UsageError } from "@fluidframework/container-utils";
+
+import { ContainerDevtoolsProps, ContainerDevtools } from "./ContainerDevtools";
+import { IContainerDevtools } from "./IContainerDevtools";
 import {
-	AttachState,
-	IContainer,
-	ICriticalContainerError,
-	ConnectionState,
-} from "@fluidframework/container-definitions";
-import type { IRootDataObject, LoadableObjectClass, LoadableObjectRecord } from "./types";
+	ContainerList,
+	DevtoolsFeatures,
+	GetContainerList,
+	GetDevtoolsFeatures,
+	handleIncomingWindowMessage,
+	InboundHandlers,
+	ISourcedDevtoolsMessage,
+	MessageLoggingOptions,
+	postMessagesToWindow,
+} from "./messaging";
+import { IFluidDevtools } from "./IFluidDevtools";
+import { ContainerMetadata } from "./ContainerMetadata";
+import { DevtoolsFeature, DevtoolsFeatureFlags } from "./Features";
+import { DevtoolsLogger } from "./DevtoolsLogger";
+import { VisualizeSharedObject } from "./data-visualization";
 
 /**
- * Events emitted from {@link IFluidContainer}.
+ * Message logging options used by the root devtools.
  */
-export interface IFluidContainerEvents extends IEvent {
-	/**
-	 * Emitted when the {@link IFluidContainer} completes connecting to the Fluid service.
-	 *
-	 * @remarks Reflects connection state changes against the (delta) service acknowledging ops/edits.
-	 *
-	 * @see
-	 *
-	 * - {@link IFluidContainer.connectionState}
-	 *
-	 * - {@link IFluidContainer.connect}
-	 */
-	(event: "connected", listener: () => void): void;
-
-	/**
-	 * Emitted when the {@link IFluidContainer} becomes disconnected from the Fluid service.
-	 *
-	 * @remarks Reflects connection state changes against the (delta) service acknowledging ops/edits.
-	 *
-	 * @see
-	 *
-	 * - {@link IFluidContainer.connectionState}
-	 *
-	 * - {@link IFluidContainer.disconnect}
-	 */
-	(event: "disconnected", listener: () => void): void;
-
-	/**
-	 * Emitted when all local changes/edits have been acknowledged by the service.
-	 *
-	 * @remarks "dirty" event will be emitted when the next local change has been made.
-	 *
-	 * @see {@link IFluidContainer.isDirty}
-	 */
-	(event: "saved", listener: () => void): void;
-
-	/**
-	 * Emitted when the first local change has been made, following a "saved" event.
-	 *
-	 * @remarks "saved" event will be emitted once all local changes have been acknowledged by the service.
-	 *
-	 * @see {@link IFluidContainer.isDirty}
-	 */
-	(event: "dirty", listener: () => void): void;
-
-	/**
-	 * Emitted when the {@link IFluidContainer} is closed, which permanently disables it.
-	 *
-	 * @remarks Listener parameters:
-	 *
-	 * - `error`: If the container was closed due to error (as opposed to an explicit call to
-	 * {@link IFluidContainer.dispose}), this will contain details about the error that caused it.
-	 */
-	(event: "disposed", listener: (error?: ICriticalContainerError) => void);
-}
+const devtoolsMessageLoggingOptions: MessageLoggingOptions = {
+	context: "Fluid Devtools",
+};
 
 /**
- * Provides an entrypoint into the client side of collaborative Fluid data.
- * Provides access to the data as well as status on the collaboration session.
+ * Error text thrown when {@link FluidDevtools} operations are used after it has been disposed.
  *
- * @remarks Note: external implementations of this interface are not supported.
+ * @privateRemarks Exported for test purposes only.
  */
-export interface IFluidContainer extends IEventProvider<IFluidContainerEvents> {
-	/**
-	 * Provides the current connected state of the container
-	 */
-	readonly connectionState: ConnectionState;
+export const useAfterDisposeErrorText =
+	"The devtools instance has been disposed. Further operations are invalid.";
 
-	/**
-	 * A container is considered **dirty** if it has local changes that have not yet been acknowledged by the service.
-	 *
-	 * @remarks
-	 *
-	 * You should always check the `isDirty` flag before closing the container or navigating away from the page.
-	 * Closing the container while `isDirty === true` may result in the loss of operations that have not yet been
-	 * acknowledged by the service.
-	 *
-	 * A container is considered dirty in the following cases:
-	 *
-	 * 1. The container has been created in the detached state, and either it has not been attached yet or it is
-	 * in the process of being attached (container is in `attaching` state). If container is closed prior to being
-	 * attached, host may never know if the file was created or not.
-	 *
-	 * 2. The container was attached, but it has local changes that have not yet been saved to service endpoint.
-	 * This occurs as part of normal op flow where pending operation (changes) are awaiting acknowledgement from the
-	 * service. In some cases this can be due to lack of network connection. If the network connection is down,
-	 * it needs to be restored for the pending changes to be acknowledged.
-	 */
-	readonly isDirty: boolean;
-
-	/**
-	 * Whether or not the container is disposed, which permanently disables it.
-	 */
-	readonly disposed: boolean;
-
-	/**
-	 * The collection of data objects and Distributed Data Stores (DDSes) that were specified by the schema.
-	 *
-	 * @remarks These data objects and DDSes exist for the lifetime of the container.
-	 */
-	readonly initialObjects: LoadableObjectRecord;
-
-	/**
-	 * The current attachment state of the container.
-	 *
-	 * @remarks
-	 *
-	 * Once a container has been attached, it remains attached.
-	 * When loading an existing container, it will already be attached.
-	 */
-	readonly attachState: AttachState;
-
-	/**
-	 * A newly created container starts detached from the collaborative service.
-	 * Calling `attach()` uploads the new container to the service and connects to the collaborative service.
-	 *
-	 * @remarks
-	 *
-	 * This should only be called when the container is in the
-	 * {@link @fluidframework/container-definitions#AttachState.Detatched} state.
-	 *
-	 * This can be determined by observing {@link IFluidContainer.attachState}.
-	 *
-	 * @returns A promise which resolves when the attach is complete, with the string identifier of the container.
-	 */
-	attach(): Promise<string>;
-
-	/**
-	 * Attempts to connect the container to the delta stream and process operations.
-	 *
-	 * @throws Will throw an error if connection is unsuccessful.
-	 *
-	 * @remarks
-	 *
-	 * This should only be called when the container is in the
-	 * {@link @fluidframework/container-definitions#ConnectionState.Disconnected} state.
-	 *
-	 * This can be determined by observing {@link IFluidContainer.connectionState}.
-	 */
-	connect(): void;
-
-	/**
-	 * Disconnects the container from the delta stream and stops processing operations.
-	 *
-	 * @remarks
-	 *
-	 * This should only be called when the container is in the
-	 * {@link @fluidframework/container-definitions#ConnectionState.Connected} state.
-	 *
-	 * This can be determined by observing {@link IFluidContainer.connectionState}.
-	 */
-	disconnect(): void;
-
-	/**
-	 * Create a new data object or Distributed Data Store (DDS) of the specified type.
-	 *
-	 * @remarks
-	 *
-	 * In order to share the data object or DDS with other
-	 * collaborators and retrieve it later, store its handle in a collection like a SharedDirectory from your
-	 * initialObjects.
-	 *
-	 * @param objectClass - The class of the `DataObject` or `SharedObject` to create.
-	 *
-	 * @typeParam T - The class of the `DataObject` or `SharedObject`.
-	 */
-	create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T>;
-
-	/**
-	 * Dispose of the container instance, permanently disabling it.
-	 */
-	dispose(): void;
+/**
+ * Error text thrown when a user attempts to register a {@link IContainerDevtools} instance for an ID that is already
+ * registered with the {@link IFluidDevtools}.
+ *
+ * @privateRemarks Exported for test purposes only.
+ */
+export function getContainerAlreadyRegisteredErrorText(containerId: string): string {
+	return (
+		`A ContainerDevtools instance has already been registered for container ID "${containerId}".` +
+		"Existing instance must be closed before a replacement may be registered."
+	);
 }
 
 /**
- * Base {@link IFluidContainer} implementation.
+ * Properties for configuring the Devtools.
+ *
+ * @public
+ */
+export interface FluidDevtoolsProps {
+	/**
+	 * (optional) telemetry logger associated with the Fluid runtime.
+	 *
+	 * @remarks
+	 *
+	 * Note: {@link IFluidDevtools} does not register this logger with the Fluid runtime; that must be done separately.
+	 *
+	 * This is provided to the Devtools instance strictly to enable communicating supported / desired functionality with
+	 * external listeners.
+	 */
+	logger?: DevtoolsLogger;
+
+	/**
+	 * (optional) List of Containers to initialize the devtools with.
+	 *
+	 * @remarks Additional Containers can be registered with the Devtools via {@link IFluidDevtools.registerContainerDevtools}.
+	 */
+	initialContainers?: ContainerDevtoolsProps[];
+
+	/**
+	 * (optional) Configurations for generating visual representations of
+	 * {@link @fluidframework/shared-object-base#ISharedObject}s associated with individual Containers.
+	 *
+	 * @remarks
+	 *
+	 * If not specified, then only `SharedObject` types natively known by the system will be visualized, and using
+	 * default visualization implementations.
+	 *
+	 * If a visualizer configuration is specified for a shared object type that has a default visualizer, the custom one will be used.
+	 */
+	dataVisualizers?: Record<string, VisualizeSharedObject>;
+}
+
+/**
+ * {@link IFluidDevtools} implementation.
  *
  * @remarks
  *
- * Note: this implementation is not complete. Consumers who rely on {@link IFluidContainer.attach}
- * will need to utilize or provide a service-specific implementation of this type that implements that method.
+ * This class listens for incoming messages from the window (globalThis), and posts messages to it upon relevant
+ * state changes and when requested.
+ *
+ * **Messages it listens for:**
+ *
+ * - {@link GetDevtoolsFeatures.Message}: When received, {@link DevtoolsFeatures.Message} will be posted in response.
+ *
+ * - {@link GetContainerList.Message}: When received, {@link ContainerList.Message} will be posted in response.
+ *
+ * TODO: Document others as they are added.
+ *
+ * **Messages it posts:**
+ *
+ * - {@link DevtoolsFeatures.Message}: Posted only when requested via {@link GetDevtoolsFeatures.Message}.
+ *
+ * - {@link ContainerList.Message}: Posted whenever the list of registered Containers changes, or when requested
+ * (via {@link GetContainerList.Message}).
+ *
+ * TODO: Document others as they are added.
+ *
+ * @sealed
  */
-export class FluidContainer
-	extends TypedEventEmitter<IFluidContainerEvents>
-	implements IFluidContainer
-{
-	private readonly connectedHandler = () => this.emit("connected");
-	private readonly disconnectedHandler = () => this.emit("disconnected");
-	private readonly disposedHandler = (error?: ICriticalContainerError) =>
-		this.emit("disposed", error);
-	private readonly savedHandler = () => this.emit("saved");
-	private readonly dirtyHandler = () => this.emit("dirty");
-
-	public constructor(
-		private readonly container: IContainer,
-		private readonly rootDataObject: IRootDataObject,
-	) {
-		super();
-		container.on("connected", this.connectedHandler);
-		container.on("closed", this.disposedHandler);
-		container.on("disconnected", this.disconnectedHandler);
-		container.on("saved", this.savedHandler);
-		container.on("dirty", this.dirtyHandler);
-	}
-
+export class FluidDevtools implements IFluidDevtools {
 	/**
-	 * {@inheritDoc IFluidContainer.isDirty}
+	 * (optional) Telemetry logger associated with the Fluid runtime.
 	 */
-	public get isDirty(): boolean {
-		return this.container.isDirty;
-	}
+	public readonly logger: DevtoolsLogger | undefined;
 
 	/**
-	 * {@inheritDoc IFluidContainer.attachState}
+	 * Stores Container-level devtools instances registered with this object.
+	 * Maps from Container IDs to the corresponding devtools instance.
 	 */
-	public get attachState(): AttachState {
-		return this.container.attachState;
-	}
+	private readonly containers: Map<string, ContainerDevtools>;
 
 	/**
-	 * {@inheritDoc IFluidContainer.disposed}
-	 */
-	public get disposed() {
-		return this.container.closed;
-	}
-
-	/**
-	 * {@inheritDoc IFluidContainer.connectionState}
-	 */
-	public get connectionState(): ConnectionState {
-		return this.container.connectionState;
-	}
-
-	/**
-	 * {@inheritDoc IFluidContainer.initialObjects}
-	 */
-	public get initialObjects() {
-		return this.rootDataObject.initialObjects;
-	}
-
-	/**
-	 * Incomplete base implementation of {@link IFluidContainer.attach}.
+	 * Global data visualizers to apply to all {@link IContainerDevtools} instances registered with this object.
 	 *
-	 * @remarks
-	 *
-	 * Note: this implementation will unconditionally throw.
-	 * Consumers who rely on this will need to utilize or provide a service specific implementation of this base type
-	 * that provides an implementation of this method.
-	 *
-	 * The reason is because externally we are presenting a separation between the service and the `FluidContainer`,
-	 * but internally this separation is not there.
+	 * @remarks If the user specifies data visualizers alongside a specific Container, those will take precedence over these.
 	 */
-	public async attach(): Promise<string> {
-		if (this.container.attachState !== AttachState.Detached) {
-			throw new Error("Cannot attach container. Container is not in detached state.");
-		}
-		throw new Error("Cannot attach container. Attach method not provided.");
-	}
+	private readonly dataVisualizers?: Record<string, VisualizeSharedObject>;
 
 	/**
-	 * {@inheritDoc IFluidContainer.connect}
+	 * Private {@link FluidDevtools.disposed} tracking.
 	 */
-	public async connect(): Promise<void> {
-		this.container.connect?.();
-	}
+	private _disposed: boolean;
+
+	// #region Event handlers
 
 	/**
-	 * {@inheritDoc IFluidContainer.connect}
+	 * Handlers for inbound messages specific to FluidDevTools.
 	 */
-	public async disconnect(): Promise<void> {
-		this.container.disconnect?.();
-	}
-
-	/**
-	 * {@inheritDoc IFluidContainer.create}
-	 */
-	public async create<T extends IFluidLoadable>(objectClass: LoadableObjectClass<T>): Promise<T> {
-		return this.rootDataObject.create(objectClass);
-	}
-
-	/**
-	 * {@inheritDoc IFluidContainer.dispose}
-	 */
-	public dispose() {
-		this.container.close();
-		this.container.off("connected", this.connectedHandler);
-		this.container.off("closed", this.disposedHandler);
-		this.container.off("disconnected", this.disconnectedHandler);
-		this.container.off("saved", this.savedHandler);
-		this.container.off("dirty", this.dirtyHandler);
-	}
-
-	/**
-	 * FOR INTERNAL USE ONLY. NOT FOR EXTERNAL USE.
-	 * We make no stability guarantees here whatsoever.
-	 *
-	 * Gets the underlying {@link @fluidframework/container-definitions#IContainer}.
-	 *
-	 * @remarks Used to power debug tooling.
-	 *
-	 * @internal
-	 */
-	public readonly INTERNAL_CONTAINER_DO_NOT_USE?: () => IContainer = () => {
-		return this.container;
+	private readonly inboundMessageHandlers: InboundHandlers = {
+		[GetDevtoolsFeatures.MessageType]: () => {
+			this.postSupportedFeatures();
+			return true;
+		},
+		[GetContainerList.MessageType]: () => {
+			this.postContainerList();
+			return true;
+		},
 	};
+
+	/**
+	 * Event handler for messages coming from the window (globalThis).
+	 */
+	private readonly windowMessageHandler = (
+		event: MessageEvent<Partial<ISourcedDevtoolsMessage>>,
+	): void => {
+		handleIncomingWindowMessage(
+			event,
+			this.inboundMessageHandlers,
+			devtoolsMessageLoggingOptions,
+		);
+	};
+
+	/**
+	 * Event handler for the window (globalThis) `beforeUnload` event.
+	 * Disposes of the Devtools instance (which also clears the global singleton).
+	 */
+	private readonly windowBeforeUnloadHandler = (): void => {
+		this.dispose();
+	};
+
+	/**
+	 * Posts {@link DevtoolsFeatures.Message} to the window (globalThis) with the set of features supported by
+	 * this instance.
+	 */
+	private readonly postSupportedFeatures = (): void => {
+		const supportedFeatures = this.getSupportedFeatures();
+		postMessagesToWindow(
+			devtoolsMessageLoggingOptions,
+			DevtoolsFeatures.createMessage({
+				features: supportedFeatures,
+			}),
+		);
+	};
+
+	/**
+	 * Posts a {@link ContainerList.Message} to the window (globalThis).
+	 */
+	private readonly postContainerList = (): void => {
+		const containers: ContainerMetadata[] = this.getAllContainerDevtools().map(
+			(containerDevtools) => ({
+				id: containerDevtools.containerId,
+				nickname: containerDevtools.containerNickname,
+			}),
+		);
+
+		postMessagesToWindow(
+			devtoolsMessageLoggingOptions,
+			ContainerList.createMessage({
+				containers,
+			}),
+		);
+	};
+
+	// #endregion
+
+	/**
+	 * Singleton instance.
+	 */
+	private static I: FluidDevtools | undefined;
+
+	private constructor(props?: FluidDevtoolsProps) {
+		// Populate initial Container-level devtools
+		this.containers = new Map<string, ContainerDevtools>();
+		if (props?.initialContainers !== undefined) {
+			for (const containerConfig of props.initialContainers) {
+				this.containers.set(
+					containerConfig.containerId,
+					new ContainerDevtools(containerConfig),
+				);
+			}
+		}
+
+		this.logger = props?.logger;
+		this.dataVisualizers = props?.dataVisualizers;
+
+		// Register listener for inbound messages from the Window (globalThis)
+		globalThis.addEventListener?.("message", this.windowMessageHandler);
+
+		// Register the devtools instance to be disposed on Window unload
+		globalThis.addEventListener?.("beforeunload", this.windowBeforeUnloadHandler);
+
+		this._disposed = false;
+	}
+
+	/**
+	 * Creates and returns the FluidDevtools singleton.
+	 */
+	public static initialize(props?: FluidDevtoolsProps): FluidDevtools {
+		if (FluidDevtools.I !== undefined) {
+			console.warn(
+				"Devtools have already been initialized. " +
+					"Existing Devtools must be closed (see closeDevtools) before new ones may be initialized. " +
+					"Returning existing Devtools instance.",
+			);
+		} else {
+			FluidDevtools.I = new FluidDevtools(props);
+		}
+
+		return FluidDevtools.I;
+	}
+
+	/**
+	 * Gets the Devtools singleton if it has been initialized, otherwise throws.
+	 */
+	public static getOrThrow(): FluidDevtools {
+		if (FluidDevtools.I === undefined) {
+			throw new UsageError("Devtools have not yet been initialized.");
+		}
+		return FluidDevtools.I;
+	}
+
+	/**
+	 * Gets the Devtools singleton if it has been initialized, otherwise returns `undefined`.
+	 */
+	public static tryGet(): FluidDevtools | undefined {
+		return FluidDevtools.I;
+	}
+
+	/**
+	 * {@inheritDoc IFluidDevtools.registerContainerDevtools}
+	 */
+	public registerContainerDevtools(props: ContainerDevtoolsProps): void {
+		if (this.disposed) {
+			throw new UsageError(useAfterDisposeErrorText);
+		}
+
+		const { containerId, dataVisualizers: containerVisualizers } = props;
+
+		if (this.containers.has(containerId)) {
+			throw new UsageError(getContainerAlreadyRegisteredErrorText(containerId));
+		}
+
+		const dataVisualizers = mergeDataVisualizers(this.dataVisualizers, containerVisualizers);
+
+		const containerDevtools = new ContainerDevtools({
+			...props,
+			dataVisualizers,
+		});
+		this.containers.set(containerId, containerDevtools);
+
+		// Post message for container list change
+		this.postContainerList();
+	}
+
+	/**
+	 * {@inheritDoc IFluidDevtools.closeContainerDevtools}
+	 */
+	public closeContainerDevtools(containerId: string): void {
+		if (this.disposed) {
+			throw new UsageError(useAfterDisposeErrorText);
+		}
+
+		const containerDevtools = this.containers.get(containerId);
+		if (containerDevtools === undefined) {
+			console.warn(
+				`No ContainerDevtools associated with container ID "${containerId}" was found.`,
+			);
+		} else {
+			containerDevtools.dispose();
+			this.containers.delete(containerId);
+
+			// Post message for container list change
+			this.postContainerList();
+		}
+	}
+
+	/**
+	 * Gets the registered Container Devtools associated with the provided Container ID, if one exists.
+	 * Otherwise returns `undefined`.
+	 */
+	public getContainerDevtools(containerId: string): IContainerDevtools | undefined {
+		if (this.disposed) {
+			throw new UsageError(useAfterDisposeErrorText);
+		}
+
+		return this.containers.get(containerId);
+	}
+
+	/**
+	 * Gets all Container-level devtools instances.
+	 */
+	public getAllContainerDevtools(): readonly IContainerDevtools[] {
+		if (this.disposed) {
+			throw new UsageError(useAfterDisposeErrorText);
+		}
+
+		return [...this.containers.values()];
+	}
+
+	/**
+	 * {@inheritDoc @fluidframework/common-definitions#IDisposable.disposed}
+	 */
+	public get disposed(): boolean {
+		return this._disposed;
+	}
+
+	/**
+	 * {@inheritDoc @fluidframework/common-definitions#IDisposable.dispose}
+	 */
+	public dispose(): void {
+		if (this.disposed) {
+			throw new UsageError(useAfterDisposeErrorText);
+		}
+
+		// Dispose of container-level devtools
+		for (const [, containerDevtools] of this.containers) {
+			containerDevtools.dispose();
+		}
+		this.containers.clear();
+
+		// Notify listeners that the list of Containers changed.
+		this.postContainerList();
+
+		// Clear the singleton so a new one may be initialized.
+		FluidDevtools.I = undefined;
+
+		// Clean up event listeners
+		globalThis.removeEventListener?.("message", this.windowMessageHandler);
+		globalThis.removeEventListener?.("beforeunload", this.windowBeforeUnloadHandler);
+
+		this._disposed = true;
+	}
+
+	/**
+	 * Gets the set of features supported by this instance.
+	 */
+	private getSupportedFeatures(): DevtoolsFeatureFlags {
+		return {
+			[DevtoolsFeature.Telemetry]: this.logger !== undefined,
+		};
+	}
+}
+
+/**
+ * Merges an optional set of global visualizers with an optional set of Container-local visualizers, such that
+ * Container-level visualizers take precedence when present.
+ */
+function mergeDataVisualizers(
+	globalVisualizers?: Record<string, VisualizeSharedObject>,
+	containerVisualizers?: Record<string, VisualizeSharedObject>,
+): Record<string, VisualizeSharedObject> | undefined {
+	if (globalVisualizers === undefined) {
+		return containerVisualizers;
+	}
+	if (containerVisualizers === undefined) {
+		return globalVisualizers;
+	}
+	return {
+		...globalVisualizers,
+		...containerVisualizers,
+	};
+}
+
+/**
+ * Initializes the Devtools singleton and returns a handle to it.
+ *
+ * @remarks
+ *
+ * The instance is tracked as a static singleton.
+ *
+ * It is automatically disposed on webpage unload, but it can be closed earlier by calling `dispose`
+ * on the returned handle.
+ *
+ * @public
+ */
+export function initializeDevtools(props?: FluidDevtoolsProps): IFluidDevtools {
+	return FluidDevtools.initialize(props);
 }

--- a/packages/tools/client-debugger/client-debugger-view/src/test/app/App.tsx
+++ b/packages/tools/client-debugger/client-debugger-view/src/test/app/App.tsx
@@ -20,11 +20,7 @@ import { SharedMap } from "@fluidframework/map";
 import { SharedString } from "@fluidframework/sequence";
 
 import { CollaborativeTextArea, SharedStringHelper } from "@fluid-experimental/react-inputs";
-import {
-	DevtoolsLogger,
-	IFluidDevtools,
-	initializeFluidDevtools,
-} from "@fluid-tools/client-debugger";
+import { DevtoolsLogger, IFluidDevtools, initializeDevtools } from "@fluid-tools/client-debugger";
 
 import {
 	ContainerInfo,
@@ -239,7 +235,7 @@ export function App(): React.ReactElement {
 	const logger = React.useMemo(() => DevtoolsLogger.create(), []);
 
 	// Initialize devtools
-	const devtools = React.useMemo(() => initializeFluidDevtools({ logger }), [logger]);
+	const devtools = React.useMemo(() => initializeDevtools({ logger }), [logger]);
 
 	React.useEffect(() => {
 		// Dispose of devtools resources on teardown to ensure message listeners are notified.

--- a/packages/tools/client-debugger/client-debugger/.eslintrc.js
+++ b/packages/tools/client-debugger/client-debugger/.eslintrc.js
@@ -18,12 +18,15 @@ module.exports = {
 	overrides: [
 		{
 			// Overrides for test files
-			files: ["*.spec.ts", "*.test.ts", "src/test/**"],
+			files: ["*.test.ts", "src/test/**"],
 			plugins: ["chai-expect"],
 			extends: ["plugin:chai-expect/recommended"],
 			rules: {
 				"import/no-nodejs-modules": "off",
 				"unicorn/prefer-module": "off",
+
+				// Superceded by chai-expect rule
+				"@typescript-eslint/no-unused-expressions": "off",
 			},
 		},
 	],

--- a/packages/tools/client-debugger/client-debugger/.eslintrc.js
+++ b/packages/tools/client-debugger/client-debugger/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
 	overrides: [
 		{
 			// Overrides for test files
-			files: ["*.test.ts", "src/test/**"],
+			files: ["*.spec.ts", "*.test.ts", "src/test/**"],
 			plugins: ["chai-expect"],
 			extends: ["plugin:chai-expect/recommended"],
 			rules: {

--- a/packages/tools/client-debugger/client-debugger/README.md
+++ b/packages/tools/client-debugger/client-debugger/README.md
@@ -1,6 +1,6 @@
 # @fluid-tools/client-debugger
 
-This library contains a library of developer tools for use alongside the Fluid Framework.
+This library contains developer tools for use alongside the Fluid Framework.
 It is used to power our associated browser extensions.
 
 TODO: link to extensions once they are published.

--- a/packages/tools/client-debugger/client-debugger/README.md
+++ b/packages/tools/client-debugger/client-debugger/README.md
@@ -1,6 +1,9 @@
 # @fluid-tools/client-debugger
 
-The Fluid Client Debugger library contains a simple API for initializing debug sessions for recording and propogating information about a given Fluid [Container][] and its [Audience][].
+This library contains a library of developer tools for use alongside the Fluid Framework.
+It is used to power our associated browser extensions.
+
+TODO: link to extensions once they are published.
 
 <!-- AUTO-GENERATED-CONTENT:START (README_INSTALLATION_SECTION:includeHeading=TRUE&devDependency=TRUE) -->
 
@@ -21,21 +24,28 @@ npm i @fluid-tools/client-debugger -D
 
 ## Usage
 
-Initialization and cleanup of debugger sessions can fit cleanly into your application's Fluid setup and teardown process easily.
+The Devtools' API surface is designed to fit nicely into most application flows.
 
 ### Initialization
 
-To initialize a debugger session for your container, see [initializeFluidClientDebugger](https://fluidframework.com/docs/apis/client-debugger#initializefluidclientdebugger-function).
+To initialize a debugger session for your container, call `initializeDevtools`.
+This function accepts a `DevtoolsLogger` for recording and communicating telemetry data, a list of initial Fluid `Containers` to associate with the session, and (optionally) customized data visualization configurations for visualizing `Container` data.
+
+TODO: link to API docs once API shape has settled.
 
 ### Clean-up
 
-To clean up a debugger session during your application's tear-down, or when closing an individual [Container][], see [closeFluidClientDebugger](https://fluidframework.com/docs/apis/client-debugger#closefluidclientdebugger-function)
+The Devtools object is managed as a global singleton.
+That singleton is automatically cleaned up prior to the Window's "unload" event.
+So typical application flows likely won't need to worry about cleanup.
+That said, if you wish to have tighter control over when the Devtools are torn down, you can simply call the `dispose` method on the handle returned by [initialization](#initialization).
 
 ## Related Tooling
 
-For a visualizer library that takes advantage of this library, see [@fluid-tools/client-debugger-view][].
+This library is designed to work alongside our Chromium browser extension.
 
--   Additionally, see the Chromium browser extension library built upon the visualizer: [@fluid-tools/client-debugger-chrome-extension][].
+TODO: link to code on github once package names have been finalized.
+TODO: link to the various browsers' webstore pages for our extension once it has been publiched.
 
 ## Working in the package
 
@@ -51,18 +61,6 @@ Next, to build the code, run `npm run build` from the root of the mono-repo, or 
 
 To run the tests, first ensure you have followed the [build](#build) steps above.
 Next, run `npm run test` from a terminal within this directory.
-
-## Library TODOs
-
-The following are TODO items to enhance the functionality of this library.
-
--   Accept a "nickname" for the container when registering.
-    -   This will allow consumers to differentiate their debugger / container instances in a meaningful way, such that finding them is easier in visual tooling, etc.
-
-### Ideas
-
--   Accept renderer hook options?
-    -   This seems like a violation of
 
 <!-- AUTO-GENERATED-CONTENT:START (README_API_DOCS_SECTION:includeHeading=TRUE) -->
 
@@ -95,10 +93,3 @@ Use of Microsoft trademarks or logos in modified versions of this project must n
 <!-- prettier-ignore-end -->
 
 <!-- AUTO-GENERATED-CONTENT:END -->
-
-<!-- Links -->
-
-[@fluid-tools/client-debugger-chrome-extension]: https://github.com/microsoft/FluidFramework/tree/main/packages/tools/client-debugger/client-debugger-chrome-extension
-[@fluid-tools/client-debugger-view]: https://github.com/microsoft/FluidFramework/tree/main/packages/tools/client-debugger/client-debugger-view
-[audience]: https://fluidframework.com/docs/build/audience
-[container]: https://fluidframework.com/docs/build/containers

--- a/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
+++ b/packages/tools/client-debugger/client-debugger/api-report/client-debugger.api.md
@@ -378,7 +378,7 @@ export interface InboundHandlers {
 }
 
 // @public
-export function initializeFluidDevtools(props?: FluidDevtoolsProps): IFluidDevtools;
+export function initializeDevtools(props?: FluidDevtoolsProps): IFluidDevtools;
 
 // @internal
 export function isDevtoolsMessage(value: Partial<ISourcedDevtoolsMessage>): value is ISourcedDevtoolsMessage;

--- a/packages/tools/client-debugger/client-debugger/src/FluidDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidDevtools.ts
@@ -40,6 +40,13 @@ export const useAfterDisposeErrorText =
 	"The devtools instance has been disposed. Further operations are invalid.";
 
 /**
+ * Error text thrown when {@link FluidDevtools.getOrThrow} is called before the Devtools have been initialized.
+ *
+ * @privateRemarks Exported for test purposes only.
+ */
+export const accessBeforeInitializeErrorText = "Devtools have not yet been initialized.";
+
+/**
  * Error text thrown when a user attempts to register a {@link IContainerDevtools} instance for an ID that is already
  * registered with the {@link IFluidDevtools}.
  *
@@ -270,7 +277,7 @@ export class FluidDevtools implements IFluidDevtools {
 	 */
 	public static getOrThrow(): FluidDevtools {
 		if (FluidDevtools.I === undefined) {
-			throw new UsageError("Devtools have not yet been initialized.");
+			throw new UsageError(accessBeforeInitializeErrorText);
 		}
 		return FluidDevtools.I;
 	}

--- a/packages/tools/client-debugger/client-debugger/src/FluidDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidDevtools.ts
@@ -245,6 +245,11 @@ export class FluidDevtools implements IFluidDevtools {
 
 	/**
 	 * Creates and returns the FluidDevtools singleton.
+	 *
+	 * @remarks
+	 *
+	 * If the singleton has already been initialized, a warning will be logged and the existing instance will
+	 * be returned.
 	 */
 	public static initialize(props?: FluidDevtoolsProps): FluidDevtools {
 		if (FluidDevtools.I !== undefined) {

--- a/packages/tools/client-debugger/client-debugger/src/FluidDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/FluidDevtools.ts
@@ -24,10 +24,6 @@ import { DevtoolsFeature, DevtoolsFeatureFlags } from "./Features";
 import { DevtoolsLogger } from "./DevtoolsLogger";
 import { VisualizeSharedObject } from "./data-visualization";
 
-// TODOs:
-// - Devtools disposal
-// - Clear devtools on `window.beforeunload`, to ensure we do not hold onto stale resources.
-
 /**
  * Message logging options used by the root devtools.
  */
@@ -57,7 +53,7 @@ export function getContainerAlreadyRegisteredErrorText(containerId: string): str
 }
 
 /**
- * Properties for configuring a {@link IFluidDevtools}.
+ * Properties for configuring the Devtools.
  *
  * @public
  */
@@ -119,10 +115,12 @@ export interface FluidDevtoolsProps {
  * (via {@link GetContainerList.Message}).
  *
  * TODO: Document others as they are added.
+ *
+ * @sealed
  */
 export class FluidDevtools implements IFluidDevtools {
 	/**
-	 * (optional) telemetry logger associated with the Fluid runtime.
+	 * (optional) Telemetry logger associated with the Fluid runtime.
 	 */
 	public readonly logger: DevtoolsLogger | undefined;
 
@@ -174,6 +172,14 @@ export class FluidDevtools implements IFluidDevtools {
 	};
 
 	/**
+	 * Event handler for the window (globalThis) `beforeUnload` event.
+	 * Disposes of the Devtools instance (which also clears the global singleton).
+	 */
+	private readonly windowBeforeUnloadHandler = (): void => {
+		this.dispose();
+	};
+
+	/**
 	 * Posts {@link DevtoolsFeatures.Message} to the window (globalThis) with the set of features supported by
 	 * this instance.
 	 */
@@ -208,7 +214,12 @@ export class FluidDevtools implements IFluidDevtools {
 
 	// #endregion
 
-	public constructor(props?: FluidDevtoolsProps) {
+	/**
+	 * Singleton instance.
+	 */
+	private static I: FluidDevtools | undefined;
+
+	private constructor(props?: FluidDevtoolsProps) {
 		// Populate initial Container-level devtools
 		this.containers = new Map<string, ContainerDevtools>();
 		if (props?.initialContainers !== undefined) {
@@ -223,10 +234,47 @@ export class FluidDevtools implements IFluidDevtools {
 		this.logger = props?.logger;
 		this.dataVisualizers = props?.dataVisualizers;
 
-		// Register listener for inbound messages from the window (globalThis)
+		// Register listener for inbound messages from the Window (globalThis)
 		globalThis.addEventListener?.("message", this.windowMessageHandler);
 
+		// Register the devtools instance to be disposed on Window unload
+		globalThis.addEventListener?.("beforeunload", this.windowBeforeUnloadHandler);
+
 		this._disposed = false;
+	}
+
+	/**
+	 * Creates and returns the FluidDevtools singleton.
+	 */
+	public static initialize(props?: FluidDevtoolsProps): FluidDevtools {
+		if (FluidDevtools.I !== undefined) {
+			console.warn(
+				"Devtools have already been initialized. " +
+					"Existing Devtools must be closed (see closeDevtools) before new ones may be initialized. " +
+					"Returning existing Devtools instance.",
+			);
+		} else {
+			FluidDevtools.I = new FluidDevtools(props);
+		}
+
+		return FluidDevtools.I;
+	}
+
+	/**
+	 * Gets the Devtools singleton if it has been initialized, otherwise throws.
+	 */
+	public static getOrThrow(): FluidDevtools {
+		if (FluidDevtools.I === undefined) {
+			throw new UsageError("Devtools have not yet been initialized.");
+		}
+		return FluidDevtools.I;
+	}
+
+	/**
+	 * Gets the Devtools singleton if it has been initialized, otherwise returns `undefined`.
+	 */
+	public static tryGet(): FluidDevtools | undefined {
+		return FluidDevtools.I;
 	}
 
 	/**
@@ -278,7 +326,7 @@ export class FluidDevtools implements IFluidDevtools {
 	}
 
 	/**
-	 * Gets the registed Container Devtools associated with the provided Container ID, if one exists.
+	 * Gets the registered Container Devtools associated with the provided Container ID, if one exists.
 	 * Otherwise returns `undefined`.
 	 */
 	public getContainerDevtools(containerId: string): IContainerDevtools | undefined {
@@ -324,6 +372,13 @@ export class FluidDevtools implements IFluidDevtools {
 		// Notify listeners that the list of Containers changed.
 		this.postContainerList();
 
+		// Clear the singleton so a new one may be initialized.
+		FluidDevtools.I = undefined;
+
+		// Clean up event listeners
+		globalThis.removeEventListener?.("message", this.windowMessageHandler);
+		globalThis.removeEventListener?.("beforeunload", this.windowBeforeUnloadHandler);
+
 		this._disposed = true;
 	}
 
@@ -335,19 +390,6 @@ export class FluidDevtools implements IFluidDevtools {
 			[DevtoolsFeature.Telemetry]: this.logger !== undefined,
 		};
 	}
-}
-
-/**
- * Initializes a {@link IFluidDevtools}.
- *
- * @remarks The consumer takes ownership of this object, and is responsible for disposing of it when appropriate.
- *
- * @privateRemarks This is exposed as a static function to avoid exporting {@link FluidDevtools} publicly.
- *
- * @public
- */
-export function initializeFluidDevtools(props?: FluidDevtoolsProps): IFluidDevtools {
-	return new FluidDevtools(props);
 }
 
 /**
@@ -368,4 +410,20 @@ function mergeDataVisualizers(
 		...globalVisualizers,
 		...containerVisualizers,
 	};
+}
+
+/**
+ * Initializes the Devtools singleton and returns a handle to it.
+ *
+ * @remarks
+ *
+ * The instance is tracked as a static singleton.
+ *
+ * It is automatically disposed on webpage unload, but it can be closed earlier by calling `dispose`
+ * on the returned handle.
+ *
+ * @public
+ */
+export function initializeDevtools(props?: FluidDevtoolsProps): IFluidDevtools {
+	return FluidDevtools.initialize(props);
 }

--- a/packages/tools/client-debugger/client-debugger/src/IFluidDevtools.ts
+++ b/packages/tools/client-debugger/client-debugger/src/IFluidDevtools.ts
@@ -7,13 +7,17 @@ import { IDisposable } from "@fluidframework/common-definitions";
 import { ContainerDevtoolsProps } from "./ContainerDevtools";
 
 /**
- * Fluid Devtools. A single instance is used to generate and communicate stats associated with the general Fluid
+ * Fluid Devtools. A single, global instance is used to generate and communicate stats associated with the general Fluid
  * runtime (i.e., it is not associated with any single Framework entity).
  *
  * @remarks
  *
  * Supports registering {@link @fluidframework/container-definitions#IContainer}s for Container-level stats
  * (via {@link IFluidDevtools.registerContainerDevtools}).
+ *
+ * The lifetime of the associated singleton is bound by that of the Window (globalThis), and it will be automatically
+ * disposed of on Window unload.
+ * If you wish to dispose of it earlier, you may call its {@link @fluidframework/common-definitions#IDisposable.dispose} method.
  *
  * @public
  */

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -4,41 +4,15 @@
  */
 
 /**
- * Contains a simple API for initializing debug sessions for recording and propogating information
- * about a given {@link @fluidframework/container-definitions#IContainer | Fluid Container} and its
- * {@link @fluidframework/container-definitions#Audience}.
+ * Contains an API for initializing developer tooling alongside the Fluid Framework.
  *
- * Debugger instances are created per `Container` instance and are bound to the `globalThis` context
- * to be accessible to related tools.
+ * This tooling is built for use alongside our Chromium browser extension.
+ * It listens for incoming messages from the corresponding extension, and posts direct responses as well as automatic
+ * updates for Fluid state changes.
  *
- * - See the package README for more details on related tools that are enabled via these debugger instances.
+ * Individual {@link IFluidContainer | Fluid Containers} can be registered to generate Container-level stats.
  *
- * @remarks
- *
- * The general usage pattern for this library is to first initialize a debugger for a given Fluid Client
- * ({@link @fluidframework/container-definitions#IContainer} and {@link @fluidframework/container-definitions#IAudience})
- * by calling {@link initializeFluidClientDebugger} during application setup / any time after your container has been
- * attached.
- *
- * Then, during application teardown, call {@link closeFluidClientDebugger} to clean up the debugger and its resources.
- *
- * @example Initialization
- *
- * ```typescript
- * initializeFluidClientDebugger({
- *  containerId,
- *  container,
- *  containerData: {
- *      rootMap: sharedMap
- *  },
- * });
- * ```
- *
- * @example Disposal
- *
- * ```typescript
- * closeFluidClientDebugger(containerId);
- * ```
+ * See the package README for more details.
  *
  * @packageDocumentation
  */

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -10,7 +10,7 @@
  * It listens for incoming messages from the corresponding extension, and posts direct responses as well as automatic
  * updates for Fluid state changes.
  *
- * Individual {@link IFluidContainer | Fluid Containers} can be registered to generate Container-level stats.
+ * Individual {@link @fluidframework/container-definitions#IContainer | Fluid Containers} can be registered to generate Container-level stats.
  *
  * See the package README for more details.
  *

--- a/packages/tools/client-debugger/client-debugger/src/index.ts
+++ b/packages/tools/client-debugger/client-debugger/src/index.ts
@@ -77,7 +77,7 @@ export {
 } from "./Features";
 export { IFluidDevtools } from "./IFluidDevtools";
 export { DevtoolsLogger } from "./DevtoolsLogger";
-export { FluidDevtoolsProps, initializeFluidDevtools } from "./FluidDevtools";
+export { FluidDevtoolsProps, initializeDevtools } from "./FluidDevtools";
 export {
 	AudienceChangeLogEntry,
 	ConnectionStateChangeLogEntry,

--- a/packages/tools/client-debugger/client-debugger/src/test/FluidDevtools.test.ts
+++ b/packages/tools/client-debugger/client-debugger/src/test/FluidDevtools.test.ts
@@ -17,8 +17,12 @@ import { createMockContainer } from "./Utilities";
 // - Test window messaging
 
 describe("FluidDevtools unit tests", () => {
+	afterEach(() => {
+		FluidDevtools.tryGet()?.dispose();
+	});
+
 	it("Container change events", () => {
-		const devtools = new FluidDevtools();
+		const devtools = FluidDevtools.initialize();
 
 		expect(devtools.getAllContainerDevtools().length).to.equal(0);
 
@@ -48,7 +52,7 @@ describe("FluidDevtools unit tests", () => {
 	});
 
 	it("Disposal", () => {
-		const devtools = new FluidDevtools();
+		const devtools = FluidDevtools.initialize();
 
 		devtools.dispose();
 
@@ -72,7 +76,7 @@ describe("FluidDevtools unit tests", () => {
 	});
 
 	it("Registering a duplicate Container ID throws", () => {
-		const devtools = new FluidDevtools();
+		const devtools = FluidDevtools.initialize();
 
 		const containerId = "test-container-id";
 

--- a/packages/tools/client-debugger/client-debugger/src/test/FluidDevtools.test.ts
+++ b/packages/tools/client-debugger/client-debugger/src/test/FluidDevtools.test.ts
@@ -8,6 +8,7 @@ import { expect } from "chai";
 import {
 	FluidDevtools,
 	getContainerAlreadyRegisteredErrorText,
+	initializeDevtools,
 	useAfterDisposeErrorText,
 } from "../FluidDevtools";
 import { ContainerDevtoolsProps } from "../ContainerDevtools";
@@ -37,15 +38,14 @@ describe("FluidDevtools unit tests", () => {
 		expect(devtools.getAllContainerDevtools().length).to.equal(1);
 
 		const containerDevtools = devtools.getContainerDevtools(containerId);
-		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 		expect(containerDevtools).to.not.be.undefined;
-		// eslint-disable-next-line @typescript-eslint/no-unused-expressions, @typescript-eslint/no-non-null-assertion
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		expect(containerDevtools!.disposed).to.be.false;
 
 		devtools.closeContainerDevtools(containerId);
 
 		expect(devtools.getAllContainerDevtools().length).to.equal(0);
-		// eslint-disable-next-line @typescript-eslint/no-unused-expressions, @typescript-eslint/no-non-null-assertion
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		expect(containerDevtools!.disposed).to.be.true;
 
 		devtools.dispose();
@@ -56,7 +56,6 @@ describe("FluidDevtools unit tests", () => {
 
 		devtools.dispose();
 
-		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 		expect(devtools.disposed).to.be.true;
 
 		const container = createMockContainer();
@@ -96,5 +95,29 @@ describe("FluidDevtools unit tests", () => {
 		expect(() => devtools.registerContainerDevtools(container2Props)).to.throw(
 			getContainerAlreadyRegisteredErrorText(containerId),
 		);
+	});
+
+	it("tryGet", () => {
+		expect(FluidDevtools.tryGet()).to.be.undefined;
+
+		const devtools = initializeDevtools({});
+
+		expect(FluidDevtools.tryGet()).to.not.be.undefined;
+
+		devtools.dispose();
+
+		expect(FluidDevtools.tryGet()).to.be.undefined;
+	});
+
+	it("getOrThrow", () => {
+		expect(() => FluidDevtools.getOrThrow()).to.throw();
+
+		const devtools = initializeDevtools({});
+
+		expect(() => FluidDevtools.getOrThrow()).to.not.throw();
+
+		devtools.dispose();
+
+		expect(() => FluidDevtools.getOrThrow()).to.throw();
 	});
 });

--- a/packages/tools/client-debugger/client-debugger/src/test/FluidDevtools.test.ts
+++ b/packages/tools/client-debugger/client-debugger/src/test/FluidDevtools.test.ts
@@ -7,6 +7,7 @@ import { expect } from "chai";
 
 import {
 	FluidDevtools,
+	accessBeforeInitializeErrorText,
 	getContainerAlreadyRegisteredErrorText,
 	initializeDevtools,
 	useAfterDisposeErrorText,
@@ -110,9 +111,7 @@ describe("FluidDevtools unit tests", () => {
 	});
 
 	it("getOrThrow", () => {
-		expect(() => FluidDevtools.getOrThrow()).to.throw(
-			"Devtools have not yet been initialized.",
-		);
+		expect(() => FluidDevtools.getOrThrow()).to.throw(accessBeforeInitializeErrorText);
 
 		const devtools = initializeDevtools({});
 
@@ -120,8 +119,6 @@ describe("FluidDevtools unit tests", () => {
 
 		devtools.dispose();
 
-		expect(() => FluidDevtools.getOrThrow()).to.throw(
-			"Devtools have not yet been initialized.",
-		);
+		expect(() => FluidDevtools.getOrThrow()).to.throw(accessBeforeInitializeErrorText);
 	});
 });

--- a/packages/tools/client-debugger/client-debugger/src/test/FluidDevtools.test.ts
+++ b/packages/tools/client-debugger/client-debugger/src/test/FluidDevtools.test.ts
@@ -110,7 +110,9 @@ describe("FluidDevtools unit tests", () => {
 	});
 
 	it("getOrThrow", () => {
-		expect(() => FluidDevtools.getOrThrow()).to.throw();
+		expect(() => FluidDevtools.getOrThrow()).to.throw(
+			"Devtools have not yet been initialized.",
+		);
 
 		const devtools = initializeDevtools({});
 
@@ -118,6 +120,8 @@ describe("FluidDevtools unit tests", () => {
 
 		devtools.dispose();
 
-		expect(() => FluidDevtools.getOrThrow()).to.throw();
+		expect(() => FluidDevtools.getOrThrow()).to.throw(
+			"Devtools have not yet been initialized.",
+		);
 	});
 });


### PR DESCRIPTION
Updates the devtools library to not require consumers to explicitly dispose of their devtools object during app teardown. This has a couple of major benefits:
1. Requiring consumers to dispose of the object puts substantial burden on consumers to keep track of the devtools object in all relevant places, which may or may not be reasonable for a (presumably) dev-build-only entity.
2. We can ensure teardown occurs on page close / refresh, which helps ensure the Chrome extension can clean up stale data.

This PR also updates the package's `packageDocumentation` comment and README overview to reflect the new flow (and cleans up a significant amount of outdated info).

See #15312 for an example of how this improves usage in application flow.