### PR TITLE
Fixes in token revocation flow

### DIFF
--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -230,7 +230,7 @@ export function configureWebSocketServices(
 	throttleAndUsageStorageManager?: core.IThrottleAndUsageStorageManager,
 	verifyMaxMessageSize?: boolean,
 	socketTracker?: core.IWebSocketTracker,
-	tokenRevocationManager?: core.ITokenRevocationManager,
+	revokedTokenChecker?: core.IRevokedTokenChecker,
 ) {
 	webSocketServer.on("connection", (socket: core.IWebSocket) => {
 		// Map from client IDs on this connection to the object ID and user info.
@@ -342,8 +342,8 @@ export function configureWebSocketServices(
 
 			try {
 				// Check if token is revoked
-				if (tokenRevocationManager && claims.jti) {
-					const isTokenRevoked: boolean = await tokenRevocationManager.isTokenRevoked(
+				if (revokedTokenChecker && claims.jti) {
+					const isTokenRevoked: boolean = await revokedTokenChecker.isTokenRevoked(
 						claims.tenantId,
 						claims.documentId,
 						claims.jti,

--- a/server/routerlicious/packages/lambdas/src/alfred/index.ts
+++ b/server/routerlicious/packages/lambdas/src/alfred/index.ts
@@ -349,7 +349,7 @@ export function configureWebSocketServices(
 						claims.jti,
 					);
 					if (isTokenRevoked) {
-						throw new NetworkError(
+						throw new core.TokenRevokedError(
 							403,
 							"Permission denied. Token has been revoked",
 							false /* canRetry */,

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -42,7 +42,7 @@ export function create(
 	producer: IProducer,
 	documentRepository: IDocumentRepository,
 	documentDeleteService: IDocumentDeleteService,
-	tokenManager?: ITokenRevocationManager,
+	tokenRevocationManager?: ITokenRevocationManager,
 ) {
 	// Maximum REST request size
 	const requestSize = config.get("alfred:restJsonSize");
@@ -100,7 +100,7 @@ export function create(
 		appTenants,
 		documentRepository,
 		documentDeleteService,
-		tokenManager,
+		tokenRevocationManager,
 	);
 
 	app.use(routes.api);

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -12,6 +12,7 @@ import {
 	ICache,
 	IDocumentRepository,
 	ITokenRevocationManager,
+	IRevokedTokenChecker,
 } from "@fluidframework/server-services-core";
 import { json, urlencoded } from "body-parser";
 import compression from "compression";
@@ -43,6 +44,7 @@ export function create(
 	documentRepository: IDocumentRepository,
 	documentDeleteService: IDocumentDeleteService,
 	tokenRevocationManager?: ITokenRevocationManager,
+	revokedTokenChecker?: IRevokedTokenChecker,
 ) {
 	// Maximum REST request size
 	const requestSize = config.get("alfred:restJsonSize");
@@ -101,6 +103,7 @@ export function create(
 		documentRepository,
 		documentDeleteService,
 		tokenRevocationManager,
+		revokedTokenChecker,
 	);
 
 	app.use(routes.api);

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/customizations.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/customizations.ts
@@ -3,11 +3,18 @@
  * Licensed under the MIT License.
  */
 
-import { IDocumentRepository, IStorageNameAllocator } from "@fluidframework/server-services-core";
+import {
+	IDocumentRepository,
+	IStorageNameAllocator,
+	ITokenRevocationManager,
+	IRevokedTokenChecker,
+} from "@fluidframework/server-services-core";
 import { IDocumentDeleteService } from "./services";
 
 export interface IAlfredResourcesCustomizations {
 	documentRepository?: IDocumentRepository;
 	storageNameAllocator?: IStorageNameAllocator;
 	documentDeleteService?: IDocumentDeleteService;
+	tokenRevocationManager?: ITokenRevocationManager;
+	revokedTokenChecker?: IRevokedTokenChecker;
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -254,7 +254,7 @@ async function verifyTokenWrapper(
 		validateTokenClaimsExpiration(claims, maxTokenLifetimeSec);
 	}
 
-	if (revokedTokenChecker && claims.jti) {
+	if (!tokenCacheEnabled && revokedTokenChecker && claims.jti) {
 		const tokenRevoked = await revokedTokenChecker.isTokenRevoked(
 			tenantId,
 			documentId,
@@ -272,7 +272,7 @@ async function verifyTokenWrapper(
 			maxTokenLifetimeSec,
 			ensureSingleUseToken: false,
 			singleUseTokenCache: undefined,
-			enableTokenCache: true,
+			enableTokenCache: tokenCacheEnabled,
 			tokenCache,
 			revokedTokenChecker,
 		};

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -43,7 +43,7 @@ export function create(
 	storage: core.IDocumentStorage,
 	tenantThrottlers: Map<string, core.IThrottler>,
 	jwtTokenCache?: core.ICache,
-	tokenRevocationManager?: core.ITokenRevocationManager,
+	revokedTokenChecker?: core.IRevokedTokenChecker,
 ): Router {
 	const router: Router = Router();
 
@@ -94,7 +94,7 @@ export function create(
 				isTokenExpiryEnabled,
 				enableJwtTokenCache,
 				jwtTokenCache,
-				tokenRevocationManager,
+				revokedTokenChecker,
 			);
 			handleResponse(
 				validP.then(() => undefined),
@@ -213,7 +213,7 @@ const verifyRequest = async (
 	isTokenExpiryEnabled: boolean,
 	tokenCacheEnabled: boolean,
 	tokenCache?: core.ICache,
-	tokenRevocationManager?: core.ITokenRevocationManager,
+	revokedTokenChecker?: core.IRevokedTokenChecker,
 ) =>
 	Promise.all([
 		verifyTokenWrapper(
@@ -223,7 +223,7 @@ const verifyRequest = async (
 			isTokenExpiryEnabled,
 			tokenCacheEnabled,
 			tokenCache,
-			tokenRevocationManager,
+			revokedTokenChecker,
 		),
 		checkDocumentExistence(request, storage),
 	]);
@@ -235,7 +235,7 @@ async function verifyTokenWrapper(
 	isTokenExpiryEnabled: boolean,
 	tokenCacheEnabled: boolean,
 	tokenCache?: core.ICache,
-	tokenRevocationManager?: core.ITokenRevocationManager,
+	revokedTokenChecker?: core.IRevokedTokenChecker,
 ): Promise<void> {
 	const token = request.headers["access-token"] as string;
 	if (!token) {
@@ -254,8 +254,8 @@ async function verifyTokenWrapper(
 		validateTokenClaimsExpiration(claims, maxTokenLifetimeSec);
 	}
 
-	if (tokenRevocationManager && claims.jti) {
-		const tokenRevoked = await tokenRevocationManager.isTokenRevoked(
+	if (revokedTokenChecker && claims.jti) {
+		const tokenRevoked = await revokedTokenChecker.isTokenRevoked(
 			tenantId,
 			documentId,
 			claims.jti,
@@ -274,6 +274,7 @@ async function verifyTokenWrapper(
 			singleUseTokenCache: undefined,
 			enableTokenCache: true,
 			tokenCache,
+			revokedTokenChecker,
 		};
 		return verifyToken(tenantId, documentId, token, tenantManager, options);
 	}

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
@@ -32,7 +32,7 @@ export function create(
 	tenantThrottlers: Map<string, IThrottler>,
 	clusterThrottlers: Map<string, IThrottler>,
 	jwtTokenCache?: ICache,
-	tokenManager?: ITokenRevocationManager,
+	tokenRevocationManager?: ITokenRevocationManager,
 ): Router {
 	const deltasCollectionName = config.get("mongo:collectionNames:deltas");
 	const rawDeltasCollectionName = config.get("mongo:collectionNames:rawdeltas");
@@ -84,7 +84,7 @@ export function create(
 		["/v1/:tenantId/:id", "/:tenantId/:id/v1"],
 		validateRequestParams("tenantId", "id"),
 		throttle(generalTenantThrottler, winston, tenantThrottleOptions),
-		verifyStorageToken(tenantManager, config, tokenManager, defaultTokenValidationOptions),
+		verifyStorageToken(tenantManager, config, tokenRevocationManager, defaultTokenValidationOptions),
 		(request, response, next) => {
 			const from = stringToSequenceNumber(request.query.from);
 			const to = stringToSequenceNumber(request.query.to);
@@ -110,7 +110,7 @@ export function create(
 		"/raw/:tenantId/:id",
 		validateRequestParams("tenantId", "id"),
 		throttle(generalTenantThrottler, winston, tenantThrottleOptions),
-		verifyStorageToken(tenantManager, config, tokenManager, defaultTokenValidationOptions),
+		verifyStorageToken(tenantManager, config, tokenRevocationManager, defaultTokenValidationOptions),
 		(request, response, next) => {
 			const tenantId = getParam(request.params, "tenantId") || appTenants[0].id;
 
@@ -141,7 +141,12 @@ export function create(
 			winston,
 			getDeltasTenantThrottleOptions,
 		),
-		verifyStorageToken(tenantManager, config, tokenManager, defaultTokenValidationOptions),
+		verifyStorageToken(
+			tenantManager,
+			config,
+			tokenRevocationManager,
+			defaultTokenValidationOptions,
+		),
 		(request, response, next) => {
 			const from = stringToSequenceNumber(request.query.from);
 			const to = stringToSequenceNumber(request.query.to);

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
@@ -6,9 +6,9 @@
 import {
 	ICache,
 	IDeltaService,
+	IRevokedTokenChecker,
 	ITenantManager,
 	IThrottler,
-	ITokenRevocationManager,
 } from "@fluidframework/server-services-core";
 import {
 	verifyStorageToken,
@@ -32,7 +32,7 @@ export function create(
 	tenantThrottlers: Map<string, IThrottler>,
 	clusterThrottlers: Map<string, IThrottler>,
 	jwtTokenCache?: ICache,
-	tokenRevocationManager?: ITokenRevocationManager,
+	revokedTokenChecker?: IRevokedTokenChecker,
 ): Router {
 	const deltasCollectionName = config.get("mongo:collectionNames:deltas");
 	const rawDeltasCollectionName = config.get("mongo:collectionNames:rawdeltas");
@@ -66,6 +66,7 @@ export function create(
 		singleUseTokenCache: undefined,
 		enableTokenCache: enableJwtTokenCache,
 		tokenCache: jwtTokenCache,
+		revokedTokenChecker,
 	};
 
 	function stringToSequenceNumber(value: any): number {
@@ -84,7 +85,7 @@ export function create(
 		["/v1/:tenantId/:id", "/:tenantId/:id/v1"],
 		validateRequestParams("tenantId", "id"),
 		throttle(generalTenantThrottler, winston, tenantThrottleOptions),
-		verifyStorageToken(tenantManager, config, tokenRevocationManager, defaultTokenValidationOptions),
+		verifyStorageToken(tenantManager, config, defaultTokenValidationOptions),
 		(request, response, next) => {
 			const from = stringToSequenceNumber(request.query.from);
 			const to = stringToSequenceNumber(request.query.to);
@@ -110,7 +111,7 @@ export function create(
 		"/raw/:tenantId/:id",
 		validateRequestParams("tenantId", "id"),
 		throttle(generalTenantThrottler, winston, tenantThrottleOptions),
-		verifyStorageToken(tenantManager, config, tokenRevocationManager, defaultTokenValidationOptions),
+		verifyStorageToken(tenantManager, config, defaultTokenValidationOptions),
 		(request, response, next) => {
 			const tenantId = getParam(request.params, "tenantId") || appTenants[0].id;
 
@@ -141,12 +142,7 @@ export function create(
 			winston,
 			getDeltasTenantThrottleOptions,
 		),
-		verifyStorageToken(
-			tenantManager,
-			config,
-			tokenRevocationManager,
-			defaultTokenValidationOptions,
-		),
+		verifyStorageToken(tenantManager, config, defaultTokenValidationOptions),
 		(request, response, next) => {
 			const from = stringToSequenceNumber(request.query.from);
 			const to = stringToSequenceNumber(request.query.to);

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -11,6 +11,7 @@ import {
 	ICache,
 	IDocumentRepository,
 	ITokenRevocationManager,
+	IRevokeTokenOptions,
 } from "@fluidframework/server-services-core";
 import {
 	verifyStorageToken,
@@ -294,10 +295,6 @@ export function create(
 			defaultTokenValidationOptions,
 		),
 		async (request, response, next) => {
-			// TODO: remove debug code
-			const correlationId = getCorrelationIdWithHttpFallback(request, response);
-			console.log(`yunho: correlation id=${correlationId}`);
-
 			const documentId = getParam(request.params, "id");
 			const tenantId = getParam(request.params, "tenantId");
 			const lumberjackProperties = getLumberBaseProperties(documentId, tenantId);
@@ -313,7 +310,16 @@ export function create(
 				);
 			}
 			if (tokenRevocationManager) {
-				const resultP = tokenRevocationManager.revokeToken(tenantId, documentId, tokenId);
+				const correlationId = getCorrelationIdWithHttpFallback(request, response);
+				const options: IRevokeTokenOptions = {
+					httpCorrelationId: correlationId,
+				};
+				const resultP = tokenRevocationManager.revokeToken(
+					tenantId,
+					documentId,
+					tokenId,
+					options,
+				);
 				return handleResponse(resultP, response);
 			} else {
 				return handleResponse(

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -312,7 +312,7 @@ export function create(
 			if (tokenRevocationManager) {
 				const correlationId = getCorrelationIdWithHttpFallback(request, response);
 				const options: IRevokeTokenOptions = {
-					httpCorrelationId: correlationId,
+					correlationId,
 				};
 				const resultP = tokenRevocationManager.revokeToken(
 					tenantId,

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -287,11 +287,7 @@ export function create(
 		validateRequestParams("tenantId", "id"),
 		throttle(generalTenantThrottler, winston, tenantThrottleOptions),
 		validateTokenScopeClaims(TokenRevokeScopeType),
-		verifyStorageToken(
-			tenantManager,
-			config,
-			defaultTokenValidationOptions,
-		),
+		verifyStorageToken(tenantManager, config, defaultTokenValidationOptions),
 		async (request, response, next) => {
 			const documentId = getParam(request.params, "id");
 			const tenantId = getParam(request.params, "tenantId");

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts
@@ -9,6 +9,7 @@ import {
 	IDocumentRepository,
 	IDocumentStorage,
 	IProducer,
+	IRevokedTokenChecker,
 	ITenantManager,
 	IThrottler,
 	ITokenRevocationManager,
@@ -35,6 +36,7 @@ export function create(
 	documentRepository: IDocumentRepository,
 	documentDeleteService: IDocumentDeleteService,
 	tokenRevocationManager?: ITokenRevocationManager,
+	revokedTokenChecker?: IRevokedTokenChecker,
 ): Router {
 	const router: Router = Router();
 	const deltasRoute = deltas.create(
@@ -45,7 +47,7 @@ export function create(
 		tenantThrottlers,
 		clusterThrottlers,
 		singleUseTokenCache,
-		tokenRevocationManager,
+		revokedTokenChecker,
 	);
 	const documentsRoute = documents.create(
 		storage,
@@ -58,6 +60,7 @@ export function create(
 		documentRepository,
 		documentDeleteService,
 		tokenRevocationManager,
+		revokedTokenChecker,
 	);
 	const apiRoute = api.create(
 		config,
@@ -66,7 +69,7 @@ export function create(
 		storage,
 		tenantThrottlers,
 		singleUseTokenCache,
-		tokenRevocationManager,
+		revokedTokenChecker,
 	);
 
 	router.use(cors());

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts
@@ -34,7 +34,7 @@ export function create(
 	appTenants: IAlfredTenant[],
 	documentRepository: IDocumentRepository,
 	documentDeleteService: IDocumentDeleteService,
-	tokenManager?: ITokenRevocationManager,
+	tokenRevocationManager?: ITokenRevocationManager,
 ): Router {
 	const router: Router = Router();
 	const deltasRoute = deltas.create(
@@ -45,7 +45,7 @@ export function create(
 		tenantThrottlers,
 		clusterThrottlers,
 		singleUseTokenCache,
-		tokenManager,
+		tokenRevocationManager,
 	);
 	const documentsRoute = documents.create(
 		storage,
@@ -57,7 +57,7 @@ export function create(
 		tenantManager,
 		documentRepository,
 		documentDeleteService,
-		tokenManager,
+		tokenRevocationManager,
 	);
 	const apiRoute = api.create(
 		config,
@@ -66,7 +66,7 @@ export function create(
 		storage,
 		tenantThrottlers,
 		singleUseTokenCache,
-		tokenManager,
+		tokenRevocationManager,
 	);
 
 	router.use(cors());

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/index.ts
@@ -12,6 +12,7 @@ import {
 	ICache,
 	IDocumentRepository,
 	ITokenRevocationManager,
+	IRevokedTokenChecker,
 } from "@fluidframework/server-services-core";
 import { Router } from "express";
 import { Provider } from "nconf";
@@ -37,6 +38,7 @@ export function create(
 	documentRepository: IDocumentRepository,
 	documentDeleteService: IDocumentDeleteService,
 	tokenRevocationManager?: ITokenRevocationManager,
+	revokedTokenChecker?: IRevokedTokenChecker,
 ) {
 	return {
 		api: api.create(
@@ -52,6 +54,7 @@ export function create(
 			documentRepository,
 			documentDeleteService,
 			tokenRevocationManager,
+			revokedTokenChecker,
 		),
 	};
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/index.ts
@@ -36,7 +36,7 @@ export function create(
 	appTenants: IAlfredTenant[],
 	documentRepository: IDocumentRepository,
 	documentDeleteService: IDocumentDeleteService,
-	tokenManager?: ITokenRevocationManager,
+	tokenRevocationManager?: ITokenRevocationManager,
 ) {
 	return {
 		api: api.create(
@@ -51,7 +51,7 @@ export function create(
 			appTenants,
 			documentRepository,
 			documentDeleteService,
-			tokenManager,
+			tokenRevocationManager,
 		),
 	};
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -59,7 +59,7 @@ export class AlfredRunner implements IRunner {
 		private readonly verifyMaxMessageSize?: boolean,
 		private readonly redisCache?: ICache,
 		private readonly socketTracker?: IWebSocketTracker,
-		private readonly tokenManager?: ITokenRevocationManager,
+		private readonly tokenRevocationManager?: ITokenRevocationManager,
 	) {}
 
 	// eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -79,7 +79,7 @@ export class AlfredRunner implements IRunner {
 			this.producer,
 			this.documentRepository,
 			this.documentDeleteService,
-			this.tokenManager,
+			this.tokenRevocationManager,
 		);
 		alfred.set("port", this.port);
 
@@ -121,6 +121,7 @@ export class AlfredRunner implements IRunner {
 			this.throttleAndUsageStorageManager,
 			this.verifyMaxMessageSize,
 			this.socketTracker,
+			this.tokenRevocationManager,
 		);
 
 		// Listen on provided port, on all network interfaces.
@@ -129,8 +130,8 @@ export class AlfredRunner implements IRunner {
 		httpServer.on("listening", () => this.onListening());
 
 		// Start token manager
-		if (this.tokenManager) {
-			this.tokenManager.start().catch((error) => {
+		if (this.tokenRevocationManager) {
+			this.tokenRevocationManager.start().catch((error) => {
 				this.runningDeferred.reject(error);
 			});
 		}

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -112,6 +112,7 @@ export class AlfredResources implements core.IResources {
 		public redisCache?: core.ICache,
 		public socketTracker?: core.IWebSocketTracker,
 		public tokenRevocationManager?: core.ITokenRevocationManager,
+		public revokedTokenChecker?: core.IRevokedTokenChecker,
 	) {
 		const socketIoAdapterConfig = config.get("alfred:socketIoAdapter");
 		const httpServerConfig: services.IHttpServerConfig = config.get("system:httpServer");
@@ -504,8 +505,10 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 		);
 		let socketTracker: core.IWebSocketTracker | undefined;
 		let tokenRevocationManager: core.ITokenRevocationManager | undefined;
+		let revokedTokenChecker: core.IRevokedTokenChecker | undefined;
 		if (tokenRevocationEnabled) {
 			socketTracker = new utils.WebSocketTracker();
+			revokedTokenChecker = new utils.DummyRevokedTokenChecker();
 			tokenRevocationManager = new utils.DummyTokenRevocationManager();
 			await tokenRevocationManager.initialize();
 		}
@@ -539,6 +542,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 			redisCache,
 			socketTracker,
 			tokenRevocationManager,
+			revokedTokenChecker,
 		);
 	}
 }
@@ -571,6 +575,7 @@ export class AlfredRunnerFactory implements core.IRunnerFactory<AlfredResources>
 			resources.redisCache,
 			resources.socketTracker,
 			resources.tokenRevocationManager,
+			resources.revokedTokenChecker,
 		);
 	}
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -498,7 +498,10 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 			customizations?.documentDeleteService ?? new DocumentDeleteService();
 
 		// Set up token revocation if enabled
-		const tokenRevocationEnabled: boolean = config.get("tokenRevocation:enable") as boolean;
+		const tokenRevocationEnabled: boolean = utils.getBooleanFromConfig(
+			"tokenRevocation:enable",
+			config,
+		);
 		let socketTracker: core.IWebSocketTracker | undefined;
 		let tokenRevocationManager: core.ITokenRevocationManager | undefined;
 		if (tokenRevocationEnabled) {

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -316,6 +316,6 @@
 		}
 	],
 	"tokenRevocation": {
-		"enable": false
+		"enable": true
 	}
 }

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -73,6 +73,9 @@
 			},
 			"ClassDeclaration_MongoDatabaseManager": {
 				"forwardCompat": false
+			},
+			"InterfaceDeclaration_ITokenRevocationResponse": {
+				"backCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -76,6 +76,9 @@
 			},
 			"InterfaceDeclaration_ITokenRevocationResponse": {
 				"backCompat": false
+			},
+			"InterfaceDeclaration_ITokenRevocationManager": {
+				"backCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/services-core/src/index.ts
+++ b/server/routerlicious/packages/services-core/src/index.ts
@@ -153,6 +153,7 @@ export { IZookeeperClient, ZookeeperClientConstructor } from "./zookeeper";
 export {
 	IWebSocketTracker,
 	ITokenRevocationManager,
+	ITokenRevocationChecker,
 	ITokenRevocationResponse,
 	IRevokeTokenOptions,
 	TokenRevocationError,

--- a/server/routerlicious/packages/services-core/src/index.ts
+++ b/server/routerlicious/packages/services-core/src/index.ts
@@ -156,5 +156,6 @@ export {
 	ITokenRevocationResponse,
 	IRevokeTokenOptions,
 	TokenRevocationError,
+	TokenRevokedError,
 	createCompositeTokenId,
 } from "./tokenRevocationManager";

--- a/server/routerlicious/packages/services-core/src/index.ts
+++ b/server/routerlicious/packages/services-core/src/index.ts
@@ -153,7 +153,7 @@ export { IZookeeperClient, ZookeeperClientConstructor } from "./zookeeper";
 export {
 	IWebSocketTracker,
 	ITokenRevocationManager,
-	ITokenRevocationChecker,
+	IRevokedTokenChecker,
 	ITokenRevocationResponse,
 	IRevokeTokenOptions,
 	TokenRevocationError,

--- a/server/routerlicious/packages/services-core/src/index.ts
+++ b/server/routerlicious/packages/services-core/src/index.ts
@@ -154,6 +154,7 @@ export {
 	IWebSocketTracker,
 	ITokenRevocationManager,
 	ITokenRevocationResponse,
+	IRevokeTokenOptions,
 	TokenRevocationError,
 	createCompositeTokenId,
 } from "./tokenRevocationManager";

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -2366,6 +2366,7 @@ declare function get_current_InterfaceDeclaration_ITokenRevocationResponse():
 declare function use_old_InterfaceDeclaration_ITokenRevocationResponse(
     use: TypeOnly<old.ITokenRevocationResponse>);
 use_old_InterfaceDeclaration_ITokenRevocationResponse(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITokenRevocationResponse());
 
 /*

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -2342,6 +2342,7 @@ declare function get_current_InterfaceDeclaration_ITokenRevocationManager():
 declare function use_old_InterfaceDeclaration_ITokenRevocationManager(
     use: TypeOnly<old.ITokenRevocationManager>);
 use_old_InterfaceDeclaration_ITokenRevocationManager(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITokenRevocationManager());
 
 /*

--- a/server/routerlicious/packages/services-core/src/tokenRevocationManager.ts
+++ b/server/routerlicious/packages/services-core/src/tokenRevocationManager.ts
@@ -91,7 +91,7 @@ export class TokenRevocationError extends NetworkError {
  * Indicate that a connect is rejected/dropped because the token has been revoked.
  */
 export class TokenRevokedError extends NetworkError {
-	public readonly type: string = "TokenRevoked";
+	public readonly errorType: string = "TokenRevoked";
 	constructor(
 		/**
 		 * HTTP status code that describes the error.
@@ -119,10 +119,10 @@ export class TokenRevokedError extends NetworkError {
 		super(code, message, canRetry, isFatal, retryAfterMs);
 	}
 
-	public get details(): INetworkErrorDetails & { type: string } {
+	public get details(): INetworkErrorDetails & { errorType: string } {
 		return {
 			message: this.message,
-			type: this.type,
+			errorType: this.errorType,
 			canRetry: this.canRetry,
 			isFatal: this.isFatal,
 			retryAfter: this.retryAfter,
@@ -134,9 +134,9 @@ export class TokenRevokedError extends NetworkError {
 	 * Explicitly define how to serialize as JSON so that socket.io can emit relevant info.
 	 * @public
 	 */
-	public toJSON(): INetworkErrorDetails & { code: number; type: string } {
+	public toJSON(): INetworkErrorDetails & { code: number; errorType: string } {
 		return {
-			type: this.type,
+			errorType: this.errorType,
 			...super.toJSON(),
 		};
 	}

--- a/server/routerlicious/packages/services-core/src/tokenRevocationManager.ts
+++ b/server/routerlicious/packages/services-core/src/tokenRevocationManager.ts
@@ -146,7 +146,7 @@ export interface IRevokeTokenOptions {
 	correlationId: string;
 }
 
-export interface ITokenRevocationChecker {
+export interface IRevokedTokenChecker {
 	// Check if a given token id is revoked
 	isTokenRevoked(tenantId: string, documentId: string, jwtId: string): Promise<boolean>;
 }
@@ -174,9 +174,9 @@ export interface ITokenRevocationManager {
 	): Promise<ITokenRevocationResponse>;
 
 	/**
-	 * @deprecated move this function to ITokenRevocationChecker
+	 * @deprecated move this function to IRevokedTokenChecker
 	 */
-	isTokenRevoked(tenantId: string, documentId: string, jwtId: string): Promise<boolean>;
+	isTokenRevoked?(tenantId: string, documentId: string, jwtId: string): Promise<boolean>;
 }
 
 export function createCompositeTokenId(

--- a/server/routerlicious/packages/services-core/src/tokenRevocationManager.ts
+++ b/server/routerlicious/packages/services-core/src/tokenRevocationManager.ts
@@ -146,6 +146,11 @@ export interface IRevokeTokenOptions {
 	correlationId: string;
 }
 
+export interface ITokenRevocationChecker {
+	// Check if a given token id is revoked
+	isTokenRevoked(tenantId: string, documentId: string, jwtId: string): Promise<boolean>;
+}
+
 /**
  * Interface of Json Web Token(JWT) manager
  * It is mainly used to manage token revocation
@@ -168,7 +173,9 @@ export interface ITokenRevocationManager {
 		options?: IRevokeTokenOptions,
 	): Promise<ITokenRevocationResponse>;
 
-	// Check if a given token id is revoked
+	/**
+	 * @deprecated move this function to ITokenRevocationChecker
+	 */
 	isTokenRevoked(tenantId: string, documentId: string, jwtId: string): Promise<boolean>;
 }
 

--- a/server/routerlicious/packages/services-core/src/tokenRevocationManager.ts
+++ b/server/routerlicious/packages/services-core/src/tokenRevocationManager.ts
@@ -81,6 +81,10 @@ export class TokenRevocationError extends NetworkError {
 	}
 }
 
+export interface IRevokeTokenOptions {
+	httpCorrelationId: string;
+}
+
 /**
  * Interface of Json Web Token(JWT) manager
  * It is mainly used to manage token revocation
@@ -100,6 +104,7 @@ export interface ITokenRevocationManager {
 		tenantId: string,
 		documentId: string,
 		jwtId: string,
+		options?: IRevokeTokenOptions,
 	): Promise<ITokenRevocationResponse>;
 
 	// Check if a given token id is revoked

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -103,6 +103,9 @@
 			"RemovedFunctionDeclaration_validateTokenRevocationClaims": {
 				"forwardCompat": false,
 				"backCompat": false
+			},
+			"ClassDeclaration_DummyTokenRevocationManager": {
+				"backCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -20,8 +20,8 @@ import {
 } from "@fluidframework/server-services-client";
 import type {
 	ICache,
+	IRevokedTokenChecker,
 	ITenantManager,
-	ITokenRevocationManager,
 } from "@fluidframework/server-services-core";
 import type { RequestHandler, Request, Response } from "express";
 import type { Provider } from "nconf";
@@ -129,6 +129,7 @@ interface IVerifyTokenOptions {
 	singleUseTokenCache: ICache | undefined;
 	enableTokenCache: boolean;
 	tokenCache: ICache | undefined;
+	revokedTokenChecker: IRevokedTokenChecker | undefined;
 }
 
 export function respondWithNetworkError(response: Response, error: NetworkError): Response {
@@ -175,6 +176,18 @@ export async function verifyToken(
 				maxTokenLifetimeSec = defaultMaxTokenLifetimeSec;
 			}
 			tokenLifetimeMs = validateTokenClaimsExpiration(claims, maxTokenLifetimeSec);
+		}
+
+		// Revoked token check
+		if (options.revokedTokenChecker && claims.jti) {
+			const isTokenRevoked = await options.revokedTokenChecker.isTokenRevoked(
+				tenantId,
+				documentId,
+				claims.jti,
+			);
+			if (isTokenRevoked) {
+				throw new NetworkError(403, "Permission denied. Access token has been revoked.");
+			}
 		}
 
 		// Check token cache first
@@ -229,13 +242,13 @@ export async function verifyToken(
 export function verifyStorageToken(
 	tenantManager: ITenantManager,
 	config: Provider,
-	tokenRevocationManager: ITokenRevocationManager | undefined,
 	options: IVerifyTokenOptions = {
 		requireDocumentId: true,
 		ensureSingleUseToken: false,
 		singleUseTokenCache: undefined,
 		enableTokenCache: false,
 		tokenCache: undefined,
+		revokedTokenChecker: undefined,
 	},
 ): RequestHandler {
 	const maxTokenLifetimeSec = getNumberFromConfig("auth:maxTokenLifetimeSec", config);
@@ -303,8 +316,8 @@ export function verifyStorageToken(
 			if (isTokenExpiryEnabled) {
 				tokenLifetimeMs = validateTokenClaimsExpiration(claims, maxTokenLifetimeSec);
 			}
-			if (tokenRevocationManager && claims.jti) {
-				const tokenRevoked = await tokenRevocationManager.isTokenRevoked(
+			if (options.revokedTokenChecker && claims.jti) {
+				const tokenRevoked = await options.revokedTokenChecker.isTokenRevoked(
 					tenantId,
 					documentId,
 					claims.jti,

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -229,7 +229,7 @@ export async function verifyToken(
 export function verifyStorageToken(
 	tenantManager: ITenantManager,
 	config: Provider,
-	tokenManager: ITokenRevocationManager | undefined,
+	tokenRevocationManager: ITokenRevocationManager | undefined,
 	options: IVerifyTokenOptions = {
 		requireDocumentId: true,
 		ensureSingleUseToken: false,
@@ -303,8 +303,8 @@ export function verifyStorageToken(
 			if (isTokenExpiryEnabled) {
 				tokenLifetimeMs = validateTokenClaimsExpiration(claims, maxTokenLifetimeSec);
 			}
-			if (tokenManager && claims.jti) {
-				const tokenRevoked = await tokenManager.isTokenRevoked(
+			if (tokenRevocationManager && claims.jti) {
+				const tokenRevoked = await tokenRevocationManager.isTokenRevoked(
 					tenantId,
 					documentId,
 					claims.jti,

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -40,5 +40,9 @@ export {
 export { IThrottleConfig, ISimpleThrottleConfig, getThrottleConfig } from "./throttlerConfigs";
 export { IThrottleMiddlewareOptions, throttle } from "./throttlerMiddleware";
 export { WinstonLumberjackEngine } from "./winstonLumberjackEngine";
-export { WebSocketTracker, DummyTokenRevocationManager } from "./tokenRevocationManager";
+export {
+	WebSocketTracker,
+	DummyTokenRevocationManager,
+	DummyRevokedTokenChecker,
+} from "./tokenRevocationManager";
 export { getBooleanFromConfig, getNumberFromConfig } from "./configUtils";

--- a/server/routerlicious/packages/services-utils/src/test/types/validateServerServicesUtilsPrevious.generated.ts
+++ b/server/routerlicious/packages/services-utils/src/test/types/validateServerServicesUtilsPrevious.generated.ts
@@ -35,6 +35,7 @@ declare function get_current_ClassDeclaration_DummyTokenRevocationManager():
 declare function use_old_ClassDeclaration_DummyTokenRevocationManager(
     use: TypeOnly<old.DummyTokenRevocationManager>);
 use_old_ClassDeclaration_DummyTokenRevocationManager(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_DummyTokenRevocationManager());
 
 /*

--- a/server/routerlicious/packages/services-utils/src/tokenRevocationManager.ts
+++ b/server/routerlicious/packages/services-utils/src/tokenRevocationManager.ts
@@ -6,6 +6,7 @@ import {
 	IWebSocket,
 	IWebSocketTracker,
 	ITokenRevocationManager,
+	IRevokedTokenChecker,
 	ITokenRevocationResponse,
 } from "@fluidframework/server-services-core";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
@@ -79,6 +80,17 @@ export class WebSocketTracker implements IWebSocketTracker {
 	}
 }
 
+export class DummyRevokedTokenChecker implements IRevokedTokenChecker {
+	public async isTokenRevoked(
+		tenantId: string,
+		documentId: string,
+		jwtId: string,
+	): Promise<boolean> {
+		Lumberjack.info(`DummyRevokedTokenChecker isTokenRevoked called`);
+		return false;
+	}
+}
+
 export class DummyTokenRevocationManager implements ITokenRevocationManager {
 	public async start() {
 		Lumberjack.info(`DummyTokenRevocationManager started`);
@@ -100,15 +112,5 @@ export class DummyTokenRevocationManager implements ITokenRevocationManager {
 	): Promise<ITokenRevocationResponse> {
 		Lumberjack.info(`DummyTokenRevocationManager revokeToken called`);
 		throw new NetworkError(501, "Token revocation is not supported for now", false, true);
-	}
-
-	// Check if a given token id is revoked
-	public async isTokenRevoked(
-		tenantId: string,
-		documentId: string,
-		jwtId: string,
-	): Promise<boolean> {
-		Lumberjack.info(`DummyTokenRevocationManager isTokenRevoked called`);
-		return false;
 	}
 }

--- a/server/routerlicious/packages/services-utils/src/tokenRevocationManager.ts
+++ b/server/routerlicious/packages/services-utils/src/tokenRevocationManager.ts
@@ -81,15 +81,15 @@ export class WebSocketTracker implements IWebSocketTracker {
 
 export class DummyTokenRevocationManager implements ITokenRevocationManager {
 	public async start() {
-		Lumberjack.info(`DummyTokenManager started`);
+		Lumberjack.info(`DummyTokenRevocationManager started`);
 	}
 
 	public async initialize(): Promise<void> {
-		Lumberjack.info(`DummyTokenManager initialize called`);
+		Lumberjack.info(`DummyTokenRevocationManager initialize called`);
 	}
 
 	public async close(): Promise<void> {
-		Lumberjack.info(`DummyTokenManager closed`);
+		Lumberjack.info(`DummyTokenRevocationManager closed`);
 	}
 
 	// Revoke the access of a token given its jwtId
@@ -98,7 +98,7 @@ export class DummyTokenRevocationManager implements ITokenRevocationManager {
 		documentId: string,
 		jwtId: string,
 	): Promise<ITokenRevocationResponse> {
-		Lumberjack.info(`DummyTokenManager revokeToken called`);
+		Lumberjack.info(`DummyTokenRevocationManager revokeToken called`);
 		throw new NetworkError(501, "Token revocation is not supported for now", false, true);
 	}
 
@@ -108,7 +108,7 @@ export class DummyTokenRevocationManager implements ITokenRevocationManager {
 		documentId: string,
 		jwtId: string,
 	): Promise<boolean> {
-		Lumberjack.info(`DummyTokenManager isTokenRevoked called`);
+		Lumberjack.info(`DummyTokenRevocationManager isTokenRevoked called`);
 		return false;
 	}
 }


### PR DESCRIPTION
This PR include changes below:
1. Add new interface IRevokedTokenChecker to separate revoked token check from revokeToken (ITokenRevocationManager)
2. Add the new interface to the new verifyToken flow in Alfred
3. Add isTokenRevoked check in connect_document event and fail the event if the token has been revoked.
4. Pass http correlation id to revokeToken function for tracking purposes.
5. Renaming some variables. It introduces a small build break in FRS. I will work with them to fix it when we need to do a oss bump