### PR TITLE
ci: Add changeset-required to changset metadata

### DIFF
--- a/.github/workflows/changeset-reporter.yml
+++ b/.github/workflows/changeset-reporter.yml
@@ -26,14 +26,14 @@ jobs:
         run: echo "CHANGESET=$(cat changeset-metadata.json)" >> $GITHUB_ENV
 
       - name: Required but missing
-        if: fromJson(env.CHANGESET).changesetFound == false && contains(github.event.pull_request.labels.*.name, 'changeset-required')
+        if: fromJson(env.CHANGESET).required == true && fromJson(env.CHANGESET).changesetFound == false
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset
           path: ./.github/workflows/data/changeset-missing.md
 
       - name: Required and present
-        if: fromJson(env.CHANGESET).changesetFound == true && contains(github.event.pull_request.labels.*.name, 'changeset-required')
+        if: fromJson(env.CHANGESET).required == true && fromJson(env.CHANGESET).changesetFound == true
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset
@@ -42,7 +42,7 @@ jobs:
             This PR requires a changeset and it has one! Good job!
 
       - name: Changeset not required
-        if: fromJson(env.CHANGESET).changesetFound == true && !contains(github.event.pull_request.labels.*.name, 'changeset-required')
+        if: fromJson(env.CHANGESET).required == false && fromJson(env.CHANGESET).changesetFound == true
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset

--- a/.github/workflows/pr-check-changeset.yml
+++ b/.github/workflows/pr-check-changeset.yml
@@ -51,6 +51,17 @@ jobs:
           # JSON output is piped through jq to compact it to a single line
           pnpm exec flub check changeset --branch=${{ github.base_ref }} --json | jq -c > changeset-metadata.json
 
+      # Sets required = true/false based on the changeset-required label on the PR
+      - name: Changeset required
+        if: contains(github.event.pull_request.labels.*.name, 'changeset-required')
+        run: |
+          echo $(jq -c '. += {required: true}' changeset-metadata.json) > changeset-metadata.json
+
+      - name: Changeset not required
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'changeset-required') }}
+        run: |
+          echo $(jq -c '. += {required: false}' changeset-metadata.json) > changeset-metadata.json
+
       - name: Upload changeset status
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # ratchet:actions/upload-artifact@v3
         with:


### PR DESCRIPTION
The changeset-reporter job is not able to access the PR labels easily, so we append the label status to the metadata that we upload from the PR.