### PR TITLE
refactor(ci): Get npm feed URLs from centralized variable group

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -125,6 +125,7 @@ variables:
   - name: toolAbsolutePath
     value:  $(Build.SourcesDirectory)/tools/telemetry-generator
     readonly: true
+  - group: ado-feeds
 
 stages:
   - ${{ if ne(convertToJson(parameters.checks), '[]') }}:
@@ -464,6 +465,7 @@ stages:
               inputs:
                 targetType: 'inline'
                 workingDirectory: ${{ variables.toolAbsolutePath }}
+                # Note: $(ado-feeds-build) and $(ado-feeds-office) come from the ado-feeds variable group
                 script: |
                   echo Initialize package
                   npm init --yes
@@ -475,8 +477,8 @@ stages:
                   echo "@fluidframework:registry=${{ variables.feed }}" >> ./.npmrc
                   echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
                   echo "@fluid-internal:registry=${{ variables.devFeed }}" >> ./.npmrc
-                  echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
-                  echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
+                  echo "@ff-internal:registry=$(ado-feeds-build)" >> ./.npmrc
+                  echo "@microsoft:registry=$(ado-feeds-office)" >> ./.npmrc
                   echo "always-auth=true" >> ./.npmrc
                   cat .npmrc
 

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -23,12 +23,14 @@ stages:
   dependsOn: build
   displayName: Publish Internal Test Packages
   condition: and(succeeded(), eq(variables['testBuild'], true))
+  variables:
+  - group: ado-feeds
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:
       namespace: ${{ parameters.namespace }}
-      devFeedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/test/npm/registry/
-      feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/test/npm/registry/
+      devFeedName: $(ado-feeds-test) # Comes from the ado-feeds variable group
+      feedName: $(ado-feeds-test) # Comes from the ado-feeds variable group
       official: false
       environment: test-package-build-feed
       pool: ${{ parameters.pool }}
@@ -38,12 +40,14 @@ stages:
   dependsOn: build
   displayName: Publish Internal Packages
   condition: and(succeeded(), eq(variables['testBuild'], false))
+  variables:
+  - group: ado-feeds
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:
       namespace: ${{ parameters.namespace }}
-      devFeedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
-      feedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
+      devFeedName: $(ado-feeds-dev) # Comes from the ado-feeds variable group
+      feedName: $(ado-feeds-build) # Comes from the ado-feeds variable group
       official: false
       environment: package-build-feed
       pool: ${{ parameters.pool }}
@@ -53,13 +57,15 @@ stages:
   dependsOn: build
   displayName: Publish Official Packages
   condition: and(succeeded(), or(eq(variables['release'], 'release'), eq(variables['release'], 'prerelease')))
+  variables:
+  - group: ado-feeds
   jobs:
   - template: include-publish-npm-package-deployment.yml
     parameters:
       namespace: ${{ parameters.namespace }}
       # internal/msinternal/example packages are deleted for official releases, but in case something goes wrong with that,
       # using the `dev` registry is safe.
-      devFeedName: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
+      devFeedName: $(ado-feeds-dev) # Comes from the ado-feeds variable group
       feedName: https://registry.npmjs.org
       official: true
       environment: package-npmjs-feed

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -27,19 +27,20 @@ jobs:
     pool: ${{ parameters.poolBuild }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     variables:
+    - group: ado-feeds
     - name: isTestBranch
       value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}
       readonly: true
     - name: feed
       ${{ if eq(variables.isTestBranch, 'true') }}:
-        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
+        value: $(ado-feeds-internal) # Comes from the ado-feeds variable group
       ${{ else }}:
-        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
+        value: $(ado-feeds-build) # Comes from the ado-feeds variable group
     - name: devFeed
       ${{ if eq(variables.isTestBranch, 'true') }}:
-        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
+        value: $(ado-feeds-internal) # Comes from the ado-feeds variable group
       ${{ else }}:
-        value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
+        value: $(ado-feeds-dev) # Comes from the ado-feeds variable group
 
     steps:
     # Setup. Need to checkout the repo in order to run @fluid-tools/telemetry-generator which we don't publish right now.
@@ -91,6 +92,7 @@ jobs:
       inputs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.testWorkspace }}
+        # Note: $(ado-feeds-build) and $(ado-feeds-office) come from the ado-feeds variable group
         script: |
           echo Initialize package
           npm init --yes
@@ -103,8 +105,8 @@ jobs:
           echo "@fluid-experimental:registry=$(feed)" >> ./.npmrc
           echo "@fluid-tools:registry=$(feed)" >> ./.npmrc
           echo "@fluid-internal:registry=$(devFeed)" >> ./.npmrc
-          echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
-          echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
+          echo "@ff-internal:registry=$(ado-feeds-build)" >> ./.npmrc
+          echo "@microsoft:registry=$(ado-feeds-office)" >> ./.npmrc
           echo "always-auth=true" >> ./.npmrc
           cat .npmrc
 

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -80,6 +80,7 @@ jobs:
       condition: ${{ parameters.condition }}
       timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
       variables:
+      - group: ado-feeds
       - name: isTestBranch
         value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}
         readonly: true
@@ -98,14 +99,14 @@ jobs:
         value: true
       - name: feed
         ${{ if eq(variables.isTestBranch, 'true') }}:
-          value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
+          value: $(ado-feeds-internal) # Comes from the ado-feeds variable group
         ${{ else }}:
-          value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/
+          value: $(ado-feeds-build) # Comes from the ado-feeds variable group
       - name: devFeed
         ${{ if eq(variables.isTestBranch, 'true') }}:
-          value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/internal/npm/registry/
+          value: $(ado-feeds-internal) # Comes from the ado-feeds variable group
         ${{ else }}:
-          value: https://pkgs.dev.azure.com/fluidframework/internal/_packaging/dev/npm/registry/
+          value: $(ado-feeds-dev) # Comes from the ado-feeds variable group
       - name: artifactPipeline
         ${{ if eq(parameters.downloadAzureTestArtifacts, true) }}:
           value: Build - azure
@@ -207,6 +208,7 @@ jobs:
         inputs:
           targetType: 'inline'
           workingDirectory: ${{ parameters.testWorkspace }}
+          # Note: $(ado-feeds-build) and $(ado-feeds-office) come from the ado-feeds variable group
           script: |
             echo Initialize package
             npm init --yes
@@ -218,8 +220,8 @@ jobs:
             echo "@fluidframework:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
             echo "@fluid-internal:registry=${{ variables.devFeed }}" >> ./.npmrc
-            echo "@ff-internal:registry=https://pkgs.dev.azure.com/fluidframework/internal/_packaging/build/npm/registry/" >> ./.npmrc
-            echo "@microsoft:registry=https://office.pkgs.visualstudio.com/_packaging/Office/npm/registry/" >> ./.npmrc
+            echo "@ff-internal:registry=$(ado-feeds-build)" >> ./.npmrc
+            echo "@microsoft:registry=$(ado-feeds-office)" >> ./.npmrc
             echo "always-auth=true" >> ./.npmrc
             cat .npmrc
 


### PR DESCRIPTION
## Description

Re-applying #15507 with updated variable names that don't cause cyclical references.