### PR TITLE
fix(ci): Fix removal of coloring from t9s log file

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -316,6 +316,7 @@ jobs:
         env:
           ${{ parameters.env }}
         inputs:
+          targetType: 'inline'
           script: |
             printenv
 

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -311,16 +311,6 @@ jobs:
             customRegistry: 'useNpmrc'
 
       # run the test
-      - task: Bash@3
-        displayName: 'Check if env variables for t9s logging are making it up to here'
-        env:
-          ${{ parameters.env }}
-        inputs:
-          targetType: 'inline'
-          script: |
-            printenv
-
-      # run the test
       - task: Npm@1
         displayName: '[test] ${{ parameters.testCommand }} ${{ variant.flags }}'
         continueOnError: ${{ parameters.continueOnError }}

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -311,6 +311,15 @@ jobs:
             customRegistry: 'useNpmrc'
 
       # run the test
+      - task: Bash@3
+        displayName: 'Check if env variables for t9s logging are making it up to here'
+        env:
+          ${{ parameters.env }}
+        inputs:
+          script: |
+            printenv
+
+      # run the test
       - task: Npm@1
         displayName: '[test] ${{ parameters.testCommand }} ${{ variant.flags }}'
         continueOnError: ${{ parameters.continueOnError }}

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -90,7 +90,7 @@ stages:
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
           # Disable colorization for tinylicious logs (not useful when printing to a file)
-          logger__colorize: false
+          logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
           logger__morganFormat: tiny
         additionalSteps:
 

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -60,7 +60,7 @@ stages:
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
           # Disable colorization for tinylicious logs (not useful when printing to a file)
-          logger__colorize: false
+          logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
           logger__morganFormat: tiny
         additionalSteps:
 


### PR DESCRIPTION
## Description

Fixes the removal of colorization codes in the tinylicious log files generated in CI. ADO was transforming `false` into `False` and causing the env variable (for [winston](https://github.com/winstonjs/winston/)) to not have any effect.

Tinylicious log file size improved slightly, from 20.7Mb to 19.4Mb:

<img width="503" alt="image" src="https://user-images.githubusercontent.com/716334/236951016-f991ccf9-572e-454c-b86f-d4dbb8f755bb.png">

But the real improvement is readability (half the improvement, from `logger__morganFormat`, was already taking in, this cleans up the remaining colorization codes):

<img width="747" alt="image" src="https://user-images.githubusercontent.com/716334/236950783-38ed4a05-4f80-4c49-bed2-7603ccd4d7c7.png">

Previously:

<img width="708" alt="image" src="https://user-images.githubusercontent.com/716334/236950929-d02eafe9-424f-4c4b-891e-7233a9b065e7.png">

[AB#3723](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3723)