### PR TITLE
build(build-tools): Upgrade Typescript to ~4.9

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -94,7 +94,7 @@
 		"prettier": "~2.6.2",
 		"rimraf": "^4.4.0",
 		"run-script-os": "^1.1.6",
-		"typescript": "~4.5.5"
+		"typescript": "~4.9.5"
 	},
 	"packageManager": "pnpm@7.30.5+sha512.917887efe886843726dd45618dbe29cdb458963a13d8a551f1614bdfb6fe735e45f42b9a2dabb4453a33ad7c7ff6c9dfd491261880a346730cd9702b98cd35b2",
 	"engines": {

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -142,7 +142,7 @@
 		"rimraf": "^4.4.0",
 		"ts-node": "^10.2.1",
 		"tslib": "^2.3.1",
-		"typescript": "~4.5.5"
+		"typescript": "~4.9.5"
 	},
 	"engines": {
 		"node": ">=14.0.0"

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -110,7 +110,7 @@
 		"eslint-plugin-unused-imports": "~2.0.0",
 		"mocha": "^10.2.0",
 		"prettier": "~2.6.2",
-		"typescript": "~4.5.5"
+		"typescript": "~4.9.5"
 	},
 	"engines": {
 		"node": ">=14.13.0"

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -37,7 +37,6 @@
 		"jszip": "^3.10.1",
 		"msgpack-lite": "^0.1.26",
 		"pako": "^2.0.4",
-		"typescript": "~4.5.5",
 		"webpack": "^5.74.0"
 	},
 	"devDependencies": {
@@ -55,6 +54,7 @@
 		"eslint-plugin-unicorn": "~40.0.0",
 		"eslint-plugin-unused-imports": "~2.0.0",
 		"prettier": "~2.6.2",
-		"rimraf": "^4.4.0"
+		"rimraf": "^4.4.0",
+		"typescript": "~4.9.5"
 	}
 }

--- a/build-tools/packages/readme-command/package.json
+++ b/build-tools/packages/readme-command/package.json
@@ -79,7 +79,7 @@
 		"rimraf": "^4.4.0",
 		"ts-node": "^10.2.1",
 		"tslib": "^2.3.1",
-		"typescript": "~4.5.5"
+		"typescript": "~4.9.5"
 	},
 	"engines": {
 		"node": ">=14.0.0"

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -105,7 +105,7 @@
 		"rimraf": "^4.4.0",
 		"ts-node": "^10.2.1",
 		"tslib": "^2.3.1",
-		"typescript": "~4.5.5"
+		"typescript": "~4.9.5"
 	},
 	"engines": {
 		"node": ">=14.0.0"


### PR DESCRIPTION
As part of getting the build-tools fully ESM, we need to upgrade TypeScript. This upgrade **only** affects the build-tools release group.