### PR TITLE
Remove code coverage and add failed tests logging

### DIFF
--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -139,7 +139,7 @@ jobs:
                 workingDir: ${{ parameters.buildDirectory }}
                 customCommand: 'run ${{ taskTestStep }}'
               condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
-        # Rename the failed tinylicious log
+        # Rename the tinylicious log file, only if tests failed
         - task: Bash@3
           displayName: Rename tinylicious log
           inputs: 

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -36,6 +36,9 @@ parameters:
   type: string
   default: client
 
+- name: stageName
+  type: string
+
 jobs:
   # Job - Build
   - job: build
@@ -136,6 +139,27 @@ jobs:
                 workingDir: ${{ parameters.buildDirectory }}
                 customCommand: 'run ${{ taskTestStep }}'
               condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+        # Rename the failed tinylicious log
+        - task: Bash@3
+          displayName: Rename tinylicious log
+          inputs: 
+            targetType: 'inline'
+            workingDirectory: ${{ parameters.buildDirectory }}
+            script: |
+              oldname=${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log
+              stageName=${{ parameters.stageName }}
+              newname=$(echo $oldname | sed 's/\.log$/'"_$stageName.log"/)
+              mv $oldname $newname
+          condition: and(failed(), contains('${{ taskTestStep }}', 'tinylicious'))
+        # Publish tinylicious log for troubleshooting
+        - task: PublishPipelineArtifact@1
+          displayName: Publish Artifact - Tinylicious Log
+          inputs:
+            targetPath: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious_${{ parameters.stageName }}.log'
+            artifactName: 'tinyliciousLog_${{ parameters.stageName }}'
+            publishLocation: 'pipeline'
+          condition: and(failed(), contains('${{ taskTestStep }}', 'tinylicious'))
+          continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
 
       # Test - Upload results
       - task: PublishTestResults@2

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -137,36 +137,6 @@ jobs:
                 customCommand: 'run ${{ taskTestStep }}'
               condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
 
-      # Test - Upload coverage results
-      # Some webpacked file using externals introduce file name with quotes in them
-      # and Istanbul's cobertura reporter doesn't escape them causing parse error when we publish
-      # A quick fix to patch the file with sed. (See https://github.com/bcoe/c8/issues/302)
-      - ${{ if eq(variables['testCoverage'], true) }}:
-        - task: Bash@3
-          displayName: 'Check for nyc/report directory'
-          inputs:
-            targetType: 'inline'
-            workingDirectory: ${{ parameters.buildDirectory }}
-            script: |
-              test -d nyc/report && echo '##vso[task.setvariable variable=ReportDirExists;]true' || echo 'No nyc/report directory'
-          condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
-        - task: Bash@3
-          displayName: Patch Coverage Results
-          inputs:
-            targetType: 'inline'
-            workingDirectory: ${{ parameters.buildDirectory }}/nyc/report
-            script: |
-              sed -e 's/\(filename=\".*[\\/]external .*\)"\(.*\)""/\1\&quot;\2\&quot;"/' cobertura-coverage.xml > cobertura-coverage-patched.xml
-          condition: and(succeededOrFailed(), eq(variables['ReportDirExists'], 'true'))
-        - task: PublishCodeCoverageResults@1
-          displayName: Publish Code Coverage
-          inputs:
-            codeCoverageTool: Cobertura
-            summaryFileLocation: ${{ parameters.buildDirectory }}/nyc/report/cobertura-coverage-patched.xml
-            reportDirectory: ${{ parameters.buildDirectory }}/nyc/report
-            failIfCoverageEmpty: true
-          condition: and(succeededOrFailed(), eq(variables['ReportDirExists'], 'true'))
-
       # Test - Upload results
       - task: PublishTestResults@2
         displayName: Publish Test Results
@@ -176,3 +146,8 @@ jobs:
           searchFolder: ${{ parameters.buildDirectory }}/nyc
           mergeTestResults: false
         condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+
+      # Log Test Failures
+      - template: include-log-test-failures.yml
+        parameters:
+          buildDirectory: ${{ parameters.buildDirectory }}

--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -168,3 +168,4 @@ stages:
           timeoutInMinutes: 360
           taskBuild : ${{ parameters.taskBuild }}
           taskTest: ${{ parameters.taskTest }}
+          stageName: ${{ stageName }}


### PR DESCRIPTION
## Description

[AB#4232](https://dev.azure.com/fluidframework/internal/_sprints/taskboard/Team%20Curtis/internal/CY23Q2/Team%20Curtis%20-%202023.04-B?workitem=4232) Make some enhancement for the Test Stability pipeline

1. Remove the code-coverage reporting, will save ~ 5 mins per iteration, and we have 100 iterations
2. Publish tinylicious logs (identifiable for the specific iteration), will be easier to troubleshoot when the tinylicious tests fail


Successful testing has been conducted on the [test branch](https://dev.azure.com/fluidframework/internal/_sprints/taskboard/Team%20Curtis/internal/CY23Q2/Team%20Curtis%20-%202023.04-B?workitem=4232), confirming that the implementation is functioning correctly.