### PR TITLE
server: fix Historian and Alfred default throttling configs

### DIFF
--- a/server/charts/historian/templates/historian-configmap.yaml
+++ b/server/charts/historian/templates/historian-configmap.yaml
@@ -38,53 +38,13 @@ data:
         },
         "throttling": {
             "restCallsPerTenant": {
-                "generalRestCall": {
-                    "maxPerMs": {{ .Values.historian.throttling.restCallsPerTenant.generalRestCall.maxPerMs }},
-                    "maxBurst": {{ .Values.historian.throttling.restCallsPerTenant.generalRestCall.maxBurst }},
-                    "minCooldownIntervalInMs": {{ .Values.historian.throttling.restCallsPerTenant.generalRestCall.minCooldownIntervalInMs }},
-                    "minThrottleIntervalInMs": {{ .Values.historian.throttling.restCallsPerTenant.generalRestCall.minThrottleIntervalInMs }},
-                    "maxInMemoryCacheSize": {{ .Values.historian.throttling.restCallsPerTenant.generalRestCall.maxInMemoryCacheSize }},
-                    "maxInMemoryCacheAgeInMs": {{ .Values.historian.throttling.restCallsPerTenant.generalRestCall.maxInMemoryCacheAgeInMs }},
-                    "enableEnhancedTelemetry": {{ .Values.historian.throttling.restCallsPerTenant.generalRestCall.enableEnhancedTelemetry }}
-                },
-                "getSummary": {
-                    "maxPerMs": {{ .Values.historian.throttling.restCallsPerTenant.getSummary.maxPerMs }},
-                    "maxBurst": {{ .Values.historian.throttling.restCallsPerTenant.getSummary.maxBurst }},
-                    "minCooldownIntervalInMs": {{ .Values.historian.throttling.restCallsPerTenant.getSummary.minCooldownIntervalInMs }},
-                    "minThrottleIntervalInMs": {{ .Values.historian.throttling.restCallsPerTenant.getSummary.minThrottleIntervalInMs }},
-                    "maxInMemoryCacheSize": {{ .Values.historian.throttling.restCallsPerTenant.getSummary.maxInMemoryCacheSize }},
-                    "maxInMemoryCacheAgeInMs": {{ .Values.historian.throttling.restCallsPerTenant.getSummary.maxInMemoryCacheAgeInMs }},
-                    "enableEnhancedTelemetry": {{ .Values.historian.throttling.restCallsPerTenant.getSummary.enableEnhancedTelemetry }}
-                },
-                "createSummary": {
-                    "maxPerMs": {{ .Values.historian.throttling.restCallsPerTenant.createSummary.maxPerMs }},
-                    "maxBurst": {{ .Values.historian.throttling.restCallsPerTenant.createSummary.maxBurst }},
-                    "minCooldownIntervalInMs": {{ .Values.historian.throttling.restCallsPerTenant.createSummary.minCooldownIntervalInMs }},
-                    "minThrottleIntervalInMs": {{ .Values.historian.throttling.restCallsPerTenant.createSummary.minThrottleIntervalInMs }},
-                    "maxInMemoryCacheSize": {{ .Values.historian.throttling.restCallsPerTenant.createSummary.maxInMemoryCacheSize }},
-                    "maxInMemoryCacheAgeInMs": {{ .Values.historian.throttling.restCallsPerTenant.createSummary.maxInMemoryCacheAgeInMs }},
-                    "enableEnhancedTelemetry": {{ .Values.historian.throttling.restCallsPerTenant.createSummary.enableEnhancedTelemetry }}
-                }
+                "generalRestCall": {{ toJson .Values.historian.throttling.restCallsPerTenant.generalRestCall }},
+                "getSummary": {{ toJson .Values.historian.throttling.restCallsPerTenant.getSummary }},
+                "createSummary": {{ toJson .Values.historian.throttling.restCallsPerTenant.createSummary }}
             },
             "restCallsPerCluster": {
-                "getSummary": {
-                    "maxPerMs": {{ .Values.historian.throttling.restCallsPerCluster.getSummary.maxPerMs }},
-                    "maxBurst": {{ .Values.historian.throttling.restCallsPerCluster.getSummary.maxBurst }},
-                    "minCooldownIntervalInMs": {{ .Values.historian.throttling.restCallsPerCluster.getSummary.minCooldownIntervalInMs }},
-                    "minThrottleIntervalInMs": {{ .Values.historian.throttling.restCallsPerCluster.getSummary.minThrottleIntervalInMs }},
-                    "maxInMemoryCacheSize": {{ .Values.historian.throttling.restCallsPerCluster.getSummary.maxInMemoryCacheSize }},
-                    "maxInMemoryCacheAgeInMs": {{ .Values.historian.throttling.restCallsPerCluster.getSummary.maxInMemoryCacheAgeInMs }},
-                    "enableEnhancedTelemetry": {{ .Values.historian.throttling.restCallsPerCluster.getSummary.enableEnhancedTelemetry }}
-                },
-                "createSummary": {
-                    "maxPerMs": {{ .Values.historian.throttling.restCallsPerCluster.createSummary.maxPerMs }},
-                    "maxBurst": {{ .Values.historian.throttling.restCallsPerCluster.createSummary.maxBurst }},
-                    "minCooldownIntervalInMs": {{ .Values.historian.throttling.restCallsPerCluster.createSummary.minCooldownIntervalInMs }},
-                    "minThrottleIntervalInMs": {{ .Values.historian.throttling.restCallsPerCluster.createSummary.minThrottleIntervalInMs }},
-                    "maxInMemoryCacheSize": {{ .Values.historian.throttling.restCallsPerCluster.createSummary.maxInMemoryCacheSize }},
-                    "maxInMemoryCacheAgeInMs": {{ .Values.historian.throttling.restCallsPerCluster.createSummary.maxInMemoryCacheAgeInMs }},
-                    "enableEnhancedTelemetry": {{ .Values.historian.throttling.restCallsPerCluster.createSummary.enableEnhancedTelemetry }}
-                }
+                "getSummary": {{ toJson .Values.historian.throttling.restCallsPerCluster.getSummary }},
+                "createSummary": {{ toJson .Values.historian.throttling.restCallsPerCluster.createSummary }}
             }
         },
         "restGitService": {

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -22,12 +22,13 @@ historian:
     track: true
     endpoint: "error_tracking_endpoint"
   throttling:
-    maxRequestsPerMs: 1000000
-    maxRequestBurst: 1000000
-    minCooldownIntervalInMs: 1000000
-    minThrottleIntervalInMs: 1000000
-    maxInMemoryCacheSize: 1000
-    maxInMemoryCacheAgeInMs: 60000
+    restCallsPerTenant:
+      generalRestCall: disabled
+      getSummary: disabled
+      createSummary: disabled
+    restCallsPerCluster:
+      getSummary: disabled
+      createSummary: disabled
   restGitService:
     disableGitCache: false
 

--- a/server/historian/packages/historian-base/src/runnerFactory.ts
+++ b/server/historian/packages/historian-base/src/runnerFactory.ts
@@ -100,7 +100,9 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
 				redisParamsForThrottling,
 			);
 
