### PR TITLE
fix(ci): Fix build-docs pipeline

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -118,8 +118,6 @@ resources:
 stages:
 - stage: build
   displayName: 'Build website'
-  env:
-    COREPACK_DEFAULT_TO_LATEST: 0
   dependsOn: [] # run in parallel
   jobs:
     - job: debug_variables
@@ -193,9 +191,9 @@ stages:
           inputs:
             version: 16.x
 
-        - template: include-install-pnpm.yml
+        - template: templates/include-install-pnpm.yml
           parameters:
-            buildDirectory: ${{ parameters.buildDirectory }}
+            buildDirectory: $(Build.SourcesDirectory)/docs
 
         - task: Bash@3
           displayName: Install dependencies

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -36,6 +36,8 @@ steps:
 
 - task: Bash@3
   displayName: Install and configure pnpm
+  env:
+    COREPACK_DEFAULT_TO_LATEST: 0
   inputs:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}


### PR DESCRIPTION
## Description

Fixes a misplaced `env:` section, a path to a template, and the use of a nonexistent parameter, that are preventing the bulid-docs pipeline from completing successfully.

Pipeline running from a test/ branch with these changes [ran successfully](https://dev.azure.com/fluidframework/internal/_build/results?buildId=159834&view=results) (msft internal).