### PR TITLE
[AzureClient] Increase container connect timeout in e2e tests

### DIFF
--- a/azure/packages/test/end-to-end-tests/src/test/audience.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/audience.spec.ts
@@ -14,7 +14,7 @@ import { createAzureClient } from "./AzureClientFactory";
 import { waitForMember } from "./utils";
 
 describe("Fluid audience", () => {
-	const connectTimeoutMs = 5000;
+	const connectTimeoutMs = 10000;
 	let client: AzureClient;
 	let schema: ContainerSchema;
 

--- a/azure/packages/test/end-to-end-tests/src/test/audience.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/audience.spec.ts
@@ -14,7 +14,7 @@ import { createAzureClient } from "./AzureClientFactory";
 import { waitForMember } from "./utils";
 
 describe("Fluid audience", () => {
-	const connectTimeoutMs = 10000;
+	const connectTimeoutMs = 10_000;
 	let client: AzureClient;
 	let schema: ContainerSchema;
 

--- a/azure/packages/test/end-to-end-tests/src/test/containerCopy.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/containerCopy.spec.ts
@@ -14,7 +14,7 @@ import { createAzureClient } from "./AzureClientFactory";
 import { mapWait } from "./utils";
 
 describe("Container copy scenarios", () => {
-	const connectTimeoutMs = 10000;
+	const connectTimeoutMs = 10_000;
 	let client: AzureClient;
 	let schema: ContainerSchema;
 

--- a/azure/packages/test/end-to-end-tests/src/test/containerCopy.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/containerCopy.spec.ts
@@ -14,7 +14,7 @@ import { createAzureClient } from "./AzureClientFactory";
 import { mapWait } from "./utils";
 
 describe("Container copy scenarios", () => {
-	const connectTimeoutMs = 5000;
+	const connectTimeoutMs = 10000;
 	let client: AzureClient;
 	let schema: ContainerSchema;
 

--- a/azure/packages/test/end-to-end-tests/src/test/containerCreate.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/containerCreate.spec.ts
@@ -18,7 +18,7 @@ const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderB
 });
 
 describe("Container create scenarios", () => {
-	const connectTimeoutMs = 10000;
+	const connectTimeoutMs = 10_000;
 	let client: AzureClient;
 	let schema: ContainerSchema;
 

--- a/azure/packages/test/end-to-end-tests/src/test/containerCreate.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/containerCreate.spec.ts
@@ -18,7 +18,7 @@ const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderB
 });
 
 describe("Container create scenarios", () => {
-	const connectTimeoutMs = 5000;
+	const connectTimeoutMs = 10000;
 	let client: AzureClient;
 	let schema: ContainerSchema;
 

--- a/azure/packages/test/end-to-end-tests/src/test/ddsTests.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/ddsTests.spec.ts
@@ -15,7 +15,7 @@ import { CounterTestDataObject, TestDataObject } from "./TestDataObject";
 import { mapWait } from "./utils";
 
 describe("Fluid data updates", () => {
-	const connectTimeoutMs = 5000;
+	const connectTimeoutMs = 10000;
 	let client: AzureClient;
 	let schema: ContainerSchema;
 

--- a/azure/packages/test/end-to-end-tests/src/test/ddsTests.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/ddsTests.spec.ts
@@ -15,7 +15,7 @@ import { CounterTestDataObject, TestDataObject } from "./TestDataObject";
 import { mapWait } from "./utils";
 
 describe("Fluid data updates", () => {
-	const connectTimeoutMs = 10000;
+	const connectTimeoutMs = 10_000;
 	let client: AzureClient;
 	let schema: ContainerSchema;
 


### PR DESCRIPTION
## Description

Increase container connect timeout in azure e2e tests from 5s to 10s
