### PR TITLE
[GC stress] Fail the test to validate new yaml pipeline

### DIFF
--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -114,7 +114,7 @@ async function main() {
 		}
 	});
 
-	let testFailed: boolean = false;
+	let testFailed: boolean = true;
 	const fileLogger = await FileLogger.loggerP;
 	// Check for InactiveObject or SweepReadyObject logs
 	fileLogger.observer.on("logEvent", (logEvent: ITelemetryBaseEvent) => {

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -77,7 +77,7 @@ stages:
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 200
-        testCommand: start:t9s:gc:ci:tombstone
+        testCommand: start:t9s:gc
         splitTestVariants: 
           - name: Tombstone Mode
         env:


### PR DESCRIPTION
Experimenting with changes to yaml pipeline by adding a job to create work item on failure - https://github.com/microsoft/FluidFramework/commit/ef9064a9b108e3b169f1ea2323ad216a86a229d5.

This change fails the test to see the new job works.

## Reviewer guidance
This is for an experimental stress test in test/gc-stress branch. This is not in the main FF branch and does not affect its stress test.