### PR TITLE
Fix caching in afr driver

### DIFF
--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -128,10 +128,7 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 				},
 			);
 
-			const _id = await this.initializeFromSnapshot(
-				normalizedSnapshotContents,
-				latestSnapshotId,
-			);
+			const _id = await this.initializeFromSnapshot(normalizedSnapshotContents);
 			this.firstVersionsCall = false;
 			return [
 				{
@@ -317,12 +314,15 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 			},
 		);
 
+		// Also add the result into the cache.
+		await this.snapshotTreeCache
+			.put(this.getCacheKey(versionId), normalizedWholeSummary)
+			.catch(() => undefined);
 		return normalizedWholeSummary;
 	}
 
 	private async initializeFromSnapshot(
 		normalizedWholeSummary: INormalizedWholeSummary,
-		versionId: string | null,
 	): Promise<string> {
 		const snapshotId = normalizedWholeSummary.id;
 		assert(snapshotId !== undefined, 0x275 /* "Root tree should contain the id" */);
@@ -330,15 +330,6 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 			this.snapshotTreeCache.put(this.getCacheKey(snapshotId), normalizedWholeSummary),
 			this.initBlobCache(normalizedWholeSummary.blobs),
 		];
-		if (snapshotId !== versionId && versionId !== null) {
-			// versionId could be "latest". When summarizer checks cache for "latest", we want it to be available.
-			// TODO: For in-memory cache, <latest,snapshotTree> will be a shared pointer with <snapshotId,snapshotTree>,
-			// However, for something like Redis, this will cache the same value twice. Alternatively, could we simply
-			// cache with versionId?
-			cachePs.push(
-				this.snapshotTreeCache.put(this.getCacheKey(versionId), normalizedWholeSummary),
-			);
-		}
 
 		await Promise.all(cachePs);
 


### PR DESCRIPTION
## Description

Fixing: https://dev.azure.com/fluidframework/internal/_workitems/edit/4209

1.) Update the cache on network call response in storage manager.
2.) No need to cache latest in initializeSnapshot with latest id, as if it came from cache, then no need to update again and we are doing so on network call response.
