### PR TITLE
[GC stress] Adjust the various timeouts to account for snapshot cache expiry

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -52,11 +52,11 @@
 			"totalSendCount": 16000,
 			"faultInjectionMs": {
 				"min": 0,
-				"max": 600000
+				"max": 900000
 			},
 			"optionOverrides": {
 				"tinylicious": {
-					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 21 mins. Sweep Timeout: 22 mins.",
+					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 					"configurations": {
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
@@ -67,7 +67,7 @@
 							"sweepAllowed": [false],
 							"disableGC": [false],
 							"runFullGC": [false],
-							"inactiveTimeoutMs": [1260000],
+							"inactiveTimeoutMs": [1200000],
 							"sessionExpiryTimeoutMs": [900000]
 						}
 					}
@@ -99,11 +99,11 @@
 			"totalSendCount": 16000,
 			"faultInjectionMs": {
 				"min": 0,
-				"max": 600000
+				"max": 900000
 			},
 			"optionOverrides": {
 				"tinylicious": {
-					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 21 mins. Sweep Timeout: 22 mins.",
+					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 					"configurations": {
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000]
 					},
@@ -113,7 +113,7 @@
 							"sweepAllowed": [true],
 							"disableGC": [false],
 							"runFullGC": [false],
-							"inactiveTimeoutMs": [1260000],
+							"inactiveTimeoutMs": [1200000],
 							"sessionExpiryTimeoutMs": [900000]
 						}
 					}

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -52,7 +52,7 @@
 			"totalSendCount": 16000,
 			"faultInjectionMs": {
 				"min": 0,
-				"max": 900000
+				"max": 600000
 			},
 			"optionOverrides": {
 				"tinylicious": {
@@ -73,10 +73,10 @@
 					}
 				},
 				"odsp": {
-					"comment": "SessionExpiry: 15 mins. SnapshotCacheExpiry: 5 mins. Inactive Timeout: 24 mins. Sweep Timeout: 25 mins.",
+					"comment": "SessionExpiry: 15 mins. SnapshotCacheExpiry: 5 mins. Inactive Timeout: 25 mins. Sweep Timeout: 26 mins.",
 					"configurations": {
 						"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs": [300000],
-						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1500000],
+						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1560000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
 					},
 					"container": {
@@ -85,7 +85,7 @@
 							"sweepAllowed": [false],
 							"disableGC": [false],
 							"runFullGC": [false],
-							"inactiveTimeoutMs": [1440000],
+							"inactiveTimeoutMs": [1500000],
 							"sessionExpiryTimeoutMs": [900000]
 						}
 					}
@@ -99,7 +99,7 @@
 			"totalSendCount": 16000,
 			"faultInjectionMs": {
 				"min": 0,
-				"max": 900000
+				"max": 600000
 			},
 			"optionOverrides": {
 				"tinylicious": {
@@ -119,10 +119,10 @@
 					}
 				},
 				"odsp": {
-					"comment": "SessionExpiry: 15 mins. SnapshotCacheExpiry: 5 mins. Inactive Timeout: 24 mins. Sweep Timeout: 25 mins.",
+					"comment": "SessionExpiry: 15 mins. SnapshotCacheExpiry: 5 mins. Inactive Timeout: 25 mins. Sweep Timeout: 26 mins.",
 					"configurations": {
 						"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs": [300000],
-						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1500000]
+						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1560000]
 					},
 					"container": {
 						"gcOptions": {
@@ -130,7 +130,7 @@
 							"sweepAllowed": [false],
 							"disableGC": [false],
 							"runFullGC": [false],
-							"inactiveTimeoutMs": [1440000],
+							"inactiveTimeoutMs": [1500000],
 							"sessionExpiryTimeoutMs": [900000]
 						}
 					}

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -52,11 +52,11 @@
 			"totalSendCount": 16000,
 			"faultInjectionMs": {
 				"min": 0,
-				"max": 900000
+				"max": 600000
 			},
 			"optionOverrides": {
-				"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 				"tinylicious": {
+					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 21 mins. Sweep Timeout: 22 mins.",
 					"configurations": {
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
@@ -67,15 +67,16 @@
 							"sweepAllowed": [false],
 							"disableGC": [false],
 							"runFullGC": [false],
-							"inactiveTimeoutMs": [1200000],
+							"inactiveTimeoutMs": [1260000],
 							"sessionExpiryTimeoutMs": [900000]
 						}
 					}
 				},
 				"odsp": {
+					"comment": "SessionExpiry: 15 mins. SnapshotCacheExpiry: 5 mins. Inactive Timeout: 24 mins. Sweep Timeout: 25 mins.",
 					"configurations": {
-						"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs": [450000],
-						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000],
+						"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs": [300000],
+						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1500000],
 						"Fluid.GarbageCollection.ThrowOnTombstoneUsage": [true]
 					},
 					"container": {
@@ -84,7 +85,7 @@
 							"sweepAllowed": [false],
 							"disableGC": [false],
 							"runFullGC": [false],
-							"inactiveTimeoutMs": [1200000],
+							"inactiveTimeoutMs": [1440000],
 							"sessionExpiryTimeoutMs": [900000]
 						}
 					}
