### PR TITLE
Remove sessionId from GraphCommit

### DIFF
--- a/experimental/dds/tree2/src/core/rebase/types.ts
+++ b/experimental/dds/tree2/src/core/rebase/types.ts
@@ -50,8 +50,6 @@ export function mintRevisionTag(): RevisionTag {
 export interface GraphCommit<TChange> {
 	/** The tag for this commit. If this commit is rebased, the corresponding rebased commit will retain this tag. */
 	readonly revision: RevisionTag;
-	/** An identifier representing the session/user/client that made this commit */
-	readonly sessionId: SessionId;
 	/** The change that will result from applying this commit */
 	readonly change: TChange;
 	/** The parent of this commit, on whose change this commit's change is based */
@@ -70,10 +68,9 @@ export function mintCommit<TChange>(
 	parent: GraphCommit<TChange>,
 	commit: Omit<GraphCommit<TChange>, "parent">,
 ): GraphCommit<TChange> {
-	const { revision, sessionId, change } = commit;
+	const { revision, change } = commit;
 	return {
 		revision,
-		sessionId,
 		change,
 		parent,
 	};

--- a/experimental/dds/tree2/src/core/rebase/utils.ts
+++ b/experimental/dds/tree2/src/core/rebase/utils.ts
@@ -231,7 +231,6 @@ export function rebaseBranch<TChange>(
 			]);
 			newHead = {
 				revision: c.revision,
-				sessionId: c.sessionId,
 				change,
 				parent: newHead,
 			};

--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -86,7 +86,6 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 	/**
 	 * Construct a new branch.
 	 * @param head - the head of the branch
-	 * @param sessionId - the session ID used to author commits made by this branch
 	 * @param rebaser - the rebaser used for rebasing and merging commits across branches
 	 * @param changeFamily - determines the set of changes that this branch can commit
 	 * @param undoRedoManager - an optional {@link UndoRedoManager} to manage the undo/redo operations of this
@@ -95,7 +94,6 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 	 */
 	public constructor(
 		private head: GraphCommit<TChange>,
-		public readonly sessionId: string,
 		public readonly changeFamily: ChangeFamily<TEditor, TChange>,
 		private readonly undoRedoManager?: UndoRedoManager<TChange, TEditor>,
 		private readonly anchors?: AnchorSet,
@@ -137,7 +135,6 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		this.assertNotDisposed();
 		this.head = mintCommit(this.head, {
 			revision,
-			sessionId: this.sessionId,
 			change,
 		});
 
@@ -200,7 +197,6 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 			const change = this.changeFamily.rebaser.compose(anonymousCommits);
 			this.head = mintCommit(startCommit, {
 				revision: mintRevisionTag(),
-				sessionId: this.sessionId,
 				change,
 			});
 
@@ -333,7 +329,6 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		this.assertNotDisposed();
 		const fork = new SharedTreeBranch(
 			this.head,
-			this.sessionId,
 			this.changeFamily,
 			this.undoRedoManager?.clone(repairDataStoreProvider),
 			anchors,

--- a/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/sharedTreeCore.ts
@@ -33,6 +33,7 @@ import {
 	ChangeFamilyEditor,
 	IRepairDataStoreProvider,
 	mintRevisionTag,
+	GraphCommit,
 } from "../core";
 import { brand, isJsonObject, JsonCompatibleReadOnly, TransactionResult } from "../util";
 import { createEmitter, TransformEvents } from "../events";
@@ -230,7 +231,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 	 * Submits an op to the Fluid runtime containing the given commit
 	 * @param commit - the commit to submit
 	 */
-	private submitCommit(commit: Commit<TChange>): void {
+	private submitCommit(commit: GraphCommit<TChange>): void {
 		// Edits should not be submitted until all transactions finish
 		assert(!this.isTransacting(), "Unexpected edit submitted during transaction");
 
@@ -240,7 +241,11 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		if (this.detachedRevision !== undefined) {
 			const newRevision: SeqNumber = brand((this.detachedRevision as number) + 1);
 			this.detachedRevision = newRevision;
-			this.editManager.addSequencedChange(commit, newRevision, this.detachedRevision);
+			this.editManager.addSequencedChange(
+				{ ...commit, sessionId: this.editManager.localSessionId },
+				newRevision,
+				this.detachedRevision,
+			);
 		}
 		const message: Message = {
 			revision: commit.revision,

--- a/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaseBranch.spec.ts
@@ -18,7 +18,6 @@ function newCommit(
 	return {
 		change: TestChange.mint(inputContext, intention),
 		revision: intention.toString() as RevisionTag,
-		sessionId: "TestSession",
 		parent,
 	};
 }

--- a/experimental/dds/tree2/src/test/rebase/rebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/rebase/rebaser.spec.ts
@@ -68,7 +68,6 @@ describe("rebaser", () => {
 				for (const revision of main) {
 					cur = {
 						revision: makeRevisionTag(revision),
-						sessionId: "",
 						change: {},
 						parent: cur,
 					};
@@ -80,7 +79,6 @@ describe("rebaser", () => {
 				for (const revision of branch.slice(1)) {
 					cur = {
 						revision: makeRevisionTag(revision),
-						sessionId: "",
 						change: {},
 						parent: cur,
 					};

--- a/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
@@ -476,10 +476,9 @@ describe("Branches", () => {
 		const initCommit: GraphCommit<DefaultChangeset> = {
 			change: defaultChangeFamily.rebaser.compose([]),
 			revision: nullRevisionTag,
-			sessionId: "testSession",
 		};
 
-		const branch = new SharedTreeBranch(initCommit, "testSession", defaultChangeFamily);
+		const branch = new SharedTreeBranch(initCommit, defaultChangeFamily);
 		if (onChange !== undefined) {
 			branch.on("change", onChange);
 		}
@@ -490,7 +489,6 @@ describe("Branches", () => {
 	function createRevertible(from: DefaultBranch): DefaultBranch {
 		return new SharedTreeBranch(
 			from.getHead(),
-			from.sessionId,
 			defaultChangeFamily,
 			UndoRedoManager.create(new MockRepairDataStoreProvider(), defaultChangeFamily),
 		);

--- a/experimental/dds/tree2/src/test/undo/undoRedoManager.spec.ts
+++ b/experimental/dds/tree2/src/test/undo/undoRedoManager.spec.ts
@@ -8,7 +8,6 @@ import {
 	ChangeFamilyEditor,
 	ChangeRebaser,
 	GraphCommit,
-	SessionId,
 	UndoRedoManager,
 	mintRevisionTag,
 } from "../../core";
@@ -17,16 +16,14 @@ import { UndoRedoManagerCommitType, ReversibleCommit } from "../../core/undo/und
 import { TestChange, testChangeFamilyFactory } from "../testChange";
 import { MockRepairDataStore, MockRepairDataStoreProvider } from "../utils";
 
-const localSessionId: SessionId = "0";
-
 describe("UndoRedoManager", () => {
 	describe("trackCommit", () => {
 		it("should create an undoable commit with the previous head as the parent", () => {
 			const parent = {
-				commit: createTestGraphCommit([], 0, localSessionId),
+				commit: createTestGraphCommit([], 0),
 				repairData: new MockRepairDataStore(),
 			};
-			const childCommit = createTestGraphCommit([0], 1, localSessionId);
+			const childCommit = createTestGraphCommit([0], 1);
 			const manager = undoRedoManagerFactory(parent);
 			manager.trackCommit(childCommit, UndoRedoManagerCommitType.Undoable);
 
@@ -37,10 +34,10 @@ describe("UndoRedoManager", () => {
 
 		it("should create a redoable commit with the previous head as the parent", () => {
 			const parent = {
-				commit: createTestGraphCommit([], 0, localSessionId),
+				commit: createTestGraphCommit([], 0),
 				repairData: new MockRepairDataStore(),
 			};
-			const childCommit = createTestGraphCommit([0], 1, localSessionId);
+			const childCommit = createTestGraphCommit([0], 1);
 			const manager = undoRedoManagerFactory(undefined, parent);
 			manager.trackCommit(childCommit, UndoRedoManagerCommitType.Redoable);
 
@@ -51,11 +48,11 @@ describe("UndoRedoManager", () => {
 
 		it("pops the head undoable commit and pushes to the redoable commit tree when an undo commit is tracked", () => {
 			const initialCommit = {
-				commit: createTestGraphCommit([], 0, localSessionId),
+				commit: createTestGraphCommit([], 0),
 				repairData: new MockRepairDataStore(),
 			};
 			const manager = undoRedoManagerFactory(initialCommit);
-			const fakeInvertedCommit = createTestGraphCommit([0, 1], 2, localSessionId);
+			const fakeInvertedCommit = createTestGraphCommit([0, 1], 2);
 			manager.trackCommit(fakeInvertedCommit, UndoRedoManagerCommitType.Undo);
 			// The head undo commit will not be the new inverted commit
 			assert.equal(manager.headUndoable, undefined);
@@ -65,11 +62,11 @@ describe("UndoRedoManager", () => {
 
 		it("pops the head redoable commit and pushes to the undoable commit tree when a redo commit is tracked", () => {
 			const initialCommit = {
-				commit: createTestGraphCommit([], 0, localSessionId),
+				commit: createTestGraphCommit([], 0),
 				repairData: new MockRepairDataStore(),
 			};
 			const manager = undoRedoManagerFactory(initialCommit);
-			const fakeInvertedCommit = createTestGraphCommit([0, 1], 2, localSessionId);
+			const fakeInvertedCommit = createTestGraphCommit([0, 1], 2);
 			manager.trackCommit(fakeInvertedCommit, UndoRedoManagerCommitType.Redo);
 			// The head undo commit will not be the new inverted commit
 			assert.equal(manager.headRedoable, undefined);
@@ -79,11 +76,11 @@ describe("UndoRedoManager", () => {
 
 		it("should add undoable commits to the undoable commit tree without changing the redoable commit tree", () => {
 			const initialCommit = {
-				commit: createTestGraphCommit([], 0, localSessionId),
+				commit: createTestGraphCommit([], 0),
 				repairData: new MockRepairDataStore(),
 			};
 			const manager = undoRedoManagerFactory(initialCommit);
-			const fakeInvertedCommit = createTestGraphCommit([0, 1], 2, localSessionId);
+			const fakeInvertedCommit = createTestGraphCommit([0, 1], 2);
 			manager.trackCommit(fakeInvertedCommit, UndoRedoManagerCommitType.Undoable);
 			// The head undo commit will not be the new inverted commit
 			assert.equal(manager.headUndoable?.commit, fakeInvertedCommit);
@@ -93,11 +90,11 @@ describe("UndoRedoManager", () => {
 
 		it("should add redoable commits to the redoable commit tree without changing the undoable commit tree", () => {
 			const initialCommit = {
-				commit: createTestGraphCommit([], 0, localSessionId),
+				commit: createTestGraphCommit([], 0),
 				repairData: new MockRepairDataStore(),
 			};
 			const manager = undoRedoManagerFactory(initialCommit);
-			const fakeInvertedCommit = createTestGraphCommit([0, 1], 2, localSessionId);
+			const fakeInvertedCommit = createTestGraphCommit([0, 1], 2);
 			manager.trackCommit(fakeInvertedCommit, UndoRedoManagerCommitType.Redoable);
 			// The head undo commit will not be the new inverted commit
 			assert.equal(manager.headUndoable, initialCommit);
@@ -108,7 +105,7 @@ describe("UndoRedoManager", () => {
 
 	describe("undo", () => {
 		it("should create an invert of the head undoable commit", () => {
-			const commit = createTestGraphCommit([], 0, localSessionId);
+			const commit = createTestGraphCommit([], 0);
 			const initialCommit = {
 				commit,
 				repairData: new MockRepairDataStore(),
@@ -121,7 +118,7 @@ describe("UndoRedoManager", () => {
 
 		it("should return undefined if there is no head undoable commit", () => {
 			const manager = undoRedoManagerFactory();
-			const undoChange = manager.undo(createTestGraphCommit([], 0, localSessionId));
+			const undoChange = manager.undo(createTestGraphCommit([], 0));
 
 			assert.equal(undoChange, undefined);
 		});
@@ -129,7 +126,7 @@ describe("UndoRedoManager", () => {
 
 	describe("redo", () => {
 		it("should create an invert of the head redoable commit", () => {
-			const commit = createTestGraphCommit([], 0, localSessionId);
+			const commit = createTestGraphCommit([], 0);
 			const initialCommit = {
 				commit,
 				repairData: new MockRepairDataStore(),
@@ -142,7 +139,7 @@ describe("UndoRedoManager", () => {
 
 		it("should return undefined if there is no head redoble commit", () => {
 			const manager = undoRedoManagerFactory();
-			const redoChange = manager.redo(createTestGraphCommit([], 0, localSessionId));
+			const redoChange = manager.redo(createTestGraphCommit([], 0));
 
 			assert.equal(redoChange, undefined);
 		});
@@ -165,12 +162,10 @@ function undoRedoManagerFactory(
 function createTestGraphCommit(
 	inputContext: readonly number[],
 	intention: number | number[],
-	sessionId: SessionId,
 	revision = mintRevisionTag(),
 ): GraphCommit<TestChange> {
 	return {
 		revision,
-		sessionId,
 		change: TestChange.mint(inputContext, intention),
 	};
 }


### PR DESCRIPTION
## Description

`sessionId` is a relatively redundant field on `GraphCommit`s. With the exception of commits on the trunk, adjacent commits in branches all have the same sessionId. Removing this field from `SharedTreeBranch` has the additional benefit of making it possible to model the trunk as a `SharedTreeBranch` in the future.

This does not change the persisted data format of the summarized `EditManager`, athough the data format can now be simplified in the future by not including the session ID in the peer branches.
