### PR TITLE
Fix tinylicious-client peer dependency on fluid-framework

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -84,9 +84,6 @@
 		"start-server-and-test": "^1.11.7",
 		"typescript": "~4.5.5"
 	},
-	"peerDependencies": {
-		"fluid-framework": ">=2.0.0-internal.4.1.0 <2.0.0-internal.5.0.0"
-	},
 	"typeValidation": {
 		"broken": {}
 	}

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -79,7 +79,7 @@
 		"typescript": "~4.5.5"
 	},
 	"peerDependencies": {
-		"fluid-framework": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0"
+		"fluid-framework": "workspace:~"
 	},
 	"typeValidation": {
 		"broken": {}

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -78,9 +78,6 @@
 		"tinylicious": "0.7.2",
 		"typescript": "~4.5.5"
 	},
-	"peerDependencies": {
-		"fluid-framework": "workspace:~"
-	},
 	"typeValidation": {
 		"broken": {}
 	}


### PR DESCRIPTION
During my FHL project, I found that `npm i` was failing when I tried to upgrade from `1.3.6` to `2.0.0-internal.4.x`, I'm not sure what the proper fix is, but `@fluidframework/tinylicious-client` packages in major version 12.0.0-internal.4.x1 have the wrong `fluid-framework` peer dependency.

Update: we are deciding to remove the peer dependencies and add them back later.