### PR TITLE
Update EditManager trunk to use SharedTreeBranch

### DIFF
--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -13,7 +13,6 @@ import {
 	mapIterable,
 	Mutable,
 	RecursiveReadonly,
-	zipIterables,
 } from "../util";
 import {
 	AnchorSet,
@@ -49,12 +48,6 @@ export interface Commit<TChangeset> extends Omit<GraphCommit<TChangeset>, "paren
 export interface SequencedCommit<TChangeset> extends Commit<TChangeset> {
 	sequenceNumber: SeqNumber;
 }
-/**
- * A commit in the commit graph that has been sequenced with a sequence number; these make up the trunk
- */
-interface TrunkCommit<TChangeset> extends SequencedCommit<TChangeset> {
-	parent?: TrunkCommit<TChangeset>;
-}
 
 export const minimumPossibleSequenceNumber: SeqNumber = brand(Number.MIN_SAFE_INTEGER);
 const nullRevisionTag = assertIsRevisionTag("00000000-0000-4000-8000-000000000000");
@@ -80,14 +73,14 @@ export class EditManager<
 	extends SimpleDependee
 	implements ISubscribable<EditManagerEvents<TChangeset>>
 {
-	/**
-	 * The head commit of the "trunk" branch. The trunk represents the list of received sequenced changes.
-	 */
-	private trunk: TrunkCommit<TChangeset>;
+	/** The "trunk" branch. The trunk represents the list of received sequenced changes. */
+	private readonly trunk: SharedTreeBranch<TEditor, TChangeset>;
+	/** Records extra data associated with trunk commits */
+	private readonly trunkMetadata = new Map<RevisionTag, { sequenceNumber: SeqNumber, sessionId: SessionId }>();
+		/** A map from a sequence number to the commit in the trunk which has that sequence number */
+		private readonly sequenceMap = new BTree<SeqNumber, GraphCommit<TChangeset>>();
 
-	/**
-	 * The {@link UndoRedoManager} associated with the trunk.
-	 */
+	/** The {@link UndoRedoManager} associated with the trunk */
 	private readonly trunkUndoRedoManager: UndoRedoManager<TChangeset, TEditor>;
 
 	/**
@@ -102,9 +95,7 @@ export class EditManager<
 	 */
 	public readonly localBranch: SharedTreeBranch<TEditor, TChangeset>;
 
-	/**
-	 * The {@link UndoRedoManager} associated with the local branch.
-	 */
+	/** The {@link UndoRedoManager} associated with the local branch. */
 	private readonly localBranchUndoRedoManager: UndoRedoManager<TChangeset, TEditor>;
 
 	/**
@@ -116,22 +107,15 @@ export class EditManager<
 		Set<SharedTreeBranch<TEditor, TChangeset>>
 	>();
 
-	/**
-	 * The sequence number of the newest commit on the trunk that has been received by all peers
-	 */
+	/** The sequence number of the newest commit on the trunk that has been received by all peers */
 	private minimumSequenceNumber: SeqNumber = brand(-1);
-
-	/**
-	 * A map from a sequence number to the commit in the trunk which has that sequence number
-	 */
-	private readonly sequenceMap = new BTree<SeqNumber, TrunkCommit<TChangeset>>();
 
 	/**
 	 * An immutable "origin" commit singleton on which the trunk is based.
 	 * This makes it possible to model the trunk in the same way as any other branch
 	 * (it branches off of a base commit) which simplifies some logic.
 	 */
-	private readonly trunkBase: TrunkCommit<TChangeset>;
+	private readonly trunkBase: GraphCommit<TChangeset>;
 
 	private readonly events = createEmitter<EditManagerEvents<TChangeset>>();
 
@@ -143,7 +127,6 @@ export class EditManager<
 	}
 
 	/**
-	 *
 	 * @param changeFamily - the change family of changes on the trunk and local branch
 	 * @param localSessionId - the id of the local session that will be used for local commits
 	 * @param repairDataStoreProvider - used for undoing/redoing the local branch
@@ -159,18 +142,16 @@ export class EditManager<
 		super("EditManager");
 		this.trunkBase = {
 			revision: nullRevisionTag,
-			sessionId: "",
 			change: changeFamily.rebaser.compose([]),
-			sequenceNumber: minimumPossibleSequenceNumber,
 		};
-		this.trunk = this.trunkBase;
 		this.localBranchUndoRedoManager = UndoRedoManager.create(
 			repairDataStoreProvider,
 			changeFamily,
 		);
 		this.trunkUndoRedoManager = this.localBranchUndoRedoManager.clone();
+		this.trunk = new SharedTreeBranch(this.trunkBase, changeFamily, this.trunkUndoRedoManager);
 		this.localBranch = new SharedTreeBranch(
-			this.trunk,
+			this.trunk.getHead(),
 			changeFamily,
 			this.localBranchUndoRedoManager,
 			anchors,
@@ -193,20 +174,17 @@ export class EditManager<
 	 */
 	private registerBranch(branch: SharedTreeBranch<TEditor, TChangeset>): void {
 		const trackBranch = (b: SharedTreeBranch<TEditor, TChangeset>): SeqNumber => {
-			const trunkCommit = findCommonAncestor(this.trunk, b.getHead());
-			assert(
-				isTrunkCommit(trunkCommit),
-				0x66f /* Expected commit to be on the trunk branch */,
-			);
+			const trunkCommit = findCommonAncestor(this.trunk.getHead(), b.getHead()) ?? fail("Expected branch to be related to trunk");
+			const sequenceNumber = this.trunkMetadata.get(trunkCommit.revision)?.sequenceNumber ?? minimumPossibleSequenceNumber;
 			const branches = getOrCreate(
 				this.trunkBranches,
-				trunkCommit.sequenceNumber,
+				sequenceNumber,
 				() => new Set(),
 			);
 
 			assert(!branches.has(b), 0x670 /* Branch was registered more than once */);
 			branches.add(b);
-			return trunkCommit.sequenceNumber;
+			return sequenceNumber;
 		};
 
 		const untrackBranch = (
@@ -290,20 +268,22 @@ export class EditManager<
 				// regenerating the entire commit graph. It is, in general, safe to chop off the tail like this if we know
 				// that there are no outstanding references to any of the commits being removed. For example, there must be
 				// no existing branches that are based off of any of the commits being removed.
-				(newTrunkTail as Mutable<TrunkCommit<TChangeset>>).parent = this.trunkBase;
+				(newTrunkTail as Mutable<GraphCommit<TChangeset>>).parent = this.trunkBase;
 
+				const sequenceNumber = this.trunkMetadata.get(newTrunkTail.revision)?.sequenceNumber ?? minimumPossibleSequenceNumber;
 				this.sequenceMap.forRange(
 					minimumPossibleSequenceNumber,
-					newTrunkTail.sequenceNumber,
+					sequenceNumber,
 					false,
 					(_seq, { revision }) => {
+						this.trunkMetadata.delete(revision);
 						this.localBranchUndoRedoManager.untrackCommitType(revision);
 					},
 				);
 
 				deleted = this.sequenceMap.deleteRange(
 					minimumPossibleSequenceNumber,
-					newTrunkTail.sequenceNumber,
+					sequenceNumber,
 					false,
 				);
 
@@ -321,7 +301,7 @@ export class EditManager<
 				this.trunkBranches.isEmpty,
 				0x672 /* Expected no registered branches when clearing trunk */,
 			);
-			this.trunk = this.trunkBase;
+			this.trunk.setHead(this.trunkBase);
 			this.sequenceMap.clear();
 			this.peerLocalBranches.clear();
 		}
@@ -331,9 +311,9 @@ export class EditManager<
 
 	public isEmpty(): boolean {
 		return (
-			this.trunk === this.trunkBase &&
+			this.trunk.getHead() === this.trunkBase &&
 			this.peerLocalBranches.size === 0 &&
-			this.localBranch.getHead() === this.trunk &&
+			this.localBranch.getHead() === this.trunk.getHead() &&
 			this.minimumSequenceNumber === -1
 		);
 	}
@@ -348,27 +328,16 @@ export class EditManager<
 		// Note that option (A) would be a simple change to `addSequencedChange` whereas (B) would likely require
 		// rebasing trunk changes over the inverse of trunk changes.
 		assert(
-			this.localBranch.getHead() === this.trunk,
+			this.localBranch.getHead() === this.trunk.getHead(),
 			0x428 /* Clients with local changes cannot be used to generate summaries */,
 		);
 
-		const trunkPath = getPathFromBase(this.trunk, this.trunkBase);
-		assert(
-			this.sequenceMap.size === trunkPath.length,
-			0x572 /* Expected sequence map to be the same size as the trunk */,
-		);
-		const trunk = Array.from(
-			mapIterable(
-				zipIterables(this.sequenceMap.keys(), trunkPath),
-				([sequenceNumber, commit]) => ({ ...commit, sequenceNumber }),
-			),
-		);
-
+		const trunk = getPathFromBase(this.trunk.getHead(), this.trunkBase).map((c) => ({...c, ...this.trunkMetadata.get(c.revision) ?? fail("Expected metadata for trunk commit") }));
 		const branches = new Map<SessionId, SummarySessionBranch<TChangeset>>(
 			mapIterable(this.peerLocalBranches.entries(), ([sessionId, branch]) => {
 				const branchPath: GraphCommit<TChangeset>[] = [];
 				const ancestor =
-					findCommonAncestor([branch, branchPath], this.trunk) ??
+					findCommonAncestor([branch, branchPath], this.trunk.getHead()) ??
 					fail("Expected branch to be based on trunk");
 
 				return [
@@ -390,36 +359,37 @@ export class EditManager<
 			"Attempted to load from summary after edit manager was already mutated",
 		);
 		this.sequenceMap.clear();
-		this.trunk = data.trunk.reduce((base, c) => {
-			const commit = mintTrunkCommit(base, c);
+		this.trunk.setHead(data.trunk.reduce((base, c) => {
+			const commit = mintCommit(base, c);
 			this.trunkUndoRedoManager.repairDataStoreProvider.applyDelta(
 				this.changeFamily.intoDelta(commit.change),
 			);
 			this.sequenceMap.set(c.sequenceNumber, commit);
+			this.trunkMetadata.set(c.revision, { sequenceNumber: c.sequenceNumber, sessionId: c.sessionId });
 			return commit;
-		}, this.trunkBase);
+		}, this.trunkBase));
 
-		this.localBranch.setHead(this.trunk);
+		this.localBranch.setHead(this.trunk.getHead());
 
 		for (const [sessionId, branch] of data.branches) {
 			const commit: GraphCommit<TChangeset> =
-				findAncestor(this.trunk, (r) => r.revision === branch.base) ??
+				findAncestor(this.trunk.getHead(), (r) => r.revision === branch.base) ??
 				fail("Expected summary branch to be based off of a revision in the trunk");
 
 			this.peerLocalBranches.set(sessionId, branch.commits.reduce(mintCommit, commit));
 		}
 	}
 
-	public getTrunk(): readonly RecursiveReadonly<Commit<TChangeset>>[] {
-		return getPathFromBase(this.trunk, this.trunkBase);
+	public getTrunkChanges(): readonly RecursiveReadonly<TChangeset>[] {
+		return getPathFromBase(this.trunk.getHead(), this.trunkBase).map((c) => c.change);
 	}
 
 	public getTrunkHead(): GraphCommit<TChangeset> {
-		return this.trunk;
+		return this.trunk.getHead();
 	}
 
 	public getLocalChanges(): readonly RecursiveReadonly<TChangeset>[] {
-		return getPathFromBase(this.localBranch.getHead(), this.trunk).map((c) => c.change);
+		return getPathFromBase(this.localBranch.getHead(), this.trunk.getHead()).map((c) => c.change);
 	}
 
 	public addSequencedChange(
@@ -431,7 +401,7 @@ export class EditManager<
 			// `newCommit` should correspond to the oldest change in `localChanges`, so we move it into trunk.
 			// `localChanges` are already rebased to the trunk, so we can use the stored change instead of rebasing the
 			// change in the incoming commit.
-			const localPath = getPathFromBase(this.localBranch.getHead(), this.trunk);
+			const localPath = getPathFromBase(this.localBranch.getHead(), this.trunk.getHead());
 			// Get the first revision in the local branch, and then remove it
 			const { change } =
 				localPath.shift() ??
@@ -443,7 +413,7 @@ export class EditManager<
 			{
 				// TODO: Replace the line below with this line when UndoRedoManager is better optimized.
 				// this.localBranch.rebaseOnto(this.trunk, this.trunkUndoRedoManager);
-				this.localBranch.setHead(localPath.reduce(mintCommit, this.trunk));
+				this.localBranch.setHead(localPath.reduce(mintCommit, this.trunk.getHead()));
 			}
 
 			return;
@@ -459,19 +429,19 @@ export class EditManager<
 			this.changeFamily.rebaser,
 			getOrCreate(this.peerLocalBranches, newCommit.sessionId, () => baseRevisionInTrunk),
 			baseRevisionInTrunk,
-			this.trunk,
+			this.trunk.getHead(),
 		);
 
-		if (rebasedBranch === this.trunk) {
+		if (rebasedBranch === this.trunk.getHead()) {
 			// If the branch is fully caught up and empty after being rebased, then push to the trunk directly
 			this.pushToTrunk(sequenceNumber, newCommit);
-			this.peerLocalBranches.set(newCommit.sessionId, this.trunk);
+			this.peerLocalBranches.set(newCommit.sessionId, this.trunk.getHead());
 		} else {
 			const newChangeFullyRebased = rebaseChange(
 				this.changeFamily.rebaser,
 				newCommit.change,
 				rebasedBranch,
-				this.trunk,
+				this.trunk.getHead(),
 			);
 
 			this.peerLocalBranches.set(newCommit.sessionId, mintCommit(rebasedBranch, newCommit));
@@ -485,7 +455,7 @@ export class EditManager<
 		// Constructing this short-lived SharedTreeBranch for the trunk allows the local branch
 		// to rebase onto it. TODO: Investigate if `this.trunk` can be a SharedTreeBranch.
 		const trunkBranch = new SharedTreeBranch(
-			this.trunk,
+			this.trunk.getHead(),
 			this.changeFamily,
 			this.trunkUndoRedoManager,
 		);
@@ -509,19 +479,21 @@ export class EditManager<
 		commit: Commit<TChangeset>,
 		local = false,
 	): void {
-		this.trunk = mintTrunkCommit(this.trunk, commit, sequenceNumber);
+		this.trunk.setHead(mintCommit(this.trunk.getHead(), commit));
+		const trunkHead = this.trunk.getHead();
 		if (local) {
 			const type =
-				this.localBranchUndoRedoManager.getCommitType(this.trunk.revision) ??
+				this.localBranchUndoRedoManager.getCommitType(trunkHead.revision) ??
 				fail("Local commit types must be tracked until they are sequenced.");
 
-			this.trunkUndoRedoManager.trackCommit(this.trunk, type);
+			this.trunkUndoRedoManager.trackCommit(trunkHead, type);
 		}
 		this.trunkUndoRedoManager.repairDataStoreProvider.applyDelta(
 			this.changeFamily.intoDelta(commit.change),
 		);
-		this.sequenceMap.set(sequenceNumber, this.trunk);
-		this.events.emit("newTrunkHead", this.trunk);
+		this.sequenceMap.set(sequenceNumber, trunkHead);
+		this.trunkMetadata.set(trunkHead.revision, {sequenceNumber, sessionId: commit.sessionId});
+		this.events.emit("newTrunkHead", trunkHead);
 	}
 }
 
@@ -554,34 +526,4 @@ function getPathFromBase<TCommit extends { parent?: TCommit }>(
 		0x573 /* Expected branches to be related */,
 	);
 	return path;
-}
-
-function isTrunkCommit<TChange>(commit?: GraphCommit<TChange>): commit is TrunkCommit<TChange> {
-	return commit !== undefined && (commit as TrunkCommit<TChange>).sequenceNumber !== undefined;
-}
-
-function mintTrunkCommit<TChange>(
-	parent: TrunkCommit<TChange>,
-	commit: Commit<TChange>,
-	sequenceNumber: SeqNumber,
-): TrunkCommit<TChange>;
-function mintTrunkCommit<TChange>(
-	parent: TrunkCommit<TChange>,
-	commit: SequencedCommit<TChange>,
-): TrunkCommit<TChange>;
-function mintTrunkCommit<TChange>(
-	parent: TrunkCommit<TChange>,
-	commit: Commit<TChange>,
-	explicitSequenceNumber?: SeqNumber,
-): TrunkCommit<TChange> {
-	const sequenceNumber =
-		explicitSequenceNumber ?? (commit as SequencedCommit<TChange>).sequenceNumber;
-
-	return {
-		revision: commit.revision,
-		sessionId: commit.sessionId,
-		change: commit.change,
-		sequenceNumber,
-		parent,
-	};
 }

--- a/experimental/dds/tree2/src/shared-tree-core/editManager.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManager.ts
@@ -451,15 +451,8 @@ export class EditManager<
 				change: newChangeFullyRebased,
 			});
 		}
