### PR TITLE
build: support workspace as dependency version

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -219,7 +219,10 @@ export class BuildGraph {
 				const child = this.buildPackages.get(name);
 				if (child) {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					if (semver.satisfies(child.pkg.version, version!)) {
+					const satisfied =
+						version!.startsWith("workspace:") ||
+						semver.satisfies(child.pkg.version, version!);
+					if (satisfied) {
 						if (depFilter(child.pkg)) {
 							verbose(
 								`Package dependency: ${node.pkg.nameColored} => ${child.pkg.nameColored}`,

--- a/build-tools/packages/build-tools/src/fluidBuild/symlinkUtils.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/symlinkUtils.ts
@@ -159,7 +159,7 @@ export async function symlinkPackage(
 	for (const { name: dep, version } of pkg.combinedDependencies) {
 		const depBuildPackage = buildPackages.get(dep);
 		// Check and fix link if it is a known package and version satisfy the version.
-		// TODO: check of extranous symlinks
+		// TODO: check of extraneous symlinks
 		if (depBuildPackage) {
 			const sameMonoRepo = MonoRepo.isSame(pkg.monoRepo, depBuildPackage.monoRepo);
 			const satisfied =


### PR DESCRIPTION
The repo switch to use "workspace:" as the monorepo dependency version.  Add `fluid-build` support for that.