### PR TITLE
Reorder sequence format type declarations

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
@@ -6,57 +6,29 @@
 import { ITreeCursorSynchronous, JsonableTree, RevisionTag } from "../../core";
 import { ChangesetLocalId, NodeChangeset } from "../modular-schema";
 
-export type NodeChangeType = NodeChangeset;
-export type Changeset<TNodeChange = NodeChangeType> = MarkList<TNodeChange>;
+/**
+ * The contents of a node to be created
+ */
+export type ProtoNode = JsonableTree;
 
-export type MarkList<TNodeChange = NodeChangeType, TMark = Mark<TNodeChange>> = TMark[];
-
-export type Mark<TNodeChange = NodeChangeType> =
-	| InputSpanningMark<TNodeChange>
-	| OutputSpanningMark<TNodeChange>;
-
-export type ObjectMark<TNodeChange = NodeChangeType> = Exclude<Mark<TNodeChange>, Skip>;
+export type NodeCount = number;
+export type Skip = number;
 
 /**
- * A mark that spans one or more cells.
- * The spanned cells may be populated (e.g., "Delete") or not (e.g., "Revive").
+ * A monotonically increasing positive integer assigned to an individual mark within the changeset.
+ * MoveIds are scoped to a single changeset, so referring to MoveIds across changesets requires
+ * qualifying them by change tag.
+ *
+ * The uniqueness of IDs is leveraged to uniquely identify the matching move-out for a move-in/return and vice-versa.
  */
-export type CellSpanningMark<TNodeChange> = Exclude<Mark<TNodeChange>, NewAttach<TNodeChange>>;
+export type MoveId = ChangesetLocalId;
 