-
-		// Constructing this short-lived SharedTreeBranch for the trunk allows the local branch
-		// to rebase onto it. TODO: Investigate if `this.trunk` can be a SharedTreeBranch.
-		const trunkBranch = new SharedTreeBranch(
-			this.trunk.getHead(),
-			this.changeFamily,
-			this.trunkUndoRedoManager,
-		);
-		this.localBranch.rebaseOnto(trunkBranch);
+		
+		this.localBranch.rebaseOnto(this.trunk);
 	}
 
 	public findLocalCommit(

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -735,9 +735,7 @@ function checkChangeList(manager: TestEditManager, intentions: number[]): void {
 }
 
 function getAllChanges(manager: TestEditManager): RecursiveReadonly<TestChange>[] {
-	return manager
-		.getTrunkChanges()
-		.concat(manager.getLocalChanges());
+	return manager.getTrunkChanges().concat(manager.getLocalChanges());
 }
 
 /** Adds a sequenced change to an `EditManager` and returns the delta that was caused by the change */

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -252,11 +252,11 @@ describe("EditManager", () => {
 				);
 			}
 
-			assert.equal(manager.getTrunk().length, 10);
+			assert.equal(manager.getTrunkChanges().length, 10);
 			manager.advanceMinimumSequenceNumber(brand(5));
-			assert.equal(manager.getTrunk().length, 5);
+			assert.equal(manager.getTrunkChanges().length, 5);
 			manager.advanceMinimumSequenceNumber(brand(10));
-			assert.equal(manager.getTrunk().length, 0);
+			assert.equal(manager.getTrunkChanges().length, 0);
 
 			for (let i = 10; i < 20; ++i) {
 				manager.addSequencedChange(
@@ -270,11 +270,11 @@ describe("EditManager", () => {
 				);
 			}
 
-			assert.equal(manager.getTrunk().length, 10);
+			assert.equal(manager.getTrunkChanges().length, 10);
 			manager.advanceMinimumSequenceNumber(brand(15));
-			assert.equal(manager.getTrunk().length, 5);
+			assert.equal(manager.getTrunkChanges().length, 5);
 			manager.advanceMinimumSequenceNumber(brand(20));
-			assert.equal(manager.getTrunk().length, 0);
+			assert.equal(manager.getTrunkChanges().length, 0);
 		});
 
 		it("Evicts trunk commits after but not exactly at the minimum sequence number", () => {
@@ -289,7 +289,7 @@ describe("EditManager", () => {
 				brand(0),
 			);
 
-			assert.equal(manager.getTrunk().length, 1);
+			assert.equal(manager.getTrunkChanges().length, 1);
 			manager.addSequencedChange(
 				{
 					change: TestChange.mint([], []),
@@ -300,9 +300,9 @@ describe("EditManager", () => {
 				brand(1),
 			);
 
-			assert.equal(manager.getTrunk().length, 2);
+			assert.equal(manager.getTrunkChanges().length, 2);
 			manager.advanceMinimumSequenceNumber(brand(1));
-			assert.equal(manager.getTrunk().length, 2);
+			assert.equal(manager.getTrunkChanges().length, 2);
 
 			// If a change's sequence number is also the minimum sequence number,
 			// it should not be evicted
@@ -316,9 +316,9 @@ describe("EditManager", () => {
 				brand(3),
 			);
 
-			assert.equal(manager.getTrunk().length, 3);
+			assert.equal(manager.getTrunkChanges().length, 3);
 			manager.advanceMinimumSequenceNumber(brand(3));
-			assert.equal(manager.getTrunk().length, 1);
+			assert.equal(manager.getTrunkChanges().length, 1);
 		});
 
 		it("Rebases anchors over local changes", () => {
@@ -736,8 +736,7 @@ function checkChangeList(manager: TestEditManager, intentions: number[]): void {
 
 function getAllChanges(manager: TestEditManager): RecursiveReadonly<TestChange>[] {
 	return manager
-		.getTrunk()
-		.map((c) => c.change)
+		.getTrunkChanges()
 		.concat(manager.getLocalChanges());
 }
 

--- a/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -389,5 +389,5 @@ function getTrunkLength<TEditor extends ChangeFamilyEditor, TChange>(
 		editManager !== undefined,
 		"EditManager in SharedTreeCore has been moved/deleted. Please update glass box tests.",
 	);
-	return editManager.getTrunk().length;
+	return editManager.getTrunkChanges().length;
 }

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -242,8 +242,8 @@ describe("SharedTree", () => {
 			t1.editManager !== undefined && t2.editManager !== undefined,
 			"EditManager has moved. This test must be updated.",
 		);
-		assert(t1.editManager.getTrunk().length < 10);
-		assert(t2.editManager.getTrunk().length < 10);
+		assert(t1.editManager.getTrunkChanges().length < 10);
+		assert(t2.editManager.getTrunkChanges().length < 10);
 	});
 
 	it("can process changes while detached", async () => {


### PR DESCRIPTION
## Description

This replaces `EditManager`s head trunk commit with a `SharedTreeBranch`. The branch methods are not fully leveraged yet (for example, `pushToTrunk` resorts to a call to `setHead`), but we may be able to improve this after a future refactor of `UndoRedoManager`. Since `SharedTreeBranches` do not track session IDs or sequence numbers, `TrunkCommit` has been removed in favor of a trunk metadata lookup map that serves the same purpose. There is also some minor cleanup to a test method and some removal of whitespace in private docs.