### PR TITLE
build(devtools-view): Use `~` dependency to prevent breaking update

### DIFF
--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -45,7 +45,7 @@
 	},
 	"dependencies": {
 		"@fluentui/react": "^8.109.3",
-		"@fluentui/react-components": "^9.19.1",
+		"@fluentui/react-components": "~9.19.1",
 		"@fluentui/react-hooks": "^8.6.24",
 		"@fluentui/react-icons": "^2.0.201",
 		"@fluid-experimental/devtools-core": "workspace:~",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15520,7 +15520,7 @@ importers:
         specifier: ^8.109.3
         version: 8.109.3(@types/react-dom@17.0.18)(@types/react@17.0.52)(react-dom@17.0.2)(react@17.0.2)
       '@fluentui/react-components':
-        specifier: ^9.19.1
+        specifier: ~9.19.1
         version: 9.19.1(@types/react-dom@17.0.18)(@types/react@17.0.52)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.2)
       '@fluentui/react-hooks':
         specifier: ^8.6.24

--- a/syncpack.config.cjs
+++ b/syncpack.config.cjs
@@ -115,7 +115,7 @@ module.exports = {
 				"webpack-dev-server",
 
 				// Required due to use of "unstable" tree component APIs
-				"@fluent-ui/react-components",
+				"@fluentui/react-components",
 			],
 			packages: ["**"],
 			range: "~",

--- a/syncpack.config.cjs
+++ b/syncpack.config.cjs
@@ -113,6 +113,9 @@ module.exports = {
 				"typescript",
 				"vue",
 				"webpack-dev-server",
+
+				// Required due to use of "unstable" tree component APIs
+				"@fluent-ui/react-components",
 			],
 			packages: ["**"],
 			range: "~",


### PR DESCRIPTION
A recent minor update of `@fluent-ui/react-components` includes a breaking change to their unstable `tree` APIs, which break our build. This was detected in #15568.

Since we are depending on an unstable API, we shouldn't be using a `^` dependency.