### PR TITLE
Disable summarizer for shared string failure to load test 

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -66,13 +66,6 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
 						},
 					},
 				});
-				// {
-				// 	summaryOptions: {
-				// 		summaryConfigOverrides: {
-				// 			state: "disabled",
-				// 		},
-				// 	},
-				// }
 
 				const loader = new Loader({
 					urlResolver: provider.urlResolver,

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -59,7 +59,20 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
 			{
 				// creating client
 				const codeDetails = { package: "no-dynamic-pkg" };
-				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
+				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]], {
+					summaryOptions: {
+						summaryConfigOverrides: {
+							state: "disabled",
+						},
+					},
+				});
+				// {
+				// 	summaryOptions: {
+				// 		summaryConfigOverrides: {
+				// 			state: "disabled",
+				// 		},
+				// 	},
+				// }
 
 				const loader = new Loader({
 					urlResolver: provider.urlResolver,
@@ -82,7 +95,13 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
 			{
 				// normal load client
 				const codeDetails = { package: "no-dynamic-pkg" };
-				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
+				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]], {
+					summaryOptions: {
+						summaryConfigOverrides: {
+							state: "disabled",
+						},
+					},
+				});
 
 				const loader = new Loader({
 					urlResolver: provider.urlResolver,
@@ -132,7 +151,13 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
 					},
 				};
 				const codeDetails = { package: "no-dynamic-pkg" };
-				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
+				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]], {
+					summaryOptions: {
+						summaryConfigOverrides: {
+							state: "disabled",
+						},
+					},
+				});
 
 				const loader = new Loader({
 					urlResolver: provider.urlResolver,
@@ -167,7 +192,13 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
 		{
 			// creating client
 			const codeDetails = { package: "no-dynamic-pkg" };
-			const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
+			const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]], {
+				summaryOptions: {
+					summaryConfigOverrides: {
+						state: "disabled",
+					},
+				},
+			});
 
 			const loader = new Loader({
 				urlResolver: provider.urlResolver,
@@ -211,7 +242,13 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
 		{
 			// normal load client
 			const codeDetails = { package: "no-dynamic-pkg" };
-			const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
+			const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]], {
+				summaryOptions: {
+					summaryConfigOverrides: {
+						state: "disabled",
+					},
+				},
+			});
 
 			const loader = new Loader({
 				urlResolver: provider.urlResolver,

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -59,13 +59,7 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
 			{
 				// creating client
 				const codeDetails = { package: "no-dynamic-pkg" };
-				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]], {
-					summaryOptions: {
-						summaryConfigOverrides: {
-							state: "disabled",
-						},
-					},
-				});
+				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
 
 				const loader = new Loader({
 					urlResolver: provider.urlResolver,
@@ -88,13 +82,7 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
 			{
 				// normal load client
 				const codeDetails = { package: "no-dynamic-pkg" };
-				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]], {
-					summaryOptions: {
-						summaryConfigOverrides: {
-							state: "disabled",
-						},
-					},
-				});
+				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
 
 				const loader = new Loader({
 					urlResolver: provider.urlResolver,
@@ -185,13 +173,7 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
 		{
 			// creating client
 			const codeDetails = { package: "no-dynamic-pkg" };
-			const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]], {
-				summaryOptions: {
-					summaryConfigOverrides: {
-						state: "disabled",
-					},
-				},
-			});
+			const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
 
 			const loader = new Loader({
 				urlResolver: provider.urlResolver,
@@ -235,13 +217,7 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
 		{
 			// normal load client
 			const codeDetails = { package: "no-dynamic-pkg" };
-			const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]], {
-				summaryOptions: {
-					summaryConfigOverrides: {
-						state: "disabled",
-					},
-				},
-			});
+			const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]]);
 
 			const loader = new Loader({
 				urlResolver: provider.urlResolver,

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -135,6 +135,8 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
 				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]], {
 					summaryOptions: {
 						summaryConfigOverrides: {
+							// disable the summarizer to prevent the above fault injection from happening
+							// happening in the summarizer client
 							state: "disabled",
 						},
 					},

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -135,7 +135,7 @@ describeNoCompat("SharedString", (getTestObjectProvider) => {
 				const codeLoader = new LocalCodeLoader([[codeDetails, fluidExport]], {
 					summaryOptions: {
 						summaryConfigOverrides: {
-							// disable the summarizer to prevent the above fault injection from happening
+							// disable the summarizer to prevent the above fault injection from
 							// happening in the summarizer client
 							state: "disabled",
 						},


### PR DESCRIPTION
The test for failing to load a shared string emitted some unexpected telemetry from summarizer, so I disabled the summarizer for this test. More investigation is needed to determine why the problematic telemetry was emitted in the first place. 

[AB#4045](https://dev.azure.com/fluidframework/internal/_workitems/edit/4045)