### PR TITLE
[GC] Refactor the GC functions to clearly distinguish mark and sweep phases

### DIFF
--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -430,6 +430,14 @@ export class GarbageCollector implements IGarbageCollector {
 	}
 
 	/**
+	 * Returns a the GC details generated from the base summary. This is used to initialize the GC state of the nodes
+	 * in the container.
+	 */
+	public async getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase> {
+		return this.baseGCDetailsP;
+	}
+
+	/**
 	 * Runs garbage collection and updates the reference / used state of the nodes in the container.
 	 * @returns stats of the GC run or undefined if GC did not run.
 	 */
@@ -482,26 +490,25 @@ export class GarbageCollector implements IGarbageCollector {
 			logger,
 			{ eventName: "GarbageCollection" },
 			async (event) => {
+				/** Pre-GC step. Includes initializing base state and notifying the runtime that GC is starting. */
 				await this.runPreGCSteps();
 
-				// Get the runtime's GC data and run GC on the reference graph in it.
-				const gcData = await this.runtime.getGCData(fullGC);
-				const gcResult = runGarbageCollection(gcData.gcNodes, ["/"]);
-
-				const gcStats = await this.runPostGCSteps(
-					gcData,
-					gcResult,
-					logger,
-					currentReferenceTimestampMs,
-				);
+				/** GC step. Includes running GC algorithm on the reference graph, running Mark and Sweep phases. */
+				const gcStats = await this.runGC(fullGC, currentReferenceTimestampMs, logger);
 				event.end({ ...gcStats, timestamp: currentReferenceTimestampMs });
-				this.completedRuns++;
+
+				/** Post-GC step. Includes logging events and other cleanup. */
+				await this.runPostGCSteps(logger);
 				return gcStats;
 			},
 			{ end: true, cancel: "error" },
 		);
 	}
 
