### PR TITLE
tree: Flatten fields in schema-aware types

### DIFF
--- a/api-report/tree2.api.md
+++ b/api-report/tree2.api.md
@@ -1290,7 +1290,7 @@ export interface NodeData {
     value?: TreeValue;
 }
 
-// @alpha
+// @alpha @deprecated
 type NodeDataFor<Mode extends ApiMode, TSchema extends TreeSchema> = TypedNode<TSchema, Mode>;
 
 // @alpha (undocumented)
@@ -1764,7 +1764,7 @@ TFields extends {
 ][InternalTypedSchemaTypes._dummy];
 
 // @alpha
-type TypedNode<TSchema extends TreeSchema, Mode extends ApiMode> = CollectOptions<Mode, TypedFields<Mode extends ApiMode.Editable ? ApiMode.EditableUnwrapped : Mode, TSchema["localFieldsObject"]>, TSchema["value"], TSchema["name"]>;
+type TypedNode<TSchema extends TreeSchema, Mode extends ApiMode = ApiMode.Editable> = InternalTypedSchemaTypes.FlattenKeys<CollectOptions<Mode, TypedFields<Mode extends ApiMode.Editable ? ApiMode.EditableUnwrapped : Mode, TSchema["localFieldsObject"]>, TSchema["value"], TSchema["name"]>>;
 
 // @alpha (undocumented)
 export interface TypedSchemaCollection<T extends GlobalFieldSchema> extends SchemaCollection {

--- a/examples/benchmarks/bubblebench/editable-shared-tree/src/schema.ts
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/src/schema.ts
@@ -4,7 +4,7 @@
  */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { ValueSchema, SchemaAware, SchemaBuilder, TreeSchema } from "@fluid-experimental/tree2";
+import { ValueSchema, SchemaAware, SchemaBuilder } from "@fluid-experimental/tree2";
 
 const builder = new SchemaBuilder("bubble-bench");
 
@@ -33,16 +33,11 @@ export const rootAppStateSchema = SchemaBuilder.fieldSequence(clientSchema);
 
 export const appSchemaData = builder.intoDocumentSchema(rootAppStateSchema);
 
-type Typed<
-	TSchema extends TreeSchema,
-	TMode extends SchemaAware.ApiMode = SchemaAware.ApiMode.Editable,
-> = SchemaAware.NodeDataFor<TMode, TSchema>;
+export type Bubble = SchemaAware.TypedNode<typeof bubbleSchema>;
+export type Client = SchemaAware.TypedNode<typeof clientSchema>;
 
-export type Bubble = Typed<typeof bubbleSchema>;
-export type Client = Typed<typeof clientSchema>;
-
-export type FlexBubble = Typed<typeof bubbleSchema, SchemaAware.ApiMode.Simple>;
-export type FlexClient = Typed<typeof clientSchema, SchemaAware.ApiMode.Simple>;
+export type FlexBubble = SchemaAware.TypedNode<typeof bubbleSchema, SchemaAware.ApiMode.Simple>;
+export type FlexClient = SchemaAware.TypedNode<typeof clientSchema, SchemaAware.ApiMode.Simple>;
 
 // TODO: experiment with this interface pattern. Maybe it makes better intellisense and errors?
 // TODO: Intellisense is pretty bad here if not using interface.

--- a/examples/data-objects/inventory-app/src/schema.ts
+++ b/examples/data-objects/inventory-app/src/schema.ts
@@ -26,4 +26,4 @@ export const rootField = SchemaBuilder.field(FieldKinds.value, inventory);
 
 export const schema = builder.intoDocumentSchema(rootField);
 
-export type Inventory = SchemaAware.NodeDataFor<SchemaAware.ApiMode.Editable, typeof inventory>;
+export type Inventory = SchemaAware.TypedNode<typeof inventory>;

--- a/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
+++ b/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
@@ -38,7 +38,7 @@ import {
 } from "./modular-schema";
 import { singleMapTreeCursor } from "./mapTreeCursor";
 import { isPrimitive } from "./editable-tree";
-import { AllowedTypesToTypedTrees, ApiMode, NodeDataFor, TypedField } from "./schema-aware";
+import { AllowedTypesToTypedTrees, ApiMode, TypedField, TypedNode } from "./schema-aware";
 
 /**
  * This library defines a tree data format that can infer its types from context.
@@ -353,7 +353,7 @@ export function cursorFromContextualData(
 export function cursorForTypedTreeData<T extends TreeSchema>(
 	schemaData: SchemaDataAndPolicy,
 	schema: T,
-	data: NodeDataFor<ApiMode.Simple, T>,
+	data: TypedNode<T, ApiMode.Simple>,
 ): ITreeCursorSynchronous {
 	return cursorFromContextualData(
 		schemaData,

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/typedSchema/schemaBuilder.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/typedSchema/schemaBuilder.ts
@@ -53,7 +53,8 @@ export type RecursiveTreeSchema = unknown;
 export type RecursiveTreeSchemaSpecification = unknown;
 
 {
-	type _check = requireAssignableTo<TreeSchemaSpecification, RecursiveTreeSchemaSpecification>;
+	type _check1 = requireAssignableTo<TreeSchemaSpecification, RecursiveTreeSchemaSpecification>;
+	type _check2 = requireAssignableTo<TreeSchema, RecursiveTreeSchema>;
 }
 
 /**

--- a/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAware.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAware.ts
@@ -266,7 +266,7 @@ export type TypedNode<
 /**
  * Generate a schema aware API for a single tree schema.
  * @alpha
- * @deprecated Use `TypedNode` instead (and revers the type parameter order).
+ * @deprecated Use `TypedNode` instead (and reverse the type parameter order).
  */
 export type NodeDataFor<Mode extends ApiMode, TSchema extends TreeSchema> = TypedNode<
 	TSchema,

--- a/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAware.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAware.ts
@@ -245,29 +245,29 @@ export type UntypedApi<Mode extends ApiMode> = {
 }[Mode];
 
 /**
- * Generate a schema aware API for a list of types.
- *
- * @remarks
- * The arguments here are in an order that makes the truncated strings printed for the types more useful.
- * This is important since this generic type is not inlined when recursing.
- * That mens it will show up in IntelliSense and errors.
+ * Generate a schema aware API for a single tree schema.
  * @alpha
  */
-export type TypedNode<TSchema extends TreeSchema, Mode extends ApiMode> = CollectOptions<
-	Mode,
-	TypedFields<
-		Mode extends ApiMode.Editable ? ApiMode.EditableUnwrapped : Mode,
-		TSchema["localFieldsObject"]
-	>,
-	TSchema["value"],
-	TSchema["name"]
+export type TypedNode<
+	TSchema extends TreeSchema,
+	Mode extends ApiMode = ApiMode.Editable,
+> = InternalTypedSchemaTypes.FlattenKeys<
+	CollectOptions<
+		Mode,
+		TypedFields<
+			Mode extends ApiMode.Editable ? ApiMode.EditableUnwrapped : Mode,
+			TSchema["localFieldsObject"]
+		>,
+		TSchema["value"],
+		TSchema["name"]
+	>
 >;
 
 /**
  * Generate a schema aware API for a single tree schema.
  * @alpha
+ * @deprecated Use `TypedNode` instead (and revers the type parameter order).
  */
-// TODO: make InternalTypedSchemaTypes.FlattenKeys work here for recursive types?
 export type NodeDataFor<Mode extends ApiMode, TSchema extends TreeSchema> = TypedNode<
 	TSchema,
 	Mode
@@ -281,7 +281,7 @@ export type NodeDataFor<Mode extends ApiMode, TSchema extends TreeSchema> = Type
 export function downCast<TSchema extends TreeSchema>(
 	schema: TSchema,
 	tree: UntypedTreeCore,
-): tree is NodeDataFor<ApiMode.Editable, TSchema> {
+): tree is TypedNode<TSchema> {
 	if (typeof tree !== "object") {
 		return false;
 	}

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
@@ -102,8 +102,7 @@ type x = typeof numberSchema.name;
 const schemaData = builder.intoLibrary();
 
 // Example Use:
-type BallTreeX = TypedNode<typeof ballSchema, ApiMode.Flexible>;
-type BallTree = NodeDataFor<ApiMode.Flexible, typeof ballSchema>;
+type BallTree = TypedNode<typeof ballSchema, ApiMode.Flexible>;
 
 {
 	type check1_ = requireAssignableTo<BallTree, ContextuallyTypedNodeDataObject>;
@@ -167,7 +166,7 @@ type FlexNumber =
 // Test terminal cases:
 {
 	type F = NodeDataFor<ApiMode.Flexible, typeof numberSchema>;
-	type E = NodeDataFor<ApiMode.Editable, typeof numberSchema>;
+	type E = TypedNode<typeof numberSchema>;
 	type Eu = NodeDataFor<ApiMode.EditableUnwrapped, typeof numberSchema>;
 	type S = NodeDataFor<ApiMode.Simple, typeof numberSchema>;
 	type _check1 = requireTrue<areSafelyAssignable<F, FlexNumber>>;
@@ -200,10 +199,10 @@ type SimpleBall = {
 
 // Test non recursive cases:
 {
-	type F = NodeDataFor<ApiMode.Flexible, typeof ballSchema>;
-	type E = NodeDataFor<ApiMode.Editable, typeof ballSchema>;
-	type Eu = NodeDataFor<ApiMode.EditableUnwrapped, typeof ballSchema>;
-	type S = NodeDataFor<ApiMode.Simple, typeof ballSchema>;
+	type F = TypedNode<typeof ballSchema, ApiMode.Flexible>;
+	type E = TypedNode<typeof ballSchema>;
+	type Eu = TypedNode<typeof ballSchema, ApiMode.EditableUnwrapped>;
+	type S = TypedNode<typeof ballSchema, ApiMode.Simple>;
 	type _check1 = requireTrue<areSafelyAssignable<F, FlexBall>>;
 	type _check2 = requireAssignableTo<E, SimpleBall & UntypedTreeCore>;
 	type _check3 = requireAssignableTo<Eu, SimpleBall & UntypedTreeCore>;
@@ -264,10 +263,10 @@ type SimpleBall = {
 	}
 
 	{
-		type F = NodeDataFor<ApiMode.Flexible, typeof parent>;
-		type E = NodeDataFor<ApiMode.Editable, typeof parent>;
-		type Eu = NodeDataFor<ApiMode.EditableUnwrapped, typeof parent>;
-		type S = NodeDataFor<ApiMode.Simple, typeof parent>;
+		type F = TypedNode<typeof parent, ApiMode.Flexible>;
+		type E = TypedNode<typeof parent>;
+		type Eu = TypedNode<typeof parent, ApiMode.EditableUnwrapped>;
+		type S = TypedNode<typeof parent, ApiMode.Simple>;
 		type _check1 = requireTrue<areSafelyAssignable<F, FlexParent>>;
 		type _check2 = requireAssignableTo<E, SimpleParent & UntypedTreeCore>;
 		type _check3 = requireAssignableTo<Eu, SimpleParent & UntypedTreeCore>;
@@ -315,9 +314,9 @@ type SimpleBall = {
 			x: ExpectedSimple2 | undefined;
 		};
 
-		type Flexible = NodeDataFor<ApiMode.Flexible, typeof rec>;
-		type Edit = NodeDataFor<ApiMode.Editable, typeof rec>;
-		type Simple = NodeDataFor<ApiMode.Simple, typeof rec>;
+		type Flexible = TypedNode<typeof rec, ApiMode.Flexible>;
+		type Edit = TypedNode<typeof rec>;
+		type Simple = TypedNode<typeof rec, ApiMode.Simple>;
 		type Simple2 = SimpleNodeDataFor<typeof rec>;
 
 		// Check Simple's field type unit tests
@@ -342,10 +341,10 @@ type SimpleBall = {
 
 // Test recursive cases:
 {
-	type F = NodeDataFor<ApiMode.Flexible, typeof boxSchema>;
-	type E = NodeDataFor<ApiMode.Editable, typeof boxSchema>;
-	type Eu = NodeDataFor<ApiMode.EditableUnwrapped, typeof boxSchema>;
-	type S = NodeDataFor<ApiMode.Simple, typeof boxSchema>;
+	type F = TypedNode<typeof boxSchema, ApiMode.Flexible>;
+	type E = TypedNode<typeof boxSchema>;
+	type Eu = TypedNode<typeof boxSchema, ApiMode.EditableUnwrapped>;
+	type S = TypedNode<typeof boxSchema, ApiMode.Simple>;
 
 	interface FlexBox {
 		[typeNameSymbol]?: "box";

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaAware.spec.ts
@@ -9,7 +9,6 @@
 
 import {
 	ApiMode,
-	NodeDataFor,
 	AllowedTypesToTypedTrees,
 	TypedNode,
 	EditableField,
@@ -165,10 +164,10 @@ type FlexNumber =
 
 // Test terminal cases:
 {
-	type F = NodeDataFor<ApiMode.Flexible, typeof numberSchema>;
+	type F = TypedNode<typeof numberSchema, ApiMode.Flexible>;
 	type E = TypedNode<typeof numberSchema>;
-	type Eu = NodeDataFor<ApiMode.EditableUnwrapped, typeof numberSchema>;
-	type S = NodeDataFor<ApiMode.Simple, typeof numberSchema>;
+	type Eu = TypedNode<typeof numberSchema, ApiMode.EditableUnwrapped>;
+	type S = TypedNode<typeof numberSchema, ApiMode.Simple>;
 	type _check1 = requireTrue<areSafelyAssignable<F, FlexNumber>>;
 	type _check2 = requireAssignableTo<E, UntypedTreeCore>;
 	type _check3 = requireTrue<areSafelyAssignable<Eu, number>>;

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaComplex.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaComplex.ts
@@ -34,17 +34,11 @@ export const rootFieldSchema = SchemaBuilder.fieldValue(stringTaskSchema, listTa
 export const appSchemaData = builder.intoDocumentSchema(rootFieldSchema);
 
 // Schema aware types
-export type StringTask = SchemaAware.NodeDataFor<
-	SchemaAware.ApiMode.Editable,
-	typeof stringTaskSchema
->;
+export type StringTask = SchemaAware.TypedNode<typeof stringTaskSchema>;
 
-export type ListTask = SchemaAware.NodeDataFor<SchemaAware.ApiMode.Editable, typeof listTaskSchema>;
+export type ListTask = SchemaAware.TypedNode<typeof listTaskSchema>;
 
-type FlexibleListTask = SchemaAware.NodeDataFor<
-	SchemaAware.ApiMode.Flexible,
-	typeof listTaskSchema
->;
+type FlexibleListTask = SchemaAware.TypedNode<typeof listTaskSchema, SchemaAware.ApiMode.Flexible>;
 
 type FlexibleTask = SchemaAware.AllowedTypesToTypedTrees<
 	SchemaAware.ApiMode.Flexible,

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaSimple.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaSimple.ts
@@ -20,9 +20,9 @@ export const pointSchema = builder.object("point", {
 export const appSchemaData = builder.intoDocumentSchema(SchemaBuilder.fieldSequence(pointSchema));
 
 // Schema aware types
-export type Number = SchemaAware.NodeDataFor<SchemaAware.ApiMode.Editable, typeof numberSchema>;
+export type Number = SchemaAware.TypedNode<typeof numberSchema>;
 
-export type Point = SchemaAware.NodeDataFor<SchemaAware.ApiMode.Editable, typeof pointSchema>;
+export type Point = SchemaAware.TypedNode<typeof pointSchema>;
 
 // Example Use
 function dotProduct(a: Point, b: Point): number {
@@ -31,12 +31,9 @@ function dotProduct(a: Point, b: Point): number {
 
 // More Schema aware APIs
 {
-	type FlexibleNumber = SchemaAware.NodeDataFor<
-		SchemaAware.ApiMode.Flexible,
-		typeof numberSchema
-	>;
+	type FlexibleNumber = SchemaAware.TypedNode<typeof numberSchema, SchemaAware.ApiMode.Flexible>;
 
-	type FlexiblePoint = SchemaAware.NodeDataFor<SchemaAware.ApiMode.Flexible, typeof pointSchema>;
+	type FlexiblePoint = SchemaAware.TypedNode<typeof pointSchema, SchemaAware.ApiMode.Flexible>;
 
 	const point: FlexiblePoint = {
 		x: 1,

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.bench.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.bench.ts
@@ -78,7 +78,7 @@ interface JSDeepTree {
 	foo: JSDeepTree | number;
 }
 
-type JSDeepTree2 = SchemaAware.NodeDataFor<SchemaAware.ApiMode.Simple, typeof linkedListSchema>;
+type JSDeepTree2 = SchemaAware.TypedNode<typeof linkedListSchema, SchemaAware.ApiMode.Simple>;
 
 {
 	type _check = requireAssignableTo<JSDeepTree, JSDeepTree2>;

--- a/experimental/framework/tree-react-api/src/test/schema.ts
+++ b/experimental/framework/tree-react-api/src/test/schema.ts
@@ -19,4 +19,4 @@ export const rootField = SchemaBuilder.field(FieldKinds.value, inventory);
 
 export const schema = builder.intoDocumentSchema(rootField);
 
-export type Inventory = SchemaAware.NodeDataFor<SchemaAware.ApiMode.Editable, typeof inventory>;
+export type Inventory = SchemaAware.TypedNode<typeof inventory>;


### PR DESCRIPTION
## Description

Field flattening (making the intelisense look like single objects instead of a bunch of anded together objects) has been added back to SchemaAware.

With the new schema system, this can be done in TypedNode, removing the use-case for NodeDataFor which has now been deprecated and had all its use removed.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