-		const configureThrottler = (throttleConfig: Partial<utils.IThrottleConfig>): core.IThrottler => {
+		const configureThrottler = (
+			throttleConfig: Partial<utils.IThrottleConfig>,
+		): core.IThrottler => {
 			const throttlerHelper = new services.ThrottlerHelper(
 				redisThrottleAndUsageStorageManager,
 				throttleConfig.maxPerMs,
@@ -120,19 +122,19 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
 		// Rest API Throttler
 		const restApiTenantGeneralThrottleConfig = utils.getThrottleConfig(
 			config.get("throttling:restCallsPerTenant:generalRestCall"),
-        );
+		);
 		const restTenantGeneralThrottler = configureThrottler(restApiTenantGeneralThrottleConfig);
 
 		const restApiTenantGetSummaryThrottleConfig = utils.getThrottleConfig(
 			config.get("throttling:restCallsPerTenant:getSummary"),
-        );
+		);
 		const restTenantGetSummaryThrottler = configureThrottler(
 			restApiTenantGetSummaryThrottleConfig,
 		);
 
 		const restApiTenantCreateSummaryThrottleConfig = utils.getThrottleConfig(
 			config.get("throttling:restCallsPerTenant:createSummary"),
-        );
+		);
 		const restTenantCreateSummaryThrottler = configureThrottler(
 			restApiTenantCreateSummaryThrottleConfig,
 		);
@@ -153,14 +155,14 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
 
 		const restApiClusterCreateSummaryThrottleConfig = utils.getThrottleConfig(
 			config.get("throttling:restCallsPerCluster:createSummary"),
-        );
+		);
 		const throttlerCreateSummaryPerCluster = configureThrottler(
 			restApiClusterCreateSummaryThrottleConfig,
 		);
 
 		const restApiClusterGetSummaryThrottleConfig = utils.getThrottleConfig(
 			config.get("throttling:restCallsPerCluster:getSummary"),
-        );
+		);
 		const throttlerGetSummaryPerCluster = configureThrottler(
 			restApiClusterGetSummaryThrottleConfig,
 		);

--- a/server/historian/packages/historian-base/src/runnerFactory.ts
+++ b/server/historian/packages/historian-base/src/runnerFactory.ts
@@ -5,6 +5,7 @@
 import { AsyncLocalStorage } from "async_hooks";
 import * as services from "@fluidframework/server-services";
 import * as core from "@fluidframework/server-services-core";
