### PR TITLE
Remove bigBlobs secret feature from DataObject

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -15,6 +15,16 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 -   Avoid using code formatting in the title (it's fine to use in the body).
 -   To explain the benefit of your change, use the [What's New](https://fluidframework.com/docs/updates/v1.0.0/) section on FluidFramework.com.
 
+# 2.0.0-internal.4.3.0
+
+## 2.0.0-internal.4.3.0 Breaking changes
+
+-   [bigBlobs request handling removed from DataObject](#bigBlobs-request-handling-removed-from-DataObject)
+
+### bigBlobs request handling removed from DataObject
+
+Previously, `DataObject` would perform undocumented special handling for requests to it starting with `bigBlobs/` to pull objects out of its `root` directory. This special handling has been removed.
+
 # 2.0.0-internal.4.1.0
 
 ## 2.0.0-internal.4.1.0 Breaking changes

--- a/api-report/aqueduct.api.md
+++ b/api-report/aqueduct.api.md
@@ -68,7 +68,6 @@ export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRu
 export abstract class DataObject<I extends DataObjectTypes = DataObjectTypes> extends PureDataObject<I> {
     protected getUninitializedErrorString(item: string): string;
     initializeInternal(existing: boolean): Promise<void>;
-    request(request: IRequest): Promise<IResponse>;
     protected get root(): ISharedDirectory;
 }
 

--- a/packages/framework/aqueduct/src/data-objects/dataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/dataObject.ts
@@ -3,9 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest, IResponse } from "@fluidframework/core-interfaces";
 import { ISharedDirectory, MapFactory, SharedDirectory } from "@fluidframework/map";
-import { RequestParser, create404Response } from "@fluidframework/runtime-utils";
 import { PureDataObject } from "./pureDataObject";
 import { DataObjectTypes } from "./types";
 
@@ -24,23 +22,6 @@ export abstract class DataObject<
 > extends PureDataObject<I> {
 	private internalRoot: ISharedDirectory | undefined;
 	private readonly rootDirectoryId = "root";
-
-	/**
-	 * {@inheritDoc PureDataObject.request}
-	 */
-	public async request(request: IRequest): Promise<IResponse> {
-		const requestParser = RequestParser.create(request);
-		const itemId = requestParser.pathParts[0];
-		if (itemId === "bigBlobs") {
-			const value = this.root.get<string>(requestParser.pathParts.join("/"));
-			if (value === undefined) {
-				return create404Response(requestParser);
-			}
-			return { mimeType: "fluid/object", status: 200, value };
-		} else {
-			return super.request(requestParser);
-		}
-	}
 
 	/**
 	 * The root directory will either be ready or will return an error. If an error is thrown


### PR DESCRIPTION
This was an initial approach to blob handling from ~4 years ago that AFAICT no one uses and I can't imagine we would recommend at this point.  It's also undocumented and doesn't affect API compatibility so seems safe to remove in `main`.