### PR TITLE
ci: Use valid output variable names

### DIFF
--- a/.github/workflows/changeset-reporter.yml
+++ b/.github/workflows/changeset-reporter.yml
@@ -24,17 +24,17 @@ jobs:
 
       - name: Load status
         id: status
-        run: echo "changeset-status=$(cat changeset-status)" >> $GITHUB_OUTPUT
+        run: echo "status=$(cat changeset-status)" >> $GITHUB_OUTPUT
 
       - name: Required but missing
-        if: steps.status.outputs.changeset-status != '0' && contains(github.event.pull_request.labels.*.name, 'changeset-required')
+        if: steps.status.outputs.status != '0' && contains(github.event.pull_request.labels.*.name, 'changeset-required')
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset
           path: ./.github/workflows/data/changeset-missing.md
 
       - name: Required and present
-        if: steps.status.outputs.changeset-status == '0' && contains(github.event.pull_request.labels.*.name, 'changeset-required')
+        if: steps.status.outputs.status == '0' && contains(github.event.pull_request.labels.*.name, 'changeset-required')
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset
@@ -43,7 +43,7 @@ jobs:
             This PR requires a changeset and it has one! Good job!
 
       - name: Changeset not required
-        if: steps.status.outputs.changeset-status == '0' && !contains(github.event.pull_request.labels.*.name, 'changeset-required')
+        if: steps.status.outputs.status == '0' && !contains(github.event.pull_request.labels.*.name, 'changeset-required')
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset


### PR DESCRIPTION
Environment variables can't safely have dashes in their names, so the changeset-reporter workflow is not working correctly.