### PR TITLE
MergeTree: Clean up handling for removed segments below the min seq

### DIFF
--- a/api-report/merge-tree.api.md
+++ b/api-report/merge-tree.api.md
@@ -93,7 +93,7 @@ export interface BlockAction<TClientData> {
     (block: IMergeBlock, pos: number, refSeq: number, clientId: number, start: number | undefined, end: number | undefined, accum: TClientData): boolean;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface BlockUpdateActions {
     // (undocumented)
     child: (block: IMergeBlock, index: number) => void;

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -264,7 +264,9 @@ export interface IncrementalSegmentAction<TContext> {
 export interface IncrementalBlockAction<TContext> {
 	(state: IncrementalMapState<TContext>);
 }
-
+/**
+ * @deprecated - unused and will be removed
+ */
 export interface BlockUpdateActions {
 	child: (block: IMergeBlock, index: number) => void;
 }
@@ -362,6 +364,10 @@ export class MergeBlock extends MergeNode implements IMergeBlock {
 		}
 		this.children[index] = child;
 	}
+}
+
+export function seqLTE(seq: number, minOrRefSeq: number) {
+	return seq !== UnassignedSequenceNumber && seq <= minOrRefSeq;
 }
 
 export abstract class BaseSegment extends MergeNode implements ISegment {

--- a/packages/dds/merge-tree/src/partialLengths.ts
+++ b/packages/dds/merge-tree/src/partialLengths.ts
@@ -12,6 +12,7 @@ import {
 	IMergeBlock,
 	IRemovalInfo,
 	ISegment,
+	seqLTE,
 	toRemovalInfo,
 } from "./mergeTreeNodes";
 import { SortedSet } from "./sortedSet";
@@ -352,22 +353,21 @@ export class PartialSequenceLengths {
 		);
 		combinedPartialLengths.segmentCount = block.childCount;
 
-		function seqLTE(seq: number | undefined, minSeq: number) {
-			return seq !== undefined && seq !== UnassignedSequenceNumber && seq <= minSeq;
-		}
-
 		for (let i = 0; i < block.childCount; i++) {
 			const child = block.children[i];
 			if (child.isLeaf()) {
 				// Leaf segment
 				const segment = child;
-				if (seqLTE(segment.seq, collabWindow.minSeq)) {
+				if (segment.seq !== undefined && seqLTE(segment.seq, collabWindow.minSeq)) {
 					combinedPartialLengths.minLength += segment.cachedLength;
 				} else {
 					PartialSequenceLengths.insertSegment(combinedPartialLengths, segment);
 				}
 				const removalInfo = toRemovalInfo(segment);
-				if (seqLTE(removalInfo?.removedSeq, collabWindow.minSeq)) {
+				if (
+					removalInfo?.removedSeq !== undefined &&
+					seqLTE(removalInfo.removedSeq, collabWindow.minSeq)
+				) {
 					combinedPartialLengths.minLength -= segment.cachedLength;
 				} else if (removalInfo !== undefined) {
 					PartialSequenceLengths.insertSegment(

--- a/packages/dds/merge-tree/src/zamboni.ts
+++ b/packages/dds/merge-tree/src/zamboni.ts
@@ -8,7 +8,14 @@
 import { UnassignedSequenceNumber } from "./constants";
 import { MergeTree } from "./mergeTree";
 import { MergeTreeMaintenanceType } from "./mergeTreeDeltaCallback";
-import { IMergeBlock, IMergeNode, ISegment, MaxNodesInBlock } from "./mergeTreeNodes";
+import {
+	IMergeBlock,
+	IMergeNode,
+	ISegment,
+	MaxNodesInBlock,
+	seqLTE,
+	toRemovalInfo,
+} from "./mergeTreeNodes";
 import { matchProperties } from "./properties";
 
 export const zamboniSegmentsMax = 2;
@@ -126,8 +133,9 @@ function scourNode(node: IMergeBlock, holdNodes: IMergeNode[], mergeTree: MergeT
 		if (childNode.isLeaf()) {
 			const segment = childNode;
 			if (segment.segmentGroups.empty) {
-				if (segment.removedSeq !== undefined) {
-					if (segment.removedSeq > mergeTree.collabWindow.minSeq) {
+				const removalInfo = toRemovalInfo(segment);
+				if (removalInfo !== undefined) {
+					if (!seqLTE(removalInfo.removedSeq, mergeTree.collabWindow.minSeq)) {
 						holdNodes.push(segment);
 					} else if (!segment.trackingCollection.empty) {
 						holdNodes.push(segment);


### PR DESCRIPTION
# Description
Clean up and unify some handling of removed segments below the min seq. Adds some testability improvement to visualize them.

related [AB#1882](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/1882)