### PR TITLE
ci: Fix changeset-required workflows

### DIFF
--- a/.github/workflows/changeset-reporter.yml
+++ b/.github/workflows/changeset-reporter.yml
@@ -30,10 +30,6 @@ jobs:
       - name: Load changeset metadata into env variable
         run: echo "CHANGESET=$(cat changeset-metadata.json)" >> $GITHUB_ENV
 
-      - name: Load PR number
-        id: load_pr
-        run: echo "pr=$(jq '.pr' changeset-metadata.json)" >> $GITHUB_OUTPUT
-
       - name: Required but missing
         if: fromJson(env.CHANGESET).required == true && fromJson(env.CHANGESET).changesetFound == false
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1

--- a/.github/workflows/changeset-reporter.yml
+++ b/.github/workflows/changeset-reporter.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
         with:
           persist-credentials: false
-          # ref: ${{ github.event.pull_request.head.sha }} # Check out the head commit, not the merge commit
 
       - name: Download results
         uses: dawidd6/action-download-artifact@bd10f381a96414ce2b13a11bfa89902ba7cea07f # ratchet:dawidd6/action-download-artifact@v2.24.3

--- a/.github/workflows/changeset-reporter.yml
+++ b/.github/workflows/changeset-reporter.yml
@@ -15,6 +15,11 @@ jobs:
   load_report:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
+        with:
+          persist-credentials: false
+          # ref: ${{ github.event.pull_request.head.sha }} # Check out the head commit, not the merge commit
+
       - name: Download results
         uses: dawidd6/action-download-artifact@bd10f381a96414ce2b13a11bfa89902ba7cea07f # ratchet:dawidd6/action-download-artifact@v2.24.3
         with:
@@ -25,18 +30,24 @@ jobs:
       - name: Load changeset metadata into env variable
         run: echo "CHANGESET=$(cat changeset-metadata.json)" >> $GITHUB_ENV
 
+      - name: Load PR number
+        id: load_pr
+        run: echo "pr=$(jq '.pr' changeset-metadata.json)" >> $GITHUB_OUTPUT
+
       - name: Required but missing
         if: fromJson(env.CHANGESET).required == true && fromJson(env.CHANGESET).changesetFound == false
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset
-          path: ./.github/workflows/data/changeset-missing.md
+          number: ${{ fromJson(env.CHANGESET).pr }}
+          path: ${{ github.workspace }}/.github/workflows/data/changeset-missing.md
 
       - name: Required and present
         if: fromJson(env.CHANGESET).required == true && fromJson(env.CHANGESET).changesetFound == true
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset
+          number: ${{ fromJson(env.CHANGESET).pr }}
           recreate: true
           message: |
             This PR requires a changeset and it has one! Good job!
@@ -46,4 +57,5 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
         with:
           header: changeset
+          number: ${{ fromJson(env.CHANGESET).pr }}
           delete: true

--- a/.github/workflows/pr-check-changeset.yml
+++ b/.github/workflows/pr-check-changeset.yml
@@ -50,7 +50,7 @@ jobs:
           # JSON output is piped through jq to compact it to a single line
           pnpm exec flub check changeset --branch=${{ github.base_ref }} --json | jq -c > changeset-metadata.json
 
-      # We save the PR umber because downstream pipelines are triggered by workflow_run, and the PR number is not easily
+      # We save the PR number because downstream pipelines are triggered by workflow_run, and the PR number is not easily
       # retrievable in such workflows
       - name: Add PR number to metadata
         run: |

--- a/.github/workflows/pr-check-changeset.yml
+++ b/.github/workflows/pr-check-changeset.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           echo "{'branch': '${{ github.base_ref }}', 'required': false, 'changesetFound': true}" > ./changeset-metadata.json
 
-      # We save the PR umber because downstream pipelines are triggered by workflow_run, and the PR number is not easily
+      # We save the PR number because downstream pipelines are triggered by workflow_run, and the PR number is not easily
       # retrievable in such workflows
       - name: Add PR number to metadata
         run: |

--- a/.github/workflows/pr-check-changeset.yml
+++ b/.github/workflows/pr-check-changeset.yml
@@ -80,9 +80,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'changeset-required') }}
     steps:
-      # Always output changesetFound=true and required = false to signal that changesets aren't needed. changesetFound
+      # Always output changesetFound = true and required = false to signal that changesets aren't needed. changesetFound
       # must be set because it's not nullable.
-      - name: Set required=false,
+      - name: Changeset metadata
         run: |
           echo "{'branch': '${{ github.base_ref }}', 'required': false, 'changesetFound': true}" > ./changeset-metadata.json
 

--- a/.github/workflows/pr-check-changeset.yml
+++ b/.github/workflows/pr-check-changeset.yml
@@ -45,11 +45,16 @@ jobs:
         if: github.repository_owner != 'microsoft'
 
       # Check whether a changeset was added. This step will have the outcome '1' if there is no changeset.
-      - id: changeset-status
-        name: Changeset status
+      - name: Changeset metadata
         run: |
           # JSON output is piped through jq to compact it to a single line
           pnpm exec flub check changeset --branch=${{ github.base_ref }} --json | jq -c > changeset-metadata.json
+
+      # We save the PR umber because downstream pipelines are triggered by workflow_run, and the PR number is not easily
+      # retrievable in such workflows
+      - name: Add PR number to metadata
+        run: |
+          echo $(jq -c '. += { pr: "${{ github.event.number }}" }' changeset-metadata.json) > changeset-metadata.json
 
       # Sets required = true/false based on the changeset-required label on the PR
       - name: Changeset required
@@ -62,7 +67,7 @@ jobs:
         run: |
           echo $(jq -c '. += {required: false}' changeset-metadata.json) > changeset-metadata.json
 
-      - name: Upload changeset status
+      - name: Upload changeset metadata
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # ratchet:actions/upload-artifact@v3
         with:
           name: changeset-metadata
@@ -75,13 +80,19 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'changeset-required') }}
     steps:
-      - id: changeset-status
-        name: Changeset disabled
+      # Always output changesetFound=true and required = false to signal that changesets aren't needed. changesetFound
+      # must be set because it's not nullable.
+      - name: Set required=false,
         run: |
-          # Always output changesetFound=true to signal that changesets aren't needed
-          echo "{'branch': '${{ github.base_ref }}','changesetFound': true}" > ./changeset-metadata.json
+          echo "{'branch': '${{ github.base_ref }}', 'required': false, 'changesetFound': true}" > ./changeset-metadata.json
 
-      - name: Upload changeset status
+      # We save the PR umber because downstream pipelines are triggered by workflow_run, and the PR number is not easily
+      # retrievable in such workflows
+      - name: Add PR number to metadata
+        run: |
+          echo $(jq -c '. += { pr: "${{ github.event.number }}" }' changeset-metadata.json) > changeset-metadata.json
+
+      - name: Upload changeset metadata
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # ratchet:actions/upload-artifact@v3
         with:
           name: changeset-metadata


### PR DESCRIPTION
Fixes the following issues with the changeset workflows:

1. Now it correctly passes the PR number to the downstream workflow, since this information is not available in the context.
2. It also uploads metadata even when a changeset is not required so that the downstream job doesn't fail.

Related to [AB#3974](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3974).