### PR TITLE
Update rebase utilities

### DIFF
--- a/experimental/dds/tree2/src/core/rebase/utils.ts
+++ b/experimental/dds/tree2/src/core/rebase/utils.ts
@@ -304,10 +304,31 @@ function inverseFromCommit<TChange>(
 }
 
 /**
+ * Find the furthest ancestor of some descendant.
+ * @param descendant - a descendant. If an empty `path` array is included, it will be populated
+ * with the chain of ancestry for `descendant` from most distant to closest (not including the furthest ancestor,
+ * but otherwise including `descendant`).
+ * @returns the furthest ancestor of `descendant`, or `descendant` itself if `descendant` has no ancestors.
+ */
+export function findAncestor<T extends { parent?: T }>(
+	descendant: T | [descendant: T, path?: T[]],
+): T;
+/**
+ * Find the furthest ancestor of some descendant.
+ * @param descendant - a descendant. If an empty `path` array is included, it will be populated
+ * with the chain of ancestry for `descendant` from most distant to closest (not including the furthest ancestor,
+ * but otherwise including `descendant`).
+ * @returns the furthest ancestor of `descendant`, or `descendant` itself if `descendant` has no ancestors. Returns
+ * `undefined` if `descendant` is undefined.
+ */
+export function findAncestor<T extends { parent?: T }>(
+	descendant: T | [descendant: T | undefined, path?: T[]] | undefined,
+): T | undefined;
+/**
  * Find an ancestor of some descendant.
  * @param descendant - a descendant. If an empty `path` array is included, it will be populated
- * with the chain of ancestry for `descendant` from most distant to closest (including `descendant`,
- * but not including the ancestor found by `predicate`).
+ * with the chain of ancestry for `descendant` from most distant to closest (not including the ancestor found by `predicate`,
+ * but otherwise including `descendant`).
  * @param predicate - a function which will be evaluated on every ancestor of `descendant` until it returns true.
  * @returns the closest ancestor of `descendant` that satisfies `predicate`, or `undefined` if no such ancestor exists.
  * @example
@@ -326,8 +347,12 @@ function inverseFromCommit<TChange>(
  * ```
  */
 export function findAncestor<T extends { parent?: T }>(
-	descendant: T | [descendant: T, path?: T[]] | undefined,
+	descendant: T | [descendant: T | undefined, path?: T[]] | undefined,
 	predicate: (t: T) => boolean,
+): T | undefined;
+export function findAncestor<T extends { parent?: T }>(
+	descendant: T | [descendant: T | undefined, path?: T[]] | undefined,
+	predicate: (t: T) => boolean = (t) => t.parent === undefined,
 ): T | undefined {
 	let d: T | undefined;
 	let path: T[] | undefined;

--- a/experimental/dds/tree2/src/test/rebase/findAncestor.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/findAncestor.spec.ts
@@ -19,35 +19,24 @@ function node(parent?: Node): Node {
 	};
 }
 
