### PR TITLE
Add restartOnCheckpointFailure flag for scribe, deli, scriptorium

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -127,6 +127,7 @@ data:
             "groupId": "{{ template "deli.fullname" . }}",
             "checkpointBatchSize": 10,
             "checkpointTimeIntervalMsec": 1000,
+            "restartOnCheckpointFailure": {{ .Values.deli.restartOnCheckpointFailure }}
         },
         "scribe": {
             "kafkaClientId": "{{ template "scribe.fullname" . }}",
@@ -136,7 +137,8 @@ data:
                 "maxTime": {{ .Values.scribe.checkpointHeuristics.maxTime }},
                 "maxMessages": {{ .Values.scribe.checkpointHeuristics.maxMessages }}
             },
-            "getDeltasViaAlfred": {{ .Values.scribe.getDeltasViaAlfred }}
+            "getDeltasViaAlfred": {{ .Values.scribe.getDeltasViaAlfred }},
+            "restartOnCheckpointFailure": {{ .Values.scribe.restartOnCheckpointFailure }}
         },
         "system": {
             "httpServer": {
@@ -177,7 +179,8 @@ data:
             "kafkaClientId": "{{ template "scriptorium.fullname" . }}",
             "groupId": "{{ template "scriptorium.fullname" . }}",
             "checkpointBatchSize": 1,
-            "checkpointTimeIntervalMsec": 1000
+            "checkpointTimeIntervalMsec": 1000,
+            "restartOnCheckpointFailure": {{ .Values.scriptorium.restartOnCheckpointFailure }}
         },
         "paparazzi": {
             "queue": "paparazziQueue"

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -62,10 +62,12 @@ deli:
         idleTime: 10000
         maxTime: 60000
         maxMessages: 500
+    restartOnCheckpointFailure: true
 
 scriptorium:
     name: scriptorium
     replicas: 8
+    restartOnCheckpointFailure: true
 
 scribe:
     name: scribe
@@ -76,6 +78,7 @@ scribe:
         idleTime: 10000
         maxTime: 60000
         maxMessages: 500
+    restartOnCheckpointFailure: true
         
 riddler:
     name: riddler

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -57,7 +57,7 @@ export class DocumentContextManager extends EventEmitter {
 			() => this.tail,
 		);
 		this.contexts.add(context);
-		context.addListener("checkpoint", () => this.updateCheckpoint());
+		context.addListener("checkpoint", () => this.updateCheckpoint(context.restartOnCheckpointFailureFlag));
 		context.addListener("error", (error, errorData: IContextErrorData) =>
 			this.emit("error", error, errorData),
 		);
@@ -108,7 +108,7 @@ export class DocumentContextManager extends EventEmitter {
 		this.removeAllListeners();
 	}
 
-	private updateCheckpoint() {
+	private updateCheckpoint(restartOnCheckpointFailure?: boolean) {
 		if (this.closed) {
 			return;
 		}
@@ -128,7 +128,7 @@ export class DocumentContextManager extends EventEmitter {
 
 		// Checkpoint once the offset has changed
 		if (queuedMessage.offset !== this.lastCheckpoint.offset) {
-			this.partitionContext.checkpoint(queuedMessage);
+			this.partitionContext.checkpoint(queuedMessage, restartOnCheckpointFailure);
 			this.lastCheckpoint = queuedMessage;
 		}
 	}

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -57,7 +57,9 @@ export class DocumentContextManager extends EventEmitter {
 			() => this.tail,
 		);
 		this.contexts.add(context);
-		context.addListener("checkpoint", () => this.updateCheckpoint(context.restartOnCheckpointFailureFlag));
+		context.addListener("checkpoint", (contextObject, restartOnCheckpointFailure?: boolean) =>
+			this.updateCheckpoint(restartOnCheckpointFailure),
+		);
 		context.addListener("error", (error, errorData: IContextErrorData) =>
 			this.emit("error", error, errorData),
 		);

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -57,7 +57,7 @@ export class DocumentContextManager extends EventEmitter {
 			() => this.tail,
 		);
 		this.contexts.add(context);
-		context.addListener("checkpoint", (contextObject, restartOnCheckpointFailure?: boolean) =>
+		context.addListener("checkpoint", (restartOnCheckpointFailure?: boolean) =>
 			this.updateCheckpoint(restartOnCheckpointFailure),
 		);
 		context.addListener("error", (error, errorData: IContextErrorData) =>

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -87,7 +87,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 
 		// Update the tail and broadcast the checkpoint
 		this.tailInternal = message;
-		this.emit("checkpoint", this, restartOnCheckpointFailure);
+		this.emit("checkpoint", restartOnCheckpointFailure);
 	}
 
 	public error(error: any, errorData: IContextErrorData) {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -23,8 +23,6 @@ export class DocumentContext extends EventEmitter implements IContext {
 	private closed = false;
 	private contextError = undefined;
 
-	private restartOnCheckpointFailure: boolean = true;
-
 	constructor(
 		private readonly routingKey: IRoutingKey,
 		head: IQueuedMessage,
@@ -45,10 +43,6 @@ export class DocumentContext extends EventEmitter implements IContext {
 
 	public get tail(): IQueuedMessage {
 		return this.tailInternal;
-	}
-
-	public get restartOnCheckpointFailureFlag(): boolean {
-		return this.restartOnCheckpointFailure;
 	}
 
 	/**
@@ -93,8 +87,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 
 		// Update the tail and broadcast the checkpoint
 		this.tailInternal = message;
-		this.restartOnCheckpointFailure = restartOnCheckpointFailure ?? this.restartOnCheckpointFailure;
-		this.emit("checkpoint", this);
+		this.emit("checkpoint", this, restartOnCheckpointFailure);
 	}
 
 	public error(error: any, errorData: IContextErrorData) {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -23,6 +23,8 @@ export class DocumentContext extends EventEmitter implements IContext {
 	private closed = false;
 	private contextError = undefined;
 
+	private restartOnCheckpointFailure: boolean = true;
+
 	constructor(
 		private readonly routingKey: IRoutingKey,
 		head: IQueuedMessage,
@@ -43,6 +45,10 @@ export class DocumentContext extends EventEmitter implements IContext {
 
 	public get tail(): IQueuedMessage {
 		return this.tailInternal;
+	}
+
+	public get restartOnCheckpointFailureFlag(): boolean {
+		return this.restartOnCheckpointFailure;
 	}
 
 	/**
@@ -71,7 +77,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 		this.headInternal = head;
 	}
 
-	public checkpoint(message: IQueuedMessage) {
+	public checkpoint(message: IQueuedMessage, restartOnCheckpointFailure?: boolean) {
 		if (this.closed) {
 			return;
 		}
@@ -87,6 +93,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 
 		// Update the tail and broadcast the checkpoint
 		this.tailInternal = message;
+		this.restartOnCheckpointFailure = restartOnCheckpointFailure ?? this.restartOnCheckpointFailure;
 		this.emit("checkpoint", this);
 	}
 

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
@@ -25,7 +25,7 @@ export class Context extends EventEmitter implements IContext {
 	/**
 	 * Updates the checkpoint for the partition
 	 */
-	public checkpoint(queuedMessage: IQueuedMessage) {
+	public checkpoint(queuedMessage: IQueuedMessage, restartFlag?: boolean) {
 		if (this.closed) {
 			return;
 		}
@@ -38,7 +38,7 @@ export class Context extends EventEmitter implements IContext {
 
 			// Close context on error. Once the checkpointManager enters an error state it will stay there.
 			// We will look to restart on checkpointing given it likely indicates a Kafka connection issue.
-			this.error(error, { restart: true });
+			this.error(error, { restart: restartFlag ?? true });
 		});
 	}
 

--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -26,7 +26,7 @@ export class CheckpointContext {
 	 * Checkpoints to the database & kafka
 	 * Note: This is an async method, but you should not await this
 	 */
-	public async checkpoint(checkpoint: ICheckpointParams) {
+	public async checkpoint(checkpoint: ICheckpointParams, restartOnCheckpointFailure?: boolean) {
 		// Exit early if already closed
 		if (this.closed) {
 			return;
@@ -72,7 +72,7 @@ export class CheckpointContext {
 					kafkaCheckpointMessage.offset > this.lastKafkaCheckpointOffset)
 			) {
 				this.lastKafkaCheckpointOffset = kafkaCheckpointMessage.offset;
-				this.context.checkpoint(kafkaCheckpointMessage);
+				this.context.checkpoint(kafkaCheckpointMessage, restartOnCheckpointFailure);
 			}
 		} catch (ex) {
 			// TODO flag context as error / use this.context.error() instead?

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -275,6 +275,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 		private sessionMetric: Lumber<LumberEventName.SessionResult> | undefined,
 		private sessionStartMetric: Lumber<LumberEventName.StartSessionResult> | undefined,
 		private readonly checkpointService: ICheckpointService,
+		private readonly restartOnCheckpointFailure: boolean,
 		private readonly sequencedSignalClients: Map<string, ISequencedSignalClient> = new Map(),
 	) {
 		super();
@@ -415,7 +416,10 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 			this.updateCheckpointMessages(rawMessage);
 
 			if (this.checkpointInfo.currentKafkaCheckpointMessage) {
-				this.context.checkpoint(this.checkpointInfo.currentKafkaCheckpointMessage);
+				this.context.checkpoint(
+					this.checkpointInfo.currentKafkaCheckpointMessage,
+					this.restartOnCheckpointFailure,
+				);
 			}
 
 			return undefined;
@@ -1876,7 +1880,10 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 				if (reason === CheckpointReason.ClearCache) {
 					checkpointParams.clear = true;
 				}
-				void this.checkpointContext.checkpoint(checkpointParams);
+				void this.checkpointContext.checkpoint(
+					checkpointParams,
+					this.restartOnCheckpointFailure,
+				);
 				const checkpointReason = CheckpointReason[checkpointParams.reason];
 				const checkpointResult = `Writing checkpoint. Reason: ${checkpointReason}`;
 				const lumberjackProperties = {

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -63,6 +63,7 @@ export class DeliLambdaFactory
 		private readonly signalProducer: IProducer | undefined,
 		private readonly reverseProducer: IProducer,
 		private readonly serviceConfiguration: IServiceConfiguration,
+		private readonly restartOnCheckpointFailure: boolean,
 	) {
 		super();
 	}
@@ -213,6 +214,7 @@ export class DeliLambdaFactory
 			sessionMetric,
 			sessionStartMetric,
 			this.checkpointService,
+			this.restartOnCheckpointFailure,
 		);
 
 		deliLambda.on("close", (closeType) => {

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -104,6 +104,7 @@ export class ScribeLambda implements IPartitionLambda {
 		messages: ISequencedDocumentMessage[],
 		private scribeSessionMetric: Lumber<LumberEventName.ScribeSessionResult> | undefined,
 		private readonly transientTenants: Set<string>,
+		private readonly restartOnCheckpointFailure: boolean,
 	) {
 		this.lastOffset = scribe.logOffset;
 		this.setStateFromCheckpoint(scribe);
@@ -115,7 +116,7 @@ export class ScribeLambda implements IPartitionLambda {
 		// we had already checkpointed at a given offset.
 		if (message.offset <= this.lastOffset) {
 			this.updateCheckpointMessages(message);
-			this.context.checkpoint(message);
+			this.context.checkpoint(message, this.restartOnCheckpointFailure);
 			return;
 		}
 
@@ -551,7 +552,7 @@ export class ScribeLambda implements IPartitionLambda {
 		this.pendingP.then(
 			() => {
 				this.pendingP = undefined;
-				this.context.checkpoint(queuedMessage);
+				this.context.checkpoint(queuedMessage, this.restartOnCheckpointFailure);
 
 				const pendingScribe = this.pendingCheckpointScribe;
 				const pendingOffset = this.pendingCheckpointOffset;

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -78,6 +78,7 @@ export class ScribeLambdaFactory
 		private readonly getDeltasViaAlfred: boolean,
 		private readonly transientTenants: string[],
 		private readonly checkpointService: ICheckpointService,
+		private readonly restartOnCheckpointFailure: boolean,
 	) {
 		super();
 	}
@@ -273,6 +274,7 @@ export class ScribeLambdaFactory
 			opsSinceLastSummary,
 			scribeSessionMetric,
 			new Set(this.transientTenants),
+			this.restartOnCheckpointFailure,
 		);
 
 		await this.sendLambdaStartResult(tenantId, documentId, {

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -40,6 +40,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 	private readonly telemetryEnabled: boolean;
 	private pendingMetric: Lumber<LumberEventName.ScriptoriumProcessBatch> | undefined;
 	private readonly maxDbBatchSize: number;
+	private readonly restartOnCheckpointFailure: boolean;
 
 	constructor(
 		private readonly opCollection: ICollection<any>,
@@ -49,6 +50,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 		this.clientFacadeRetryEnabled = isRetryEnabled(this.opCollection);
 		this.telemetryEnabled = this.providerConfig?.enableTelemetry;
 		this.maxDbBatchSize = this.providerConfig?.maxDbBatchSize ?? 1000;
+		this.restartOnCheckpointFailure = this.providerConfig?.restartOnCheckpointFailure;
 	}
 
 	public handler(message: IQueuedMessage) {
@@ -172,7 +174,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 				// checkpoint batch offset
 				try {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					this.context.checkpoint(batchOffset!);
+					this.context.checkpoint(batchOffset!, this.restartOnCheckpointFailure);
 					status = ScriptoriumStatus.CheckpointComplete;
 					metric?.setProperty("timestampCheckpointComplete", new Date().toISOString());
 				} catch (error) {

--- a/server/routerlicious/packages/lambdas/src/test/deli/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/lambda.spec.ts
@@ -166,6 +166,7 @@ describe("Routerlicious", () => {
 					undefined,
 					testReverseProducer,
 					DefaultServiceConfiguration,
+					true,
 				);
 				lambda = await factory.create(
 					{ documentId: testId, tenantId: testTenantId },
@@ -191,6 +192,7 @@ describe("Routerlicious", () => {
 							enableWriteClientSignals: true,
 						},
 					},
+					true,
 				);
 				lambdaWithSignals = await factoryWithSignals.create(
 					{ documentId: testId, tenantId: testTenantId },
@@ -213,6 +215,7 @@ describe("Routerlicious", () => {
 							maintainBatches: true,
 						},
 					},
+					true,
 				);
 				lambdaWithBatching = await factoryWithBatching.create(
 					{ documentId: testId, tenantId: testTenantId },

--- a/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
@@ -139,7 +139,7 @@ describe("Routerlicious", () => {
 					false,
 					[],
 					testCheckpointService,
-					true
+					true,
 				);
 
 				testContext = new TestContext();

--- a/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
@@ -139,6 +139,7 @@ describe("Routerlicious", () => {
 					false,
 					[],
 					testCheckpointService,
+					true
 				);
 
 				testContext = new TestContext();

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -390,6 +390,7 @@ export class LocalOrderer implements IOrderer {
 			scribeMessages.map((message) => message.operation),
 			undefined,
 			new Set<string>(),
+			true,
 		);
 	}
 

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -290,6 +290,7 @@ export class LocalOrderer implements IOrderer {
 					undefined,
 					undefined,
 					checkpointService,
+					true,
 				);
 			},
 		);

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -124,7 +124,8 @@
 			"idleTime": 10000,
 			"maxTime": 60000,
 			"maxMessages": 500
-		}
+		},
+		"restartOnCheckpointFailure": true
 	},
 	"scribe": {
 		"kafkaClientId": "scribe",
@@ -134,7 +135,8 @@
 			"maxTime": 60000,
 			"maxMessages": 500
 		},
-		"getDeltasViaAlfred": true
+		"getDeltasViaAlfred": true,
+		"restartOnCheckpointFailure": true
 	},
 	"system": {
 		"httpServer": {
@@ -189,7 +191,8 @@
 		"checkpointBatchSize": 1,
 		"checkpointTimeIntervalMsec": 1000,
 		"enableTelemetry": true,
-		"maxDbBatchSize": 1000
+		"maxDbBatchSize": 1000,
+		"restartOnCheckpointFailure": true
 	},
 	"copier": {
 		"topic": "rawdeltas",

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -134,8 +134,7 @@
 			"maxTime": 60000,
 			"maxMessages": 500
 		},
-		"getDeltasViaAlfred": true,
-		"restartOnCheckpointFailure": false
+		"getDeltasViaAlfred": true
 	},
 	"system": {
 		"httpServer": {

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -134,7 +134,8 @@
 			"maxTime": 60000,
 			"maxMessages": 500
 		},
-		"getDeltasViaAlfred": true
+		"getDeltasViaAlfred": true,
+		"restartOnCheckpointFailure": false
 	},
 	"system": {
 		"httpServer": {

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -40,6 +40,9 @@ export async function deliCreate(
 
 	const localCheckpointEnabled = config.get("checkpoints:localCheckpointEnabled");
 
+	const restartOnCheckpointFailure =
+		(config.get("deli:restartOnCheckpointFailure") as boolean) ?? true;
+
 	// Generate tenant manager which abstracts access to the underlying storage provider
 	const authEndpoint = config.get("auth:endpoint");
 	const internalHistorianUrl = config.get("worker:internalBlobStorageUrl");
@@ -159,6 +162,7 @@ export async function deliCreate(
 		undefined,
 		reverseProducer,
 		serviceConfiguration,
+		restartOnCheckpointFailure,
 	);
 }
 

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -53,6 +53,7 @@ export async function scribeCreate(
 	const getDeltasViaAlfred = config.get("scribe:getDeltasViaAlfred") as boolean;
 	const transientTenants = config.get("shared:transientTenants") as string[];
 	const localCheckpointEnabled = config.get("checkpoints:localCheckpointEnabled") as boolean;
+	const restartOnCheckpointFailure = (config.get("scribe:restartOnCheckpointFailure") as boolean) ?? true;
 
 	// Generate tenant manager which abstracts access to the underlying storage provider
 	const authEndpoint = config.get("auth:endpoint");
@@ -153,6 +154,7 @@ export async function scribeCreate(
 		getDeltasViaAlfred,
 		transientTenants,
 		checkpointService,
+		restartOnCheckpointFailure,
 	);
 }
 

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -53,7 +53,8 @@ export async function scribeCreate(
 	const getDeltasViaAlfred = config.get("scribe:getDeltasViaAlfred") as boolean;
 	const transientTenants = config.get("shared:transientTenants") as string[];
 	const localCheckpointEnabled = config.get("checkpoints:localCheckpointEnabled") as boolean;
-	const restartOnCheckpointFailure = (config.get("scribe:restartOnCheckpointFailure") as boolean) ?? true;
+	const restartOnCheckpointFailure =
+		(config.get("scribe:restartOnCheckpointFailure") as boolean) ?? true;
 
 	// Generate tenant manager which abstracts access to the underlying storage provider
 	const authEndpoint = config.get("auth:endpoint");

--- a/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
@@ -40,6 +40,8 @@ export async function create(
 
 	const enableTelemetry = (config.get("scriptorium:enableTelemetry") as boolean) ?? false;
 	const maxDbBatchSize = config.get("scriptorium:maxDbBatchSize") as number;
+	const restartOnCheckpointFailure =
+		(config.get("scriptorium:restartOnCheckpointFailure") as boolean) ?? true;
 
 	// Database connection for global db if enabled
 	const factory = await services.getDbFactory(config);
@@ -118,5 +120,6 @@ export async function create(
 	return new ScriptoriumLambdaFactory(operationsDbManager, opCollection, {
 		enableTelemetry,
 		maxDbBatchSize,
+		restartOnCheckpointFailure,
 	});
 }

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -58,7 +58,7 @@ export interface IContext {
 	/**
 	 * Updates the checkpoint
 	 */
-	checkpoint(queuedMessage: IQueuedMessage): void;
+	checkpoint(queuedMessage: IQueuedMessage, restartFlag?: boolean): void;
 
 	/**
 	 * Closes the context with an error.


### PR DESCRIPTION
Add restartOnCheckpointFailure flag for scribe, deli, scriptorium

## Description

Services restart every time there is an exception in kafka checkpoint. This PR allows to configure if it should restart or not on such exceptions.