### PR TITLE
improvement(devtools-view): Scale theme provider div vertically

### DIFF
--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -183,7 +183,7 @@ export function DevtoolsView(): React.ReactElement {
 	}, [messageRelay, setSupportedFeatures]);
 
 	return (
-		<FluentProvider theme={getFluentUIThemeToUse()}>
+		<FluentProvider theme={getFluentUIThemeToUse()} style={{ height: "100%" }}>
 			{supportedFeatures === undefined ? (
 				<Waiting />
 			) : (


### PR DESCRIPTION
For whatever reason, `FluentThemeProvider` ends up being rendered as a div, and there does not appear to be a way to override this behavior. This change applies `height: "100%"` to that div to ensure our theme background fills the vertical space of the panel.

![image](https://github.com/microsoft/FluidFramework/assets/54606601/889059bf-8aa7-4ce5-9994-333685803ada)
