### PR TITLE
Update rebaseBranch return type

### DIFF
--- a/experimental/dds/tree2/src/core/rebase/utils.ts
+++ b/experimental/dds/tree2/src/core/rebase/utils.ts
@@ -9,7 +9,7 @@ import { GraphCommit, mintRevisionTag, mintCommit } from "./types";
 
 /**
  * Contains information about how the commit graph changed as the result of rebasing a source branch onto another target branch.
- * @example
+ * @remarks
  * ```text
  * Consider the commit graph below containing two branches, X and Y, with head commits C and E, respectively.
  * Branch Y branches off of Branch X at their common ancestor commit A, i.e. "Y is based off of X at commit A".
@@ -24,7 +24,7 @@ import { GraphCommit, mintRevisionTag, mintCommit } from "./types";
  *
  * Commits D' and E' are the rebased versions of commits D and E, respectively. This results in:
  * deletedSourceCommits: [D, E],
- * rebasedTargetCommits: [B, C],
+ * targetCommits: [B, C],
  * rebasedSourceCommits: [D', E']
  * ```
  */
@@ -38,7 +38,7 @@ export interface RebasedCommits<TChange> {
 	 * All commits on the target branch that the source branch's commits were rebased over. These are now the direct
 	 * ancestors of {@link rebasedSourceCommits}.
 	 */
-	rebasedTargetCommits: GraphCommit<TChange>[];
+	targetCommits: GraphCommit<TChange>[];
 	/**
 	 * All commits on the new source branch that are rebases of commits on the original source branch. These are the rebased versions
 	 * of {@link deletedSourceCommits}.
@@ -157,7 +157,7 @@ export function rebaseBranch<TChange>(
 		return [
 			sourceHead,
 			undefined,
-			{ deletedSourceCommits: [], rebasedTargetCommits: [], rebasedSourceCommits: [] },
+			{ deletedSourceCommits: [], targetCommits: [], rebasedSourceCommits: [] },
 		];
 	}
 
@@ -181,12 +181,12 @@ export function rebaseBranch<TChange>(
 	/** The commit on the target branch that the new source branch branches off of (i.e. the new common ancestor) */
 	const newBase = targetPath[newBaseIndex];
 	// Figure out how much of the trunk to start rebasing over.
-	const rebasedTargetCommits = targetPath.slice(0, newBaseIndex + 1);
+	const targetCommits = targetPath.slice(0, newBaseIndex + 1);
 	const deletedSourceCommits = [...sourcePath];
 
 	// If the source and target rebase path begin with a range that has all the same revisions, remove it; it is
 	// equivalent on both branches and doesn't need to be rebased.
-	const targetRebasePath = [...rebasedTargetCommits];
+	const targetRebasePath = [...targetCommits];
 	const minLength = Math.min(sourcePath.length, targetRebasePath.length);
 	for (let i = 0; i < minLength; i++) {
 		if (sourcePath[0].revision === targetRebasePath[0].revision) {
@@ -212,7 +212,7 @@ export function rebaseBranch<TChange>(
 			undefined,
 			{
 				deletedSourceCommits,
-				rebasedTargetCommits,
+				targetCommits,
 				rebasedSourceCommits,
 			},
 		];
@@ -247,7 +247,7 @@ export function rebaseBranch<TChange>(
 		changeRebaser.compose([...inverses, ...targetRebasePath]),
 		{
 			deletedSourceCommits,
-			rebasedTargetCommits,
+			targetCommits,
 			rebasedSourceCommits,
 		},
 	];

--- a/experimental/dds/tree2/src/core/rebase/utils.ts
+++ b/experimental/dds/tree2/src/core/rebase/utils.ts
@@ -9,22 +9,41 @@ import { GraphCommit, mintRevisionTag, mintCommit } from "./types";
 
 /**
  * Contains information about how the commit graph changed as the result of rebasing a source branch onto another target branch.
+ * @example
+ * ```text
+ * Consider the commit graph below containing two branches, X and Y, with head commits C and E, respectively.
+ * Branch Y branches off of Branch X at their common ancestor commit A, i.e. "Y is based off of X at commit A".
+ *
+ *   A ─ B ─ C ← Branch X
+ *   └─ D ─ E ← Branch Y
+ *
+ * Branch Y is then rebased onto Branch X. This results in the following commit graph:
+ *
+ *   A ─ B ─ C ← Branch X
+ *           └─ D'─ E'← Branch Y
+ *
+ * Commits D' and E' are the rebased versions of commits D and E, respectively. This results in:
+ * deletedSourceCommits: [D, E],
+ * rebasedTargetCommits: [B, C],
+ * rebasedSourceCommits: [D', E']
+ * ```
  */
 export interface RebasedCommits<TChange> {
 	/**
-	 * The new common ancestor of the two branches, i.e. the commit where the rebased source branch now branches from the target branch.
-	 * This is not always the same as the target commit of a rebase operation; sometimes the rebase will rebase past the target commit
-	 * (see remarks in {@link rebaseBranch}).
-	 */
-	newBase: GraphCommit<TChange>;
-	/**
-	 * All commits that belonged to the source branch before the rebase, but no longer do after the rebase
+	 * The commits on the original source branch that were rebased. These are no longer referenced by the source branch and have
+	 * been replaced with new versions on the new source branch, see {@link rebasedSourceCommits}.
 	 */
 	deletedSourceCommits: GraphCommit<TChange>[];
 	/**
-	 * All commits which were not part of the source branch before the rebase, but are after the rebase
+	 * All commits on the target branch that the source branch's commits were rebased over. These are now the direct
+	 * ancestors of {@link rebasedSourceCommits}.
 	 */
-	newSourceCommits: GraphCommit<TChange>[];
+	rebasedTargetCommits: GraphCommit<TChange>[];
+	/**
+	 * All commits on the new source branch that are rebases of commits on the original source branch. These are the rebased versions
+	 * of {@link deletedSourceCommits}.
+	 */
+	rebasedSourceCommits: GraphCommit<TChange>[];
 }
 
 /**
@@ -61,7 +80,7 @@ export function rebaseBranch<TChange>(
 ): [
 	newSourceHead: GraphCommit<TChange>,
 	sourceChange: TChange | undefined,
-	commits: Omit<RebasedCommits<TChange>, "newBase">,
+	commits: RebasedCommits<TChange>,
 ];
 
 /**
@@ -138,7 +157,7 @@ export function rebaseBranch<TChange>(
 		return [
 			sourceHead,
 			undefined,
-			{ newBase: ancestor, deletedSourceCommits: [], newSourceCommits: [] },
+			{ deletedSourceCommits: [], rebasedTargetCommits: [], rebasedSourceCommits: [] },
 		];
 	}
 
@@ -162,12 +181,12 @@ export function rebaseBranch<TChange>(
 	/** The commit on the target branch that the new source branch branches off of (i.e. the new common ancestor) */
 	const newBase = targetPath[newBaseIndex];
 	// Figure out how much of the trunk to start rebasing over.
-	const targetRebasePath = targetPath.slice(0, newBaseIndex + 1);
+	const rebasedTargetCommits = targetPath.slice(0, newBaseIndex + 1);
 	const deletedSourceCommits = [...sourcePath];
-	const newSourceCommits = [...targetRebasePath];
 
 	// If the source and target rebase path begin with a range that has all the same revisions, remove it; it is
 	// equivalent on both branches and doesn't need to be rebased.
+	const targetRebasePath = [...rebasedTargetCommits];
 	const minLength = Math.min(sourcePath.length, targetRebasePath.length);
 	for (let i = 0; i < minLength; i++) {
 		if (sourcePath[0].revision === targetRebasePath[0].revision) {
@@ -176,23 +195,25 @@ export function rebaseBranch<TChange>(
 		}
 	}
 
+	const rebasedSourceCommits: GraphCommit<TChange>[] = [];
+
 	// If all commits that are about to be rebased over on the target branch already comprise the start of the source branch,
 	// are in the same order, and have no other commits interleaving them, then no rebasing needs to occur. Those commits can
 	// simply be removed from the source branch, and the remaining commits on the source branch are reparented off of the new
 	// base commit.
 	if (targetRebasePath.length === 0) {
 		for (const c of sourcePath) {
-			newSourceCommits.push(
-				mintCommit(newSourceCommits[newSourceCommits.length - 1] ?? newBase, c),
+			rebasedSourceCommits.push(
+				mintCommit(rebasedSourceCommits[rebasedSourceCommits.length - 1] ?? newBase, c),
 			);
 		}
 		return [
-			newSourceCommits[newSourceCommits.length - 1],
+			rebasedSourceCommits[rebasedSourceCommits.length - 1] ?? newBase,
 			undefined,
 			{
-				newBase,
 				deletedSourceCommits,
-				newSourceCommits,
+				rebasedTargetCommits,
+				rebasedSourceCommits,
 			},
 		];
 	}
@@ -213,7 +234,7 @@ export function rebaseBranch<TChange>(
 				change,
 				parent: newHead,
 			};
-			newSourceCommits.push(newHead);
+			rebasedSourceCommits.push(newHead);
 			targetRebasePath.push({ ...c, change });
 		}
 		inverses.unshift(
@@ -225,9 +246,9 @@ export function rebaseBranch<TChange>(
 		newHead,
 		changeRebaser.compose([...inverses, ...targetRebasePath]),
 		{
-			newBase,
 			deletedSourceCommits,
-			newSourceCommits,
+			rebasedTargetCommits,
+			rebasedSourceCommits,
 		},
 	];
 }

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -290,11 +290,8 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const rebaseResult = this.rebaseBranch(this.head, branch);
 		if (rebaseResult !== undefined) {
 			// The net change to this branch is provided by the `rebaseBranch` API
-			const [
-				newHead,
-				change,
-				{ deletedSourceCommits, rebasedTargetCommits, rebasedSourceCommits },
-			] = rebaseResult;
+			const [newHead, change, { deletedSourceCommits, targetCommits, rebasedSourceCommits }] =
+				rebaseResult;
 
 			this.undoRedoManager.updateAfterRebase(newHead, undoRedoManager);
 
@@ -303,7 +300,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 				type: "rebase",
 				change,
 				removedCommits: deletedSourceCommits,
-				newCommits: rebasedTargetCommits.concat(rebasedSourceCommits),
+				newCommits: targetCommits.concat(rebasedSourceCommits),
 			});
 		}
 	}
@@ -323,7 +320,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const rebaseResult = this.rebaseBranch(branch.head, this.head);
 		if (rebaseResult !== undefined) {
 			// Compute the net change to this branch
-			const [newHead, _, { rebasedTargetCommits, rebasedSourceCommits }] = rebaseResult;
+			const [newHead, _, { targetCommits, rebasedSourceCommits }] = rebaseResult;
 
 			this.undoRedoManager.updateAfterMerge(newHead, branch.undoRedoManager);
 
@@ -333,7 +330,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 			this.emitAndRebaseAnchors({
 				type: "append",
 				change: this.changeFamily.rebaser.compose(changes),
-				newCommits: rebasedTargetCommits.concat(rebasedSourceCommits),
+				newCommits: targetCommits.concat(rebasedSourceCommits),
 			});
 		}
 	}

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -290,7 +290,11 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const rebaseResult = this.rebaseBranch(this.head, branch);
 		if (rebaseResult !== undefined) {
 			// The net change to this branch is provided by the `rebaseBranch` API
-			const [newHead, change, { deletedSourceCommits, newSourceCommits }] = rebaseResult;
+			const [
+				newHead,
+				change,
+				{ deletedSourceCommits, rebasedTargetCommits, rebasedSourceCommits },
+			] = rebaseResult;
 
 			this.undoRedoManager.updateAfterRebase(newHead, undoRedoManager);
 
@@ -299,7 +303,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 				type: "rebase",
 				change,
 				removedCommits: deletedSourceCommits,
-				newCommits: newSourceCommits,
+				newCommits: rebasedTargetCommits.concat(rebasedSourceCommits),
 			});
 		}
 	}
