### PR TITLE
fix(build-tools): Remove readme from plugins list

### DIFF
--- a/build-tools/packages/build-cli/docs/bump.md
+++ b/build-tools/packages/build-cli/docs/bump.md
@@ -13,8 +13,8 @@ Bumps the version of a release group or package to the next minor, major, or pat
 ```
 USAGE
   $ flub bump PACKAGE_OR_RELEASE_GROUP [-v] [-t major|minor|patch | --exact <value>] [--scheme
-    semver|internal|virtualPatch | ] [--exactDepType ^|~|] [-d ^|~||workspace:*|workspace:^|workspace:~] [-x | --install
-    | --commit |  |  | ]
+    semver|internal|virtualPatch | ] [--exactDepType ^|~||workspace:*|workspace:^|workspace:~] [-d
+    ^|~||workspace:*|workspace:^|workspace:~] [-x | --install | --commit |  |  | ]
 
 ARGUMENTS
   PACKAGE_OR_RELEASE_GROUP  The name of a package or a release group.
@@ -36,7 +36,7 @@ FLAGS
   --exactDepType=<option>              [DEPRECATED - Use interdependencyRange instead.] Controls the type of dependency
                                        that is used between packages within the release group. Use "" to indicate exact
                                        dependencies.
-                                       <options: ^|~|>
+                                       <options: ^|~||workspace:*|workspace:^|workspace:~>
   --[no-]install                       Update lockfiles by running 'npm install' automatically.
   --scheme=<option>                    Override the version scheme used by the release group or package.
                                        <options: semver|internal|virtualPatch>

--- a/build-tools/packages/build-cli/docs/generate.md
+++ b/build-tools/packages/build-cli/docs/generate.md
@@ -6,7 +6,6 @@ Generate commands are used to create/update code, docs, readmes, etc.
 * [`flub generate buildVersion`](#flub-generate-buildversion)
 * [`flub generate bundleStats`](#flub-generate-bundlestats)
 * [`flub generate packageJson`](#flub-generate-packagejson)
-* [`flub generate readme`](#flub-generate-readme)
 
 ## `flub generate buildVersion`
 
@@ -71,32 +70,4 @@ FLAGS
 
 DESCRIPTION
   Generate mono repo package json
-```
-
-## `flub generate readme`
-
-Adds commands to README.md in current directory.
-
-```
-USAGE
-  $ flub generate readme --dir <value> [--multi] [--aliases]
-
-FLAGS
-  --[no-]aliases  include aliases in the command list
-  --dir=<value>   (required) [default: docs] output directory for multi docs
-  --multi         create a different markdown page for each topic
-
-DESCRIPTION
-  Adds commands to README.md in current directory.
-
-  The readme must have any of the following tags inside of it for it to be replaced or else it will do nothing:
-
-  # Usage
-  <!-- usage -->
-  # Commands
-  <!-- commands -->
-  # Table of contents
-  <!-- toc -->
-
-  Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
 ```

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -29,7 +29,7 @@
 		"build:docs": "api-extractor run --local",
 		"build:machine-diagram": "jssm-viz -i \"./src/machines/*.fsl\"",
 		"build:manifest": "cross-env NODE_OPTIONS='--experimental-abortcontroller' oclif manifest",
-		"build:readme": "node \"./bin/dev\" generate readme --multi",
+		"build:readme": "fluid-readme generate readme --multi",
 		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf dist lib oclif.manifest.json *.tsbuildinfo *.build.log",
 		"clean:manifest": "rimraf oclif.manifest.json",
