### PR TITLE
Deprecate PureDataObject.getFluidObjectFromDirectory

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -31,7 +31,7 @@ Previously, `DataObject` would perform undocumented special handling for request
 
 ### PureDataObject.getFluidObjectFromDirectory deprecated
 
-`PureDataObject.getFluidObjectFromDirectory` has been deprecated and will be removed in an upcoming release.  Instead prefer to interface directly with the directory and handles.
+`PureDataObject.getFluidObjectFromDirectory` has been deprecated and will be removed in an upcoming release. Instead prefer to interface directly with the directory and handles.
 
 # 2.0.0-internal.4.1.0
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -25,6 +25,14 @@ It's important to communicate breaking changes to our stakeholders. To write a g
 
 Previously, `DataObject` would perform undocumented special handling for requests to it starting with `bigBlobs/` to pull objects out of its `root` directory. This special handling has been removed.
 
+## 2.0.0-internal.4.3.0 Upcoming changes
+
+-   [PureDataObject.getFluidObjectFromDirectory deprecated](#PureDataObject.getFluidObjectFromDirectory-deprecated)
+
+### PureDataObject.getFluidObjectFromDirectory deprecated
+
+`PureDataObject.getFluidObjectFromDirectory` has been deprecated and will be removed in an upcoming release.  Instead prefer to interface directly with the directory and handles.
+
 # 2.0.0-internal.4.1.0
 
 ## 2.0.0-internal.4.1.0 Breaking changes

--- a/api-report/aqueduct.api.md
+++ b/api-report/aqueduct.api.md
@@ -129,6 +129,7 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
     finishInitialization(existing: boolean): Promise<void>;
     // (undocumented)
     static getDataObject(runtime: IFluidDataStoreRuntime): Promise<PureDataObject<DataObjectTypes>>;
+    // @deprecated
     getFluidObjectFromDirectory<T extends IFluidLoadable>(key: string, directory: IDirectory, getObjectFromDirectory?: (id: string, directory: IDirectory) => IFluidHandle | undefined): Promise<T | undefined>;
     get handle(): IFluidHandle<this>;
     protected hasInitialized(): Promise<void>;

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -171,6 +171,8 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 	 * @param directory - directory containing the object
 	 * @param getObjectFromDirectory - optional callback for fetching object from the directory, allows users to
 	 * define custom types/getters for object retrieval
+	 *
+	 * @deprecated - 2.0.0-internal.4.3.0 - Will be removed in an upcoming release.
 	 */
 	public async getFluidObjectFromDirectory<T extends IFluidLoadable>(
 		key: string,


### PR DESCRIPTION
This method doesn't add any value above just accessing directories and handles directly - it's just dead weight in the bundle at this point (also, it never really belonged on PureDataObject as it bears no relation to the contents of that object).  I've got a PR open with Loop to proactively remove the last couple usages there.