### PR TITLE
build(devtools): Fix packageVersion.ts discrepency

### DIFF
--- a/packages/tools/client-debugger/devtools/src/packageVersion.ts
+++ b/packages/tools/client-debugger/devtools/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/devtools";
-export const pkgVersion = "2.0.0-internal.4.2.0";
+export const pkgVersion = "2.0.0-internal.4.3.0";


### PR DESCRIPTION
Version was not fully updated when package was added in #15490.

Updated via `npm run build` in the package directory.