### PR TITLE
Use client build for azure test packages

### DIFF
--- a/tools/pipelines/fluid-afr-perf-test.yml
+++ b/tools/pipelines/fluid-afr-perf-test.yml
@@ -41,7 +41,6 @@ stages:
           testPackage: "@fluidframework/azure-scenario-runner"
           testWorkspace: ${{ variables.testWorkspace }}
           testCommand: start
-          downloadAzureTestArtifacts: true
           artifactBuildId: $(resources.pipeline.azure.runID)
           env:
             FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
@@ -61,7 +60,6 @@ stages:
           testPackage: "@fluidframework/azure-scenario-runner"
           testWorkspace: ${{ variables.testWorkspace }}
           testCommand: start
-          downloadAzureTestArtifacts: true
           artifactBuildId: $(resources.pipeline.azure.runID)
           env:
             FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
@@ -81,7 +79,6 @@ stages:
           testPackage: "@fluidframework/azure-scenario-runner"
           testWorkspace: ${{ variables.testWorkspace }}
           testCommand: start
-          downloadAzureTestArtifacts: true
           artifactBuildId: $(resources.pipeline.azure.runID)
           env:
             FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
@@ -101,7 +98,6 @@ stages:
           testPackage: "@fluidframework/azure-scenario-runner"
           testWorkspace: ${{ variables.testWorkspace }}
           testCommand: start
-          downloadAzureTestArtifacts: true
           artifactBuildId: $(resources.pipeline.azure.runID)
           env:
             FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -91,6 +91,8 @@ jobs:
         value: $(Pipeline.Workspace)/client/pack/scoped/${{ variables.testPackageFilePattern }}
       - name: skipComponentGovernanceDetection
         value: true
+      - name: artifactPipeline
+        value: Build - client packages
       - name: feed
         ${{ if eq(variables.isTestBranch, 'true') }}:
           value: $(ado-feeds-internal) # Comes from the ado-feeds variable group
@@ -100,9 +102,7 @@ jobs:
         ${{ if eq(variables.isTestBranch, 'true') }}:
           value: $(ado-feeds-internal) # Comes from the ado-feeds variable group
         ${{ else }}:
-          value: $(ado-feeds-dev) # Comes from the ado-feeds variable group
-      - name: artifactPipeline
-          value: Build - client packages
+          value: $(ado-feeds-dev) # Comes from the ado-feeds variable group\
 
       steps:
       # Setup

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -40,15 +40,9 @@ parameters:
   type: string
   default: null
 
-- name: downloadAzureTestArtifacts
-  type: boolean
-  default: false
-
 # Id of the pipeline run that contains the artifacts to download.
 # Needed to workaround a bug in the DownloadPipelineArtifact task that might cause artifacts to be downloaded from the
 # incorrect pipeline run (see https://github.com/microsoft/azure-pipelines-tasks/issues/13518).
-# Make sure that the value provided corresponds to a run of the 'Build - azure' pipeline if downloadAzureTestArtifacts=true
-# or a run of the 'Build - client packages' otherwise.
 - name: artifactBuildId
   type: string
 
@@ -107,9 +101,6 @@ jobs:
           value: $(ado-feeds-internal) # Comes from the ado-feeds variable group
         ${{ else }}:
           value: $(ado-feeds-dev) # Comes from the ado-feeds variable group
-      - name: artifactPipeline
-        ${{ if eq(parameters.downloadAzureTestArtifacts, true) }}:
-          value: Build - azure
         ${{ else }}:
           value: Build - client packages
 

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -101,7 +101,7 @@ jobs:
           value: $(ado-feeds-internal) # Comes from the ado-feeds variable group
         ${{ else }}:
           value: $(ado-feeds-dev) # Comes from the ado-feeds variable group
-        ${{ else }}:
+      - name: artifactPipeline
           value: Build - client packages
 
       steps:

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -40,7 +40,7 @@ stages:
         testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         testCommand: test:realsvc:azure
-        artifactBuildId: 159959
+        artifactBuildId: $(resources.pipeline.client.runID)
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
           azure__fluid__relay__service__tenantId: $(azure-fluid-relay-service-tenantId)

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -40,7 +40,7 @@ stages:
         testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         testCommand: test:realsvc:azure
