### PR TITLE
Revert "refactor(ci): Get npm feed URLs from centralized variable group"

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -129,7 +129,6 @@ variables:
   - name: toolAbsolutePath
     value:  $(Build.SourcesDirectory)/tools/telemetry-generator
     readonly: true
-  - group: ado-feeds
 
 stages:
   - ${{ if ne(convertToJson(parameters.checks), '[]') }}:
@@ -470,7 +469,6 @@ stages:
               inputs:
                 targetType: 'inline'
                 workingDirectory: ${{ variables.toolAbsolutePath }}
-                # Note: $(buildFeed) and $(officeFeed) come from the ado-feeds variable group
                 script: |
                   echo Initialize package
                   npm init --yes
@@ -482,8 +480,8 @@ stages:
                   echo "@fluidframework:registry=${{ variables.feed }}" >> ./.npmrc
                   echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
                   echo "@fluid-internal:registry=${{ variables.devFeed }}" >> ./.npmrc
-                  echo "@ff-internal:registry=$(buildFeed)" >> ./.npmrc
-                  echo "@microsoft:registry=$(officeFeed)" >> ./.npmrc
+                  echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
+                  echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
                   echo "always-auth=true" >> ./.npmrc
                   cat .npmrc
 

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -23,14 +23,12 @@ stages:
   dependsOn: build
   displayName: Publish Internal Test Packages
   condition: and(succeeded(), eq(variables['testBuild'], true))
-  variables:
-  - group: ado-feeds
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:
       namespace: ${{ parameters.namespace }}
-      devFeedName: $(testFeed) # Comes from the ado-feeds variable group
-      feedName: $(testFeed) # Comes from the ado-feeds variable group
+      devFeedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/test/npm/registry/
+      feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/test/npm/registry/
       official: false
       environment: test-package-build-feed
       pool: ${{ parameters.pool }}
@@ -40,14 +38,12 @@ stages:
   dependsOn: build
   displayName: Publish Internal Packages
   condition: and(succeeded(), eq(variables['testBuild'], false))
-  variables:
-  - group: ado-feeds
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:
       namespace: ${{ parameters.namespace }}
-      devFeedName: $(devFeed) # Comes from the ado-feeds variable group
-      feedName: $(buildFeed) # Comes from the ado-feeds variable group
+      devFeedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
+      feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
       official: false
       environment: package-build-feed
       pool: ${{ parameters.pool }}
@@ -57,15 +53,13 @@ stages:
   dependsOn: build
   displayName: Publish Official Packages
   condition: and(succeeded(), or(eq(variables['release'], 'release'), eq(variables['release'], 'prerelease')))
-  variables:
-  - group: ado-feeds
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:
       namespace: ${{ parameters.namespace }}
       # internal/msinternal/example packages are deleted for official releases, but in case something goes wrong with that,
       # using the `dev` registry is safe.
-      devFeedName: $(devFeed) # Comes from the ado-feeds variable group
+      devFeedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
       feedName: https://registry.npmjs.org
       official: true
       environment: package-npmjs-feed

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -27,20 +27,19 @@ jobs:
     pool: ${{ parameters.poolBuild }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     variables:
-    - group: ado-feeds
     - name: isTestBranch
       value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}
       readonly: true
     - name: feed
       ${{ if eq(variables.isTestBranch, 'true') }}:
-        value: $(internalFeed) # Comes from the ado-feeds variable group
+        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
       ${{ else }}:
-        value: $(buildFeed) # Comes from the ado-feeds variable group
+        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
     - name: devFeed
       ${{ if eq(variables.isTestBranch, 'true') }}:
-        value: $(internalFeed) # Comes from the ado-feeds variable group
+        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
       ${{ else }}:
-        value: $(devFeed) # Comes from the ado-feeds variable group
+        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
 
     steps:
     # Setup. Need to checkout the repo in order to run @fluid-tools/telemetry-generator which we don't publish right now.
@@ -92,7 +91,6 @@ jobs:
       inputs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.testWorkspace }}
-        # Note: $(buildFeed) and $(officeFeed) come from the ado-feeds variable group
         script: |
           echo Initialize package
           npm init --yes
@@ -105,8 +103,8 @@ jobs:
           echo "@fluid-experimental:registry=$(feed)" >> ./.npmrc
           echo "@fluid-tools:registry=$(feed)" >> ./.npmrc
           echo "@fluid-internal:registry=$(devFeed)" >> ./.npmrc
-          echo "@ff-internal:registry=$(buildFeed)" >> ./.npmrc
-          echo "@microsoft:registry=$(officeFeed)" >> ./.npmrc
+          echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
+          echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
           echo "always-auth=true" >> ./.npmrc
           cat .npmrc
 

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -80,7 +80,6 @@ jobs:
       condition: ${{ parameters.condition }}
       timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
       variables:
-      - group: ado-feeds
       - name: isTestBranch
         value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}
         readonly: true
@@ -99,14 +98,14 @@ jobs:
         value: true
       - name: feed
         ${{ if eq(variables.isTestBranch, 'true') }}:
-          value: $(internalFeed) # Comes from the ado-feeds variable group
+          value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
         ${{ else }}:
-          value: $(buildFeed) # Comes from the ado-feeds variable group
+          value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
       - name: devFeed
         ${{ if eq(variables.isTestBranch, 'true') }}:
-          value: $(internalFeed) # Comes from the ado-feeds variable group
+          value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
         ${{ else }}:
-          value: $(devFeed) # Comes from the ado-feeds variable group
+          value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
       - name: artifactPipeline
         ${{ if eq(parameters.downloadAzureTestArtifacts, true) }}:
           value: Build - azure
@@ -208,7 +207,6 @@ jobs:
         inputs:
           targetType: 'inline'
           workingDirectory: ${{ parameters.testWorkspace }}
-          # Note: $(buildFeed) and $(officeFeed) come from the ado-feeds variable group
           script: |
             echo Initialize package
             npm init --yes
@@ -220,8 +218,8 @@ jobs:
             echo "@fluidframework:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@fluid-internal:registry=${{ variables.devFeed }}" >> ./.npmrc
-            echo "@ff-internal:registry=$(buildFeed)" >> ./.npmrc
-            echo "@microsoft:registry=$(officeFeed)" >> ./.npmrc
+            echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
+            echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
             echo "always-auth=true" >> ./.npmrc
             cat .npmrc
 


### PR DESCRIPTION
This causes some issues on internal test runs due to duplicate variable names.