### PR TITLE
refactor(ci): Get npm feed URLs from centralized variable group

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -129,6 +129,7 @@ variables:
   - name: toolAbsolutePath
     value:  $(Build.SourcesDirectory)/tools/telemetry-generator
     readonly: true
+  - group: ado-feeds
 
 stages:
   - ${{ if ne(convertToJson(parameters.checks), '[]') }}:
@@ -469,6 +470,7 @@ stages:
               inputs:
                 targetType: 'inline'
                 workingDirectory: ${{ variables.toolAbsolutePath }}
+                # Note: $(buildFeed) and $(officeFeed) come from the ado-feeds variable group
                 script: |
                   echo Initialize package
                   npm init --yes
@@ -480,8 +482,8 @@ stages:
                   echo "@fluidframework:registry=${{ variables.feed }}" >> ./.npmrc
                   echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
                   echo "@fluid-internal:registry=${{ variables.devFeed }}" >> ./.npmrc
-                  echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
-                  echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
+                  echo "@ff-internal:registry=$(buildFeed)" >> ./.npmrc
+                  echo "@microsoft:registry=$(officeFeed)" >> ./.npmrc
                   echo "always-auth=true" >> ./.npmrc
                   cat .npmrc
 

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -40,6 +40,8 @@ stages:
   dependsOn: build
   displayName: Publish Internal Packages
   condition: and(succeeded(), eq(variables['testBuild'], false))
+  variables:
+  - group: ado-feeds
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:
@@ -55,6 +57,8 @@ stages:
   dependsOn: build
   displayName: Publish Official Packages
   condition: and(succeeded(), or(eq(variables['release'], 'release'), eq(variables['release'], 'prerelease')))
+  variables:
+  - group: ado-feeds
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -18,14 +18,13 @@ parameters:
   type: object
   default: Small
 
-variables:
-  - group: ado-feeds
-
 stages:
 - stage: publish_npm_internal_test
   dependsOn: build
   displayName: Publish Internal Test Packages
   condition: and(succeeded(), eq(variables['testBuild'], true))
+  variables:
+  - group: ado-feeds
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -18,6 +18,9 @@ parameters:
   type: object
   default: Small
 
+variables:
+  - group: ado-feeds
+
 stages:
 - stage: publish_npm_internal_test
   dependsOn: build
@@ -27,8 +30,8 @@ stages:
   - template: include-publish-npm-package-deployment.yml
     parameters:
       namespace: ${{ parameters.namespace }}
-      devFeedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/test/npm/registry/
-      feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/test/npm/registry/
+      devFeedName: $(testFeed) # Comes from the ado-feeds variable group
+      feedName: $(testFeed) # Comes from the ado-feeds variable group
       official: false
       environment: test-package-build-feed
       pool: ${{ parameters.pool }}
@@ -42,8 +45,8 @@ stages:
   - template: include-publish-npm-package-deployment.yml
     parameters:
       namespace: ${{ parameters.namespace }}
-      devFeedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
-      feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
+      devFeedName: $(devFeed) # Comes from the ado-feeds variable group
+      feedName: $(buildFeed) # Comes from the ado-feeds variable group
       official: false
       environment: package-build-feed
       pool: ${{ parameters.pool }}
@@ -59,7 +62,7 @@ stages:
       namespace: ${{ parameters.namespace }}
       # internal/msinternal/example packages are deleted for official releases, but in case something goes wrong with that,
       # using the `dev` registry is safe.
-      devFeedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
+      devFeedName: $(devFeed) # Comes from the ado-feeds variable group
       feedName: https://registry.npmjs.org
       official: true
       environment: package-npmjs-feed

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -21,15 +21,13 @@ parameters:
   type: number
   default: 60
 
-variables:
-  - group: ado-feeds
-
 jobs:
   - job: runTests
     displayName: Run tests
     pool: ${{ parameters.poolBuild }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     variables:
+    - group: ado-feeds
     - name: isTestBranch
       value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}
       readonly: true

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -21,6 +21,9 @@ parameters:
   type: number
   default: 60
 
