### PR TITLE
feat: Support JSON output in check:changeset

### DIFF
--- a/.github/workflows/changeset-reporter.yml
+++ b/.github/workflows/changeset-reporter.yml
@@ -22,7 +22,7 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
           name: changeset-metadata
 
-      - name: Load release metadata into env variable
+      - name: Load changeset metadata into env variable
         run: echo "CHANGESET=$(cat changeset-metadata.json)" >> $GITHUB_ENV
 
       - name: Required but missing

--- a/.github/workflows/changeset-reporter.yml
+++ b/.github/workflows/changeset-reporter.yml
@@ -20,21 +20,20 @@ jobs:
         with:
           workflow: pr-check-changeset.yml
           run_id: ${{ github.event.workflow_run.id }}
-          name: changeset-status
+          name: changeset-metadata
 
-      - name: Load status
-        id: status
-        run: echo "status=$(cat changeset-status)" >> $GITHUB_OUTPUT
+      - name: Load release metadata into env variable
+        run: echo "CHANGESET=$(cat changeset-metadata.json)" >> $GITHUB_ENV
 
       - name: Required but missing
-        if: steps.status.outputs.status != '0' && contains(github.event.pull_request.labels.*.name, 'changeset-required')
+        if: fromJson(env.CHANGESET).changesetFound == false && contains(github.event.pull_request.labels.*.name, 'changeset-required')
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset
           path: ./.github/workflows/data/changeset-missing.md
 
       - name: Required and present
-        if: steps.status.outputs.status == '0' && contains(github.event.pull_request.labels.*.name, 'changeset-required')
+        if: fromJson(env.CHANGESET).changesetFound == true && contains(github.event.pull_request.labels.*.name, 'changeset-required')
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset
@@ -43,7 +42,7 @@ jobs:
             This PR requires a changeset and it has one! Good job!
 
       - name: Changeset not required
-        if: steps.status.outputs.status == '0' && !contains(github.event.pull_request.labels.*.name, 'changeset-required')
+        if: fromJson(env.CHANGESET).changesetFound == true && !contains(github.event.pull_request.labels.*.name, 'changeset-required')
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset

--- a/.github/workflows/pr-check-changeset.yml
+++ b/.github/workflows/pr-check-changeset.yml
@@ -48,15 +48,14 @@ jobs:
       - id: changeset-status
         name: Changeset status
         run: |
-          set +e # don't exit on failure
-          pnpm exec flub check changeset --branch=${{ github.base_ref }}
-          echo "$?" > ./changeset-status
+          # JSON output is piped through jq to compact it to a single line
+          pnpm exec flub check changeset --branch=${{ github.base_ref }} --json | jq -c > changeset-metadata.json
 
       - name: Upload changeset status
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # ratchet:actions/upload-artifact@v3
         with:
-          name: changeset-status
-          path: ./changeset-status
+          name: changeset-metadata.json
+          path: ./changeset-metadata
           retention-days: 3
 
   # Any PR without the changeset-required label will be ignored.
@@ -68,12 +67,12 @@ jobs:
       - id: changeset-status
         name: Changeset disabled
         run: |
-          # Always output 0 to signal that changesets aren't needed
-          echo "0" > ./changeset-status
+          # Always output changesetFound=true to signal that changesets aren't needed
+          echo "{'branch': '${{ github.base_ref }}','changesetFound': true}" > ./changeset-metadata.json
 
       - name: Upload changeset status
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # ratchet:actions/upload-artifact@v3
         with:
-          name: changeset-status
-          path: ./changeset-status
+          name: changeset-metadata.json
+          path: ./changeset-metadata
           retention-days: 3

--- a/build-tools/packages/build-cli/docs/check.md
+++ b/build-tools/packages/build-cli/docs/check.md
@@ -51,11 +51,14 @@ Checks if a changeset was added when compared against a branch. This is used in 
 
 ```
 USAGE
-  $ flub check changeset -b <value> [-v]
+  $ flub check changeset -b <value> [-v] [--json]
 
 FLAGS
   -b, --branch=<value>  (required) The branch to compare against.
   -v, --verbose         Verbose logging.
+
+GLOBAL FLAGS
+  --json  Format output as json.
 
 EXAMPLES
   Check if a changeset was added when compared to the 'main' branch.

--- a/build-tools/packages/build-cli/src/commands/check/changeset.ts
+++ b/build-tools/packages/build-cli/src/commands/check/changeset.ts
@@ -4,12 +4,15 @@
  */
 import { Flags } from "@oclif/core";
 import chalk from "chalk";
+import { sortPackageJson as sortJson } from "sort-package-json";
 
 import { BaseCommand } from "../../base";
 import { Repository } from "../../lib";
 
 export default class CheckChangesetCommand extends BaseCommand<typeof CheckChangesetCommand> {
 	static summary = `Checks if a changeset was added when compared against a branch. This is used in CI to enforce that changesets are present for a PR.`;
+
+	static enableJsonFlag = true;
 
 	static flags = {
 		branch: Flags.string({
@@ -31,7 +34,11 @@ export default class CheckChangesetCommand extends BaseCommand<typeof CheckChang
 		},
 	];
 
-	public async run(): Promise<void> {
+	public async run(): Promise<{
+		changesetFound: boolean;
+		branch: string;
+		changesetPath?: string;
+	}> {
 		const context = await this.getContext();
 		const repo = new Repository({ baseDir: context.gitRepo.resolvedRoot });
 		const remote = await repo.getRemote(context.originRemotePartialUrl);
@@ -50,9 +57,24 @@ export default class CheckChangesetCommand extends BaseCommand<typeof CheckChang
 		if (changedChangesetFiles.length === 0) {
 			this.errorLog(`No changeset files were added when compared to ${branch}.`);
 			this.verbose(`Changed files: ${JSON.stringify(files, undefined, 2)}`);
+
+			// When we output JSON, we don't want to exit with a failure error code. Instead we return the failure as part of
+			// the JSON.
+			if (this.flags.json === true) {
+				return sortJson({
+					changesetFound: false,
+					branch,
+				});
+			}
 			this.exit(1);
 		}
 
-		this.log(chalk.green(`Found a changeset file: ${changedChangesetFiles}.`));
+		this.log(chalk.green(`Found a changeset file: ${changedChangesetFiles[0]}.`));
+
+		return sortJson({
+			changesetFound: true,
+			branch,
+			changesetPath: changedChangesetFiles[0],
+		});
 	}
 }


### PR DESCRIPTION
The changeset workflows continue to challenge me. The simple 0/1 output isn't working for reasons I cannot explain, so I have added JSON support to the check:changeset command. When the `--json` flag is passed, the exit code will not be 1 in the case of a missing changeset. Instead the JSON output includes a boolean value that should be checked.

I included the workflow changes in this PR so reviewers can see how these command changes will be consumed. They won't be merged with this PR - they'll be made separately (see #15472) after these changes are available in the client release group.