### PR TITLE
Only submit ops and signals when socket is connected

### DIFF
--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -82,8 +82,6 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     // (undocumented)
     protected readonly socket: Socket;
     submit(messages: IDocumentMessage[]): void;
-    // (undocumented)
-    protected submitCore(type: string, messages: IDocumentMessage[]): void;
     submitSignal(message: IDocumentMessage): void;
     get version(): string;
 }

--- a/api-report/driver-base.api.md
+++ b/api-report/driver-base.api.md
@@ -57,6 +57,13 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     static readonly eventsToForward: string[];
     get existing(): boolean;
     // (undocumented)
+    protected getConnectionDetailsProps(): {
+        disposed: boolean;
+        socketConnected: boolean;
+        clientId: string | undefined;
+        connectionId: string | undefined;
+    };
+    // (undocumented)
     protected get hasDetails(): boolean;
     get initialClients(): ISignalClient[];
     // (undocumented)

--- a/api-report/local-driver.api.md
+++ b/api-report/local-driver.api.md
@@ -56,8 +56,6 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
     disconnectClient(disconnectReason: string): void;
     nackClient(code: number | undefined, type: NackErrorType | undefined, message: any): void;
     submit(messages: IDocumentMessage[]): void;
-    // (undocumented)
-    protected submitCore(type: string, messages: IDocumentMessage[]): void;
     submitSignal(message: any): void;
 }
 

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -315,10 +315,6 @@ export class DocumentDeltaConnection
 		}
 	}
 
-	protected submitCore(type: string, messages: IDocumentMessage[]) {
-		this.emitMessages(type, [messages]);
-	}
-
 	/**
 	 * Submits a new delta operation to the server
 	 *
@@ -326,7 +322,7 @@ export class DocumentDeltaConnection
 	 */
 	public submit(messages: IDocumentMessage[]): void {
 		this.checkNotDisposed();
-		this.submitCore("submitOp", messages);
+		this.emitMessages("submitOp", [messages]);
 	}
 
 	/**
@@ -336,7 +332,7 @@ export class DocumentDeltaConnection
 	 */
 	public submitSignal(message: IDocumentMessage): void {
 		this.checkNotDisposed();
-		this.submitCore("submitSignal", [message]);
+		this.emitMessages("submitSignal", [[message]]);
 	}
 
 	/**

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -310,8 +310,9 @@ export class DocumentDeltaConnection
 		// Although the implementation here disconnects the socket and does not reuse it, other subclasses
 		// (e.g. OdspDocumentDeltaConnection) may reuse the socket.  In these cases, we need to avoid emitting
 		// on the still-live socket.
-		this.checkNotDisposed();
-		this.socket.emit(type, this.clientId, messages);
+		if (!this.disposed) {
+			this.socket.emit(type, this.clientId, messages);
+		}
 	}
 
 	protected submitCore(type: string, messages: IDocumentMessage[]) {
@@ -324,6 +325,7 @@ export class DocumentDeltaConnection
 	 * @param message - delta operation to submit
 	 */
 	public submit(messages: IDocumentMessage[]): void {
+		this.checkNotDisposed();
 		this.submitCore("submitOp", messages);
 	}
 
@@ -333,6 +335,7 @@ export class DocumentDeltaConnection
 	 * @param message - signal to submit
 	 */
 	public submitSignal(message: IDocumentMessage): void {
+		this.checkNotDisposed();
 		this.submitCore("submitSignal", [message]);
 	}
 

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -309,7 +309,7 @@ export class DocumentDeltaConnection
 	protected emitMessages(type: string, messages: IDocumentMessage[][]) {
 		// Although the implementation here disconnects the socket and does not reuse it, other subclasses
 		// (e.g. OdspDocumentDeltaConnection) may reuse the socket.  In these cases, we need to avoid emitting
-		// on the still-live socket. Also in case, connection is not yet disposed, then don't emit the messages.
+		// on the still-live socket.
 		this.checkNotDisposed();
 		this.socket.emit(type, this.clientId, messages);
 	}

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -63,10 +63,6 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
 		super(socket, documentId, new TelemetryNullLogger());
 	}
 
-	protected submitCore(type: string, messages: IDocumentMessage[]) {
-		this.emitMessages(type, [messages]);
-	}
-
 	/**
 	 * Submits a new delta operation to the server
 	 */
