### PR TITLE
Decrease time to debug for Current Mocha Test

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -304,7 +304,17 @@
 			],
 			"cwd": "${fileDirname}",
 			"skipFiles": ["<node_internals>/**", "**/node_modules/**"],
-			"outFiles": ["${workspaceFolder}/**/dist/**/*.js"],
+			"outFiles": [
+				// This config avoids loading dependent packages' test files, while using the same technique
+				// as the "Debug Current Test (JS)" config to load source maps for test files in the current
+				// package.
+				// This reduces the number of source files VSCode needs to load to debug the e2e tests
+				// considerably, which decreases the time it takes to start debugging.
+				"${workspaceFolder}/**/dist/**/!(*.spec,*.test,*.tests).js",
+				"${fileDirname}/../../dist/**/*.js",
+				"${fileDirname}/../../../dist/**/*.js",
+				"${fileDirname}/../../../../dist/**/*.js"
+			],
 			"preLaunchTask": "Build Current Tests",
 			"internalConsoleOptions": "openOnSessionStart"
 		},


### PR DESCRIPTION
## Description

Tweaks the `outFiles` for "Debug Current Mocha Test" to only include test files for the package being debugged. This reduces the number of files VSCode needs to load considerably while using this launch target, which translates to faster debug times for e2e tests.

The only developer experience that this should affect is if:
- Package A depends on package B
- A developer wants to debug a test in package A
- That test executes code at runtime defined in a test file in package B
- The developer wants to put a break point in package B's test file

Previously, that break point would be hit. Now, the developer would need to place the breakpoint in JS rather than TS.
This scenario seems exceedingly rare: test files should basically never be imported by another module, especially not cross-package-boundary.
In a couple places in the repo we've used a pattern where tightly coupled packages export common test utilities under a separate "test index" which a downstream package might reference.
An example of this pattern is `merge-tree` defining `TestClient`, which is referenced in `sequence` to write some lower-level SharedString tests.
This pattern should still work fine, since only .spec.ts files are excluded, not a glob like "everything under the test folder".