### PR TITLE
Update stress test closing summarizer feature flags that were missed

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -28,19 +28,19 @@
 				"odsp": {
 					"configurations": {
 						"Fluid.Container.summarizeProtocolTree2": [true, false],
-						"Fluid.ContainerRuntime.Test.SummarizationRecoveryMethod": ["restart", "default"]
+						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod": ["restart", "default"]
 					}
 				},
 				"odsp-odsp-df": {
 					"configurations": {
 						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
 						"Fluid.Container.summarizeProtocolTree2": [true, false],
-						"Fluid.ContainerRuntime.Test.SummarizationRecoveryMethod": ["restart", "default"]
+						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod": ["restart", "default"]
 					}
 				},
 				"tinylicious": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.SummarizationRecoveryMethod": ["restart", "default"]
+						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod": ["restart", "default"]
 					}
 				}
 			},
@@ -70,7 +70,7 @@
 			"optionOverrides": {
 				"routerlicious": {
 					"configurations": {
-						"Fluid.ContainerRuntime.Test.SummarizationRecoveryMethod": ["restart", "default"]
+						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod": ["restart", "default"]
 					}
 				}
 			}
@@ -100,7 +100,7 @@
 				"odsp": {
 					"configurations": {
 						"Fluid.Container.summarizeProtocolTree2": [true, false],
-						"Fluid.ContainerRuntime.Test.SummarizationRecoveryMethod": ["restart", "default"]
+						"Fluid.ContainerRuntime.Test.SummaryStateUpdateMethod": ["restart", "default"]
 					}
 				}
 			}


### PR DESCRIPTION
Update the stress test as the summary state update flag was renamed.

This PR updated https://github.com/microsoft/FluidFramework/pull/15140/files the feature flag for closing the summarizer on refresh, but did not update the stress tests accordingly.