@@ -98,11 +99,11 @@
 			"totalSendCount": 16000,
 			"faultInjectionMs": {
 				"min": 0,
-				"max": 900000
+				"max": 600000
 			},
 			"optionOverrides": {
-				"comment": "SessionExpiry: 15 mins. Inactive Timeout: 20 mins. Sweep Timeout: 22 mins.",
 				"tinylicious": {
+					"comment": "SessionExpiry: 15 mins. Inactive Timeout: 21 mins. Sweep Timeout: 22 mins.",
 					"configurations": {
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000]
 					},
@@ -112,23 +113,24 @@
 							"sweepAllowed": [true],
 							"disableGC": [false],
 							"runFullGC": [false],
-							"inactiveTimeoutMs": [1200000],
+							"inactiveTimeoutMs": [1260000],
 							"sessionExpiryTimeoutMs": [900000]
 						}
 					}
 				},
 				"odsp": {
+					"comment": "SessionExpiry: 15 mins. SnapshotCacheExpiry: 5 mins. Inactive Timeout: 24 mins. Sweep Timeout: 25 mins.",
 					"configurations": {
-						"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs": [450000],
-						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1320000]
+						"Fluid.Driver.Odsp.TestOverride.SnapshotCacheExpiryTimeoutMs": [300000],
+						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [1500000]
 					},
 					"container": {
 						"gcOptions": {
 							"gcAllowed": [true],
-							"sweepAllowed": [true],
+							"sweepAllowed": [false],
 							"disableGC": [false],
 							"runFullGC": [false],
-							"inactiveTimeoutMs": [1200000],
+							"inactiveTimeoutMs": [1440000],
 							"sessionExpiryTimeoutMs": [900000]
 						}
 					}


### PR DESCRIPTION
## Description
https://github.com/microsoft/FluidFramework/pull/14454 added snapshot cache expiry to the GC stress tests. However, the inactive timeout and sweep timeout was not adjusted accordingly. This means there is a small window where a client may be able to load inactive / sweep ready objects. We see 3 instances of `sweepReadyObject_Loaded` since #14454 was merged.

This change adjusts the time based on snapshot cache expiry. It does the following for odsp runs only:
- Reduced snapshot cache expiry to 5 mins.
- Reduced faultInjection max time to 10 mins so that snapshot cache expiry is half of it.  The idea is that on average half the sessions that fail because of faultInjection will load from cached snapshot and other half will not.
- Increased inactive timeout to 25 mins and sweep timeout to 26 mins. This means there is a 5 mins buffer time (same as before) between session expiry (15 mins) + snapshot cache expiry (5 mins) to inactive timeout (25 mins). This buffer should be good enough for ops to propagate to all clients.

## Reviewer guidance
This is for an experimental stress test in test/gc-stress branch. This is not in the main FF branch and does not affect its stress test.