### PR TITLE
Update test-tools to 0.2.158186

### DIFF
--- a/azure/package.json
+++ b/azure/package.json
@@ -83,7 +83,7 @@
 		"@changesets/cli": "^2.26.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.13.1",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@microsoft/api-documenter": "^7.21.6",
 		"@microsoft/api-extractor": "^7.34.4",
 		"c8": "^7.7.1",

--- a/azure/packages/external-controller/package.json
+++ b/azure/packages/external-controller/package.json
@@ -61,7 +61,7 @@
 		"@fluidframework/local-driver": "workspace:~",
 		"@fluidframework/server-local-server": "^0.1038.4000",
 		"@fluidframework/test-client-utils": "workspace:~",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -78,7 +78,7 @@
 		"@commitlint/config-conventional": "^17.1.0",
 		"@commitlint/cz-commitlint": "^17.1.2",
 		"@fluidframework/build-common": "^1.1.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@microsoft/api-documenter": "^7.21.6",
 		"@microsoft/api-extractor": "^7.34.4",
 		"c8": "^7.7.1",

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@commitlint/config-conventional': ^17.1.0
       '@commitlint/cz-commitlint': ^17.1.2
       '@fluidframework/build-common': ^1.1.0
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@microsoft/api-documenter': ^7.21.6
       '@microsoft/api-extractor': ^7.34.4
       c8: ^7.7.1
@@ -35,7 +35,7 @@ importers:
       '@commitlint/config-conventional': 17.2.0
       '@commitlint/cz-commitlint': 17.2.0_yes7iyjckc3rubj3ixzwc3ince
       '@fluidframework/build-common': 1.1.0
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@microsoft/api-documenter': 7.21.6
       '@microsoft/api-extractor': 7.34.4
       c8: 7.11.3
@@ -1062,8 +1062,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/test-tools/0.2.3074:
-    resolution: {integrity: sha512-ZRSSKPXMm/ni/hDztf38GMBtzFez0Q9XXaY5abd2rQz76A3wIK+yzQerTqnZYBnwrzGwZi22Ne1FXND1JeFMZA==}
+  /@fluidframework/test-tools/0.2.158186:
+    resolution: {integrity: sha512-PwO7X/Kg46befSo28mSuef95/fQUmfOFWmoY1FdWAMz+6srX4o/8B4KVaKQ/3nmFD5a/PQHYHqyzAxWiFZYpfQ==}
     hasBin: true
     dev: true
 

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -57,7 +57,7 @@
 		"@fluid-tools/build-cli": "^0.17.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@fluidframework/test-utils": "workspace:~",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -55,7 +55,7 @@
 		"@fluid-tools/build-cli": "^0.17.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -69,7 +69,7 @@
 		"@fluid-tools/build-cli": "^0.17.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/apps/presence-tracker/package.json
+++ b/examples/apps/presence-tracker/package.json
@@ -47,7 +47,7 @@
 		"@fluid-tools/build-cli": "^0.17.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/apps/task-selection/package.json
+++ b/examples/apps/task-selection/package.json
@@ -56,7 +56,7 @@
 		"@fluid-tools/build-cli": "^0.17.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/benchmarks/bubblebench/baseline/package.json
+++ b/examples/benchmarks/bubblebench/baseline/package.json
@@ -57,7 +57,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/benchmarks/bubblebench/common/package.json
+++ b/examples/benchmarks/bubblebench/common/package.json
@@ -73,7 +73,7 @@
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^14.18.38",
 		"@types/react": "^17.0.44",