+	/**
+	 * Runs any steps before actual GC starts. It initializes state from base snapshot (required first time GC runs)
+	 * and notifies runtime that GC is starting.
+	 */
 	private async runPreGCSteps() {
 		// Ensure that state has been initialized from the base snapshot data.
 		await this.initializeGCStateFromBaseSnapshotP;
@@ -509,26 +516,230 @@ export class GarbageCollector implements IGarbageCollector {
 		await this.runtime.updateStateBeforeGC();
 	}
 
-	private async runPostGCSteps(
-		gcData: IGarbageCollectionData,
-		gcResult: IGCResult,
-		logger: ITelemetryLogger,
+	/**
+	 * Runs garbage collection. It generates the reference graph, runs GC algorithm on it to find references and
+	 * unreferenced nodes and runs Mark and Sweep phases.
+	 */
+	private async runGC(
+		fullGC: boolean,
 		currentReferenceTimestampMs: number,
+		logger: ITelemetryLogger,
 	): Promise<IGCStats> {
-		// Generate statistics from the current run. This is done before updating the current state because it
-		// generates some of its data based on previous state of the system.
+		const gcData = await this.runtime.getGCData(fullGC);
+		const gcResult = runGarbageCollection(gcData.gcNodes, ["/"]);
+
+		// Generate stats before running Mark / Sweep phase because it uses previous GC state which will get updated
+		// in these stages.
 		const gcStats = this.generateStats(gcResult);
 
-		// Update the current mark state and update the runtime of all used routes or ids that used as per the GC run.
-		const sweepReadyNodes = this.updateMarkPhase(
+		// Run the Mark phase. It will mark nodes as referenced / unreferenced appropriately and return a list of
+		// node ids that are ready to be swept.
+		const sweepReadyNodeIds = this.runMarkPhase(
 			gcData,
 			gcResult,
 			currentReferenceTimestampMs,
 			logger,
 		);
+
+		// Run the Sweep phase. It will delete sweep ready nodes and return updated GC data - gcData which has deleted
+		// nodes removed.
+		const updatedGCData = this.runSweepPhase(
+			gcData,
+			gcResult,
+			sweepReadyNodeIds,
+			currentReferenceTimestampMs,
+			logger,
+		);
+
+		this.gcDataFromLastRun = cloneGCData(updatedGCData);
+		return gcStats;
+	}
+
+	/**
+	 * Runs any steps after GC completes. It logs unreferenced events, increments counters and does other cleanup.
+	 */
+	private async runPostGCSteps(logger: ITelemetryLogger) {
+		// Log pending unreferenced events such as a node being used after inactive. This is done after GC runs and
+		// updates its state so that we don't send false positives based on intermediate state. For example, we may get
+		// reference to an unreferenced node from another unreferenced node which means the node wasn't revived.
+		await this.telemetryTracker.logPendingEvents(logger);
+		this.newReferencesSinceLastRun.clear();
+		this.completedRuns++;
+	}
+
+	/**
+	 * Runs the GC Mark phase. It does the following:
+	 * 1. Finds references between previous and current runs and mark these nodes referenced by clearing tracking for them.
+	 * 2. Marks unreferenced nodes in this run by starting tracking for them.
+	 * 3. Marks referenced nodes in this run by clearing tracking for them.
+	 * 4. Calls the runtime to update nodes that were marked referenced.
+	 *
+	 * @param gcData - The data representing the reference graph on which GC is run.
+	 * @param gcResult - The result of the GC run on the gcData.
+	 * @param currentReferenceTimestampMs - The timestamp to be used for unreferenced nodes' timestamp.
+	 * @param logger - The logger to be used to log any telemetry.
+	 * @returns - A list of sweep ready nodes, i.e., nodes that ready to be deleted.
+	 */
+	private runMarkPhase(
+		gcData: IGarbageCollectionData,
+		gcResult: IGCResult,
+		currentReferenceTimestampMs: number,
+		logger: ITelemetryLogger,
+	): string[] {
+		// 1. Find references between the previous and current GC runs. Mark these nodes as referenced by clearing
+		// their unreferenced tracker, if any.
+		const allNodesReferencedBetweenGCs =
+			this.findAllNodesReferencedBetweenGCs(gcData, this.gcDataFromLastRun, logger) ??
+			gcResult.referencedNodeIds;
+		for (const nodeId of allNodesReferencedBetweenGCs) {
+			const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
+			if (nodeStateTracker !== undefined) {
+				// Stop tracking so as to clear out any running timers.
+				nodeStateTracker.stopTracking();
+				// Delete the node as we don't need to track it any more.
+				this.unreferencedNodesState.delete(nodeId);
+			}
+		}
+
+		// 2. Mark unreferenced nodes in this run by starting unreferenced tracking for them.
+		// 3. Mark referenced nodes in this run by clearing unreferenced tracking for them.
+		const sweepReadyNodeIds: string[] = [];
+		for (const nodeId of gcResult.deletedNodeIds) {
+			const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
+			if (nodeStateTracker === undefined) {
+				this.unreferencedNodesState.set(
+					nodeId,
+					new UnreferencedStateTracker(
+						currentReferenceTimestampMs,
+						this.configs.inactiveTimeoutMs,
+						currentReferenceTimestampMs,
+						this.configs.sweepTimeoutMs,
+					),
+				);
+			} else {
+				// If a node was already unreferenced, update its tracking information. Since the current reference time
+				// is from the ops seen, this will ensure that we keep updating unreferenced state as time moves forward.
+				nodeStateTracker.updateTracking(currentReferenceTimestampMs);
+
+				// If a node is sweep ready, store it so it can be returned.
+				if (nodeStateTracker.state === UnreferencedState.SweepReady) {
+					sweepReadyNodeIds.push(nodeId);
+				}
+			}
+		}
+
+		// 4. Call the runtime to update referenced nodes.
 		this.runtime.updateUsedRoutes(gcResult.referencedNodeIds);
 
-		// Log events for objects that are ready to be deleted by sweep.
+		return sweepReadyNodeIds;
+	}
+
+	/**
+	 * Since GC runs periodically, the GC data that is generated only tells us the state of the world at that point in
+	 * time. There can be nodes that were referenced in between two runs and their unreferenced state needs to be
+	 * updated. For example, in the following scenarios not updating the unreferenced timestamp can lead to deletion of
+	 * these objects while there can be in-memory referenced to it:
+	 * 1. A node transitions from `unreferenced -> referenced -> unreferenced` between two runs. When the reference is
+	 * added, the object may have been accessed and in-memory reference to it added.
+	 * 2. A reference is added from one unreferenced node to one or more unreferenced nodes. Even though the node[s] were
+	 * unreferenced, they could have been accessed and in-memory reference to them added.
+	 *
+	 * This function identifies nodes that were referenced since the last run.
+	 * If these nodes are currently unreferenced, they will be assigned new unreferenced state by the current run.
+	 *
+	 * @returns - a list of all nodes referenced from the last local summary until now.
+	 */
+	private findAllNodesReferencedBetweenGCs(
+		currentGCData: IGarbageCollectionData,
+		previousGCData: IGarbageCollectionData | undefined,
+		logger: ITelemetryLogger,
+	): string[] | undefined {
+		// If we haven't run GC before there is nothing to do.
+		// No previousGCData, means nothing is unreferenced, and there are no reference state trackers to clear
+		if (previousGCData === undefined) {
+			return undefined;
+		}
+
+		/**
+		 * If there are references that were not explicitly notified to GC, log an error because this should never happen.
+		 * If it does, this may result in the unreferenced timestamps of these nodes not updated when they were referenced.
+		 */
+		this.telemetryTracker.logIfMissingExplicitReferences(
+			currentGCData,
+			previousGCData,
+			this.newReferencesSinceLastRun,
+			logger,
+		);
+
+		// No references were added since the last run so we don't have to update reference states of any unreferenced
+		// nodes. There is no in between state at this point.
+		if (this.newReferencesSinceLastRun.size === 0) {
+			return undefined;
+		}
+
+		/**
+		 * Generate a super set of the GC data that contains the nodes and edges from last run, plus any new node and
+		 * edges that have been added since then. To do this, combine the GC data from the last run and the current
+		 * run, and then add the references since last run.
+		 *
+		 * Note on why we need to combine the data from previous run, current run and all references in between -
+		 * 1. We need data from last run because some of its references may have been deleted since then. If those
+		 * references added new outbound references before they were deleted, we need to detect them.
+		 *
+		 * 2. We need new outbound references since last run because some of them may have been deleted later. If those
+		 * references added new outbound references before they were deleted, we need to detect them.
+		 *
+		 * 3. We need data from the current run because currently we may not detect when DDSes are referenced:
+		 * - We don't require DDSes handles to be stored in a referenced DDS.
+		 * - A new data store may have "root" DDSes already created and we don't detect them today.
+		 */
+		const gcDataSuperSet = concatGarbageCollectionData(previousGCData, currentGCData);
+		const newOutboundRoutesSinceLastRun: string[] = [];
+		this.newReferencesSinceLastRun.forEach((outboundRoutes: string[], sourceNodeId: string) => {
+			if (gcDataSuperSet.gcNodes[sourceNodeId] === undefined) {
+				gcDataSuperSet.gcNodes[sourceNodeId] = outboundRoutes;
+			} else {
+				gcDataSuperSet.gcNodes[sourceNodeId].push(...outboundRoutes);
+			}
+			newOutboundRoutesSinceLastRun.push(...outboundRoutes);
+		});
+
+		/**
+		 * Run GC on the above reference graph starting with root and all new outbound routes. This will generate a
+		 * list of all nodes that could have been referenced since the last run. If any of these nodes are unreferenced,
+		 * unreferenced, stop tracking them and remove from unreferenced list.
+		 * Note that some of these nodes may be unreferenced now and if so, the current run will mark them as
+		 * unreferenced and add unreferenced state.
+		 */
+		const gcResult = runGarbageCollection(gcDataSuperSet.gcNodes, [
+			"/",
+			...newOutboundRoutesSinceLastRun,
+		]);
+		return gcResult.referencedNodeIds;
+	}
+
+	/**
+	 * Runs the GC Sweep phase. It does the following:
+	 * 1. Calls the runtime to delete nodes that are sweep ready.
+	 * 2. Clears tracking for deleted nodes.
+	 * 3. Updates the passed in gcData by removing deleted nodes from it.
+	 *
+	 * @param gcData - The data representing the reference graph on which GC is run.
+	 * @param gcResult - The result of the GC run on the gcData.
+	 * @param sweepReadyNodes - List of nodes that are sweep ready.
+	 * @param currentReferenceTimestampMs - The timestamp to be used for unreferenced nodes' timestamp.
+	 * @param logger - The logger to be used to log any telemetry.
+	 * @returns - GC data that has deleted nodes removed.
+	 */
+	private runSweepPhase(
+		gcData: IGarbageCollectionData,
+		gcResult: IGCResult,
+		sweepReadyNodes: string[],
+		currentReferenceTimestampMs: number,
+		logger: ITelemetryLogger,
+	): IGarbageCollectionData {
+		// Log events for objects that are ready to be deleted by sweep. This will give us data on sweep when
+		// its not enabled.
 		this.telemetryTracker.logSweepEvents(
 			logger,
 			currentReferenceTimestampMs,
@@ -537,30 +748,61 @@ export class GarbageCollector implements IGarbageCollector {
 			this.getLastSummaryTimestampMs(),
 		);
 
-		let updatedGCData: IGarbageCollectionData = gcData;
-
-		if (this.configs.shouldRunSweep) {
-			updatedGCData = this.runSweepPhase(sweepReadyNodes, gcData);
-		} else if (this.configs.testMode) {
-			// If we are running in GC test mode, delete objects for unused routes. This enables testing scenarios
-			// involving access to deleted data.
+		/**
+		 * Currently, there are 3 modes for sweep:
+		 * Test mode - Unreferenced nodes are immediately deleted without waiting for them to be sweep ready.
+		 * Tombstone mode - Sweep ready modes are marked as tombstones instead of being deleted.
+		 * Sweep mode - Sweep ready modes are deleted.
+		 *
+		 * These modes serve as staging for applications that want to enable sweep by providing an incremental
+		 * way to test and validate sweep works as expected.
+		 */
+		if (this.configs.testMode) {
+			// If we are running in GC test mode, unreferenced nodes (gcResult.deletedNodeIds) are deleted.
 			this.runtime.updateUnusedRoutes(gcResult.deletedNodeIds);
-		} else if (this.configs.tombstoneMode) {
+			return gcData;
+		}
+
+		if (this.configs.tombstoneMode) {
 			this.tombstones = sweepReadyNodes;
 			// If we are running in GC tombstone mode, update tombstoned routes. This enables testing scenarios
 			// involving access to "deleted" data without actually deleting the data from summaries.
-			// Note: we will not tombstone in test mode.
 			this.runtime.updateTombstonedRoutes(this.tombstones);
+			return gcData;
 		}
 
-		this.gcDataFromLastRun = cloneGCData(updatedGCData);
+		if (!this.configs.shouldRunSweep) {
+			return gcData;
+		}
 
-		// Log pending unreferenced events such as a node being used after inactive. This is done after GC runs and
-		// updates its state so that we don't send false positives based on intermediate state. For example, we may get
-		// reference to an unreferenced node from another unreferenced node which means the node wasn't revived.
-		await this.telemetryTracker.logPendingEvents(logger);
+		// 1. Call the runtime to delete sweep ready nodes. The runtime returns a list of nodes it deleted.
+		// TODO: GC:Validation - validate that removed routes are not double delete and that the child routes of
+		// removed routes are deleted as well.
+		const deletedNodeIds = this.runtime.deleteSweepReadyNodes(sweepReadyNodes);
 
-		return gcStats;
+		// 2. Clear unreferenced state tracking for deleted nodes.
+		for (const nodeId of deletedNodeIds) {
+			const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
+			// TODO: GC:Validation - assert that the nodeStateTracker is defined
+			if (nodeStateTracker !== undefined) {
+				// Stop tracking so as to clear out any running timers.
+				nodeStateTracker.stopTracking();
+				// Delete the node as we don't need to track it any more.
+				this.unreferencedNodesState.delete(nodeId);
+			}
+			// TODO: GC:Validation - assert that the deleted node is not a duplicate
+			this.deletedNodes.add(nodeId);
+		}
+
+		// 3. Update and return the passed in gcData by removing deleted nodes from it.
+		const deletedNodeIdsSet = new Set<string>(deletedNodeIds);
+		const gcNodes: { [id: string]: string[] } = {};
+		for (const [id, outboundRoutes] of Object.entries(gcData.gcNodes)) {
+			if (!deletedNodeIdsSet.has(id)) {
+				gcNodes[id] = Array.from(outboundRoutes);
+			}
+		}
+		return { gcNodes };
 	}
 
 	/**
@@ -607,14 +849,6 @@ export class GarbageCollector implements IGarbageCollector {
 			sweepEnabled: false, // DEPRECATED - to be removed
 			sweepTimeoutMs: this.configs.sweepTimeoutMs,
 		};
-	}
-
-	/**
-	 * Returns a the GC details generated from the base summary. This is used to initialize the GC state of the nodes
-	 * in the container.
-	 */
-	public async getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase> {
-		return this.baseGCDetailsP;
 	}
 
 	/**
@@ -725,203 +959,6 @@ export class GarbageCollector implements IGarbageCollector {
 	public dispose(): void {
 		this.sessionExpiryTimer?.clear();
 		this.sessionExpiryTimer = undefined;
-	}
-
-	/**
-	 * Updates the state of the system as per the current GC run. It does the following:
-	 * 1. Sets up the current GC state as per the gcData.
-	 * 2. Starts tracking for nodes that have become unreferenced in this run.
-	 * 3. Clears tracking for nodes that were unreferenced but became referenced in this run.
-	 * @param gcData - The data representing the reference graph on which GC is run.
-	 * @param gcResult - The result of the GC run on the gcData.
-	 * @param currentReferenceTimestampMs - The timestamp to be used for unreferenced nodes' timestamp.
-	 * @returns - A list of sweep ready nodes. (Nodes ready to be deleted)
-	 */
-	private updateMarkPhase(
-		gcData: IGarbageCollectionData,
-		gcResult: IGCResult,
-		currentReferenceTimestampMs: number,
-		logger: ITelemetryLogger,
-	) {
-		// Get references from the current GC run + references between previous and current run and then update each
-		// node's state
-		const allNodesReferencedBetweenGCs =
-			this.findAllNodesReferencedBetweenGCs(gcData, this.gcDataFromLastRun, logger) ??
-			gcResult.referencedNodeIds;
-		this.newReferencesSinceLastRun.clear();
-
-		// Iterate through the referenced nodes and stop tracking if they were unreferenced before.
-		for (const nodeId of allNodesReferencedBetweenGCs) {
-			const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
-			if (nodeStateTracker !== undefined) {
-				// Stop tracking so as to clear out any running timers.
-				nodeStateTracker.stopTracking();
-				// Delete the node as we don't need to track it any more.
-				this.unreferencedNodesState.delete(nodeId);
-			}
-		}
-
-		/**
-		 * If a node became unreferenced in this run, start tracking it.
-		 * If a node was already unreferenced, update its tracking information. Since the current reference time is
-		 * from the ops seen, this will ensure that we keep updating the unreferenced state as time moves forward.
-		 *
-		 * If a node is sweep ready, store and then return it.
-		 */
-		const sweepReadyNodes: string[] = [];
-		for (const nodeId of gcResult.deletedNodeIds) {
-			const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
-			if (nodeStateTracker === undefined) {
-				this.unreferencedNodesState.set(
-					nodeId,
-					new UnreferencedStateTracker(
-						currentReferenceTimestampMs,
-						this.configs.inactiveTimeoutMs,
-						currentReferenceTimestampMs,
-						this.configs.sweepTimeoutMs,
-					),
-				);
-			} else {
-				nodeStateTracker.updateTracking(currentReferenceTimestampMs);
-				if (nodeStateTracker.state === UnreferencedState.SweepReady) {
-					sweepReadyNodes.push(nodeId);
-				}
-			}
-		}
-
-		return sweepReadyNodes;
-	}
-
-	/**
-	 * Deletes nodes from both the runtime and garbage collection
-	 * @param sweepReadyNodes - nodes that are ready to be deleted
-	 */
-	private runSweepPhase(sweepReadyNodes: string[], gcData: IGarbageCollectionData) {
-		// TODO: GC:Validation - validate that removed routes are not double deleted
-		// TODO: GC:Validation - validate that the child routes of removed routes are deleted as well
-		const sweptRoutes = this.runtime.deleteSweepReadyNodes(sweepReadyNodes);
-		const updatedGCData = this.deleteSweptRoutes(sweptRoutes, gcData);
-
-		for (const nodeId of sweptRoutes) {
-			const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
-			// TODO: GC:Validation - assert that the nodeStateTracker is defined
-			if (nodeStateTracker !== undefined) {
-				// Stop tracking so as to clear out any running timers.
-				nodeStateTracker.stopTracking();
-				// Delete the node as we don't need to track it any more.
-				this.unreferencedNodesState.delete(nodeId);
-			}
-			// TODO: GC:Validation - assert that the deleted node is not a duplicate
-			this.deletedNodes.add(nodeId);
-		}
-
-		return updatedGCData;
-	}
-
-	/**
-	 * @returns IGarbageCollectionData after deleting the sweptRoutes from the gcData
-	 */
-	private deleteSweptRoutes(
-		sweptRoutes: string[],
-		gcData: IGarbageCollectionData,
-	): IGarbageCollectionData {
-		const sweptRoutesSet = new Set<string>(sweptRoutes);
-		const gcNodes: { [id: string]: string[] } = {};
-		for (const [id, outboundRoutes] of Object.entries(gcData.gcNodes)) {
-			if (!sweptRoutesSet.has(id)) {
-				gcNodes[id] = Array.from(outboundRoutes);
-			}
-		}
-
-		// TODO: GC:Validation - assert that the nodeId is in gcData
-
-		return {
-			gcNodes,
-		};
-	}
-
-	/**
-	 * Since GC runs periodically, the GC data that is generated only tells us the state of the world at that point in
-	 * time. There can be nodes that were referenced in between two runs and their unreferenced state needs to be
-	 * updated. For example, in the following scenarios not updating the unreferenced timestamp can lead to deletion of
-	 * these objects while there can be in-memory referenced to it:
-	 * 1. A node transitions from `unreferenced -> referenced -> unreferenced` between two runs. When the reference is
-	 * added, the object may have been accessed and in-memory reference to it added.
-	 * 2. A reference is added from one unreferenced node to one or more unreferenced nodes. Even though the node[s] were
-	 * unreferenced, they could have been accessed and in-memory reference to them added.
-	 *
-	 * This function identifies nodes that were referenced since the last run.
-	 * If these nodes are currently unreferenced, they will be assigned new unreferenced state by the current run.
-	 *
-	 * @returns - a list of all nodes referenced from the last local summary until now.
-	 */
-	private findAllNodesReferencedBetweenGCs(
-		currentGCData: IGarbageCollectionData,
-		previousGCData: IGarbageCollectionData | undefined,
-		logger: ITelemetryLogger,
-	): string[] | undefined {
-		// If we haven't run GC before there is nothing to do.
-		// No previousGCData, means nothing is unreferenced, and there are no reference state trackers to clear
-		if (previousGCData === undefined) {
-			return undefined;
-		}
-
-		/**
-		 * If there are references that were not explicitly notified to GC, log an error because this should never happen.
-		 * If it does, this may result in the unreferenced timestamps of these nodes not updated when they were referenced.
-		 */
-		this.telemetryTracker.logIfMissingExplicitReferences(
-			currentGCData,
-			previousGCData,
-			this.newReferencesSinceLastRun,
-			logger,
-		);
-
-		// No references were added since the last run so we don't have to update reference states of any unreferenced
-		// nodes. There is no in between state at this point.
-		if (this.newReferencesSinceLastRun.size === 0) {
-			return undefined;
-		}
-
-		/**
-		 * Generate a super set of the GC data that contains the nodes and edges from last run, plus any new node and
-		 * edges that have been added since then. To do this, combine the GC data from the last run and the current
-		 * run, and then add the references since last run.
-		 *
-		 * Note on why we need to combine the data from previous run, current run and all references in between -
-		 * 1. We need data from last run because some of its references may have been deleted since then. If those
-		 * references added new outbound references before they were deleted, we need to detect them.
-		 *
-		 * 2. We need new outbound references since last run because some of them may have been deleted later. If those
-		 * references added new outbound references before they were deleted, we need to detect them.
-		 *
-		 * 3. We need data from the current run because currently we may not detect when DDSes are referenced:
-		 * - We don't require DDSes handles to be stored in a referenced DDS.
-		 * - A new data store may have "root" DDSes already created and we don't detect them today.
-		 */
-		const gcDataSuperSet = concatGarbageCollectionData(previousGCData, currentGCData);
-		const newOutboundRoutesSinceLastRun: string[] = [];
-		this.newReferencesSinceLastRun.forEach((outboundRoutes: string[], sourceNodeId: string) => {
-			if (gcDataSuperSet.gcNodes[sourceNodeId] === undefined) {
-				gcDataSuperSet.gcNodes[sourceNodeId] = outboundRoutes;
-			} else {
-				gcDataSuperSet.gcNodes[sourceNodeId].push(...outboundRoutes);
-			}
-			newOutboundRoutesSinceLastRun.push(...outboundRoutes);
-		});
-
-		/**
-		 * Run GC on the above reference graph starting with root and all new outbound routes. This will generate a
-		 * list of all nodes that could have been referenced since the last run. If any of these nodes are unreferenced,
-		 * unreferenced, stop tracking them and remove from unreferenced list.
-		 * Note that some of these nodes may be unreferenced now and if so, the current run will mark them as
-		 * unreferenced and add unreferenced state.
-		 */
-		const gcResult = runGarbageCollection(gcDataSuperSet.gcNodes, [
-			"/",
-			...newOutboundRoutesSinceLastRun,
-		]);
-		return gcResult.referencedNodeIds;
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -490,17 +490,17 @@ export class GarbageCollector implements IGarbageCollector {
 			logger,
 			{ eventName: "GarbageCollection" },
 			async (event) => {
-				// Pre-GC step.
+				/** Pre-GC steps */
 				// Ensure that state has been initialized from the base snapshot data.
 				await this.initializeGCStateFromBaseSnapshotP;
 				// Let the runtime update its pending state before GC runs.
 				await this.runtime.updateStateBeforeGC();
 
-				// GC step. Includes running GC algorithm on the reference graph, running Mark and Sweep phases.
+				/** GC step */
 				const gcStats = await this.runGC(fullGC, currentReferenceTimestampMs, logger);
 				event.end({ ...gcStats, timestamp: currentReferenceTimestampMs });
 
-				// Post-GC step.
+				/** Post-GC steps */
 				// Log pending unreferenced events such as a node being used after inactive. This is done after GC runs and
 				// updates its state so that we don't send false positives based on intermediate state. For example, we may get
 				// reference to an unreferenced node from another unreferenced node which means the node wasn't revived.

--- a/packages/runtime/container-runtime/src/gc/gcHelpers.ts
+++ b/packages/runtime/container-runtime/src/gc/gcHelpers.ts
@@ -151,12 +151,19 @@ export function concatGarbageCollectionStates(
 /**
  * Helper function that clones the GC data.
  * @param gcData - The GC data to clone.
+ * @param filter - Optional function to filter out node ids not to be included in the cloned GC data. Returns
+ * true to filter out nodes.
  * @returns a clone of the given GC data.
  */
-export function cloneGCData(gcData: IGarbageCollectionData): IGarbageCollectionData {
+export function cloneGCData(
+	gcData: IGarbageCollectionData,
+	filter?: (id: string) => boolean,
+): IGarbageCollectionData {
 	const clonedGCNodes: { [id: string]: string[] } = {};
 	for (const [id, outboundRoutes] of Object.entries(gcData.gcNodes)) {
-		clonedGCNodes[id] = Array.from(outboundRoutes);
+		if (filter?.(id) !== true) {
+			clonedGCNodes[id] = Array.from(outboundRoutes);
+		}
 	}
 	return {
 		gcNodes: clonedGCNodes,


### PR DESCRIPTION
## Description
This change refactors the code around the main garbage collection run by separating it into 3 steps:
1. Pre GC step - This includes initializing from base state (if not already done) and notifying container runtime that GC is starting.
2. GC step - This includes 2 main parts - running mark phase and running sweep phase.
3. Post GC step - This includes clearing state and logging any events.

The goal is to clearly indicate what logic runs in which step and also consolidate the logic of mark and sweep phases.

## Reviewer Guidance
This is a refactor. There is no change in functionality.