@@ -319,7 +323,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const rebaseResult = this.rebaseBranch(branch.head, this.head);
 		if (rebaseResult !== undefined) {
 			// Compute the net change to this branch
-			const [newHead, _, commits] = rebaseResult;
+			const [newHead, _, { rebasedTargetCommits, rebasedSourceCommits }] = rebaseResult;
 
 			this.undoRedoManager.updateAfterMerge(newHead, branch.undoRedoManager);
 
@@ -329,7 +333,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 			this.emitAndRebaseAnchors({
 				type: "append",
 				change: this.changeFamily.rebaser.compose(changes),
-				newCommits: commits.newSourceCommits,
+				newCommits: rebasedTargetCommits.concat(rebasedSourceCommits),
 			});
 		}
 	}

--- a/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
@@ -85,7 +85,8 @@ describe("rebaseBranch", () => {
 		assert.equal(n4_1, n4);
 		assert.equal(change, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, []);
-		assert.deepEqual(commits.newSourceCommits, []);
+		assert.deepEqual(commits.rebasedTargetCommits, []);
+		assert.deepEqual(commits.rebasedSourceCommits, []);
 	});
 
 	it("does nothing if already rebased at target", () => {
@@ -101,7 +102,8 @@ describe("rebaseBranch", () => {
 		assert.equal(n3_1, n3);
 		assert.equal(change, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, []);
-		assert.deepEqual(commits.newSourceCommits, []);
+		assert.deepEqual(commits.rebasedTargetCommits, []);
+		assert.deepEqual(commits.rebasedSourceCommits, []);
 	});
 
 	it("can rebase a branch onto the head of another branch", () => {
@@ -124,7 +126,8 @@ describe("rebaseBranch", () => {
 		);
 		assertOutputContext(change, 1, 2, 3, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n4, n5]);
-		assert.deepEqual(commits.newSourceCommits, [n2, n3, ...newPath]);
+		assert.deepEqual(commits.rebasedTargetCommits, [n2, n3]);
+		assert.deepEqual(commits.rebasedSourceCommits, newPath);
 	});
 
 	it("can rebase a branch onto the middle of another branch", () => {
@@ -147,8 +150,8 @@ describe("rebaseBranch", () => {
 		);
 		assertOutputContext(change, 1, 2, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n4, n5]);
-		assert.deepEqual(commits.newSourceCommits, [n2, ...newPath]);
-		assert.equal(commits.newBase, n2);
+		assert.deepEqual(commits.rebasedTargetCommits, [n2]);
+		assert.deepEqual(commits.rebasedSourceCommits, newPath);
 	});
 
 	it("skips and advances over commits with the same revision tag", () => {
@@ -173,8 +176,8 @@ describe("rebaseBranch", () => {
 		});
 		assert.equal(change, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1, n5]);
-		assert.deepEqual(commits.newSourceCommits, [n2, n3, ...newPath]);
-		assert.equal(commits.newBase, n3);
+		assert.deepEqual(commits.rebasedTargetCommits, [n2, n3]);
+		assert.deepEqual(commits.rebasedSourceCommits, newPath);
 	});
 
 	it("correctly rebases over branches that share some commits", () => {
@@ -199,7 +202,8 @@ describe("rebaseBranch", () => {
 		});
 		assertOutputContext(change, 1, 2, 3, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1, n5]);
-		assert.deepEqual(commits.newSourceCommits, [n2, n3, n4, ...newPath]);
+		assert.deepEqual(commits.rebasedTargetCommits, [n2, n3, n4]);
+		assert.deepEqual(commits.rebasedSourceCommits, newPath);
 	});
 
 	it("reports no change for equivalent branches", () => {
@@ -218,7 +222,8 @@ describe("rebaseBranch", () => {
 		assert.equal(n3_2, n3);
 		assert.equal(change, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1]);
-		assert.deepEqual(commits.newSourceCommits, [n2, n3]);
+		assert.deepEqual(commits.rebasedTargetCommits, [n2, n3]);
+		assert.deepEqual(commits.rebasedSourceCommits, []);
 	});
 });
 

