### PR TITLE
improvement(devtools-core): Update SharedMatrix data visualization to better match data representation

### DIFF
--- a/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
@@ -151,27 +151,19 @@ export const visualizeSharedMatrix: VisualizeSharedObject = async (
 
 	const { rowCount, colCount: columnCount, id: fluidObjectId } = sharedMatrix;
 
-	// Output will list child contents by row first, then by cell (column).
-	const rows: Record<string, VisualTreeNode> = {};
+	// Output will list cells as a flat list, keyed by their row,column indices (e.g. `[0,1]`)
+	const cells: Record<string, VisualChildNode> = {};
 	for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-		const cells: Record<string, VisualChildNode> = {};
 		for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
 			const cell = sharedMatrix.getCell(rowIndex, columnIndex) as unknown;
 			const renderedCell = await visualizeChildData(cell);
-			cells[columnIndex] = renderedCell;
+			cells[`[${rowIndex},${columnIndex}]`] = renderedCell;
 		}
-		rows[rowIndex] = {
-			children: cells,
-			metadata: {
-				cells: columnCount,
-			},
-			nodeKind: VisualNodeKind.TreeNode,
-		};
 	}
 
 	return {
 		fluidObjectId,
-		children: rows,
+		children: cells,
 		metadata: {
 			rows: rowCount,
 			columns: columnCount,

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
@@ -288,67 +288,51 @@ describe("DefaultVisualizers unit tests", () => {
 		const expected: FluidObjectTreeNode = {
 			fluidObjectId: "test-matrix",
 			children: {
-				0: {
+				"[0,0]": {
+					value: "Hello",
+					nodeKind: VisualNodeKind.ValueNode,
+					typeMetadata: "string",
+				},
+				"[0,1]": {
+					value: "World",
+					nodeKind: VisualNodeKind.ValueNode,
+					typeMetadata: "string",
+				},
+				"[0,2]": {
+					value: undefined,
+					nodeKind: VisualNodeKind.ValueNode,
+					typeMetadata: "undefined",
+				},
+				"[1,0]": {
+					value: 1,
+					nodeKind: VisualNodeKind.ValueNode,
+					typeMetadata: "number",
+				},
+				"[1,1]": {
+					value: true,
+					nodeKind: VisualNodeKind.ValueNode,
+					typeMetadata: "boolean",
+				},
+				"[1,2]": {
 					children: {
-						0: {
-							value: "Hello",
+						a: {
+							value: null,
 							nodeKind: VisualNodeKind.ValueNode,
-							typeMetadata: "string",
+							typeMetadata: "null",
 						},
-						1: {
-							value: "World",
-							nodeKind: VisualNodeKind.ValueNode,
-							typeMetadata: "string",
-						},
-						2: {
+						b: {
 							value: undefined,
 							nodeKind: VisualNodeKind.ValueNode,
 							typeMetadata: "undefined",
 						},
-					},
-					nodeKind: VisualNodeKind.TreeNode,
-					metadata: {
-						cells: 3,
-					},
-				},
-				1: {
-					children: {
-						0: {
-							value: 1,
-							nodeKind: VisualNodeKind.ValueNode,
-							typeMetadata: "number",
-						},
-						1: {
-							value: true,
+						c: {
+							value: false,
 							nodeKind: VisualNodeKind.ValueNode,
 							typeMetadata: "boolean",
 						},
-						2: {
-							children: {
-								a: {
-									value: null,
-									nodeKind: VisualNodeKind.ValueNode,
-									typeMetadata: "null",
-								},
-								b: {
-									value: undefined,
-									nodeKind: VisualNodeKind.ValueNode,
-									typeMetadata: "undefined",
-								},
-								c: {
-									value: false,
-									nodeKind: VisualNodeKind.ValueNode,
-									typeMetadata: "boolean",
-								},
-							},
-							typeMetadata: "object",
-							nodeKind: VisualNodeKind.TreeNode,
-						},
 					},
+					typeMetadata: "object",
 					nodeKind: VisualNodeKind.TreeNode,
-					metadata: {
-						cells: 3,
-					},
 				},
 			},
 			metadata: {


### PR DESCRIPTION
The existing SharedMatrix visualization introduced hierarchical nesting for rows and columns, but this doesn't match the data representation, and it adds overhead when navigating the nested view. This PR updates the visualization to display a flat list of cells, keyed by their row-column indices.

Before:
![image](https://github.com/microsoft/FluidFramework/assets/54606601/2a3e01d8-2821-49ec-b8db-04aaa2930714)

After:
![image](https://github.com/microsoft/FluidFramework/assets/54606601/25b62ebd-d452-43a6-a8e9-21a7d755ffaa)
