### PR TITLE
fix(fluid-build): Handle all workspace ranges when checking symlinks

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/symlinkUtils.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/symlinkUtils.ts
@@ -163,7 +163,7 @@ export async function symlinkPackage(
 		if (depBuildPackage) {
 			const sameMonoRepo = MonoRepo.isSame(pkg.monoRepo, depBuildPackage.monoRepo);
 			const satisfied =
-				version === "workspace:*" || semver.satisfies(depBuildPackage.version, version);
+				version.startsWith("workspace:") || semver.satisfies(depBuildPackage.version, version);
 			verbose(
 				`${pkg.nameColored}: Dependent ${depBuildPackage.nameColored} version ${
 					depBuildPackage.version

--- a/build-tools/packages/build-tools/src/fluidBuild/symlinkUtils.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/symlinkUtils.ts
@@ -163,7 +163,8 @@ export async function symlinkPackage(
 		if (depBuildPackage) {
 			const sameMonoRepo = MonoRepo.isSame(pkg.monoRepo, depBuildPackage.monoRepo);
 			const satisfied =
-				version.startsWith("workspace:") || semver.satisfies(depBuildPackage.version, version);
+				version.startsWith("workspace:") ||
+				semver.satisfies(depBuildPackage.version, version);
 			verbose(
 				`${pkg.nameColored}: Dependent ${depBuildPackage.nameColored} version ${
 					depBuildPackage.version


### PR DESCRIPTION
fluid-build was only considering `workspace:*` ranges instead of all workspace ranges. This change lets the package manager handle symlinks between packages in the same release group, leaving fluid-build to symlink cross-release group.