--- a/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
@@ -85,7 +85,7 @@ describe("rebaseBranch", () => {
 		assert.equal(n4_1, n4);
 		assert.equal(change, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, []);
-		assert.deepEqual(commits.rebasedTargetCommits, []);
+		assert.deepEqual(commits.targetCommits, []);
 		assert.deepEqual(commits.rebasedSourceCommits, []);
 	});
 
@@ -102,7 +102,7 @@ describe("rebaseBranch", () => {
 		assert.equal(n3_1, n3);
 		assert.equal(change, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, []);
-		assert.deepEqual(commits.rebasedTargetCommits, []);
+		assert.deepEqual(commits.targetCommits, []);
 		assert.deepEqual(commits.rebasedSourceCommits, []);
 	});
 
@@ -126,7 +126,7 @@ describe("rebaseBranch", () => {
 		);
 		assertOutputContext(change, 1, 2, 3, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n4, n5]);
-		assert.deepEqual(commits.rebasedTargetCommits, [n2, n3]);
+		assert.deepEqual(commits.targetCommits, [n2, n3]);
 		assert.deepEqual(commits.rebasedSourceCommits, newPath);
 	});
 
@@ -150,7 +150,7 @@ describe("rebaseBranch", () => {
 		);
 		assertOutputContext(change, 1, 2, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n4, n5]);