--- a/examples/benchmarks/bubblebench/editable-shared-tree/package.json
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/package.json
@@ -59,7 +59,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/benchmarks/bubblebench/ot/package.json
+++ b/examples/benchmarks/bubblebench/ot/package.json
@@ -59,7 +59,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/benchmarks/bubblebench/sharedtree/package.json
+++ b/examples/benchmarks/bubblebench/sharedtree/package.json
@@ -58,7 +58,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -53,7 +53,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -55,7 +55,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@fluidframework/test-utils": "workspace:~",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -53,7 +53,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/inventory-app/package.json
+++ b/examples/data-objects/inventory-app/package.json
@@ -53,7 +53,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@rushstack/eslint-config": "^2.5.1",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -53,7 +53,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -51,7 +51,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -62,7 +62,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -51,7 +51,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -50,7 +50,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -50,7 +50,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -50,7 +50,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -68,7 +68,7 @@
 	"devDependencies": {
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -58,7 +58,7 @@
 		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@fluidframework/test-utils": "workspace:~",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -87,7 +87,7 @@
 	"devDependencies": {
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/cors": "^2.8.4",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/express": "^4.11.0",

--- a/examples/version-migration/live-schema-upgrade/package.json
+++ b/examples/version-migration/live-schema-upgrade/package.json
@@ -57,7 +57,7 @@
 		"@fluid-tools/build-cli": "^0.17.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/version-migration/schema-upgrade/package.json
+++ b/examples/version-migration/schema-upgrade/package.json
@@ -68,7 +68,7 @@
 		"@fluid-tools/build-cli": "^0.17.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/view-integration/container-views/package.json
+++ b/examples/view-integration/container-views/package.json
@@ -55,7 +55,7 @@
 		"@fluid-tools/build-cli": "^0.17.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -51,7 +51,7 @@
 		"@fluid-tools/build-cli": "^0.17.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/examples/view-integration/view-framework-sampler/package.json
+++ b/examples/view-integration/view-framework-sampler/package.json
@@ -54,7 +54,7 @@
 		"@fluid-tools/build-cli": "^0.17.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "22.2.3",
 		"@types/jest-environment-puppeteer": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
 		"@fluid-tools/build-cli": "^0.17.0",
 		"@fluidframework/build-common": "^1.1.0",
 		"@fluidframework/build-tools": "^0.17.0",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@microsoft/api-documenter": "^7.21.6",
 		"@microsoft/api-extractor": "^7.34.4",
 		"@octokit/core": "^4.0.5",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -52,7 +52,7 @@
 		"@fluidframework/build-tools": "^0.17.0",
 		"@fluidframework/eslint-config-fluid": "^2.0.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/test-tools": "^0.2.3074",
+		"@fluidframework/test-tools": "^0.2.158186",
 		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.4.1.0",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@fluid-tools/build-cli': ^0.17.0
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/build-tools': ^0.17.0
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@microsoft/api-documenter': ^7.21.6
       '@microsoft/api-extractor': ^7.34.4
       '@octokit/core': ^4.0.5
@@ -37,7 +37,7 @@ importers:
       '@fluid-tools/build-cli': 0.17.0
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/build-tools': 0.17.0
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@microsoft/api-documenter': 7.21.6
       '@microsoft/api-extractor': 7.34.4
       '@octokit/core': 4.2.0
@@ -225,7 +225,7 @@ importers:
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/server-local-server': ^0.1038.4000
       '@fluidframework/test-client-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -274,7 +274,7 @@ importers:
       '@fluidframework/local-driver': link:../../../packages/drivers/local-driver
       '@fluidframework/server-local-server': 0.1038.4000
       '@fluidframework/test-client-utils': link:../../../packages/framework/test-client-utils
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -475,7 +475,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/sequence': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@fluidframework/test-utils': workspace:~
       '@fluidframework/view-interfaces': workspace:~
       '@types/expect-puppeteer': 2.2.1
@@ -526,7 +526,7 @@ importers:
       '@fluid-tools/build-cli': 0.17.0_gcaeyjp6ykwlupauelnobztche
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
@@ -566,7 +566,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -613,7 +613,7 @@ importers:
       '@fluid-tools/build-cli': 0.17.0_gcaeyjp6ykwlupauelnobztche
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -659,7 +659,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@fluidframework/view-adapters': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
@@ -729,7 +729,7 @@ importers:
       '@fluid-tools/build-cli': 0.17.0_gcaeyjp6ykwlupauelnobztche
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -772,7 +772,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/common-utils': ^1.1.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@fluidframework/tinylicious-client': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
@@ -807,7 +807,7 @@ importers:
       '@fluid-tools/build-cli': 0.17.0_gcaeyjp6ykwlupauelnobztche
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -847,7 +847,7 @@ importers:
       '@fluidframework/request-handler': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/task-manager': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -892,7 +892,7 @@ importers:
       '@fluid-tools/build-cli': 0.17.0_gcaeyjp6ykwlupauelnobztche
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -931,7 +931,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -970,7 +970,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1007,7 +1007,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@fluidframework/view-interfaces': workspace:~
       '@types/mocha': ^9.1.1
       '@types/node': ^14.18.38
@@ -1045,7 +1045,7 @@ importers:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/mocha': 9.1.1
       '@types/node': 14.18.38
       '@types/react': 17.0.52
@@ -1077,7 +1077,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1119,7 +1119,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1159,7 +1159,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1201,7 +1201,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1240,7 +1240,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1280,7 +1280,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1487,7 +1487,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/ink': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1527,7 +1527,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1568,7 +1568,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/task-manager': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@fluidframework/test-utils': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
@@ -1607,7 +1607,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
@@ -1721,7 +1721,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@fluidframework/view-interfaces': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
@@ -1758,7 +1758,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1793,7 +1793,7 @@ importers:
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@rushstack/eslint-config': ^2.5.1
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
@@ -1830,7 +1830,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@rushstack/eslint-config': 2.6.2_kufnqfq7tb5rpdawkdb6g5smma
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
@@ -1938,7 +1938,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -1971,7 +1971,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2001,7 +2001,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2037,7 +2037,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2082,7 +2082,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/request-handler': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@fluidframework/view-adapters': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
@@ -2130,7 +2130,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2167,7 +2167,7 @@ importers:
       '@fluidframework/common-definitions': ^0.20.1
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2198,7 +2198,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2269,7 +2269,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2304,7 +2304,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2338,7 +2338,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2373,7 +2373,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2407,7 +2407,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/build-common': ^1.1.0
       '@fluidframework/eslint-config-fluid': ^2.0.0
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2442,7 +2442,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2596,7 +2596,7 @@ importers:
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/sequence': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@fluidframework/undo-redo': workspace:~
       '@fluidframework/view-interfaces': workspace:~
       '@types/expect-puppeteer': 2.2.1
@@ -2660,7 +2660,7 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -2923,7 +2923,7 @@ importers:
       '@fluidframework/map': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/sequence': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@fluidframework/test-utils': workspace:~
       '@fluidframework/view-adapters': workspace:~
       '@types/expect-puppeteer': 2.2.1
@@ -2970,7 +2970,7 @@ importers:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
@@ -3141,7 +3141,7 @@ importers:
       '@fluidframework/sequence': workspace:~
       '@fluidframework/task-manager': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@fluidframework/tinylicious-driver': workspace:~
       '@types/cors': ^2.8.4
       '@types/expect-puppeteer': 2.2.1
@@ -3234,7 +3234,7 @@ importers:
     devDependencies:
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/cors': 2.8.13
       '@types/expect-puppeteer': 2.2.1
       '@types/express': 4.17.14
@@ -3426,7 +3426,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@fluidframework/tinylicious-driver': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
@@ -3473,7 +3473,7 @@ importers:
       '@fluid-tools/build-cli': 0.17.0_gcaeyjp6ykwlupauelnobztche
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -3524,7 +3524,7 @@ importers:
       '@fluidframework/sequence': workspace:~
       '@fluidframework/task-manager': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@fluidframework/tinylicious-driver': workspace:~
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
@@ -3596,7 +3596,7 @@ importers:
       '@fluid-tools/build-cli': 0.17.0_gcaeyjp6ykwlupauelnobztche
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -3648,7 +3648,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/map': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@fluidframework/view-adapters': workspace:~
       '@fluidframework/view-interfaces': workspace:~
       '@types/expect-puppeteer': 2.2.1
@@ -3696,7 +3696,7 @@ importers:
       '@fluid-tools/build-cli': 0.17.0_gcaeyjp6ykwlupauelnobztche
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -3734,7 +3734,7 @@ importers:
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -3774,7 +3774,7 @@ importers:
       '@fluid-tools/build-cli': 0.17.0_gcaeyjp6ykwlupauelnobztche
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -3811,7 +3811,7 @@ importers:
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^2.0.0
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -3859,7 +3859,7 @@ importers:
       '@fluid-tools/build-cli': 0.17.0_gcaeyjp6ykwlupauelnobztche
       '@fluidframework/build-common': 1.1.0
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 22.2.3
       '@types/jest-environment-puppeteer': 2.2.0
@@ -7535,7 +7535,7 @@ importers:
       '@fluidframework/protocol-definitions': ^1.1.0
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/server-services-client': ^0.1039.1000
-      '@fluidframework/test-tools': ^0.2.3074
+      '@fluidframework/test-tools': ^0.2.158186
       '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.4.1.0
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
@@ -7565,7 +7565,7 @@ importers:
       '@fluidframework/build-tools': 0.17.0_@types+node@14.18.38
       '@fluidframework/eslint-config-fluid': 2.0.0_kufnqfq7tb5rpdawkdb6g5smma
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/test-tools': 0.2.3074
+      '@fluidframework/test-tools': 0.2.158186
       '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.4.1.0
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
@@ -16971,8 +16971,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-tools/0.2.3074:
-    resolution: {integrity: sha512-ZRSSKPXMm/ni/hDztf38GMBtzFez0Q9XXaY5abd2rQz76A3wIK+yzQerTqnZYBnwrzGwZi22Ne1FXND1JeFMZA==}
+  /@fluidframework/test-tools/0.2.158186:
+    resolution: {integrity: sha512-PwO7X/Kg46befSo28mSuef95/fQUmfOFWmoY1FdWAMz+6srX4o/8B4KVaKQ/3nmFD5a/PQHYHqyzAxWiFZYpfQ==}
     hasBin: true
     dev: true
 


### PR DESCRIPTION
## Description

Update test-tools to 0.2.158186.

This removes their use of lerna.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
