### PR TITLE
ci: Load JSON in changeset workflows

### DIFF
--- a/.github/workflows/changeset-reporter.yml
+++ b/.github/workflows/changeset-reporter.yml
@@ -20,21 +20,20 @@ jobs:
         with:
           workflow: pr-check-changeset.yml
           run_id: ${{ github.event.workflow_run.id }}
-          name: changeset-status
+          name: changeset-metadata
 
-      - name: Load status
-        id: status
-        run: echo "status=$(cat changeset-status)" >> $GITHUB_OUTPUT
+      - name: Load release metadata into env variable
+        run: echo "CHANGESET=$(cat changeset-metadata.json)" >> $GITHUB_ENV
 
       - name: Required but missing
-        if: steps.status.outputs.status != '0' && contains(github.event.pull_request.labels.*.name, 'changeset-required')
+        if: fromJson(env.CHANGESET).changesetFound == false && contains(github.event.pull_request.labels.*.name, 'changeset-required')
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset
           path: ./.github/workflows/data/changeset-missing.md
 
       - name: Required and present
-        if: steps.status.outputs.status == '0' && contains(github.event.pull_request.labels.*.name, 'changeset-required')
+        if: fromJson(env.CHANGESET).changesetFound == true && contains(github.event.pull_request.labels.*.name, 'changeset-required')
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset
@@ -43,7 +42,7 @@ jobs:
             This PR requires a changeset and it has one! Good job!
 
       - name: Changeset not required
-        if: steps.status.outputs.status == '0' && !contains(github.event.pull_request.labels.*.name, 'changeset-required')
+        if: fromJson(env.CHANGESET).changesetFound == true && !contains(github.event.pull_request.labels.*.name, 'changeset-required')
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset

--- a/.github/workflows/pr-check-changeset.yml
+++ b/.github/workflows/pr-check-changeset.yml
@@ -48,15 +48,14 @@ jobs:
       - id: changeset-status
         name: Changeset status
         run: |
-          set +e # don't exit on failure
-          pnpm exec flub check changeset --branch=${{ github.base_ref }}
-          echo "$?" > ./changeset-status
+          # JSON output is piped through jq to compact it to a single line
+          pnpm exec flub check changeset --branch=${{ github.base_ref }} --json | jq -c > changeset-metadata.json
 
       - name: Upload changeset status
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # ratchet:actions/upload-artifact@v3
         with:
-          name: changeset-status
-          path: ./changeset-status
+          name: changeset-metadata.json
+          path: ./changeset-metadata
           retention-days: 3
 
   # Any PR without the changeset-required label will be ignored.
@@ -68,12 +67,12 @@ jobs:
       - id: changeset-status
         name: Changeset disabled
         run: |
-          # Always output 0 to signal that changesets aren't needed
-          echo "0" > ./changeset-status
+          # Always output changesetFound=true to signal that changesets aren't needed
+          echo "{'branch': '${{ github.base_ref }}','changesetFound': true}" > ./changeset-metadata.json
 
       - name: Upload changeset status
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # ratchet:actions/upload-artifact@v3
         with:
-          name: changeset-status
-          path: ./changeset-status
+          name: changeset-metadata.json
+          path: ./changeset-metadata
           retention-days: 3


### PR DESCRIPTION
Depends on #15465.

This PR updates the changeset workflows to use the JSON output of `flub check changeset` instead of the exit code.