-		assert.deepEqual(commits.rebasedTargetCommits, [n2]);
+		assert.deepEqual(commits.targetCommits, [n2]);
 		assert.deepEqual(commits.rebasedSourceCommits, newPath);
 	});
 
@@ -176,7 +176,7 @@ describe("rebaseBranch", () => {
 		});
 		assert.equal(change, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1, n5]);
-		assert.deepEqual(commits.rebasedTargetCommits, [n2, n3]);
+		assert.deepEqual(commits.targetCommits, [n2, n3]);
 		assert.deepEqual(commits.rebasedSourceCommits, newPath);
 	});
 
@@ -202,7 +202,7 @@ describe("rebaseBranch", () => {
 		});
 		assertOutputContext(change, 1, 2, 3, 4, 5);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1, n5]);
-		assert.deepEqual(commits.rebasedTargetCommits, [n2, n3, n4]);
+		assert.deepEqual(commits.targetCommits, [n2, n3, n4]);
 		assert.deepEqual(commits.rebasedSourceCommits, newPath);
 	});
 
@@ -222,7 +222,7 @@ describe("rebaseBranch", () => {
 		assert.equal(n3_2, n3);
 		assert.equal(change, undefined);
 		assert.deepEqual(commits.deletedSourceCommits, [n2_1, n3_1]);
-		assert.deepEqual(commits.rebasedTargetCommits, [n2, n3]);
+		assert.deepEqual(commits.targetCommits, [n2, n3]);
 		assert.deepEqual(commits.rebasedSourceCommits, []);
 	});
 });


### PR DESCRIPTION
## Description

This updates the commit graph information return by `rebaseBranch` to be more in line with actual usage requirements. This will allow for some necessary performance optimizations.