@@ -74,7 +70,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
 		// We use a promise resolve to force a turn break given message processing is sync
 		// eslint-disable-next-line @typescript-eslint/no-floating-promises
 		Promise.resolve().then(() => {
-			this.submitCore("submitOp", messages);
+			this.emitMessages("submitOp", [messages]);
 		});
 	}
 
@@ -82,7 +78,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
 	 * Submits a new signal to the server
 	 */
 	public submitSignal(message: any): void {
-		this.submitCore("submitSignal", [message]);
+		this.emitMessages("submitSignal", [[message]]);
 	}
 
 	/**

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -644,7 +644,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 	}
 
 	private get connected(): boolean {
-		return this.disposed && this.socket.connected;
+		return !this.disposed && this.socket.connected;
 	}
 
 	protected emitMessages(type: string, messages: IDocumentMessage[][]) {

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -644,10 +644,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 	}
 
 	private get connected(): boolean {
-		if (!this.disposed && this.socket.connected) {
-			return true;
-		}
-		return false;
+		return this.disposed && this.socket.connected;
 	}
 
 	protected emitMessages(type: string, messages: IDocumentMessage[][]) {

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -648,9 +648,31 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 	}
 
 	protected emitMessages(type: string, messages: IDocumentMessage[][]) {
+		// Only submit the op/signals if we are connected.
 		if (this.connected) {
 			this.socket.emit(type, this.clientId, messages);
 		}
+	}
+
+	protected submitCore(type: string, messages: IDocumentMessage[]) {
+		this.emitMessages(type, [messages]);
+	}
+
+	/**
+ 	* Submits a new delta operation to the server
+ 	* @param message - delta operation to submit
+ 	*/
+	public submit(messages: IDocumentMessage[]): void {
+		this.submitCore("submitOp", messages);
+	}
+
+	/**
+	 * Submits a new signal to the server
+	 *
+	 * @param message - signal to submit
+	 */
+	public submitSignal(message: IDocumentMessage): void {
+		this.submitCore("submitSignal", [message]);
 	}
 
 	/**

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -633,7 +633,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 
 	public get disposed() {
 		if (!(this._disposed || this.socket.connected)) {
-			// Send error event if this connection is not yet disposed after socket is disconnected for 30s.
+			// Send error event if this connection is not yet disposed after socket is disconnected for 15s.
 			if (this.connectionNotYetDisposedTimeout === undefined) {
 				this.connectionNotYetDisposedTimeout = setTimeout(() => {
 					if (!this._disposed) {
@@ -645,7 +645,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 							}),
 						});
 					}
-				}, 30000);
+				}, 15000);
 			}
 		}
 		return this._disposed;

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -471,9 +471,9 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 			this.logger.sendTelemetryEvent(
 				{
 					eventName: "ServerDisconnect",
-					clientId: this.hasDetails ? this.clientId : undefined,
+					driverVersion: pkgVersion,
 					details: JSON.stringify({
-						connection: this.connectionId,
+						...this.getConnectionDetailsProps(),
 					}),
 				},
 				error,
@@ -659,9 +659,9 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 	}
 
 	/**
- 	* Submits a new delta operation to the server
- 	* @param message - delta operation to submit
- 	*/
+	 * Submits a new delta operation to the server
+	 * @param message - delta operation to submit
+	 */
 	public submit(messages: IDocumentMessage[]): void {
 		this.submitCore("submitOp", messages);
 	}

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -637,7 +637,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 			if (this.connectionNotYetDisposedTimeout === undefined) {
 				this.connectionNotYetDisposedTimeout = setTimeout(() => {
 					if (!this._disposed) {
-						this.logger.sendTelemetryEvent({
+						this.logger.sendErrorEvent({
 							eventName: "ConnectionNotYetDisposed",
 							driverVersion: pkgVersion,
 							details: JSON.stringify({


### PR DESCRIPTION
## Description

Fix: https://dev.azure.com/fluidframework/internal/_workitems/edit/4174
Only submit ops and signals when socket is connected. This is to fix the assert 0x244 which we were hitting in case connection is not yet disposed but socket is already connected. This was happening in loop.
Scenario:
We have multiple containers in the given sessionId which share socket. When socket disconnects all the containers  need to go through disconnection flow. During the disconnect flow of 1 container, when we raise disconnect event on that container, the app tries to submit a deletePresence signal on a different container which has not gone through the disconnect flow yet and its connection is not yet disposed while the socket is disconnected causing this assert and this exception is recorded in the other container which emitted the "disconnect" event which should be expected.

We should have dropped the signal in the happy path.  