-function assertAncestor(
-	descendant: Node,
-	expectedAncestor: Node | undefined,
-	expectedPath?: Node[],
-): void {
-	const path: Node[] = [];
-	const foundAncestor = findAncestor([descendant, path], (n) => n === expectedAncestor);
-	assert.equal(foundAncestor, expectedAncestor);
-	if (expectedPath !== undefined) {
+describe("findAncestor", () => {
+	function assertAncestor(
+		descendant: Node | undefined,
+		expectedAncestor: Node | undefined,
+		expectedPath: Node[],
+	): void {
+		let foundAncestor = findAncestor(descendant, (n) => n === expectedAncestor);
+		assert.equal(foundAncestor, expectedAncestor);
+		const path: Node[] = [];
+		foundAncestor = findAncestor([descendant, path], (n) => n === expectedAncestor);
+		assert.equal(foundAncestor, expectedAncestor);
 		assert.deepEqual(path, expectedPath);
 	}
-}
 
-function assertCommonAncestor(
-	a: Node,
-	b: Node,
-	expectedAncestor: Node | undefined,
-	expectedPathA: Node[],
-	expectedPathB: Node[],
-): void {
-	const foundPathA: Node[] = [];
-	const foundPathB: Node[] = [];
-	const foundAncestor = findCommonAncestor([a, foundPathA], [b, foundPathB]);
-	assert.equal(foundAncestor, expectedAncestor, "Found unexpected ancestor node");
-	assert.deepEqual(foundPathA, expectedPathA);
-	assert.deepEqual(foundPathB, expectedPathB);
-}
+	it("returns undefined for undefined descendant", () => {
+		assertAncestor(undefined, undefined, []);
+	});
 
-describe("findAncestor", () => {
 	it("finds nothing", () => {
 		const a = node();
 		assertAncestor(a, undefined, []);
@@ -71,6 +60,14 @@ describe("findAncestor", () => {
 		assertAncestor(c, a, [b, c]);
 	});
 
+	it("finds farthest ancestor", () => {
+		const a = node();
+		const b = node(a);
+		const c = node(b);
+		assert.equal(findAncestor(a), a);
+		assert.equal(findAncestor(c), a);
+	});
+
 	it("has a working example doc comment", () => {
 		interface Parented {
 			id: string;
@@ -87,6 +84,21 @@ describe("findAncestor", () => {
 });
 
 describe("findCommonAncestor", () => {
+	function assertCommonAncestor(
+		a: Node,
+		b: Node,
+		expectedAncestor: Node | undefined,
+		expectedPathA: Node[],
+		expectedPathB: Node[],
+	): void {
+		const foundPathA: Node[] = [];
+		const foundPathB: Node[] = [];
+		const foundAncestor = findCommonAncestor([a, foundPathA], [b, foundPathB]);
+		assert.equal(foundAncestor, expectedAncestor, "Found unexpected ancestor node");
+		assert.deepEqual(foundPathA, expectedPathA);
+		assert.deepEqual(foundPathB, expectedPathB);
+	}
+
 	it("finds nothing", () => {
 		const a = node();
 		const b = node();

--- a/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
@@ -6,17 +6,28 @@
 import { strict as assert, fail } from "assert";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 // Allow importing from these specific files which are being tested:
-/* eslint-disable-next-line import/no-internal-modules */
-import { GraphCommit, RevisionTag, findCommonAncestor, rebaseBranch } from "../../core/rebase";
+import {
+	GraphCommit,
+	RevisionTag,
+	findAncestor,
+	findCommonAncestor,
+	rebaseBranch,
+	/* eslint-disable-next-line import/no-internal-modules */
+} from "../../core/rebase";
 import { NonEmptyTestChange, TestChange, TestChangeRebaser } from "../testChange";
 
 function newCommit(
-	inputContext: readonly number[],
 	intention: number | number[],
 	parent?: GraphCommit<TestChange>,
 ): GraphCommit<TestChange> {
+	const inputContext2: number[] = [];
+	if (parent !== undefined) {
+		const path: GraphCommit<TestChange>[] = [];
+		const ancestor = findAncestor([parent, path]);
+		inputContext2.push(...[ancestor, ...path].map((c) => Number.parseInt(c.revision, 10)));
+	}
 	return {
-		change: TestChange.mint(inputContext, intention),
+		change: TestChange.mint(inputContext2, intention),
 		revision: intention.toString() as RevisionTag,
 		sessionId: "TestSession",
 		parent,
@@ -56,9 +67,9 @@ describe("rebaseBranch", () => {
 	it("fails if branches are disjoint", () => {
 		// 1 ─ 2
 		// 3
-		const n1 = newCommit([], 1);
-		const n2 = newCommit([1], 2, n1);
-		const n3 = newCommit([], 3);
+		const n1 = newCommit(1);
+		const n2 = newCommit(2, n1);
+		const n3 = newCommit(3);
 
 		assert.throws(
 			() => rebaseBranch(new TestChangeRebaser(), n3, n2),
@@ -74,9 +85,9 @@ describe("rebaseBranch", () => {
 	it("does nothing if already rebased onto target", () => {
 		// 1
 		// └─ 2 ─ 3
-		const n1 = newCommit([], 1);
-		const n2 = newCommit([1], 2, n1);
-		const n3 = newCommit([1, 2], 3, n2);
+		const n1 = newCommit(1);
+		const n2 = newCommit(2, n1);
+		const n3 = newCommit(3, n2);
 
 		// (1)
 		//  └─ 2 ─ 3
@@ -91,11 +102,11 @@ describe("rebaseBranch", () => {
 	it("can rebase a branch onto the head of another branch", () => {
 		// 1 ─ 2 ─ 3
 		// └─ 4 ─ 5
-		const n1 = newCommit([], 1);
-		const n2 = newCommit([1], 2, n1);
-		const n3 = newCommit([1, 2], 3, n2);
-		const n4 = newCommit([1], 4, n1);
-		const n5 = newCommit([1, 4], 5, n4);
+		const n1 = newCommit(1);
+		const n2 = newCommit(2, n1);
+		const n3 = newCommit(3, n2);
+		const n4 = newCommit(4, n1);
+		const n5 = newCommit(5, n4);
 
 		// 1 ─ 2 ─(3)
 		//         └─ 4'─ 5'
@@ -115,11 +126,11 @@ describe("rebaseBranch", () => {
 	it("can rebase a branch onto the middle of another branch", () => {
 		// 1 ─ 2 ─ 3
 		// └─ 4 ─ 5
-		const n1 = newCommit([], 1);
-		const n2 = newCommit([1], 2, n1);
-		const n3 = newCommit([1, 2], 3, n2);
-		const n4 = newCommit([1], 4, n1);
-		const n5 = newCommit([1, 4], 5, n4);
+		const n1 = newCommit(1);
+		const n2 = newCommit(2, n1);
+		const n3 = newCommit(3, n2);
+		const n4 = newCommit(4, n1);
+		const n5 = newCommit(5, n4);
 
 		// 1 ─(2)─ 3
 		//     └─ 4'─ 5'
@@ -139,13 +150,13 @@ describe("rebaseBranch", () => {
 	it("skips and advances over commits with the same revision tag", () => {
 		// 1 ─ 2 ─ 3 ─ 4
 		// └─ 2'─ 3'─ 5
-		const n1 = newCommit([], 1);
-		const n2 = newCommit([1], 2, n1);
-		const n3 = newCommit([1, 2], 3, n2);
-		const n4 = newCommit([1, 2, 3], 4, n3);
-		const n2_1 = newCommit([1], 2, n1);
-		const n3_1 = newCommit([1, 2], 3, n2_1);
-		const n5 = newCommit([1, 2, 3], 5, n3_1);
+		const n1 = newCommit(1);
+		const n2 = newCommit(2, n1);
+		const n3 = newCommit(3, n2);
+		const n4 = newCommit(4, n3);
+		const n2_1 = newCommit(2, n1);
+		const n3_1 = newCommit(3, n2_1);
+		const n5 = newCommit(5, n3_1);
 
 		// 1 ─(2)─ 3 ─ 4
 		//         └─ 5'
@@ -165,13 +176,13 @@ describe("rebaseBranch", () => {
 	it("correctly rebases over branches that share some commits", () => {
 		// 1 ─ 2 ─ 3 ─ 4
 		// └─ 2'─ 3'─ 5
-		const n1 = newCommit([], 1);
-		const n2 = newCommit([1], 2, n1);
-		const n3 = newCommit([1, 2], 3, n2);
-		const n4 = newCommit([1, 2, 3], 4, n3);
-		const n2_1 = newCommit([1], 2, n1);
-		const n3_1 = newCommit([1, 2], 3, n2_1);
-		const n5 = newCommit([1, 2, 3], 5, n3_1);
+		const n1 = newCommit(1);
+		const n2 = newCommit(2, n1);
+		const n3 = newCommit(3, n2);
+		const n4 = newCommit(4, n3);
+		const n2_1 = newCommit(2, n1);
+		const n3_1 = newCommit(3, n2_1);
+		const n5 = newCommit(5, n3_1);
 
 		// 1 ─ 2 ─ 3 ─(4)
 		//             └─ 5'
@@ -191,12 +202,12 @@ describe("rebaseBranch", () => {
 	it("reports no change for equivalent branches", () => {
 		// 1 ─ 2 ─ 3 ─ 4
 		// └─ 2'─ 3'
-		const n1 = newCommit([], 1);
-		const n2 = newCommit([1], 2, n1);
-		const n3 = newCommit([1, 2], 3, n2);
-		const n4 = newCommit([1, 2, 3], 4, n3);
-		const n2_1 = newCommit([1], 2, n1);
-		const n3_1 = newCommit([1, 2], 3, n2_1);
+		const n1 = newCommit(1);
+		const n2 = newCommit(2, n1);
+		const n3 = newCommit(3, n2);
+		const n4 = newCommit(4, n3);
+		const n2_1 = newCommit(2, n1);
+		const n3_1 = newCommit(3, n2_1);
 
 		// 1 ─ 2 ─(3)─ 4
 		//         └─


### PR DESCRIPTION
## Description

* Improve documentation of `findAncestor` and make its input types more consistent (`descendant` can now be undefined both inside and outside of the path tuple). 
* Add overloads of `findAncestor` which do not take a path predicate, meaning "find the furthest ancestor".
* Simplify some `rebaseBranch` tests.