+import * as utils from "@fluidframework/server-services-utils";
 import { Provider } from "nconf";
 import Redis from "ioredis";
 import winston from "winston";
@@ -99,16 +100,7 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
 				redisParamsForThrottling,
 			);
 
-		interface IThrottleConfig {
-			maxPerMs: number;
-			maxBurst: number;
-			minCooldownIntervalInMs: number;
-			minThrottleIntervalInMs: number;
-			maxInMemoryCacheSize: number;
-			maxInMemoryCacheAgeInMs: number;
-			enableEnhancedTelemetry?: boolean;
-		}
-		const configureThrottler = (throttleConfig: Partial<IThrottleConfig>): core.IThrottler => {
+		const configureThrottler = (throttleConfig: Partial<utils.IThrottleConfig>): core.IThrottler => {
 			const throttlerHelper = new services.ThrottlerHelper(
 				redisThrottleAndUsageStorageManager,
 				throttleConfig.maxPerMs,
@@ -126,18 +118,21 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
 		};
 
 		// Rest API Throttler
-		const restApiTenantGeneralThrottleConfig: Partial<IThrottleConfig> =
-			config.get("throttling:restCallsPerTenant:generalRestCall") ?? {};
+		const restApiTenantGeneralThrottleConfig = utils.getThrottleConfig(
+			config.get("throttling:restCallsPerTenant:generalRestCall"),
+        );
 		const restTenantGeneralThrottler = configureThrottler(restApiTenantGeneralThrottleConfig);
 
-		const restApiTenantGetSummaryThrottleConfig: Partial<IThrottleConfig> =
-			config.get("throttling:restCallsPerTenant:getSummary") ?? {};
+		const restApiTenantGetSummaryThrottleConfig = utils.getThrottleConfig(
+			config.get("throttling:restCallsPerTenant:getSummary"),
+        );
 		const restTenantGetSummaryThrottler = configureThrottler(
 			restApiTenantGetSummaryThrottleConfig,
 		);
 
-		const restApiTenantCreateSummaryThrottleConfig: Partial<IThrottleConfig> =
-			config.get("throttling:restCallsPerTenant:createSummary") ?? {};
+		const restApiTenantCreateSummaryThrottleConfig = utils.getThrottleConfig(
+			config.get("throttling:restCallsPerTenant:createSummary"),
+        );
 		const restTenantCreateSummaryThrottler = configureThrottler(
 			restApiTenantCreateSummaryThrottleConfig,
 		);
@@ -156,14 +151,16 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
 			restTenantGeneralThrottler,
 		);
 
-		const restApiClusterCreateSummaryThrottleConfig: Partial<IThrottleConfig> =
-			config.get("throttling:restCallsPerCluster:createSummary") ?? {};
+		const restApiClusterCreateSummaryThrottleConfig = utils.getThrottleConfig(
+			config.get("throttling:restCallsPerCluster:createSummary"),
+        );
 		const throttlerCreateSummaryPerCluster = configureThrottler(
 			restApiClusterCreateSummaryThrottleConfig,
 		);
 
-		const restApiClusterGetSummaryThrottleConfig: Partial<IThrottleConfig> =
-			config.get("throttling:restCallsPerCluster:getSummary") ?? {};
+		const restApiClusterGetSummaryThrottleConfig = utils.getThrottleConfig(
+			config.get("throttling:restCallsPerCluster:getSummary"),
+        );
 		const throttlerGetSummaryPerCluster = configureThrottler(
 			restApiClusterGetSummaryThrottleConfig,
 		);

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -21,6 +21,7 @@ alfred:
   enableConnectionCountLogging: false
   throttling:
     restCallsPerTenant:
+      generalRestCall:
         maxPerMs: 1000000
         maxBurst: 1000000
         minCooldownIntervalInMs: 1000000
@@ -28,11 +29,15 @@ alfred:
         maxInMemoryCacheSize: 1000
         maxInMemoryCacheAgeInMs: 60000
         enableEnhancedTelemetry: false
+      createDoc: disabled
+      getDeltas: disabled
+      getSession: disabled
     restCallsPerCluster:
-        createDoc: 
-            maxPerInterval: 1000000
-            intervalInMs: 1000000
-        getDeltas: disabled
+      createDoc:
+        maxPerInterval: 1000000
+        intervalInMs: 1000000
+      getDeltas: disabled
+      getSession: disabled
     socketConnectionsPerTenant: disabled
     socketConnectionsPerCluster: disabled
     submitOps: disabled
@@ -43,113 +48,113 @@ alfred:
   enforceServerGeneratedDocumentId: false
   socketIo:
     perMessageDeflate: true
-    
+
 storage:
-    enableWholeSummaryUpload: false
-    storageUrl: storage_url
+  enableWholeSummaryUpload: false
+  storageUrl: storage_url
 
 checkpoints:
-    localCheckpointEnabled: false
+  localCheckpointEnabled: false
 
 session:
-    enforceDiscoveryFlow: false
+  enforceDiscoveryFlow: false
 
 deli:
-    name: deli
-    replicas: 8
-    checkpointHeuristics:
-        enable: false
-        idleTime: 10000
-        maxTime: 60000
-        maxMessages: 500
-    restartOnCheckpointFailure: true
+  name: deli
+  replicas: 8
+  checkpointHeuristics:
+    enable: false
+    idleTime: 10000
+    maxTime: 60000
+    maxMessages: 500
+  restartOnCheckpointFailure: true
 
 scriptorium:
-    name: scriptorium
-    replicas: 8
-    restartOnCheckpointFailure: true
+  name: scriptorium
+  replicas: 8
+  restartOnCheckpointFailure: true
 
 scribe:
-    name: scribe
-    replicas: 8
-    getDeltasViaAlfred: true
-    checkpointHeuristics:
-        enable: false
-        idleTime: 10000
-        maxTime: 60000
-        maxMessages: 500
-    restartOnCheckpointFailure: true
-        
+  name: scribe
+  replicas: 8
+  getDeltasViaAlfred: true
+  checkpointHeuristics:
+    enable: false
+    idleTime: 10000
+    maxTime: 60000
+    maxMessages: 500
+  restartOnCheckpointFailure: true
+
 riddler:
-    name: riddler
-    replicas: 2
-    tenants: []
+  name: riddler
+  replicas: 2
+  tenants: []
 
 historian:
-    externalUrl: historian_external_url
-    internalUrl: historian_internal_url
+  externalUrl: historian_external_url
+  internalUrl: historian_internal_url
 
 zookeeper:
-    local: false
-    url: zookeeper_url:port
+  local: false
+  url: zookeeper_url:port
 
 system:
-    httpServer:
-        connectionTimeout: 0
+  httpServer:
+    connectionTimeout: 0
 
 usage:
-    clientConnectivityCountingEnabled: false
-    signalUsageCountingEnabled: false
+  clientConnectivityCountingEnabled: false
+  signalUsageCountingEnabled: false
 
 shared:
-    transientTenants: []
+  transientTenants: []
 
 mongodb:
-    operationsDbEndpoint: mongodb_url
-    globalDbEndpoint: mongoglobaldb_url
-    globalDbEnabled: false
-    expireAfterSeconds: -1
-    createCosmosDBIndexes: false
-    bufferMaxEntries: 50
-    softDeletionRetentionPeriodMs: 2592000000
-    offlineWindowMs: 86400000
-    softDeletionEnabled: false
-    permanentDeletionEnabled: false
-    deletionIntervalMs: 3600000
+  operationsDbEndpoint: mongodb_url
+  globalDbEndpoint: mongoglobaldb_url
+  globalDbEnabled: false
+  expireAfterSeconds: -1
+  createCosmosDBIndexes: false
+  bufferMaxEntries: 50
+  softDeletionRetentionPeriodMs: 2592000000
+  offlineWindowMs: 86400000
+  softDeletionEnabled: false
+  permanentDeletionEnabled: false
+  deletionIntervalMs: 3600000
 
 rabbitmq:
-    connectionString: ""
+  connectionString: ""
 
 redis:
-    url: redis_url
-    port: 6379
-    tls: false
+  url: redis_url
+  port: 6379
+  tls: false
 
 redis2:
-    url: redis_url
-    port: 6379
-    tls: false
+  url: redis_url
+  port: 6379
+  tls: false
 
 redisForThrottling:
-    url: redis_url
-    port: 6379
-    tls: false
+  url: redis_url
+  port: 6379
+  tls: false
 
 redisForTenantCache:
-    url: redis_url
-    port: 6379
-    tls: false
+  url: redis_url
+  port: 6379
+  tls: false
 
 kafka:
-    topics:
-        rawdeltas: rawdeltas
-        deltas: deltas
-    url: kafka_url:port
-    libname: rdkafka
+  topics:
+    rawdeltas: rawdeltas
+    deltas: deltas
+  url: kafka_url:port
+  libname: rdkafka
 
 ingress:
-    class: nginx-prod
+  class: nginx-prod
 
 error:
-    track: true
-    endpoint: "error_tracking_endpoint"
+  track: true
+  endpoint: "error_tracking_endpoint"


### PR DESCRIPTION
## Description

#15221 accidentally fixed an issue with Alfred's throttling configs for K8s deployment because the correct default values did not exist in the `values.yml` for Historian and Alfred.

This PR adds the default values, but also applies the same changes from #15221 to Historian.
