### PR TITLE
Add audience size to connection state change events

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1942,6 +1942,7 @@ export class Container
 				this.lastVisible !== undefined ? performance.now() - this.lastVisible : undefined,
 			checkpointSequenceNumber,
 			quorumSize: this._protocolHandler?.quorum.getMembers().size,
+			audienceSize: this._protocolHandler?.audience.getMembers().size,
 			...this._deltaManager.connectionProps,
 		});
 


### PR DESCRIPTION
The ConnectionStateChanged events currently have the quorum size as one of the properties logged. This change adds the audience size as well. This will tell us how many clients (read + write) are connected to the document at the time of connection.

The primary reason for adding this is to help with GC debugging. When an inactive / sweepReady object usage error is logged in a non-summarizer client, if it was the only client when it connected, we can draw certain conclusions - Any client that is connected to the document when the error is logged would have the object as unreferenced (since they loaded after this client) and could not have revived (referenced) this object. So, the error is reliably pointing at a bug.

[AB#4244](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4244)