### PR TITLE
ci: Use correct changeset metadata path

### DIFF
--- a/.github/workflows/pr-check-changeset.yml
+++ b/.github/workflows/pr-check-changeset.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Upload changeset status
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # ratchet:actions/upload-artifact@v3
         with:
-          name: changeset-metadata.json
-          path: ./changeset-metadata
+          name: changeset-metadata
+          path: ./changeset-metadata.json
           retention-days: 3
 
   # Any PR without the changeset-required label will be ignored.
@@ -73,6 +73,6 @@ jobs:
       - name: Upload changeset status
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # ratchet:actions/upload-artifact@v3
         with:
-          name: changeset-metadata.json
-          path: ./changeset-metadata
+          name: changeset-metadata
+          path: ./changeset-metadata.json
           retention-days: 3


### PR DESCRIPTION
The path and name of the metadata file was reversed, so the files weren't getting uploaded.