### PR TITLE
Disable batch size tests on t9s

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -606,9 +606,8 @@ describeNoCompat("Message size", (getTestObjectProvider) => {
 						// This is not supported by the local server due to chunking. See ADO:2690
 						// This test is flaky on tinylicious. See ADO:2964
 						if (
-							config.payloadGenerator === generateRandomStringOfSize &&
-							(provider.driver.type === "local" ||
-								provider.driver.type === "tinylicious")
+							provider.driver.type === "local" ||
+							provider.driver.type === "tinylicious"
 						) {
 							this.skip();
 						}


### PR DESCRIPTION
## Description

These tests fail with connection resets on Tinylicious. Disabling them for this server, as they already do get the proper coverage from FRS/ODSP.