+variables:
+  - group: ado-feeds
+
 jobs:
   - job: runTests
     displayName: Run tests
@@ -32,14 +35,14 @@ jobs:
       readonly: true
     - name: feed
       ${{ if eq(variables.isTestBranch, 'true') }}:
-        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
+        value: $(internalFeed) # Comes from the ado-feeds variable group
       ${{ else }}:
-        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
+        value: $(buildFeed) # Comes from the ado-feeds variable group
     - name: devFeed
       ${{ if eq(variables.isTestBranch, 'true') }}:
-        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
+        value: $(internalFeed) # Comes from the ado-feeds variable group
       ${{ else }}:
-        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
+        value: $(devFeed) # Comes from the ado-feeds variable group
 
     steps:
     # Setup. Need to checkout the repo in order to run @fluid-tools/telemetry-generator which we don't publish right now.
@@ -91,6 +94,7 @@ jobs:
       inputs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.testWorkspace }}
+        # Note: $(buildFeed) and $(officeFeed) come from the ado-feeds variable group
         script: |
           echo Initialize package
           npm init --yes
@@ -103,8 +107,8 @@ jobs:
           echo "@fluid-experimental:registry=$(feed)" >> ./.npmrc
           echo "@fluid-tools:registry=$(feed)" >> ./.npmrc
           echo "@fluid-internal:registry=$(devFeed)" >> ./.npmrc
-          echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
-          echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
+          echo "@ff-internal:registry=$(buildFeed)" >> ./.npmrc
+          echo "@microsoft:registry=$(officeFeed)" >> ./.npmrc
           echo "always-auth=true" >> ./.npmrc
           cat .npmrc
 

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -72,9 +72,6 @@ parameters:
   type: stepList
   default: []
 
-variables:
-  - group: ado-feeds
-
 jobs:
   - ${{ each variant in parameters.splitTestVariants }}:
     - job:
@@ -83,6 +80,7 @@ jobs:
       condition: ${{ parameters.condition }}
       timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
       variables:
+      - group: ado-feeds
       - name: isTestBranch
         value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}
         readonly: true

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -72,6 +72,9 @@ parameters:
   type: stepList
   default: []
 
+variables:
+  - group: ado-feeds
+
 jobs:
   - ${{ each variant in parameters.splitTestVariants }}:
     - job:
@@ -98,14 +101,14 @@ jobs:
         value: true
       - name: feed
         ${{ if eq(variables.isTestBranch, 'true') }}:
-          value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
+          value: $(internalFeed) # Comes from the ado-feeds variable group
         ${{ else }}:
-          value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
+          value: $(buildFeed) # Comes from the ado-feeds variable group
       - name: devFeed
         ${{ if eq(variables.isTestBranch, 'true') }}:
-          value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
+          value: $(internalFeed) # Comes from the ado-feeds variable group
         ${{ else }}:
-          value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
+          value: $(devFeed) # Comes from the ado-feeds variable group
       - name: artifactPipeline
         ${{ if eq(parameters.downloadAzureTestArtifacts, true) }}:
           value: Build - azure
@@ -207,6 +210,7 @@ jobs:
         inputs:
           targetType: 'inline'
           workingDirectory: ${{ parameters.testWorkspace }}
+          # Note: $(buildFeed) and $(officeFeed) come from the ado-feeds variable group
           script: |
             echo Initialize package
             npm init --yes
@@ -218,8 +222,8 @@ jobs:
             echo "@fluidframework:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@fluid-internal:registry=${{ variables.devFeed }}" >> ./.npmrc
-            echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
-            echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
+            echo "@ff-internal:registry=$(buildFeed)" >> ./.npmrc
+            echo "@microsoft:registry=$(officeFeed)" >> ./.npmrc
             echo "always-auth=true" >> ./.npmrc
             cat .npmrc
 


### PR DESCRIPTION
## Description

Update pipelines to get the URLs for the different npm feed from the centralized variable group we created a while ago.

More detailed test results in the comments in [AB#3266](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3266).