### PR TITLE
Remove terminal override for tree workspace

### DIFF
--- a/experimental/dds/tree2/.vscode/Tree.code-workspace
+++ b/experimental/dds/tree2/.vscode/Tree.code-workspace
@@ -9,7 +9,5 @@
 			"path": ".."
 		}
 	],
-	"settings": {
-		"terminal.integrated.cwd": "../../.."
-	}
+	"settings": {}
 }


### PR DESCRIPTION
## Description

For some cases (ex: Terminal menu-> new) vscode prompts me for which place I want to create a terminal when I make a new terminal in the workspace.

As is, if I pick tree2, it puts the terminal at the repo root, and if I pick fluid-framework it puts the terminal 3 directories above the repo root.

With this change it behaves as expected.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