-/**
- * A mark that spans one or more nodes in the input context of its changeset.
- */
-export type InputSpanningMark<TNodeChange> =
-	| Skip
-	| Detach<TNodeChange>
-	| Modify<TNodeChange>
-	| SkipLikeReattach<TNodeChange>;
-
-/**
- * A mark that spans one or more nodes in the output context of its changeset.
- */
-export type OutputSpanningMark<TNodeChange> =
-	| Skip
-	| NewAttach<TNodeChange>
-	| Modify<TNodeChange>
-	| Reattach<TNodeChange>;
-
-/**
- * A Reattach whose target nodes are already reattached and have not been detached by some other change.
- * Such a Reattach has no effect when applied and is therefore akin to a Skip mark.
- */
-export type SkipLikeReattach<TNodeChange> = Reattach<TNodeChange> &
-	Conflicted & {
-		lastDeletedBy?: never;
-	};
-
-/**
- * A Detach with a conflicted destination.
- * Such a Detach has no effect when applied and is therefore akin to a Skip mark.
- */
-export type SkipLikeDetach<TNodeChange> = (MoveOut<TNodeChange> | ReturnFrom<TNodeChange>) & {
-	isDstConflicted: true;
-};
+export interface HasMoveId {
+	/**
+	 * The sequential ID assigned to a change within a transaction.
+	 */
+	id: MoveId;
+}
 
 export interface Conflicted {
 	/**
@@ -67,9 +39,36 @@ export interface Conflicted {
 
 export type CanConflict = Partial<Conflicted>;
 
-export interface Modify<TNodeChange = NodeChangeType> {
-	type: "Modify";
-	changes: TNodeChange;
+export type NodeChangeType = NodeChangeset;
+
+export enum Tiebreak {
+	Left,
+	Right,
+}
+export enum Effects {
+	All = "All",
+	Move = "Move",
+	Delete = "Delete",
+	None = "None",
+}
+
+export interface PriorOp {
+	change: RevisionTag;
+}
+
+/**
+ * Represents a position within a contiguous range of nodes detached by a single changeset.
+ * Note that `LineageEvent`s with the same revision are not necessarily referring to the same detach.
+ * `LineageEvent`s for a given revision can only be meaningfully compared if it is known that they must refer to the
+ * same detach.
+ */
+export interface LineageEvent {
+	readonly revision: RevisionTag;
+
+	/**
+	 * The position of this mark within a range of nodes which were detached in this revision.
+	 */
+	readonly offset: number;
 }
 
 export interface HasChanges<TNodeChange = NodeChangeType> {
@@ -97,91 +96,6 @@ export interface HasPlaceFields {
 	 * Events are stored in the order in which they were rebased over.
 	 */
 	lineage?: LineageEvent[];
-}
-
-export interface HasTiebreakPolicy extends HasPlaceFields {
-	/**
-	 * Omit if `Tiebreak.Right` for terseness.
-	 */
-	tiebreak?: Tiebreak;
-}
-
-/**
- * Represents a position within a contiguous range of nodes detached by a single changeset.
- * Note that `LineageEvent`s with the same revision are not necessarily referring to the same detach.
- * `LineageEvent`s for a given revision can only be meaningfully compared if it is known that they must refer to the
- * same detach.
- */
-export interface LineageEvent {
-	readonly revision: RevisionTag;
-
-	/**
-	 * The position of this mark within a range of nodes which were detached in this revision.
-	 */
-	readonly offset: number;
-}
-
-export interface Insert<TNodeChange = NodeChangeType>
-	extends HasTiebreakPolicy,
-		HasRevisionTag,
-		HasChanges<TNodeChange> {
-	type: "Insert";
-	content: ProtoNode[];
-
-	/**
-	 * The first ID in a block associated with the nodes being inserted.
-	 * The node `content[i]` is associated with `id + i`.
-	 */
-	id: ChangesetLocalId;
-}
-
-export interface MoveIn extends HasMoveId, HasPlaceFields, HasRevisionTag, CanConflict {
-	type: "MoveIn";
-	/**
-	 * The actual number of nodes being moved-in. This count excludes nodes that were concurrently deleted.
-	 */
-	count: NodeCount;
-	/**
-	 * When true, the corresponding MoveOut has a conflict.
-	 * This is independent of whether this mark has a conflict.
-	 */
-	isSrcConflicted?: true;
-}
-
-/**
- * An attach mark that allocates new cells.
- */
-export type NewAttach<TNodeChange = NodeChangeType> = Insert<TNodeChange> | MoveIn;
-
-export type Attach<TNodeChange = NodeChangeType> = NewAttach<TNodeChange> | Reattach<TNodeChange>;
-
-export type Detach<TNodeChange = NodeChangeType> =
-	| Delete<TNodeChange>
-	| MoveOut<TNodeChange>
-	| ReturnFrom<TNodeChange>;
-
-export type Reattach<TNodeChange = NodeChangeType> = Revive<TNodeChange> | ReturnTo;
-
-export interface Delete<TNodeChange = NodeChangeType>
-	extends HasRevisionTag,
-		HasChanges<TNodeChange>,
-		CanConflict {
-	type: "Delete";
-	count: NodeCount;
-}
-
-export interface MoveOut<TNodeChange = NodeChangeType>
-	extends HasRevisionTag,
-		HasMoveId,
-		HasChanges<TNodeChange>,
-		CanConflict {
-	type: "MoveOut";
-	count: NodeCount;
-	/**
-	 * When true, the corresponding MoveIn has a conflict.
-	 * This is independent of whether this mark has a conflict.
-	 */
-	isDstConflicted?: true;
 }
 
 export interface HasReattachFields extends HasPlaceFields {
@@ -219,6 +133,83 @@ export interface HasReattachFields extends HasPlaceFields {
 	 */
 	lastDetachedBy?: RevisionTag;
 }
+
+export interface HasTiebreakPolicy extends HasPlaceFields {
+	/**
+	 * Omit if `Tiebreak.Right` for terseness.
+	 */
+	tiebreak?: Tiebreak;
+}
+
+export enum RangeType {
+	Set = "Set",
+	Slice = "Slice",
+}
+
+export interface HasRevisionTag {
+	/**
+	 * The revision this mark is part of.
+	 * Only set for marks in fields which are a composition of multiple revisions.
+	 */
+	revision?: RevisionTag;
+}
+
+export interface Insert<TNodeChange = NodeChangeType>
+	extends HasTiebreakPolicy,
+		HasRevisionTag,
+		HasChanges<TNodeChange> {
+	type: "Insert";
+	content: ProtoNode[];
+
+	/**
+	 * The first ID in a block associated with the nodes being inserted.
+	 * The node `content[i]` is associated with `id + i`.
+	 */
+	id: ChangesetLocalId;
+}
+
+export interface MoveIn extends HasMoveId, HasPlaceFields, HasRevisionTag, CanConflict {
+	type: "MoveIn";
+	/**
+	 * The actual number of nodes being moved-in. This count excludes nodes that were concurrently deleted.
+	 */
+	count: NodeCount;
+	/**
+	 * When true, the corresponding MoveOut has a conflict.
+	 * This is independent of whether this mark has a conflict.
+	 */
+	isSrcConflicted?: true;
+}
+
+export interface Delete<TNodeChange = NodeChangeType>
+	extends HasRevisionTag,
+		HasChanges<TNodeChange>,
+		CanConflict {
+	type: "Delete";
+	count: NodeCount;
+}
+
+export interface MoveOut<TNodeChange = NodeChangeType>
+	extends HasRevisionTag,
+		HasMoveId,
+		HasChanges<TNodeChange>,
+		CanConflict {
+	type: "MoveOut";
+	count: NodeCount;
+	/**
+	 * When true, the corresponding MoveIn has a conflict.
+	 * This is independent of whether this mark has a conflict.
+	 */
+	isDstConflicted?: true;
+}
+
+/**
+ * A Detach with a conflicted destination.
+ * Such a Detach has no effect when applied and is therefore akin to a Skip mark.
+ */
+export type SkipLikeDetach<TNodeChange> = (MoveOut<TNodeChange> | ReturnFrom<TNodeChange>) & {
+	isDstConflicted: true;
+};
 
 export interface Revive<TNodeChange = NodeChangeType>
 	extends HasReattachFields,
@@ -269,56 +260,67 @@ export interface ReturnFrom<TNodeChange = NodeChangeType>
 	isDstConflicted?: true;
 }
 
-export interface PriorOp {
-	change: RevisionTag;
-}
+/**
+ * An attach mark that allocates new cells.
+ */
+export type NewAttach<TNodeChange = NodeChangeType> = Insert<TNodeChange> | MoveIn;
 
-export enum RangeType {
-	Set = "Set",
-	Slice = "Slice",
-}
+export type Reattach<TNodeChange = NodeChangeType> = Revive<TNodeChange> | ReturnTo;
 
-export interface HasRevisionTag {
-	/**
-	 * The revision this mark is part of.
-	 * Only set for marks in fields which are a composition of multiple revisions.
-	 */
-	revision?: RevisionTag;
+/**
+ * A Reattach whose target nodes are already reattached and have not been detached by some other change.
+ * Such a Reattach has no effect when applied and is therefore akin to a Skip mark.
+ */
+export type SkipLikeReattach<TNodeChange> = Reattach<TNodeChange> &
+	Conflicted & {
+		lastDeletedBy?: never;
+	};
+
+export type Attach<TNodeChange = NodeChangeType> = NewAttach<TNodeChange> | Reattach<TNodeChange>;
+
+export type Detach<TNodeChange = NodeChangeType> =
+	| Delete<TNodeChange>
+	| MoveOut<TNodeChange>
+	| ReturnFrom<TNodeChange>;
+
+export interface Modify<TNodeChange = NodeChangeType> {
+	type: "Modify";
+	changes: TNodeChange;
 }
 
 /**
- * A monotonically increasing positive integer assigned to an individual mark within the changeset.
- * MoveIds are scoped to a single changeset, so referring to MoveIds across changesets requires
- * qualifying them by change tag.
- *
- * The uniqueness of IDs is leveraged to uniquely identify the matching move-out for a move-in/return and vice-versa.
+ * A mark that spans one or more nodes in the input context of its changeset.
  */
-export type MoveId = ChangesetLocalId;
-
-export interface HasMoveId {
-	/**
-	 * The sequential ID assigned to a change within a transaction.
-	 */
-	id: MoveId;
-}
+export type InputSpanningMark<TNodeChange> =
+	| Skip
+	| Detach<TNodeChange>
+	| Modify<TNodeChange>
+	| SkipLikeReattach<TNodeChange>;
 
 /**
- * The contents of a node to be created
+ * A mark that spans one or more nodes in the output context of its changeset.
  */
-export type ProtoNode = JsonableTree;
+export type OutputSpanningMark<TNodeChange> =
+	| Skip
+	| NewAttach<TNodeChange>
+	| Modify<TNodeChange>
+	| Reattach<TNodeChange>;
 
-export type NodeCount = number;
-export type Skip = number;
-export enum Tiebreak {
-	Left,
-	Right,
-}
-export enum Effects {
-	All = "All",
-	Move = "Move",
-	Delete = "Delete",
-	None = "None",
-}
+export type Mark<TNodeChange = NodeChangeType> =
+	| InputSpanningMark<TNodeChange>
+	| OutputSpanningMark<TNodeChange>;
+
+export type MarkList<TNodeChange = NodeChangeType, TMark = Mark<TNodeChange>> = TMark[];
+
+export type Changeset<TNodeChange = NodeChangeType> = MarkList<TNodeChange>;
+
+export type ObjectMark<TNodeChange = NodeChangeType> = Exclude<Mark<TNodeChange>, Skip>;
+
+/**
+ * A mark that spans one or more cells.
+ * The spanned cells may be populated (e.g., "Delete") or not (e.g., "Revive").
+ */
+export type CellSpanningMark<TNodeChange> = Exclude<Mark<TNodeChange>, NewAttach<TNodeChange>>;
 
 export function isEmpty<T>(change: Changeset<T>): boolean {
 	return change.length === 0;


### PR DESCRIPTION
## Description

This reorders the formats used in sequence-field's persisted types so that they only reference previously defined types. This is necessary for the format's schema declaration to use `const` variables rather than hoisted functions on generic types, and should make review of adding that schema easier.

PR should contain no code changes, only moves.