-        artifactBuildId: $(resources.pipeline.client.runID)
+        artifactBuildId: 159959
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
           azure__fluid__relay__service__tenantId: $(azure-fluid-relay-service-tenantId)

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -40,8 +40,7 @@ stages:
         testPackage: "@fluidframework/azure-end-to-end-tests"
         testWorkspace: ${{ variables.testWorkspace }}
         testCommand: test:realsvc:azure
-        downloadAzureTestArtifacts: true
-        artifactBuildId: $(resources.pipeline.azure.runID)
+        artifactBuildId: $(resources.pipeline.client.runID)
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
           azure__fluid__relay__service__tenantId: $(azure-fluid-relay-service-tenantId)
@@ -57,7 +56,6 @@ stages:
         testPackage: "@fluidframework/azure-end-to-end-tests"
         testWorkspace: ${{ variables.testWorkspace }}
         testCommand: test:realsvc:tinylicious
-        downloadAzureTestArtifacts: true
-        artifactBuildId: $(resources.pipeline.azure.runID)
+        artifactBuildId: $(resources.pipeline.client.runID)
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-# test-azure-frs pipeline
+# test-real-service-e2e pipeline
 
 name: $(Build.BuildId)
 
@@ -10,31 +10,23 @@ pr: none
 
 resources:
   pipelines:
-  - pipeline: client
+  - pipeline: client   # Name of the pipeline resource
     source: Build - client packages
-    branch: main # Default to using the latest build of the main branch instead of from any branch
+    branch: main # Default branch for manual/scheduled triggers if none is selected
     trigger:
       branches:
-        include:
-        - releases/*
-        - main
-        - next
-        - lts
-  - pipeline: azure
-    source: Build - azure
-    branch: main # Default to using the latest build of the main branch instead of from any branch
-    trigger:
-      branches:
-        include:
-        - releases/*
-        - main
-        - next
-        - lts
+      - release/*
+      - main
+      - next
+      - lts
 
 variables:
 - group: prague-key-vault
 - name: testWorkspace
   value: $(Pipeline.Workspace)/test
+- name: testPackage
+  value: "@fluidframework/azure-end-to-end-tests"
+  readonly: true
 
 stages:
   # Run Azure Client FRS Tests

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -12,7 +12,7 @@ resources:
   pipelines:
   - pipeline: client   # Name of the pipeline resource
     source: Build - client packages
-    branch: test/** # Default branch for manual/scheduled triggers if none is selected
+    branch: test/fixFrsPipeline # Default branch for manual/scheduled triggers if none is selected
     trigger:
       branches:
       - release/*

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -12,7 +12,7 @@ resources:
   pipelines:
   - pipeline: client   # Name of the pipeline resource
     source: Build - client packages
-    branch: main # Default branch for manual/scheduled triggers if none is selected
+    branch: test/** # Default branch for manual/scheduled triggers if none is selected
     trigger:
       branches:
       - release/*

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -12,7 +12,7 @@ resources:
   pipelines:
   - pipeline: client   # Name of the pipeline resource
     source: Build - client packages
-    branch: test/fixFrsPipeline # Default branch for manual/scheduled triggers if none is selected
+    branch: main # Default branch for manual/scheduled triggers if none is selected
     trigger:
       branches:
       - release/*

--- a/tools/pipelines/test-azure-frs.yml
+++ b/tools/pipelines/test-azure-frs.yml
@@ -37,7 +37,7 @@ stages:
     - template: templates/include-test-real-service.yml
       parameters:
         poolBuild: Small
-        testPackage: "@fluidframework/azure-end-to-end-tests"
+        testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         testCommand: test:realsvc:azure
         artifactBuildId: $(resources.pipeline.client.runID)
@@ -53,7 +53,7 @@ stages:
     - template: templates/include-test-real-service.yml
       parameters:
         poolBuild: Small
-        testPackage: "@fluidframework/azure-end-to-end-tests"
+        testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         testCommand: test:realsvc:tinylicious
         artifactBuildId: $(resources.pipeline.client.runID)


### PR DESCRIPTION
## Description

Azure packages were recently moved back into the client release group, but the azure test pipelines will still try to pull the latest build from the azure release group. This PR changes this behavior to pull from the client release group.