@@ -104,7 +104,7 @@
 		"type-fest": "^2.19.0"
 	},
 	"devDependencies": {
-		"@fluid-internal/readme-command": "~0.16.0",
+		"@fluid-internal/readme-command": "workspace:*",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
@@ -159,7 +159,6 @@
 			"-V"
 		],
 		"plugins": [
-			"@fluid-internal/readme-command",
 			"@oclif/plugin-autocomplete",
 			"@oclif/plugin-commands",
 			"@oclif/plugin-help",

--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -62,7 +62,7 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 		exactDepType: Flags.string({
 			description:
 				'[DEPRECATED - Use interdependencyRange instead.] Controls the type of dependency that is used between packages within the release group. Use "" to indicate exact dependencies.',
-			options: [...RangeOperators],
+			options: [...RangeOperators, ...WorkspaceRanges],
 			deprecated: {
 				to: "interdependencyRange",
 				message: "The exactDepType flag is deprecated. Use interdependencyRange instead.",

--- a/build-tools/packages/build-cli/src/lib/package.ts
+++ b/build-tools/packages/build-cli/src/lib/package.ts
@@ -14,10 +14,10 @@ import {
 import {
 	InterdependencyRange,
 	ReleaseVersion,
-	WorkspaceRanges,
 	detectVersionScheme,
 	getVersionRange,
 	isInterdependencyRange,
+	isInternalVersionRange,
 	isPrereleaseVersion,
 	isRangeOperator,
 	isWorkspaceRange,
@@ -603,14 +603,18 @@ export async function setVersion(
 		newRange = `${interdependencyRange}${translatedVersion.version}`;
 	}
 
-	if (!isInterdependencyRange(newRange)) {
+	if (
+		newRange !== undefined &&
+		isInternalVersionRange(newRange, true) === false &&
+		!isInterdependencyRange(newRange)
+	) {
 		throw new Error(`New range is invalid: ${newRange}`);
 	}
 
 	const packagesToCheckAndUpdate = releaseGroupOrPackage.packages;
 	const dependencyVersionMap = new Map<string, DependencyWithRange>();
 	for (const pkg of packagesToCheckAndUpdate) {
-		dependencyVersionMap.set(pkg.name, { pkg, range: newRange });
+		dependencyVersionMap.set(pkg.name, { pkg, range: newRange as InterdependencyRange });
 	}
 
 	for (const pkg of packagesToCheckAndUpdate) {

--- a/build-tools/packages/readme-command/package.json
+++ b/build-tools/packages/readme-command/package.json
@@ -7,7 +7,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "build-tools/packages/build-cli"
+		"directory": "build-tools/packages/readme-command"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",
@@ -15,7 +15,7 @@
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",
 	"bin": {
-		"flub": "./bin/run"
+		"fluid-readme": "./bin/run"
 	},
 	"files": [
 		"/bin",

--- a/build-tools/packages/version-tools/README.md
+++ b/build-tools/packages/version-tools/README.md
@@ -92,7 +92,6 @@ USAGE
 <!-- prettier-ignore-start -->
 <!-- commands -->
 * [`fluv autocomplete [SHELL]`](#fluv-autocomplete-shell)
-* [`fluv generate readme`](#fluv-generate-readme)
 * [`fluv help [COMMANDS]`](#fluv-help-commands)
 * [`fluv version VERSION`](#fluv-version-version)
 * [`fluv version latest`](#fluv-version-latest)
@@ -125,34 +124,6 @@ EXAMPLES
 ```
 
 _See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v2.1.3/src/commands/autocomplete/index.ts)_
-
-## `fluv generate readme`
-
-Adds commands to README.md in current directory.
-
-```
-USAGE
-  $ fluv generate readme --dir <value> [--multi] [--aliases]
-
-FLAGS
-  --[no-]aliases  include aliases in the command list
-  --dir=<value>   (required) [default: docs] output directory for multi docs
-  --multi         create a different markdown page for each topic
-
-DESCRIPTION
-  Adds commands to README.md in current directory.
-
-  The readme must have any of the following tags inside of it for it to be replaced or else it will do nothing:
-
-  # Usage
-  <!-- usage -->
-  # Commands
-  <!-- commands -->
-  # Table of contents
-  <!-- toc -->
-
-  Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
-```
 
 ## `fluv help [COMMANDS]`
 

--- a/build-tools/packages/version-tools/api-report/version-tools.api.md
+++ b/build-tools/packages/version-tools/api-report/version-tools.api.md
@@ -46,6 +46,9 @@ export type InterdependencyRange = WorkspaceRange | RangeOperator | RangeOperato
 export function isInterdependencyRange(r: any): r is InterdependencyRange;
 
 // @public
+export function isInternalVersionRange(range: string, allowAnyPrereleaseId?: boolean): boolean;
+
+// @public
 export function isInternalVersionScheme(version: semver.SemVer | string | undefined, allowPrereleases?: boolean, allowAnyPrereleaseId?: boolean): boolean;
 
 // @public

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -27,7 +27,7 @@
 		"build:compile": "npm run build:commonjs && npm run build:readme",
 		"build:docs": "api-extractor run --local",
 		"build:manifest": "cross-env NODE_OPTIONS='--experimental-abortcontroller' oclif manifest",
-		"build:readme": "node \"./bin/dev\" generate readme",
+		"build:readme": "fluid-readme generate readme",
 		"build:test": "tsc --project ./src/test/tsconfig.json",
 		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf dist lib oclif.manifest.json *.tsbuildinfo *.build.log",
@@ -78,7 +78,7 @@
 		"table": "^6.8.0"
 	},
 	"devDependencies": {
-		"@fluid-internal/readme-command": "~0.16.0",
+		"@fluid-internal/readme-command": "workspace:*",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.4",
@@ -121,7 +121,6 @@
 			"-V"
 		],
 		"plugins": [
-			"@fluid-internal/readme-command",
 			"@oclif/plugin-autocomplete",
 			"@oclif/plugin-help"
 		],

--- a/build-tools/packages/version-tools/src/index.ts
+++ b/build-tools/packages/version-tools/src/index.ts
@@ -26,6 +26,7 @@ export {
 	changePreReleaseIdentifier,
 	getVersionRange,
 	fromInternalScheme,
+	isInternalVersionRange,
 	isInternalVersionScheme,
 	toInternalScheme,
 } from "./internalVersionScheme";

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
 
   packages/build-cli:
     specifiers:
-      '@fluid-internal/readme-command': ~0.16.0
+      '@fluid-internal/readme-command': workspace:*
       '@fluid-tools/version-tools': workspace:*
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': workspace:*
@@ -453,7 +453,7 @@ importers:
 
   packages/version-tools:
     specifiers:
-      '@fluid-internal/readme-command': ~0.16.0
+      '@fluid-internal/readme-command': workspace:*
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@microsoft/api-extractor': ^7.34.4


### PR DESCRIPTION
The newly added readme command (see #15396) was loaded as an oclif plugin but that throws warnings in the shipped package because the readme plugin isn't present. We don't need to use the command as a plugin, so this PR removes it from the plugins list and updates the usage to call the bin created by the readme command.

Also fixes isInternalRange to be more correct.